### PR TITLE
Chest placement fix

### DIFF
--- a/pumpkin/src/block/blocks/chest.rs
+++ b/pumpkin/src/block/blocks/chest.rs
@@ -283,6 +283,10 @@ async fn compute_chest_props(
             let clicked_props =
                 ChestLikeProperties::from_state_id(clicked_block_state.id, &clicked_block);
 
+            if clicked_props.r#type != ChestType::Single {
+                return (ChestType::Single, chest_facing);
+            }
+
             if clicked_props.facing.rotate_clockwise() == face {
                 return (ChestType::Left, clicked_props.facing);
             } else if clicked_props.facing.rotate_counter_clockwise() == face {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

Fixed an issue where chests connect when you shift click on another double chest (creating a triple chest).

## Testing

Manual

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
