### PR TITLE
Fix HoverEvent::show_entity calls

### DIFF
--- a/pumpkin-data/build/entity_type.rs
+++ b/pumpkin-data/build/entity_type.rs
@@ -18,7 +18,7 @@ pub struct EntityType {
 
 pub struct NamedEntityType<'a>(&'a str, &'a EntityType);
 
-impl<'a> ToTokens for NamedEntityType<'a> {
+impl ToTokens for NamedEntityType<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let name = self.0;
         let entity = self.1;

--- a/pumpkin-data/build/entity_type.rs
+++ b/pumpkin-data/build/entity_type.rs
@@ -16,26 +16,30 @@ pub struct EntityType {
     pub eye_height: f32,
 }
 
-impl ToTokens for EntityType {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let id = LitInt::new(&self.id.to_string(), proc_macro2::Span::call_site());
+pub struct NamedEntityType<'a>(&'a str, &'a EntityType);
 
-        let max_health = match self.max_health {
+impl<'a> ToTokens for NamedEntityType<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let name = self.0;
+        let entity = self.1;
+        let id = LitInt::new(&entity.id.to_string(), proc_macro2::Span::call_site());
+
+        let max_health = match entity.max_health {
             Some(mh) => quote! { Some(#mh) },
             None => quote! { None },
         };
 
-        let attackable = match self.attackable {
+        let attackable = match entity.attackable {
             Some(a) => quote! { Some(#a) },
             None => quote! { None },
         };
 
-        let summonable = self.summonable;
-        let fire_immune = self.fire_immune;
-        let eye_height = self.eye_height;
+        let summonable = entity.summonable;
+        let fire_immune = entity.fire_immune;
+        let eye_height = entity.eye_height;
 
-        let dimension0 = self.dimension[0];
-        let dimension1 = self.dimension[1];
+        let dimension0 = entity.dimension[0];
+        let dimension1 = entity.dimension[1];
 
         tokens.extend(quote! {
             EntityType {
@@ -46,6 +50,7 @@ impl ToTokens for EntityType {
                 fire_immune: #fire_immune,
                 dimension: [#dimension0, #dimension1], // Correctly construct the array
                 eye_height: #eye_height,
+                resource_name: #name,
             }
         });
     }
@@ -67,7 +72,7 @@ pub(crate) fn build() -> TokenStream {
         let id_lit = LitInt::new(&id.to_string(), proc_macro2::Span::call_site());
         let upper_name = format_ident!("{}", name.to_uppercase());
 
-        let entity_tokens = entity.to_token_stream();
+        let entity_tokens = NamedEntityType(name, entity).to_token_stream();
 
         consts.extend(quote! {
             pub const #upper_name: EntityType = #entity_tokens;
@@ -91,6 +96,7 @@ pub(crate) fn build() -> TokenStream {
             pub fire_immune: bool,
             pub dimension: [f32; 2],
             pub eye_height: f32,
+            pub resource_name: &'static str,
         }
 
         impl EntityType {

--- a/pumpkin-util/src/text/hover.rs
+++ b/pumpkin-util/src/text/hover.rs
@@ -38,13 +38,13 @@ impl HoverEvent {
     pub fn show_text(text: TextComponent) -> Self {
         Self::ShowText(vec![text.0])
     }
-    pub fn show_entity<P>(id: P, kind: Option<P>, name: Option<TextComponent>) -> Self
+    pub fn show_entity<P>(id: P, kind: P, name: Option<TextComponent>) -> Self
     where
         P: Into<Cow<'static, str>>,
     {
         Self::ShowEntity {
             id: id.into(),
-            r#type: kind.map(|kind| kind.into()),
+            r#type: Some(kind.into()),
             name: match name {
                 Some(name) => Some(vec![name.0]),
                 None => None,

--- a/pumpkin/src/command/commands/clear.rs
+++ b/pumpkin/src/command/commands/clear.rs
@@ -53,9 +53,7 @@ fn clear_command_text_output(item_count: usize, targets: &[Arc<Player>]) -> Text
                     ))
                     .hover_event(HoverEvent::show_entity(
                         target.living_entity.entity.entity_uuid.to_string(),
-                        Some(
-                            format!("{:?}", target.living_entity.entity.entity_type).to_lowercase(),
-                        ),
+                        target.living_entity.entity.entity_type.resource_name.into(),
                         Some(TextComponent::text(target.gameprofile.name.clone())),
                     )),
             ],

--- a/pumpkin/src/command/commands/give.rs
+++ b/pumpkin/src/command/commands/give.rs
@@ -72,10 +72,12 @@ impl CommandExecutor for GiveExecutor {
                     TextComponent::text(targets[0].gameprofile.name.to_string())
                         .hover_event(HoverEvent::show_entity(
                             targets[0].living_entity.entity.entity_uuid.to_string(),
-                            Some(
-                                format!("{:?}", targets[0].living_entity.entity.entity_type)
-                                    .to_lowercase(),
-                            ),
+                            targets[0]
+                                .living_entity
+                                .entity
+                                .entity_type
+                                .resource_name
+                                .into(),
                             Some(TextComponent::text(targets[0].gameprofile.name.clone())),
                         ))
                         .click_event(ClickEvent::SuggestCommand(

--- a/pumpkin/src/command/commands/kill.rs
+++ b/pumpkin/src/command/commands/kill.rs
@@ -42,7 +42,7 @@ impl CommandExecutor for KillExecutor {
             let mut entity_display =
                 TextComponent::text(name.clone()).hover_event(HoverEvent::show_entity(
                     entity.entity_uuid.to_string(),
-                    Some(format!("{:?}", entity.entity_type).to_lowercase()),
+                    entity.entity_type.resource_name.into(),
                     Some(TextComponent::text(name.clone())),
                 ));
 
@@ -88,7 +88,7 @@ impl CommandExecutor for KillSelfExecutor {
                 [TextComponent::text(name.clone())
                     .hover_event(HoverEvent::show_entity(
                         entity.entity_uuid.to_string(),
-                        Some(format!("{:?}", entity.entity_type).to_lowercase()),
+                        entity.entity_type.resource_name.into(),
                         Some(TextComponent::text(name.clone())),
                     ))
                     .click_event(ClickEvent::SuggestCommand(

--- a/pumpkin/src/command/commands/msg.rs
+++ b/pumpkin/src/command/commands/msg.rs
@@ -45,10 +45,7 @@ impl CommandExecutor for MsgExecutor {
                         &TextComponent::text(target.gameprofile.name.clone())
                             .hover_event(HoverEvent::show_entity(
                                 target.living_entity.entity.entity_uuid.to_string(),
-                                Some(
-                                    format!("{:?}", target.living_entity.entity.entity_type)
-                                        .to_lowercase(),
-                                ),
+                                target.living_entity.entity.entity_type.resource_name.into(),
                                 Some(TextComponent::text(target.gameprofile.name.clone())),
                             ))
                             .click_event(ClickEvent::SuggestCommand(
@@ -66,10 +63,7 @@ impl CommandExecutor for MsgExecutor {
                     &TextComponent::text(player.gameprofile.name.clone())
                         .hover_event(HoverEvent::show_entity(
                             player.living_entity.entity.entity_uuid.to_string(),
-                            Some(
-                                format!("{:?}", player.living_entity.entity.entity_type)
-                                    .to_lowercase(),
-                            ),
+                            player.living_entity.entity.entity_type.resource_name.into(),
                             Some(TextComponent::text(player.gameprofile.name.clone())),
                         ))
                         .click_event(ClickEvent::SuggestCommand(


### PR DESCRIPTION
## Description
Give valid entity type to HoverEvent::show_entity calls.

Previously, executing a command such as /give, /msg, etc would cause the client to close connection because of an invalid entity type in HoverEvent within the chat message sent to the player.

Modified pumkin-data to expose the resource name of entities.
Also made the `kind` parameter not `Option`, because a value of `None` also causes the client to crash.

## Previous Behavior
https://github.com/user-attachments/assets/4f514ad9-27da-478a-b311-881bd84936cb

## Behavior with Fix
https://github.com/user-attachments/assets/b0a64455-6c03-4f95-a984-976155aaed5c

