### PR TITLE
Fix gamemode switcher

### DIFF
--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -522,7 +522,7 @@ impl World {
                 self.dimension_type.name(),
                 biome::hash_seed(self.level.seed.0), // seed
                 gamemode as u8,
-                base_config.default_gamemode as i8,
+                -1, // undefined
                 false,
                 false,
                 None,

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -522,7 +522,10 @@ impl World {
                 self.dimension_type.name(),
                 biome::hash_seed(self.level.seed.0), // seed
                 gamemode as u8,
-                -1, // undefined
+                player
+                    .previous_gamemode
+                    .load()
+                    .map_or(-1, |gamemode| gamemode as i8),
                 false,
                 false,
                 None,


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Use undefined previous gamemode on join to let the client decide which gamemode to switch to.
Fixes #718 

## Testing
Could not reproduce the bug

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
