### PR TITLE
Mini properties repair

### DIFF
--- a/pumpkin/src/block/properties/cardinal.rs
+++ b/pumpkin/src/block/properties/cardinal.rs
@@ -70,7 +70,6 @@ pub async fn evaluate_fence_direction(
                 return North::True.value();
             }
 
-            let mut connections = 0u8;
             let mut x = 0u8;
             let mut z = 0u8;
             for side in &[
@@ -82,7 +81,6 @@ pub async fn evaluate_fence_direction(
                 let other_side_block = BlockPos(block_pos.0.add(&side.to_offset()));
                 let block = world.get_block(&other_side_block).await.unwrap();
                 if block.id != 0 {
-                    connections += 1;
                     if *side == BlockDirection::North || *side == BlockDirection::South {
                         x += 1;
                     } else {
@@ -90,16 +88,16 @@ pub async fn evaluate_fence_direction(
                     }
                 }
             }
-            if connections > 2 || x == 2 || z == 2 {
+            if (z == 0 || z == 2) && x == 2 || (x == 0 && z == 2) {
                 return North::False.value();
             }
 
             return North::True.value();
         }
         if block.id != 0 {
-            let other_side_block = BlockPos(other_side_block.0.add(&Vector3::new(0, 1, 0)));
+            let other_side_block = BlockPos(block_pos.0.add(&Vector3::new(0, 1, 0)));
             let block = world.get_block(&other_side_block).await.unwrap();
-            if block.id != 0 && block.name.ends_with("_wall") {
+            if block.id != 0 {
                 return North::Tall.value();
             }
             return North::Low.value();
@@ -118,14 +116,14 @@ impl BlockProperty for Down {
         &self,
         world: &World,
         block: &Block,
-        face: &BlockDirection,
+        _face: &BlockDirection,
         block_pos: &BlockPos,
         _use_item_on: &SUseItemOn,
         _player_direction: &Direction,
         _properties: &BlockProperties,
         _other: bool,
     ) -> String {
-        evaluate_fence_direction(world, block, face, block_pos).await
+        evaluate_fence_direction(world, block, &BlockDirection::Bottom, block_pos).await
     }
 }
 #[async_trait]
@@ -134,14 +132,14 @@ impl BlockProperty for East {
         &self,
         world: &World,
         block: &Block,
-        face: &BlockDirection,
+        _face: &BlockDirection,
         block_pos: &BlockPos,
         _use_item_on: &SUseItemOn,
         _player_direction: &Direction,
         _properties: &BlockProperties,
         _other: bool,
     ) -> String {
-        evaluate_fence_direction(world, block, face, block_pos).await
+        evaluate_fence_direction(world, block, &BlockDirection::East, block_pos).await
     }
 }
 #[async_trait]
@@ -150,14 +148,14 @@ impl BlockProperty for North {
         &self,
         world: &World,
         block: &Block,
-        face: &BlockDirection,
+        _face: &BlockDirection,
         block_pos: &BlockPos,
         _use_item_on: &SUseItemOn,
         _player_direction: &Direction,
         _properties: &BlockProperties,
         _other: bool,
     ) -> String {
-        evaluate_fence_direction(world, block, face, block_pos).await
+        evaluate_fence_direction(world, block, &BlockDirection::North, block_pos).await
     }
 }
 #[async_trait]
@@ -166,14 +164,14 @@ impl BlockProperty for South {
         &self,
         world: &World,
         block: &Block,
-        face: &BlockDirection,
+        _face: &BlockDirection,
         block_pos: &BlockPos,
         _use_item_on: &SUseItemOn,
         _player_direction: &Direction,
         _properties: &BlockProperties,
         _other: bool,
     ) -> String {
-        evaluate_fence_direction(world, block, face, block_pos).await
+        evaluate_fence_direction(world, block, &BlockDirection::South, block_pos).await
     }
 }
 #[async_trait]
@@ -182,14 +180,14 @@ impl BlockProperty for Up {
         &self,
         world: &World,
         block: &Block,
-        face: &BlockDirection,
+        _face: &BlockDirection,
         block_pos: &BlockPos,
         _use_item_on: &SUseItemOn,
         _player_direction: &Direction,
         _properties: &BlockProperties,
         _other: bool,
     ) -> String {
-        evaluate_fence_direction(world, block, face, block_pos).await
+        evaluate_fence_direction(world, block, &BlockDirection::Top, block_pos).await
     }
 }
 #[async_trait]
@@ -198,13 +196,13 @@ impl BlockProperty for West {
         &self,
         world: &World,
         block: &Block,
-        face: &BlockDirection,
+        _face: &BlockDirection,
         block_pos: &BlockPos,
         _use_item_on: &SUseItemOn,
         _player_direction: &Direction,
         _properties: &BlockProperties,
         _other: bool,
     ) -> String {
-        evaluate_fence_direction(world, block, face, block_pos).await
+        evaluate_fence_direction(world, block, &BlockDirection::West, block_pos).await
     }
 }

--- a/pumpkin/src/block/properties/waterlog.rs
+++ b/pumpkin/src/block/properties/waterlog.rs
@@ -4,6 +4,7 @@ use pumpkin_macros::block_property;
 use pumpkin_protocol::server::play::SUseItemOn;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::block::{registry::Block, BlockDirection};
+use pumpkin_world::item::ItemStack;
 
 use super::{BlockProperties, BlockProperty, BlockPropertyMetadata, Direction};
 
@@ -14,18 +15,28 @@ pub struct Waterlogged(bool);
 impl BlockProperty for Waterlogged {
     async fn on_place(
         &self,
-        _world: &World,
-        block: &Block,
+        world: &World,
+        _block: &Block,
         _face: &BlockDirection,
-        _block_pos: &BlockPos,
+        block_pos: &BlockPos,
         _use_item_on: &SUseItemOn,
         _player_direction: &Direction,
         _properties: &BlockProperties,
         _other: bool,
     ) -> String {
+        let block = world.get_block(block_pos).await.unwrap();
         if block.name == "water" {
             return Self::True().value();
         }
         Self::False().value()
+    }
+    async fn on_interact(&self, value: String, _block: &Block, item: &ItemStack) -> String {
+        if value == Self::True().value() && item.item.id == 941 {
+            return Self::False().value();
+        }
+        if value == Self::False().value() && item.item.id == 942 {
+            return Self::True().value();
+        }
+        value
     }
 }

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -994,7 +994,7 @@ impl Player {
             let block_state = world.get_block_state(&location).await?;
             let new_state = server
                 .block_properties_manager
-                .on_interact(block, block_state, &ItemStack::new(0, Item::AIR))
+                .on_interact(block, block_state, &stack)
                 .await;
             world.set_block_state(&location, new_state).await;
             self.client


### PR DESCRIPTION
## Description
Added the ability to waterlog blocks when you place them on water, or when you use a bucket.
Also repaired the properties to fences/walls, which were broken due to a error on the rework properties transfer

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
