### PR TITLE
fix: command permission handling

### DIFF
--- a/pumpkin/src/command/client_cmd_suggestions.rs
+++ b/pumpkin/src/command/client_cmd_suggestions.rs
@@ -20,6 +20,14 @@ pub async fn send_c_commands_packet(player: &Arc<Player>, dispatcher: &RwLock<Co
             continue;
         };
 
+        let Some(permission) = dispatcher.get_permission_lvl(key) else {
+            continue;
+        };
+
+        if !cmd_src.has_permission_lvl(permission) {
+            continue;
+        }
+
         let (is_executable, child_nodes) =
             nodes_to_proto_node_builders(&cmd_src, &tree.nodes, &tree.children);
 

--- a/pumpkin/src/command/commands/cmd_fill.rs
+++ b/pumpkin/src/command/commands/cmd_fill.rs
@@ -2,13 +2,12 @@ use crate::command::args::arg_block::BlockArgumentConsumer;
 use crate::command::args::arg_position_block::BlockPosArgumentConsumer;
 use crate::command::args::{ConsumedArgs, FindArg};
 use crate::command::tree::CommandTree;
-use crate::command::tree_builder::{argument, literal, require};
+use crate::command::tree_builder::{argument, literal};
 use crate::command::{CommandError, CommandExecutor, CommandSender};
 
 use async_trait::async_trait;
 use pumpkin_core::math::position::WorldPosition;
 use pumpkin_core::math::vector3::Vector3;
-use pumpkin_core::permission::PermissionLvl;
 use pumpkin_core::text::TextComponent;
 
 const NAMES: [&str; 1] = ["fill"];
@@ -156,20 +155,18 @@ impl CommandExecutor for SetblockExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(|sender| sender.has_permission_lvl(PermissionLvl::Two) && sender.world().is_some())
-            .with_child(
-                argument(ARG_FROM, BlockPosArgumentConsumer).with_child(
-                    argument(ARG_TO, BlockPosArgumentConsumer).with_child(
-                        argument(ARG_BLOCK, BlockArgumentConsumer)
-                            .with_child(literal("destroy").execute(SetblockExecutor(Mode::Destroy)))
-                            .with_child(literal("hollow").execute(SetblockExecutor(Mode::Hollow)))
-                            .with_child(literal("keep").execute(SetblockExecutor(Mode::Keep)))
-                            .with_child(literal("outline").execute(SetblockExecutor(Mode::Outline)))
-                            .with_child(literal("replace").execute(SetblockExecutor(Mode::Replace)))
-                            .execute(SetblockExecutor(Mode::Replace)),
-                    ),
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(
+            argument(ARG_FROM, BlockPosArgumentConsumer).with_child(
+                argument(ARG_TO, BlockPosArgumentConsumer).with_child(
+                    argument(ARG_BLOCK, BlockArgumentConsumer)
+                        .with_child(literal("destroy").execute(SetblockExecutor(Mode::Destroy)))
+                        .with_child(literal("hollow").execute(SetblockExecutor(Mode::Hollow)))
+                        .with_child(literal("keep").execute(SetblockExecutor(Mode::Keep)))
+                        .with_child(literal("outline").execute(SetblockExecutor(Mode::Outline)))
+                        .with_child(literal("replace").execute(SetblockExecutor(Mode::Replace)))
+                        .execute(SetblockExecutor(Mode::Replace)),
                 ),
             ),
-    )
+        )
 }

--- a/pumpkin/src/command/commands/cmd_fill.rs
+++ b/pumpkin/src/command/commands/cmd_fill.rs
@@ -155,18 +155,17 @@ impl CommandExecutor for SetblockExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION)
-        .with_child(
-            argument(ARG_FROM, BlockPosArgumentConsumer).with_child(
-                argument(ARG_TO, BlockPosArgumentConsumer).with_child(
-                    argument(ARG_BLOCK, BlockArgumentConsumer)
-                        .with_child(literal("destroy").execute(SetblockExecutor(Mode::Destroy)))
-                        .with_child(literal("hollow").execute(SetblockExecutor(Mode::Hollow)))
-                        .with_child(literal("keep").execute(SetblockExecutor(Mode::Keep)))
-                        .with_child(literal("outline").execute(SetblockExecutor(Mode::Outline)))
-                        .with_child(literal("replace").execute(SetblockExecutor(Mode::Replace)))
-                        .execute(SetblockExecutor(Mode::Replace)),
-                ),
+    CommandTree::new(NAMES, DESCRIPTION).with_child(
+        argument(ARG_FROM, BlockPosArgumentConsumer).with_child(
+            argument(ARG_TO, BlockPosArgumentConsumer).with_child(
+                argument(ARG_BLOCK, BlockArgumentConsumer)
+                    .with_child(literal("destroy").execute(SetblockExecutor(Mode::Destroy)))
+                    .with_child(literal("hollow").execute(SetblockExecutor(Mode::Hollow)))
+                    .with_child(literal("keep").execute(SetblockExecutor(Mode::Keep)))
+                    .with_child(literal("outline").execute(SetblockExecutor(Mode::Outline)))
+                    .with_child(literal("replace").execute(SetblockExecutor(Mode::Replace)))
+                    .execute(SetblockExecutor(Mode::Replace)),
             ),
-        )
+        ),
+    )
 }

