### PR TITLE
Don't boradcast Equipment Change back to player

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -64,7 +64,10 @@ impl LivingEntity {
             .world
             .read()
             .await
-            .broadcast_packet_all(&CSetEquipment::new(self.entity_id().into(), equipment))
+            .broadcast_packet_except(
+                &[self.entity.entity_uuid],
+                &CSetEquipment::new(self.entity_id().into(), equipment),
+            )
             .await;
     }
 


### PR DESCRIPTION
## Description
Scrolling quickly in the hotbar in the current version desyncs the client. By not sending equipment updates to the player it won't desync


## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
