### PR TITLE
Fixes BlockOutOfWorldBounds server crash when bedrock gets updated

### DIFF
--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -217,7 +217,6 @@ impl SubchunkBlocks {
 impl ChunkBlocks {
     /// Gets the given block in the chunk
     pub fn get_block(&self, position: ChunkRelativeBlockCoordinates) -> Option<u16> {
-
         match &self {
             Self::Homogeneous(block) => Some(*block),
             Self::Subchunks(subchunks) => subchunks

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -219,7 +219,7 @@ impl ChunkBlocks {
     /// Gets the given block in the chunk
     pub fn get_block(&self, position: ChunkRelativeBlockCoordinates) -> Option<u16> {
         if position.y.0 < -64 {
-            return Some(Block::AIR.id)
+            return Some(Block::AIR.id);
         }
 
         match &self {

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -1,4 +1,3 @@
-use pumpkin_data::block::Block;
 use pumpkin_nbt::nbt_long_array;
 use pumpkin_util::math::{position::BlockPos, vector2::Vector2};
 use serde::{Deserialize, Serialize};
@@ -218,9 +217,6 @@ impl SubchunkBlocks {
 impl ChunkBlocks {
     /// Gets the given block in the chunk
     pub fn get_block(&self, position: ChunkRelativeBlockCoordinates) -> Option<u16> {
-        if position.y.0 < -64 {
-            return Some(Block::AIR.id);
-        }
 
         match &self {
             Self::Homogeneous(block) => Some(*block),

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -1,3 +1,4 @@
+use pumpkin_data::block::Block;
 use pumpkin_nbt::nbt_long_array;
 use pumpkin_util::math::{position::BlockPos, vector2::Vector2};
 use serde::{Deserialize, Serialize};
@@ -217,6 +218,10 @@ impl SubchunkBlocks {
 impl ChunkBlocks {
     /// Gets the given block in the chunk
     pub fn get_block(&self, position: ChunkRelativeBlockCoordinates) -> Option<u16> {
+        if position.y.0 < -64 {
+            return Some(Block::AIR.id)
+        }
+
         match &self {
             Self::Homogeneous(block) => Some(*block),
             Self::Subchunks(subchunks) => subchunks

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1456,7 +1456,13 @@ impl World {
         direction: &BlockDirection,
         flags: BlockFlags,
     ) {
-        let (block, block_state) = self.get_block_and_block_state(block_pos).await.unwrap();
+        let (block, block_state) = match self.get_block_and_block_state(block_pos).await {
+            Ok(block) => block,
+            Err(_error) => {
+                // Neighbor is outside the world. Don't try to update it
+                return;
+            }
+        };
 
         if flags.contains(BlockFlags::SKIP_REDSTONE_WIRE_STATE_REPLACEMENT)
             && block.id == Block::REDSTONE_WIRE.id

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -96,7 +96,6 @@ bitflags! {
 
 #[derive(Debug, Error)]
 pub enum GetBlockError {
-    BlockOutOfWorldBounds,
     InvalidBlockId,
 }
 
@@ -1365,11 +1364,7 @@ impl World {
         };
         let chunk: tokio::sync::RwLockReadGuard<ChunkData> = chunk.read().await;
 
-        let Some(id) = chunk.blocks.get_block(relative) else {
-            return Err(GetBlockError::BlockOutOfWorldBounds);
-        };
-
-        Ok(id)
+        Ok(chunk.blocks.get_block(relative).unwrap_or(Block::AIR.id))
     }
 
     /// Gets a `Block` from the block registry. Returns `None` if the block was not found.

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -97,6 +97,7 @@ bitflags! {
 #[derive(Debug, Error)]
 pub enum GetBlockError {
     InvalidBlockId,
+    BlockOutOfWorldBounds
 }
 
 impl std::fmt::Display for GetBlockError {
@@ -1364,7 +1365,11 @@ impl World {
         };
         let chunk: tokio::sync::RwLockReadGuard<ChunkData> = chunk.read().await;
 
-        Ok(chunk.blocks.get_block(relative).unwrap_or(Block::AIR.id))
+        let Some(id) = chunk.blocks.get_block(relative) else {
+            return Err(GetBlockError::BlockOutOfWorldBounds);
+        };
+
+        Ok(id)
     }
 
     /// Gets a `Block` from the block registry. Returns `None` if the block was not found.

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -97,7 +97,7 @@ bitflags! {
 #[derive(Debug, Error)]
 pub enum GetBlockError {
     InvalidBlockId,
-    BlockOutOfWorldBounds
+    BlockOutOfWorldBounds,
 }
 
 impl std::fmt::Display for GetBlockError {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Server previously would crash if any player was below y -64 (bedrock).

Fixes https://github.com/Pumpkin-MC/Pumpkin/issues/651

## Changed
ChunkBlocks.get_block now returns the ID for AIR under y level -64

**Note:** This does not implement player damage under y -128. It simply fixes the BlockOutOfWorldBounds error. Player will fall forever in current state.

**EDIT:** The actual issue is the lowest level of bedrock (y=-64) tries to update neighbors on y=-65 which doesn't exist.
