### PR TITLE
Fix rustyline-async division by zero panic

### DIFF
--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -46,7 +46,7 @@ rand = "0.8"
 num-bigint = "0.4"
 
 # Console line reading
-rustyline-async = "0.4.5"
+rustyline-async = { git = "https://github.com/zyansheep/rustyline-async.git", rev = "6dda63402becfcfa11968a3531e8a17aed3ec994" }
 
 # encryption
 rsa = { version = "0.9", features = ["sha1"] }


### PR DESCRIPTION
## Description
Fixes [ #594](https://github.com/Pumpkin-MC/Pumpkin/issues/594).
Fixed in [commit 6dda634](https://github.com/zyansheep/rustyline-async/commit/6dda63402becfcfa11968a3531e8a17aed3ec994) in [rustyline-async](https://github.com/zyansheep/rustyline-async).
Isn't pushed to [crates.io](https://crates.io/crates/rustyline-async) so I pinned [rustyline-async](https://github.com/zyansheep/rustyline-async) to commit [6dda634](https://github.com/zyansheep/rustyline-async/commit/6dda63402becfcfa11968a3531e8a17aed3ec994).

## Testing
Passes docker build after regenerating lockfile
