### PR TITLE
implement item durability

### DIFF
--- a/pumpkin-data/build/item.rs
+++ b/pumpkin-data/build/item.rs
@@ -328,6 +328,22 @@ pub(crate) fn build() -> TokenStream {
                     _ => None
                 }
             }
+
+            pub fn has_property_changed(&self, field: &str) -> bool {
+                let components = &self.components;
+
+                if let Some(original_item) = Item::from_id(self.id) {
+                    let original_components = &original_item.components;
+
+                    return match field {
+                        "damage" => original_components.damage != components.damage,
+                        _ => false
+                    };
+                }
+
+                false
+            }
+
         }
 
         impl Tagable for Item {

--- a/pumpkin-data/build/item.rs
+++ b/pumpkin-data/build/item.rs
@@ -28,6 +28,8 @@ pub struct ItemComponents {
     pub max_damage: Option<u16>,
     #[serde(rename = "minecraft:attribute_modifiers")]
     pub attribute_modifiers: Option<Vec<Modifier>>,
+    #[serde(rename = "minecraft:break_sound")]
+    pub break_sound: Option<String>,
     #[serde(rename = "minecraft:tool")]
     pub tool: Option<ToolComponent>,
 }
@@ -49,6 +51,15 @@ impl ToTokens for ItemComponents {
                 let text = d.get_text();
                 let item_name = LitStr::new(&text, Span::call_site());
                 quote! { Some(#item_name) }
+            }
+            None => quote! { None },
+        };
+
+        let break_sound = match self.break_sound.clone() {
+            Some(text) => {
+                let text = text.replace("minecraft:", "");
+                let break_sound = LitStr::new(&text, Span::call_site());
+                quote! { Some(#break_sound) }
             }
             None => quote! { None },
         };
@@ -153,6 +164,7 @@ impl ToTokens for ItemComponents {
         tokens.extend(quote! {
             ItemComponents {
                 item_name: #item_name,
+                break_sound: #break_sound,
                 max_stack_size: #max_stack_size,
                 jukebox_playable: #jukebox_playable,
                 damage: #damage,
@@ -252,6 +264,7 @@ pub(crate) fn build() -> TokenStream {
 
         #[derive(Clone, Copy, Debug)]
         pub struct ItemComponents {
+            pub break_sound: Option<&'static str>,
             pub item_name: Option<&'static str>,
             pub max_stack_size: u8,
             pub jukebox_playable: Option<&'static str>,

--- a/pumpkin-protocol/src/client/play/set_container_content.rs
+++ b/pumpkin-protocol/src/client/play/set_container_content.rs
@@ -5,7 +5,7 @@ use pumpkin_data::packet::clientbound::PLAY_CONTAINER_SET_CONTENT;
 use pumpkin_macros::packet;
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[packet(PLAY_CONTAINER_SET_CONTENT)]
 pub struct CSetContainerContent<'a> {
     window_id: VarInt,

--- a/pumpkin-protocol/src/client/play/set_container_slot.rs
+++ b/pumpkin-protocol/src/client/play/set_container_slot.rs
@@ -5,7 +5,7 @@ use pumpkin_data::packet::clientbound::PLAY_CONTAINER_SET_SLOT;
 use pumpkin_macros::packet;
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[packet(PLAY_CONTAINER_SET_SLOT)]
 pub struct CSetContainerSlot<'a> {
     window_id: i8,

--- a/pumpkin-util/src/constants/mod.rs
+++ b/pumpkin-util/src/constants/mod.rs
@@ -1,0 +1,1 @@
+pub mod structured_component_constants;

--- a/pumpkin-util/src/constants/structured_component_constants.rs
+++ b/pumpkin-util/src/constants/structured_component_constants.rs
@@ -1,0 +1,8 @@
+pub const MAX_DAMAGE: &str = "max_damage";
+pub const DAMAGE: &str = "damage";
+
+pub const MINECRAFT_MAX_DAMAGE: &str = "minecraft:max_damage";
+pub const MINECRAFT_DAMAGE: &str = "minecraft:damage";
+
+pub const MAX_DAMAGE_COMPONENT_TYPE: i32 = 2;
+pub const DAMAGE_COMPONENT_TYPE: i32 = 3;

--- a/pumpkin-util/src/lib.rs
+++ b/pumpkin-util/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod biome;
+pub mod constants;
 pub mod gamemode;
 pub mod loot_table;
 pub mod math;

--- a/pumpkin/src/block/mod.rs
+++ b/pumpkin/src/block/mod.rs
@@ -191,7 +191,10 @@ trait ItemEntryExt {
 impl ItemEntryExt for ItemEntry {
     fn get_items(&self) -> Vec<ItemStack> {
         let item = &self.name.replace("minecraft:", "");
-        vec![ItemStack::new(1, Item::from_registry_key(item).unwrap())]
+        vec![ItemStack::new(
+            1,
+            Item::from_registry_key(item).unwrap().clone(),
+        )]
     }
 }
 

--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -43,7 +43,7 @@ impl ItemEntity {
         }
     }
     pub async fn send_meta_packet(&self) {
-        let slot = Slot::new(self.item.id, *self.item_count.lock().await);
+        let slot = Slot::new(&self.item, *self.item_count.lock().await);
         self.entity
             .send_meta_data(&[Metadata::new(8, MetaDataType::ItemStack, &slot)])
             .await;

--- a/pumpkin/src/item/items/hoe.rs
+++ b/pumpkin/src/item/items/hoe.rs
@@ -8,6 +8,7 @@ use pumpkin_data::block::Block;
 use pumpkin_data::entity::EntityType;
 use pumpkin_data::item::Item;
 use pumpkin_data::tag::Tagable;
+use pumpkin_util::GameMode;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::block::BlockDirection;
 use std::sync::Arc;
@@ -31,6 +32,19 @@ impl ItemMetadata for HoeItem {
 
 #[async_trait]
 impl PumpkinItem for HoeItem {
+    async fn on_after_dig(
+        &self,
+        _item: &Item,
+        player: &Player,
+        _location: BlockPos,
+        _block: &Block,
+        _server: &Server,
+    ) {
+        if player.gamemode.load() != GameMode::Creative {
+            self.increment_damage(player).await;
+        }
+    }
+
     async fn use_on_block(
         &self,
         _item: &Item,
@@ -94,6 +108,10 @@ impl PumpkinItem for HoeItem {
                     Arc::new(ItemEntity::new(entity, Block::HANGING_ROOTS.item_id, 1).await);
                 world.spawn_entity(item_entity.clone()).await;
                 item_entity.send_meta_packet().await;
+            }
+
+            if player.gamemode.load() != GameMode::Creative {
+                self.increment_damage(player).await;
             }
         }
     }

--- a/pumpkin/src/item/items/mod.rs
+++ b/pumpkin/src/item/items/mod.rs
@@ -1,5 +1,6 @@
 mod egg;
 mod hoe;
+mod pickaxe;
 mod snowball;
 mod sword;
 mod trident;
@@ -8,6 +9,7 @@ use std::sync::Arc;
 
 use egg::EggItem;
 use hoe::HoeItem;
+use pickaxe::PickaxeItem;
 use snowball::SnowBallItem;
 use sword::SwordItem;
 use trident::TridentItem;
@@ -20,6 +22,7 @@ pub fn default_registry() -> Arc<ItemRegistry> {
     manager.register(SnowBallItem);
     manager.register(HoeItem);
     manager.register(EggItem);
+    manager.register(PickaxeItem);
     manager.register(SwordItem);
     manager.register(TridentItem);
 

--- a/pumpkin/src/item/items/pickaxe.rs
+++ b/pumpkin/src/item/items/pickaxe.rs
@@ -1,0 +1,41 @@
+use crate::entity::player::Player;
+use crate::item::pumpkin_item::{ItemMetadata, PumpkinItem};
+use crate::server::Server;
+use async_trait::async_trait;
+use pumpkin_data::block::Block;
+use pumpkin_data::item::Item;
+use pumpkin_data::tag::Tagable;
+use pumpkin_util::GameMode;
+use pumpkin_util::math::position::BlockPos;
+pub struct PickaxeItem;
+
+impl ItemMetadata for PickaxeItem {
+    fn ids() -> Box<[u16]> {
+        Item::get_tag_values("#minecraft:pickaxes")
+            .expect("This is a valid vanilla tag")
+            .iter()
+            .map(|key| {
+                Item::from_registry_key(key)
+                    .expect("We just got this key from the registry")
+                    .id
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice()
+    }
+}
+
+#[async_trait]
+impl PumpkinItem for PickaxeItem {
+    async fn on_after_dig(
+        &self,
+        _item: &Item,
+        player: &Player,
+        _location: BlockPos,
+        _block: &Block,
+        _server: &Server,
+    ) {
+        if player.gamemode.load() != GameMode::Creative {
+            self.increment_damage(player).await;
+        }
+    }
+}

--- a/pumpkin/src/item/pumpkin_item.rs
+++ b/pumpkin/src/item/pumpkin_item.rs
@@ -1,3 +1,4 @@
+use crate::entity::Entity;
 use crate::entity::player::Player;
 use crate::server::Server;
 use async_trait::async_trait;
@@ -13,6 +14,17 @@ pub trait ItemMetadata {
 #[async_trait]
 pub trait PumpkinItem: Send + Sync {
     async fn normal_use(&self, _block: &Item, _player: &Player) {}
+    async fn on_attack(&self, _item: &Item, _victim: &Entity) {}
+
+    async fn on_after_dig(
+        &self,
+        _item: &Item,
+        _player: &Player,
+        _location: BlockPos,
+        _block: &Block,
+        _server: &Server,
+    ) {
+    }
 
     async fn use_on_block(
         &self,
@@ -23,6 +35,18 @@ pub trait PumpkinItem: Send + Sync {
         _block: &Block,
         _server: &Server,
     ) {
+    }
+
+    async fn increment_damage(&self, _player: &Player) {
+        let mut inventory = _player.inventory().lock().await;
+
+        // This is considering that the method held_item_mut
+        // will return the item that was just used. I believe
+        // only items that are not tools (like armor and elytra)
+        // can 'be used' without being in hand.
+        if let Some(held) = inventory.held_item_mut() {
+            held.damage_item();
+        }
     }
 
     fn can_mine(&self, _player: &Player) -> bool {

--- a/pumpkin/src/item/registry.rs
+++ b/pumpkin/src/item/registry.rs
@@ -1,7 +1,10 @@
+use crate::entity::Entity;
 use crate::entity::player::Player;
 use crate::server::Server;
-use pumpkin_data::block::Block;
 use pumpkin_data::item::Item;
+use pumpkin_data::sound::SoundCategory;
+use pumpkin_data::{block::Block, sound::Sound};
+use pumpkin_inventory::player::PlayerInventory;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::block::BlockDirection;
 use std::collections::HashMap;
@@ -23,6 +26,59 @@ impl ItemRegistry {
         let pumpkin_block = self.get_pumpkin_item(item.id);
         if let Some(pumpkin_block) = pumpkin_block {
             pumpkin_block.normal_use(item, player).await;
+
+            let mut inventory = player.inventory.lock().await;
+
+            self.handle_possible_broken_item(&mut inventory, player)
+                .await;
+        }
+    }
+
+    pub async fn on_attack(&self, entity: &Entity, item: &Item, player: &Player) {
+        let pumpkin_block = self.get_pumpkin_item(item.id);
+
+        if let Some(pumpkin_block) = pumpkin_block {
+            pumpkin_block.on_attack(item, entity).await;
+
+            let mut inventory = player.inventory.lock().await;
+
+            self.handle_possible_broken_item(&mut inventory, player)
+                .await;
+        }
+    }
+
+    // TODO: we probably need a method to take care of items that can break when they're
+    // not in the main/secondary hand (e.g Elytra)
+    //
+    // Note: this method assume that get_selected_slot will the item used, which might
+    // be in the main or secondary hand
+    async fn handle_possible_broken_item(&self, inventory: &mut PlayerInventory, player: &Player) {
+        let slot_id = inventory.get_selected_slot();
+
+        if let Some(item_stack) = inventory.held_item().cloned() {
+            if !item_stack.is_broken() {
+                player
+                    .update_single_slot(inventory, slot_id, item_stack)
+                    .await;
+
+                return;
+            }
+
+            inventory.decrease_current_stack(1);
+
+            player.empty_slot(inventory, slot_id).await;
+
+            let item: Item = item_stack.item;
+
+            if let Some(sound_name) = item.components.break_sound {
+                if let Some(sound) = Sound::from_name(sound_name) {
+                    player
+                        .world()
+                        .await
+                        .play_sound(sound, SoundCategory::Players, &player.position())
+                        .await;
+                }
+            }
         }
     }
 
@@ -37,8 +93,34 @@ impl ItemRegistry {
     ) {
         let pumpkin_item = self.get_pumpkin_item(item.id);
         if let Some(pumpkin_item) = pumpkin_item {
-            return pumpkin_item
+            pumpkin_item
                 .use_on_block(item, player, location, face, block, server)
+                .await;
+
+            let mut inventory = player.inventory.lock().await;
+
+            self.handle_possible_broken_item(&mut inventory, player)
+                .await;
+        }
+    }
+
+    pub async fn on_after_dig(
+        &self,
+        item: &Item,
+        player: &Player,
+        location: BlockPos,
+        block: &Block,
+        server: &Server,
+    ) {
+        let pumpkin_item = self.get_pumpkin_item(item.id);
+        if let Some(pumpkin_item) = pumpkin_item {
+            pumpkin_item
+                .on_after_dig(item, player, location, block, server)
+                .await;
+
+            let mut inventory = player.inventory.lock().await;
+
+            self.handle_possible_broken_item(&mut inventory, player)
                 .await;
         }
     }


### PR DESCRIPTION
## Description

- What was changed?
  - It is possible now to increment the damage of a given item after use_item, use_item_on, on_attack and normal_use events or whatever other event that an item might handle.
  - We're now [saving](https://github.com/Pumpkin-MC/Pumpkin/pull/714/files#diff-e9446902ce129f03dc215f96671f01948d5662ee2923ca8e2092578ca85f7638R142) and [reading](https://github.com/Pumpkin-MC/Pumpkin/pull/714/files#diff-e9446902ce129f03dc215f96671f01948d5662ee2923ca8e2092578ca85f7638R165) item's damage for a given player.

- Why were these changes necessary?
It is part of the vanilla game.
- What is the impact of this change?
This is the first step to read and write item components (data) when saving/reading a player's data in a world. Also this change introduces [a way of sending structured components](https://github.com/Pumpkin-MC/Pumpkin/pull/714/files#diff-06dc7126c393ec5adad4a7769e2d5f7ab1475fb99502cd754675cb30ace807f7R36) for a given `Slot`.

- Are there any known issues or limitations?
This PR does not account for the unbreakable enchantment since it's not yet implemented.

## Demo
Turn sound on :loud_sound: to hear the breaking sound :D

https://github.com/user-attachments/assets/3b636303-0772-431d-8e7f-5fbf7652e453

