### PR TITLE
Changed bossbar title to TextComponent instead of String

### DIFF
--- a/pumpkin/src/command/args/arg_textcomponent.rs
+++ b/pumpkin/src/command/args/arg_textcomponent.rs
@@ -1,0 +1,80 @@
+use async_trait::async_trait;
+use pumpkin_core::text::TextComponent;
+use pumpkin_protocol::client::play::{CommandSuggestion, ProtoCmdArgParser, ProtoCmdArgSuggestionType};
+use crate::command::args::{Arg, ArgumentConsumer, FindArg, GetClientSideArgParser};
+use crate::command::CommandSender;
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::RawArgs;
+use crate::server::Server;
+
+pub(crate) struct TextComponentArgConsumer;
+
+impl GetClientSideArgParser for TextComponentArgConsumer {
+    fn get_client_side_parser(&self) -> ProtoCmdArgParser {
+        ProtoCmdArgParser::Component
+    }
+
+    fn get_client_side_suggestion_type_override(&self) -> Option<ProtoCmdArgSuggestionType> {
+        None
+    }
+}
+
+#[async_trait]
+impl ArgumentConsumer for TextComponentArgConsumer {
+    async fn consume<'a>(
+        &'a self,
+        _sender: &CommandSender<'a>,
+        _server: &'a Server,
+        args: &mut RawArgs<'a>,
+    ) -> Option<Arg<'a>> {
+        let s = args.pop()?;
+
+        let text_component = parse_text_component(s);
+
+        let Some(text_component) = text_component else {
+            if s.starts_with("\"") && s.ends_with("\"") {
+                let s = s.replace("\"", "");
+                return Some(Arg::TextComponent(TextComponent::text(s)));
+            }
+            return None;
+        };
+
+        Some(Arg::TextComponent(text_component))
+    }
+
+    async fn suggest<'a>(
+        &'a self,
+        _sender: &CommandSender<'a>,
+        _server: &'a Server,
+        _input: &'a str,
+    ) -> Result<Option<Vec<CommandSuggestion>>, CommandError> {
+        Ok(None)
+    }
+}
+
+impl<'a> FindArg<'a> for TextComponentArgConsumer {
+    type Data = TextComponent;
+
+    fn find_arg(args: &super::ConsumedArgs, name: &str) -> Result<Self::Data, CommandError> {
+        match args.get(name) {
+            Some(Arg::TextComponent(data)) => Ok(data.clone()),
+            _ => Err(CommandError::InvalidConsumption(Some(name.to_string()))),
+        }
+    }
+}
+
+fn parse_text_component(input: &str) -> Option<TextComponent> {
+    if input.starts_with("[") && input.ends_with("]") {
+        let text_component_array: Option<Vec<TextComponent>> = serde_json::from_str(input).unwrap_or(None);
+        let Some(mut text_component_array) = text_component_array else {
+            return None;
+        };
+        let mut constructed_text_component = text_component_array[0].clone();
+        text_component_array.remove(0);
+        constructed_text_component.extra = text_component_array;
+
+        Some(constructed_text_component)
+    } else {
+        serde_json::from_str(input).unwrap_or(None)
+    }
+}

--- a/pumpkin/src/command/args/arg_textcomponent.rs
+++ b/pumpkin/src/command/args/arg_textcomponent.rs
@@ -1,11 +1,13 @@
-use async_trait::async_trait;
-use pumpkin_core::text::TextComponent;
-use pumpkin_protocol::client::play::{CommandSuggestion, ProtoCmdArgParser, ProtoCmdArgSuggestionType};
 use crate::command::args::{Arg, ArgumentConsumer, FindArg, GetClientSideArgParser};
-use crate::command::CommandSender;
 use crate::command::dispatcher::CommandError;
 use crate::command::tree::RawArgs;
+use crate::command::CommandSender;
 use crate::server::Server;
