### PR TITLE
fix listening to `RUST_LOG`

### DIFF
--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -85,14 +85,15 @@ fn init_logger() {
             logger = logger.without_timestamps();
         }
 
-        if ADVANCED_CONFIG.logging.env {
-            logger = logger.env();
-        }
-
         logger = logger.with_level(convert_logger_filter(ADVANCED_CONFIG.logging.level));
 
         logger = logger.with_colors(ADVANCED_CONFIG.logging.color);
         logger = logger.with_threads(ADVANCED_CONFIG.logging.threads);
+
+        if ADVANCED_CONFIG.logging.env {
+            logger = logger.env();
+        }
+
         logger.init().unwrap();
     }
 }


### PR DESCRIPTION
Per the logger documentation:

> Enables the user to choose log level by setting RUST_LOG=<level> environment variable. This will use the default level set by with_level if RUST_LOG is not set or can't be parsed as a standard log level.
> This must be called after with_level. If called before with_level, it will have no effect.

Personally, I feel that using a config file, which defaults to *false* to configure whether or not to listen to the environment for enabling and disabling logging is a bit dumb. Usually environment variables are meant to allow you to modify the configuration of a program for one "environment", not necessarily permanently. Especially when you get more complicated environment filtering.

For me, I'm content with `Info` or even `Debug` as the default, but will occasionally bump the log level to tracing for specific sessions. That's not something I want to make a permanent change, so I execute the program as `RUST_LOG=tracing cargo run` instead of having to go into a file and modify it, then undo the change later. The fact that you can't do this by default is counter-intuitive.

Although I'm sure there are better sources for it, I personally believe that [this stackoverflow](https://stackoverflow.com/questions/11077223/what-order-of-reading-configuration-values#:~:text=The%20standard%20that,it%20looks%20for.) sums up my experience and feelings around precedence

Additionally, I'd like to use this as a springboard to advocate for a few things, primarily introducing the idea of migrating away from `log` to `tracing`, as there's a lot more that can be done with regards to performance measuring and testing.