--- a/pumpkin/src/command/commands/cmd_gamemode.rs
+++ b/pumpkin/src/command/commands/cmd_gamemode.rs
@@ -107,12 +107,11 @@ impl CommandExecutor for GamemodeTargetPlayer {
 
 #[allow(clippy::redundant_closure_for_method_calls)]
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION)
-        .with_child(
-            argument(ARG_GAMEMODE, GamemodeArgumentConsumer)
-                .with_child(require(|sender| sender.is_player()).execute(GamemodeTargetSelf))
-                .with_child(
-                    argument(ARG_TARGET, PlayersArgumentConsumer).execute(GamemodeTargetPlayer),
-                ),
-        )
+    CommandTree::new(NAMES, DESCRIPTION).with_child(
+        argument(ARG_GAMEMODE, GamemodeArgumentConsumer)
+            .with_child(require(|sender| sender.is_player()).execute(GamemodeTargetSelf))
+            .with_child(
+                argument(ARG_TARGET, PlayersArgumentConsumer).execute(GamemodeTargetPlayer),
+            ),
+    )
 }

--- a/pumpkin/src/command/commands/cmd_gamemode.rs
+++ b/pumpkin/src/command/commands/cmd_gamemode.rs
@@ -4,7 +4,6 @@ use crate::command::args::arg_gamemode::GamemodeArgumentConsumer;
 use crate::command::args::GetCloned;
 
 use crate::TextComponent;
-use pumpkin_core::permission::PermissionLvl;
 
 use crate::command::args::arg_players::PlayersArgumentConsumer;
 
@@ -108,13 +107,12 @@ impl CommandExecutor for GamemodeTargetPlayer {
 
 #[allow(clippy::redundant_closure_for_method_calls)]
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(|sender| sender.has_permission_lvl(PermissionLvl::Two)).with_child(
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(
             argument(ARG_GAMEMODE, GamemodeArgumentConsumer)
                 .with_child(require(|sender| sender.is_player()).execute(GamemodeTargetSelf))
                 .with_child(
                     argument(ARG_TARGET, PlayersArgumentConsumer).execute(GamemodeTargetPlayer),
                 ),
-        ),
-    )
+        )
 }

--- a/pumpkin/src/command/commands/cmd_give.rs
+++ b/pumpkin/src/command/commands/cmd_give.rs
@@ -74,12 +74,11 @@ impl CommandExecutor for GiveExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION)
-        .with_child(
-            argument_default_name(PlayersArgumentConsumer).with_child(
-                argument(ARG_ITEM, ItemArgumentConsumer)
-                    .execute(GiveExecutor)
-                    .with_child(argument_default_name(item_count_consumer()).execute(GiveExecutor)),
-            ),
-        )
+    CommandTree::new(NAMES, DESCRIPTION).with_child(
+        argument_default_name(PlayersArgumentConsumer).with_child(
+            argument(ARG_ITEM, ItemArgumentConsumer)
+                .execute(GiveExecutor)
+                .with_child(argument_default_name(item_count_consumer()).execute(GiveExecutor)),
+        ),
+    )
 }

--- a/pumpkin/src/command/commands/cmd_give.rs
+++ b/pumpkin/src/command/commands/cmd_give.rs
@@ -7,9 +7,8 @@ use crate::command::args::arg_item::ItemArgumentConsumer;
 use crate::command::args::arg_players::PlayersArgumentConsumer;
 use crate::command::args::{ConsumedArgs, FindArg, FindArgDefaultName};
 use crate::command::tree::CommandTree;
-use crate::command::tree_builder::{argument, argument_default_name, require};
+use crate::command::tree_builder::{argument, argument_default_name};
 use crate::command::{CommandError, CommandExecutor, CommandSender};
-use pumpkin_core::permission::PermissionLvl;
 
 const NAMES: [&str; 1] = ["give"];
 
@@ -75,13 +74,12 @@ impl CommandExecutor for GiveExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(|sender| sender.has_permission_lvl(PermissionLvl::Two)).with_child(
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(
             argument_default_name(PlayersArgumentConsumer).with_child(
                 argument(ARG_ITEM, ItemArgumentConsumer)
                     .execute(GiveExecutor)
                     .with_child(argument_default_name(item_count_consumer()).execute(GiveExecutor)),
             ),
-        ),
-    )
+        )
 }

