### PR TITLE
Fix last_pos of new LivingEntity

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -42,9 +42,10 @@ pub struct LivingEntity {
 }
 impl LivingEntity {
     pub fn new(entity: Entity) -> Self {
+        let pos = entity.pos.load();
         Self {
             entity,
-            last_pos: AtomicCell::new(entity.pos.load()),
+            last_pos: AtomicCell::new(pos),
             time_until_regen: AtomicI32::new(0),
             last_damage_taken: AtomicCell::new(0.0),
             health: AtomicCell::new(20.0),

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -44,7 +44,7 @@ impl LivingEntity {
     pub fn new(entity: Entity) -> Self {
         Self {
             entity,
-            last_pos: AtomicCell::new(Vector3::new(0.0, 0.0, 0.0)),
+            last_pos: AtomicCell::new(entity.pos.load()),
             time_until_regen: AtomicI32::new(0),
             last_damage_taken: AtomicCell::new(0.0),
             health: AtomicCell::new(20.0),


### PR DESCRIPTION
## Description
Fix the initial last_pos of a LivingEntity.
In LivingEntity::new(), set last_pos to entity.pos instead of 0,0,0.
This is important because otherwise, when first sending position of a new mob, assuming you use the difference _pos - last_pos_ to send position, the entity will appear to jump somewhere else.

## Testing
Passed cargo check, cargo fmt --check, and cargo test.
