### PR TITLE
Fix effect command crashing the server because of invalid bounds

### DIFF
--- a/pumpkin/src/command/commands/effect.rs
+++ b/pumpkin/src/command/commands/effect.rs
@@ -62,8 +62,7 @@ impl CommandExecutor for GiveExecutor {
                     .name("seconds")
                     .min(1)
                     .max(1_000_000)
-                    .find_arg_default_name(args)?
-                    .unwrap()
+                    .find_arg_default_name(args)??
                     * 20
             }
             Time::Infinite => -1,
@@ -75,8 +74,7 @@ impl CommandExecutor for GiveExecutor {
                 .name("amplifier")
                 .min(0)
                 .max(255)
-                .find_arg_default_name(args)?
-                .unwrap(),
+                .find_arg_default_name(args)??,
         };
 
         let mut hide_particles = self.2;

--- a/pumpkin/src/command/commands/help.rs
+++ b/pumpkin/src/command/commands/help.rs
@@ -112,7 +112,7 @@ impl CommandExecutor for BaseHelpExecutor {
         let page_number = match page_number_consumer().find_arg_default_name(args) {
             Err(_) => 1,
             Ok(Ok(number)) => number,
-            Ok(Err(())) => {
+            Ok(Err(_)) => {
                 sender
                     .send_message(
                         TextComponent::text("Invalid page number.")

--- a/pumpkin/src/command/commands/particle.rs
+++ b/pumpkin/src/command/commands/particle.rs
@@ -41,8 +41,8 @@ impl CommandExecutor for Executor {
             let pos = pos.unwrap_or(player.living_entity.entity.pos.load());
             let delta = delta.unwrap_or(Vector3::new(0.0, 0.0, 0.0));
             let delta: Vector3<f32> = Vector3::new(delta.x as f32, delta.y as f32, delta.z as f32);
-            let speed = speed.unwrap_or(Ok(0.0)).unwrap_or(0.0);
-            let count = count.unwrap_or(Ok(0)).unwrap_or(0);
+            let speed = speed.unwrap_or(Ok(0.0))?;
+            let count = count.unwrap_or(Ok(0))?;
 
             player
                 .world()

--- a/pumpkin/src/command/commands/transfer.rs
+++ b/pumpkin/src/command/commands/transfer.rs
@@ -46,7 +46,7 @@ impl CommandExecutor for TargetSelfExecutor {
         let port = match port_consumer().find_arg_default_name(args) {
             Err(_) => 25565,
             Ok(Ok(count)) => count,
-            Ok(Err(())) => {
+            Ok(Err(_)) => {
                 sender
                     .send_message(
                         TextComponent::text("Port must be between 1 and 65535.")
@@ -88,7 +88,7 @@ impl CommandExecutor for TargetPlayerExecutor {
         let port = match port_consumer().find_arg_default_name(args) {
             Err(_) => 25565,
             Ok(Ok(count)) => count,
-            Ok(Err(())) => {
+            Ok(Err(_)) => {
                 sender
                     .send_message(
                         TextComponent::text("Port must be between 1 and 65535.")


### PR DESCRIPTION
## Description

This commit fixes the server crash on invalid arguments for the effect command, hower it does not provide translation support for the error message and also doesn't change a lot of other things, the primary goal here is really just to fix this one crash.

Previously you could just crash the Pumpkin server by providing an invalid value for a bounded argument when using the `effect` command. Error handling for `give`, and `particle` was also inconsistent.

In the handler for `particle` the server just ignored the invalid argument and used defaults instead which is not the same behaviour that the java server exhibits.

Give just didn't provide the proper error message, also note that the current upper bound for the command is `i32::MAX` which is not the same as in the java server, this PR doesn't address that either however.

## Testing

Tested the commands manually after running the server, unit tests were not implemented as the command executor doesn't have any automatic test coverage at the moment, and setting that up would be out of scope for this PR.
