### PR TITLE
Fix creative block breaking bug

### DIFF
--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -996,6 +996,7 @@ impl Player {
                                 broken_state,
                             )
                             .await;
+                        self.update_sequence(player_action.sequence.0);
                         return;
                     }
                     self.start_mining_time.store(


### PR DESCRIPTION
## Description
During fluid flow testing, we discovered that the handling for creative breaking was not sending the updates. This would put the client in a state of assuming the block wasn't broken yet, so it would remain empty on the client side, even when told that it wasn't empty.

## Testing
Manual