--- a/pumpkin/src/command/commands/cmd_op.rs
+++ b/pumpkin/src/command/commands/cmd_op.rs
@@ -2,14 +2,13 @@ use crate::{
     command::{
         args::{arg_players::PlayersArgumentConsumer, Arg, ConsumedArgs},
         tree::CommandTree,
-        tree_builder::{argument, require},
+        tree_builder::argument,
         CommandError, CommandExecutor, CommandSender,
     },
     data::{op_data::OPERATOR_CONFIG, SaveJSONConfiguration},
 };
 use async_trait::async_trait;
 use pumpkin_config::{op::Op, BASIC_CONFIG};
-use pumpkin_core::permission::PermissionLvl;
 use pumpkin_core::text::TextComponent;
 use CommandError::InvalidConsumption;
 
@@ -73,8 +72,6 @@ impl CommandExecutor for OpExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(|sender| sender.has_permission_lvl(PermissionLvl::Three))
-            .with_child(argument(ARG_TARGET, PlayersArgumentConsumer).execute(OpExecutor)),
-    )
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(argument(ARG_TARGET, PlayersArgumentConsumer).execute(OpExecutor))
 }

--- a/pumpkin/src/command/commands/cmd_say.rs
+++ b/pumpkin/src/command/commands/cmd_say.rs
@@ -5,10 +5,9 @@ use pumpkin_protocol::client::play::CSystemChatMessage;
 use crate::command::{
     args::{arg_message::MsgArgConsumer, Arg, ConsumedArgs},
     tree::CommandTree,
-    tree_builder::{argument, require},
+    tree_builder::argument,
     CommandError, CommandExecutor, CommandSender,
 };
-use pumpkin_core::permission::PermissionLvl;
 use CommandError::InvalidConsumption;
 
 const NAMES: [&str; 1] = ["say"];
@@ -42,8 +41,6 @@ impl CommandExecutor for SayExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(|sender| sender.has_permission_lvl(PermissionLvl::Two))
-            .with_child(argument(ARG_MESSAGE, MsgArgConsumer).execute(SayExecutor)),
-    )
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(argument(ARG_MESSAGE, MsgArgConsumer).execute(SayExecutor))
 }

--- a/pumpkin/src/command/commands/cmd_seed.rs
+++ b/pumpkin/src/command/commands/cmd_seed.rs
@@ -1,9 +1,7 @@
-use crate::command::tree_builder::require;
 use crate::command::{
     args::ConsumedArgs, tree::CommandTree, CommandError, CommandExecutor, CommandSender,
 };
 use async_trait::async_trait;
-use pumpkin_core::permission::PermissionLvl;
 use pumpkin_core::text::click::ClickEvent;
 use pumpkin_core::text::hover::HoverEvent;
 use pumpkin_core::text::{color::NamedColor, TextComponent};
@@ -56,8 +54,5 @@ impl CommandExecutor for PumpkinExecutor {
 
 pub fn init_command_tree() -> CommandTree {
     CommandTree::new(NAMES, DESCRIPTION)
-        .with_child(require(|sender| {
-            sender.has_permission_lvl(PermissionLvl::Two)
-        }))
         .execute(PumpkinExecutor)
 }

--- a/pumpkin/src/command/commands/cmd_seed.rs
+++ b/pumpkin/src/command/commands/cmd_seed.rs
@@ -53,6 +53,5 @@ impl CommandExecutor for PumpkinExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION)
-        .execute(PumpkinExecutor)
+    CommandTree::new(NAMES, DESCRIPTION).execute(PumpkinExecutor)
 }

--- a/pumpkin/src/command/commands/cmd_setblock.rs
+++ b/pumpkin/src/command/commands/cmd_setblock.rs
@@ -6,9 +6,8 @@ use crate::command::args::arg_block::BlockArgumentConsumer;
 use crate::command::args::arg_position_block::BlockPosArgumentConsumer;
 use crate::command::args::{ConsumedArgs, FindArg};
 use crate::command::tree::CommandTree;
-use crate::command::tree_builder::{argument, literal, require};
+use crate::command::tree_builder::{argument, literal};
 use crate::command::{CommandError, CommandExecutor, CommandSender};
-use pumpkin_core::permission::PermissionLvl;
 
 const NAMES: [&str; 1] = ["setblock"];
 
