### PR TITLE
Fixed block rotation on chest, signs, and furnaces

### DIFF
--- a/pumpkin-world/src/block/mod.rs
+++ b/pumpkin-world/src/block/mod.rs
@@ -7,7 +7,7 @@ use pumpkin_util::math::vector3::Vector3;
 
 pub use state::BlockState;
 
-#[derive(FromPrimitive, PartialEq, Clone, Copy)]
+#[derive(FromPrimitive, PartialEq, Clone, Copy, Debug)]
 pub enum BlockDirection {
     Bottom = 0,
     Top,

--- a/pumpkin/src/block/blocks/chest.rs
+++ b/pumpkin/src/block/blocks/chest.rs
@@ -6,10 +6,14 @@ use pumpkin_data::{
 };
 use pumpkin_inventory::{Chest, OpenContainer};
 use pumpkin_macros::pumpkin_block;
+use pumpkin_protocol::server::play::SUseItemOn;
 use pumpkin_protocol::{client::play::CBlockAction, codec::var_int::VarInt};
 use pumpkin_util::math::position::BlockPos;
+use pumpkin_world::block::BlockDirection;
 use pumpkin_world::block::registry::{Block, get_block};
 
+use crate::block::properties::Direction;
+use crate::world::World;
 use crate::{
     block::{pumpkin_block::PumpkinBlock, registry::BlockActionResult},
     entity::player::Player,
@@ -27,6 +31,35 @@ pub struct ChestBlock;
 
 #[async_trait]
 impl PumpkinBlock for ChestBlock {
+    async fn on_place(
+        &self,
+        server: &Server,
+        world: &World,
+        block: &Block,
+        face: &BlockDirection,
+        block_pos: &BlockPos,
+        use_item_on: &SUseItemOn,
+        player_direction: &Direction,
+        other: bool,
+    ) -> u16 {
+        let player_direction = player_direction.opposite();
+
+        // TODO: check if next to other chest and combine
+
+        server
+            .block_properties_manager
+            .on_place_state(
+                world,
+                block,
+                face,
+                block_pos,
+                use_item_on,
+                &player_direction,
+                other,
+            )
+            .await
+    }
+
     async fn normal_use(
         &self,
         block: &Block,

--- a/pumpkin/src/block/blocks/furnace.rs
+++ b/pumpkin/src/block/blocks/furnace.rs
@@ -1,11 +1,14 @@
-use crate::block::registry::BlockActionResult;
+use crate::block::properties::Direction;
 use crate::entity::player::Player;
+use crate::{block::registry::BlockActionResult, world::World};
 use async_trait::async_trait;
 use pumpkin_data::item::Item;
 use pumpkin_data::screen::WindowType;
 use pumpkin_inventory::Furnace;
 use pumpkin_macros::pumpkin_block;
+use pumpkin_protocol::server::play::SUseItemOn;
 use pumpkin_util::math::position::BlockPos;
+use pumpkin_world::block::BlockDirection;
 use pumpkin_world::block::registry::Block;
 
 use crate::{block::pumpkin_block::PumpkinBlock, server::Server};
@@ -15,6 +18,33 @@ pub struct FurnaceBlock;
 
 #[async_trait]
 impl PumpkinBlock for FurnaceBlock {
+    async fn on_place(
+        &self,
+        server: &Server,
+        world: &World,
+        block: &Block,
+        face: &BlockDirection,
+        block_pos: &BlockPos,
+        use_item_on: &SUseItemOn,
+        player_direction: &Direction,
+        other: bool,
+    ) -> u16 {
+        let player_direction = player_direction.opposite();
+
+        server
+            .block_properties_manager
+            .on_place_state(
+                world,
+                block,
+                face,
+                block_pos,
+                use_item_on,
+                &player_direction,
+                other,
+            )
+            .await
+    }
+
     async fn normal_use(
         &self,
         block: &Block,

--- a/pumpkin/src/block/mod.rs
+++ b/pumpkin/src/block/mod.rs
@@ -5,12 +5,15 @@ use properties::{
     attachment::Attachment,
     axis::Axis,
     cardinal::{Down, East, North, South, Up, West},
+    chest_type::ChestType,
     face::Face,
     facing::Facing,
     half::Half,
     layers::Layers,
+    lit::Lit,
     open::Open,
     powered::Powered,
+    rotation::Rotation,
     signal_fire::SignalFire,
     slab_type::SlabType,
     stair_shape::StairShape,
@@ -119,12 +122,15 @@ pub fn default_block_properties_manager() -> Arc<BlockPropertiesManager> {
     manager.register(Facing::North);
     manager.register(Half::Bottom);
     manager.register(Layers::Lay1);
+    manager.register(Lit::True());
     manager.register(North::False);
     manager.register(Open::False());
     manager.register(Powered::False());
+    manager.register(Rotation::Rotation0);
     manager.register(Unstable::False());
     manager.register(SignalFire::False());
     manager.register(SlabType::Bottom);
+    manager.register(ChestType::Single);
     manager.register(South::False);
     manager.register(StairShape::Straight);
     manager.register(Up::False);

--- a/pumpkin/src/block/properties/chest_type.rs
+++ b/pumpkin/src/block/properties/chest_type.rs
@@ -1,0 +1,48 @@
+use crate::world::World;
+use async_trait::async_trait;
+use pumpkin_macros::block_property;
+use pumpkin_protocol::server::play::SUseItemOn;
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_world::block::{
+    BlockDirection,
+    registry::{Block, State},
+};
+
+use super::{BlockProperties, BlockProperty, BlockPropertyMetadata, Direction};
+
+#[block_property("type")]
+pub enum ChestType {
+    Single,
+    Left,
+    Right,
+}
+
+#[async_trait]
+impl BlockProperty for ChestType {
+    async fn on_place(
+        &self,
+        _world: &World,
+        _block: &Block,
+        _face: &BlockDirection,
+        _block_pos: &BlockPos,
+        _use_item_on: &SUseItemOn,
+        _player_direction: &Direction,
+        _properties: &BlockProperties,
+        _other: bool,
+    ) -> String {
+        // TODO: determine if should combine
+        Self::Single.value()
+    }
+
+    async fn can_update(
+        &self,
+        value: String,
+        _block: &Block,
+        _block_state: &State,
+        _face: &BlockDirection,
+        _use_item_on: &SUseItemOn,
+        _other: bool,
+    ) -> bool {
+        value == Self::Single.value()
+    }
+}

--- a/pumpkin/src/block/properties/lit.rs
+++ b/pumpkin/src/block/properties/lit.rs
@@ -1,0 +1,9 @@
+use super::BlockProperty;
+use async_trait::async_trait;
+use pumpkin_macros::block_property;
+
+#[block_property("lit")]
+pub struct Lit(bool);
+
+#[async_trait]
+impl BlockProperty for Lit {}

--- a/pumpkin/src/block/properties/rotation.rs
+++ b/pumpkin/src/block/properties/rotation.rs
@@ -1,0 +1,56 @@
+use crate::world::World;
+use async_trait::async_trait;
+use pumpkin_macros::block_property;
+use pumpkin_protocol::server::play::SUseItemOn;
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_world::block::{BlockDirection, registry::Block};
+
+use super::{BlockProperties, BlockProperty, BlockPropertyMetadata, Direction};
+
+// #[block_property("rotation")]
+#[block_property("rotation", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])]
+pub enum Rotation {
+    Rotation0,
+    Rotation1,
+    Rotation2,
+    Rotation3,
+    Rotation4,
+    Rotation5,
+    Rotation6,
+    Rotation7,
+    Rotation8,
+    Rotation9,
+    Rotation10,
+    Rotation11,
+    Rotation12,
+    Rotation13,
+    Rotation14,
+    Rotation15,
+}
+
+#[async_trait]
+impl BlockProperty for Rotation {
+    async fn on_place(
+        &self,
+        _world: &World,
+        _block: &Block,
+        face: &BlockDirection,
+        _block_pos: &BlockPos,
+        _use_item_on: &SUseItemOn,
+        player_direction: &Direction,
+        _properties: &BlockProperties,
+        _other: bool,
+    ) -> String {
+        // TODO: Player direction should be extended for additional angles
+        let rotation = match face {
+            BlockDirection::Bottom => match player_direction {
+                Direction::North => Self::Rotation8,
+                Direction::East => Self::Rotation12,
+                Direction::South => Self::Rotation0,
+                Direction::West => Self::Rotation4,
+            },
+            _ => Self::Rotation0,
+        };
+        rotation.value()
+    }
+}

--- a/pumpkin/src/block/properties/stair_shape.rs
+++ b/pumpkin/src/block/properties/stair_shape.rs
@@ -33,7 +33,7 @@ impl BlockProperty for StairShape {
         _other: bool,
     ) -> String {
         let block_half = evaluate_half(*face, use_item_on);
-        let (front_block_pos, back_block_pos) = calculate_positions(player_direction, block_pos);
+        let (front_block_pos, back_block_pos) = calculate_positions(*player_direction, block_pos);
 
         let front_block_and_state = world.get_block_and_block_state(&front_block_pos).await;
         let back_block_and_state = world.get_block_and_block_state(&back_block_pos).await;
@@ -128,7 +128,7 @@ impl BlockProperty for StairShape {
     }
 }
 
-fn calculate_positions(player_direction: &Direction, block_pos: &BlockPos) -> (BlockPos, BlockPos) {
+fn calculate_positions(player_direction: Direction, block_pos: &BlockPos) -> (BlockPos, BlockPos) {
     match player_direction {
         Direction::North => (
             BlockPos(Vector3::new(

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -1417,15 +1417,17 @@ impl Player {
         block_position: BlockPos,
         selected_face: &BlockDirection,
     ) {
+        let front_text = match selected_face {
+            BlockDirection::Top => selected_face.to_offset().z == 1,
+            _ => true,
+        };
+
         if block.states.iter().any(|state| {
             state.block_entity_type == Some(block_entity!("sign"))
                 || state.block_entity_type == Some(block_entity!("hanging_sign"))
         }) {
             self.client
-                .send_packet(&COpenSignEditor::new(
-                    block_position,
-                    selected_face.to_offset().z == 1,
-                ))
+                .send_packet(&COpenSignEditor::new(block_position, front_text))
                 .await;
         }
     }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Fixes rotation on chest, signs, and furnaces. Block properties are not currently saved in world file.

## Testing
Open world two players
Place sign on ground or on wall, text faces you
Place chest, faces you
Place furnace, faces you

## Limitations
Sign on ground does allow for angles.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
