### PR TITLE
Corrected player detection on place block

### DIFF
--- a/pumpkin-util/src/math/boundingbox.rs
+++ b/pumpkin-util/src/math/boundingbox.rs
@@ -59,7 +59,7 @@ impl BoundingBox {
             && self.max_z > other.min_z
     }
 
-    pub fn intersects_block(&self, position: &BlockPos, bounding_box: &Vec<f32>) -> bool {
+    pub fn intersects_block(&self, position: &BlockPos, bounding_box: &[f32]) -> bool {
         for i in 0..bounding_box.len() / 6 {
             let other = BoundingBox {
                 min_x: position.0.x as f64 + bounding_box[i * 6] as f64,

--- a/pumpkin-util/src/math/boundingbox.rs
+++ b/pumpkin-util/src/math/boundingbox.rs
@@ -59,6 +59,23 @@ impl BoundingBox {
             && self.max_z > other.min_z
     }
 
+    pub fn intersects_block(&self, position: &BlockPos, bounding_box: &Vec<f32>) -> bool {
+        for i in 0..bounding_box.len() / 6 {
+            let other = BoundingBox {
+                min_x: position.0.x as f64 + bounding_box[i * 6] as f64,
+                min_y: position.0.y as f64 + bounding_box[i * 6 + 1] as f64,
+                min_z: position.0.z as f64 + bounding_box[i * 6 + 2] as f64,
+                max_x: position.0.x as f64 + bounding_box[i * 6 + 3] as f64,
+                max_y: position.0.y as f64 + bounding_box[i * 6 + 4] as f64,
+                max_z: position.0.z as f64 + bounding_box[i * 6 + 5] as f64,
+            };
+            if self.intersects(&other) {
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn squared_magnitude(&self, pos: Vector3<f64>) -> f64 {
         let d = f64::max(f64::max(self.min_x - pos.x, pos.x - self.max_x), 0.0);
         let e = f64::max(f64::max(self.min_y - pos.y, pos.y - self.max_y), 0.0);

--- a/pumpkin-world/src/block/block_registry.rs
+++ b/pumpkin-world/src/block/block_registry.rs
@@ -91,7 +91,7 @@ pub fn get_block_by_item<'a>(item_id: u16) -> Option<&'a Block> {
     BLOCKS_BY_ID.get(block_id)
 }
 
-pub fn get_block_collision_shapes<'a>(block_id: u16) -> Option<Vec<f32>> {
+pub fn get_block_collision_shapes(block_id: u16) -> Option<Vec<f32>> {
     let block = BLOCKS_BY_ID.get(&BLOCK_ID_BY_STATE_ID[&block_id])?;
     let state = &block.states[STATE_INDEX_BY_STATE_ID[&block_id] as usize];
     let mut shapes: Vec<f32> = vec![];

--- a/pumpkin-world/src/block/block_registry.rs
+++ b/pumpkin-world/src/block/block_registry.rs
@@ -90,6 +90,23 @@ pub fn get_block_by_item<'a>(item_id: u16) -> Option<&'a Block> {
     let block_id = BLOCK_ID_BY_ITEM_ID.get(&item_id)?;
     BLOCKS_BY_ID.get(block_id)
 }
+
+pub fn get_block_collision_shapes<'a>(block_id: u16) -> Option<Vec<f32>> {
+    let block = BLOCKS_BY_ID.get(&BLOCK_ID_BY_STATE_ID[&block_id])?;
+    let state = &block.states[STATE_INDEX_BY_STATE_ID[&block_id] as usize];
+    let mut shapes: Vec<f32> = vec![];
+    for i in 0..state.collision_shapes.len() {
+        let shape = &BLOCKS.shapes[state.collision_shapes[i] as usize];
+        shapes.push(shape.min[0]);
+        shapes.push(shape.min[1]);
+        shapes.push(shape.min[2]);
+        shapes.push(shape.max[0]);
+        shapes.push(shape.max[1]);
+        shapes.push(shape.max[2]);
+    }
+    Some(shapes)
+}
+
 #[expect(dead_code)]
 #[derive(Deserialize, Clone, Debug)]
 pub struct TopLevel {
@@ -126,7 +143,6 @@ pub struct State {
     pub collision_shapes: Vec<u16>,
     pub block_entity_type: Option<u32>,
 }
-#[expect(dead_code)]
 #[derive(Deserialize, Clone, Debug)]
 struct Shape {
     min: [f32; 3],

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -36,14 +36,14 @@ use pumpkin_protocol::{
         SPlayerRotation, SSetCreativeSlot, SSetHeldItem, SSwingArm, SUseItemOn, Status,
     },
 };
-use pumpkin_util::math::{boundingbox::BoundingBox, position::BlockPos};
+use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::text::color::NamedColor;
 use pumpkin_util::{
     math::{vector3::Vector3, wrap_degrees},
     text::TextComponent,
     GameMode,
 };
-use pumpkin_world::block::block_registry::Block;
+use pumpkin_world::block::block_registry::{get_block_collision_shapes, Block};
 use pumpkin_world::item::item_registry::get_item_by_id;
 use pumpkin_world::item::ItemStack;
 use pumpkin_world::{
@@ -1190,11 +1190,15 @@ impl Player {
             world_pos
         };
 
-        let block_bounding_box = BoundingBox::from_block(&world_pos);
+        // To this point we must have the new block state
+        let block_bounding_box = match get_block_collision_shapes(block.default_state_id) {
+            Some(bounding_box) => bounding_box,
+            None => vec![],
+        };
         let mut intersects = false;
         for player in world.get_nearby_players(entity.pos.load(), 20.0).await {
             let bounding_box = player.1.living_entity.entity.bounding_box.load();
-            if bounding_box.intersects(&block_bounding_box) {
+            if bounding_box.intersects_block(&world_pos, &block_bounding_box) {
                 intersects = true;
             }
         }

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -1191,10 +1191,8 @@ impl Player {
         };
 
         // To this point we must have the new block state
-        let block_bounding_box = match get_block_collision_shapes(block.default_state_id) {
-            Some(bounding_box) => bounding_box,
-            None => vec![],
-        };
+        let block_bounding_box =
+            get_block_collision_shapes(block.default_state_id).unwrap_or_default();
         let mut intersects = false;
         for player in world.get_nearby_players(entity.pos.load(), 20.0).await {
             let bounding_box = player.1.living_entity.entity.bounding_box.load();


### PR DESCRIPTION
## Description
Changed the system of detection of intersection of the player with the placed blocks so that it respects the collision of the block.
This should fix the issues #267 and #353.

Note: Since the blocks are not yet placed with the right state I have implemented it using the default state

## Testing

https://github.com/user-attachments/assets/18fdc878-278c-4f67-aa80-b18b661473a3

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
