### PR TITLE
Command parity to vanilla

### DIFF
--- a/pumpkin-data/build/entity_type.rs
+++ b/pumpkin-data/build/entity_type.rs
@@ -52,18 +52,6 @@ pub(crate) fn build() -> TokenStream {
         })
         .collect::<TokenStream>();
 
-    let type_to_str = json
-        .iter()
-        .map(|sound| {
-            let name = ident(sound.0.to_pascal_case());
-            let identifier = format!("minecraft:{}", sound.0);
-
-            quote! {
-                Self::#name => #identifier,
-            }
-        })
-        .collect::<TokenStream>();
-
     quote! {
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
         #[repr(u8)]
@@ -84,18 +72,6 @@ pub(crate) fn build() -> TokenStream {
                     #type_from_name
                     _ => None
                 }
-            }
-
-            pub const fn to_str(&self) -> &'static str {
-                match self {
-                    #type_to_str
-                }
-            }
-        }
-
-        impl std::fmt::Display for EntityType {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(f, "{}", self.to_str())
             }
         }
     }

--- a/pumpkin-data/build/entity_type.rs
+++ b/pumpkin-data/build/entity_type.rs
@@ -91,9 +91,11 @@ pub(crate) fn build() -> TokenStream {
                     #type_to_str
                 }
             }
+        }
 
-            pub fn to_string(&self) -> String {
-                self.to_str().to_string()
+        impl std::fmt::Display for EntityType {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "{}", self.to_str())
             }
         }
     }

--- a/pumpkin-data/build/entity_type.rs
+++ b/pumpkin-data/build/entity_type.rs
@@ -52,8 +52,20 @@ pub(crate) fn build() -> TokenStream {
         })
         .collect::<TokenStream>();
 
+    let type_to_str = json
+        .iter()
+        .map(|sound| {
+            let name = ident(sound.0.to_pascal_case());
+            let identifier = format!("minecraft:{}", sound.0);
+
+            quote! {
+                Self::#name => #identifier,
+            }
+        })
+        .collect::<TokenStream>();
+
     quote! {
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Copy, PartialEq, Eq, Debug)]
         #[repr(u8)]
         pub enum EntityType {
             #variants
@@ -72,6 +84,16 @@ pub(crate) fn build() -> TokenStream {
                     #type_from_name
                     _ => None
                 }
+            }
+
+            pub const fn to_str(&self) -> &'static str {
+                match self {
+                    #type_to_str
+                }
+            }
+
+            pub fn to_string(&self) -> String {
+                self.to_str().to_string()
             }
         }
     }

