### PR TITLE
Add sound for others when placing blocks

### DIFF
--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -35,8 +35,7 @@ use pumpkin_inventory::player::{
 };
 use pumpkin_macros::send_cancellable;
 use pumpkin_protocol::client::play::{
-    CBlockUpdate, COpenSignEditor, CPlayerInfoUpdate, CPlayerPosition, CSetContainerSlot,
-    CSetHeldItem, CSystemChatMessage, EquipmentSlot, InitChat, PlayerAction,
+    CBlockUpdate, COpenSignEditor, CPlayerInfoUpdate, CPlayerPosition, CSetContainerSlot, CSetHeldItem, CSystemChatMessage, CWorldEvent, EquipmentSlot, InitChat, PlayerAction
 };
 use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_protocol::codec::var_int::VarInt;
@@ -1733,6 +1732,14 @@ impl Player {
             server
                 .block_registry
                 .player_placed(world, &block, new_state, &final_block_pos, face, self)
+                .await;
+
+            // Block place particles + sound
+            world
+                .broadcast_packet_except(
+                    &[self.gameprofile.id],
+                    &CWorldEvent::new(2001, location, i32::from(new_state), false),
+                )
                 .await;
 
             // The block was placed successfully, so decrement their inventory


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Send WorldEvent packet which plays sound and particles.
The one who places the block predicts the sound clientside

## Testing
Place blocks next to another player and listen for sound on both clients

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
