### PR TITLE
Entity physics

### DIFF
--- a/pumpkin-data/src/collision_shape.rs
+++ b/pumpkin-data/src/collision_shape.rs
@@ -31,4 +31,11 @@ impl CollisionShape {
             max: self.max + vec3,
         }
     }
+    
+    pub fn to_box(&self) -> BoundingBox {
+        BoundingBox {
+            min: self.min,
+            max: self.max,
+        }
+    }
 }

--- a/pumpkin-util/src/math/boundingbox.rs
+++ b/pumpkin-util/src/math/boundingbox.rs
@@ -1,4 +1,34 @@
-use super::{position::BlockPos, vector3::Vector3};
+use super::{position::BlockPos, vector2::Vector2, vector3::Axis, vector3::Vector3};
+
+#[derive(Clone, Copy, Debug)]
+pub struct BoundingPlane {
+    pub min: Vector2<f64>,
+    pub max: Vector2<f64>
+}
+impl BoundingPlane {
+    pub fn intersects(&self, other: &Self) -> bool {
+        self.min.x < other.max.x
+            && self.max.x > other.min.x
+            && self.min.z < other.max.z
+            && self.max.z > other.min.z
+    }
+    
+    // Projecting a 3D box into 2D
+    pub fn from_box(bounding_box: &BoundingBox, excluded: Axis) -> Self {
+        let [axis1, axis2] = Axis::excluding(excluded);
+        
+        Self {
+            min: Vector2::new(
+                bounding_box.get_side(false).get_axis(axis1),
+                bounding_box.get_side(false).get_axis(axis2),
+            ),
+            max: Vector2::new(
+                bounding_box.get_side(true).get_axis(axis1),
+                bounding_box.get_side(true).get_axis(axis2),
+            ),
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub struct BoundingBox {
@@ -78,6 +108,100 @@ impl BoundingBox {
         let e = f64::max(f64::max(self.min.y - pos.y, pos.y - self.max.y), 0.0);
         let f = f64::max(f64::max(self.min.z - pos.z, pos.z - self.max.z), 0.0);
         super::squared_magnitude(d, e, f)
+    }
+    
+    pub fn add_pos(&self, pos: BlockPos) -> Self {
+        Self {
+            min: self.min + pos.to_f64(),
+            max: self.max + pos.to_f64(),
+        }
+    }
+    
+    pub fn get_side(&self, max: bool) -> Vector3<f64> {
+        if max {
+            self.max
+        } else {
+            self.min
+        }
+    }
+    
+    pub fn min_block_pos(&self) -> BlockPos {
+        BlockPos::new(
+            self.min.x.floor() as i32,
+            self.min.y.floor() as i32,
+            self.min.z.floor() as i32,
+        )
+    }
+    pub fn max_block_pos(&self) -> BlockPos {
+        BlockPos::new(
+            self.max.x.ceil() as i32,
+            self.max.y.ceil() as i32,
+            self.max.z.ceil() as i32,
+        )
+    }
+    
+    pub fn shift(&self, delta: Vector3<f64>) -> Self {
+        Self {
+            min: self.min + delta,
+            max: self.max + delta,
+        }
+    }
+
+    pub fn stretch(&self, other: Vector3<f64>) -> Self {
+        let mut new = *self;
+
+        if other.x < 0.0 {
+            new.min.x += other.x;
+        } else if other.x > 0.0 {
+            new.max.x += other.x;
+        }
+
+        if other.y < 0.0 {
+            new.min.y += other.y;
+        } else if other.y > 0.0 {
+            new.max.y += other.y;
+        }
+
+        if other.z < 0.0 {
+            new.min.z += other.z;
+        } else if other.z > 0.0 {
+            new.max.z += other.z;
+        }
+
+        new
+    }
+    
+    pub fn calculate_collision_time(
+        &self, // moving
+        other: &Self,
+        movement: Vector3<f64>,
+        axis: Axis,
+        max_time: f64 // Start with 1.0
+    ) -> Option<f64> {
+        let movement_on_axis = movement.get_axis(axis);
+        if movement_on_axis == 0.0 {
+            return None;
+        }
+        
+        let move_positive = movement_on_axis.is_sign_positive();
+        
+        let self_plane_const = self.get_side(move_positive).get_axis(axis);
+        let other_plane_const = other.get_side(!move_positive).get_axis(axis);
+        
+        let collision_time = (other_plane_const - self_plane_const) / movement_on_axis;
+        
+        if collision_time < 0.0 || collision_time >= max_time {
+            return None;
+        }
+        
+        let self_moved = self.shift(movement * collision_time);
+        let self_plane_moved = BoundingPlane::from_box(&self_moved, axis);
+        let other_plane = BoundingPlane::from_box(&other, axis);
+        if !self_plane_moved.intersects(&other_plane) {
+            return None;
+        }
+        
+        return Some(collision_time);
     }
 }
 

--- a/pumpkin-util/src/math/vector3.rs
+++ b/pumpkin-util/src/math/vector3.rs
@@ -5,6 +5,42 @@ use num_traits::{Float, Num};
 
 use super::vector2::Vector2;
 
+#[derive(Copy,Clone,Debug,PartialEq,Hash,Eq)]
+pub enum Axis {
+    X,
+    Y,
+    Z
+}
+impl Axis {
+    pub fn all() -> [Self; 3] {
+        [Self::Y, Self::X, Self::Z]
+    }
+    pub fn excluding(axis: Self) -> [Self; 2] {
+        match axis {
+            Self::X => [Self::Y, Self::Z],
+            Self::Y => [Self::X, Self::Z],
+            Self::Z => [Self::X, Self::Y],
+        }
+    }
+}
+impl<T: Copy> Vector3<T> {
+    pub fn get_axis(&self, a: Axis) -> T {
+        match a {
+            Axis::X => self.x,
+            Axis::Y => self.y,
+            Axis::Z => self.z
+        }
+    }
+    
+    pub fn set_axis(&mut self, a: Axis, value: T) {
+        match a {
+            Axis::X => self.x = value,
+            Axis::Y => self.y = value,
+            Axis::Z => self.z = value
+        };
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Hash, Eq, Default)]
 pub struct Vector3<T> {
     pub x: T,

--- a/pumpkin/src/block/mod.rs
+++ b/pumpkin/src/block/mod.rs
@@ -47,17 +47,12 @@ use fluid::lava::FlowingLava;
 use fluid::water::FlowingWater;
 use loot::LootTableExt;
 use pumpkin_data::block_properties::Integer0To15;
-use pumpkin_data::entity::EntityType;
 use pumpkin_data::{Block, BlockState};
 
 use pumpkin_util::math::position::BlockPos;
-use pumpkin_util::math::vector3::Vector3;
 use pumpkin_world::BlockStateId;
-use pumpkin_world::item::ItemStack;
-use rand::Rng;
 
 use crate::block::registry::BlockRegistry;
-use crate::entity::item::ItemEntity;
 use crate::world::World;
 use crate::{block::blocks::crafting_table::CraftingTableBlock, entity::player::Player};
 use crate::{block::blocks::jukebox::JukeboxBlock, entity::experience_orb::ExperienceOrbEntity};
@@ -158,7 +153,7 @@ pub async fn drop_loot(
             Block::properties(block, state_id).map_or_else(Vec::new, |props| props.to_props());
 
         for stack in loot_table.get_loot(&props) {
-            drop_stack(world, pos, stack).await;
+            world.drop_stack(pos, stack).await;
         }
     }
 
@@ -171,19 +166,6 @@ pub async fn drop_loot(
             }
         }
     }
-}
-
-async fn drop_stack(world: &Arc<World>, pos: &BlockPos, stack: ItemStack) {
-    let height = EntityType::ITEM.dimension[1] / 2.0;
-    let pos = Vector3::new(
-        f64::from(pos.0.x) + 0.5 + rand::thread_rng().gen_range(-0.25..0.25),
-        f64::from(pos.0.y) + 0.5 + rand::thread_rng().gen_range(-0.25..0.25) - f64::from(height),
-        f64::from(pos.0.z) + 0.5 + rand::thread_rng().gen_range(-0.25..0.25),
-    );
-
-    let entity = world.create_entity(pos, EntityType::ITEM);
-    let item_entity = Arc::new(ItemEntity::new(entity, stack).await);
-    world.spawn_entity(item_entity).await;
 }
 
 pub async fn calc_block_breaking(player: &Player, state: &BlockState, block_name: &str) -> f32 {

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -308,7 +308,7 @@ impl LivingEntity {
         }
     }
     
-    async fn base_tick(&self) {
+    pub async fn base_tick(&self) {
         //self.entity.tick(caller.clone(), server).await;
         //self.tick_move(caller.as_ref(), server).await;
         self.tick_effects().await;

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -308,7 +308,7 @@ impl LivingEntity {
         }
     }
     
-    async fn base_tick(&self, caller: Arc<dyn EntityBase>, server: &Server) {
+    async fn base_tick(&self, _caller: Arc<dyn EntityBase>, _server: &Server) {
         //self.entity.tick(caller.clone(), server).await;
         //self.tick_move(caller.as_ref(), server).await;
         self.tick_effects().await;
@@ -347,7 +347,7 @@ impl EntityBase for LivingEntity {
         };
         
         self.tick_move(self.entity.velocity.load()).await;
-        self.base_tick(Arc::clone(&caller), server);
+        self.base_tick(Arc::clone(&caller), server).await;
     }
     
     async fn damage(&self, amount: f32, damage_type: DamageType) -> bool {

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -308,7 +308,7 @@ impl LivingEntity {
         }
     }
     
-    async fn base_tick(&self, _caller: Arc<dyn EntityBase>, _server: &Server) {
+    async fn base_tick(&self) {
         //self.entity.tick(caller.clone(), server).await;
         //self.tick_move(caller.as_ref(), server).await;
         self.tick_effects().await;
@@ -337,7 +337,7 @@ impl LivingEntity {
 impl EntityBase for LivingEntity {
     
     async fn tick(&self, caller: Arc<dyn EntityBase>, server: &Server) {
-        self.entity.tick(caller.clone(), server).await;
+        self.entity.tick(caller, server).await;
         
         if let Err(e) = self.handle_physics(0.08, server).await {
             log::error!("Physics failed: {:?}", e);
@@ -347,7 +347,7 @@ impl EntityBase for LivingEntity {
         };
         
         self.tick_move(self.entity.velocity.load()).await;
-        self.base_tick(Arc::clone(&caller), server).await;
+        self.base_tick().await;
     }
     
     async fn damage(&self, amount: f32, damage_type: DamageType) -> bool {

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -1067,7 +1067,8 @@ impl Entity {
         // TODO Add tripwires, really anything the player intersects with
     }
 
-    // Faulty
+    // Faulty on testing. Idk why
+    // Only sometimes works
     /*
     async fn push_out_of_blocks(&self, world: &World) -> Result<Option<Vector3<f64>>, GetBlockError> {
         let block_pos = self.block_pos.load();

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -1067,6 +1067,8 @@ impl Entity {
         // TODO Add tripwires, really anything the player intersects with
     }
 
+    // Faulty
+    /*
     async fn push_out_of_blocks(&self, world: &World) -> Result<Option<Vector3<f64>>, GetBlockError> {
         let block_pos = self.block_pos.load();
         
@@ -1112,6 +1114,7 @@ impl Entity {
         }
         Ok(movement)
     }
+    */
 
     /// Applies knockback to the entity, following vanilla Minecraft's mechanics.
     ///

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -117,7 +117,7 @@ pub trait EntityBase: Send + Sync {
     async fn handle_physics(
         &self,
         gravity: f64,
-        server: f64,
+        server: &Server,
     ) -> Result<(), GetBlockError> {
         let entity = self.get_entity();
         let living = self.get_living_entity();
@@ -137,10 +137,11 @@ pub trait EntityBase: Send + Sync {
         let mut velo = entity.velocity.load();
         velo.y -= gravity;
         
+        Entity::check_block_collision(entity, server).await;
+        
+        /*
         let bounding_box = entity.bounding_box.load();
         
-        Entity::check_block_collision(entity, server).await;
-        /*
         let mut in_cobweb = false;
         let mut in_water = false;
         let mut in_lava = false;
@@ -315,7 +316,7 @@ pub trait EntityBase: Send + Sync {
             ).await;
         }
         
-        entity.look_at(entity.velocity.load());
+        entity.look_at(entity.velocity.load()).await;
         if let Some(live) = living {
         	live.send_pos_rot().await;
         }

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -316,9 +316,11 @@ pub trait EntityBase: Send + Sync {
             ).await;
         }
         
-        entity.look_at(entity.velocity.load()).await;
+        //entity.look_at(entity.velocity.load()).await;
         if let Some(live) = living {
         	live.send_pos_rot().await;
+        } else {
+        	entity.send_pos_rot().await;
         }
         entity.send_velocity().await;
         

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -666,8 +666,12 @@ impl Player {
         }
 
         self.last_attacked_ticks.fetch_add(1, Relaxed);
-
-        self.living_entity.tick(self.clone(), server).await;
+        
+        self.living_entity.entity.tick(self.clone(), server).await;
+        let _ = self.handle_physics(0.08, server).await; // Check block collisions
+        self.living_entity.base_tick().await;
+        
+        
         self.hunger_manager.tick(self.as_ref()).await;
 
         // experience handling

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -501,7 +501,7 @@ impl Player {
             return;
         }
 
-        if victim.get_living_entity().is_some() {
+        if let Some(live_victim) = victim.get_living_entity() {
             let mut knockback_strength = 1.0;
             player_attack_sound(&pos, &world, attack_type).await;
             match attack_type {
@@ -514,8 +514,7 @@ impl Player {
             if config.knockback {
                 combat::handle_knockback(
                     attacker_entity,
-                    &world,
-                    victim_entity,
+                    live_victim,
                     knockback_strength,
                 )
                 .await;


### PR DESCRIPTION
## Description
Add entity physics: gravity, friction, block collisions on movement. This is in entity/mod.rs.
Also fixed knockback.

Note, it's based off old code so 
1. I used some old methods with GetBlockError in world/mod.rs, they're all marked as "deprecated"
2. Physics is incomplete. no_clip (being in a block) and being in a fluid will have to be redone with the new Entity::check_block_collisions. E.g. if in water: entity.in_water.store(true), change velocity. The old code is currently commented out. 

Another issue: liquid flow pushing is not done.

## Testing
cargo run
Entities land on the ground correctly. 
Though sometimes they go into walls when knocked back.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)