### PR TITLE
Network Serialization Quality of Life and Safety Improvements

### DIFF
--- a/pumpkin-data/build/damage_type.rs
+++ b/pumpkin-data/build/damage_type.rs
@@ -7,7 +7,7 @@ use syn::{Ident, LitInt};
 
 #[derive(Deserialize)]
 struct DamageTypeEntry {
-    id: u32,
+    id: u8,
     components: DamageTypeData,
 }
 
@@ -111,7 +111,7 @@ pub(crate) fn build() -> TokenStream {
             pub effects: Option<DamageEffects>,
             pub message_id: &'static str,
             pub scaling: DamageScaling,
-            pub id: u32,
+            pub id: u8,
         }
 
         #[derive(Clone, Copy, Debug, PartialEq)]

--- a/pumpkin-data/build/message_type.rs
+++ b/pumpkin-data/build/message_type.rs
@@ -34,16 +34,16 @@ pub(crate) fn build() -> TokenStream {
     let mut variants = TokenStream::new();
 
     for (name, typee) in json.iter() {
-        let i = typee.id;
+        let i = typee.id as u8;
         let name = format_ident!("{}", name.to_uppercase());
         variants.extend([quote! {
-            pub const #name: u32 = #i;
+            pub const #name: u8 = #i;
         }]);
     }
 
-    let raw_id = json.len() as u32;
+    let raw_id = json.len() as u8;
     variants.extend([quote! {
-        pub const RAW: u32 = #raw_id; // One higher than highest vanilla id
+        pub const RAW: u8 = #raw_id; // One higher than highest vanilla id
     }]);
 
     quote! {

--- a/pumpkin-nbt/src/lib.rs
+++ b/pumpkin-nbt/src/lib.rs
@@ -187,6 +187,7 @@ pub fn get_nbt_string<R: Read>(bytes: &mut NbtReadHelper<R>) -> Result<String, E
     Ok(string.to_string())
 }
 
+// TODO: This is a bit hacky
 pub(crate) const NBT_ARRAY_TAG: &str = "__nbt_array";
 pub(crate) const NBT_INT_ARRAY_TAG: &str = "__nbt_int_array";
 pub(crate) const NBT_LONG_ARRAY_TAG: &str = "__nbt_long_array";

--- a/pumpkin-protocol/src/client/config/known_packs.rs
+++ b/pumpkin-protocol/src/client/config/known_packs.rs
@@ -1,13 +1,10 @@
-use std::io::Write;
-
 use pumpkin_data::packet::clientbound::CONFIG_SELECT_KNOWN_PACKS;
 use pumpkin_macros::packet;
+use serde::Serialize;
 
-use crate::{
-    ClientPacket, KnownPack,
-    ser::{NetworkWriteExt, WritingError},
-};
+use crate::KnownPack;
 
+#[derive(Serialize)]
 #[packet(CONFIG_SELECT_KNOWN_PACKS)]
 pub struct CKnownPacks<'a> {
     pub known_packs: &'a [KnownPack<'a>],
@@ -16,16 +13,5 @@ pub struct CKnownPacks<'a> {
 impl<'a> CKnownPacks<'a> {
     pub fn new(known_packs: &'a [KnownPack]) -> Self {
         Self { known_packs }
-    }
-}
-
-impl ClientPacket for CKnownPacks<'_> {
-    fn write_packet_data(&self, write: impl Write) -> Result<(), WritingError> {
-        let mut write = write;
-        write.write_list::<KnownPack>(self.known_packs, |p, v| {
-            p.write_string(v.namespace)?;
-            p.write_string(v.id)?;
-            p.write_string(v.version)
-        })
     }
 }

--- a/pumpkin-protocol/src/client/config/registry_data.rs
+++ b/pumpkin-protocol/src/client/config/registry_data.rs
@@ -2,7 +2,7 @@ use pumpkin_data::packet::clientbound::CONFIG_REGISTRY_DATA;
 use pumpkin_macros::packet;
 use serde::Serialize;
 
-use crate::codec::identifier::Identifier;
+use crate::{codec::identifier::Identifier, ser::network_serialize_no_prefix};
 
 #[derive(Serialize)]
 #[packet(CONFIG_REGISTRY_DATA)]
@@ -23,9 +23,11 @@ impl<'a> CRegistryData<'a> {
 #[derive(Serialize)]
 pub struct RegistryEntry {
     pub entry_id: Identifier,
+    #[serde(serialize_with = "network_serialize_no_prefix")]
     pub data: Option<Box<[u8]>>,
 }
 
+// TODO: No unwraps
 impl RegistryEntry {
     pub fn from_nbt(name: &str, nbt: &impl Serialize) -> Self {
         let mut data_buf = Vec::new();

--- a/pumpkin-protocol/src/client/config/registry_data.rs
+++ b/pumpkin-protocol/src/client/config/registry_data.rs
@@ -1,15 +1,10 @@
-use std::io::Write;
-
 use pumpkin_data::packet::clientbound::CONFIG_REGISTRY_DATA;
 use pumpkin_macros::packet;
 use serde::Serialize;
 
-use crate::{
-    ClientPacket,
-    codec::identifier::Identifier,
-    ser::{NetworkWriteExt, WritingError},
-};
+use crate::codec::identifier::Identifier;
 
+#[derive(Serialize)]
 #[packet(CONFIG_REGISTRY_DATA)]
 pub struct CRegistryData<'a> {
     pub registry_id: &'a Identifier,
@@ -25,6 +20,7 @@ impl<'a> CRegistryData<'a> {
     }
 }
 
+#[derive(Serialize)]
 pub struct RegistryEntry {
     pub entry_id: Identifier,
     pub data: Option<Box<[u8]>>,
@@ -46,16 +42,5 @@ impl RegistryEntry {
             entry_id: Identifier::pumpkin(name),
             data: Some(data_buf.into_boxed_slice()),
         }
-    }
-}
-
-impl ClientPacket for CRegistryData<'_> {
-    fn write_packet_data(&self, write: impl Write) -> Result<(), WritingError> {
-        let mut write = write;
-        write.write_identifier(self.registry_id)?;
-        write.write_list::<RegistryEntry>(self.entries, |p, v| {
-            p.write_identifier(&v.entry_id)?;
-            p.write_option(&v.data, |p, v| p.write_slice(v))
-        })
     }
 }

--- a/pumpkin-protocol/src/client/config/server_links.rs
+++ b/pumpkin-protocol/src/client/config/server_links.rs
@@ -1,4 +1,4 @@
-use crate::{Link, VarInt};
+use crate::Link;
 use pumpkin_data::packet::clientbound::CONFIG_SERVER_LINKS;
 use pumpkin_macros::packet;
 use serde::Serialize;
