### PR TITLE
Made getting players by name case-insensitive

### DIFF
--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -626,7 +626,7 @@ impl World {
     /// Gets a Player by username
     pub async fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
         for player in self.current_players.lock().await.values() {
-            if player.gameprofile.name == name {
+            if player.gameprofile.name.to_lowercase() == name.to_lowercase() {
                 return Some(player.clone());
             }
         }


### PR DESCRIPTION
## Description

Made the player name and the parameter lower case when matching them. This way, things like player arguments in commands don't need to be case-sensitive. Overall a revolutionary change.

## Testing


Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)