@@ -80,16 +79,14 @@ impl CommandExecutor for SetblockExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(|sender| sender.has_permission_lvl(PermissionLvl::Two) && sender.world().is_some())
-            .with_child(
-                argument(ARG_BLOCK_POS, BlockPosArgumentConsumer).with_child(
-                    argument(ARG_BLOCK, BlockArgumentConsumer)
-                        .with_child(literal("replace").execute(SetblockExecutor(Mode::Replace)))
-                        .with_child(literal("destroy").execute(SetblockExecutor(Mode::Destroy)))
-                        .with_child(literal("keep").execute(SetblockExecutor(Mode::Keep)))
-                        .execute(SetblockExecutor(Mode::Replace)),
-                ),
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(
+            argument(ARG_BLOCK_POS, BlockPosArgumentConsumer).with_child(
+                argument(ARG_BLOCK, BlockArgumentConsumer)
+                    .with_child(literal("replace").execute(SetblockExecutor(Mode::Replace)))
+                    .with_child(literal("destroy").execute(SetblockExecutor(Mode::Destroy)))
+                    .with_child(literal("keep").execute(SetblockExecutor(Mode::Keep)))
+                    .execute(SetblockExecutor(Mode::Replace)),
             ),
-    )
+        )
 }

--- a/pumpkin/src/command/commands/cmd_setblock.rs
+++ b/pumpkin/src/command/commands/cmd_setblock.rs
@@ -79,14 +79,13 @@ impl CommandExecutor for SetblockExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION)
-        .with_child(
-            argument(ARG_BLOCK_POS, BlockPosArgumentConsumer).with_child(
-                argument(ARG_BLOCK, BlockArgumentConsumer)
-                    .with_child(literal("replace").execute(SetblockExecutor(Mode::Replace)))
-                    .with_child(literal("destroy").execute(SetblockExecutor(Mode::Destroy)))
-                    .with_child(literal("keep").execute(SetblockExecutor(Mode::Keep)))
-                    .execute(SetblockExecutor(Mode::Replace)),
-            ),
-        )
+    CommandTree::new(NAMES, DESCRIPTION).with_child(
+        argument(ARG_BLOCK_POS, BlockPosArgumentConsumer).with_child(
+            argument(ARG_BLOCK, BlockArgumentConsumer)
+                .with_child(literal("replace").execute(SetblockExecutor(Mode::Replace)))
+                .with_child(literal("destroy").execute(SetblockExecutor(Mode::Destroy)))
+                .with_child(literal("keep").execute(SetblockExecutor(Mode::Keep)))
+                .execute(SetblockExecutor(Mode::Replace)),
+        ),
+    )
 }

--- a/pumpkin/src/command/commands/cmd_stop.rs
+++ b/pumpkin/src/command/commands/cmd_stop.rs
@@ -38,4 +38,3 @@ impl CommandExecutor for StopExecutor {
 pub fn init_command_tree() -> CommandTree {
     CommandTree::new(NAMES, DESCRIPTION).execute(StopExecutor)
 }
-

--- a/pumpkin/src/command/commands/cmd_stop.rs
+++ b/pumpkin/src/command/commands/cmd_stop.rs
@@ -4,9 +4,7 @@ use pumpkin_core::text::TextComponent;
 
 use crate::command::args::ConsumedArgs;
 use crate::command::tree::CommandTree;
-use crate::command::tree_builder::require;
 use crate::command::{CommandError, CommandExecutor, CommandSender};
-use pumpkin_core::permission::PermissionLvl;
 
 const NAMES: [&str; 1] = ["stop"];
 
@@ -38,7 +36,6 @@ impl CommandExecutor for StopExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(|sender| sender.has_permission_lvl(PermissionLvl::Four)).execute(StopExecutor),
-    )
+    CommandTree::new(NAMES, DESCRIPTION).execute(StopExecutor)
 }
+

