### PR TITLE
observer and piston placement fix (get_facing)

### DIFF
--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -29,14 +29,11 @@ use pumpkin_util::math::{
     wrap_degrees,
 };
 use serde::Serialize;
-use std::{
-    f32::consts::PI,
-    sync::{
-        Arc,
-        atomic::{
-            AtomicBool, AtomicI32,
-            Ordering::{Relaxed, SeqCst},
-        },
+use std::sync::{
+    Arc,
+    atomic::{
+        AtomicBool, AtomicI32,
+        Ordering::{Relaxed, SeqCst},
     },
 };
 use tokio::sync::RwLock;
@@ -375,33 +372,25 @@ impl Entity {
     }
 
     pub fn get_facing(&self) -> Facing {
-        let pitch = self.pitch.load() * (PI / 180.0);
-        let yaw = -self.yaw.load() * (PI / 180.0);
+        let pitch = self.pitch.load().to_radians();
+        let yaw = -self.yaw.load().to_radians();
 
-        let sin_pitch = pitch.sin();
-        let cos_pitch = pitch.cos();
-        let sin_yaw = yaw.sin();
-        let cos_yaw = yaw.cos();
+        let (sin_p, cos_p) = pitch.sin_cos();
+        let (sin_y, cos_y) = yaw.sin_cos();
 
-        let abs_sin_yaw = sin_yaw.abs();
-        let abs_sin_pitch = sin_pitch.abs();
-        let abs_cos_yaw = cos_yaw.abs();
+        let x = sin_y * cos_p;
+        let y = -sin_p;
+        let z = cos_y * cos_p;
 
-        let o = abs_sin_yaw * cos_pitch.abs();
+        let ax = x.abs();
+        let ay = y.abs();
+        let az = z.abs();
 
-        if abs_sin_yaw > abs_cos_yaw {
-            if abs_sin_pitch > o {
-                if sin_pitch < 0.0 {
-                    Facing::Up
-                } else {
-                    Facing::Down
-                }
-            } else if sin_yaw > 0.0 {
-                Facing::East
-            } else {
-                Facing::West
-            }
-        } else if cos_yaw > 0.0 {
+        if ax > ay && ax > az {
+            if x > 0.0 { Facing::East } else { Facing::West }
+        } else if ay > ax && ay > az {
+            if y > 0.0 { Facing::Up } else { Facing::Down }
+        } else if z > 0.0 {
             Facing::South
         } else {
             Facing::North


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

When looking straight down, placing an observer is often not possible, so I tried to figure out why.

With the decompiled code I found the function `get_facing()` in Pumpkin seems to be based upon (`orderedByNearest`). I replaced the current one with the implementation almost exactly to vanilla without optimizing for now, with the exception that vanilla returns an array of nearest directions, which might be useful in the future, I don't know.

This fixes observer and piston placements.

## Testing
I tested with python. I have the java function and my function. For each case, I generate random angles:
```python
    pitch = random.uniform(-90, 90)
    yaw = random.uniform(-180, 180)
```
I run `100000000` iterations (if you plan on running this, probably lower this).
I don't know if I should add it to the project's tests, but here is the python file for now:
```python
import math
import random

def java_like_facing(pitch_deg, yaw_deg):
    pitch = math.radians(pitch_deg)
    yaw = -math.radians(yaw_deg)

    sin_pitch = math.sin(pitch)
    cos_pitch = math.cos(pitch)
    sin_yaw = math.sin(yaw)
    cos_yaw = math.cos(yaw)

    bl = sin_yaw > 0.0
    bl2 = sin_pitch < 0.0
    bl3 = cos_yaw > 0.0

    abs_sin_yaw = sin_yaw if bl else -sin_yaw
    abs_sin_pitch = -sin_pitch if bl2 else sin_pitch
    abs_cos_yaw = cos_yaw if bl3 else -cos_yaw

    o = abs_sin_yaw * cos_pitch
    p = abs_cos_yaw * cos_pitch

    direction = "East" if bl else "West"
    direction2 = "Up" if bl2 else "Down"
    direction3 = "South" if bl3 else "North"

    if abs_sin_yaw > abs_cos_yaw:
        if abs_sin_pitch > o:
            return direction2
        else:
            return (
            direction
                if p > abs_sin_pitch
                else direction
            )
    elif abs_sin_pitch > p:
        return direction2
    else:
        return (
        direction3
            if o > abs_sin_pitch
            else direction3
        )

# Simplified version of the logic
def simplified_facing(pitch_deg, yaw_deg):
    pitch = math.radians(pitch_deg)
    yaw = -math.radians(yaw_deg)

    sp, cp = math.sin(pitch), math.cos(pitch)
    sy, cy = math.sin(yaw), math.cos(yaw)

    x = sy * cp
    y = -sp
    z = cy * cp

    ax, ay, az = abs(x), abs(y), abs(z)

    if ax > ay and ax > az:
        return "East" if x > 0.0 else "West"
    elif ay > ax and ay > az:
        return "Up" if y > 0.0 else "Down"
    else:
        return "South" if z > 0.0 else "North"

# Run comparison test
fails = 0
for _ in range(100000000):
    pitch = random.uniform(-90, 90)
    yaw = random.uniform(-180, 180)
    if java_like_facing(pitch, yaw) != simplified_facing(pitch, yaw):
        fails += 1

print(fails)
```
