### PR TITLE
add the missing Acknowledge Block Change packet when the player break…

### DIFF
--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -723,6 +723,10 @@ impl Player {
                                 .on_broken(block, self, location, server)
                                 .await;
                         }
+
+                        self.client
+                            .send_packet(&CAcknowledgeBlockChange::new(player_action.sequence))
+                            .await;
                     }
                 }
                 Status::CancelledDigging => {

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -723,10 +723,6 @@ impl Player {
                                 .on_broken(block, self, location, server)
                                 .await;
                         }
-
-                        self.client
-                            .send_packet(&CAcknowledgeBlockChange::new(player_action.sequence))
-                            .await;
                     }
                 }
                 Status::CancelledDigging => {
@@ -765,10 +761,6 @@ impl Player {
                             .on_broken(block, self, location, server)
                             .await;
                     }
-                    // TODO: Send this every tick
-                    self.client
-                        .send_packet(&CAcknowledgeBlockChange::new(player_action.sequence))
-                        .await;
                 }
                 Status::DropItemStack
                 | Status::DropItem
@@ -779,6 +771,10 @@ impl Player {
             },
             None => self.kick(TextComponent::text("Invalid status")).await,
         }
+
+        self.client
+            .send_packet(&CAcknowledgeBlockChange::new(player_action.sequence))
+            .await;
     }
 
     pub async fn handle_keep_alive(&self, keep_alive: SKeepAlive) {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
fix the issue #422 with the setblock by adding the Acknowledge Block Change packet when block is break in creative

<!-- A description of the tests performed to verify the changes -->
## Testing
follow the bug instruction

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
- [ ] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
