### PR TITLE
Read commands from stdin

### DIFF
--- a/pumpkin-config/src/commands.rs
+++ b/pumpkin-config/src/commands.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 pub struct CommandsConfig {
     /// Whether commands from the console are accepted.
     pub use_console: bool,
+    /// Whether to use rusty line for tty input.
+    pub use_tty: bool,
     /// Whether commands from players are logged in the console.
     pub log_console: bool, // TODO: commands...
     /// The `op` permission level of everyone that is not in the `ops` file.
@@ -17,6 +19,7 @@ impl Default for CommandsConfig {
         Self {
             use_console: true,
             log_console: true,
+            use_tty: true,
             default_op_level: PermissionLvl::Zero,
         }
     }

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -150,11 +150,6 @@ pub static LOGGER_IMPL: LazyLock<Option<(ReadlineLogWrapper, LevelFilter)>> = La
                 }
             }
         } else {
-            if advanced_config().commands.use_tty && !stdin().is_terminal() {
-                log::warn!(
-                    "The input is not a TTY; falling back to simple logger and ignoring `use_tty` setting"
-                );
-            }
             let logger = simplelog::SimpleLogger::new(level, config.build());
             Some((ReadlineLogWrapper::new(logger, None), level))
         }
@@ -213,6 +208,11 @@ impl PumpkinServer {
                 if let Some(rl) = wrapper.take_readline() {
                     setup_console(rl, server.clone());
                 } else {
+                    if advanced_config().commands.use_tty {
+                        log::warn!(
+                            "The input is not a TTY; falling back to simple logger and ignoring `use_tty` setting"
+                        );
+                    }
                     setup_stdin_console(server.clone()).await;
                 }
             }

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -387,8 +387,7 @@ fn setup_stdin_console(server: Arc<Server>) {
     tokio::spawn(async move {
         while !SHOULD_STOP.load(std::sync::atomic::Ordering::Relaxed) {
             let mut line = String::new();
-            if let Ok(_) = stdin().read_line(&mut line) {
-            } else {
+            if stdin().read_line(&mut line).is_err() {
                 break;
             };
             let command = &line[..line.len() - 1]; // Remove the newline

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -395,16 +395,15 @@ fn setup_stdin_console(server: Arc<Server>, handle: Handle) {
             handle.spawn(async move {
                 let command = &line[..line.len() - 1]; // Remove the newline
                 send_cancellable! {{
-                        ServerCommandEvent::new(command.to_string());
+                    ServerCommandEvent::new(command.to_string());
 
-                        'after: {
-                            let dispatcher = &server_clone.command_dispatcher.read().await;
-                            dispatcher
-                                .handle_command(&mut command::CommandSender::Console, &server_clone, command)
-                                .await;
-                        };
-                    }
-                }
+                    'after: {
+                        let dispatcher = &server_clone.command_dispatcher.read().await;
+                        dispatcher
+                            .handle_command(&mut command::CommandSender::Console, &server_clone, command)
+                            .await;
+                    };
+                }}
             });
         }
     });

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -404,9 +404,8 @@ async fn setup_stdin_console(server: Arc<Server>) {
             };
             if line.is_empty() || line.as_bytes()[line.len() - 1] != b'\n' {
                 log::warn!("Console command was not terminated with a newline");
-                continue;
             }
-            rt.block_on(tx.send(line.trim()))
+            rt.block_on(tx.send(line.trim().to_string()))
                 .expect("Failed to send command to server");
         }
     });
@@ -419,7 +418,7 @@ async fn setup_stdin_console(server: Arc<Server>) {
                     'after: {
                         let dispatcher = &server.command_dispatcher.read().await;
                         dispatcher
-                            .handle_command(&mut command::CommandSender::Console, &server, command)
+                            .handle_command(&mut command::CommandSender::Console, &server, command.as_str())
                             .await;
                     };
                 }}

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -134,7 +134,21 @@ pub static LOGGER_IMPL: LazyLock<Option<(ReadlineLogWrapper, LevelFilter)>> = La
             .and_then(Result::ok)
             .unwrap_or(LevelFilter::Info);
 
-        if advanced_config().commands.use_tty && stdin().is_terminal() {
+        if advanced_config().commands.use_tty {
+            if !stdin().is_terminal() {
+                // we do not have a logger yet, create a temporary one
+                log::set_max_level(level);
+                let logger = *simplelog::SimpleLogger::new(level, config.build());
+                log::warn!(
+                    logger: logger,
+                    "The input is not a terminal, the console reader may fail to initialize!"
+                );
+                log::info!(
+                    logger: logger,
+                    "Note: to fix this, set `use_tty` to false in `features.toml`"
+                );
+                logger.flush();
+            }
             match Readline::new("$ ".to_owned()) {
                 Ok((rl, stdout)) => {
                     let logger = simplelog::WriteLogger::new(level, config.build(), stdout);
@@ -150,11 +164,6 @@ pub static LOGGER_IMPL: LazyLock<Option<(ReadlineLogWrapper, LevelFilter)>> = La
                 }
             }
         } else {
-            if advanced_config().commands.use_tty && !stdin().is_terminal() {
-                log::warn!(
-                    "The input is not a TTY; falling back to simple logger and ignoring `use_tty` setting"
-                );
-            }
             let logger = simplelog::SimpleLogger::new(level, config.build());
             Some((ReadlineLogWrapper::new(logger, None), level))
         }

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -388,11 +388,16 @@ fn setup_stdin_console(server: Arc<Server>, handle: Handle) {
     std::thread::spawn(move || {
         while !SHOULD_STOP.load(std::sync::atomic::Ordering::Relaxed) {
             let mut line = String::new();
-            if stdin().read_line(&mut line).is_err() {
+            if let Ok(size) = stdin().read_line(&mut line) {
+                // if no bytes were read, we may have hit EOF
+                if size == 0 {
+                    break;
+                }
+            } else {
                 break;
             };
             let server_clone = server.clone();
-            if line.len() == 0 || line.as_bytes()[line.len() - 1] != b'\n' {
+            if line.is_empty() || line.as_bytes()[line.len() - 1] != b'\n' {
                 log::warn!("Console command was not terminated with a newline");
                 continue;
             }


### PR DESCRIPTION
## Description

This PR allows reading commands from stdin. Stdin is very important since many server hosting softwares redirect stdin and executing console commands that way.

Without this PR, any commands in non-tty mode will be simply ignored.

## Needs improvement

When the user press Ctrl+C, the signal is correctly captured, and the server saves and stops. However, since `stdin().read_line` is blocking, it waits for a newline if there is not a newline. Users may have to press an extra enter to fully close the server. Server hosting softs that send a `stop` command via stdin will not be effected.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
