### PR TITLE
fixed rotate_ccw

### DIFF
--- a/pumpkin-world/src/block/mod.rs
+++ b/pumpkin-world/src/block/mod.rs
@@ -206,8 +206,8 @@ impl HorizontalFacingExt for HorizontalFacing {
         match self {
             HorizontalFacing::North => HorizontalFacing::West,
             HorizontalFacing::South => HorizontalFacing::East,
-            HorizontalFacing::West => HorizontalFacing::North,
-            HorizontalFacing::East => HorizontalFacing::South,
+            HorizontalFacing::West => HorizontalFacing::South,
+            HorizontalFacing::East => HorizontalFacing::North,
         }
     }
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
The rotate_ccw had a small error. This fixes an issue with repeater locking. I don't know if I should, but I made this in a separate PR since it's probably affecting more than just that.

## Testing
I don't think this needs testing, but the game runs and repeater locking works in normal cases now
