### PR TITLE
Text component refactor

### DIFF
--- a/pumpkin-nbt/src/serializer.rs
+++ b/pumpkin-nbt/src/serializer.rs
@@ -11,6 +11,12 @@ use crate::{
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+pub trait SerializeChild {
+    fn serialize_child<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer;
+}
+
 pub struct Serializer {
     output: BytesMut,
     state: State,
@@ -54,6 +60,19 @@ impl Serializer {
         };
         Ok(())
     }
+}
+
+/// Serializes struct using Serde Serializer to unnamed (network) NBT (Exclusive to TextComponent)
+pub fn to_bytes_text_component<T>(value: &T) -> Result<BytesMut>
+where
+    T: SerializeChild,
+{
+    let mut serializer = Serializer {
+        output: BytesMut::new(),
+        state: State::Root(None),
+    };
+    value.serialize_child(&mut serializer)?;
+    Ok(serializer.output)
 }
 
 /// Serializes struct using Serde Serializer to unnamed (network) NBT

--- a/pumpkin-util/src/translation.rs
+++ b/pumpkin-util/src/translation.rs
@@ -1,14 +1,16 @@
-use std::{borrow::Cow, collections::HashMap, sync::LazyLock};
+use std::{collections::HashMap, sync::LazyLock};
+
+use crate::text::TextComponentBase;
 
 const EN_US_JSON: &str = include_str!("../../assets/en_us.json");
 
 pub static EN_US: LazyLock<HashMap<String, String>> =
     LazyLock::new(|| serde_json::from_str(EN_US_JSON).expect("Could not parse en_us.json."));
 
