### PR TITLE
Fix dead lock

### DIFF
--- a/pumpkin-world/src/entity/entity_data_flags.rs
+++ b/pumpkin-world/src/entity/entity_data_flags.rs
@@ -7,6 +7,9 @@ pub static DATA_SILENT: u8 = 4;
 pub static DATA_NO_GRAVITY: u8 = 5;
 pub static DATA_POSE: u8 = 6;
 pub static DATA_TICKS_FROZEN: u8 = 7;
+// OminousItemSpawner
+// DATA_ITEM
+pub static DATA_ITEM_OMINOUS_ITEM_SPAWNER: u8 = 8;
 // LivingEntity
 pub static DATA_LIVING_ENTITY_FLAGS: u8 = 8;
 pub static DATA_HEALTH_ID: u8 = 9;
@@ -15,6 +18,361 @@ pub static DATA_EFFECT_AMBIENCE_ID: u8 = 11;
 pub static DATA_ARROW_COUNT_ID: u8 = 12;
 pub static DATA_STINGER_COUNT_ID: u8 = 13;
 pub static SLEEPING_POS_ID: u8 = 14;
+// Mob
+pub static DATA_MOB_FLAGS_ID: u8 = 15;
+// PathfinderMob
+// AgeableMob
+// DATA_BABY_ID
+pub static DATA_BABY_ID_AGEABLE_MOB: u8 = 16;
+// Interaction
+// DATA_WIDTH_ID
+pub static DATA_WIDTH_ID_INTERACTION: u8 = 8;
+// DATA_HEIGHT_ID
+pub static DATA_HEIGHT_ID_INTERACTION: u8 = 9;
+pub static DATA_RESPONSE_ID: u8 = 10;
+// Animal
+// TamableAnimal
+// DATA_FLAGS_ID
+pub static DATA_FLAGS_ID_TAMABLE_ANIMAL: u8 = 17;
+pub static DATA_OWNERUUID_ID: u8 = 18;
+// Display
+pub static DATA_TRANSFORMATION_INTERPOLATION_START_DELTA_TICKS_ID: u8 = 8;
+pub static DATA_TRANSFORMATION_INTERPOLATION_DURATION_ID: u8 = 9;
+pub static DATA_POS_ROT_INTERPOLATION_DURATION_ID: u8 = 10;
+pub static DATA_TRANSLATION_ID: u8 = 11;
+pub static DATA_SCALE_ID: u8 = 12;
+pub static DATA_LEFT_ROTATION_ID: u8 = 13;
+pub static DATA_RIGHT_ROTATION_ID: u8 = 14;
+pub static DATA_BILLBOARD_RENDER_CONSTRAINTS_ID: u8 = 15;
+pub static DATA_BRIGHTNESS_OVERRIDE_ID: u8 = 16;
+pub static DATA_VIEW_RANGE_ID: u8 = 17;
+pub static DATA_SHADOW_RADIUS_ID: u8 = 18;
+pub static DATA_SHADOW_STRENGTH_ID: u8 = 19;
+// DATA_WIDTH_ID
+pub static DATA_WIDTH_ID_DISPLAY: u8 = 20;
+// DATA_HEIGHT_ID
+pub static DATA_HEIGHT_ID_DISPLAY: u8 = 21;
+pub static DATA_GLOW_COLOR_OVERRIDE_ID: u8 = 22;
+// Display.BlockDisplay
+// DATA_BLOCK_STATE_ID
+pub static DATA_BLOCK_STATE_ID_DISPLAY_BLOCK_DISPLAY: u8 = 0;
+// Display.ItemDisplay
+pub static DATA_ITEM_STACK_ID: u8 = 0;
+pub static DATA_ITEM_DISPLAY_ID: u8 = 1;
+// Display.TextDisplay
+pub static DATA_TEXT_ID: u8 = 0;
+pub static DATA_LINE_WIDTH_ID: u8 = 1;
+pub static DATA_BACKGROUND_COLOR_ID: u8 = 2;
+pub static DATA_TEXT_OPACITY_ID: u8 = 3;
+pub static DATA_STYLE_FLAGS_ID: u8 = 4;
+// AgeableWaterCreature
+// Squid
+// GlowSquid
+pub static DATA_DARK_TICKS_REMAINING: u8 = 17;
+// ExperienceOrb
+pub static DATA_VALUE: u8 = 8;
+// AreaEffectCloud
+pub static DATA_RADIUS: u8 = 8;
+pub static DATA_WAITING: u8 = 9;
+pub static DATA_PARTICLE: u8 = 10;
+// ArmorStand
+pub static DATA_CLIENT_FLAGS: u8 = 15;
+pub static DATA_HEAD_POSE: u8 = 16;
+pub static DATA_BODY_POSE: u8 = 17;
+pub static DATA_LEFT_ARM_POSE: u8 = 18;
+pub static DATA_RIGHT_ARM_POSE: u8 = 19;
+pub static DATA_LEFT_LEG_POSE: u8 = 20;
+pub static DATA_RIGHT_LEG_POSE: u8 = 21;
+// BlockAttachedEntity
+// HangingEntity
+// ItemFrame
+// DATA_ITEM
+pub static DATA_ITEM_ITEM_FRAME: u8 = 8;
+pub static DATA_ROTATION: u8 = 9;
+// Painting
+pub static DATA_PAINTING_VARIANT_ID: u8 = 8;
+// VehicleEntity
+pub static DATA_ID_HURT: u8 = 8;
+pub static DATA_ID_HURTDIR: u8 = 9;
+pub static DATA_ID_DAMAGE: u8 = 10;
+// AbstractBoat
+pub static DATA_ID_PADDLE_LEFT: u8 = 11;
+pub static DATA_ID_PADDLE_RIGHT: u8 = 12;
+pub static DATA_ID_BUBBLE_TIME: u8 = 13;
+// AbstractMinecart
+pub static DATA_ID_CUSTOM_DISPLAY_BLOCK: u8 = 11;
+pub static DATA_ID_DISPLAY_OFFSET: u8 = 12;
+// MinecartFurnace
+pub static DATA_ID_FUEL: u8 = 13;
+// MinecartCommandBlock
+pub static DATA_ID_COMMAND_NAME: u8 = 13;
+pub static DATA_ID_LAST_OUTPUT: u8 = 14;
+// AmbientCreature
+// Bat
+// DATA_ID_FLAGS
+pub static DATA_ID_FLAGS_BAT: u8 = 16;
+// EndCrystal
+pub static DATA_BEAM_TARGET: u8 = 8;
+pub static DATA_SHOW_BOTTOM: u8 = 9;
+// EnderDragon
+pub static DATA_PHASE: u8 = 16;
+// Monster
+// WitherBoss
+pub static DATA_TARGET_A: u8 = 16;
+pub static DATA_TARGET_B: u8 = 17;
+pub static DATA_TARGET_C: u8 = 18;
+pub static DATA_ID_INV: u8 = 19;
+// Projectile
+// FishingHook
+pub static DATA_HOOKED_ENTITY: u8 = 8;
+pub static DATA_BITING: u8 = 9;
+// EyeOfEnder
+// DATA_ITEM_STACK
+pub static DATA_ITEM_STACK_EYE_OF_ENDER: u8 = 8;
+// AbstractArrow
+pub static ID_FLAGS: u8 = 8;
+pub static PIERCE_LEVEL: u8 = 9;
+pub static IN_GROUND: u8 = 10;
+// ThrownTrident
+pub static ID_LOYALTY: u8 = 11;
+pub static ID_FOIL: u8 = 12;
+// Arrow
+pub static ID_EFFECT_COLOR: u8 = 11;
+// AbstractHurtingProjectile
+// WitherSkull
+pub static DATA_DANGEROUS: u8 = 8;
+// Fireball
+// DATA_ITEM_STACK
+pub static DATA_ITEM_STACK_FIREBALL: u8 = 8;
+// FireworkRocketEntity
+pub static DATA_ID_FIREWORKS_ITEM: u8 = 8;
+pub static DATA_ATTACHED_TO_TARGET: u8 = 9;
+pub static DATA_SHOT_AT_ANGLE: u8 = 10;
+// ThrowableProjectile
+// ThrowableItemProjectile
+// DATA_ITEM_STACK
+pub static DATA_ITEM_STACK_THROWABLE_ITEM_PROJECTILE: u8 = 8;
+// FallingBlockEntity
+pub static DATA_START_POS: u8 = 8;
+// PrimedTnt
+pub static DATA_FUSE_ID: u8 = 8;
+// DATA_BLOCK_STATE_ID
+pub static DATA_BLOCK_STATE_ID_PRIMED_TNT: u8 = 9;
+// ItemEntity
+// DATA_ITEM
+pub static DATA_ITEM_ITEM_ENTITY: u8 = 8;
+// PatrollingMonster
+// Raider
+pub static IS_CELEBRATING: u8 = 16;
+// Rabbit
+// DATA_TYPE_ID
+pub static DATA_TYPE_ID_RABBIT: u8 = 17;
+// ShoulderRidingEntity
+// Parrot
+// DATA_VARIANT_ID
+pub static DATA_VARIANT_ID_PARROT: u8 = 19;
+// Turtle
+pub static HAS_EGG: u8 = 17;
+pub static LAYING_EGG: u8 = 18;
+// WaterAnimal
+// AbstractFish
+// FROM_BUCKET
+pub static FROM_BUCKET_ABSTRACT_FISH: u8 = 16;
+// Pufferfish
+pub static PUFF_STATE: u8 = 17;
+// AbstractGolem
+// IronGolem
+// DATA_FLAGS_ID
+pub static DATA_FLAGS_ID_IRON_GOLEM: u8 = 16;
+// Bee
+// DATA_FLAGS_ID
+pub static DATA_FLAGS_ID_BEE: u8 = 17;
+// DATA_REMAINING_ANGER_TIME
+pub static DATA_REMAINING_ANGER_TIME_BEE: u8 = 18;
+// SnowGolem
+pub static DATA_PUMPKIN_ID: u8 = 16;
+// AbstractCow
+// Cow
+// DATA_VARIANT_ID
+pub static DATA_VARIANT_ID_COW: u8 = 17;
+// AbstractSchoolingFish
+// Salmon
+// DATA_TYPE
+pub static DATA_TYPE_SALMON: u8 = 17;
+// Cat
+// DATA_VARIANT_ID
+pub static DATA_VARIANT_ID_CAT: u8 = 19;
+pub static IS_LYING: u8 = 20;
+pub static RELAX_STATE_ONE: u8 = 21;
+// DATA_COLLAR_COLOR
+pub static DATA_COLLAR_COLOR_CAT: u8 = 22;
+// PolarBear
+pub static DATA_STANDING_ID: u8 = 17;
+// TropicalFish
+// DATA_ID_TYPE_VARIANT
+pub static DATA_ID_TYPE_VARIANT_TROPICAL_FISH: u8 = 17;
+// Fox
+// DATA_TYPE_ID
+pub static DATA_TYPE_ID_FOX: u8 = 17;
+// DATA_FLAGS_ID
+pub static DATA_FLAGS_ID_FOX: u8 = 18;
+pub static DATA_TRUSTED_ID_0: u8 = 19;
+pub static DATA_TRUSTED_ID_1: u8 = 20;
+// Ocelot
+pub static DATA_TRUSTING: u8 = 17;
+// Chicken
+// DATA_VARIANT_ID
+pub static DATA_VARIANT_ID_CHICKEN: u8 = 17;
+// Panda
+pub static UNHAPPY_COUNTER: u8 = 17;
+pub static SNEEZE_COUNTER: u8 = 18;
+pub static EAT_COUNTER: u8 = 19;
+pub static MAIN_GENE_ID: u8 = 20;
+pub static HIDDEN_GENE_ID: u8 = 21;
+// DATA_ID_FLAGS
+pub static DATA_ID_FLAGS_PANDA: u8 = 22;
+// MushroomCow
+// DATA_TYPE
+pub static DATA_TYPE_MUSHROOM_COW: u8 = 17;
+// Pig
+// DATA_BOOST_TIME
+pub static DATA_BOOST_TIME_PIG: u8 = 17;
+// DATA_VARIANT_ID
+pub static DATA_VARIANT_ID_PIG: u8 = 18;
+// Dolphin
+pub static GOT_FISH: u8 = 17;
+pub static MOISTNESS_LEVEL: u8 = 18;
+// Sniffer
+pub static DATA_STATE: u8 = 17;
+pub static DATA_DROP_SEED_AT_TICK: u8 = 18;
+// Allay
+pub static DATA_DANCING: u8 = 16;
+pub static DATA_CAN_DUPLICATE: u8 = 17;
+// Sheep
+pub static DATA_WOOL_ID: u8 = 17;
+// AbstractHorse
+// DATA_ID_FLAGS
+pub static DATA_ID_FLAGS_ABSTRACT_HORSE: u8 = 17;
+// Camel
+pub static DASH: u8 = 18;
+pub static LAST_POSE_CHANGE_TICK: u8 = 19;
+// Goat
+pub static DATA_IS_SCREAMING_GOAT: u8 = 17;
+pub static DATA_HAS_LEFT_HORN: u8 = 18;
+pub static DATA_HAS_RIGHT_HORN: u8 = 19;
+// Wolf
+pub static DATA_INTERESTED_ID: u8 = 19;
+// DATA_COLLAR_COLOR
+pub static DATA_COLLAR_COLOR_WOLF: u8 = 20;
+// DATA_REMAINING_ANGER_TIME
+pub static DATA_REMAINING_ANGER_TIME_WOLF: u8 = 21;
+// DATA_VARIANT_ID
+pub static DATA_VARIANT_ID_WOLF: u8 = 22;
+pub static DATA_SOUND_VARIANT_ID: u8 = 23;
+// Frog
+// DATA_VARIANT_ID
+pub static DATA_VARIANT_ID_FROG: u8 = 17;
+pub static DATA_TONGUE_TARGET_ID: u8 = 18;
+// Horse
+// DATA_ID_TYPE_VARIANT
+pub static DATA_ID_TYPE_VARIANT_HORSE: u8 = 18;
+// AbstractChestedHorse
+pub static DATA_ID_CHEST: u8 = 18;
+// Llama
+pub static DATA_STRENGTH_ID: u8 = 19;
+// DATA_VARIANT_ID
+pub static DATA_VARIANT_ID_LLAMA: u8 = 20;
+// Axolotl
+pub static DATA_VARIANT: u8 = 17;
+pub static DATA_PLAYING_DEAD: u8 = 18;
+// FROM_BUCKET
+pub static FROM_BUCKET_AXOLOTL: u8 = 19;
+// Armadillo
+pub static ARMADILLO_STATE: u8 = 17;
+// AbstractVillager
+pub static DATA_UNHAPPY_COUNTER: u8 = 17;
+// Villager
+// DATA_VILLAGER_DATA
+pub static DATA_VILLAGER_DATA_VILLAGER: u8 = 18;
+// Vex
+// DATA_FLAGS_ID
+pub static DATA_FLAGS_ID_VEX: u8 = 16;
+// FlyingMob
+// Ghast
+pub static DATA_IS_CHARGING: u8 = 16;
+// Zoglin
+// DATA_BABY_ID
+pub static DATA_BABY_ID_ZOGLIN: u8 = 16;
+// Zombie
+// DATA_BABY_ID
+pub static DATA_BABY_ID_ZOMBIE: u8 = 16;
+pub static DATA_SPECIAL_TYPE_ID: u8 = 17;
+pub static DATA_DROWNED_CONVERSION_ID: u8 = 18;
+// Blaze
+// DATA_FLAGS_ID
+pub static DATA_FLAGS_ID_BLAZE: u8 = 16;
+// Guardian
+pub static DATA_ID_MOVING: u8 = 16;
+pub static DATA_ID_ATTACK_TARGET: u8 = 17;
+// Strider
+// DATA_BOOST_TIME
+pub static DATA_BOOST_TIME_STRIDER: u8 = 17;
+pub static DATA_SUFFOCATING: u8 = 18;
+// Spider
+// DATA_FLAGS_ID
+pub static DATA_FLAGS_ID_SPIDER: u8 = 16;
+// Phantom
+// ID_SIZE
+pub static ID_SIZE_PHANTOM: u8 = 16;
+// AbstractSkeleton
+// Skeleton
+pub static DATA_STRAY_CONVERSION_ID: u8 = 16;
+// AbstractIllager
+// SpellcasterIllager
+pub static DATA_SPELL_CASTING_ID: u8 = 17;
+// Witch
+pub static DATA_USING_ITEM: u8 = 17;
+// Bogged
+pub static DATA_SHEARED: u8 = 16;
+// Slime
+// ID_SIZE
+pub static ID_SIZE_SLIME: u8 = 16;
+// Creeper
+pub static DATA_SWELL_DIR: u8 = 16;
+pub static DATA_IS_POWERED: u8 = 17;
+pub static DATA_IS_IGNITED: u8 = 18;
+// EnderMan
+pub static DATA_CARRY_STATE: u8 = 16;
+pub static DATA_CREEPY: u8 = 17;
+pub static DATA_STARED_AT: u8 = 18;
+// Pillager
+pub static IS_CHARGING_CROSSBOW: u8 = 17;
+// ZombieVillager
+pub static DATA_CONVERTING_ID: u8 = 19;
+// DATA_VILLAGER_DATA
+pub static DATA_VILLAGER_DATA_ZOMBIE_VILLAGER: u8 = 20;
+// Shulker
+pub static DATA_ATTACH_FACE_ID: u8 = 16;
+pub static DATA_PEEK_ID: u8 = 17;
+pub static DATA_COLOR_ID: u8 = 18;
+// Creaking
+pub static CAN_MOVE: u8 = 16;
+pub static IS_ACTIVE: u8 = 17;
+pub static IS_TEARING_DOWN: u8 = 18;
+pub static HOME_POS: u8 = 19;
+// AbstractPiglin
+// DATA_IMMUNE_TO_ZOMBIFICATION
+pub static DATA_IMMUNE_TO_ZOMBIFICATION_ABSTRACT_PIGLIN: u8 = 16;
+// Piglin
+// DATA_BABY_ID
+pub static DATA_BABY_ID_PIGLIN: u8 = 17;
+pub static DATA_IS_CHARGING_CROSSBOW: u8 = 18;
+pub static DATA_IS_DANCING: u8 = 19;
+// Hoglin
+// DATA_IMMUNE_TO_ZOMBIFICATION
+pub static DATA_IMMUNE_TO_ZOMBIFICATION_HOGLIN: u8 = 17;
+// Warden
+pub static CLIENT_ANGER_LEVEL: u8 = 16;
 // Player
 pub static DATA_PLAYER_ABSORPTION_ID: u8 = 15;
 pub static DATA_SCORE_ID: u8 = 16;
