### PR TITLE
Fixed overflow for 32 bits

### DIFF
--- a/pumpkin-util/src/math/mod.rs
+++ b/pumpkin-util/src/math/mod.rs
@@ -49,7 +49,7 @@ pub const fn ceil_log2(value: u32) -> u8 {
         smallest_encompassing_power_of_two(value)
     };
 
-    MULTIPLY_DE_BRUIJN_BIT_POSITION[(((value as usize) * 125613361) >> 27) & 31]
+    MULTIPLY_DE_BRUIJN_BIT_POSITION[((((value as u64) * 125613361) >> 27) & 31) as usize]
 }
 
 /// Maximum return value: 30


### PR DESCRIPTION
## Description
There was an usize overflow error in compile time, due it is 32 bits for 32 bit arch, so I made it 64 bits, then casted to usize

## Testing
I tested nothing