-pub fn get_translation_en_us(key: &str, with: Vec<Cow<'static, str>>) -> Option<String> {
+pub fn get_translation_en_us(key: &str, with: Vec<TextComponentBase>) -> Option<String> {
     let mut translation = EN_US.get(key)?.clone();
-    for replace in with {
-        translation = translation.replacen("%s", &replace, 1);
+    for replace in &with {
+        translation = translation.replacen("%s", &replace.clone().to_pretty_console(), 1);
     }
     Some(translation)
 }

--- a/pumpkin/src/command/args/arg_textcomponent.rs
+++ b/pumpkin/src/command/args/arg_textcomponent.rs
@@ -72,8 +72,9 @@ fn parse_text_component(input: &str) -> Option<TextComponent> {
         let mut text_component_array = text_component_array?;
         let mut constructed_text_component = text_component_array[0].clone();
         text_component_array.remove(0);
-        constructed_text_component.extra = text_component_array;
-
+        for child in &text_component_array {
+            constructed_text_component = constructed_text_component.add_child(child.clone());
+        }
         Some(constructed_text_component)
     } else {
         serde_json::from_str(input).unwrap_or(None)

--- a/pumpkin/src/command/commands/cmd_deop.rs
+++ b/pumpkin/src/command/commands/cmd_deop.rs
@@ -49,8 +49,10 @@ impl CommandExecutor for DeopExecutor {
                 .await;
 
             let player_name = &player.gameprofile.name;
-            let msg =
-                TextComponent::translate("commands.deop.success", [player_name.clone().into()]);
+            let msg = TextComponent::translate(
+                "commands.deop.success",
+                [TextComponent::text(player_name.clone())].into(),
+            );
             sender.send_message(msg).await;
         }
         Ok(())

--- a/pumpkin/src/command/commands/cmd_fill.rs
+++ b/pumpkin/src/command/commands/cmd_fill.rs
@@ -146,7 +146,7 @@ impl CommandExecutor for SetblockExecutor {
         sender
             .send_message(TextComponent::translate(
                 "commands.fill.success",
-                [placed_blocks.to_string().into()],
+                [TextComponent::text(placed_blocks.to_string())].into(),
             ))
             .await;
 

--- a/pumpkin/src/command/commands/cmd_gamemode.rs
+++ b/pumpkin/src/command/commands/cmd_gamemode.rs
@@ -40,12 +40,12 @@ impl CommandExecutor for GamemodeTargetSelf {
         if let Player(target) = sender {
             if target.gamemode.load() != gamemode {
                 target.set_gamemode(gamemode).await;
-                let gamemode_string = format!("{gamemode:?}");
-                // TODO: translate gamemode
+                let gamemode_string = format!("{gamemode:?}").to_lowercase();
+                let gamemode_string = format!("gameMode.{gamemode_string}");
                 target
                     .send_system_message(&TextComponent::translate(
                         "commands.gamemode.success.self",
-                        [gamemode_string.into()],
+                        [TextComponent::translate(gamemode_string, [].into())].into(),
                     ))
                     .await;
             }
@@ -78,12 +78,12 @@ impl CommandExecutor for GamemodeTargetPlayer {
         for target in targets {
             if target.gamemode.load() != gamemode {
                 target.set_gamemode(gamemode).await;
-                let gamemode_string = format!("{gamemode:?}");
-                // TODO: translate gamemode
+                let gamemode_string = format!("{gamemode:?}").to_lowercase();
+                let gamemode_string = format!("gameMode.{gamemode_string}");
                 target
                     .send_system_message(&TextComponent::translate(
                         "gameMode.changed",
-                        [gamemode_string.clone().into()],
+                        [TextComponent::translate(gamemode_string.clone(), [].into())].into(),
                     ))
                     .await;
                 if target_count == 1 {
@@ -91,9 +91,10 @@ impl CommandExecutor for GamemodeTargetPlayer {
                         .send_message(TextComponent::translate(
                             "commands.gamemode.success.other",
                             [
-                                target.gameprofile.name.clone().into(),
-                                gamemode_string.into(),
-                            ],
+                                TextComponent::text(target.gameprofile.name.clone()),
+                                TextComponent::translate(gamemode_string, [].into()),
+                            ]
+                            .into(),
                         ))
                         .await;
                 }

--- a/pumpkin/src/command/commands/cmd_give.rs
+++ b/pumpkin/src/command/commands/cmd_give.rs
@@ -59,19 +59,19 @@ impl CommandExecutor for GiveExecutor {
             TextComponent::translate(
                 "commands.give.success.single",
                 [
-                    item_count.to_string().into(),
-                    item_name.to_string().into(),
-                    targets[0].gameprofile.name.to_string().into(),
-                ],
+                    TextComponent::text(item_count.to_string()),
+                    TextComponent::text(item_name.to_string()),
+                    TextComponent::text(targets[0].gameprofile.name.to_string()),
+                ].into(),
             )
         } else {
             TextComponent::translate(
                 "commands.give.success.single",
                 [
-                    item_count.to_string().into(),
-                    item_name.to_string().into(),
-                    targets.len().to_string().into(),
-                ],
+                    TextComponent::text(item_count.to_string()),
+                    TextComponent::text(item_name.to_string()),
+                    TextComponent::text(targets.len().to_string()),
+                ].into(),
             )
         };
         sender.send_message(msg).await;

--- a/pumpkin/src/command/commands/cmd_give.rs
+++ b/pumpkin/src/command/commands/cmd_give.rs
@@ -62,7 +62,8 @@ impl CommandExecutor for GiveExecutor {
                     TextComponent::text(item_count.to_string()),
                     TextComponent::text(item_name.to_string()),
                     TextComponent::text(targets[0].gameprofile.name.to_string()),
-                ].into(),
+                ]
+                .into(),
             )
         } else {
             TextComponent::translate(
@@ -71,7 +72,8 @@ impl CommandExecutor for GiveExecutor {
                     TextComponent::text(item_count.to_string()),
                     TextComponent::text(item_name.to_string()),
                     TextComponent::text(targets.len().to_string()),
-                ].into(),
+                ]
+                .into(),
             )
         };
         sender.send_message(msg).await;

--- a/pumpkin/src/command/commands/cmd_kick.rs
+++ b/pumpkin/src/command/commands/cmd_kick.rs
@@ -34,7 +34,7 @@ impl CommandExecutor for KickExecutor {
 
         let reason = match args.get(&ARG_REASON) {
             Some(Arg::Msg(r)) => TextComponent::text(r.clone()),
-            _ => TextComponent::translate("multiplayer.disconnect.kicked", []),
+            _ => TextComponent::translate("multiplayer.disconnect.kicked", [].into()),
         };
 
         for target in targets {

--- a/pumpkin/src/command/commands/cmd_kill.rs
+++ b/pumpkin/src/command/commands/cmd_kill.rs
@@ -36,11 +36,11 @@ impl CommandExecutor for KillExecutor {
         }
 
         let msg = if target_count == 1 {
-            TextComponent::translate("commands.kill.success.single", [name.into()])
+            TextComponent::translate("commands.kill.success.single", [TextComponent::text(name)].into())
         } else {
             TextComponent::translate(
                 "commands.kill.success.multiple",
-                [target_count.to_string().into()],
+                [TextComponent::text(target_count.to_string())].into(),
             )
         };
 

--- a/pumpkin/src/command/commands/cmd_kill.rs
+++ b/pumpkin/src/command/commands/cmd_kill.rs
@@ -36,7 +36,10 @@ impl CommandExecutor for KillExecutor {
         }
 
         let msg = if target_count == 1 {
-            TextComponent::translate("commands.kill.success.single", [TextComponent::text(name)].into())
+            TextComponent::translate(
+                "commands.kill.success.single",
+                [TextComponent::text(name)].into(),
+            )
         } else {
             TextComponent::translate(
                 "commands.kill.success.multiple",

--- a/pumpkin/src/command/commands/cmd_list.rs
+++ b/pumpkin/src/command/commands/cmd_list.rs
@@ -34,7 +34,8 @@ impl CommandExecutor for ListExecutor {
                     TextComponent::text(players.len().to_string()),
                     TextComponent::text(BASIC_CONFIG.max_players.to_string()),
                     TextComponent::text(get_player_names(players)),
-                ].into(),
+                ]
+                .into(),
             ))
             .await;
 

--- a/pumpkin/src/command/commands/cmd_list.rs
+++ b/pumpkin/src/command/commands/cmd_list.rs
@@ -31,10 +31,10 @@ impl CommandExecutor for ListExecutor {
             .send_message(TextComponent::translate(
                 "commands.list.players",
                 [
-                    players.len().to_string().into(),
-                    BASIC_CONFIG.max_players.to_string().into(),
-                    get_player_names(players).into(),
-                ],
+                    TextComponent::text(players.len().to_string()),
+                    TextComponent::text(BASIC_CONFIG.max_players.to_string()),
+                    TextComponent::text(get_player_names(players)),
+                ].into(),
             ))
             .await;
 

--- a/pumpkin/src/command/commands/cmd_op.rs
+++ b/pumpkin/src/command/commands/cmd_op.rs
@@ -39,7 +39,7 @@ impl CommandExecutor for OpExecutor {
 
             if player.permission_lvl.load() == new_level {
                 sender
-                    .send_message(TextComponent::translate("commands.op.failed", []))
+                    .send_message(TextComponent::translate("commands.op.failed", [].into()))
                     .await;
                 continue;
             }
@@ -70,7 +70,7 @@ impl CommandExecutor for OpExecutor {
             sender
                 .send_message(TextComponent::translate(
                     "commands.op.success",
-                    [player_name.clone().into()],
+                    [TextComponent::text(player_name.clone())].into(),
                 ))
                 .await;
         }

--- a/pumpkin/src/command/commands/cmd_setblock.rs
+++ b/pumpkin/src/command/commands/cmd_setblock.rs
@@ -69,13 +69,13 @@ impl CommandExecutor for SetblockExecutor {
                 TextComponent::translate(
                     "commands.setblock.success",
                     [
-                        pos.0.x.to_string().into(),
-                        pos.0.y.to_string().into(),
-                        pos.0.z.to_string().into(),
-                    ],
+                        TextComponent::text(pos.0.x.to_string()),
+                        TextComponent::text(pos.0.y.to_string()),
+                        TextComponent::text(pos.0.z.to_string()),
+                    ].into(),
                 )
             } else {
-                TextComponent::translate("commands.setblock.failed", [])
+                TextComponent::translate("commands.setblock.failed", [].into())
             })
             .await;
 

--- a/pumpkin/src/command/commands/cmd_setblock.rs
+++ b/pumpkin/src/command/commands/cmd_setblock.rs
@@ -72,7 +72,8 @@ impl CommandExecutor for SetblockExecutor {
                         TextComponent::text(pos.0.x.to_string()),
                         TextComponent::text(pos.0.y.to_string()),
                         TextComponent::text(pos.0.z.to_string()),
-                    ].into(),
+                    ]
+                    .into(),
                 )
             } else {
                 TextComponent::translate("commands.setblock.failed", [].into())

--- a/pumpkin/src/command/commands/cmd_stop.rs
+++ b/pumpkin/src/command/commands/cmd_stop.rs
@@ -22,7 +22,8 @@ impl CommandExecutor for StopExecutor {
     ) -> Result<(), CommandError> {
         sender
             .send_message(
-                TextComponent::translate("commands.stop.stopping", []).color_named(NamedColor::Red),
+                TextComponent::translate("commands.stop.stopping", [].into())
+                    .color_named(NamedColor::Red),
             )
             .await;
 

--- a/pumpkin/src/command/commands/cmd_teleport.rs
+++ b/pumpkin/src/command/commands/cmd_teleport.rs
@@ -195,7 +195,10 @@ impl CommandExecutor for TpSelfToEntityExecutor {
             }
             _ => {
                 sender
-                    .send_message(TextComponent::translate("permissions.requires.player", []))
+                    .send_message(TextComponent::translate(
+                        "permissions.requires.player",
+                        [].into(),
+                    ))
                     .await;
             }
         };
@@ -223,7 +226,10 @@ impl CommandExecutor for TpSelfToPosExecutor {
             }
             _ => {
                 sender
-                    .send_message(TextComponent::translate("permissions.requires.player", []))
+                    .send_message(TextComponent::translate(
+                        "permissions.requires.player",
+                        [].into(),
+                    ))
                     .await;
             }
         };

