### PR TITLE
Only show commands that player can execute

### DIFF
--- a/pumpkin/src/command/commands/help.rs
+++ b/pumpkin/src/command/commands/help.rs
@@ -128,6 +128,12 @@ impl CommandExecutor for BaseHelpExecutor {
                 Command::Tree(tree) => Some(tree),
                 Command::Alias(_) => None,
             })
+            .filter(|tree| {
+                dispatcher
+                    .permissions
+                    .get(&tree.names[0])
+                    .map_or(true, |perm| sender.has_permission_lvl(*perm))
+            })
             .collect();
 
         commands.sort_by(|a, b| a.names[0].cmp(&b.names[0]));


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This PR modifies the help command to also filter commands based on if the command sender has permission to execute said command.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
