### PR TITLE
Changed hover types

### DIFF
--- a/pumpkin-protocol/src/lib.rs
+++ b/pumpkin-protocol/src/lib.rs
@@ -191,7 +191,7 @@ impl PositionFlag {
 
 pub enum Label {
     BuiltIn(LinkType),
-    TextComponent(TextComponent),
+    TextComponent(Box<TextComponent>),
 }
 
 impl Serialize for Label {

--- a/pumpkin-util/src/text/mod.rs
+++ b/pumpkin-util/src/text/mod.rs
@@ -126,7 +126,12 @@ impl TextComponent {
     pub fn get_text(self) -> String {
         match self.0.content {
             TextContent::Text { text } => text.into_owned(),
-            TextContent::Translate { translate, with: _ } => translate.into_owned(),
+            TextContent::Translate { translate, with } => {
+                let translate = translate.into_owned();
+                get_translation_en_us(&translate, with)
+                    .unwrap_or(translate.to_string())
+                    .clone()
+            }
             TextContent::EntityNames {
                 selector,
                 separator: _,

--- a/pumpkin/src/command/commands/cmd_plugin.rs
+++ b/pumpkin/src/command/commands/cmd_plugin.rs
@@ -57,11 +57,11 @@ impl CommandExecutor for ListExecutor {
             let component = if *loaded {
                 TextComponent::text(fmt)
                     .color_named(NamedColor::Green)
-                    .hover_event(HoverEvent::ShowText(hover_text.into()))
+                    .hover_event(HoverEvent::show_text(TextComponent::text(hover_text)))
             } else {
                 TextComponent::text(fmt)
                     .color_named(NamedColor::Red)
-                    .hover_event(HoverEvent::ShowText(hover_text.into()))
+                    .hover_event(HoverEvent::show_text(TextComponent::text(hover_text)))
             };
             message = message.add_child(component);
         }

--- a/pumpkin/src/command/commands/cmd_plugins.rs
+++ b/pumpkin/src/command/commands/cmd_plugins.rs
@@ -47,11 +47,11 @@ impl CommandExecutor for ListExecutor {
             let component = if *loaded {
                 TextComponent::text(fmt)
                     .color_named(NamedColor::Green)
-                    .hover_event(HoverEvent::ShowText(hover_text.into()))
+                    .hover_event(HoverEvent::show_text(TextComponent::text(hover_text)))
             } else {
                 TextComponent::text(fmt)
                     .color_named(NamedColor::Red)
-                    .hover_event(HoverEvent::ShowText(hover_text.into()))
+                    .hover_event(HoverEvent::show_text(TextComponent::text(hover_text)))
             };
             message = message.add_child(component);
         }

--- a/pumpkin/src/command/commands/cmd_pumpkin.rs
+++ b/pumpkin/src/command/commands/cmd_pumpkin.rs
@@ -33,7 +33,9 @@ impl CommandExecutor for PumpkinExecutor {
         sender
             .send_message(
                 TextComponent::text(format!("Pumpkin {CARGO_PKG_VERSION} ({GIT_VERSION})"))
-                    .hover_event(HoverEvent::ShowText(Cow::from("Click to Copy Version")))
+                    .hover_event(HoverEvent::show_text(TextComponent::text(Cow::from(
+                        "Click to Copy Version",
+                    ))))
                     .click_event(ClickEvent::CopyToClipboard(Cow::from(format!(
                         "Pumpkin {CARGO_PKG_VERSION} ({GIT_VERSION})"
                     ))))
@@ -43,9 +45,9 @@ impl CommandExecutor for PumpkinExecutor {
                             .click_event(ClickEvent::CopyToClipboard(Cow::from(
                                 CARGO_PKG_DESCRIPTION,
                             )))
-                            .hover_event(HoverEvent::ShowText(Cow::from(
+                            .hover_event(HoverEvent::show_text(TextComponent::text(Cow::from(
                                 "Click to Copy Description",
-                            )))
+                            ))))
                             .color_named(NamedColor::White),
                     )
                     .add_child(
@@ -55,9 +57,9 @@ impl CommandExecutor for PumpkinExecutor {
                         .click_event(ClickEvent::CopyToClipboard(Cow::from(format!(
                             "(Minecraft {CURRENT_MC_VERSION}, Protocol {CURRENT_MC_PROTOCOL})"
                         ))))
-                        .hover_event(HoverEvent::ShowText(Cow::from(
+                        .hover_event(HoverEvent::show_text(TextComponent::text(Cow::from(
                             "Click to Copy Minecraft Version",
-                        )))
+                        ))))
                         .color_named(NamedColor::Gold),
                     )
                     .add_child(TextComponent::text(" "))
@@ -67,9 +69,9 @@ impl CommandExecutor for PumpkinExecutor {
                             .click_event(ClickEvent::OpenUrl(Cow::from(
                                 "https://github.com/Pumpkin-MC/Pumpkin",
                             )))
-                            .hover_event(HoverEvent::ShowText(Cow::from(
+                            .hover_event(HoverEvent::show_text(TextComponent::text(Cow::from(
                                 "Click to open repository.",
-                            )))
+                            ))))
                             .color_named(NamedColor::Blue)
                             .bold()
                             .underlined(),
@@ -79,7 +81,9 @@ impl CommandExecutor for PumpkinExecutor {
                     .add_child(
                         TextComponent::text("Website")
                             .click_event(ClickEvent::OpenUrl(Cow::from("https://pumpkinmc.org/")))
-                            .hover_event(HoverEvent::ShowText(Cow::from("Click to open website.")))
+                            .hover_event(HoverEvent::show_text(TextComponent::text(Cow::from(
+                                "Click to open website.",
+                            ))))
                             .color_named(NamedColor::Blue)
                             .bold()
                             .underlined(),

--- a/pumpkin/src/command/commands/cmd_seed.rs
+++ b/pumpkin/src/command/commands/cmd_seed.rs
@@ -40,8 +40,9 @@ impl CommandExecutor for PumpkinExecutor {
                 TextComponent::text("Seed: [")
                     .add_child(
                         TextComponent::text(seed.clone())
-                            .hover_event(HoverEvent::ShowText(Cow::from(
-                                "Click to Copy to Clipboard",
+                            .hover_event(HoverEvent::show_text(TextComponent::translate(
+                                Cow::from("chat.copy.click"),
+                                vec![],
                             )))
                             .click_event(ClickEvent::CopyToClipboard(Cow::from(seed)))
                             .color_named(NamedColor::Green),

--- a/pumpkin/src/net/packet/login.rs
+++ b/pumpkin/src/net/packet/login.rs
@@ -77,7 +77,7 @@ static LINKS: LazyLock<Vec<Link>> = LazyLock::new(|| {
 
     for (key, value) in &ADVANCED_CONFIG.server_links.custom {
         links.push(Link::new(
-            Label::TextComponent(TextComponent::text(key)),
+            Label::TextComponent(TextComponent::text(key).into()),
             value,
         ));
     }


### PR DESCRIPTION
## Description

On the HoverEvents changed the ShowText type to allow using TextComponent on it, made the same chage to the "name" attribute of ShowEntity. 
> [!CAUTION]
> This solution perhaps is not the most suitable, since it is more a workaround, I explain, since when passing a single TextComponentBase the game is not able to read it, we take advantage of the fact that we can pass an array of them so the error doesn't jump, but this forces us to use Vec instead of Box.

In the seed command, the hover message has been changed so it will be translated as its behavior in vanilla.
Also fixed the "get_text" function from TextComponent to make it possible to use translations on it.

## Testing

**Translated hover text of seed command (In spanish (●'◡'●))**
![image](https://github.com/user-attachments/assets/66c48721-5513-43a5-8ccb-c32595adf4eb)

**Showing that translations works on ShowEntity (Using the seed command as base)**
![image](https://github.com/user-attachments/assets/975650ab-1383-4978-85aa-d29b799818c3)

### Extra
Cool *(At least for me)* logo I made to ingame because icons with transparecy feels strange on servers menu
![image](https://github.com/user-attachments/assets/5d176549-7701-427d-9c08-7bf29d156267)

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
