### PR TITLE
Show player respawn screen if the chat or menu is open

### DIFF
--- a/pumpkin/src/command/commands/kill.rs
+++ b/pumpkin/src/command/commands/kill.rs
@@ -33,7 +33,7 @@ impl CommandExecutor for Executor {
         let target_count = targets.len();
         let mut name = String::new();
         for target in targets {
-            target.living_entity.kill().await;
+            target.kill().await;
             name.clone_from(&target.gameprofile.name);
         }
 
@@ -80,7 +80,7 @@ impl CommandExecutor for SelfExecutor {
         let name = target.gameprofile.name.clone();
         let entity = &target.living_entity.entity;
 
-        target.living_entity.kill().await;
+        target.kill().await;
 
         sender
             .send_message(TextComponent::translate(

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -973,10 +973,10 @@ impl Player {
 
     pub async fn kill(&self) {
         self.living_entity.kill().await;
-        self.send_combat_kill().await;
+        self.handle_killed().await;
     }
 
-    async fn send_combat_kill(&self) {
+    async fn handle_killed(&self) {
         self.set_client_loaded(false);
         self.client
             .send_packet(&CCombatDeath::new(
@@ -1302,7 +1302,7 @@ impl EntityBase for Player {
         if result {
             let health = self.living_entity.health.load();
             if health <= 0.0 {
-                self.send_combat_kill().await;
+                self.handle_killed().await;
             }
         }
         result


### PR DESCRIPTION
## Description

This PR fixes #541. After a player was killed the PLAY_PLAYER_COMBAT_KILL packet will be send to the player. This means the player sees the respawn screen even if he has the chat open or is in the menu. The sending of this packet was already implemented in the kill function of the player but this function was never used.

To achieve this I changed that in the kill command use the kill function of the player and after a damage of a player it will be check if the player is death and the packet will also be send.

The only way a player can still be killed without this packet is if the kill method of the living entity is directly called.