--- a/pumpkin/src/command/commands/cmd_teleport.rs
+++ b/pumpkin/src/command/commands/cmd_teleport.rs
@@ -238,9 +238,7 @@ impl CommandExecutor for TpSelfToPosExecutor {
 
 pub fn init_command_tree() -> CommandTree {
     CommandTree::new(NAMES, DESCRIPTION)
-        .with_child(
-            argument(ARG_LOCATION, Position3DArgumentConsumer).execute(TpSelfToPosExecutor),
-        )
+        .with_child(argument(ARG_LOCATION, Position3DArgumentConsumer).execute(TpSelfToPosExecutor))
         .with_child(
             argument(ARG_DESTINATION, EntityArgumentConsumer).execute(TpSelfToEntityExecutor),
         )

--- a/pumpkin/src/command/commands/cmd_teleport.rs
+++ b/pumpkin/src/command/commands/cmd_teleport.rs
@@ -9,10 +9,9 @@ use crate::command::args::arg_rotation::RotationArgumentConsumer;
 use crate::command::args::ConsumedArgs;
 use crate::command::args::FindArg;
 use crate::command::tree::CommandTree;
-use crate::command::tree_builder::{argument, literal, require};
+use crate::command::tree_builder::{argument, literal};
 use crate::command::CommandError;
 use crate::command::{CommandExecutor, CommandSender};
-use pumpkin_core::permission::PermissionLvl;
 
 const NAMES: [&str; 2] = ["teleport", "tp"];
 const DESCRIPTION: &str = "Teleports entities, including players."; // todo
@@ -238,41 +237,39 @@ impl CommandExecutor for TpSelfToPosExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(|sender| sender.has_permission_lvl(PermissionLvl::Two))
-            .with_child(
-                argument(ARG_LOCATION, Position3DArgumentConsumer).execute(TpSelfToPosExecutor),
-            )
-            .with_child(
-                argument(ARG_DESTINATION, EntityArgumentConsumer).execute(TpSelfToEntityExecutor),
-            )
-            .with_child(
-                argument(ARG_TARGETS, EntitiesArgumentConsumer)
-                    .with_child(
-                        argument(ARG_LOCATION, Position3DArgumentConsumer)
-                            .execute(TpEntitiesToPosExecutor)
-                            .with_child(
-                                argument(ARG_ROTATION, RotationArgumentConsumer)
-                                    .execute(TpEntitiesToPosWithRotationExecutor),
-                            )
-                            .with_child(
-                                literal("facing")
-                                    .with_child(
-                                        literal("entity").with_child(
-                                            argument(ARG_FACING_ENTITY, EntityArgumentConsumer)
-                                                .execute(TpEntitiesToPosFacingEntityExecutor),
-                                        ),
-                                    )
-                                    .with_child(
-                                        argument(ARG_FACING_LOCATION, Position3DArgumentConsumer)
-                                            .execute(TpEntitiesToPosFacingPosExecutor),
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(
+            argument(ARG_LOCATION, Position3DArgumentConsumer).execute(TpSelfToPosExecutor),
+        )
+        .with_child(
+            argument(ARG_DESTINATION, EntityArgumentConsumer).execute(TpSelfToEntityExecutor),
+        )
+        .with_child(
+            argument(ARG_TARGETS, EntitiesArgumentConsumer)
+                .with_child(
+                    argument(ARG_LOCATION, Position3DArgumentConsumer)
+                        .execute(TpEntitiesToPosExecutor)
+                        .with_child(
+                            argument(ARG_ROTATION, RotationArgumentConsumer)
+                                .execute(TpEntitiesToPosWithRotationExecutor),
+                        )
+                        .with_child(
+                            literal("facing")
+                                .with_child(
+                                    literal("entity").with_child(
+                                        argument(ARG_FACING_ENTITY, EntityArgumentConsumer)
+                                            .execute(TpEntitiesToPosFacingEntityExecutor),
                                     ),
-                            ),
-                    )
-                    .with_child(
-                        argument(ARG_DESTINATION, EntityArgumentConsumer)
-                            .execute(TpEntitiesToEntityExecutor),
-                    ),
-            ),
-    )
+                                )
+                                .with_child(
+                                    argument(ARG_FACING_LOCATION, Position3DArgumentConsumer)
+                                        .execute(TpEntitiesToPosFacingPosExecutor),
+                                ),
+                        ),
+                )
+                .with_child(
+                    argument(ARG_DESTINATION, EntityArgumentConsumer)
+                        .execute(TpEntitiesToEntityExecutor),
+                ),
+        )
 }

--- a/pumpkin/src/command/commands/cmd_time.rs
+++ b/pumpkin/src/command/commands/cmd_time.rs
@@ -6,8 +6,7 @@ use crate::command::args::arg_bounded_num::BoundedNumArgumentConsumer;
 use crate::command::args::FindArgDefaultName;
 use crate::command::tree_builder::{argument_default_name, literal};
 use crate::command::{
-    tree::CommandTree, CommandError, CommandExecutor, CommandSender,
-    ConsumedArgs,
+    tree::CommandTree, CommandError, CommandExecutor, CommandSender, ConsumedArgs,
 };
 
 const NAMES: [&str; 1] = ["time"];
@@ -125,16 +124,20 @@ impl CommandExecutor for TimeChangeExecutor {
 
 pub fn init_command_tree() -> CommandTree {
     CommandTree::new(NAMES, DESCRIPTION)
-        .with_child(literal("add").with_child(
-            argument_default_name(arg_number()).execute(TimeChangeExecutor(Mode::Add)),
-        ))
+        .with_child(
+            literal("add").with_child(
+                argument_default_name(arg_number()).execute(TimeChangeExecutor(Mode::Add)),
+            ),
+        )
         .with_child(
             literal("query")
                 .with_child(literal("daytime").execute(TimeQueryExecutor(QueryMode::DayTime)))
                 .with_child(literal("gametime").execute(TimeQueryExecutor(QueryMode::GameTime)))
                 .with_child(literal("day").execute(TimeQueryExecutor(QueryMode::Day))),
         )
-        .with_child(literal("set").with_child(
-            argument_default_name(arg_number()).execute(TimeChangeExecutor(Mode::Set)),
-        ))
+        .with_child(
+            literal("set").with_child(
+                argument_default_name(arg_number()).execute(TimeChangeExecutor(Mode::Set)),
+            ),
+        )
 }

--- a/pumpkin/src/command/commands/cmd_time.rs
+++ b/pumpkin/src/command/commands/cmd_time.rs
@@ -6,10 +6,9 @@ use crate::command::args::arg_bounded_num::BoundedNumArgumentConsumer;
 use crate::command::args::FindArgDefaultName;
 use crate::command::tree_builder::{argument_default_name, literal};
 use crate::command::{
-    tree::CommandTree, tree_builder::require, CommandError, CommandExecutor, CommandSender,
+    tree::CommandTree, CommandError, CommandExecutor, CommandSender,
     ConsumedArgs,
 };
-use pumpkin_core::permission::PermissionLvl;
 
 const NAMES: [&str; 1] = ["time"];
 
@@ -125,19 +124,17 @@ impl CommandExecutor for TimeChangeExecutor {
 }
 
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(|sender| sender.has_permission_lvl(PermissionLvl::Two))
-            .with_child(literal("add").with_child(
-                argument_default_name(arg_number()).execute(TimeChangeExecutor(Mode::Add)),
-            ))
-            .with_child(
-                literal("query")
-                    .with_child(literal("daytime").execute(TimeQueryExecutor(QueryMode::DayTime)))
-                    .with_child(literal("gametime").execute(TimeQueryExecutor(QueryMode::GameTime)))
-                    .with_child(literal("day").execute(TimeQueryExecutor(QueryMode::Day))),
-            )
-            .with_child(literal("set").with_child(
-                argument_default_name(arg_number()).execute(TimeChangeExecutor(Mode::Set)),
-            )),
-    )
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(literal("add").with_child(
+            argument_default_name(arg_number()).execute(TimeChangeExecutor(Mode::Add)),
+        ))
+        .with_child(
+            literal("query")
+                .with_child(literal("daytime").execute(TimeQueryExecutor(QueryMode::DayTime)))
+                .with_child(literal("gametime").execute(TimeQueryExecutor(QueryMode::GameTime)))
+                .with_child(literal("day").execute(TimeQueryExecutor(QueryMode::Day))),
+        )
+        .with_child(literal("set").with_child(
+            argument_default_name(arg_number()).execute(TimeChangeExecutor(Mode::Set)),
+        ))
 }

