### PR TITLE
Fix rubberbanding after death

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -256,7 +256,9 @@ impl EntityBase for LivingEntity {
             let time = self
                 .death_time
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            if time >= 20 {
+
+            // Only remove entity and send remove packets once
+            if time == 20 {
                 // Spawn Death particles
                 self.entity
                     .world


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Make so the server doesn't send death packets every tick after a living entity is dead, even if the entity were to tick after it's supposed removal.
Fixes #728 

## Testing
Slam myself into the ground in survival mode, could not replicate mentioned issue.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