@@ -22,8 +380,3 @@ pub static DATA_PLAYER_MODE_CUSTOMISATION: u8 = 17;
 pub static DATA_PLAYER_MAIN_HAND: u8 = 18;
 pub static DATA_SHOULDER_LEFT: u8 = 19;
 pub static DATA_SHOULDER_RIGHT: u8 = 20;
-// Mob
-pub static DATA_MOB_FLAGS_ID: u8 = 15;
-// Allay
-pub static DATA_DANCING: u8 = 16;
-// todo: Maybe we should grab data from minecraft instead of doing it manually

--- a/pumpkin-world/src/entity/entity_data_flags.rs
+++ b/pumpkin-world/src/entity/entity_data_flags.rs
@@ -1,0 +1,29 @@
+// Entity
+pub static DATA_SHARED_FLAGS_ID: u8 = 0;
+pub static DATA_AIR_SUPPLY_ID: u8 = 1;
+pub static DATA_CUSTOM_NAME: u8 = 2;
+pub static DATA_CUSTOM_NAME_VISIBLE: u8 = 3;
+pub static DATA_SILENT: u8 = 4;
+pub static DATA_NO_GRAVITY: u8 = 5;
+pub static DATA_POSE: u8 = 6;
+pub static DATA_TICKS_FROZEN: u8 = 7;
+// LivingEntity
+pub static DATA_LIVING_ENTITY_FLAGS: u8 = 8;
+pub static DATA_HEALTH_ID: u8 = 9;
+pub static DATA_EFFECT_PARTICLES: u8 = 10;
+pub static DATA_EFFECT_AMBIENCE_ID: u8 = 11;
+pub static DATA_ARROW_COUNT_ID: u8 = 12;
+pub static DATA_STINGER_COUNT_ID: u8 = 13;
+pub static SLEEPING_POS_ID: u8 = 14;
+// Player
+pub static DATA_PLAYER_ABSORPTION_ID: u8 = 15;
+pub static DATA_SCORE_ID: u8 = 16;
+pub static DATA_PLAYER_MODE_CUSTOMISATION: u8 = 17;
+pub static DATA_PLAYER_MAIN_HAND: u8 = 18;
+pub static DATA_SHOULDER_LEFT: u8 = 19;
+pub static DATA_SHOULDER_RIGHT: u8 = 20;
+// Mob
+pub static DATA_MOB_FLAGS_ID: u8 = 15;
+// Allay
+pub static DATA_DANCING: u8 = 16;
+// todo: Maybe we should grab data from minecraft instead of doing it manually

