### PR TITLE
Rewrote TNT logic

### DIFF
--- a/pumpkin-util/src/math/position.rs
+++ b/pumpkin-util/src/math/position.rs
@@ -1,11 +1,12 @@
 use super::vector3::Vector3;
 use std::fmt;
+use std::hash::Hash;
 
 use crate::math::vector2::Vector2;
 use num_traits::Euclid;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 /// Aka Block Position
 pub struct BlockPos(pub Vector3<i32>);
 

--- a/pumpkin/src/block/blocks/tnt.rs
+++ b/pumpkin/src/block/blocks/tnt.rs
@@ -13,8 +13,8 @@ use pumpkin_data::item::Item;
 use pumpkin_data::sound::SoundCategory;
 use pumpkin_macros::pumpkin_block;
 use pumpkin_util::math::position::BlockPos;
-use rand::Rng;
 use pumpkin_util::math::vector3::Vector3;
+use rand::Rng;
 
 #[pumpkin_block("minecraft:tnt")]
 pub struct TNTBlock;
@@ -55,7 +55,9 @@ impl PumpkinBlock for TNTBlock {
     async fn explode(&self, _block: &Block, world: &Arc<World>, location: BlockPos) {
         let entity = world.create_entity(location.to_f64(), EntityType::TNT);
         let angle = rand::random::<f64>() * std::f64::consts::TAU;
-        entity.set_velocity(Vector3::new(-angle.sin() * 0.02, 0.2, -angle.cos() * 0.02)).await;
+        entity
+            .set_velocity(Vector3::new(-angle.sin() * 0.02, 0.2, -angle.cos() * 0.02))
+            .await;
         let fuse = rand::thread_rng().gen_range(0..DEFAULT_FUSE / 4) + DEFAULT_FUSE / 8;
         let tnt = Arc::new(TNTEntity::new(entity, DEFAULT_POWER, fuse));
         world.spawn_entity(tnt.clone()).await;

--- a/pumpkin/src/block/blocks/tnt.rs
+++ b/pumpkin/src/block/blocks/tnt.rs
@@ -14,6 +14,7 @@ use pumpkin_data::sound::SoundCategory;
 use pumpkin_macros::pumpkin_block;
 use pumpkin_util::math::position::BlockPos;
 use rand::Rng;
+use pumpkin_util::math::vector3::Vector3;
 
 #[pumpkin_block("minecraft:tnt")]
 pub struct TNTBlock;
@@ -53,6 +54,8 @@ impl PumpkinBlock for TNTBlock {
     }
     async fn explode(&self, _block: &Block, world: &Arc<World>, location: BlockPos) {
         let entity = world.create_entity(location.to_f64(), EntityType::TNT);
+        let angle = rand::random::<f64>() * std::f64::consts::TAU;
+        entity.set_velocity(Vector3::new(-angle.sin() * 0.02, 0.2, -angle.cos() * 0.02)).await;
         let fuse = rand::thread_rng().gen_range(0..DEFAULT_FUSE / 4) + DEFAULT_FUSE / 8;
         let tnt = Arc::new(TNTEntity::new(entity, DEFAULT_POWER, fuse));
         world.spawn_entity(tnt.clone()).await;


### PR DESCRIPTION
A lot of small mistakes were in the previous impl, fixed for performance and validity

## Description

- Used HashSet instead of Vector to reduce calculations when going through all blocks to destroy them

- Added @FlorianLang06 's yz-fix Where y and z were used wrong.

- Aligned code more to how Java does it

- Added 0.0625 to Y as java does it. (0.0625 * entity height)

- Added velocity, but this won't look right until velocity is implemented.

## Testing

Only in-game testing