+use async_trait::async_trait;
+use pumpkin_core::text::TextComponent;
+use pumpkin_protocol::client::play::{
+    CommandSuggestion, ProtoCmdArgParser, ProtoCmdArgSuggestionType,
+};
 
 pub(crate) struct TextComponentArgConsumer;
 
@@ -32,8 +34,8 @@ impl ArgumentConsumer for TextComponentArgConsumer {
         let text_component = parse_text_component(s);
 
         let Some(text_component) = text_component else {
-            if s.starts_with("\"") && s.ends_with("\"") {
-                let s = s.replace("\"", "");
+            if s.starts_with('"') && s.ends_with('"') {
+                let s = s.replace('"', "");
                 return Some(Arg::TextComponent(TextComponent::text(s)));
             }
             return None;
@@ -52,7 +54,7 @@ impl ArgumentConsumer for TextComponentArgConsumer {
     }
 }
 
-impl<'a> FindArg<'a> for TextComponentArgConsumer {
+impl FindArg<'_> for TextComponentArgConsumer {
     type Data = TextComponent;
 
     fn find_arg(args: &super::ConsumedArgs, name: &str) -> Result<Self::Data, CommandError> {
@@ -64,11 +66,10 @@ impl<'a> FindArg<'a> for TextComponentArgConsumer {
 }
 
 fn parse_text_component(input: &str) -> Option<TextComponent> {
-    if input.starts_with("[") && input.ends_with("]") {
-        let text_component_array: Option<Vec<TextComponent>> = serde_json::from_str(input).unwrap_or(None);
-        let Some(mut text_component_array) = text_component_array else {
-            return None;
-        };
+    if input.starts_with('[') && input.ends_with(']') {
+        let text_component_array: Option<Vec<TextComponent>> =
+            serde_json::from_str(input).unwrap_or(None);
+        let mut text_component_array = text_component_array?;
         let mut constructed_text_component = text_component_array[0].clone();
         text_component_array.remove(0);
         constructed_text_component.extra = text_component_array;

--- a/pumpkin/src/command/args/mod.rs
+++ b/pumpkin/src/command/args/mod.rs
@@ -2,11 +2,11 @@ use std::{collections::HashMap, hash::Hash, sync::Arc};
 
 use arg_bounded_num::{NotInBounds, Number};
 use async_trait::async_trait;
+use pumpkin_core::text::TextComponent;
 use pumpkin_core::{
     math::{position::WorldPosition, vector2::Vector2, vector3::Vector3},
     GameMode,
 };
-use pumpkin_core::text::TextComponent;
 use pumpkin_protocol::client::play::{
     CommandSuggestion, ProtoCmdArgParser, ProtoCmdArgSuggestionType,
 };
@@ -37,8 +37,8 @@ pub(crate) mod arg_position_block;
 pub(crate) mod arg_resource_location;
 pub(crate) mod arg_rotation;
 pub(crate) mod arg_simple;
-mod coordinate;
 pub(crate) mod arg_textcomponent;
+mod coordinate;
 
 /// see [`crate::commands::tree_builder::argument`]
 #[async_trait]

--- a/pumpkin/src/command/args/mod.rs
+++ b/pumpkin/src/command/args/mod.rs
@@ -6,6 +6,7 @@ use pumpkin_core::{
     math::{position::WorldPosition, vector2::Vector2, vector3::Vector3},
     GameMode,
 };
+use pumpkin_core::text::TextComponent;
 use pumpkin_protocol::client::play::{
     CommandSuggestion, ProtoCmdArgParser, ProtoCmdArgSuggestionType,
 };
@@ -37,6 +38,7 @@ pub(crate) mod arg_resource_location;
 pub(crate) mod arg_rotation;
 pub(crate) mod arg_simple;
 mod coordinate;
+pub(crate) mod arg_textcomponent;
 
 /// see [`crate::commands::tree_builder::argument`]
 #[async_trait]
@@ -87,6 +89,7 @@ pub(crate) enum Arg<'a> {
     BossbarColor(BossbarColor),
     BossbarStyle(BossbarDivisions),
     Msg(String),
+    TextComponent(TextComponent),
     Num(Result<Number, NotInBounds>),
     Bool(bool),
     #[allow(unused)]

--- a/pumpkin/src/world/bossbar.rs
+++ b/pumpkin/src/world/bossbar.rs
@@ -34,7 +34,7 @@ pub enum BossbarFlags {
 #[derive(Clone)]
 pub struct Bossbar {
     pub uuid: Uuid,
-    pub title: String,
+    pub title: TextComponent,
     pub health: f32,
     pub color: BossbarColor,
     pub division: BossbarDivisions,
@@ -43,7 +43,7 @@ pub struct Bossbar {
 
 impl Bossbar {
     #[must_use]
-    pub fn new(title: String) -> Self {
+    pub fn new(title: TextComponent) -> Self {
         let uuid = Uuid::new_v4();
 
         Self {
@@ -63,7 +63,7 @@ impl Player {
         // Maybe this section could be implemented. feel free to change
         let bossbar = bossbar.clone();
         let boss_action = BosseventAction::Add {
-            title: TextComponent::text(bossbar.title),
+            title: bossbar.title,
             health: bossbar.health,
             color: (bossbar.color as u8).into(),
             division: (bossbar.division as u8).into(),
@@ -87,8 +87,8 @@ impl Player {
         self.client.send_packet(&packet).await;
     }
 
-    pub async fn update_bossbar_title(&self, uuid: &Uuid, title: String) {
-        let boss_action = BosseventAction::UpdateTile(TextComponent::text(title));
+    pub async fn update_bossbar_title(&self, uuid: &Uuid, title: TextComponent) {
+        let boss_action = BosseventAction::UpdateTile(title);
 
         let packet = CBossEvent::new(uuid, boss_action);
         self.client.send_packet(&packet).await;

--- a/pumpkin/src/world/custom_bossbar.rs
+++ b/pumpkin/src/world/custom_bossbar.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
+use pumpkin_core::text::TextComponent;
 
 #[derive(Debug, Error)]
 pub enum BossbarUpdateError {
@@ -236,7 +237,7 @@ impl CustomBossbars {
         &mut self,
         server: &Server,
         resource_location: &str,
-        new_title: &str,
+        new_title: TextComponent,
     ) -> Result<(), BossbarUpdateError> {
         let bossbar = self.custom_bossbars.get_mut(resource_location);
         if let Some(bossbar) = bossbar {
@@ -246,7 +247,7 @@ impl CustomBossbars {
                 )));
             }
 
-            bossbar.bossbar_data.title = new_title.to_string();
+            bossbar.bossbar_data.title = new_title;
 
             if !bossbar.visible {
                 return Ok(());

--- a/pumpkin/src/world/custom_bossbar.rs
+++ b/pumpkin/src/world/custom_bossbar.rs
@@ -2,11 +2,11 @@ use crate::command::args::GetCloned;
 use crate::entity::player::Player;
 use crate::server::Server;
 use crate::world::bossbar::{Bossbar, BossbarColor, BossbarDivisions};
+use pumpkin_core::text::TextComponent;
 use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
-use pumpkin_core::text::TextComponent;
 
 #[derive(Debug, Error)]
 pub enum BossbarUpdateError {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
This PR migrates from the String implementation to the Vanilla TextComponent

<!-- A description of the tests performed to verify the changes -->
## Testing
Open up the game and use `/bossbar add minecraft:test {"text":"Pumpkin","color":"gold"}`
Use `/bossbar set minecraft:test players @a`
You should now see the colored bossbar

![image](https://github.com/user-attachments/assets/9ddae4ab-aa60-4bc8-a148-9a371dc41827)


<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [X] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [X] Code does not produce any clippy warnings: `cargo clippy`
- [X] All unit tests pass: `cargo test`
- [ ] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
