### PR TITLE
Fix entity velocity in Client Play Entity Spawn packet

### DIFF
--- a/pumpkin-protocol/src/client/play/spawn_entity.rs
+++ b/pumpkin-protocol/src/client/play/spawn_entity.rs
@@ -44,8 +44,8 @@ impl CSpawnEntity {
             data,
             velocity: Vector3::new(
                 (velocity.x.clamp(-3.9, 3.9) * 8000.0) as i16,
-                (velocity.x.clamp(-3.9, 3.9) * 8000.0) as i16,
-                (velocity.x.clamp(-3.9, 3.9) * 8000.0) as i16,
+                (velocity.y.clamp(-3.9, 3.9) * 8000.0) as i16,
+                (velocity.z.clamp(-3.9, 3.9) * 8000.0) as i16,
             ),
         }
     }


### PR DESCRIPTION
## Description

Title, changes the Y and Z fields in the Vector3 constructor to use their respective velocity fields instead of the X velocity. Probably a tired copy & paste oversight, remember to take breaks and stay hydrated!
Cheers to the team! :)

## Testing

Found whilst looking for issue with ThrownItemEntity's trajectory, said trajectory now seems to work as intended, haven't tested it with other mobs due to the lack of AI but shouldn't be an issue.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