--- a/pumpkin-util/src/text/hover.rs
+++ b/pumpkin-util/src/text/hover.rs
@@ -45,10 +45,7 @@ impl HoverEvent {
     {
         Self::ShowEntity {
             id: id.into(),
-            kind: match kind {
-                Some(kind) => Some(kind.into()),
-                None => None,
-            },
+            kind: kind.map(|kind| kind.into()),
             name: match name {
                 Some(name) => Some(vec![name.0]),
                 None => None,

--- a/pumpkin-util/src/text/hover.rs
+++ b/pumpkin-util/src/text/hover.rs
@@ -39,14 +39,16 @@ impl HoverEvent {
     pub fn show_text(text: TextComponent) -> Self {
         Self::ShowText(vec![text.0])
     }
-    pub fn show_entity(
-        id: Cow<'static, str>,
-        kind: Option<Cow<'static, str>>,
-        name: Option<TextComponent>,
-    ) -> Self {
+    pub fn show_entity<P>(id: P, kind: Option<P>, name: Option<TextComponent>) -> Self
+    where
+        P: Into<Cow<'static, str>>,
+    {
         Self::ShowEntity {
-            id,
-            kind,
+            id: id.into(),
+            kind: match kind {
+                Some(kind) => Some(kind.into()),
+                None => None,
+            },
             name: match name {
                 Some(name) => Some(vec![name.0]),
                 None => None,

--- a/pumpkin-world/src/item/item_registry.rs
+++ b/pumpkin-world/src/item/item_registry.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+use pumpkin_util::text::TextComponent;
 use serde::Deserialize;
 
 const ITEMS_JSON: &str = include_str!("../../../assets/items.json");
@@ -42,8 +43,16 @@ pub struct Item {
     pub components: ItemComponents,
 }
 
+impl Item {
+    pub fn translated_name(&self) -> TextComponent {
+        serde_json::from_str(&self.components.item_name).expect("Could not parse item name.")
+    }
+}
+
 #[derive(Deserialize, Clone, Debug)]
 pub struct ItemComponents {
+    #[serde(rename = "minecraft:item_name")]
+    pub item_name: String,
     #[serde(rename = "minecraft:max_stack_size")]
     pub max_stack_size: u8,
     #[serde(rename = "minecraft:jukebox_playable")]

--- a/pumpkin/src/command/commands/clear.rs
+++ b/pumpkin/src/command/commands/clear.rs
@@ -53,7 +53,9 @@ fn clear_command_text_output(item_count: usize, targets: &[Arc<Player>]) -> Text
                     ))
                     .hover_event(HoverEvent::show_entity(
                         target.living_entity.entity.entity_uuid.to_string(),
-                        Some(target.living_entity.entity.entity_type.to_string()),
+                        Some(
+                            format!("{:?}", target.living_entity.entity.entity_type).to_lowercase(),
+                        ),
                         Some(TextComponent::text(target.gameprofile.name.clone())),
                     )),
             ],

--- a/pumpkin/src/command/commands/clear.rs
+++ b/pumpkin/src/command/commands/clear.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use pumpkin_inventory::Container;
+use pumpkin_util::text::click::ClickEvent;
 use pumpkin_util::text::color::NamedColor;
+use pumpkin_util::text::hover::HoverEvent;
 use pumpkin_util::text::TextComponent;
 
 use crate::command::args::entities::EntitiesArgumentConsumer;
@@ -36,23 +38,38 @@ async fn clear_player(target: &Player) -> usize {
 
 fn clear_command_text_output(item_count: usize, targets: &[Arc<Player>]) -> TextComponent {
     match targets {
-        [target] if item_count == 0 => TextComponent::text(format!(
-            "No items were found on player {}",
-            target.gameprofile.name
-        ))
+        [target] if item_count == 0 => TextComponent::translate(
+            "clear.failed.single",
+            vec![TextComponent::text(target.gameprofile.name.clone())],
+        )
         .color_named(NamedColor::Red),
-        [target] => TextComponent::text(format!(
-            "Removed {} item(s) on player {}",
-            item_count, target.gameprofile.name
-        )),
-        targets if item_count == 0 => {
-            TextComponent::text(format!("No items were found on {} players", targets.len()))
-                .color_named(NamedColor::Red)
-        }
-        targets => TextComponent::text(format!(
-            "Removed {item_count} item(s) from {} players",
-            targets.len()
-        )),
+        [target] => TextComponent::translate(
+            "commands.clear.success.single",
+            vec![
+                TextComponent::text(item_count.to_string()),
+                TextComponent::text(target.gameprofile.name.clone())
+                    .click_event(ClickEvent::SuggestCommand(
+                        format!("/tell {} ", target.gameprofile.name.clone()).into(),
+                    ))
+                    .hover_event(HoverEvent::show_entity(
+                        target.living_entity.entity.entity_uuid.to_string(),
+                        Some(target.living_entity.entity.entity_type.to_string()),
+                        Some(TextComponent::text(target.gameprofile.name.clone())),
+                    )),
+            ],
+        ),
+        targets if item_count == 0 => TextComponent::translate(
+            "clear.failed.multiple",
+            vec![TextComponent::text(targets.len().to_string())],
+        )
+        .color_named(NamedColor::Red),
+        targets => TextComponent::translate(
+            "commands.clear.success.multiple",
+            vec![
+                TextComponent::text(item_count.to_string()),
+                TextComponent::text(targets.len().to_string()),
+            ],
+        ),
     }
 }
 

--- a/pumpkin/src/command/commands/give.rs
+++ b/pumpkin/src/command/commands/give.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
+use pumpkin_util::text::click::ClickEvent;
 use pumpkin_util::text::color::{Color, NamedColor};
+use pumpkin_util::text::hover::HoverEvent;
 use pumpkin_util::text::TextComponent;
 
 use crate::command::args::bounded_num::BoundedNumArgumentConsumer;
@@ -60,17 +62,39 @@ impl CommandExecutor for GiveExecutor {
                 "commands.give.success.single",
                 [
                     TextComponent::text(item_count.to_string()),
-                    TextComponent::text(item_name.to_string()),
-                    TextComponent::text(targets[0].gameprofile.name.to_string()),
+                    TextComponent::text("[")
+                        .add_child(item.translated_name())
+                        .add_child(TextComponent::text("]"))
+                        .hover_event(HoverEvent::ShowItem {
+                            id: item_name.to_string().into(),
+                            count: Some(item_count),
+                            tag: None,
+                        }),
+                    TextComponent::text(targets[0].gameprofile.name.to_string())
+                        .hover_event(HoverEvent::show_entity(
+                            targets[0].living_entity.entity.entity_uuid.to_string(),
+                            Some(targets[0].living_entity.entity.entity_type.to_string()),
+                            Some(TextComponent::text(targets[0].gameprofile.name.clone())),
+                        ))
+                        .click_event(ClickEvent::SuggestCommand(
+                            format!("/tell {} ", targets[0].gameprofile.name.clone()).into(),
+                        )),
                 ]
                 .into(),
             )
         } else {
             TextComponent::translate(
-                "commands.give.success.single",
+                "commands.give.success.multiple",
                 [
                     TextComponent::text(item_count.to_string()),
-                    TextComponent::text(item_name.to_string()),
+                    TextComponent::text("[")
+                        .add_child(item.translated_name())
+                        .add_child(TextComponent::text("]"))
+                        .hover_event(HoverEvent::ShowItem {
+                            id: item_name.to_string().into(),
+                            count: Some(item_count),
+                            tag: None,
+                        }),
                     TextComponent::text(targets.len().to_string()),
                 ]
                 .into(),

--- a/pumpkin/src/command/commands/give.rs
+++ b/pumpkin/src/command/commands/give.rs
@@ -73,7 +73,10 @@ impl CommandExecutor for GiveExecutor {
                     TextComponent::text(targets[0].gameprofile.name.to_string())
                         .hover_event(HoverEvent::show_entity(
                             targets[0].living_entity.entity.entity_uuid.to_string(),
-                            Some(targets[0].living_entity.entity.entity_type.to_string()),
+                            Some(
+                                format!("{:?}", targets[0].living_entity.entity.entity_type)
+                                    .to_lowercase(),
+                            ),
                             Some(TextComponent::text(targets[0].gameprofile.name.clone())),
                         ))
                         .click_event(ClickEvent::SuggestCommand(

--- a/pumpkin/src/command/commands/kill.rs
+++ b/pumpkin/src/command/commands/kill.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
-use pumpkin_util::text::color::NamedColor;
+use pumpkin_data::entity;
+use pumpkin_util::text::click::ClickEvent;
+use pumpkin_util::text::hover::HoverEvent;
 use pumpkin_util::text::TextComponent;
 
 use crate::command::args::entities::EntitiesArgumentConsumer;
@@ -36,10 +38,21 @@ impl CommandExecutor for KillExecutor {
         }
 
         let msg = if target_count == 1 {
-            TextComponent::translate(
-                "commands.kill.success.single",
-                [TextComponent::text(name)].into(),
-            )
+            let entity = &targets[0].living_entity.entity;
+            let mut entity_display =
+                TextComponent::text(name.clone()).hover_event(HoverEvent::show_entity(
+                    entity.entity_uuid.to_string(),
+                    Some(entity.entity_type.to_string()),
+                    Some(TextComponent::text(name.clone())),
+                ));
+
+            if entity.entity_type == entity::EntityType::Player {
+                entity_display = entity_display.click_event(ClickEvent::SuggestCommand(
+                    format!("/tell {} ", name.clone()).into(),
+                ));
+            }
+
+            TextComponent::translate("commands.kill.success.single", [entity_display].into())
         } else {
             TextComponent::translate(
                 "commands.kill.success.multiple",
@@ -47,7 +60,7 @@ impl CommandExecutor for KillExecutor {
             )
         };
 
-        sender.send_message(msg.color_named(NamedColor::Blue)).await;
+        sender.send_message(msg).await;
 
         Ok(())
     }
@@ -64,8 +77,26 @@ impl CommandExecutor for KillSelfExecutor {
         _args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
         let target = sender.as_player().ok_or(CommandError::InvalidRequirement)?;
+        let name = target.gameprofile.name.clone();
+        let entity = &target.living_entity.entity;
 
         target.living_entity.kill().await;
+
+        sender
+            .send_message(TextComponent::translate(
+                "commands.kill.success.single",
+                [TextComponent::text(name.clone())
+                    .hover_event(HoverEvent::show_entity(
+                        entity.entity_uuid.to_string(),
+                        Some(entity.entity_type.to_string()),
+                        Some(TextComponent::text(name.clone())),
+                    ))
+                    .click_event(ClickEvent::SuggestCommand(
+                        format!("/tell {} ", name.clone()).into(),
+                    ))]
+                .into(),
+            ))
+            .await;
 
         Ok(())
     }

--- a/pumpkin/src/command/commands/kill.rs
+++ b/pumpkin/src/command/commands/kill.rs
@@ -42,7 +42,7 @@ impl CommandExecutor for KillExecutor {
             let mut entity_display =
                 TextComponent::text(name.clone()).hover_event(HoverEvent::show_entity(
                     entity.entity_uuid.to_string(),
-                    Some(entity.entity_type.to_string()),
+                    Some(format!("{:?}", entity.entity_type).to_lowercase()),
                     Some(TextComponent::text(name.clone())),
                 ));
 
@@ -88,7 +88,7 @@ impl CommandExecutor for KillSelfExecutor {
                 [TextComponent::text(name.clone())
                     .hover_event(HoverEvent::show_entity(
                         entity.entity_uuid.to_string(),
-                        Some(entity.entity_type.to_string()),
+                        Some(format!("{:?}", entity.entity_type).to_lowercase()),
                         Some(TextComponent::text(name.clone())),
                     ))
                     .click_event(ClickEvent::SuggestCommand(

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod kick;
 pub mod kill;
 pub mod list;
 pub mod me;
+pub mod msg;
 pub mod op;
 pub mod playsound;
 pub mod plugin;

--- a/pumpkin/src/command/commands/msg.rs
+++ b/pumpkin/src/command/commands/msg.rs
@@ -1,0 +1,92 @@
+use async_trait::async_trait;
+use pumpkin_data::world::{MSG_COMMAND_INCOMING, MSG_COMMAND_OUTGOING};
+use pumpkin_util::text::{click::ClickEvent, hover::HoverEvent, TextComponent};
+
+use crate::command::{
+    args::{
+        message::MsgArgConsumer, players::PlayersArgumentConsumer, Arg, ConsumedArgs,
+        FindArgDefaultName,
+    },
+    tree::CommandTree,
+    tree_builder::{argument, argument_default_name},
+    CommandError, CommandExecutor, CommandSender,
+};
+use CommandError::InvalidConsumption;
+
+const NAMES: [&str; 3] = ["msg", "tell", "w"];
+
+const DESCRIPTION: &str = "Sends a private message to one or more players.";
+
+const ARG_MESSAGE: &str = "message";
+
+struct MsgExecutor;
+
+#[async_trait]
+impl CommandExecutor for MsgExecutor {
+    async fn execute<'a>(
+        &self,
+        sender: &mut CommandSender<'a>,
+        _server: &crate::server::Server,
+        args: &ConsumedArgs<'a>,
+    ) -> Result<(), CommandError> {
+        let Some(Arg::Msg(msg)) = args.get(ARG_MESSAGE) else {
+            return Err(InvalidConsumption(Some(ARG_MESSAGE.into())));
+        };
+        let targets = PlayersArgumentConsumer.find_arg_default_name(args)?;
+        let player = sender.as_player().ok_or(CommandError::InvalidRequirement)?;
+
+        for target in targets {
+            player
+                .send_message(
+                    &TextComponent::text(msg.clone()),
+                    MSG_COMMAND_OUTGOING,
+                    &TextComponent::text(player.gameprofile.name.clone()),
+                    Some(
+                        &TextComponent::text(target.gameprofile.name.clone())
+                            .hover_event(HoverEvent::show_entity(
+                                target.living_entity.entity.entity_uuid.to_string(),
+                                Some(
+                                    format!("{:?}", target.living_entity.entity.entity_type)
+                                        .to_lowercase(),
+                                ),
+                                Some(TextComponent::text(target.gameprofile.name.clone())),
+                            ))
+                            .click_event(ClickEvent::SuggestCommand(
+                                format!("/tell {} ", target.gameprofile.name.clone()).into(),
+                            )),
+                    ),
+                )
+                .await;
+        }
+        for target in targets {
+            target
+                .send_message(
+                    &TextComponent::text(msg.clone()),
+                    MSG_COMMAND_INCOMING,
+                    &TextComponent::text(player.gameprofile.name.clone())
+                        .hover_event(HoverEvent::show_entity(
+                            player.living_entity.entity.entity_uuid.to_string(),
+                            Some(
+                                format!("{:?}", player.living_entity.entity.entity_type)
+                                    .to_lowercase(),
+                            ),
+                            Some(TextComponent::text(player.gameprofile.name.clone())),
+                        ))
+                        .click_event(ClickEvent::SuggestCommand(
+                            format!("/tell {} ", player.gameprofile.name.clone()).into(),
+                        )),
+                    Some(&TextComponent::text(target.gameprofile.name.clone())),
+                )
+                .await;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).then(
+        argument_default_name(PlayersArgumentConsumer)
+            .then(argument(ARG_MESSAGE, MsgArgConsumer).execute(MsgExecutor)),
+    )
+}

--- a/pumpkin/src/command/commands/pumpkin.rs
+++ b/pumpkin/src/command/commands/pumpkin.rs
@@ -32,7 +32,7 @@ impl CommandExecutor for PumpkinExecutor {
     ) -> Result<(), CommandError> {
         sender
             .send_message(
-                TextComponent::text(format!("Pumpkin {CARGO_PKG_VERSION} ({GIT_VERSION})"))
+                TextComponent::text(format!("Pumpkin {CARGO_PKG_VERSION} ({GIT_VERSION})\n"))
                     .hover_event(HoverEvent::show_text(TextComponent::text(Cow::from(
                         "Click to Copy Version",
                     ))))
@@ -41,18 +41,22 @@ impl CommandExecutor for PumpkinExecutor {
                     ))))
                     .color_named(NamedColor::Green)
                     .add_child(
-                        TextComponent::text(format!(", {CARGO_PKG_DESCRIPTION}"))
-                            .click_event(ClickEvent::CopyToClipboard(Cow::from(
-                                CARGO_PKG_DESCRIPTION,
-                            )))
-                            .hover_event(HoverEvent::show_text(TextComponent::text(Cow::from(
-                                "Click to Copy Description",
-                            ))))
-                            .color_named(NamedColor::White),
+                        TextComponent::text(format!(
+                            "{}\n{}\n",
+                            &CARGO_PKG_DESCRIPTION[0..35],
+                            &CARGO_PKG_DESCRIPTION[37..]
+                        ))
+                        .click_event(ClickEvent::CopyToClipboard(Cow::from(
+                            CARGO_PKG_DESCRIPTION,
+                        )))
+                        .hover_event(HoverEvent::show_text(TextComponent::text(Cow::from(
+                            "Click to Copy Description",
+                        ))))
+                        .color_named(NamedColor::White),
                     )
                     .add_child(
                         TextComponent::text(format!(
-                            " (Minecraft {CURRENT_MC_VERSION}, Protocol {CURRENT_MC_PROTOCOL})"
+                            "(Minecraft {CURRENT_MC_VERSION}, Protocol {CURRENT_MC_PROTOCOL})\n"
                         ))
                         .click_event(ClickEvent::CopyToClipboard(Cow::from(format!(
                             "(Minecraft {CURRENT_MC_VERSION}, Protocol {CURRENT_MC_PROTOCOL})"
@@ -62,10 +66,9 @@ impl CommandExecutor for PumpkinExecutor {
                         ))))
                         .color_named(NamedColor::Gold),
                     )
-                    .add_child(TextComponent::text(" "))
                     // https://pumpkinmc.org/
                     .add_child(
-                        TextComponent::text("Github Repository")
+                        TextComponent::text("[Github Repository]")
                             .click_event(ClickEvent::OpenUrl(Cow::from(
                                 "https://github.com/Pumpkin-MC/Pumpkin",
                             )))
@@ -77,9 +80,9 @@ impl CommandExecutor for PumpkinExecutor {
                             .underlined(),
                     )
                     // Added docs. and a space for spacing
-                    .add_child(TextComponent::text(" "))
+                    .add_child(TextComponent::text("  "))
                     .add_child(
-                        TextComponent::text("Website")
+                        TextComponent::text("[Website]")
                             .click_event(ClickEvent::OpenUrl(Cow::from("https://pumpkinmc.org/")))
                             .hover_event(HoverEvent::show_text(TextComponent::text(Cow::from(
                                 "Click to open website.",

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -10,8 +10,8 @@ use crate::world::World;
 use args::ConsumedArgs;
 use async_trait::async_trait;
 use commands::{
-    clear, deop, fill, gamemode, give, help, kick, kill, list, me, op, playsound, plugin, plugins,
-    pumpkin, say, setblock, stop, summon, teleport, time, title, worldborder,
+    clear, deop, fill, gamemode, give, help, kick, kill, list, me, msg, op, playsound, plugin,
+    plugins, pumpkin, say, setblock, stop, summon, teleport, time, title, worldborder,
 };
 use dispatcher::CommandError;
 use pumpkin_util::math::vector3::Vector3;
@@ -137,6 +137,7 @@ pub fn default_dispatcher() -> CommandDispatcher {
     dispatcher.register(playsound::init_command_tree(), PermissionLvl::Two);
     dispatcher.register(title::init_command_tree(), PermissionLvl::Two);
     dispatcher.register(summon::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(msg::init_command_tree(), PermissionLvl::Zero);
 
     dispatcher
 }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -19,9 +19,9 @@ use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_protocol::{
     bytebuf::packet_id::Packet,
     client::play::{
-        CActionBar, CCombatDeath, CEntityStatus, CGameEvent, CHurtAnimation, CKeepAlive,
-        CPlayDisconnect, CPlayerAbilities, CPlayerInfoUpdate, CPlayerPosition, CSetHealth,
-        CSubtitle, CSystemChatMessage, CTitleText, GameEvent, PlayerAction,
+        CActionBar, CCombatDeath, CDisguisedChatMessage, CEntityStatus, CGameEvent, CHurtAnimation,
+        CKeepAlive, CPlayDisconnect, CPlayerAbilities, CPlayerInfoUpdate, CPlayerPosition,
+        CSetHealth, CSubtitle, CSystemChatMessage, CTitleText, GameEvent, PlayerAction,
     },
     server::play::{
         SChatCommand, SChatMessage, SClientCommand, SClientInformationPlay, SClientTickEnd,
@@ -712,6 +712,23 @@ impl Player {
             .broadcast_packet_all(&CSetEntityMetadata::new(
                 self.entity_id().into(),
                 Metadata::new(18, 0.into(), config.main_hand as u8),
+            ))
+            .await;
+    }
+
+    pub async fn send_message(
+        &self,
+        message: &TextComponent,
+        chat_type: u32,
+        sender_name: &TextComponent,
+        target_name: Option<&TextComponent>,
+    ) {
+        self.client
+            .send_packet(&CDisguisedChatMessage::new(
+                message,
+                (chat_type + 1).into(),
+                sender_name,
+                target_name,
             ))
             .await;
     }

--- a/pumpkin/src/world/custom_bossbar.rs
+++ b/pumpkin/src/world/custom_bossbar.rs
@@ -9,11 +9,11 @@ use thiserror::Error;
 use uuid::Uuid;
 
 #[derive(Debug, Error)]
-pub enum BossbarUpdateError {
+pub enum BossbarUpdateError<'a> {
     #[error("Invalid resource location")]
     InvalidResourceLocation(String),
     #[error("No changes")]
-    NoChanges(String),
+    NoChanges(&'a str, Option<&'a str>),
 }
 
 /// Representing the stored custom boss bars from level.dat
@@ -148,9 +148,7 @@ impl CustomBossbars {
         let bossbar = self.custom_bossbars.get_mut(&resource_location);
         if let Some(bossbar) = bossbar {
             if bossbar.value == value && bossbar.max == max_value {
-                return Err(BossbarUpdateError::NoChanges(String::from(
-                    "That's already the value of this bossbar",
-                )));
+                return Err(BossbarUpdateError::NoChanges("value", None));
             }
 
             let ratio = f64::from(value) / f64::from(max_value);
@@ -199,15 +197,11 @@ impl CustomBossbars {
         let bossbar = self.custom_bossbars.get_mut(&resource_location);
         if let Some(bossbar) = bossbar {
             if bossbar.visible == new_visibility && new_visibility {
-                return Err(BossbarUpdateError::NoChanges(String::from(
-                    "The bossbar is already visible",
-                )));
+                return Err(BossbarUpdateError::NoChanges("visibility", Some("visible")));
             }
 
             if bossbar.visible == new_visibility && !new_visibility {
-                return Err(BossbarUpdateError::NoChanges(String::from(
-                    "The bossbar is already hidden",
-                )));
+                return Err(BossbarUpdateError::NoChanges("visibility", Some("hidden")));
             }
 
             bossbar.visible = new_visibility;
@@ -242,9 +236,7 @@ impl CustomBossbars {
         let bossbar = self.custom_bossbars.get_mut(resource_location);
         if let Some(bossbar) = bossbar {
             if bossbar.bossbar_data.title == new_title {
-                return Err(BossbarUpdateError::NoChanges(String::from(
-                    "That's already the name of this bossbar",
-                )));
+                return Err(BossbarUpdateError::NoChanges("name", None));
             }
 
             bossbar.bossbar_data.title = new_title;
@@ -283,9 +275,7 @@ impl CustomBossbars {
         let bossbar = self.custom_bossbars.get_mut(&resource_location);
         if let Some(bossbar) = bossbar {
             if bossbar.bossbar_data.color == new_color {
-                return Err(BossbarUpdateError::NoChanges(String::from(
-                    "That's already the color of this bossbar",
-                )));
+                return Err(BossbarUpdateError::NoChanges("color", None));
             }
 
             bossbar.bossbar_data.color = new_color;
@@ -325,9 +315,7 @@ impl CustomBossbars {
         let bossbar = self.custom_bossbars.get_mut(&resource_location);
         if let Some(bossbar) = bossbar {
             if bossbar.bossbar_data.division == new_division {
-                return Err(BossbarUpdateError::NoChanges(String::from(
-                    "That's already the style of this bossbar",
-                )));
+                return Err(BossbarUpdateError::NoChanges("style", None));
             }
 
             bossbar.bossbar_data.division = new_division;
@@ -381,9 +369,7 @@ impl CustomBossbars {
                 .collect();
 
             if removed_players.is_empty() && added_players.is_empty() {
-                return Err(BossbarUpdateError::NoChanges(String::from(
-                    "Those players are already on the bossbar with nobody to add or remove",
-                )));
+                return Err(BossbarUpdateError::NoChanges("players", None));
             }
 
             if bossbar.visible {


### PR DESCRIPTION
## Description
Added parity with vanilla to texts from the following commands:
- Clear
- Kill
- Give
- Msg

The pumpkin command has also been formatted to make it more readable.
Other minors changes are:
1.  Updated show_entity from HoverEvents to make it easier to use.
2.  On EntityType added to_str and to_string which returns the identifier of the entity. (Resource location)
3.  On item added translated_name which returns the TextComponent::translate suitable for that item.

Note: Many of the changes requires [F3 + H] (Advanced Tooltips) to be shown.

## Update
Added msg command to match with the changes above, for its implementation the function send_message was added to Player.

## Testing

**Pumpkin commands**
![image](https://github.com/user-attachments/assets/a11fbd9b-dac3-458d-9c7c-8d0752c8d925)
**Player selection and tell**
![image](https://github.com/user-attachments/assets/0fe203ea-55d3-429e-8f93-f45b18756591)
**Item show**
![image](https://github.com/user-attachments/assets/d6e7877e-59d6-4d34-84d3-fe275fc82829)
**Msg command**
![image](https://github.com/user-attachments/assets/0a64b57d-c612-4f8a-88ee-1bd13c09bffe)


Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
