### PR TITLE
Fix other no_mangle

### DIFF
--- a/pumpkin-api-macros/src/lib.rs
+++ b/pumpkin-api-macros/src/lib.rs
@@ -47,7 +47,7 @@ pub fn plugin_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
         pub static GLOBAL_RUNTIME: std::sync::LazyLock<std::sync::Arc<tokio::runtime::Runtime>> =
             std::sync::LazyLock::new(|| std::sync::Arc::new(tokio::runtime::Runtime::new().unwrap()));
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub static METADATA: pumpkin::plugin::PluginMetadata = pumpkin::plugin::PluginMetadata {
             name: env!("CARGO_PKG_NAME"),
             version: env!("CARGO_PKG_VERSION"),


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
I am sorry for missing this in #622 but there are two instances of `#[no_mangle]` being used in the api-macros crate, this pr fixes the other one as well

In rust edition 2024, the `#[no_mangle]` attribute was made unsafe. This PR wraps the `no_mangle` attribute used within the `pumpkin-api-macros` crate with `#[unsafe(no_mangle)]` to fix rust complaining about it being unsafe.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