--- a/pumpkin/src/command/commands/cmd_transfer.rs
+++ b/pumpkin/src/command/commands/cmd_transfer.rs
@@ -119,19 +119,16 @@ impl CommandExecutor for TransferTargetPlayer {
 
 #[allow(clippy::redundant_closure_for_method_calls)]
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION)
-        .with_child(
-            argument(ARG_HOSTNAME, SimpleArgConsumer)
-                .with_child(require(|sender| sender.is_player()).execute(TransferTargetSelf))
-                .with_child(
-                    argument_default_name(port_consumer())
-                        .with_child(
-                            require(|sender| sender.is_player()).execute(TransferTargetSelf),
-                        )
-                        .with_child(
-                            argument(ARG_PLAYERS, PlayersArgumentConsumer)
-                                .execute(TransferTargetPlayer),
-                        ),
-                ),
-        )
+    CommandTree::new(NAMES, DESCRIPTION).with_child(
+        argument(ARG_HOSTNAME, SimpleArgConsumer)
+            .with_child(require(|sender| sender.is_player()).execute(TransferTargetSelf))
+            .with_child(
+                argument_default_name(port_consumer())
+                    .with_child(require(|sender| sender.is_player()).execute(TransferTargetSelf))
+                    .with_child(
+                        argument(ARG_PLAYERS, PlayersArgumentConsumer)
+                            .execute(TransferTargetPlayer),
+                    ),
+            ),
+    )
 }

--- a/pumpkin/src/command/commands/cmd_transfer.rs
+++ b/pumpkin/src/command/commands/cmd_transfer.rs
@@ -13,7 +13,6 @@ use crate::command::tree_builder::{argument, argument_default_name, require};
 use crate::command::{
     args::ConsumedArgs, tree::CommandTree, CommandError, CommandExecutor, CommandSender,
 };
-use pumpkin_core::permission::PermissionLvl;
 
 const NAMES: [&str; 1] = ["transfer"];
 
