### PR TITLE
fixed wrongly used coordinates in explosion calculation

### DIFF
--- a/pumpkin/src/world/explosion.rs
+++ b/pumpkin/src/world/explosion.rs
@@ -18,8 +18,8 @@ impl Explosion {
     async fn get_blocks_to_destroy(&self, world: &World) -> Vec<BlockPos> {
         let mut set = Vec::new();
         for x in 0..16 {
-            for z in 0..16 {
-                'block2: for y in 0..16 {
+            for y in 0..16 {
+                'block2: for z in 0..16 {
                     if x != 0 && x != 15 && z != 0 && z != 15 && y != 0 && y != 15 {
                         continue;
                     }
@@ -56,9 +56,9 @@ impl Explosion {
                             set.push(block_pos);
                         }
 
-                        pos_x += x_div * 0.3;
-                        pos_y += y_div * 0.3;
-                        pos_z += z_div * 0.3;
+                        pos_x += x_div * 0.300_000_011_920_928_96f64;
+                        pos_y += y_div * 0.300_000_011_920_928_96f64;
+                        pos_z += z_div * 0.300_000_011_920_928_96f64;
                         h -= 0.225_000_01f32;
                     }
                 }

--- a/pumpkin/src/world/explosion.rs
+++ b/pumpkin/src/world/explosion.rs
@@ -25,8 +25,8 @@ impl Explosion {
                     }
 
                     let x = f64::from(x) / 15.0 * 2.0 - 1.0;
-                    let y = f64::from(z) / 15.0 * 2.0 - 1.0;
-                    let z = y / 15.0 * 2.0 - 1.0;
+                    let y = f64::from(y) / 15.0 * 2.0 - 1.0;
+                    let z = f64::from(z) / 15.0 * 2.0 - 1.0;
 
                     let sqrt = (x * x + y * y + z * z).sqrt();
                     let x_div = x / sqrt;


### PR DESCRIPTION
## Description

The calculation in the explosion get_blocks_to_destroy method was wrong. In the first calculation of each axis there was y and z wrongly calculated. For y was z used in the calculation and for z the already calculated y value. I check this with the vanilla code an know its correct. You can view a recording of the fix in the issue.

This fixes #617.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
