### PR TITLE
Differentiate between single and stack drops

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -989,7 +989,10 @@ impl Player {
                 EntityType::ITEM,
                 &self.world().await,
             );
-            let item_entity = Arc::new(ItemEntity::new(entity, &ItemStack::new(drop_amount, item.item)));
+            let item_entity = Arc::new(ItemEntity::new(
+                entity,
+                &ItemStack::new(drop_amount, item.item),
+            ));
             self.world().await.spawn_entity(item_entity.clone()).await;
             item_entity.send_meta_packet().await;
             // decrase item in hotbar

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -980,19 +980,20 @@ impl Player {
             .await;
     }
 
-    pub async fn drop_item(&self, server: &Server) {
+    pub async fn drop_item(&self, server: &Server, drop_stack: bool) {
         let mut inv = self.inventory.lock().await;
         if let Some(item) = inv.held_item_mut() {
+            let drop_amount = if drop_stack { item.item_count } else { 1 };
             let entity = server.add_entity(
                 self.living_entity.entity.pos.load(),
                 EntityType::ITEM,
                 &self.world().await,
             );
-            let item_entity = Arc::new(ItemEntity::new(entity, &item.clone()));
+            let item_entity = Arc::new(ItemEntity::new(entity, &ItemStack::new(drop_amount, item.item)));
             self.world().await.spawn_entity(item_entity.clone()).await;
             item_entity.send_meta_packet().await;
             // decrase item in hotbar
-            inv.decrease_current_stack(1);
+            inv.decrease_current_stack(drop_amount);
         }
     }
 

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -928,8 +928,11 @@ impl Player {
                     }
                     self.update_sequence(player_action.sequence.0);
                 }
-                Status::DropItemStack | Status::DropItem => {
-                    self.drop_item(server).await;
+                Status::DropItem => {
+                    self.drop_item(server, false).await;
+                }
+                Status::DropItemStack => {
+                    self.drop_item(server, true).await;
                 }
                 Status::ShootArrowOrFinishEating | Status::SwapItem => {
                     log::debug!("todo");


### PR DESCRIPTION
## Description
Add support for `DropItem` and `DropItemStack`. (Also prevents item dupe glitch where it would always drop the stack but only subtract a single item)

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
