### PR TITLE
Fixing repeater power on placement

### DIFF
--- a/pumpkin/src/block/blocks/redstone/redstone_wire.rs
+++ b/pumpkin/src/block/blocks/redstone/redstone_wire.rs
@@ -103,20 +103,6 @@ impl PumpkinBlock for RedstoneWireBlock {
             }
         }
 
-        // Schedules a block tick for the connected block if the side is connected and wire is powered.
-        if new_side.is_connected() && wire.power != Integer0To15::L0 {
-            let block_pos = block_pos.offset(direction.to_offset());
-            let block = world.get_block(&block_pos).await.unwrap();
-            world
-                .schedule_block_tick(
-                    &block,
-                    block_pos,
-                    0,
-                    pumpkin_world::chunk::TickPriority::ExtremelyHigh, // TODO which is the priority of the tick?
-                )
-                .await;
-        }
-
         wire = get_regulated_sides(wire, world, block_pos).await;
         if is_cross(old_state) && new_side.is_none() {
             return wire.to_state_id(block);

--- a/pumpkin/src/block/blocks/redstone/redstone_wire.rs
+++ b/pumpkin/src/block/blocks/redstone/redstone_wire.rs
@@ -103,6 +103,19 @@ impl PumpkinBlock for RedstoneWireBlock {
             }
         }
 
+        if new_side.is_connected() && wire.power != Integer0To15::L0 {
+            let block_pos = block_pos.offset(direction.to_offset());
+            let block = world.get_block(&block_pos).await.unwrap();
+            world
+                .schedule_block_tick(
+                    &block,
+                    block_pos,
+                    0,
+                    pumpkin_world::chunk::TickPriority::ExtremelyHigh, // TODO which is the priority of the tick?
+                )
+                .await;
+        }
+
         wire = get_regulated_sides(wire, world, block_pos).await;
         if is_cross(old_state) && new_side.is_none() {
             return wire.to_state_id(block);

--- a/pumpkin/src/block/blocks/redstone/redstone_wire.rs
+++ b/pumpkin/src/block/blocks/redstone/redstone_wire.rs
@@ -103,6 +103,7 @@ impl PumpkinBlock for RedstoneWireBlock {
             }
         }
 
+        // Schedules a block tick for the connected block if the side is connected and wire is powered.
         if new_side.is_connected() && wire.power != Integer0To15::L0 {
             let block_pos = block_pos.offset(direction.to_offset());
             let block = world.get_block(&block_pos).await.unwrap();

--- a/pumpkin/src/block/blocks/redstone/repeater.rs
+++ b/pumpkin/src/block/blocks/redstone/repeater.rs
@@ -51,6 +51,15 @@ impl PumpkinBlock for RepeaterBlock {
             .opposite();
         props.facing = dir;
         props.locked = Boolean::from_bool(should_be_locked(&dir, world, block_pos).await);
+
+        // copied from on_neighbor_update
+        if !props.locked.to_bool() && !world.is_block_tick_scheduled(block_pos, block).await {
+            props.powered = match should_be_powered(props, world, block_pos).await {
+                true => Boolean::True,
+                false => Boolean::False,
+            };
+        }
+
         props.to_state_id(block)
     }
 

--- a/pumpkin/src/block/blocks/redstone/repeater.rs
+++ b/pumpkin/src/block/blocks/redstone/repeater.rs
@@ -52,7 +52,7 @@ impl PumpkinBlock for RepeaterBlock {
         props.facing = dir;
         props.locked = Boolean::from_bool(should_be_locked(&dir, world, block_pos).await);
 
-        // copied from on_neighbor_update
+        // check if the repeater should be powered
         if !props.locked.to_bool() && !world.is_block_tick_scheduled(block_pos, block).await {
             props.powered = match should_be_powered(props, world, block_pos).await {
                 true => Boolean::True,

--- a/pumpkin/src/block/blocks/redstone/repeater.rs
+++ b/pumpkin/src/block/blocks/redstone/repeater.rs
@@ -53,7 +53,7 @@ impl PumpkinBlock for RepeaterBlock {
         props.locked = Boolean::from_bool(should_be_locked(&dir, world, block_pos).await);
 
         // check if the repeater should be powered
-        if !props.locked.to_bool() && !world.is_block_tick_scheduled(block_pos, block).await {
+        if !props.locked.to_bool() {
             props.powered = if should_be_powered(props, world, block_pos).await {
                 Boolean::True
             } else {

--- a/pumpkin/src/block/blocks/redstone/repeater.rs
+++ b/pumpkin/src/block/blocks/redstone/repeater.rs
@@ -52,7 +52,6 @@ impl PumpkinBlock for RepeaterBlock {
         props.facing = dir;
         props.locked = Boolean::from_bool(should_be_locked(&dir, world, block_pos).await);
 
-        // check if the repeater should be powered
         if !props.locked.to_bool() {
             props.powered = if should_be_powered(props, world, block_pos).await {
                 Boolean::True

--- a/pumpkin/src/block/blocks/redstone/repeater.rs
+++ b/pumpkin/src/block/blocks/redstone/repeater.rs
@@ -54,10 +54,11 @@ impl PumpkinBlock for RepeaterBlock {
 
         // check if the repeater should be powered
         if !props.locked.to_bool() && !world.is_block_tick_scheduled(block_pos, block).await {
-            props.powered = match should_be_powered(props, world, block_pos).await {
-                true => Boolean::True,
-                false => Boolean::False,
-            };
+            props.powered = if should_be_powered(props, world, block_pos).await {
+                Boolean::True
+            } else {
+                Boolean::False
+            }
         }
 
         props.to_state_id(block)


### PR DESCRIPTION
## Description
(edited after I realized a part of what I was doing was probably out of the scope of this PR)

This pull request introduces the following change:

1. **Power Check for Repeater Placement**: Added code to check if a repeater should be powered on placement.

This fixes #762. For example if you try having a redstone torch and then place a repeater, it will be placed in a powered state.

## Testing
I tested manually, not sure if I need to do more