### PR TITLE
Serialize fields without length prefixes

### DIFF
--- a/pumpkin-protocol/src/client/config/plugin_message.rs
+++ b/pumpkin-protocol/src/client/config/plugin_message.rs
@@ -2,10 +2,13 @@ use pumpkin_data::packet::clientbound::CONFIG_CUSTOM_PAYLOAD;
 use pumpkin_macros::packet;
 use serde::Serialize;
 
+use crate::ser::network_serialize_no_prefix;
+
 #[derive(Serialize)]
 #[packet(CONFIG_CUSTOM_PAYLOAD)]
 pub struct CPluginMessage<'a> {
     pub channel: &'a str,
+    #[serde(serialize_with = "network_serialize_no_prefix")]
     pub data: &'a [u8],
 }
 

--- a/pumpkin-protocol/src/client/login/plugin_request.rs
+++ b/pumpkin-protocol/src/client/login/plugin_request.rs
@@ -2,13 +2,14 @@ use pumpkin_data::packet::clientbound::LOGIN_CUSTOM_QUERY;
 use pumpkin_macros::packet;
 use serde::Serialize;
 
-use crate::VarInt;
+use crate::{VarInt, ser::network_serialize_no_prefix};
 
 #[derive(Serialize)]
 #[packet(LOGIN_CUSTOM_QUERY)]
 pub struct CLoginPluginRequest<'a> {
     pub message_id: VarInt,
     pub channel: &'a str,
+    #[serde(serialize_with = "network_serialize_no_prefix")]
     pub data: &'a [u8],
 }
 

--- a/pumpkin-protocol/src/client/play/block_entity_data.rs
+++ b/pumpkin-protocol/src/client/play/block_entity_data.rs
@@ -3,13 +3,14 @@ use pumpkin_macros::packet;
 use pumpkin_util::math::position::BlockPos;
 use serde::Serialize;
 
-use crate::VarInt;
+use crate::{VarInt, ser::network_serialize_no_prefix};
 
 #[derive(Serialize)]
 #[packet(PLAY_BLOCK_ENTITY_DATA)]
 pub struct CBlockEntityData {
     location: BlockPos,
     r#type: VarInt,
+    #[serde(serialize_with = "network_serialize_no_prefix")]
     nbt_data: Box<[u8]>,
 }
 

--- a/pumpkin-protocol/src/client/play/particle.rs
+++ b/pumpkin-protocol/src/client/play/particle.rs
@@ -3,7 +3,7 @@ use pumpkin_macros::packet;
 use pumpkin_util::math::vector3::Vector3;
 use serde::Serialize;
 
-use crate::VarInt;
+use crate::{VarInt, ser::network_serialize_no_prefix};
 
 #[derive(Serialize)]
 #[packet(PLAY_LEVEL_PARTICLES)]
@@ -16,6 +16,7 @@ pub struct CParticle<'a> {
     max_speed: f32,
     particle_count: i32,
     pariticle_id: VarInt,
+    #[serde(serialize_with = "network_serialize_no_prefix")]
     data: &'a [u8],
 }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Serialize some more packet fields without length prefixes.
Fixes #729 also signs and server brand now works.

## Testing
Can place are write on signs, can sweep attack mobs and F3 server brand is displayed correctly

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
