### PR TITLE
fix: Fire stacking bug quick fix

### DIFF
--- a/pumpkin/src/block/blocks/fire/mod.rs
+++ b/pumpkin/src/block/blocks/fire/mod.rs
@@ -23,12 +23,14 @@ impl FireBlockBase {
         Block::FIRE
     }
 
-    pub fn can_place_on(_block: &Block) -> bool {
-        // TODO: make sure the block can be lit
-        // block
-        //     .is_tagged_with("minecraft:soul_fire_base_blocks")
-        //     .unwrap()
-        true
+    pub fn can_place_on(block: &Block) -> bool {
+        let block = block.clone();
+
+        // Make sure the block below is not a fire block or fluid block
+        block != Block::SOUL_FIRE
+            && block != Block::FIRE
+            && block != Block::WATER
+            && block != Block::LAVA
     }
 
     pub async fn can_place_at(world: &World, block_pos: &BlockPos) -> bool {


### PR DESCRIPTION
## Description
We check whether the block below the fire is a fire or fluid block, and decide to place or not place fire on top of it.

Fixes #798

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
