### PR TITLE
Velocity missing game profile

### DIFF
--- a/pumpkin/src/net/mod.rs
+++ b/pumpkin/src/net/mod.rs
@@ -490,7 +490,7 @@ impl Client {
                     .await;
             }
             SAcknowledgeFinishConfig::PACKET_ID => {
-                self.handle_config_acknowledged();
+                self.handle_config_acknowledged().await;
             }
             SKnownPacks::PACKET_ID => {
                 self.handle_known_packs(server, SKnownPacks::read(bytebuf)?)
@@ -544,9 +544,7 @@ impl Client {
 
     /// Checks if the client can join the server.
     pub async fn can_not_join(&self) -> Option<TextComponent> {
-        let profile: tokio::sync::MutexGuard<'_, Option<GameProfile>> =
-            self.gameprofile.lock().await;
-
+        let profile = self.gameprofile.lock().await;
         let Some(profile) = profile.as_ref() else {
             return Some(TextComponent::text("Missing GameProfile"));
         };

--- a/pumpkin/src/net/packet/config.rs
+++ b/pumpkin/src/net/packet/config.rs
@@ -92,9 +92,15 @@ impl Client {
         self.send_packet(&CFinishConfig::new()).await;
     }
 
-    pub fn handle_config_acknowledged(&self) {
+    pub async fn handle_config_acknowledged(&self) {
         log::debug!("Handling config acknowledge");
         self.connection_state.store(ConnectionState::Play);
+
+        if let Some(reason) = self.can_not_join().await {
+            self.kick(&reason).await;
+            return;
+        }
+
         self.make_player
             .store(true, std::sync::atomic::Ordering::Relaxed);
     }

--- a/pumpkin/src/net/packet/login.rs
+++ b/pumpkin/src/net/packet/login.rs
@@ -158,12 +158,6 @@ impl Client {
 
             *gameprofile = Some(profile);
         }
-
-        drop(gameprofile);
-
-        if let Some(reason) = self.can_not_join().await {
-            self.kick(&reason).await;
-        }
     }
 
     pub async fn handle_encryption_response(


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Moved `can_not_join` check from login state to end of configuration.
This fixes the "Missing GameProfile" issue, when using velocity, reported on discord.

## Testing
Joining both on velocity and without a proxy, while being banned/not banned.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
