### PR TITLE
Fix vanilla generated chunk lighting, load extra top and bottom light sections, and fix build limit check

### DIFF
--- a/pumpkin-world/src/chunk/format/anvil.rs
+++ b/pumpkin-world/src/chunk/format/anvil.rs
@@ -820,8 +820,8 @@ pub fn chunk_to_bytes(chunk_data: &ChunkData) -> Result<Vec<u8>, ChunkSerializin
     let mut sections = Vec::new();
 
     for (i, section) in chunk_data.section.sections.iter().enumerate() {
-        let block_states = section.block_states.to_disk_nbt();
-        let biomes = section.biomes.to_disk_nbt();
+        let block_states = section.block_states.as_ref().map(|bs| bs.to_disk_nbt());
+        let biomes = section.biomes.as_ref().map(|b| b.to_disk_nbt());
 
         sections.push(ChunkSectionNBT {
             y: i as i8 + section_coords::block_to_section(chunk_data.section.min_y) as i8,

--- a/pumpkin-world/src/chunk/format/mod.rs
+++ b/pumpkin-world/src/chunk/format/mod.rs
@@ -52,10 +52,11 @@ impl ChunkData {
             .sections
             .into_iter()
             .map(|section| SubChunk {
-                block_states: BlockPalette::from_disk_nbt(section.block_states),
-                biomes: BiomePalette::from_disk_nbt(section.biomes),
+                block_states: section.block_states.map(BlockPalette::from_disk_nbt),
+                biomes: section.biomes.map(BiomePalette::from_disk_nbt),
                 block_light: section.block_light,
                 sky_light: section.sky_light,
+                y: section.y,
             })
             .collect();
         let min_y = section_coords::section_to_block(chunk_data.min_y_section);
@@ -111,12 +112,15 @@ impl ChunkData {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct ChunkSectionNBT {
-    block_states: ChunkSectionBlockStates,
-    biomes: ChunkSectionBiomes,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    block_states: Option<ChunkSectionBlockStates>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    biomes: Option<ChunkSectionBiomes>,
     #[serde(rename = "BlockLight", skip_serializing_if = "Option::is_none")]
     block_light: Option<Box<[u8]>>,
     #[serde(rename = "SkyLight", skip_serializing_if = "Option::is_none")]
     sky_light: Option<Box<[u8]>>,
+    // TODO: This can also be an INT in 1.18+ but here it is not yet supported
     #[serde(rename = "Y")]
     y: i8,
 }

--- a/pumpkin-world/src/generation/implementation/mod.rs
+++ b/pumpkin-world/src/generation/implementation/mod.rs
@@ -3,7 +3,7 @@ use pumpkin_util::math::{vector2::Vector2, vector3::Vector3};
 
 use crate::{
     chunk::{
-        ChunkData, ChunkSections, SubChunk,
+        CHUNK_WIDTH, ChunkData, ChunkSections, SubChunk,
         palette::{BiomePalette, BlockPalette},
     },
     generation::{
@@ -43,7 +43,15 @@ impl WorldGenerator for VanillaGenerator {
             .unwrap();
 
         let sub_chunks = generation_settings.shape.height as usize / BlockPalette::SIZE;
-        let sections = (0..sub_chunks).map(|_| SubChunk::max_sky_light()).collect();
+        let sections = (0..sub_chunks)
+            .map(|index| SubChunk {
+                block_states: Some(BlockPalette::default()),
+                biomes: Some(BiomePalette::default()),
+                sky_light: Some(SubChunk::max_sky_light_data()),
+                block_light: None,
+                y: (generation_settings.shape.min_y / (CHUNK_WIDTH as i8)) + (index as i8),
+            })
+            .collect();
         let mut sections = ChunkSections::new(sections, generation_settings.shape.min_y as i32);
 
         let mut proto_chunk = ProtoChunk::new(

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -36,7 +36,8 @@ use pumpkin_inventory::player::{
 use pumpkin_macros::send_cancellable;
 use pumpkin_protocol::client::play::{
     CBlockUpdate, COpenSignEditor, CPlayerInfoUpdate, CPlayerPosition, CSetContainerSlot,
-    CSetHeldItem, CSystemChatMessage, EquipmentSlot, InitChat, PlayerAction,
+    CSetHeldItem, CSystemChatMessage, EquipmentSlot, InitChat, PlayerAction, WORLD_HIGHEST_Y,
+    WORLD_LOWEST_Y,
 };
 use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_protocol::codec::var_int::VarInt;
@@ -1630,9 +1631,6 @@ impl Player {
         // TODO: send/configure additional commands/data based on the type of entity (horse, slime, etc)
     }
 
-    const WORLD_LOWEST_Y: i8 = -64;
-    const WORLD_MAX_Y: u16 = 384;
-
     #[allow(clippy::too_many_lines)]
     async fn run_is_block_place(
         &self,
@@ -1650,16 +1648,16 @@ impl Player {
         let _clicked_block = world.get_block(&clicked_block_pos).await?;
 
         // Check if the block is under the world
-        if location.0.y + face.to_offset().y < i32::from(Self::WORLD_LOWEST_Y) {
+        if location.0.y + face.to_offset().y < i32::from(WORLD_LOWEST_Y) {
             return Err(BlockPlacingError::BlockOutOfWorld.into());
         }
 
         // Check the world's max build height
-        if location.0.y + face.to_offset().y >= i32::from(Self::WORLD_MAX_Y) {
+        if location.0.y + face.to_offset().y >= WORLD_HIGHEST_Y {
             self.send_system_message_raw(
                 &TextComponent::translate(
                     "build.tooHigh",
-                    vec![TextComponent::text((Self::WORLD_MAX_Y - 1).to_string())],
+                    vec![TextComponent::text((WORLD_HIGHEST_Y - 1).to_string())],
                 )
                 .color_named(NamedColor::Red),
                 true,


### PR DESCRIPTION
## Description

These changes correctly load light data from worlds that were generated by the vanilla game and were moved to this server implementation. The main changes that fixes this is using the correct index for the light data masks since the client expects to receive light data for one section above and another section below the world. These extra "light only" sections also get properly loaded and sent to the client.

The block data and biome data fields have been marked optional for chunk sections since these "light only" chunks don't include those.

Additionally, there is a small fix for when the build limit is checked. Before, the wrong height value was used so the build height limit message was never shown to the player. Could have also been a separate fix but since I was moving around and creating some constants I included it here. 

## Testing

Tested by loading a vanilla generated world with a chunk that has the extra top and bottom light only sections.