### PR TITLE
added bans and ip-bans

### DIFF
--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -66,7 +66,10 @@ png = "0.17.15"
 
 # logging
 simple_logger = { version = "5.0.0", features = ["threads"] }
+# Remove time in favor of chrono?
 time = "0.3.37"
+
+chrono = { version = "0.4.39", features = ["serde"]}
 
 # commands
 async-trait = "0.1.83"

--- a/pumpkin/src/data/banlist_serializer.rs
+++ b/pumpkin/src/data/banlist_serializer.rs
@@ -1,0 +1,94 @@
+use std::net::IpAddr;
+
+use chrono::{DateTime, FixedOffset};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BannedPlayerEntry {
+    pub uuid: Uuid,
+    pub name: String,
+    #[serde(with = "format::date")]
+    pub created: DateTime<FixedOffset>,
+    pub source: String,
+    #[serde(with = "format::option_date")]
+    pub expires: Option<DateTime<FixedOffset>>,
+    pub reason: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BannedIpEntry {
+    pub ip: IpAddr,
+    #[serde(with = "format::date")]
+    pub created: DateTime<FixedOffset>,
+    pub source: String,
+    #[serde(with = "format::option_date")]
+    pub expires: Option<DateTime<FixedOffset>>,
+    pub reason: String,
+}
+
+mod format {
+    const FORMAT: &str = "%Y-%m-%d %H:%M:%S %z";
+
+    pub mod date {
+        use chrono::{DateTime, FixedOffset};
+        use serde::{self, Deserialize, Deserializer, Serializer};
+
+        use super::FORMAT;
+
+        pub fn serialize<S>(date: &DateTime<FixedOffset>, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let s = date.format(FORMAT).to_string();
+            serializer.serialize_str(&s)
+        }
+
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<FixedOffset>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let s = String::deserialize(deserializer)?;
+            DateTime::parse_from_str(&s, FORMAT).map_err(serde::de::Error::custom)
+        }
+    }
+
+    pub mod option_date {
+        use chrono::{DateTime, FixedOffset};
+        use serde::{self, Deserialize, Deserializer, Serializer};
+
+        use super::FORMAT;
+
+        #[allow(clippy::ref_option)]
+        pub fn serialize<S>(
+            date: &Option<DateTime<FixedOffset>>,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            if let Some(date) = date {
+                let s = date.format(FORMAT).to_string();
+                serializer.serialize_str(&s)
+            } else {
+                serializer.serialize_str("forever")
+            }
+        }
+
+        pub fn deserialize<'de, D>(
+            deserializer: D,
+        ) -> Result<Option<DateTime<FixedOffset>>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let s = String::deserialize(deserializer)?;
+            if s == "forever" {
+                Ok(None)
+            } else {
+                DateTime::parse_from_str(&s, FORMAT)
+                    .map(Some)
+                    .map_err(serde::de::Error::custom)
+            }
+        }
+    }
+}

--- a/pumpkin/src/data/banned_ip_data.rs
+++ b/pumpkin/src/data/banned_ip_data.rs
@@ -1,0 +1,32 @@
+use std::{net::IpAddr, path::Path, sync::LazyLock};
+
+use serde::{Deserialize, Serialize};
+
+use super::{banlist_serializer::BannedIpEntry, LoadJSONConfiguration, SaveJSONConfiguration};
+
+pub static BANNED_IP_LIST: LazyLock<tokio::sync::RwLock<BannedIpList>> =
+    LazyLock::new(|| tokio::sync::RwLock::new(BannedIpList::load()));
+
+#[derive(Deserialize, Serialize, Default)]
+#[serde(transparent)]
+pub struct BannedIpList {
+    pub banned_ips: Vec<BannedIpEntry>,
+}
+
+impl BannedIpList {
+    #[must_use]
+    pub fn is_banned(&self, ip: &IpAddr) -> bool {
+        self.banned_ips.iter().any(|entry| &entry.ip == ip)
+    }
+}
+
+impl LoadJSONConfiguration for BannedIpList {
+    fn get_path() -> &'static Path {
+        Path::new("banned-ips.json")
+    }
+    fn validate(&self) {
+        // TODO: Validate the list
+    }
+}
+
+impl SaveJSONConfiguration for BannedIpList {}

--- a/pumpkin/src/data/banned_player_data.rs
+++ b/pumpkin/src/data/banned_player_data.rs
@@ -1,0 +1,36 @@
+use std::{path::Path, sync::LazyLock};
+
+use serde::{Deserialize, Serialize};
+
+use crate::net::GameProfile;
+
+use super::{banlist_serializer::BannedPlayerEntry, LoadJSONConfiguration, SaveJSONConfiguration};
+
+pub static BANNED_PLAYER_LIST: LazyLock<tokio::sync::RwLock<BannedPlayerList>> =
+    LazyLock::new(|| tokio::sync::RwLock::new(BannedPlayerList::load()));
+
+#[derive(Deserialize, Serialize, Default)]
+#[serde(transparent)]
+pub struct BannedPlayerList {
+    pub banned_players: Vec<BannedPlayerEntry>,
+}
+
+impl BannedPlayerList {
+    #[must_use]
+    pub fn is_banned(&self, profile: &GameProfile) -> bool {
+        self.banned_players
+            .iter()
+            .any(|entry| entry.name == profile.name && entry.uuid == profile.id)
+    }
+}
+
+impl LoadJSONConfiguration for BannedPlayerList {
+    fn get_path() -> &'static Path {
+        Path::new("banned-players.json")
+    }
+    fn validate(&self) {
+        // TODO: Validate the list
+    }
+}
+
+impl SaveJSONConfiguration for BannedPlayerList {}

--- a/pumpkin/src/data/mod.rs
+++ b/pumpkin/src/data/mod.rs
@@ -6,6 +6,10 @@ const DATA_FOLDER: &str = "data/";
 
 pub mod op_data;
 
+pub mod banlist_serializer;
+pub mod banned_ip_data;
+pub mod banned_player_data;
+
 pub trait LoadJSONConfiguration {
     #[must_use]
     fn load() -> Self

--- a/pumpkin/src/net/packet/login.rs
+++ b/pumpkin/src/net/packet/login.rs
@@ -154,6 +154,12 @@ impl Client {
 
             *gameprofile = Some(profile);
         }
+
+        drop(gameprofile);
+
+        if !self.can_join().await {
+            self.kick("Banned").await;
+        }
     }
 
     pub async fn handle_encryption_response(


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Adds the ability to ban players via username and uuid, or ip.
The data is stored in `banned-players.json` and `banned-ips.json`

<!-- A description of the tests performed to verify the changes -->
## Testing
Joining the server while being banned and ip-banned
Joining the server without being banned
Loading data from vanilla servers

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [ ] Add `ban`, `ban-ip`, `pardon`, `pardon-ip` and `banlist` commands
- [ ] Fix kick message to include reason and expiration
- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