@@ -120,8 +119,8 @@ impl CommandExecutor for TransferTargetPlayer {
 
 #[allow(clippy::redundant_closure_for_method_calls)]
 pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(|sender| sender.has_permission_lvl(PermissionLvl::Three)).with_child(
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(
             argument(ARG_HOSTNAME, SimpleArgConsumer)
                 .with_child(require(|sender| sender.is_player()).execute(TransferTargetSelf))
                 .with_child(
@@ -134,6 +133,5 @@ pub fn init_command_tree() -> CommandTree {
                                 .execute(TransferTargetPlayer),
                         ),
                 ),
-        ),
-    )
+        )
 }

--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -1,11 +1,11 @@
-use pumpkin_core::text::TextComponent;
 use pumpkin_core::permission::PermissionLvl;
+use pumpkin_core::text::TextComponent;
 use pumpkin_protocol::client::play::CommandSuggestion;
 
 use super::args::ConsumedArgs;
 
 use crate::command::dispatcher::CommandError::{
-    GeneralCommandIssue, InvalidConsumption, InvalidRequirement, PermissionDenied, OtherPumpkin,
+    GeneralCommandIssue, InvalidConsumption, InvalidRequirement, OtherPumpkin, PermissionDenied,
 };
 use crate::command::tree::{Command, CommandTree, NodeType, RawArgs};
 use crate::command::CommandSender;
@@ -304,7 +304,8 @@ impl CommandDispatcher {
                 .insert(name.to_string(), Command::Alias(primary_name.to_string()));
         }
 
-        self.permissions.insert(primary_name.to_string(), permission);
+        self.permissions
+            .insert(primary_name.to_string(), permission);
         self.commands
             .insert(primary_name.to_string(), Command::Tree(tree));
     }

--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -1,10 +1,11 @@
 use pumpkin_core::text::TextComponent;
+use pumpkin_core::permission::PermissionLvl;
 use pumpkin_protocol::client::play::CommandSuggestion;
 
 use super::args::ConsumedArgs;
 
 use crate::command::dispatcher::CommandError::{
-    GeneralCommandIssue, InvalidConsumption, InvalidRequirement, OtherPumpkin,
+    GeneralCommandIssue, InvalidConsumption, InvalidRequirement, PermissionDenied, OtherPumpkin,
 };
 use crate::command::tree::{Command, CommandTree, NodeType, RawArgs};
 use crate::command::CommandSender;
@@ -23,6 +24,8 @@ pub(crate) enum CommandError {
     /// Return this if a condition that a [`Node::Require`] should ensure is met is not met.
     InvalidRequirement,
 
+    PermissionDenied,
+
     OtherPumpkin(Box<dyn PumpkinError>),
 
     GeneralCommandIssue(String),
@@ -39,6 +42,10 @@ impl CommandError {
                 log::error!("Error while parsing command \"{cmd}\": a requirement that was expected was not met.");
                 Ok("Internal Error (See logs for details)".into())
             }
+            PermissionDenied => {
+                log::warn!("Permission denied for command \"{cmd}\"");
+                Ok("I'm sorry, but you do not have permission to perform this command. Please contact the server administrator if you believe this is an error.".into())
+            }
             GeneralCommandIssue(s) => Ok(s),
             OtherPumpkin(e) => Err(e),
         }
