### PR TITLE
Add a proper error message for a non-existent command

### DIFF
--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -158,7 +158,14 @@ impl CommandDispatcher {
             .next()
             .ok_or(GeneralCommandIssue("Empty Command".to_string()))?;
         let raw_args: Vec<&str> = parts.rev().collect();
+	
+	if let None = self.commands.get(key) {
+            return Err(GeneralCommandIssue(
+                format!("Command {key} does not exist"),
+            ));
 
+	}
+	
         let Some(permission) = self.permissions.get(key) else {
             return Err(GeneralCommandIssue(
                 "Permission for Command not found".to_string(),

--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -158,14 +158,11 @@ impl CommandDispatcher {
             .next()
             .ok_or(GeneralCommandIssue("Empty Command".to_string()))?;
         let raw_args: Vec<&str> = parts.rev().collect();
-	
-	if let None = self.commands.get(key) {
-            return Err(GeneralCommandIssue(
-                format!("Command {key} does not exist"),
-            ));
 
-	}
-	
+        if !self.commands.contains_key(key) {
+            return Err(GeneralCommandIssue(format!("Command {key} does not exist")));
+        }
+
         let Some(permission) = self.permissions.get(key) else {
             return Err(GeneralCommandIssue(
                 "Permission for Command not found".to_string(),


### PR DESCRIPTION
## Description

Add a more descriptive message when a player sends a non-existent command in chat.

Message format: "Command {command} does not exist"