### PR TITLE
Fix NaN rotation in player move packets

### DIFF
--- a/pumpkin-protocol/src/server/play/player_position.rs
+++ b/pumpkin-protocol/src/server/play/player_position.rs
@@ -6,6 +6,6 @@ use pumpkin_util::math::vector3::Vector3;
 #[packet(PLAY_MOVE_PLAYER_POS)]
 pub struct SPlayerPosition {
     pub position: Vector3<f64>,
-    /// bit 0: [BIT_ON_GROUND], bit 1: [BIT_IN_WALL]
+    /// bit 0: [FLAG_ON_GROUND], bit 1: [FLAG_IN_WALL]
     pub collision: u8,
 }

--- a/pumpkin-protocol/src/server/play/player_position.rs
+++ b/pumpkin-protocol/src/server/play/player_position.rs
@@ -6,5 +6,6 @@ use pumpkin_util::math::vector3::Vector3;
 #[packet(PLAY_MOVE_PLAYER_POS)]
 pub struct SPlayerPosition {
     pub position: Vector3<f64>,
-    pub ground: bool,
+    /// bit 0: [BIT_ON_GROUND], bit 1: [BIT_IN_WALL]
+    pub collision: u8,
 }

--- a/pumpkin-protocol/src/server/play/player_position_rotation.rs
+++ b/pumpkin-protocol/src/server/play/player_position_rotation.rs
@@ -8,5 +8,6 @@ pub struct SPlayerPositionRotation {
     pub position: Vector3<f64>,
     pub yaw: f32,
     pub pitch: f32,
-    pub ground: bool,
+    /// bit 0: on_ground, bit 1: in_wall
+    pub ground: u8,
 }

--- a/pumpkin-protocol/src/server/play/player_position_rotation.rs
+++ b/pumpkin-protocol/src/server/play/player_position_rotation.rs
@@ -2,12 +2,15 @@ use pumpkin_data::packet::serverbound::PLAY_MOVE_PLAYER_POS_ROT;
 use pumpkin_macros::packet;
 use pumpkin_util::math::vector3::Vector3;
 
+pub static BIT_ON_GROUND: u8 = 0x01;
+pub static BIT_IN_WALL: u8 = 0x02;
+
 #[derive(serde::Deserialize)]
 #[packet(PLAY_MOVE_PLAYER_POS_ROT)]
 pub struct SPlayerPositionRotation {
     pub position: Vector3<f64>,
     pub yaw: f32,
     pub pitch: f32,
-    /// bit 0: on_ground, bit 1: in_wall
-    pub ground: u8,
+    /// bit 0: [BIT_ON_GROUND], bit 1: [BIT_IN_WALL]
+    pub collision: u8,
 }

--- a/pumpkin-protocol/src/server/play/player_position_rotation.rs
+++ b/pumpkin-protocol/src/server/play/player_position_rotation.rs
@@ -2,8 +2,8 @@ use pumpkin_data::packet::serverbound::PLAY_MOVE_PLAYER_POS_ROT;
 use pumpkin_macros::packet;
 use pumpkin_util::math::vector3::Vector3;
 
-pub static BIT_ON_GROUND: u8 = 0x01;
-pub static BIT_IN_WALL: u8 = 0x02;
+pub static FLAG_ON_GROUND: u8 = 0x01;
+pub static FLAG_IN_WALL: u8 = 0x02;
 
 #[derive(serde::Deserialize)]
 #[packet(PLAY_MOVE_PLAYER_POS_ROT)]
