### PR TITLE
Fix world.dat serialization

### DIFF
--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -41,7 +41,6 @@ enum_dispatch = "0.3"
 fastnbt = { git = "https://github.com/owengage/fastnbt.git" }
 
 noise = "0.9"
-rand = "0.8"
 
 # Had to use custom, because google's is broken, I made a PR.
 serde_json5 = { git = "https://github.com/kralverde/serde_json5.git" }
@@ -49,6 +48,7 @@ serde_json5 = { git = "https://github.com/kralverde/serde_json5.git" }
 derive-getters = "0.5.0"
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+temp-dir = "0.1.14"
 
 [[bench]]
 name = "chunk_noise_populate"

--- a/pumpkin-world/src/chunk/anvil.rs
+++ b/pumpkin-world/src/chunk/anvil.rs
@@ -492,6 +492,7 @@ mod tests {
     use pumpkin_util::math::vector2::Vector2;
     use std::fs;
     use std::path::PathBuf;
+    use temp_dir::TempDir;
 
     use crate::chunk::ChunkWriter;
     use crate::generation::{get_world_gen, Seed};
@@ -516,15 +517,13 @@ mod tests {
     #[test]
     fn test_writing() {
         let generator = get_world_gen(Seed(0));
-        let level_folder = LevelFolder {
-            root_folder: PathBuf::from("./tmp_Anvil"),
-            region_folder: PathBuf::from("./tmp_Anvil/region"),
-        };
-        if fs::exists(&level_folder.root_folder).unwrap() {
-            fs::remove_dir_all(&level_folder.root_folder).expect("Could not delete directory");
-        }
 
-        fs::create_dir_all(&level_folder.region_folder).expect("Could not create directory");
+        let temp_dir = TempDir::new().unwrap();
+        let level_folder = LevelFolder {
+            root_folder: temp_dir.path().to_path_buf(),
+            region_folder: temp_dir.path().join("region"),
+        };
+        fs::create_dir(&level_folder.region_folder).expect("couldn't create region folder");
 
         // Generate chunks
         let mut chunks = vec![];
@@ -560,8 +559,6 @@ mod tests {
                 assert_eq!(chunk.subchunks, read_chunk.subchunks, "Chunks don't match");
             }
         }
-
-        fs::remove_dir_all(&level_folder.root_folder).expect("Could not delete directory");
 
         println!("Checked chunks successfully");
     }

--- a/pumpkin-world/src/chunk/linear.rs
+++ b/pumpkin-world/src/chunk/linear.rs
@@ -461,6 +461,7 @@ mod tests {
     use pumpkin_util::math::vector2::Vector2;
     use std::fs;
     use std::path::PathBuf;
+    use temp_dir::TempDir;
 
     use crate::chunk::ChunkWriter;
     use crate::generation::{get_world_gen, Seed};
@@ -485,15 +486,13 @@ mod tests {
     #[test]
     fn test_writing() {
         let generator = get_world_gen(Seed(0));
-        let level_folder = LevelFolder {
-            root_folder: PathBuf::from("./tmp_Linear"),
-            region_folder: PathBuf::from("./tmp_Linear/region"),
-        };
-        if fs::exists(&level_folder.root_folder).unwrap() {
-            fs::remove_dir_all(&level_folder.root_folder).expect("Could not delete directory");
-        }
 
-        fs::create_dir_all(&level_folder.region_folder).expect("Could not create directory");
+        let temp_dir = TempDir::new().unwrap();
+        let level_folder = LevelFolder {
+            root_folder: temp_dir.path().to_path_buf(),
+            region_folder: temp_dir.path().join("region"),
+        };
+        fs::create_dir(&level_folder.region_folder).expect("couldn't create region folder");
 
         // Generate chunks
         let mut chunks = vec![];
@@ -529,8 +528,6 @@ mod tests {
                 assert_eq!(chunk.subchunks, read_chunk.subchunks, "Chunks don't match");
             }
         }
-
-        fs::remove_dir_all(&level_folder.root_folder).expect("Could not delete directory");
 
         println!("Checked chunks successfully");
     }

--- a/pumpkin-world/src/generation/implementation/overworld/biome/plains.rs
+++ b/pumpkin-world/src/generation/implementation/overworld/biome/plains.rs
@@ -1,8 +1,10 @@
 use noise::Perlin;
 use pumpkin_data::chunk::Biome;
 use pumpkin_macros::block_state;
-use pumpkin_util::math::vector2::Vector2;
-use rand::Rng;
+use pumpkin_util::{
+    math::vector2::Vector2,
+    random::{self, xoroshiro128::Xoroshiro, RandomImpl},
+};
 
 use crate::{
     chunk::Subchunks,
@@ -63,12 +65,15 @@ impl PerlinTerrainGenerator for PlainsTerrainGenerator {
         } else if y == chunk_height - 2 {
             subchunks.set_block(coordinates, block_state!("grass_block").state_id);
         } else if y == chunk_height - 1 {
+            let seed = random::get_seed();
+            let mut random = Xoroshiro::from_seed(seed);
+
             // TODO: generate flowers and grass
-            let grass: u8 = rand::thread_rng().gen_range(0..7);
+            let grass = random.next_bounded_i32(8);
             if grass == 3 {
-                let flower: u8 = rand::thread_rng().gen_range(0..20);
+                let flower = random.next_bounded_i32(20);
                 if flower == 6 {
-                    match rand::thread_rng().gen_range(0..4) {
+                    match random.next_bounded_i32(5) {
                         0 => {
                             subchunks.set_block(coordinates, block_state!("dandelion").state_id);
                         }

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -23,7 +23,7 @@ use crate::{
     lock::{anvil::AnvilLevelLocker, LevelLocker},
     world_info::{
         anvil::{AnvilLevelInfo, LEVEL_DAT_BACKUP_FILE_NAME, LEVEL_DAT_FILE_NAME},
-        LevelData, WorldInfoReader, WorldInfoWriter,
+        LevelData, WorldInfoError, WorldInfoReader, WorldInfoWriter,
     },
 };
 
@@ -76,9 +76,15 @@ impl Level {
         // TODO: Load info correctly based on world format type
         let level_info = AnvilLevelInfo.read_world_info(&level_folder);
         if let Err(error) = &level_info {
-            log::warn!("Failed to load world info!");
-            log::warn!("{:?}", error);
-            log::warn!("Using default world options!");
+            match error {
+                // If it doesn't exist, just make a new one
+                WorldInfoError::InfoNotFound => (),
+                _ => {
+                    log::error!("Failed to load world info!");
+                    log::error!("{}", error);
+                    panic!("Unsupported world data! See the logs for more info.");
+                }
+            }
         } else {
             let dat_path = level_folder.root_folder.join(LEVEL_DAT_FILE_NAME);
             if dat_path.exists() {

--- a/pumpkin-world/src/world_info/mod.rs
+++ b/pumpkin-world/src/world_info/mod.rs
@@ -7,6 +7,9 @@ use crate::{generation::Seed, level::LevelFolder};
 
 pub mod anvil;
 
+pub const MINIMUM_SUPPORTED_WORLD_DATA_VERSION: u32 = 4080; // 1.21.2
+pub const MAXIMUM_SUPPORTED_WORLD_DATA_VERSION: u32 = 4189; // 1.21.4
+
 pub(crate) trait WorldInfoReader {
     fn read_world_info(&self, level_folder: &LevelFolder) -> Result<LevelData, WorldInfoError>;
 }
@@ -23,7 +26,7 @@ pub(crate) trait WorldInfoWriter: Sync + Send {
 #[serde(rename_all = "PascalCase")]
 pub struct LevelData {
     // An integer displaying the data version.
-    pub data_version: i32,
+    pub data_version: u32,
     // The current difficulty setting.
     pub difficulty: u8,
     // the generation settings for each dimension.
@@ -95,8 +98,8 @@ impl Default for WorldVersion {
 impl Default for LevelData {
     fn default() -> Self {
         Self {
-            // TODO
-            data_version: -1,
+            // TODO: Define defaults somewhere
+            data_version: MAXIMUM_SUPPORTED_WORLD_DATA_VERSION,
             difficulty: Difficulty::Normal as u8,
             world_gen_settings: Default::default(),
             last_played: -1,
@@ -119,6 +122,8 @@ pub enum WorldInfoError {
     InfoNotFound,
     #[error("Deserialization error: {0}")]
     DeserializationError(String),
+    #[error("Unsupported world data version: {0}")]
+    UnsupportedVersion(u32),
 }
 
 impl From<std::io::Error> for WorldInfoError {

--- a/pumpkin-world/src/world_info/mod.rs
+++ b/pumpkin-world/src/world_info/mod.rs
@@ -21,10 +21,7 @@ pub(crate) trait WorldInfoWriter: Sync + Send {
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
-#[serde(default)]
 pub struct LevelData {
-    // true if cheats are enabled.
-    pub allow_commands: bool,
     // An integer displaying the data version.
     pub data_version: i32,
     // The current difficulty setting.
@@ -58,7 +55,7 @@ pub struct WorldGenSettings {
 }
 
 fn get_or_create_seed() -> Seed {
-    // TODO: if there is a seed in the config (!= 0) use it. Otherwise make a random one
+    // TODO: if there is a seed in the config (!= "") use it. Otherwise make a random one
     Seed::from(BASIC_CONFIG.seed.as_str())
 }
 
@@ -78,7 +75,9 @@ pub struct WorldVersion {
     // An integer displaying the data version.
     pub id: i32,
     // Whether the version is a snapshot or not.
-    pub snapshot: bool,
+    // TODO: fast_nbt doesnt support bools
+    // pub snapshot: bool,
+
     // Developing series. In 1.18 experimental snapshots, it was set to "ccpreview". In others, set to "main".
     pub series: String,
 }
@@ -88,7 +87,6 @@ impl Default for WorldVersion {
         Self {
             name: "1.24.4".to_string(),
             id: -1,
-            snapshot: false,
             series: "main".to_string(),
         }
     }
@@ -97,7 +95,6 @@ impl Default for WorldVersion {
 impl Default for LevelData {
     fn default() -> Self {
         Self {
-            allow_commands: true,
             // TODO
             data_version: -1,
             difficulty: Difficulty::Normal as u8,

--- a/pumpkin/src/command/commands/stop.rs
+++ b/pumpkin/src/command/commands/stop.rs
@@ -27,13 +27,13 @@ impl CommandExecutor for StopExecutor {
             )
             .await;
 
-        // TODO: Gracefully stop
-
         let kick_message = TextComponent::text("Server stopped");
         for player in server.get_all_players().await {
             player.kick(kick_message.clone()).await;
         }
         server.save().await;
+
+        // TODO: Gracefully stop
         std::process::exit(0)
     }
 }

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -50,12 +50,12 @@ pub static LOGGER_IMPL: LazyLock<Option<(Box<dyn Log>, LevelFilter)>> = LazyLock
         Some((
             Box::new(
                 logger
-                    .with_level(LevelFilter::Debug)
+                    .with_level(LevelFilter::Info)
                     .with_colors(ADVANCED_CONFIG.logging.color)
                     .with_threads(ADVANCED_CONFIG.logging.threads)
                     .env(),
             ),
-            LevelFilter::Debug,
+            LevelFilter::Info,
         ))
     } else {
         None

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -50,12 +50,12 @@ pub static LOGGER_IMPL: LazyLock<Option<(Box<dyn Log>, LevelFilter)>> = LazyLock
         Some((
             Box::new(
                 logger
-                    .with_level(LevelFilter::Info)
+                    .with_level(LevelFilter::Debug)
                     .with_colors(ADVANCED_CONFIG.logging.color)
                     .with_threads(ADVANCED_CONFIG.logging.threads)
                     .env(),
             ),
-            LevelFilter::Info,
+            LevelFilter::Debug,
         ))
     } else {
         None

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -369,10 +369,10 @@ impl PluginManager {
         // Take a snapshot of handlers to avoid lifetime issues
         let handlers = self.handlers.read().await;
 
-        log::debug!("Firing event: {}", E::get_name_static());
+        log::trace!("Firing event: {}", E::get_name_static());
 
         if let Some(handlers_vec) = handlers.get(&E::get_name_static()) {
-            log::debug!(
+            log::trace!(
                 "Found {} handlers for event: {}",
                 handlers_vec.len(),
                 E::get_name_static()

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -200,6 +200,8 @@ impl Server {
         for world in self.worlds.read().await.iter() {
             world.save().await;
         }
+
+        log::info!("Completed world save");
     }
 
     /// Adds a new living entity to the server. This does not Spawn the entity


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
The `world.dat` was not being properly serialized (the compression read/write buffers were flipped on the write function and it does not seem our nbt serializer works properly). 

This PR fixes `world.dat` serialization and deserialization and adds a backup of `world.dat` as vanilla servers do.

This also fixes world generation not aligning with loaded worlds.

## Testing
* Added a test to verify the seed persists across a save/load

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
