### PR TITLE
Fix deadlock when "packet ready" buffer is full

### DIFF
--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -167,6 +167,7 @@ impl Level {
     }
 
     pub fn mark_chunk_as_newly_watched(&self, chunk: Vector2<i32>) {
+        log::trace!("{:?} marked as newly watched", chunk);
         match self.chunk_watchers.entry(chunk) {
             Entry::Occupied(mut occupied) => {
                 let value = occupied.get_mut();
@@ -195,6 +196,7 @@ impl Level {
 
     /// Returns whether the chunk should be removed from memory
     pub fn mark_chunk_as_not_watched(&self, chunk: Vector2<i32>) -> bool {
+        log::trace!("{:?} marked as no longer watched", chunk);
         match self.chunk_watchers.entry(chunk) {
             Entry::Occupied(mut occupied) => {
                 let value = occupied.get_mut();
@@ -225,6 +227,7 @@ impl Level {
     }
 
     pub async fn clean_chunk(&self, chunk: &Vector2<i32>) {
+        log::trace!("{:?} is being cleaned", chunk);
         if let Some(data) = self.loaded_chunks.remove(chunk) {
             self.write_chunk(data).await;
         }

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -228,23 +228,26 @@ impl PumpkinServer {
             );
 
             let (tx, mut rx) = tokio::sync::mpsc::channel(64);
-            let (connection_reader, connection_writer) = connection.into_split();
-            let connection_reader = Arc::new(Mutex::new(connection_reader));
-            let connection_writer = Arc::new(Mutex::new(connection_writer));
+            let (mut connection_reader, connection_writer) = connection.into_split();
 
             let client = Arc::new(Client::new(tx, client_addr, id));
 
             let client_clone = client.clone();
             // This task will be cleaned up on its own
             tokio::spawn(async move {
-                // We clone ownership of a tx into here thru the client so this will never drop
+                let mut connection_writer = connection_writer;
+
+                // We clone ownership of `tx` into here thru the client so this will never drop
                 // since there is always a tx in memory. We need to explicitly tell the recv to stop
                 while let Some(notif) = rx.recv().await {
                     match notif {
                         PacketHandlerState::PacketReady => {
-                            let mut enc = client_clone.enc.lock().await;
-                            let buf = enc.take();
-                            if let Err(e) = connection_writer.lock().await.write_all(&buf).await {
+                            let buf = {
+                                let mut enc = client_clone.enc.lock().await;
+                                enc.take()
+                            };
+
+                            if let Err(e) = connection_writer.write_all(&buf).await {
                                 log::warn!("Failed to write packet to client: {e}");
                                 client_clone.close().await;
                                 break;
@@ -264,7 +267,7 @@ impl PumpkinServer {
                         .make_player
                         .load(std::sync::atomic::Ordering::Relaxed)
                 {
-                    let open = poll(&client, connection_reader.clone()).await;
+                    let open = poll(&client, &mut connection_reader).await;
                     if open {
                         client.process_packets(&server).await;
                     };
@@ -284,7 +287,7 @@ impl PumpkinServer {
                         .closed
                         .load(core::sync::atomic::Ordering::Relaxed)
                     {
-                        let open = poll(&player.client, connection_reader.clone()).await;
+                        let open = poll(&player.client, &mut connection_reader).await;
                         if open {
                             player.process_packets(&server).await;
                         };
@@ -384,7 +387,7 @@ fn setup_console(rl: Readline, server: Arc<Server>) -> JoinHandle<Readline> {
     })
 }
 
-async fn poll(client: &Client, connection_reader: Arc<Mutex<OwnedReadHalf>>) -> bool {
+async fn poll(client: &Client, connection_reader: &mut OwnedReadHalf) -> bool {
     loop {
         if client.closed.load(std::sync::atomic::Ordering::Relaxed) {
             // If we manually close (like a kick) we dont want to keep reading bytes
@@ -409,7 +412,7 @@ async fn poll(client: &Client, connection_reader: Arc<Mutex<OwnedReadHalf>>) -> 
         dec.reserve(4096);
         let mut buf = dec.take_capacity();
 
-        let bytes_read = connection_reader.lock().await.read_buf(&mut buf).await;
+        let bytes_read = connection_reader.read_buf(&mut buf).await;
         match bytes_read {
             Ok(cnt) => {
                 //log::debug!("Read {} bytes", cnt);

--- a/pumpkin/src/net/mod.rs
+++ b/pumpkin/src/net/mod.rs
@@ -252,10 +252,12 @@ impl Client {
             return;
         }
 
-        let mut enc = self.enc.lock().await;
-        if let Err(error) = enc.append_packet(packet) {
-            self.kick(&TextComponent::text(error.to_string())).await;
-            return;
+        {
+            let mut enc = self.enc.lock().await;
+            if let Err(error) = enc.append_packet(packet) {
+                self.kick(&TextComponent::text(error.to_string())).await;
+                return;
+            }
         }
 
         let _ = self


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
When the send packet function is invoked on the client, the lock on the encrypter was unnecessarily held for the remainder of the function. When a notification was sent to the `server_packets_channel`, the encrypter lock was still held, preventing the serialized packet from being taken and blocking the next call to the send packet function

## Testing
You can verify this worked by teleporting to the world border.
Before: Deadlock
Now: Normally chunk loading

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
