### PR TITLE
Removed fall damage when landing on powdered snow

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -203,6 +203,13 @@ impl LivingEntity {
         world.get_block(&block_pos).await == Block::WATER
     }
 
+    // Check if the entity is in powdered snow
+    pub async fn is_in_powder_snow(&self) -> bool {
+        let world = self.entity.world.read().await;
+        let block_pos = self.entity.block_pos.load();
+        world.get_block(&block_pos).await == Block::POWDER_SNOW
+    }
+
     pub async fn update_fall_distance(
         &self,
         height_difference: f64,
@@ -211,7 +218,7 @@ impl LivingEntity {
     ) {
         if ground {
             let fall_distance = self.fall_distance.swap(0.0);
-            if fall_distance <= 0.0 || dont_damage || self.is_in_water().await {
+            if fall_distance <= 0.0 || dont_damage || self.is_in_water().await || self.is_in_powder_snow().await {
                 return;
             }
 

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -203,7 +203,7 @@ impl LivingEntity {
         world.get_block(&block_pos).await == Block::WATER
     }
 
-    // Check if the entity is in powdered snow
+    // Check if the entity is in powder snow
     pub async fn is_in_powder_snow(&self) -> bool {
         let world = self.entity.world.read().await;
         let block_pos = self.entity.block_pos.load();
@@ -218,7 +218,11 @@ impl LivingEntity {
     ) {
         if ground {
             let fall_distance = self.fall_distance.swap(0.0);
-            if fall_distance <= 0.0 || dont_damage || self.is_in_water().await || self.is_in_powder_snow().await {
+            if fall_distance <= 0.0
+                || dont_damage
+                || self.is_in_water().await
+                || self.is_in_powder_snow().await
+            {
                 return;
             }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
When testing i found a bug where you take fall damage when landing on powdered snow, which shouldn't happen.
Added quick check to remove fall damage when landing on the block.

## Testing
Tested it in game, also tested how fall damage works after landing on the block in the air. Everything is good except the view is reacting like the powdered snow wasnt there, but you take the correct fall damage.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
