### PR TITLE
Terminal and exit improvements

### DIFF
--- a/pumpkin/src/command/commands/stop.rs
+++ b/pumpkin/src/command/commands/stop.rs
@@ -26,14 +26,7 @@ impl CommandExecutor for StopExecutor {
                     .color_named(NamedColor::Red),
             )
             .await;
-
-        // TODO: Gracefully stop
-
-        let kick_message = TextComponent::text("Server stopped");
-        for player in server.get_all_players().await {
-            player.kick(kick_message.clone()).await;
-        }
-        server.save().await;
+        server.handle_stop(None).await;
         std::process::exit(0)
     }
 }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -12,6 +12,7 @@ use pumpkin_util::math::boundingbox::{BoundingBox, EntityDimensions};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::math::vector3::Vector3;
+use pumpkin_util::text::color::NamedColor;
 use pumpkin_util::text::TextComponent;
 use pumpkin_world::block::registry::Block;
 use pumpkin_world::dimension::Dimension;
@@ -475,5 +476,21 @@ impl Server {
         for world in self.worlds.read().await.iter() {
             world.tick().await;
         }
+    }
+
+    pub async fn handle_stop(&self, kick_msg: Option<TextComponent>) {
+        log::warn!(
+            "{}",
+            TextComponent::text("Received interrupt signal; stopping server...")
+                .color_named(NamedColor::Red)
+                .to_pretty_console()
+        );
+
+        // TODO: Gracefully stop
+        let kick_message = kick_msg.unwrap_or_else(|| TextComponent::text("Server stopped"));
+        for player in self.get_all_players().await {
+            player.kick(kick_message.clone()).await;
+        }
+        self.save().await;
     }
 }


### PR DESCRIPTION
## Description
Solved the bad handling of Ctrl + C to exit as intended, also combined all the stop behaviors into "handle_stop".
Added history to terminal, currently only saved on Ctrl +C/D exits.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
