### PR TITLE
removed wasm disallowance for use libloading::Library;

### DIFF
--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -224,7 +224,7 @@ impl ChunkSections {
         block_state: BlockStateId,
     ) {
         let y = y - self.min_y;
-        debug_assert!(y > 0);
+        debug_assert!(y >= 0);
         let relative_y = y as usize;
 
         self.set_relative_block(relative_x, relative_y, relative_z, block_state);

--- a/pumpkin/src/plugin/loader/native.rs
+++ b/pumpkin/src/plugin/loader/native.rs
@@ -1,6 +1,5 @@
 use std::any::Any;
 
-#[cfg(not(target_family = "wasm"))]
 use libloading::Library;
 
 use super::{LoaderError, Path, Plugin, PluginLoader, PluginMetadata, async_trait};


### PR DESCRIPTION
## Description
I am playing with wasm builds now, and `#[cfg(not(target_family = "wasm"))]` is blocking me from loading it, despite I have my own implementation. Can we remove this guard, because it is not working anyway with wasm for now. And I think it will be cool and fun to reintroduce it if/when wasm builds will be actually supported.

## Testing
WASM builds do not work anyway, I tested nothing