@@ -6,12 +6,11 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(CONFIG_SERVER_LINKS)]
 pub struct CConfigServerLinks<'a> {
-    links_count: &'a VarInt,
     links: &'a [Link<'a>],
 }
 
 impl<'a> CConfigServerLinks<'a> {
-    pub fn new(links_count: &'a VarInt, links: &'a [Link<'a>]) -> Self {
-        Self { links_count, links }
+    pub fn new(links: &'a [Link<'a>]) -> Self {
+        Self { links }
     }
 }

--- a/pumpkin-protocol/src/client/config/store_cookie.rs
+++ b/pumpkin-protocol/src/client/config/store_cookie.rs
@@ -1,4 +1,4 @@
-use crate::{VarInt, codec::identifier::Identifier};
+use crate::codec::identifier::Identifier;
 use pumpkin_data::packet::clientbound::CONFIG_STORE_COOKIE;
 use pumpkin_macros::packet;
 
@@ -8,16 +8,11 @@ use pumpkin_macros::packet;
 /// The Notchian (vanilla) client only accepts cookies of up to 5 KiB in size.
 pub struct CStoreCookie<'a> {
     key: &'a Identifier,
-    payload_length: VarInt,
     payload: &'a [u8], // 5120,
 }
 
 impl<'a> CStoreCookie<'a> {
     pub fn new(key: &'a Identifier, payload: &'a [u8]) -> Self {
-        Self {
-            key,
-            payload_length: VarInt(payload.len() as i32),
-            payload,
-        }
+        Self { key, payload }
     }
 }

--- a/pumpkin-protocol/src/client/login/encryption_request.rs
+++ b/pumpkin-protocol/src/client/login/encryption_request.rs
@@ -2,15 +2,11 @@ use pumpkin_data::packet::clientbound::LOGIN_HELLO;
 use pumpkin_macros::packet;
 use serde::{Deserialize, Serialize};
 
-use crate::VarInt;
-
 #[derive(Serialize, Deserialize)]
 #[packet(LOGIN_HELLO)]
 pub struct CEncryptionRequest<'a> {
     pub server_id: &'a str, // 20
-    pub public_key_length: VarInt,
     pub public_key: &'a [u8],
-    pub verify_token_length: VarInt,
     pub verify_token: &'a [u8],
     pub should_authenticate: bool,
 }
@@ -24,9 +20,7 @@ impl<'a> CEncryptionRequest<'a> {
     ) -> Self {
         Self {
             server_id,
-            public_key_length: public_key.len().into(),
             public_key,
-            verify_token_length: verify_token.len().into(),
             verify_token,
             should_authenticate,
         }

--- a/pumpkin-protocol/src/client/login/login_success.rs
+++ b/pumpkin-protocol/src/client/login/login_success.rs
@@ -1,13 +1,10 @@
-use std::io::Write;
-
 use pumpkin_data::packet::clientbound::LOGIN_LOGIN_FINISHED;
 use pumpkin_macros::packet;
+use serde::Serialize;
 
-use crate::{
-    ClientPacket, Property,
-    ser::{NetworkWriteExt, WritingError},
-};
+use crate::Property;
 
+#[derive(Serialize)]
 #[packet(LOGIN_LOGIN_FINISHED)]
 pub struct CLoginSuccess<'a> {
     pub uuid: &'a uuid::Uuid,
@@ -22,18 +19,5 @@ impl<'a> CLoginSuccess<'a> {
             username,
             properties,
         }
-    }
-}
-
-impl ClientPacket for CLoginSuccess<'_> {
-    fn write_packet_data(&self, write: impl Write) -> Result<(), WritingError> {
-        let mut write = write;
-        write.write_uuid(self.uuid)?;
-        write.write_string(self.username)?;
-        write.write_list::<Property>(self.properties, |p, v| {
-            p.write_string(&v.name)?;
-            p.write_string(&v.value)?;
-            p.write_option(&v.signature, |p, v| p.write_string(v))
-        })
     }
 }

--- a/pumpkin-protocol/src/client/play/boss_event.rs
+++ b/pumpkin-protocol/src/client/play/boss_event.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
+use crate::ClientPacket;
 use crate::client::play::bossevent_action::BosseventAction;
 use crate::ser::{NetworkWriteExt, WritingError};
-use crate::{ClientPacket, VarInt};
 use pumpkin_data::packet::clientbound::PLAY_BOSS_EVENT;
 use pumpkin_macros::packet;
 
@@ -32,29 +32,29 @@ impl ClientPacket for CBossEvent<'_> {
                 division,
                 flags,
             } => {
-                write.write_var_int(&VarInt::from(0u8))?;
+                write.write_var_int(&0.into())?;
                 write.write_slice(&title.encode())?;
                 write.write_f32_be(*health)?;
                 write.write_var_int(color)?;
                 write.write_var_int(division)?;
                 write.write_u8_be(*flags)
             }
-            BosseventAction::Remove => write.write_var_int(&VarInt::from(1u8)),
+            BosseventAction::Remove => write.write_var_int(&1.into()),
             BosseventAction::UpdateHealth(health) => {
-                write.write_var_int(&VarInt::from(2u8))?;
+                write.write_var_int(&2.into())?;
                 write.write_f32_be(*health)
             }
             BosseventAction::UpdateTile(title) => {
-                write.write_var_int(&VarInt::from(3u8))?;
+                write.write_var_int(&3.into())?;
                 write.write_slice(&title.encode())
             }
             BosseventAction::UpdateStyle { color, dividers } => {
-                write.write_var_int(&VarInt::from(4u8))?;
+                write.write_var_int(&4.into())?;
                 write.write_var_int(color)?;
                 write.write_var_int(dividers)
             }
             BosseventAction::UpdateFlags(flags) => {
-                write.write_var_int(&VarInt::from(5u8))?;
+                write.write_var_int(&5.into())?;
                 write.write_u8_be(*flags)
             }
         }