--- a/pumpkin/src/command/commands/cmd_time.rs
+++ b/pumpkin/src/command/commands/cmd_time.rs
@@ -62,15 +62,24 @@ impl CommandExecutor for TimeQueryExecutor {
         let msg = match mode {
             QueryMode::DayTime => {
                 let curr_time = level_time.query_daytime();
-                TextComponent::translate("commands.time.query", [curr_time.to_string().into()])
+                TextComponent::translate(
+                    "commands.time.query",
+                    [TextComponent::text(curr_time.to_string())].into(),
+                )
             }
             QueryMode::GameTime => {
                 let curr_time = level_time.query_gametime();
-                TextComponent::translate("commands.time.query", [curr_time.to_string().into()])
+                TextComponent::translate(
+                    "commands.time.query",
+                    [TextComponent::text(curr_time.to_string())].into(),
+                )
             }
             QueryMode::Day => {
                 let curr_time = level_time.query_day();
-                TextComponent::translate("commands.time.query", [curr_time.to_string().into()])
+                TextComponent::translate(
+                    "commands.time.query",
+                    [TextComponent::text(curr_time.to_string())].into(),
+                )
             }
         };
 
@@ -124,13 +133,19 @@ impl CommandExecutor for TimeChangeExecutor {
                 level_time.add_time(time_count.into());
                 level_time.send_time(world).await;
                 let curr_time = level_time.query_daytime();
-                TextComponent::translate("commands.time.add", [curr_time.to_string().into()])
+                TextComponent::translate(
+                    "commands.time.add",
+                    [TextComponent::text(curr_time.to_string())].into(),
+                )
             }
             Mode::Set(_) => {
                 // set
                 level_time.set_time(time_count.into());
                 level_time.send_time(world).await;
-                TextComponent::translate("commands.time.set", [time_count.to_string().into()])
+                TextComponent::translate(
+                    "commands.time.set",
+                    [TextComponent::text(time_count.to_string())].into(),
+                )
             }
         };
 