--- a/pumpkin-world/src/entity/mod.rs
+++ b/pumpkin-world/src/entity/mod.rs
@@ -1,0 +1,1 @@
+pub mod entity_data_flags;

--- a/pumpkin-world/src/lib.rs
+++ b/pumpkin-world/src/lib.rs
@@ -7,6 +7,7 @@ pub mod chunk;
 pub mod cylindrical_chunk_iterator;
 pub mod data;
 pub mod dimension;
+pub mod entity;
 mod generation;
 pub mod item;
 pub mod level;

--- a/pumpkin/src/command/commands/pumpkin.rs
+++ b/pumpkin/src/command/commands/pumpkin.rs
@@ -43,7 +43,7 @@ impl CommandExecutor for Executor {
                     .add_child(
                         TextComponent::text(format!(
                             "{}\n{}\n",
-                            &CARGO_PKG_DESCRIPTION[0..35],
+                            &CARGO_PKG_DESCRIPTION[0..36],
                             &CARGO_PKG_DESCRIPTION[37..]
                         ))
                         .click_event(ClickEvent::CopyToClipboard {

--- a/pumpkin/src/data/player_server_data.rs
+++ b/pumpkin/src/data/player_server_data.rs
@@ -81,8 +81,7 @@ impl ServerPlayerData {
             self.last_save.store(now);
             // Save all online players periodically across all worlds
             for world in server.worlds.read().await.iter() {
-                let players = world.players.read().await;
-                for player in players.values() {
+                for player in world.current_players().await {
                     let mut nbt = NbtCompound::new();
                     player.write_nbt(&mut nbt).await;
 
@@ -111,9 +110,8 @@ impl ServerPlayerData {
 
         // Save players from all worlds
         for world in server.worlds.read().await.iter() {
-            let players = world.players.read().await;
-            for player in players.values() {
-                self.extract_data_and_save_player(player).await?;
+            for player in world.current_players().await {
+                self.extract_data_and_save_player(player.as_ref()).await?;
                 total_players += 1;
             }
         }

--- a/pumpkin/src/data/player_server_data.rs
+++ b/pumpkin/src/data/player_server_data.rs
@@ -111,7 +111,7 @@ impl ServerPlayerData {
         // Save players from all worlds
         for world in server.worlds.read().await.iter() {
             for player in world.players.read().await.values() {
-                self.extract_data_and_save_player(player.as_ref()).await?;
+                self.extract_data_and_save_player(player).await?;
                 total_players += 1;
             }
         }

--- a/pumpkin/src/data/player_server_data.rs
+++ b/pumpkin/src/data/player_server_data.rs
@@ -81,7 +81,7 @@ impl ServerPlayerData {
             self.last_save.store(now);
             // Save all online players periodically across all worlds
             for world in server.worlds.read().await.iter() {
-                for player in world.current_players().await {
+                for player in world.players.read().await.values() {
                     let mut nbt = NbtCompound::new();
                     player.write_nbt(&mut nbt).await;
 
@@ -110,7 +110,7 @@ impl ServerPlayerData {
 
         // Save players from all worlds
         for world in server.worlds.read().await.iter() {
-            for player in world.current_players().await {
+            for player in world.players.read().await.values() {
                 self.extract_data_and_save_player(player.as_ref()).await?;
                 total_players += 1;
             }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -88,6 +88,9 @@ use pumpkin_util::{
     permission::PermissionLvl,
     text::TextComponent,
 };
+use pumpkin_world::entity::entity_data_flags::{
+    DATA_PLAYER_MAIN_HAND, DATA_PLAYER_MODE_CUSTOMISATION,
+};
 use pumpkin_world::{cylindrical_chunk_iterator::Cylindrical, item::ItemStack, level::SyncChunk};
 use tokio::sync::RwLock;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -1167,8 +1170,16 @@ impl Player {
         self.living_entity
             .entity
             .send_meta_data(&[
-                Metadata::new(17, MetaDataType::Byte, config.skin_parts),
-                Metadata::new(18, MetaDataType::Byte, config.main_hand as u8),
+                Metadata::new(
+                    DATA_PLAYER_MODE_CUSTOMISATION,
+                    MetaDataType::Byte,
+                    config.skin_parts,
+                ),
+                Metadata::new(
+                    DATA_PLAYER_MAIN_HAND,
+                    MetaDataType::Byte,
+                    config.main_hand as u8,
+                ),
             ])
             .await;
     }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -89,6 +89,7 @@ use pumpkin_util::{
     text::TextComponent,
 };
 use pumpkin_world::{cylindrical_chunk_iterator::Cylindrical, item::ItemStack, level::SyncChunk};
+use tokio::sync::RwLock;
 use tokio::{sync::Mutex, task::JoinHandle};
 use uuid::Uuid;
 
@@ -180,7 +181,7 @@ pub struct Player {
     /// The player's inventory.
     pub inventory: Mutex<PlayerInventory>,
     /// The player's configuration settings. Changes when the player changes their settings.
-    pub config: Mutex<PlayerConfig>,
+    pub config: RwLock<PlayerConfig>,
     /// The player's current gamemode (e.g., Survival, Creative, Adventure).
     pub gamemode: AtomicCell<GameMode>,
     /// The player's previous gamemode
@@ -270,7 +271,7 @@ impl Player {
                 EntityType::PLAYER,
                 matches!(gamemode, GameMode::Creative | GameMode::Spectator),
             )),
-            config: Mutex::new(config),
+            config: RwLock::new(config),
             gameprofile,
             client,
             awaiting_teleport: Mutex::new(None),
@@ -1162,7 +1163,7 @@ impl Player {
 
     /// Send the player's skin layers and used hand to all players.
     pub async fn send_client_information(&self) {
-        let config = self.config.lock().await;
+        let config = self.config.read().await;
         self.living_entity
             .entity
             .send_meta_data(&[

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -329,7 +329,7 @@ impl PumpkinServer {
                         // Remove the player from its world
                         player.remove().await;
                         // Tick down the online count
-                        server.remove_player().await;
+                        server.remove_player(player).await;
                     }
                 } else {
                     // Also handle case of client connects but does not become a player (like a server

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -329,7 +329,7 @@ impl PumpkinServer {
                         // Remove the player from its world
                         player.remove().await;
                         // Tick down the online count
-                        server.remove_player(player).await;
+                        server.remove_player(&player).await;
                     }
                 } else {
                     // Also handle case of client connects but does not become a player (like a server

--- a/pumpkin/src/net/mod.rs
+++ b/pumpkin/src/net/mod.rs
@@ -146,6 +146,7 @@ pub struct Client {
     pub closed: Arc<AtomicBool>,
     /// The client's IP address.
     pub address: Mutex<SocketAddr>,
+    pub added_to_server_listing: Mutex<bool>,
     /// The packet encoder for outgoing packets.
     network_writer: Arc<Mutex<NetworkEncoder<BufWriter<OwnedWriteHalf>>>>,
     /// The packet decoder for incoming packets.
@@ -184,6 +185,7 @@ impl Client {
             tasks: TaskTracker::new(),
             outgoing_packet_queue_send: send,
             outgoing_packet_queue_recv: Some(recv),
+            added_to_server_listing: Mutex::new(false),
         }
     }
 

--- a/pumpkin/src/net/mod.rs
+++ b/pumpkin/src/net/mod.rs
@@ -146,6 +146,7 @@ pub struct Client {
     pub closed: Arc<AtomicBool>,
     /// The client's IP address.
     pub address: Mutex<SocketAddr>,
+    /// Indicates if the client is added to the server listing.
     pub added_to_server_listing: AtomicBool,
     /// The packet encoder for outgoing packets.
     network_writer: Arc<Mutex<NetworkEncoder<BufWriter<OwnedWriteHalf>>>>,

--- a/pumpkin/src/net/mod.rs
+++ b/pumpkin/src/net/mod.rs
@@ -146,7 +146,7 @@ pub struct Client {
     pub closed: Arc<AtomicBool>,
     /// The client's IP address.
     pub address: Mutex<SocketAddr>,
-    pub added_to_server_listing: Mutex<bool>,
+    pub added_to_server_listing: AtomicBool,
     /// The packet encoder for outgoing packets.
     network_writer: Arc<Mutex<NetworkEncoder<BufWriter<OwnedWriteHalf>>>>,
     /// The packet decoder for incoming packets.
@@ -185,7 +185,7 @@ impl Client {
             tasks: TaskTracker::new(),
             outgoing_packet_queue_send: send,
             outgoing_packet_queue_recv: Some(recv),
-            added_to_server_listing: Mutex::new(false),
+            added_to_server_listing: AtomicBool::new(false),
         }
     }
 

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -716,7 +716,7 @@ impl Player {
             }
         };
         // Invert hand if player is left handed
-        let animation = match self.config.lock().await.main_hand {
+        let animation = match self.config.read().await.main_hand {
             Hand::Left => match animation {
                 Animation::SwingMainArm => Animation::SwingOffhand,
                 Animation::SwingOffhand => Animation::SwingMainArm,
@@ -958,7 +958,7 @@ impl Player {
             }
 
             let (update_settings, update_watched) = {
-                let mut config = self.config.lock().await;
+                let mut config = self.config.write().await;
                 let update_settings = config.main_hand != main_hand
                     || config.skin_parts != client_information.skin_parts;
 

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -86,11 +86,9 @@ impl Context {
             dispatcher_lock.register(tree, permission);
         };
 
-        for world in self.server.worlds.read().await.iter() {
-            for player in world.players.read().await.values() {
-                let command_dispatcher = self.server.command_dispatcher.read().await;
-                client_suggestions::send_c_commands_packet(player, &command_dispatcher).await;
-            }
+        for player in self.server.get_all_players().await {
+            let command_dispatcher = self.server.command_dispatcher.read().await;
+            client_suggestions::send_c_commands_packet(&player, &command_dispatcher).await;
         }
     }
 
@@ -104,11 +102,9 @@ impl Context {
             dispatcher_lock.unregister(name);
         };
 
-        for world in self.server.worlds.read().await.iter() {
-            for player in world.players.read().await.values() {
-                let command_dispatcher = self.server.command_dispatcher.read().await;
-                client_suggestions::send_c_commands_packet(player, &command_dispatcher).await;
-            }
+        for player in self.server.get_all_players().await {
+            let command_dispatcher = self.server.command_dispatcher.read().await;
+            client_suggestions::send_c_commands_packet(&player, &command_dispatcher).await;
         }
     }
 

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -86,9 +86,11 @@ impl Context {
             dispatcher_lock.register(tree, permission);
         };
 
-        for player in self.server.get_all_players().await {
-            let command_dispatcher = self.server.command_dispatcher.read().await;
-            client_suggestions::send_c_commands_packet(&player, &command_dispatcher).await;
+        for world in self.server.worlds.read().await.iter() {
+            for player in world.players.read().await.values() {
+                let command_dispatcher = self.server.command_dispatcher.read().await;
+                client_suggestions::send_c_commands_packet(player, &command_dispatcher).await;
+            }
         }
     }
 
@@ -102,9 +104,11 @@ impl Context {
             dispatcher_lock.unregister(name);
         };
 
-        for player in self.server.get_all_players().await {
-            let command_dispatcher = self.server.command_dispatcher.read().await;
-            client_suggestions::send_c_commands_packet(&player, &command_dispatcher).await;
+        for world in self.server.worlds.read().await.iter() {
+            for player in world.players.read().await.values() {
+                let command_dispatcher = self.server.command_dispatcher.read().await;
+                client_suggestions::send_c_commands_packet(player, &command_dispatcher).await;
+            }
         }
     }
 

--- a/pumpkin/src/server/connection_cache.rs
+++ b/pumpkin/src/server/connection_cache.rs
@@ -1,11 +1,7 @@
-use core::error;
-use std::{
-    fs::File,
-    io::{Cursor, Read},
-    path::Path,
-};
-
+use super::CURRENT_MC_VERSION;
+use crate::entity::player::Player;
 use base64::{Engine as _, engine::general_purpose};
+use core::error;
 use pumpkin_config::{BASIC_CONFIG, BasicConfiguration};
 use pumpkin_data::packet::CURRENT_MC_PROTOCOL;
 use pumpkin_protocol::{
@@ -13,8 +9,12 @@ use pumpkin_protocol::{
     client::{config::CPluginMessage, status::CStatusResponse},
     codec::var_int::VarInt,
 };
-
-use super::CURRENT_MC_VERSION;
+use std::sync::Arc;
+use std::{
+    fs::File,
+    io::{Cursor, Read},
+    path::Path,
+};
 
 const DEFAULT_ICON: &[u8] = include_bytes!("../../../assets/default_icon.png");
 
@@ -90,9 +90,10 @@ impl CachedStatus {
     }
 
     // TODO: Player samples
-    pub fn add_player(&mut self) {
+    pub async fn add_player(&mut self, player: Arc<Player>) {
         let status_response = &mut self.status_response;
         if let Some(players) = &mut status_response.players {
+            *player.client.added_to_server_listing.lock().await = true;
             players.online += 1;
         }
 
@@ -100,10 +101,14 @@ impl CachedStatus {
             .expect("Failed to parse status response into JSON");
     }
 
-    pub fn remove_player(&mut self) {
+    pub async fn remove_player(&mut self, player: Arc<Player>) {
         let status_response = &mut self.status_response;
         if let Some(players) = &mut status_response.players {
-            players.online -= 1;
+            let mut added = player.client.added_to_server_listing.lock().await;
+            if *added {
+                players.online -= 1;
+                *added = false;
+            }
         }
 
         self.status_response_json = serde_json::to_string(&status_response)

--- a/pumpkin/src/server/connection_cache.rs
+++ b/pumpkin/src/server/connection_cache.rs
@@ -90,7 +90,7 @@ impl CachedStatus {
     }
 
     // TODO: Player samples
-    pub async fn add_player(&mut self, player: &Player) {
+    pub fn add_player(&mut self, player: &Player) {
         let status_response = &mut self.status_response;
         if let Some(players) = &mut status_response.players {
             player
@@ -104,7 +104,7 @@ impl CachedStatus {
             .expect("Failed to parse status response into JSON");
     }
 
-    pub async fn remove_player(&mut self, player: &Player) {
+    pub fn remove_player(&mut self, player: &Player) {
         let status_response = &mut self.status_response;
         if let Some(players) = &mut status_response.players {
             if player

--- a/pumpkin/src/server/connection_cache.rs
+++ b/pumpkin/src/server/connection_cache.rs
@@ -110,13 +110,10 @@ impl CachedStatus {
             if player
                 .client
                 .added_to_server_listing
-                .load(Ordering::Relaxed)
+                .compare_exchange(true, false, Ordering::Acquire, Ordering::Relaxed)
+                .is_ok()
             {
                 players.online -= 1;
-                player
-                    .client
-                    .added_to_server_listing
-                    .store(false, Ordering::Relaxed);
             }
         }
 

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -226,7 +226,7 @@ impl Server {
                     if let Some(config) = player.client.config.lock().await.as_ref() {
                         // TODO: Config so we can also just ignore this hehe
                         if config.server_listing {
-                            self.listing.lock().await.add_player();
+                            self.listing.lock().await.add_player(player.clone()).await;
                         }
                     }
 
@@ -243,9 +243,9 @@ impl Server {
         }}
     }
 
-    pub async fn remove_player(&self) {
+    pub async fn remove_player(&self, player: Arc<Player>) {
         // TODO: Config if we want decrease online
-        self.listing.lock().await.remove_player();
+        self.listing.lock().await.remove_player(player).await;
     }
 
     pub async fn shutdown(&self) {

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -221,15 +221,15 @@ impl Server {
                 if world
                     .add_player(player.gameprofile.id, player.clone())
                     .await.is_ok() {
-                // TODO: Config if we want increase online
-                if let Some(config) = player.client.config.lock().await.as_ref() {
-                    // TODO: Config so we can also just ignore this hehe
-                    if config.server_listing {
-                        self.listing.lock().await.add_player();
+                    // TODO: Config if we want increase online
+                    if let Some(config) = player.client.config.lock().await.as_ref() {
+                        // TODO: Config so we can also just ignore this hehe
+                        if config.server_listing {
+                            self.listing.lock().await.add_player();
+                        }
                     }
-                }
 
-                Some((player, world.clone()))
+                    Some((player, world.clone()))
                 } else {
                     None
                 }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -218,21 +218,16 @@ impl Server {
         send_cancellable! {{
             PlayerLoginEvent::new(player.clone(), TextComponent::text("You have been kicked from the server"));
             'after: {
-                if world
+                world
                     .add_player(player.gameprofile.id, player.clone())
-                    .await.is_ok() {
-                    // TODO: Config if we want increase online
-                    if let Some(config) = player.client.config.lock().await.as_ref() {
+                    .await.is_ok().then(||  { if let Some(config) = player.client.config.lock().await.as_ref() {
                         // TODO: Config so we can also just ignore this hehe
                         if config.server_listing {
                             self.listing.lock().await.add_player();
                         }
                     }
 
-                    Some((player, world.clone()))
-                } else {
-                    None
-                }
+                    Some(; (player, world.clone()) )})
             }
 
             'cancelled: {

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -226,7 +226,7 @@ impl Server {
                     if let Some(config) = player.client.config.lock().await.as_ref() {
                         // TODO: Config so we can also just ignore this hehe
                         if config.server_listing {
-                            self.listing.lock().await.add_player(player.clone()).await;
+                            self.listing.lock().await.add_player(&player).await;
                         }
                     }
 
@@ -243,7 +243,7 @@ impl Server {
         }}
     }
 
-    pub async fn remove_player(&self, player: Arc<Player>) {
+    pub async fn remove_player(&self, player: &Player) {
         // TODO: Config if we want decrease online
         self.listing.lock().await.remove_player(player).await;
     }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -226,7 +226,7 @@ impl Server {
                     if let Some(config) = player.client.config.lock().await.as_ref() {
                         // TODO: Config so we can also just ignore this hehe
                         if config.server_listing {
-                            self.listing.lock().await.add_player(&player).await;
+                            self.listing.lock().await.add_player(&player);
                         }
                     }
 
@@ -245,7 +245,7 @@ impl Server {
 
     pub async fn remove_player(&self, player: &Player) {
         // TODO: Config if we want decrease online
-        self.listing.lock().await.remove_player(player).await;
+        self.listing.lock().await.remove_player(player);
     }
 
     pub async fn shutdown(&self) {

--- a/pumpkin/src/world/chunker.rs
+++ b/pumpkin/src/world/chunker.rs
@@ -9,7 +9,7 @@ use crate::entity::player::Player;
 pub async fn get_view_distance(player: &Player) -> NonZeroU8 {
     player
         .config
-        .lock()
+        .read()
         .await
         .view_distance
         .clamp(NonZeroU8::new(2).unwrap(), BASIC_CONFIG.view_distance)

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -238,7 +238,6 @@ impl World {
             .await
             .values()
             .cloned()
-            .into_iter()
             .collect::<Vec<_>>();
         for recipient in current_players {
             let messages_received: i32 = recipient.chat_session.lock().await.messages_received;
@@ -319,7 +318,7 @@ impl World {
         particle: Particle,
     ) {
         let players = self.current_players().await;
-        for player in players.iter() {
+        for player in players {
             player
                 .spawn_particle(position, offset, max_speed, particle_count, particle)
                 .await;
@@ -1171,7 +1170,7 @@ impl World {
         } else {
             log::warn!("[add_player] Failed to get write lock on players, waiting...");
             self.players.write().await.insert(uuid, player.clone());
-        };
+        }
 
         let current_players = self.players.clone();
         player.clone().spawn_task(async move {

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -232,8 +232,15 @@ impl World {
             cache.last_seen.clone()
         };
 
-        let current_players = self.players.read().await;
-        for (_, recipient) in current_players.iter() {
+        let current_players = self
+            .players
+            .read()
+            .await
+            .values()
+            .cloned()
+            .into_iter()
+            .collect::<Vec<_>>();
+        for recipient in current_players {
             let messages_received: i32 = recipient.chat_session.lock().await.messages_received;
             let packet = &CPlayerChatMessage::new(
                 VarInt(messages_received),
@@ -243,7 +250,7 @@ impl World {
                 chat_message.message.clone(),
                 chat_message.timestamp,
                 chat_message.salt,
-                sender_last_seen.indexed_for(recipient).await,
+                sender_last_seen.indexed_for(&recipient).await,
                 Some(decorated_message.clone()),
                 FilterType::PassThrough,
                 (RAW + 1).into(), // Custom registry chat_type with no sender name
@@ -269,6 +276,10 @@ impl World {
         sender.chat_session.lock().await.messages_sent += 1;
     }
 
+    pub async fn current_players(&self) -> Vec<Arc<Player>> {
+        self.players.read().await.values().cloned().collect()
+    }
+
     /// Broadcasts a packet to all connected players within the world, excluding the specified players.
     ///
     /// Sends the specified packet to every player currently logged in to the world, excluding the players listed in the `except` parameter.
@@ -285,8 +296,16 @@ impl World {
         }
         let packet_data: Bytes = packet_buf.into();
 
-        let current_players = self.players.read().await;
-        for (_, player) in current_players.iter().filter(|c| !except.contains(c.0)) {
+        let current_players = self
+            .players
+            .read()
+            .await
+            .clone()
+            .into_iter()
+            .filter(|c| !except.contains(&c.0))
+            .map(|c| c.1)
+            .collect::<Vec<_>>();
+        for player in current_players {
             player.client.enqueue_packet_data(packet_data.clone()).await;
         }
     }
@@ -299,8 +318,8 @@ impl World {
         particle_count: i32,
         particle: Particle,
     ) {
-        let players = self.players.read().await;
-        for (_, player) in players.iter() {
+        let players = self.current_players().await;
+        for player in players.iter() {
             player
                 .spawn_particle(position, offset, max_speed, particle_count, particle)
                 .await;
@@ -379,7 +398,7 @@ impl World {
         self.tick_scheduled_block_ticks().await;
 
         // player ticks
-        for player in self.players.read().await.values() {
+        for player in self.current_players().await {
             player.tick(server).await;
         }
 
@@ -390,7 +409,7 @@ impl World {
             entity.tick(server).await;
             // This boolean thing prevents deadlocks. Since we lock players, we can't broadcast packets.
             let mut collied_player = None;
-            for player in self.players.read().await.values() {
+            for player in self.current_players().await {
                 if player
                     .living_entity
                     .entity
@@ -660,7 +679,14 @@ impl World {
 
         // Spawn players for our client.
         let id = player.gameprofile.id;
-        for (_, existing_player) in self.players.read().await.iter().filter(|c| c.0 != &id) {
+        for (_, existing_player) in self
+            .players
+            .read()
+            .await
+            .iter()
+            .filter(|c| c.0 != &id)
+            .collect::<Vec<_>>()
+        {
             let entity = &existing_player.living_entity.entity;
             let pos = entity.pos.load();
             let gameprofile = &existing_player.gameprofile;
@@ -683,7 +709,7 @@ impl World {
         }
 
         // Set skin parts and tablist
-        for player in self.players.read().await.values() {
+        for player in self.current_players().await {
             //Set / Update skin part for every player
             player.send_client_information().await;
 
@@ -809,7 +835,7 @@ impl World {
             Particle::ExplosionEmitter
         };
         let sound = IdOr::<SoundEvent>::Id(Sound::EntityGenericExplode as u16);
-        for (_, player) in self.players.read().await.iter() {
+        for player in self.current_players().await {
             if player.position().squared_distance_to_vec(position) > 4096.0 {
                 continue;
             }
@@ -1012,7 +1038,7 @@ impl World {
 
     /// Gets a `Player` by an entity id
     pub async fn get_player_by_id(&self, id: EntityId) -> Option<Arc<Player>> {
-        for player in self.players.read().await.values() {
+        for player in self.current_players().await {
             if player.entity_id() == id {
                 return Some(player.clone());
             }
@@ -1032,7 +1058,7 @@ impl World {
 
     /// Gets a `Player` by a username
     pub async fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
-        for player in self.players.read().await.values() {
+        for player in self.current_players().await {
             if player.gameprofile.name.to_lowercase() == name.to_lowercase() {
                 return Some(player.clone());
             }
@@ -1053,7 +1079,7 @@ impl World {
     ///
     /// An `Option<Arc<Player>>` containing the player if found, or `None` if not.
     pub async fn get_player_by_uuid(&self, id: uuid::Uuid) -> Option<Arc<Player>> {
-        return self.players.read().await.get(&id).cloned();
+        self.players.read().await.get(&id).cloned()
     }
 
     /// Gets a list of players whose location equals the given position in the world.
@@ -1139,10 +1165,12 @@ impl World {
     ///
     /// * `uuid`: The unique UUID of the player to add.
     /// * `player`: An `Arc<Player>` reference to the player object.
-    pub async fn add_player(&self, uuid: uuid::Uuid, player: Arc<Player>) {
-        {
-            let mut current_players = self.players.write().await;
-            current_players.insert(uuid, player.clone())
+    pub async fn add_player(&self, uuid: uuid::Uuid, player: Arc<Player>) -> Result<(), String> {
+        if let Ok(mut players) = self.players.try_write() {
+            players.insert(uuid, player.clone());
+        } else {
+            log::warn!("[add_player] Failed to get write lock on players, waiting...");
+            self.players.write().await.insert(uuid, player.clone());
         };
 
         let current_players = self.players.clone();
@@ -1169,6 +1197,7 @@ impl World {
                 log::info!("{}", event.join_message.clone().to_pretty_console());
             }
         });
+        Ok(())
     }
 
     /// Removes a player from the world and broadcasts a disconnect message if enabled.

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -685,7 +685,7 @@ impl World {
                     entity.velocity.load(),
                 ))
                 .await;
-            let config = existing_player.config.lock().await;
+            let config = existing_player.config.read().await;
             let mut buf = Vec::new();
             for meta in [
                 Metadata::new(17, MetaDataType::Byte, config.skin_parts),

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -658,14 +658,7 @@ impl World {
 
         // Spawn players for our client.
         let id = player.gameprofile.id;
-        for (_, existing_player) in self
-            .players
-            .read()
-            .await
-            .iter()
-            .filter(|c| c.0 != &id)
-            .collect::<Vec<_>>()
-        {
+        for (_, existing_player) in self.players.read().await.iter().filter(|c| c.0 != &id) {
             let entity = &existing_player.living_entity.entity;
             let pos = entity.pos.load();
             let gameprofile = &existing_player.gameprofile;

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -391,7 +391,7 @@ impl World {
         // Entity ticks
         for entity in entities_to_tick {
             entity.tick(server).await;
-            for player in self.current_players_clone().await {
+            for player in self.players.read().await.values() {
                 if player
                     .living_entity
                     .entity
@@ -401,7 +401,7 @@ impl World {
                     .expand(1.0, 0.5, 1.0)
                     .intersects(&entity.get_entity().bounding_box.load())
                 {
-                    entity.on_player_collision(player).await;
+                    entity.on_player_collision(player.clone()).await;
                     break;
                 }
             }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -59,6 +59,9 @@ use pumpkin_registry::DimensionType;
 use pumpkin_util::math::{position::BlockPos, vector3::Vector3};
 use pumpkin_util::math::{position::chunk_section_from_pos, vector2::Vector2};
 use pumpkin_util::text::{TextComponent, color::NamedColor};
+use pumpkin_world::entity::entity_data_flags::{
+    DATA_PLAYER_MAIN_HAND, DATA_PLAYER_MODE_CUSTOMISATION,
+};
 use pumpkin_world::{
     BlockStateId, GENERATION_SETTINGS, GeneratorSetting, biome, block::entities::BlockEntity,
     level::SyncChunk,
@@ -688,8 +691,16 @@ impl World {
             let config = existing_player.config.read().await;
             let mut buf = Vec::new();
             for meta in [
-                Metadata::new(17, MetaDataType::Byte, config.skin_parts),
-                Metadata::new(18, MetaDataType::Byte, config.main_hand as u8),
+                Metadata::new(
+                    DATA_PLAYER_MODE_CUSTOMISATION,
+                    MetaDataType::Byte,
+                    config.skin_parts,
+                ),
+                Metadata::new(
+                    DATA_PLAYER_MAIN_HAND,
+                    MetaDataType::Byte,
+                    config.main_hand as u8,
+                ),
             ] {
                 let mut serializer_buf = Vec::new();
 


### PR DESCRIPTION
## Description

Fix `world.players` dead lock on stress test, by releasing read locks as early as possible.

Most players read locks has been replaced with `world.current_players()`, which returns a copy of current players in a `Vec`. I have not yet documented to warn developers do not use players directly in read only operations.

This PR also fixed a typo in `/pumpkin`