@@ -48,6 +55,7 @@ impl CommandError {
 #[derive(Default)]
 pub struct CommandDispatcher {
     pub(crate) commands: HashMap<String, Command>,
+    pub(crate) permissions: HashMap<String, PermissionLvl>,
 }
 
 /// Stores registered [`CommandTree`]s and dispatches commands to them.
@@ -113,6 +121,10 @@ impl CommandDispatcher {
                     log::error!("Error while parsing command \"{cmd}\": a requirement that was expected was not met.");
                     return Vec::new();
                 }
+                Err(PermissionDenied) => {
+                    log::warn!("Permission denied for command \"{cmd}\"");
+                    return Vec::new();
+                }
                 Err(GeneralCommandIssue(issue)) => {
                     log::error!("Error while parsing command \"{cmd}\": {issue}");
                     return Vec::new();
@@ -147,6 +159,14 @@ impl CommandDispatcher {
             .ok_or(GeneralCommandIssue("Empty Command".to_string()))?;
         let raw_args: Vec<&str> = parts.rev().collect();
 
+        let Some(permission) = self.permissions.get(key) else {
+            return Err(GeneralCommandIssue("Command not found".to_string()));
+        };
+
+        if !src.has_permission_lvl(*permission) {
+            return Err(PermissionDenied);
+        }
+
         let tree = self.get_tree(key)?;
 
         // try paths until fitting path is found
@@ -178,6 +198,10 @@ impl CommandDispatcher {
                 Ok(tree)
             }
         }
+    }
+
+    pub(crate) fn get_permission_lvl(&self, key: &str) -> Option<PermissionLvl> {
+        self.permissions.get(key).copied()
     }
 
     async fn try_is_fitting_path<'a>(
@@ -270,7 +294,7 @@ impl CommandDispatcher {
     }
 
     /// Register a command with the dispatcher.
-    pub(crate) fn register(&mut self, tree: CommandTree) {
+    pub(crate) fn register(&mut self, tree: CommandTree, permission: PermissionLvl) {
         let mut names = tree.names.iter();
 
         let primary_name = names.next().expect("at least one name must be provided");
@@ -280,6 +304,7 @@ impl CommandDispatcher {
                 .insert(name.to_string(), Command::Alias(primary_name.to_string()));
         }
 
+        self.permissions.insert(primary_name.to_string(), permission);
         self.commands
             .insert(primary_name.to_string(), Command::Tree(tree));
     }
@@ -288,11 +313,11 @@ impl CommandDispatcher {
 #[cfg(test)]
 mod test {
     use crate::command::{default_dispatcher, tree::CommandTree};
-
+    use pumpkin_core::permission::PermissionLvl;
     #[test]
     fn test_dynamic_command() {
         let mut dispatcher = default_dispatcher();
         let tree = CommandTree::new(["test"], "test_desc");
-        dispatcher.register(tree);
+        dispatcher.register(tree, PermissionLvl::Zero);
     }
 }

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -112,25 +112,25 @@ impl<'a> CommandSender<'a> {
 pub fn default_dispatcher() -> CommandDispatcher {
     let mut dispatcher = CommandDispatcher::default();
 
-    dispatcher.register(cmd_pumpkin::init_command_tree());
-    dispatcher.register(cmd_bossbar::init_command_tree());
-    dispatcher.register(cmd_say::init_command_tree());
-    dispatcher.register(cmd_gamemode::init_command_tree());
-    dispatcher.register(cmd_stop::init_command_tree());
-    dispatcher.register(cmd_help::init_command_tree());
-    dispatcher.register(cmd_kill::init_command_tree());
-    dispatcher.register(cmd_kick::init_command_tree());
-    dispatcher.register(cmd_worldborder::init_command_tree());
-    dispatcher.register(cmd_teleport::init_command_tree());
-    dispatcher.register(cmd_time::init_command_tree());
-    dispatcher.register(cmd_give::init_command_tree());
-    dispatcher.register(cmd_list::init_command_tree());
-    dispatcher.register(cmd_clear::init_command_tree());
-    dispatcher.register(cmd_setblock::init_command_tree());
-    dispatcher.register(cmd_seed::init_command_tree());
-    dispatcher.register(cmd_transfer::init_command_tree());
-    dispatcher.register(cmd_fill::init_command_tree());
-    dispatcher.register(cmd_op::init_command_tree());
+    dispatcher.register(cmd_pumpkin::init_command_tree(), PermissionLvl::Zero);
+    dispatcher.register(cmd_bossbar::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_say::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_gamemode::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_stop::init_command_tree(), PermissionLvl::Four);
+    dispatcher.register(cmd_help::init_command_tree(), PermissionLvl::Zero);
+    dispatcher.register(cmd_kill::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_kick::init_command_tree(), PermissionLvl::Three);
+    dispatcher.register(cmd_worldborder::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_teleport::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_time::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_give::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_list::init_command_tree(), PermissionLvl::Zero);
+    dispatcher.register(cmd_clear::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_setblock::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_seed::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_transfer::init_command_tree(), PermissionLvl::Zero);
+    dispatcher.register(cmd_fill::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(cmd_op::init_command_tree(), PermissionLvl::Three);
 
     dispatcher
 }

--- a/pumpkin/src/command/tree_builder.rs
+++ b/pumpkin/src/command/tree_builder.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use crate::command::args::ArgumentConsumer;
 use crate::command::tree::{CommandTree, Node, NodeType};
 use crate::command::CommandSender;
-
 use super::args::DefaultNameArgConsumer;
 use super::CommandExecutor;
 

--- a/pumpkin/src/command/tree_builder.rs
+++ b/pumpkin/src/command/tree_builder.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use super::args::DefaultNameArgConsumer;
+use super::CommandExecutor;
 use crate::command::args::ArgumentConsumer;
 use crate::command::tree::{CommandTree, Node, NodeType};
 use crate::command::CommandSender;
-use super::args::DefaultNameArgConsumer;
-use super::CommandExecutor;
 
 impl CommandTree {
     /// Add a child [Node] to the root of this [`CommandTree`].


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description

This PR introduced the following:

- When registering a new command, one must specify the permission level
- If a player tries to execute a command without having permission, it will show that to the player
- When a player wants to autocomplete a command without having permission, it will not show in the autocomplete

Closes https://github.com/Pumpkin-MC/Pumpkin/issues/424

<!-- A description of the tests performed to verify the changes -->
## Testing

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [ ] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [ ] Code does not produce any clippy warnings: `cargo clippy`
- [ ] All unit tests pass: `cargo test`
- [ ] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