--- a/pumpkin/src/command/commands/cmd_worldborder.rs
+++ b/pumpkin/src/command/commands/cmd_worldborder.rs
@@ -69,7 +69,7 @@ impl CommandExecutor for WorldborderGetExecutor {
         sender
             .send_message(TextComponent::translate(
                 "commands.worldborder.get",
-                [diameter.to_string().into()],
+                [TextComponent::text(diameter.to_string())].into(),
             ))
             .await;
         Ok(())
@@ -108,7 +108,7 @@ impl CommandExecutor for WorldborderSetExecutor {
         if (distance - border.new_diameter).abs() < f64::EPSILON {
             sender
                 .send_message(
-                    TextComponent::translate(NOTHING_CHANGED_EXCEPTION, [])
+                    TextComponent::translate(NOTHING_CHANGED_EXCEPTION, [].into())
                         .color(Color::Named(NamedColor::Red)),
                 )
                 .await;
@@ -119,7 +119,7 @@ impl CommandExecutor for WorldborderSetExecutor {
         sender
             .send_message(TextComponent::translate(
                 "commands.worldborder.set.immediate",
-                [dist.into()],
+                [TextComponent::text(dist)].into(),
             ))
             .await;
         border.set_diameter(world, distance, None).await;
@@ -172,7 +172,7 @@ impl CommandExecutor for WorldborderSetTimeExecutor {
             std::cmp::Ordering::Equal => {
                 sender
                     .send_message(
-                        TextComponent::translate(NOTHING_CHANGED_EXCEPTION, [])
+                        TextComponent::translate(NOTHING_CHANGED_EXCEPTION, [].into())
                             .color(Color::Named(NamedColor::Red)),
                     )
                     .await;
@@ -183,7 +183,11 @@ impl CommandExecutor for WorldborderSetTimeExecutor {
                 sender
                     .send_message(TextComponent::translate(
                         "commands.worldborder.set.shrink",
-                        [dist.into(), time.to_string().into()],
+                        [
+                            TextComponent::text(dist),
+                            TextComponent::text(time.to_string()),
+                        ]
+                        .into(),
                     ))
                     .await;
             }
@@ -192,7 +196,11 @@ impl CommandExecutor for WorldborderSetTimeExecutor {
                 sender
                     .send_message(TextComponent::translate(
                         "commands.worldborder.set.grow",
-                        [dist.into(), time.to_string().into()],
+                        [
+                            TextComponent::text(dist),
+                            TextComponent::text(time.to_string()),
+                        ]
+                        .into(),
                     ))
                     .await;
             }
@@ -237,7 +245,7 @@ impl CommandExecutor for WorldborderAddExecutor {
         if distance == 0.0 {
             sender
                 .send_message(
-                    TextComponent::translate(NOTHING_CHANGED_EXCEPTION, [])
+                    TextComponent::translate(NOTHING_CHANGED_EXCEPTION, [].into())
                         .color(Color::Named(NamedColor::Red)),
                 )
                 .await;
@@ -250,7 +258,7 @@ impl CommandExecutor for WorldborderAddExecutor {
         sender
             .send_message(TextComponent::translate(
                 "commands.worldborder.set.immediate",
-                [dist.into()],
+                [TextComponent::text(dist)].into(),
             ))
             .await;
         border.set_diameter(world, distance, None).await;
@@ -305,7 +313,7 @@ impl CommandExecutor for WorldborderAddTimeExecutor {
             std::cmp::Ordering::Equal => {
                 sender
                     .send_message(
-                        TextComponent::translate(NOTHING_CHANGED_EXCEPTION, [])
+                        TextComponent::translate(NOTHING_CHANGED_EXCEPTION, [].into())
                             .color(Color::Named(NamedColor::Red)),
                     )
                     .await;
@@ -316,7 +324,11 @@ impl CommandExecutor for WorldborderAddTimeExecutor {
                 sender
                     .send_message(TextComponent::translate(
                         "commands.worldborder.set.shrink",
-                        [dist.into(), time.to_string().into()],
+                        [
+                            TextComponent::text(dist),
+                            TextComponent::text(time.to_string()),
+                        ]
+                        .into(),
                     ))
                     .await;
             }
@@ -325,7 +337,11 @@ impl CommandExecutor for WorldborderAddTimeExecutor {
                 sender
                     .send_message(TextComponent::translate(
                         "commands.worldborder.set.grow",
-                        [dist.into(), time.to_string().into()],
+                        [
+                            TextComponent::text(dist),
+                            TextComponent::text(time.to_string()),
+                        ]
+                        .into(),
                     ))
                     .await;
             }
@@ -359,7 +375,11 @@ impl CommandExecutor for WorldborderCenterExecutor {
         sender
             .send_message(TextComponent::translate(
                 "commands.worldborder.center.success",
-                [format!("{x:.2}").into(), format!("{z:.2}").into()],
+                [
+                    TextComponent::text(format!("{x:.2}")),
+                    TextComponent::text(format!("{z:.2}")),
+                ]
+                .into(),
             ))
             .await;
         border.set_center(world, x, z).await;
@@ -399,8 +419,11 @@ impl CommandExecutor for WorldborderDamageAmountExecutor {
         if (damage_per_block - border.damage_per_block).abs() < f32::EPSILON {
             sender
                 .send_message(
-                    TextComponent::translate("commands.worldborder.damage.amount.failed", [])
-                        .color(Color::Named(NamedColor::Red)),
+                    TextComponent::translate(
+                        "commands.worldborder.damage.amount.failed",
+                        [].into(),
+                    )
+                    .color(Color::Named(NamedColor::Red)),
                 )
                 .await;
             return Ok(());
@@ -410,7 +433,7 @@ impl CommandExecutor for WorldborderDamageAmountExecutor {
         sender
             .send_message(TextComponent::translate(
                 "commands.worldborder.damage.amount.success",
-                [damage.into()],
+                [TextComponent::text(damage)].into(),
             ))
             .await;
         border.damage_per_block = damage_per_block;
@@ -450,8 +473,11 @@ impl CommandExecutor for WorldborderDamageBufferExecutor {
         if (buffer - border.buffer).abs() < f32::EPSILON {
             sender
                 .send_message(
-                    TextComponent::translate("commands.worldborder.damage.buffer.failed", [])
-                        .color(Color::Named(NamedColor::Red)),
+                    TextComponent::translate(
+                        "commands.worldborder.damage.buffer.failed",
+                        [].into(),
+                    )
+                    .color(Color::Named(NamedColor::Red)),
                 )
                 .await;
             return Ok(());
@@ -461,7 +487,7 @@ impl CommandExecutor for WorldborderDamageBufferExecutor {
         sender
             .send_message(TextComponent::translate(
                 "commands.worldborder.damage.buffer.success",
-                [buf.into()],
+                [TextComponent::text(buf)].into(),
             ))
             .await;
         border.buffer = buffer;
@@ -501,8 +527,11 @@ impl CommandExecutor for WorldborderWarningDistanceExecutor {
         if distance == border.warning_blocks {
             sender
                 .send_message(
-                    TextComponent::translate("commands.worldborder.warning.distance.failed", [])
-                        .color(Color::Named(NamedColor::Red)),
+                    TextComponent::translate(
+                        "commands.worldborder.warning.distance.failed",
+                        [].into(),
+                    )
+                    .color(Color::Named(NamedColor::Red)),
                 )
                 .await;
             return Ok(());
@@ -511,7 +540,7 @@ impl CommandExecutor for WorldborderWarningDistanceExecutor {
         sender
             .send_message(TextComponent::translate(
                 "commands.worldborder.warning.distance.success",
-                [distance.to_string().into()],
+                [TextComponent::text(distance.to_string())].into(),
             ))
             .await;
         border.set_warning_distance(world, distance).await;
@@ -551,7 +580,7 @@ impl CommandExecutor for WorldborderWarningTimeExecutor {
         if time == border.warning_time {
             sender
                 .send_message(
-                    TextComponent::translate("commands.worldborder.warning.time.failed", [])
+                    TextComponent::translate("commands.worldborder.warning.time.failed", [].into())
                         .color(Color::Named(NamedColor::Red)),
                 )
                 .await;
@@ -561,7 +590,7 @@ impl CommandExecutor for WorldborderWarningTimeExecutor {
         sender
             .send_message(TextComponent::translate(
                 "commands.worldborder.warning.time.success",
-                [time.to_string().into()],
+                [TextComponent::text(time.to_string())].into(),
             ))
             .await;
         border.set_warning_delay(world, time).await;

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -419,7 +419,7 @@ impl Player {
                 .wait_for_keep_alive
                 .load(std::sync::atomic::Ordering::Relaxed)
             {
-                self.kick(TextComponent::translate("disconnect.timeout", []))
+                self.kick(TextComponent::translate("disconnect.timeout", [].into()))
                     .await;
                 return;
             }

--- a/pumpkin/src/net/mod.rs
+++ b/pumpkin/src/net/mod.rs
@@ -571,7 +571,7 @@ impl Client {
             ConnectionState::Login => {
                 // TextComponent implements Serialze and writes in bytes instead of String, thats the reasib we only use content
                 self.try_send_packet(&CLoginDisconnect::new(
-                    &serde_json::to_string(&reason.content).unwrap_or_else(|_| String::new()),
+                    &serde_json::to_string(&reason.0.content).unwrap_or_else(|_| String::new()),
                 ))
                 .await
             }

--- a/pumpkin/src/net/packet/handshake.rs
+++ b/pumpkin/src/net/packet/handshake.rs
@@ -20,7 +20,7 @@ impl Client {
                 std::cmp::Ordering::Less => {
                     self.kick(&TextComponent::translate(
                         "multiplayer.disconnect.outdated_client",
-                        [CURRENT_MC_VERSION.to_string().into()],
+                        [TextComponent::text(CURRENT_MC_VERSION.to_string())].into(),
                     ))
                     .await;
                 }
@@ -28,7 +28,7 @@ impl Client {
                 std::cmp::Ordering::Greater => {
                     self.kick(&TextComponent::translate(
                         "multiplayer.disconnect.incompatible",
-                        [CURRENT_MC_VERSION.to_string().into()],
+                        [TextComponent::text(CURRENT_MC_VERSION.to_string())].into(),
                     ))
                     .await;
                 }

--- a/pumpkin/src/net/packet/login.rs
+++ b/pumpkin/src/net/packet/login.rs
@@ -95,7 +95,7 @@ impl Client {
         if max_players > 0 && server.get_player_count().await >= max_players as usize {
             self.kick(&TextComponent::translate(
                 "multiplayer.disconnect.server_full",
-                [],
+                [].into(),
             ))
             .await;
             return;
@@ -189,12 +189,13 @@ impl Client {
                 Ok(new_profile) => *profile = new_profile,
                 Err(error) => {
                     self.kick(&match error {
-                        AuthError::FailedResponse => {
-                            TextComponent::translate("multiplayer.disconnect.authservers_down", [])
-                        }
+                        AuthError::FailedResponse => TextComponent::translate(
+                            "multiplayer.disconnect.authservers_down",
+                            [].into(),
+                        ),
                         AuthError::UnverifiedUsername => TextComponent::translate(
                             "multiplayer.disconnect.unverified_username",
-                            [],
+                            [].into(),
                         ),
                         e => TextComponent::text(e.to_string()),
                     })
@@ -208,7 +209,7 @@ impl Client {
             log::debug!("Player (IP '{}', username '{}') tried to log in with the same UUID ('{}') as an online player (IP '{}', username '{}')", &self.address.lock().await, &profile.name, &profile.id, &online_player.client.address.lock().await, &online_player.gameprofile.name);
             self.kick(&TextComponent::translate(
                 "multiplayer.disconnect.duplicate_login",
-                [],
+                [].into(),
             ))
             .await;
             return;
@@ -219,7 +220,7 @@ impl Client {
             log::debug!("A player (IP '{}', attempted username '{}') tried to log in with the same username as an online player (UUID '{}', IP '{}', username '{}')", &self.address.lock().await, &profile.name, &profile.id, &online_player.client.address.lock().await, &online_player.gameprofile.name);
             self.kick(&TextComponent::translate(
                 "multiplayer.disconnect.duplicate_login",
-                [],
+                [].into(),
             ))
             .await;
             return;

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -139,7 +139,7 @@ impl Player {
         if position.x.is_nan() || position.y.is_nan() || position.z.is_nan() {
             self.kick(TextComponent::translate(
                 "multiplayer.disconnect.invalid_player_movement",
-                [],
+                [].into(),
             ))
             .await;
             return;
@@ -207,7 +207,7 @@ impl Player {
         {
             self.kick(TextComponent::translate(
                 "multiplayer.disconnect.invalid_player_movement",
-                [],
+                [].into(),
             ))
             .await;
             return;
@@ -287,7 +287,7 @@ impl Player {
         if !rotation.yaw.is_finite() || !rotation.pitch.is_finite() {
             self.kick(TextComponent::translate(
                 "multiplayer.disconnect.invalid_player_movement",
-                [],
+                [].into(),
             ))
             .await;
             return;
@@ -539,7 +539,7 @@ impl Player {
         if message.chars().any(|c| c == '§' || c < ' ' || c == '\x7F') {
             self.kick(TextComponent::translate(
                 "multiplayer.disconnect.illegal_characters",
-                [],
+                [].into(),
             ))
             .await;
             return;
@@ -719,7 +719,7 @@ impl Player {
                     );
                     self.kick(TextComponent::translate(
                         "multiplayer.disconnect.invalid_entity_attacked",
-                        [],
+                        [].into(),
                     ))
                     .await;
                     return;
@@ -1152,7 +1152,7 @@ impl Player {
             self.send_system_message_raw(
                 &TextComponent::translate(
                     "build.tooHigh",
-                    vec![(WORLD_MAX_Y - 1).to_string().into()],
+                    vec![TextComponent::text((WORLD_MAX_Y - 1).to_string())],
                 )
                 .color_named(NamedColor::Red),
                 true,

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -763,7 +763,7 @@ impl World {
         // TODO: Config
         let msg_comp = TextComponent::translate(
             "multiplayer.player.joined",
-            [player.gameprofile.name.clone().into()],
+            [TextComponent::text(player.gameprofile.name.clone())].into(),
         )
         .color_named(NamedColor::Yellow);
         for player in current_players.values() {
@@ -808,7 +808,7 @@ impl World {
         // TODO: Config
         let disconn_msg = TextComponent::translate(
             "multiplayer.player.left",
-            [player.gameprofile.name.clone().into()],
+            [TextComponent::text(player.gameprofile.name.clone())].into(),
         )
         .color_named(NamedColor::Yellow);
         for player in self.current_players.lock().await.values() {


### PR DESCRIPTION
## Description

Changed the whole TextComponent structure to allow nested translated texts and avoid recursion in serialization, but keeping the api unchanged. Also changed all the translate components to fit the new format, and added translation to gamemode command.
Truly happy of beign able to solve this issue, the TextComponent had two problems:
1. It had a loop in its serialization, being that TC::serialize called to_bytes_unnamed and this in turn called TC::serialize again.
2. As it has to be converted to bytes (or so I understand) when serializing, the children and translation arguments were converted twice, which generated problems when reading it in the client.

> After having achieved this achievement (considering that I have just
started programming in rust) I am extremely happy to go to sleep.
-- Melther - 24/1/25 - 5:00

## Testing

![image](https://github.com/user-attachments/assets/1a2c9957-2196-40fa-854d-1645e68afc5f)

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