--- a/pumpkin-protocol/src/client/play/chunk_batch_end.rs
+++ b/pumpkin-protocol/src/client/play/chunk_batch_end.rs
@@ -11,7 +11,7 @@ pub struct CChunkBatchEnd {
 }
 
 impl CChunkBatchEnd {
-    pub fn new(count: usize) -> Self {
+    pub fn new(count: u16) -> Self {
         Self {
             batch_size: count.into(),
         }

--- a/pumpkin-protocol/src/client/play/chunk_data.rs
+++ b/pumpkin-protocol/src/client/play/chunk_data.rs
@@ -53,7 +53,12 @@ impl ClientPacket for CChunkData<'_> {
             // TODO: Implement, currently default to full bright
             let chunk_light = vec![0xFFu8; chunk_light_len];
 
-            light_buf.write_var_int(&chunk_light_len.into())?;
+            light_buf.write_var_int(&chunk_light_len.try_into().map_err(|_| {
+                WritingError::Message(format!(
+                    "{} is not representable as a VarInt!",
+                    chunk_light_len
+                ))
+            })?)?;
             light_buf.write_slice(&chunk_light)?;
 
             // Block count
@@ -68,7 +73,12 @@ impl ClientPacket for CChunkData<'_> {
                     data_buf.write_var_int(&registry_id.into())?;
                 }
                 NetworkPalette::Indirect(palette) => {
-                    data_buf.write_var_int(&palette.len().into())?;
+                    data_buf.write_var_int(&palette.len().try_into().map_err(|_| {
+                        WritingError::Message(format!(
+                            "{} is not representable as a VarInt!",
+                            palette.len()
+                        ))
+                    })?)?;
                     for registry_id in palette {
                         data_buf.write_var_int(&registry_id.into())?;
                     }
@@ -89,7 +99,12 @@ impl ClientPacket for CChunkData<'_> {
                     data_buf.write_var_int(&registry_id.into())?;
                 }
                 NetworkPalette::Indirect(palette) => {
-                    data_buf.write_var_int(&palette.len().into())?;
+                    data_buf.write_var_int(&palette.len().try_into().map_err(|_| {
+                        WritingError::Message(format!(
+                            "{} is not representable as a VarInt!",
+                            palette.len()
+                        ))
+                    })?)?;
                     for registry_id in palette {
                         data_buf.write_var_int(&registry_id.into())?;
                     }
@@ -105,7 +120,12 @@ impl ClientPacket for CChunkData<'_> {
         }
 
         // Chunk data
-        write.write_var_int(&data_buf.len().into())?;
+        write.write_var_int(&data_buf.len().try_into().map_err(|_| {
+            WritingError::Message(format!(
+                "{} is not representable as a VarInt!",
+                data_buf.len()
+            ))
+        })?)?;
         write.write_slice(&data_buf)?;
 
         // TODO: block entities
@@ -123,7 +143,12 @@ impl ClientPacket for CChunkData<'_> {
         write.write_bitset(&BitSet(Box::new([0])))?;
 
         // Sky light
-        write.write_var_int(&self.0.section.sections.len().into())?;
+        write.write_var_int(&self.0.section.sections.len().try_into().map_err(|_| {
+            WritingError::Message(format!(
+                "{} is not representable as a VarInt!",
+                self.0.section.sections.len()
+            ))
+        })?)?;
         write.write_slice(&light_buf)?;
 
         // Block Lighting

--- a/pumpkin-protocol/src/client/play/commands.rs
+++ b/pumpkin-protocol/src/client/play/commands.rs
@@ -10,12 +10,12 @@ use crate::{
 
 #[packet(PLAY_COMMANDS)]
 pub struct CCommands<'a> {
-    pub nodes: Vec<ProtoNode<'a>>,
+    pub nodes: Box<[ProtoNode<'a>]>,
     pub root_node_index: VarInt,
 }
 
 impl<'a> CCommands<'a> {
-    pub fn new(nodes: Vec<ProtoNode<'a>>, root_node_index: VarInt) -> Self {
+    pub fn new(nodes: Box<[ProtoNode<'a>]>, root_node_index: VarInt) -> Self {
         Self {
             nodes,
             root_node_index,
@@ -34,7 +34,7 @@ impl ClientPacket for CCommands<'_> {
 }
 
 pub struct ProtoNode<'a> {
-    pub children: Vec<VarInt>,
+    pub children: Box<[VarInt]>,
     pub node_type: ProtoNodeType<'a>,
 }
 

--- a/pumpkin-protocol/src/client/play/entity_metadata.rs
+++ b/pumpkin-protocol/src/client/play/entity_metadata.rs
@@ -2,17 +2,19 @@ use pumpkin_data::packet::clientbound::PLAY_SET_ENTITY_DATA;
 use pumpkin_macros::packet;
 use serde::Serialize;
 
-use crate::VarInt;
+use crate::{VarInt, ser::network_serialize_no_prefix};
 
 #[derive(Serialize)]
 #[packet(PLAY_SET_ENTITY_DATA)]
 pub struct CSetEntityMetadata {
     entity_id: VarInt,
-    metadata: Vec<u8>,
+    // TODO: We should migrate the serialization of this into this file
+    #[serde(serialize_with = "network_serialize_no_prefix")]
+    metadata: Box<[u8]>,
 }
 
 impl CSetEntityMetadata {
-    pub fn new(entity_id: VarInt, metadata: Vec<u8>) -> Self {
+    pub fn new(entity_id: VarInt, metadata: Box<[u8]>) -> Self {
         Self {
             entity_id,
             metadata,

--- a/pumpkin-protocol/src/client/play/login.rs
+++ b/pumpkin-protocol/src/client/play/login.rs
@@ -11,7 +11,6 @@ use crate::{VarInt, codec::identifier::Identifier};
 pub struct CLogin<'a> {
     entity_id: i32,
     is_hardcore: bool,
-    dimension_count: VarInt,
     dimension_names: &'a [Identifier],
     max_players: VarInt,
     view_distance: VarInt,
@@ -61,7 +60,6 @@ impl<'a> CLogin<'a> {
         Self {
             entity_id,
             is_hardcore,
-            dimension_count: VarInt(dimension_names.len() as i32),
             dimension_names,
             max_players,
             view_distance,

--- a/pumpkin-protocol/src/client/play/multi_block_update.rs
+++ b/pumpkin-protocol/src/client/play/multi_block_update.rs
@@ -36,7 +36,14 @@ impl Serialize for CMultiBlockUpdate {
         let mut tuple = serializer.serialize_tuple(2 + self.positions_to_state_ids.len())?;
 
         tuple.serialize_element(&vector3::packed_chunk_pos(&self.chunk_section))?;
-        tuple.serialize_element(&VarInt::from(self.positions_to_state_ids.len() as i32))?;
+        tuple.serialize_element(&VarInt(
+            self.positions_to_state_ids.len().try_into().map_err(|_| {
+                serde::ser::Error::custom(format!(
+                    "{} is not representable as a VarInt!",
+                    self.positions_to_state_ids.len()
+                ))
+            })?,
+        ))?;
 
         for (position, state_id) in &self.positions_to_state_ids {
             let long = ((*state_id as u64) << 12) | (*position as u64);

--- a/pumpkin-protocol/src/client/play/player_chat_message.rs
+++ b/pumpkin-protocol/src/client/play/player_chat_message.rs
@@ -65,6 +65,7 @@ impl CPlayerChatMessage {
     }
 }
 
+//TODO: Check if we need this custom impl
 impl ClientPacket for CPlayerChatMessage {
     fn write_packet_data(&self, write: impl Write) -> Result<(), WritingError> {
         let mut write = write;

--- a/pumpkin-protocol/src/client/play/player_info_update.rs
+++ b/pumpkin-protocol/src/client/play/player_info_update.rs
@@ -49,9 +49,19 @@ impl ClientPacket for CPlayerInfoUpdate<'_> {
                         p.write_option(init_chat, |p, v| {
                             p.write_uuid(&v.session_id)?;
                             p.write_i64_be(v.expires_at)?;
-                            p.write_var_int(&v.public_key.len().into())?;
+                            p.write_var_int(&v.public_key.len().try_into().map_err(|_| {
+                                WritingError::Message(format!(
+                                    "{} isn't representable as a VarInt",
+                                    v.public_key.len()
+                                ))
+                            })?)?;
                             p.write_slice(&v.public_key)?;
-                            p.write_var_int(&v.signature.len().into())?;
+                            p.write_var_int(&v.signature.len().try_into().map_err(|_| {
+                                WritingError::Message(format!(
+                                    "{} isn't representable as a VarInt",
+                                    v.signature.len()
+                                ))
+                            })?)?;
                             p.write_slice(&v.signature)
                         })?;
                     }

--- a/pumpkin-protocol/src/client/play/player_info_update.rs
+++ b/pumpkin-protocol/src/client/play/player_info_update.rs
@@ -27,6 +27,7 @@ impl<'a> CPlayerInfoUpdate<'a> {
     }
 }
 
+// TODO: Check if we need this custom impl
 impl ClientPacket for CPlayerInfoUpdate<'_> {
     fn write_packet_data(&self, write: impl Write) -> Result<(), WritingError> {
         let mut write = write;

--- a/pumpkin-protocol/src/client/play/player_position.rs
+++ b/pumpkin-protocol/src/client/play/player_position.rs
@@ -39,6 +39,7 @@ impl<'a> CPlayerPosition<'a> {
     }
 }
 
+// TODO: Do we need a custom impl?
 impl ClientPacket for CPlayerPosition<'_> {
     fn write_packet_data(&self, write: impl Write) -> Result<(), WritingError> {
         let mut write = write;

--- a/pumpkin-protocol/src/client/play/player_remove.rs
+++ b/pumpkin-protocol/src/client/play/player_remove.rs
@@ -2,22 +2,16 @@ use pumpkin_data::packet::clientbound::PLAY_PLAYER_INFO_REMOVE;
 use pumpkin_macros::packet;
 use serde::{Serialize, ser::SerializeSeq};
 
-use crate::VarInt;
-
 #[derive(Serialize)]
 #[packet(PLAY_PLAYER_INFO_REMOVE)]
 pub struct CRemovePlayerInfo<'a> {
-    players_count: VarInt,
     #[serde(serialize_with = "serialize_slice_uuids")]
     players: &'a [uuid::Uuid],
 }
 
 impl<'a> CRemovePlayerInfo<'a> {
-    pub fn new(players_count: VarInt, players: &'a [uuid::Uuid]) -> Self {
-        Self {
-            players_count,
-            players,
-        }
+    pub fn new(players: &'a [uuid::Uuid]) -> Self {
+        Self { players }
     }
 }
 

--- a/pumpkin-protocol/src/client/play/remove_entities.rs
+++ b/pumpkin-protocol/src/client/play/remove_entities.rs
@@ -7,15 +7,11 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_REMOVE_ENTITIES)]
 pub struct CRemoveEntities<'a> {
-    entity_count: VarInt,
     entity_ids: &'a [VarInt],
 }
 
 impl<'a> CRemoveEntities<'a> {
     pub fn new(entity_ids: &'a [VarInt]) -> Self {
-        Self {
-            entity_count: entity_ids.len().into(),
-            entity_ids,
-        }
+        Self { entity_ids }
     }
 }

--- a/pumpkin-protocol/src/client/play/server_links.rs
+++ b/pumpkin-protocol/src/client/play/server_links.rs
@@ -1,4 +1,4 @@
-use crate::{Link, VarInt};
+use crate::Link;
 use pumpkin_data::packet::clientbound::PLAY_SERVER_LINKS;
 use pumpkin_macros::packet;
 use serde::Serialize;
@@ -6,12 +6,11 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SERVER_LINKS)]
 pub struct CPlayServerLinks<'a> {
-    links_count: &'a VarInt,
     links: &'a [Link<'a>],
 }
 
 impl<'a> CPlayServerLinks<'a> {
-    pub fn new(links_count: &'a VarInt, links: &'a [Link<'a>]) -> Self {
-        Self { links_count, links }
+    pub fn new(links: &'a [Link<'a>]) -> Self {
+        Self { links }
     }
 }

--- a/pumpkin-protocol/src/client/play/set_container_content.rs
+++ b/pumpkin-protocol/src/client/play/set_container_content.rs
@@ -10,7 +10,6 @@ use serde::Serialize;
 pub struct CSetContainerContent<'a> {
     window_id: VarInt,
     state_id: VarInt,
-    count: VarInt,
     slot_data: &'a [Slot],
     carried_item: &'a Slot,
 }
@@ -25,7 +24,6 @@ impl<'a> CSetContainerContent<'a> {
         Self {
             window_id,
             state_id,
-            count: slots.len().into(),
             slot_data: slots,
             carried_item,
         }

--- a/pumpkin-protocol/src/client/play/store_cookie.rs
+++ b/pumpkin-protocol/src/client/play/store_cookie.rs
@@ -1,4 +1,4 @@
-use crate::{VarInt, codec::identifier::Identifier};
+use crate::codec::identifier::Identifier;
 use pumpkin_data::packet::clientbound::PLAY_STORE_COOKIE;
 use pumpkin_macros::packet;
 use serde::Serialize;
@@ -9,16 +9,11 @@ use serde::Serialize;
 #[packet(PLAY_STORE_COOKIE)]
 pub struct CStoreCookie<'a> {
     key: &'a Identifier,
-    payload_length: VarInt,
     payload: &'a [u8], // 5120,
 }
 
 impl<'a> CStoreCookie<'a> {
     pub fn new(key: &'a Identifier, payload: &'a [u8]) -> Self {
-        Self {
-            key,
-            payload_length: VarInt(payload.len() as i32),
-            payload,
-        }
+        Self { key, payload }
     }
 }

--- a/pumpkin-protocol/src/client/play/teleport_entity.rs
+++ b/pumpkin-protocol/src/client/play/teleport_entity.rs
@@ -42,6 +42,7 @@ impl<'a> CTeleportEntity<'a> {
     }
 }
 
+// TODO: Do we need a custom impl?
 impl ClientPacket for CTeleportEntity<'_> {
     fn write_packet_data(&self, write: impl Write) -> Result<(), WritingError> {
         let mut write = write;

--- a/pumpkin-protocol/src/codec/bit_set.rs
+++ b/pumpkin-protocol/src/codec/bit_set.rs
@@ -12,7 +12,10 @@ pub struct BitSet(pub Box<[i64]>);
 
 impl BitSet {
     pub fn encode(&self, write: &mut impl Write) -> Result<(), WritingError> {
-        write.write_var_int(&self.0.len().into())?;
+        write.write_var_int(&self.0.len().try_into().map_err(|_| {
+            WritingError::Message(format!("{} isn't representable as a VarInt", self.0.len()))
+        })?)?;
+
         for b in &self.0 {
             write.write_i64_be(*b)?;
         }

--- a/pumpkin-protocol/src/codec/var_long.rs
+++ b/pumpkin-protocol/src/codec/var_long.rs
@@ -47,6 +47,7 @@ impl VarLong {
         Ok(())
     }
 
+    // TODO: Validate that the first byte will not overflow a i64
     pub fn decode(read: &mut impl Read) -> Result<Self, ReadingError> {
         let mut val = 0;
         for i in 0..Self::MAX_SIZE.get() {

--- a/pumpkin-protocol/src/lib.rs
+++ b/pumpkin-protocol/src/lib.rs
@@ -383,6 +383,7 @@ pub struct Property {
     pub signature: Option<String>,
 }
 
+#[derive(Serialize)]
 pub struct KnownPack<'a> {
     pub namespace: &'a str,
     pub id: &'a str,

--- a/pumpkin-protocol/src/ser/mod.rs
+++ b/pumpkin-protocol/src/ser/mod.rs
@@ -11,6 +11,17 @@ use thiserror::Error;
 pub mod packet;
 pub mod serializer;
 
+// TODO: This is a bit hacky
+const NO_PREFIX_MARKER: &str = "__network_no_prefix";
+
+pub fn network_serialize_no_prefix<T, S>(input: T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: serde::Serialize,
+    S: serde::Serializer,
+{
+    serializer.serialize_newtype_struct(NO_PREFIX_MARKER, &input)
+}
+
 #[derive(Debug, Error)]
 pub enum ReadingError {
     #[error("EOF, Tried to read {0} but No bytes left to consume")]

--- a/pumpkin-protocol/src/ser/mod.rs
+++ b/pumpkin-protocol/src/ser/mod.rs
@@ -273,26 +273,55 @@ pub trait NetworkWriteExt {
     fn write_f64_be(&mut self, data: f64) -> Result<(), WritingError>;
     fn write_slice(&mut self, data: &[u8]) -> Result<(), WritingError>;
 
-    fn write_bool(&mut self, data: bool) -> Result<(), WritingError>;
+    fn write_bool(&mut self, data: bool) -> Result<(), WritingError> {
+        if data {
+            self.write_u8_be(1)
+        } else {
+            self.write_u8_be(0)
+        }
+    }
     fn write_var_int(&mut self, data: &VarInt) -> Result<(), WritingError>;
     fn write_var_long(&mut self, data: &VarLong) -> Result<(), WritingError>;
     fn write_string_bounded(&mut self, data: &str, bound: usize) -> Result<(), WritingError>;
     fn write_string(&mut self, data: &str) -> Result<(), WritingError>;
     fn write_identifier(&mut self, data: &Identifier) -> Result<(), WritingError>;
-    fn write_uuid(&mut self, data: &uuid::Uuid) -> Result<(), WritingError>;
+
+    fn write_uuid(&mut self, data: &uuid::Uuid) -> Result<(), WritingError> {
+        let (first, second) = data.as_u64_pair();
+        self.write_u64_be(first)?;
+        self.write_u64_be(second)
+    }
+
     fn write_bitset(&mut self, bitset: &BitSet) -> Result<(), WritingError>;
 
     fn write_option<G>(
         &mut self,
         data: &Option<G>,
-        write: impl FnOnce(&mut Self, &G) -> Result<(), WritingError>,
-    ) -> Result<(), WritingError>;
+        writer: impl FnOnce(&mut Self, &G) -> Result<(), WritingError>,
+    ) -> Result<(), WritingError> {
+        if let Some(data) = data {
+            self.write_bool(true)?;
+            writer(self, data)
+        } else {
+            self.write_bool(false)
+        }
+    }
 
     fn write_list<G>(
         &mut self,
-        data: &[G],
-        write: impl Fn(&mut Self, &G) -> Result<(), WritingError>,
-    ) -> Result<(), WritingError>;
+        list: &[G],
+        writer: impl Fn(&mut Self, &G) -> Result<(), WritingError>,
+    ) -> Result<(), WritingError> {
+        self.write_var_int(&list.len().try_into().map_err(|_| {
+            WritingError::Message(format!("{} isn't representable as a VarInt", list.len()))
+        })?)?;
+
+        for data in list {
+            writer(self, data)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<W: Write> NetworkWriteExt for W {
@@ -350,14 +379,6 @@ impl<W: Write> NetworkWriteExt for W {
         self.write_all(data).map_err(WritingError::IoError)
     }
 
-    fn write_bool(&mut self, data: bool) -> Result<(), WritingError> {
-        if data {
-            self.write_u8_be(1)
-        } else {
-            self.write_u8_be(0)
-        }
-    }
-
     fn write_var_int(&mut self, data: &VarInt) -> Result<(), WritingError> {
         data.encode(self)
     }
@@ -368,7 +389,10 @@ impl<W: Write> NetworkWriteExt for W {
 
     fn write_string_bounded(&mut self, data: &str, bound: usize) -> Result<(), WritingError> {
         assert!(data.len() <= bound);
-        self.write_var_int(&data.len().into())?;
+        self.write_var_int(&data.len().try_into().map_err(|_| {
+            WritingError::Message(format!("{} isn't representable as a VarInt", data.len()))
+        })?)?;
+
         self.write_all(data.as_bytes())
             .map_err(WritingError::IoError)
     }
@@ -381,40 +405,8 @@ impl<W: Write> NetworkWriteExt for W {
         data.encode(self)
     }
 
-    fn write_uuid(&mut self, data: &uuid::Uuid) -> Result<(), WritingError> {
-        let (first, second) = data.as_u64_pair();
-        self.write_u64_be(first)?;
-        self.write_u64_be(second)
-    }
-
     fn write_bitset(&mut self, data: &BitSet) -> Result<(), WritingError> {
         data.encode(self)
-    }
-
-    fn write_option<G>(
-        &mut self,
-        data: &Option<G>,
-        writer: impl FnOnce(&mut Self, &G) -> Result<(), WritingError>,
-    ) -> Result<(), WritingError> {
-        if let Some(data) = data {
-            self.write_bool(true)?;
-            writer(self, data)
-        } else {
-            self.write_bool(false)
-        }
-    }
-
-    fn write_list<G>(
-        &mut self,
-        list: &[G],
-        writer: impl Fn(&mut Self, &G) -> Result<(), WritingError>,
-    ) -> Result<(), WritingError> {
-        self.write_var_int(&list.len().into())?;
-        for data in list {
-            writer(self, data)?;
-        }
-
-        Ok(())
     }
 }
 

--- a/pumpkin-protocol/src/ser/serializer.rs
+++ b/pumpkin-protocol/src/ser/serializer.rs
@@ -2,10 +2,10 @@ use std::fmt::Display;
 
 use serde::{
     Serialize,
-    ser::{self},
+    ser::{self, Impossible},
 };
 
-use super::{NetworkWriteExt, Write, WritingError};
+use super::{NO_PREFIX_MARKER, NetworkWriteExt, Write, WritingError};
 
 pub struct Serializer<W: Write> {
     pub write: W,
@@ -20,6 +20,202 @@ impl<W: Write> Serializer<W> {
 impl ser::Error for WritingError {
     fn custom<T: Display>(msg: T) -> Self {
         Self::Message(msg.to_string())
+    }
+}
+
+/// This serializer just writes a sequence without a varint prefix and defers the rest of the
+/// serialization to the wrapped serializer
+struct NonPrefixedSeqSerializer<'a, W: Write> {
+    wrapped: &'a mut Serializer<W>,
+}
+
+macro_rules! create_fail_method {
+    ($method: ident, $ty: ty) => {
+        fn $method(self, _v: $ty) -> Result<Self::Ok, Self::Error> {
+            Err(WritingError::Serde(format!(
+                "Expected a sequence, but found {}!",
+                stringify!($ty)
+            )))
+        }
+    };
+}
+
+impl<W: Write> ser::SerializeSeq for NonPrefixedSeqSerializer<'_, W> {
+    type Ok = ();
+    type Error = WritingError;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(&mut *self.wrapped).map(|_| ())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<W: Write> ser::Serializer for NonPrefixedSeqSerializer<'_, W> {
+    type Ok = ();
+    type Error = WritingError;
+
+    type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeSeq = Self;
+
+    create_fail_method!(serialize_bool, bool);
+    create_fail_method!(serialize_bytes, &[u8]);
+    create_fail_method!(serialize_char, char);
+    create_fail_method!(serialize_f32, f32);
+    create_fail_method!(serialize_f64, f64);
+    create_fail_method!(serialize_i8, i8);
+    create_fail_method!(serialize_i16, i16);
+    create_fail_method!(serialize_i32, i32);
+    create_fail_method!(serialize_i64, i64);
+    create_fail_method!(serialize_u8, u8);
+    create_fail_method!(serialize_u16, u16);
+    create_fail_method!(serialize_u32, u32);
+    create_fail_method!(serialize_u64, u64);
+    create_fail_method!(serialize_str, &str);
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(WritingError::Serde(
+            "Expected a sequence but found a map!".into(),
+        ))
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(WritingError::Serde(format!(
+            "Expected a sequence but found a newtype struct {}!",
+            name
+        )))
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(WritingError::Serde(format!(
+            "Expected a sequence but found a newtype variant {}!",
+            name
+        )))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(WritingError::Serde(
+            "Expected a sequence but found None!".into(),
+        ))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(WritingError::Serde(format!(
+            "Expected a sequence but found Some {}!",
+            stringify!(T)
+        )))
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(WritingError::Serde(format!(
+            "Expected a sequence but found a struct {}!",
+            name
+        )))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(WritingError::Serde(format!(
+            "Expected a sequence but found a struct variant {}!",
+            name
+        )))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(WritingError::Serde(
+            "Expected a sequence but found a tuple!".into(),
+        ))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(WritingError::Serde(format!(
+            "Expected a sequence but found a tuple struct {}!",
+            name
+        )))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(WritingError::Serde(format!(
+            "Expected a sequence but found a tuple variant {}!",
+            name
+        )))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(WritingError::Serde(
+            "Expected a sequence but found a unit!".into(),
+        ))
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(WritingError::Serde(format!(
+            "Expected a sequence but found a unit struct {}!",
+            name
+        )))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(WritingError::Serde(format!(
+            "Expected a sequence but found a unit variant {}!",
+            name
+        )))
     }
 }
 
@@ -87,13 +283,13 @@ impl<W: Write> ser::Serializer for &mut Serializer<W> {
         // TODO: This is super sketchy... is there a way to do it better? Can we choose what
         // serializer to use on a struct somehow from within the struct?
         if name == "TextComponent" {
-            let mut buf = Vec::new();
-            let mut nbt_serializer = pumpkin_nbt::serializer::Serializer::new(&mut buf, None);
-            value
-                .serialize(&mut nbt_serializer)
-                .expect("Failed to serialize NBT for TextComponent within the network serializer");
-
-            self.serialize_bytes(&buf)
+            let mut nbt_serializer =
+                pumpkin_nbt::serializer::Serializer::new(&mut self.write, None);
+            value.serialize(&mut nbt_serializer).map_err(|err| {
+                WritingError::Serde(format!("Failed to serialize TextComponent NBT: {}", err))
+            })
+        } else if name == NO_PREFIX_MARKER {
+            value.serialize(NonPrefixedSeqSerializer { wrapped: self })
         } else {
             value.serialize(self)
         }
@@ -114,9 +310,16 @@ impl<W: Write> ser::Serializer for &mut Serializer<W> {
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
         self.write.write_bool(false)
     }
-    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        let Some(len) = len else {
+            return Err(WritingError::Serde(
+                "Sequences must have a known length".into(),
+            ));
+        };
+
         // here is where all arrays/list getting written, usually we prefix the length of every length with an var int. The problem is
         // that byte arrays also getting thrown in here, and we don't want to prefix them
+        self.write.write_var_int(&len.into())?;
         Ok(self)
     }
     fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>

--- a/pumpkin/src/command/client_suggestions.rs
+++ b/pumpkin/src/command/client_suggestions.rs
@@ -48,7 +48,7 @@ pub async fn send_c_commands_packet(player: &Arc<Player>, dispatcher: &CommandDi
     let mut proto_nodes = Vec::new();
     let root_node_index = root.build(&mut proto_nodes);
 
-    let packet = CCommands::new(proto_nodes, root_node_index.into());
+    let packet = CCommands::new(proto_nodes.into(), root_node_index.into());
     player.client.enqueue_packet(&packet).await;
 }
 
@@ -68,7 +68,7 @@ impl<'a> ProtoNodeBuilder<'a> {
 
         let i = buffer.len();
         buffer.push(ProtoNode {
-            children,
+            children: children.into(),
             node_type: self.node_type,
         });
         i

--- a/pumpkin/src/command/client_suggestions.rs
+++ b/pumpkin/src/command/client_suggestions.rs
@@ -48,7 +48,7 @@ pub async fn send_c_commands_packet(player: &Arc<Player>, dispatcher: &CommandDi
     let mut proto_nodes = Vec::new();
     let root_node_index = root.build(&mut proto_nodes);
 
-    let packet = CCommands::new(proto_nodes.into(), root_node_index.into());
+    let packet = CCommands::new(proto_nodes.into(), root_node_index.try_into().unwrap());
     player.client.enqueue_packet(&packet).await;
 }
 
@@ -63,7 +63,7 @@ impl<'a> ProtoNodeBuilder<'a> {
         let mut children = Vec::new();
         for node in self.child_nodes {
             let i = node.build(buffer);
-            children.push(i.into());
+            children.push(i.try_into().unwrap());
         }
 
         let i = buffer.len();

--- a/pumpkin/src/entity/hunger.rs
+++ b/pumpkin/src/entity/hunger.rs
@@ -71,7 +71,7 @@ impl NBTStorage for HungerManager {
     // TODO: Proper value checks
 
     async fn write_nbt(&self, nbt: &mut NbtCompound) {
-        nbt.put_int("foodLevel", self.level.load() as i32);
+        nbt.put_int("foodLevel", self.level.load().into());
         nbt.put_float("foodSaturationLevel", self.saturation.load());
         nbt.put_float("foodExhaustionLevel", self.exhaustion.load());
         nbt.put_int("foodTickTimer", self.tick_timer.load() as i32);

--- a/pumpkin/src/entity/hunger.rs
+++ b/pumpkin/src/entity/hunger.rs
@@ -4,9 +4,10 @@ use crossbeam::atomic::AtomicCell;
 use pumpkin_data::damage::DamageType;
 use pumpkin_nbt::compound::NbtCompound;
 
+// TODO: This entire thing should be atomic, not individual fields
 pub struct HungerManager {
     /// The current hunger level.
-    pub level: AtomicCell<u32>,
+    pub level: AtomicCell<u8>,
     /// The food saturation level.
     pub saturation: AtomicCell<f32>,
     pub exhaustion: AtomicCell<f32>,
@@ -67,6 +68,8 @@ impl HungerManager {
 
 #[async_trait]
 impl NBTStorage for HungerManager {
+    // TODO: Proper value checks
+
     async fn write_nbt(&self, nbt: &mut NbtCompound) {
         nbt.put_int("foodLevel", self.level.load() as i32);
         nbt.put_float("foodSaturationLevel", self.saturation.load());
@@ -76,7 +79,7 @@ impl NBTStorage for HungerManager {
 
     async fn read_nbt(&mut self, nbt: &mut NbtCompound) {
         self.level
-            .store(nbt.get_int("foodLevel").unwrap_or(20) as u32);
+            .store(nbt.get_int("foodLevel").unwrap_or(20) as u8);
         self.saturation
             .store(nbt.get_float("foodSaturationLevel").unwrap_or(5.0));
         self.exhaustion

--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -144,7 +144,7 @@ impl EntityBase for ItemEntity {
                     .enqueue_packet(&CTakeItemEntity::new(
                         self.entity.entity_id.into(),
                         player.entity_id().into(),
-                        total_pick_up.into(),
+                        total_pick_up.try_into().unwrap(),
                     ))
                     .await;
             }

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -80,7 +80,7 @@ impl LivingEntity {
             .broadcast_packet_all(&CTakeItemEntity::new(
                 item.entity_id.into(),
                 self.entity.entity_id.into(),
-                stack_amount.into(),
+                stack_amount.try_into().unwrap(),
             ))
             .await;
     }

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -411,7 +411,7 @@ impl Entity {
         self.world
             .read()
             .await
-            .broadcast_packet_all(&CSetEntityMetadata::new(self.entity_id.into(), buf))
+            .broadcast_packet_all(&CSetEntityMetadata::new(self.entity_id.into(), buf.into()))
             .await;
     }
 

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -4,7 +4,7 @@ use std::{
     ops::AddAssign,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32, Ordering},
+        atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU8, AtomicU32, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -217,7 +217,7 @@ pub struct Player {
     /// The player's last known experience level.
     pub last_sent_xp: AtomicI32,
     pub last_sent_health: AtomicI32,
-    pub last_sent_food: AtomicU32,
+    pub last_sent_food: AtomicU8,
     pub last_food_saturation: AtomicBool,
     /// The player's permission level.
     pub permission_lvl: AtomicCell<PermissionLvl>,
@@ -315,7 +315,7 @@ impl Player {
             chunk_manager: Mutex::new(ChunkManager::new(16)),
             last_sent_xp: AtomicI32::new(-1),
             last_sent_health: AtomicI32::new(-1),
-            last_sent_food: AtomicU32::new(0),
+            last_sent_food: AtomicU8::new(0),
             last_food_saturation: AtomicBool::new(true),
             has_played_before: AtomicBool::new(false),
             chat_session: Arc::new(Mutex::new(ChatSession::default())), // Placeholder value until the player actually sets their session id
@@ -515,7 +515,7 @@ impl Player {
     ) {
         self.client
             .enqueue_packet(&CSoundEffect::new(
-                IdOr::Id(u32::from(sound_id)),
+                IdOr::Id(sound_id),
                 category,
                 position,
                 volume,
@@ -576,7 +576,7 @@ impl Player {
                 self.client.send_packet_now(&CChunkData(&chunk)).await;
             }
             self.client
-                .send_packet_now(&CChunkBatchEnd::new(chunk_count))
+                .send_packet_now(&CChunkBatchEnd::new(chunk_count as u16))
                 .await;
         }
 
@@ -1228,7 +1228,7 @@ impl Player {
     pub async fn send_message(
         &self,
         message: &TextComponent,
-        chat_type: u32,
+        chat_type: u8,
         sender_name: &TextComponent,
         target_name: Option<&TextComponent>,
     ) {

--- a/pumpkin/src/net/container.rs
+++ b/pumpkin/src/net/container.rs
@@ -75,7 +75,7 @@ impl Player {
         inventory.increment_state_id();
         let packet = CSetContainerContent::new(
             id.into(),
-            (inventory.state_id).into(),
+            (inventory.state_id).try_into().unwrap(),
             &slots,
             &carried_item,
         );

--- a/pumpkin/src/net/packet/login.rs
+++ b/pumpkin/src/net/packet/login.rs
@@ -7,7 +7,6 @@ use pumpkin_protocol::{
         config::{CConfigAddResourcePack, CConfigServerLinks, CKnownPacks, CUpdateTags},
         login::{CLoginSuccess, CSetCompression},
     },
-    codec::var_int::VarInt,
     server::login::{SEncryptionResponse, SLoginCookieResponse, SLoginPluginResponse, SLoginStart},
 };
 use pumpkin_util::text::TextComponent;
@@ -340,15 +339,11 @@ impl Client {
         self.send_packet_now(&server.get_branding()).await;
 
         if advanced_config().server_links.enabled {
-            self.send_packet_now(&CConfigServerLinks::new(
-                &VarInt(LINKS.len() as i32),
-                &LINKS,
-            ))
-            .await;
+            self.send_packet_now(&CConfigServerLinks::new(&LINKS)).await;
         }
 
-        // TODO: Is this the right place to send them?
         // Send tags.
+        // TODO: Is this the right place to send them?
 
         self.send_packet_now(&CUpdateTags::new(&[
             pumpkin_data::tag::RegistryKey::Block,

--- a/pumpkin/src/net/packet/login.rs
+++ b/pumpkin/src/net/packet/login.rs
@@ -246,8 +246,10 @@ impl Client {
     async fn enable_compression(&self) {
         let compression = advanced_config().networking.packet_compression.info.clone();
         // We want to wait until we have sent the compression packet to the client
-        self.send_packet_now(&CSetCompression::new(compression.threshold.into()))
-            .await;
+        self.send_packet_now(&CSetCompression::new(
+            compression.threshold.try_into().unwrap(),
+        ))
+        .await;
         self.set_compression(compression).await;
     }
 

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -1399,7 +1399,7 @@ impl Player {
             packet.id,
             (last_word_start + 2).into(),
             (cmd.len() - last_word_start - 1).into(),
-            suggestions,
+            suggestions.into(),
         );
 
         self.client.enqueue_packet(&response).await;

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -1397,8 +1397,8 @@ impl Player {
 
         let response = CCommandSuggestions::new(
             packet.id,
-            (last_word_start + 2).into(),
-            (cmd.len() - last_word_start - 1).into(),
+            (last_word_start + 2).try_into().unwrap(),
+            (cmd.len() - last_word_start - 1).try_into().unwrap(),
             suggestions.into(),
         );
 

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -339,7 +339,7 @@ impl Server {
         &self,
         message: &TextComponent,
         sender_name: &TextComponent,
-        chat_type: u32,
+        chat_type: u8,
         target_name: Option<&TextComponent>,
     ) {
         send_cancellable! {{

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1248,11 +1248,8 @@ impl World {
             .remove(&player.gameprofile.id)
             .unwrap();
         let uuid = player.gameprofile.id;
-        self.broadcast_packet_except(
-            &[player.gameprofile.id],
-            &CRemovePlayerInfo::new(1.into(), &[uuid]),
-        )
-        .await;
+        self.broadcast_packet_except(&[player.gameprofile.id], &CRemovePlayerInfo::new(&[uuid]))
+            .await;
         self.broadcast_packet_all(&CRemoveEntities::new(&[player.entity_id().into()]))
             .await;
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -210,7 +210,7 @@ impl World {
         &self,
         message: &TextComponent,
         sender_name: &TextComponent,
-        chat_type: u32,
+        chat_type: u8,
         target_name: Option<&TextComponent>,
     ) {
         self.broadcast_packet_all(&CDisguisedChatMessage::new(
@@ -381,14 +381,7 @@ impl World {
         pitch: f32,
     ) {
         let seed = thread_rng().r#gen::<f64>();
-        let packet = CSoundEffect::new(
-            IdOr::Id(u32::from(sound_id)),
-            category,
-            position,
-            volume,
-            pitch,
-            seed,
-        );
+        let packet = CSoundEffect::new(IdOr::Id(sound_id), category, position, volume, pitch, seed);
         self.broadcast_packet_all(&packet).await;
     }
 
@@ -564,7 +557,7 @@ impl World {
                 entity_id,
                 base_config.hardcore,
                 &dimensions,
-                base_config.max_players.into(),
+                base_config.max_players.try_into().unwrap(),
                 base_config.view_distance.get().into(), //  TODO: view distance
                 base_config.simulation_distance.get().into(), // TODO: sim view dinstance
                 false,
@@ -859,7 +852,7 @@ impl World {
         } else {
             Particle::ExplosionEmitter
         };
-        let sound = IdOr::<SoundEvent>::Id(Sound::EntityGenericExplode as u32);
+        let sound = IdOr::<SoundEvent>::Id(Sound::EntityGenericExplode as u16);
         for (_, player) in self.players.read().await.iter() {
             if player.position().squared_distance_to_vec(position) > 4096.0 {
                 continue;


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
* Lists are now prefixed by default with network serializations, removing the need for an additional `VarInt` in packet structs. Adds a `serialize_with` function for serializing lists without a prefixed `VarInt`: `pumpkin-protocol::ser::network_serialize_no_prefix`

* Changes type of some registry ids to the minimally encompassing type

* Possibly fallible code (usize as i32, etc.) is made more explicit with `Into<VarInt>` and `TryInto<VarInt>`

* Some `unwraps` and `expects` are converted to errors

Minimally changed packet structs in this PR to try to minimize conflicts with https://github.com/Pumpkin-MC/Pumpkin/pull/657

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
