### PR TITLE
Fix players timing out after a command executes for a while

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1,8 +1,10 @@
 use std::{
-    num::NonZeroU8, sync::{
+    num::NonZeroU8,
+    sync::{
         atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32, AtomicU8},
         Arc,
-    }, time::{Duration, Instant}
+    },
+    time::{Duration, Instant},
 };
 
 use crossbeam::atomic::AtomicCell;

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -383,6 +383,7 @@ impl Player {
                 .load(std::sync::atomic::Ordering::Relaxed)
             {
                 self.kick(TextComponent::text("Timeout")).await;
+                self.cancel_tasks.notify_waiters();
                 return;
             }
             self.wait_for_keep_alive

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1,10 +1,8 @@
 use std::{
-    num::NonZeroU8,
-    sync::{
+    num::NonZeroU8, sync::{
         atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32, AtomicU8},
         Arc,
-    },
-    time::{Duration, Instant},
+    }, time::{Duration, Instant}
 };
 
 use crossbeam::atomic::AtomicCell;
@@ -383,7 +381,6 @@ impl Player {
                 .load(std::sync::atomic::Ordering::Relaxed)
             {
                 self.kick(TextComponent::text("Timeout")).await;
-                self.cancel_tasks.notify_waiters();
                 return;
             }
             self.wait_for_keep_alive
@@ -691,8 +688,7 @@ impl Player {
                     .await;
             }
             SChatCommand::PACKET_ID => {
-                self.handle_chat_command(server, SChatCommand::read(bytebuf)?)
-                    .await;
+                self.handle_chat_command(server, &(SChatCommand::read(bytebuf)?));
             }
             SChatMessage::PACKET_ID => {
                 self.handle_chat_message(SChatMessage::read(bytebuf)?).await;

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -308,10 +308,13 @@ fn setup_console(server: Arc<Server>) {
                 .expect("Failed to read console line");
 
             if !out.is_empty() {
-                let dispatcher = server.command_dispatcher.read().await;
-                dispatcher
-                    .handle_command(&mut command::CommandSender::Console, &server, &out)
-                    .await;
+                let server_clone = server.clone();
+                tokio::spawn(async move {
+                    let dispatcher = server_clone.command_dispatcher.read().await;
+                    dispatcher
+                        .handle_command(&mut command::CommandSender::Console, &server_clone, &out)
+                        .await;
+                });
             }
         }
     });

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -287,19 +287,23 @@ impl Player {
             .await;
     }
 
-    pub async fn handle_chat_command(
-        self: &Arc<Self>,
-        server: &Arc<Server>,
-        command: SChatCommand,
-    ) {
-        let dispatcher = server.command_dispatcher.read().await;
-        dispatcher
-            .handle_command(
-                &mut CommandSender::Player(self.clone()),
-                server,
-                &command.command,
-            )
-            .await;
+    pub fn handle_chat_command(self: &Arc<Self>, server: &Arc<Server>, command: &SChatCommand) {
+        let player_clone = self.clone();
+        let server_clone = server.clone();
+        let command_clone = command.command.clone();
+        // Some commands can take a long time to execute. If they do, they block packet processing for the player
+        // Thats why we will spawn a task instead
+        tokio::spawn(async move {
+            let dispatcher = server_clone.command_dispatcher.read().await;
+            dispatcher
+                .handle_command(
+                    &mut CommandSender::Player(player_clone),
+                    &server_clone,
+                    &command_clone,
+                )
+                .await;
+        });
+
         if ADVANCED_CONFIG.commands.log_console {
             log::info!(
                 "Player ({}): executed command /{}",


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Whenever the fill command is run with a large selection, the client times out. This is because the packet processing is halted because it is processing the command. The best way to solve this would be to process the command in a new task so that packet processing in not halted for commands that take longer to run. This should stop the client from timing out when they run a command that has longer run time and if they do time out while a command is running for whatever reason, the client will properly be removed from the server.

## Testing
Forcibly cause a timeout (by an extremely large selection with the fill command), and make sure that the player can rejoin the server.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
