### PR TITLE
Make the players field in World use RwLock instead of Mutex

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -635,7 +635,7 @@ impl Player {
         let uuid = self.gameprofile.id;
         current_world.remove_player(self.clone(), false).await;
         *self.living_entity.entity.world.write().await = new_world.clone();
-        new_world.players.lock().await.insert(uuid, self.clone());
+        new_world.players.write().await.insert(uuid, self.clone());
         self.unload_watched_chunks(&current_world).await;
         let last_pos = self.living_entity.last_pos.load();
         let death_dimension = self.world().await.dimension_type.name();

--- a/pumpkin/src/net/container.rs
+++ b/pumpkin/src/net/container.rs
@@ -493,7 +493,7 @@ impl Player {
             .read()
             .await
             .players
-            .lock()
+            .read()
             .await
             .iter()
             .filter_map(|(token, player)| {

--- a/pumpkin/src/net/query.rs
+++ b/pumpkin/src/net/query.rs
@@ -116,7 +116,7 @@ async fn handle_packet(
                             for world in server.worlds.read().await.iter() {
                                 let mut world_players = world
                                     .players
-                                    .lock()
+                                    .read()
                                     .await
                                     // Although there is no documented limit, we will limit to 4 players
                                     .values()

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -87,7 +87,7 @@ impl Context {
         };
 
         for world in self.server.worlds.read().await.iter() {
-            for player in world.players.lock().await.values() {
+            for player in world.players.read().await.values() {
                 client_suggestions::send_c_commands_packet(player, &self.server.command_dispatcher)
                     .await;
             }
@@ -105,7 +105,7 @@ impl Context {
         };
 
         for world in self.server.worlds.read().await.iter() {
-            for player in world.players.lock().await.values() {
+            for player in world.players.read().await.values() {
                 client_suggestions::send_c_commands_packet(player, &self.server.command_dispatcher)
                     .await;
             }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -357,7 +357,7 @@ impl Server {
         let mut players = Vec::<Arc<Player>>::new();
 
         for world in self.worlds.read().await.iter() {
-            for (_, player) in world.players.lock().await.iter() {
+            for (_, player) in world.players.read().await.iter() {
                 if player.client.address.lock().await.ip() == ip {
                     players.push(player.clone());
                 }
@@ -372,7 +372,7 @@ impl Server {
         let mut players = Vec::<Arc<Player>>::new();
 
         for world in self.worlds.read().await.iter() {
-            for (_, player) in world.players.lock().await.iter() {
+            for (_, player) in world.players.read().await.iter() {
                 players.push(player.clone());
             }
         }
@@ -418,7 +418,7 @@ impl Server {
     pub async fn get_player_count(&self) -> usize {
         let mut count = 0;
         for world in self.worlds.read().await.iter() {
-            count += world.players.lock().await.len();
+            count += world.players.read().await.len();
         }
         count
     }
@@ -427,7 +427,7 @@ impl Server {
     pub async fn has_n_players(&self, n: usize) -> bool {
         let mut count = 0;
         for world in self.worlds.read().await.iter() {
-            count += world.players.lock().await.len();
+            count += world.players.read().await.len();
             if count >= n {
                 return true;
             }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This PR changes the `players` field in the `World` struct:
```rs
pub struct World {
    /// A map of active players within the world, keyed by their unique UUID.
    pub players: Arc<Mutex<HashMap<uuid::Uuid, Arc<Player>>>>,
}
```
from a `Mutex` to a `RwLock`.

This fixes a couple deadlocks which can cause the player to time out and be unable to join the server again. Specifically any function called from within the `player.tick()` method which also broadcasted packets to players on the server would cause a deadlock as the `world.broadcast_packet_all` method (and similar) require a lock to the `players` mutex, but this mutex is already locked by the `world.lock()` method which calls `player.tick()`.

This change also theoretically helps prevent other similar deadlocks, as the only cases where mutable access to the `players` mutex is necessary are when a player join, leaves, or teleports between worlds, all other cases can be called on a `read()` lock.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
