### PR TITLE
Add the unsafe attribute to no_mangle in plugin method generation

### DIFF
--- a/pumpkin-api-macros/src/lib.rs
+++ b/pumpkin-api-macros/src/lib.rs
@@ -62,7 +62,7 @@ pub fn plugin_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
             #(#methods)*
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub fn plugin() -> Box<dyn pumpkin::plugin::Plugin> {
             Box::new(#struct_ident::new())
         }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
In rust edition 2024, the `#[no_mangle]` attribute was made unsafe. This PR wraps the `no_mangle` attribute used within the `pumpkin-api-macros` crate with `#[unsafe(no_mangle)]` to fix rust complaining about it being unsafe.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
