### PR TITLE
Make worlds field mutable using RwLock

### DIFF
--- a/pumpkin/src/command/commands/cmd_seed.rs
+++ b/pumpkin/src/command/commands/cmd_seed.rs
@@ -23,7 +23,8 @@ impl CommandExecutor for PumpkinExecutor {
     ) -> Result<(), CommandError> {
         let seed = match sender {
             CommandSender::Player(player) => player.living_entity.entity.world.level.seed.0,
-            _ => match server.worlds.first() {
+            // TODO: Maybe ask player for world, or get the current world
+            _ => match server.worlds.read().await.first() {
                 Some(world) => world.level.seed.0,
                 None => {
                     return Err(CommandError::GeneralCommandIssue(

--- a/pumpkin/src/command/commands/cmd_time.rs
+++ b/pumpkin/src/command/commands/cmd_time.rs
@@ -53,8 +53,9 @@ impl CommandExecutor for TimeQueryExecutor {
         _args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
         let mode = self.0;
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
             .expect("There should always be at least one world");
         let level_time = world.level_time.lock().await;
@@ -112,8 +113,9 @@ impl CommandExecutor for TimeChangeExecutor {
             }
         };
         let mode = self.0;
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
             .expect("There should always be at least one world");
         let mut level_time = world.level_time.lock().await;

--- a/pumpkin/src/command/commands/cmd_worldborder.rs
+++ b/pumpkin/src/command/commands/cmd_worldborder.rs
@@ -59,10 +59,11 @@ impl CommandExecutor for WorldborderGetExecutor {
         server: &Server,
         _args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
-            .expect("There should always be atleast one world");
+            .expect("There should always be at least one world");
         let border = world.worldborder.lock().await;
 
         let diameter = border.new_diameter.round() as i32;
@@ -86,10 +87,11 @@ impl CommandExecutor for WorldborderSetExecutor {
         server: &Server,
         args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
-            .expect("There should always be atleast one world");
+            .expect("There should always be at least one world");
         let mut border = world.worldborder.lock().await;
 
         let Ok(distance) = distance_consumer().find_arg_default_name(args)? else {
@@ -137,10 +139,11 @@ impl CommandExecutor for WorldborderSetTimeExecutor {
         server: &Server,
         args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
-            .expect("There should always be atleast one world");
+            .expect("There should always be at least one world");
         let mut border = world.worldborder.lock().await;
 
         let Ok(distance) = distance_consumer().find_arg_default_name(args)? else {
@@ -215,10 +218,11 @@ impl CommandExecutor for WorldborderAddExecutor {
         server: &Server,
         args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
-            .expect("There should always be atleast one world");
+            .expect("There should always be at least one world");
         let mut border = world.worldborder.lock().await;
 
         let Ok(distance) = distance_consumer().find_arg_default_name(args)? else {
@@ -268,10 +272,11 @@ impl CommandExecutor for WorldborderAddTimeExecutor {
         server: &Server,
         args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
-            .expect("There should always be atleast one world");
+            .expect("There should always be at least one world");
         let mut border = world.worldborder.lock().await;
 
         let Ok(distance) = distance_consumer().find_arg_default_name(args)? else {
@@ -348,10 +353,11 @@ impl CommandExecutor for WorldborderCenterExecutor {
         server: &Server,
         args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
-            .expect("There should always be atleast one world");
+            .expect("There should always be at least one world");
         let mut border = world.worldborder.lock().await;
 
         let Vector2 { x, z } = Position2DArgumentConsumer.find_arg_default_name(args)?;
@@ -377,10 +383,11 @@ impl CommandExecutor for WorldborderDamageAmountExecutor {
         server: &Server,
         args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
-            .expect("There should always be atleast one world");
+            .expect("There should always be at least one world");
         let mut border = world.worldborder.lock().await;
 
         let Ok(damage_per_block) = damage_per_block_consumer().find_arg_default_name(args)? else {
@@ -428,10 +435,11 @@ impl CommandExecutor for WorldborderDamageBufferExecutor {
         server: &Server,
         args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
-            .expect("There should always be atleast one world");
+            .expect("There should always be at least one world");
         let mut border = world.worldborder.lock().await;
 
         let Ok(buffer) = damage_buffer_consumer().find_arg_default_name(args)? else {
@@ -479,10 +487,11 @@ impl CommandExecutor for WorldborderWarningDistanceExecutor {
         server: &Server,
         args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
-            .expect("There should always be atleast one world");
+            .expect("There should always be at least one world");
         let mut border = world.worldborder.lock().await;
 
         let Ok(distance) = warning_distance_consumer().find_arg_default_name(args)? else {
@@ -529,10 +538,11 @@ impl CommandExecutor for WorldborderWarningTimeExecutor {
         server: &Server,
         args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let world = server
-            .worlds
+        // TODO: Maybe ask player for world, or get the current world
+        let worlds = server.worlds.read().await;
+        let world = worlds
             .first()
-            .expect("There should always be atleast one world");
+            .expect("There should always be at least one world");
         let mut border = world.worldborder.lock().await;
 
         let Ok(time) = time_consumer().find_arg_default_name(args)? else {

--- a/pumpkin/src/net/query.rs
+++ b/pumpkin/src/net/query.rs
@@ -113,7 +113,7 @@ async fn handle_packet(
                         if packet.is_full_request {
                             // Get 4 players
                             let mut players: Vec<CString> = Vec::new();
-                            for world in &server.worlds {
+                            for world in server.worlds.read().await.iter() {
                                 let mut world_players = world
                                     .current_players
                                     .lock()


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This PR wraps the
```rs
worlds: vec![Arc::new(world)]
```
field in the `Server` struct in a `RwLock`, to allow mutable access to the worlds field (to enable actions like adding and removing worlds from the server)

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
