### PR TITLE
Refactor unnecessary unsafe code and add safety comments

### DIFF
--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -243,8 +243,8 @@ impl LoadConfiguration for BasicConfiguration {
     }
 
     fn validate(&self) {
-        let min = unsafe { NonZeroU8::new_unchecked(2) };
-        let max = unsafe { NonZeroU8::new_unchecked(32) };
+        let min = NonZeroU8::new(2).unwrap();
+        let max = NonZeroU8::new(32).unwrap();
 
         assert!(
             self.view_distance.ge(&min),

--- a/pumpkin-nbt/src/tag.rs
+++ b/pumpkin-nbt/src/tag.rs
@@ -26,6 +26,7 @@ pub enum NbtTag {
 impl NbtTag {
     /// Returns the numeric id associated with the data type.
     pub const fn get_type_id(&self) -> u8 {
+        // Safety: Since Self is repr(u8), it is guaranteed to hold the discriminant in the first byte
         // See https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
         unsafe { *(self as *const Self as *const u8) }
     }

--- a/pumpkin-protocol/src/client/play/commands.rs
+++ b/pumpkin-protocol/src/client/play/commands.rs
@@ -207,6 +207,8 @@ impl ArgumentType<'_> {
     pub const SCORE_HOLDER_FLAG_ALLOW_MULTIPLE: u8 = 1;
 
     pub fn write_to_buffer(&self, write: &mut impl Write) -> Result<(), WritingError> {
+        // Safety: Since Self is repr(u32), it is guaranteed to hold the discriminant in the first 4 bytes
+        // See https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
         let id = unsafe { *(self as *const Self as *const i32) };
         write.write_var_int(&(id).into())?;
         match self {

--- a/pumpkin-world/src/cylindrical_chunk_iterator.rs
+++ b/pumpkin-world/src/cylindrical_chunk_iterator.rs
@@ -97,11 +97,10 @@ mod test {
 
     #[test]
     fn test_bounds() {
-        let mut cylinder =
-            Cylindrical::new(Vector2::new(0, 0), unsafe { NonZeroU8::new_unchecked(1) });
+        let mut cylinder = Cylindrical::new(Vector2::new(0, 0), NonZeroU8::new(1).unwrap());
 
         for view_distance in 1..=32 {
-            cylinder.view_distance = unsafe { NonZeroU8::new_unchecked(view_distance) };
+            cylinder.view_distance = NonZeroU8::new(view_distance).unwrap();
 
             for chunk in cylinder.all_chunks_within() {
                 assert!(chunk.x >= cylinder.left() && chunk.x <= cylinder.right());
@@ -121,11 +120,10 @@ mod test {
 
     #[test]
     fn all_chunks_within_capacity_estimation() {
-        let mut cylinder =
-            Cylindrical::new(Vector2::new(0, 0), unsafe { NonZeroU8::new_unchecked(1) });
+        let mut cylinder = Cylindrical::new(Vector2::new(0, 0), NonZeroU8::new(1).unwrap());
 
         for distance in 1..=64 {
-            cylinder.view_distance = unsafe { NonZeroU8::new_unchecked(distance) };
+            cylinder.view_distance = NonZeroU8::new(distance).unwrap();
             let chunks = cylinder.all_chunks_within();
             let estimated_capacity = ((distance as usize + 3).pow(2) * 3167) >> 10;
 

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -287,7 +287,7 @@ impl Player {
             // (We left shift by one so we can search around that chunk)
             watched_section: AtomicCell::new(Cylindrical::new(
                 Vector2::new(i32::MAX >> 1, i32::MAX >> 1),
-                unsafe { NonZeroU8::new_unchecked(1) },
+                NonZeroU8::new(1).unwrap(),
             )),
             wait_for_keep_alive: AtomicBool::new(false),
             keep_alive_id: AtomicI64::new(0),
@@ -807,7 +807,7 @@ impl Player {
 
         self.watched_section.store(Cylindrical::new(
             Vector2::new(i32::MAX >> 1, i32::MAX >> 1),
-            unsafe { NonZeroU8::new_unchecked(1) },
+            NonZeroU8::new(1).unwrap(),
         ));
     }
 

--- a/pumpkin/src/net/mod.rs
+++ b/pumpkin/src/net/mod.rs
@@ -108,7 +108,7 @@ impl Default for PlayerConfig {
     fn default() -> Self {
         Self {
             locale: "en_us".to_string(),
-            view_distance: unsafe { NonZeroU8::new_unchecked(10) },
+            view_distance: NonZeroU8::new(10).unwrap(),
             chat_mode: ChatMode::Enabled,
             chat_colors: true,
             skin_parts: 0,

--- a/pumpkin/src/net/packet/config.rs
+++ b/pumpkin/src/net/packet/config.rs
@@ -37,9 +37,8 @@ impl Client {
         ) {
             *self.config.lock().await = Some(PlayerConfig {
                 locale: client_information.locale,
-                view_distance: unsafe {
-                    NonZeroU8::new_unchecked(client_information.view_distance as u8)
-                },
+                // client_information.view_distance was checked above to be > 0 so compiler should optimize this out.
+                view_distance: NonZeroU8::new(client_information.view_distance as u8).unwrap(),
                 chat_mode,
                 chat_colors: client_information.chat_colors,
                 skin_parts: client_information.skin_parts,

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -793,9 +793,8 @@ impl Player {
                 *config = PlayerConfig {
                     locale: client_information.locale,
                     // A negative view distance would be impossible and makes no sense, right? Mojang: Let's make it signed :D
-                    view_distance: unsafe {
-                        NonZeroU8::new_unchecked(client_information.view_distance as u8)
-                    },
+                    // Since client_information.view_distance was checked above to be > 0, so compiler should optimize this out.
+                    view_distance: NonZeroU8::new(client_information.view_distance as u8).unwrap(),
                     chat_mode,
                     chat_colors: client_information.chat_colors,
                     skin_parts: client_information.skin_parts,

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -793,8 +793,14 @@ impl Player {
                 *config = PlayerConfig {
                     locale: client_information.locale,
                     // A negative view distance would be impossible and makes no sense, right? Mojang: Let's make it signed :D
-                    // Since client_information.view_distance was checked above to be > 0, so compiler should optimize this out.
-                    view_distance: NonZeroU8::new(client_information.view_distance as u8).unwrap(),
+                    // client_information.view_distance was checked above to be > 0, so compiler should optimize this out.
+                    view_distance: match NonZeroU8::new(client_information.view_distance as u8) {
+                        Some(dist) => dist,
+                        None => {
+                            // Unreachable branch
+                            return;
+                        }
+                    },
                     chat_mode,
                     chat_colors: client_information.chat_colors,
                     skin_parts: client_information.skin_parts,

--- a/pumpkin/src/world/chunker.rs
+++ b/pumpkin/src/world/chunker.rs
@@ -7,10 +7,12 @@ use pumpkin_world::cylindrical_chunk_iterator::Cylindrical;
 use crate::entity::player::Player;
 
 pub async fn get_view_distance(player: &Player) -> NonZeroU8 {
-    player.config.lock().await.view_distance.clamp(
-        unsafe { NonZeroU8::new_unchecked(2) },
-        BASIC_CONFIG.view_distance,
-    )
+    player
+        .config
+        .lock()
+        .await
+        .view_distance
+        .clamp(NonZeroU8::new(2).unwrap(), BASIC_CONFIG.view_distance)
 }
 
 pub async fn player_join(player: &Arc<Player>) {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->


## Description

Refactored a few simple and unnecessary uses of unsafe and added some explicit safety comments.

Should have zero impact on performance or behaviour, and reduces unsafe blocks from 19 -> 7.
5/7 of which being used for plugin libloading.

#### Specific changes

Changed nonzero integer literal `NonZero<u8>` initializations from `NonZeroU8::new_unchecked(1)` to `NonZeroU8::new(1).unwrap()` syntax, as compiler is able to [optimize](https://godbolt.org/z/MoMzTGsnd) to a no-op at `opt-level=1`

Similar to above but for after conditional statement checking nonzero-ness of number, as compiler can also [optimize](https://godbolt.org/z/v8j9Psozb) to a no-op at `opt-level=1`

Changed `NonZeroU8::new_unchecked(..)` use in unit tests to `NonZeroU8::new(..).unwrap()` syntax

Added explicit safety comments about unsafe pointer casting enums to get the discriminant



## Testing

- [x]  `cargo test` passes
- [x] `cargo clippy --all-targets` passes 

If there's anything I missed, let me know!
