### PR TITLE
Fixed typo in spawn_z

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -810,7 +810,7 @@ impl Player {
                     new_world
                         .get_top_block(Vector2::new(
                             f64::from(info.spawn_x) as i32,
-                            f64::from(info.spawn_x) as i32,
+                            f64::from(info.spawn_z) as i32,
                         ))
                         .await
                         + 1,


### PR DESCRIPTION
## Description
Changed spawn_x to spawn_z. Simple typo

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
