### PR TITLE
Fix called `Result::unwrap()` on an `Err` value: BlockOutOfWorldBounds

### DIFF
--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -566,11 +566,12 @@ impl Entity {
             for y in blockpos.0.y..=blockpos1.0.y {
                 for z in blockpos.0.z..=blockpos1.0.z {
                     let pos = BlockPos::new(x, y, z);
-                    let (block, state) = world.get_block_and_block_state(&pos).await.unwrap();
-                    world
-                        .block_registry
-                        .on_entity_collision(block, &world, entity, pos, state)
-                        .await;
+                    if let Ok((block, state)) = world.get_block_and_block_state(&pos).await {
+                        world
+                            .block_registry
+                            .on_entity_collision(block, &world, entity, pos, state)
+                            .await;
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Fixes the `called 'Result::unwrap()' on an 'Err' value: BlockOutOfWorldBounds` error by replacing the `.unwrap()` call with a if statement:
```rs
if let Ok((block, state)) = world.get_block_and_block_state(&pos).await {
    world
        .block_registry
        .on_entity_collision(block, &world, entity, pos, state)
        .await;
}
```

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