@@ -11,6 +11,6 @@ pub struct SPlayerPositionRotation {
     pub position: Vector3<f64>,
     pub yaw: f32,
     pub pitch: f32,
-    /// bit 0: [BIT_ON_GROUND], bit 1: [BIT_IN_WALL]
+    /// bit 0: [FLAG_ON_GROUND], bit 1: [FLAG_IN_WALL]
     pub collision: u8,
 }

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -384,14 +384,14 @@ impl Player {
 
                 let height_difference = pos.y - last_pos.y;
                 if entity.on_ground.load(std::sync::atomic::Ordering::Relaxed)
-                    && !packet.ground
+                    && (packet.ground & 1) != 0
                     && height_difference > 0.0
                 {
                     self.jump().await;
                 }
                 entity
                     .on_ground
-                    .store(packet.ground, std::sync::atomic::Ordering::Relaxed);
+                    .store((packet.ground & 1) != 0, std::sync::atomic::Ordering::Relaxed);
 
                 entity.set_rotation(wrap_degrees(packet.yaw) % 360.0, wrap_degrees(packet.pitch));
 
@@ -404,7 +404,7 @@ impl Player {
 
                 // TODO: Warn when player moves to quickly
                 if !self
-                    .sync_position(world, pos, last_pos, yaw, pitch, packet.ground)
+                    .sync_position(world, pos, last_pos, yaw, pitch, (packet.ground & 1) != 0)
                     .await
                 {
                     // Send the new position to all other players.
@@ -420,7 +420,7 @@ impl Player {
                                 ),
                                 yaw as u8,
                                 pitch as u8,
-                                packet.ground,
+                                (packet.ground & 1) != 0,
                             ),
                         )
                         .await;
@@ -436,7 +436,7 @@ impl Player {
                     self.living_entity
                         .update_fall_distance(
                             height_difference,
-                            packet.ground,
+                            (packet.ground & 1) != 0,
                             self.gamemode.load() == GameMode::Creative,
                         )
                         .await;

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -45,7 +45,7 @@ use pumpkin_protocol::client::play::{
 use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::server::play::{
-    SChunkBatch, SCookieResponse as SPCookieResponse, SPlayerSession, SUpdateSign,
+    BIT_ON_GROUND, SChunkBatch, SCookieResponse as SPCookieResponse, SPlayerSession, SUpdateSign,
 };
 use pumpkin_protocol::{
     client::play::{
@@ -286,15 +286,15 @@ impl Player {
                 self.living_entity.set_pos(pos);
 
                 let height_difference = pos.y - last_pos.y;
-                if entity.on_ground.load(Ordering::Relaxed) && !packet.ground && height_difference > 0.0 {
+                if entity.on_ground.load(Ordering::Relaxed) && !packet.collision & BIT_ON_GROUND != 0 && height_difference > 0.0 {
                     self.jump().await;
                 }
 
-                entity.on_ground.store(packet.ground, Ordering::Relaxed);
+                entity.on_ground.store(packet.collision & BIT_ON_GROUND != 0, Ordering::Relaxed);
                 let world = &self.world().await;
 
                 // TODO: Warn when player moves to quickly
-                if !self.sync_position(world, pos, last_pos, entity.yaw.load(), entity.pitch.load(), packet.ground).await {
+                if !self.sync_position(world, pos, last_pos, entity.yaw.load(), entity.pitch.load(), packet.collision & BIT_ON_GROUND != 0).await {
                     // Send the new position to all other players.
                     world
                         .broadcast_packet_except(
@@ -306,7 +306,7 @@ impl Player {
                                     pos.y.mul_add(4096.0, -(last_pos.y * 4096.0)) as i16,
                                     pos.z.mul_add(4096.0, -(last_pos.z * 4096.0)) as i16,
                                 ),
-                                packet.ground,
+                                packet.collision & BIT_ON_GROUND != 0,
                             ),
                         )
                         .await;
@@ -316,7 +316,7 @@ impl Player {
                     self.living_entity
                         .update_fall_distance(
                             height_difference,
-                            packet.ground,
+                            packet.collision & BIT_ON_GROUND != 0,
                             self.gamemode.load() == GameMode::Creative,
                         )
                         .await;
@@ -384,14 +384,14 @@ impl Player {
 
                 let height_difference = pos.y - last_pos.y;
                 if entity.on_ground.load(std::sync::atomic::Ordering::Relaxed)
-                    && (packet.ground & 1) != 0
+                    && (packet.collision & BIT_ON_GROUND) != 0
                     && height_difference > 0.0
                 {
                     self.jump().await;
                 }
                 entity
                     .on_ground
-                    .store((packet.ground & 1) != 0, std::sync::atomic::Ordering::Relaxed);
+                    .store((packet.collision & BIT_ON_GROUND) != 0, std::sync::atomic::Ordering::Relaxed);
 
                 entity.set_rotation(wrap_degrees(packet.yaw) % 360.0, wrap_degrees(packet.pitch));
 
@@ -404,7 +404,7 @@ impl Player {
 
                 // TODO: Warn when player moves to quickly
                 if !self
-                    .sync_position(world, pos, last_pos, yaw, pitch, (packet.ground & 1) != 0)
+                    .sync_position(world, pos, last_pos, yaw, pitch, (packet.collision & BIT_ON_GROUND) != 0)
                     .await
                 {
                     // Send the new position to all other players.
@@ -420,7 +420,7 @@ impl Player {
                                 ),
                                 yaw as u8,
                                 pitch as u8,
-                                (packet.ground & 1) != 0,
+                                (packet.collision & BIT_ON_GROUND) != 0,
                             ),
                         )
                         .await;
@@ -436,7 +436,7 @@ impl Player {
                     self.living_entity
                         .update_fall_distance(
                             height_difference,
-                            (packet.ground & 1) != 0,
+                            (packet.collision & BIT_ON_GROUND) != 0,
                             self.gamemode.load() == GameMode::Creative,
                         )
                         .await;

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -45,7 +45,7 @@ use pumpkin_protocol::client::play::{
 use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::server::play::{
-    BIT_ON_GROUND, SChunkBatch, SCookieResponse as SPCookieResponse, SPlayerSession, SUpdateSign,
+    FLAG_ON_GROUND, SChunkBatch, SCookieResponse as SPCookieResponse, SPlayerSession, SUpdateSign,
 };
 use pumpkin_protocol::{
     client::play::{
@@ -286,15 +286,15 @@ impl Player {
                 self.living_entity.set_pos(pos);
 
                 let height_difference = pos.y - last_pos.y;
-                if entity.on_ground.load(Ordering::Relaxed) && !packet.collision & BIT_ON_GROUND != 0 && height_difference > 0.0 {
+                if entity.on_ground.load(Ordering::Relaxed) && packet.collision & FLAG_ON_GROUND == 0 && height_difference > 0.0 {
                     self.jump().await;
                 }
 
-                entity.on_ground.store(packet.collision & BIT_ON_GROUND != 0, Ordering::Relaxed);
+                entity.on_ground.store(packet.collision & FLAG_ON_GROUND != 0, Ordering::Relaxed);
                 let world = &self.world().await;
 
                 // TODO: Warn when player moves to quickly
-                if !self.sync_position(world, pos, last_pos, entity.yaw.load(), entity.pitch.load(), packet.collision & BIT_ON_GROUND != 0).await {
+                if !self.sync_position(world, pos, last_pos, entity.yaw.load(), entity.pitch.load(), packet.collision & FLAG_ON_GROUND != 0).await {
                     // Send the new position to all other players.
                     world
                         .broadcast_packet_except(
@@ -306,7 +306,7 @@ impl Player {
                                     pos.y.mul_add(4096.0, -(last_pos.y * 4096.0)) as i16,
                                     pos.z.mul_add(4096.0, -(last_pos.z * 4096.0)) as i16,
                                 ),
-                                packet.collision & BIT_ON_GROUND != 0,
+                                packet.collision & FLAG_ON_GROUND != 0,
                             ),
                         )
                         .await;
@@ -316,7 +316,7 @@ impl Player {
                     self.living_entity
                         .update_fall_distance(
                             height_difference,
-                            packet.collision & BIT_ON_GROUND != 0,
+                            packet.collision & FLAG_ON_GROUND != 0,
                             self.gamemode.load() == GameMode::Creative,
                         )
                         .await;
@@ -384,14 +384,14 @@ impl Player {
 
                 let height_difference = pos.y - last_pos.y;
                 if entity.on_ground.load(std::sync::atomic::Ordering::Relaxed)
-                    && (packet.collision & BIT_ON_GROUND) != 0
+                    && (packet.collision & FLAG_ON_GROUND) != 0
                     && height_difference > 0.0
                 {
                     self.jump().await;
                 }
                 entity
                     .on_ground
-                    .store((packet.collision & BIT_ON_GROUND) != 0, std::sync::atomic::Ordering::Relaxed);
+                    .store((packet.collision & FLAG_ON_GROUND) != 0, std::sync::atomic::Ordering::Relaxed);
 
                 entity.set_rotation(wrap_degrees(packet.yaw) % 360.0, wrap_degrees(packet.pitch));
 
@@ -404,7 +404,7 @@ impl Player {
 
                 // TODO: Warn when player moves to quickly
                 if !self
-                    .sync_position(world, pos, last_pos, yaw, pitch, (packet.collision & BIT_ON_GROUND) != 0)
+                    .sync_position(world, pos, last_pos, yaw, pitch, (packet.collision & FLAG_ON_GROUND) != 0)
                     .await
                 {
                     // Send the new position to all other players.
@@ -420,7 +420,7 @@ impl Player {
                                 ),
                                 yaw as u8,
                                 pitch as u8,
-                                (packet.collision & BIT_ON_GROUND) != 0,
+                                (packet.collision & FLAG_ON_GROUND) != 0,
                             ),
                         )
                         .await;
@@ -436,7 +436,7 @@ impl Player {
                     self.living_entity
                         .update_fall_distance(
                             height_difference,
-                            (packet.collision & BIT_ON_GROUND) != 0,
+                            (packet.collision & FLAG_ON_GROUND) != 0,
                             self.gamemode.load() == GameMode::Creative,
                         )
                         .await;

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -349,9 +349,9 @@ impl Player {
         }
         // y = feet Y
         let position = packet.position;
-        if position.x.is_nan()
-            || position.y.is_nan()
-            || position.z.is_nan()
+        if !position.x.is_finite()
+            || !position.y.is_finite()
+            || !position.z.is_finite()
             || !packet.yaw.is_finite()
             || !packet.pitch.is_finite()
         {

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -352,8 +352,8 @@ impl Player {
         if position.x.is_nan()
             || position.y.is_nan()
             || position.z.is_nan()
-            || packet.yaw.is_infinite()
-            || packet.pitch.is_infinite()
+            || !packet.yaw.is_finite()
+            || !packet.pitch.is_finite()
         {
             self.kick(TextComponent::translate(
                 "multiplayer.disconnect.invalid_player_movement",


### PR DESCRIPTION
## Description

Fix #781 

`is_infinite` does not check for NaN, so use `!is_finite` instead.

The original report is wrong: We have checked for NaN position before clamping, but there is still a NaN rotation.

## Testing

Have not tested yet.