### PR TITLE
removed wasm disallowance for use libloading::Library;

### DIFF
--- a/pumpkin/src/plugin/loader/native.rs
+++ b/pumpkin/src/plugin/loader/native.rs
@@ -1,6 +1,5 @@
 use std::any::Any;
 
-#[cfg(not(target_family = "wasm"))]
 use libloading::Library;
 
 use super::{LoaderError, Path, Plugin, PluginLoader, PluginMetadata, async_trait};


### PR DESCRIPTION
## Description
I am playing with wasm builds now, and #[cfg(not(target_family = "wasm"))] is blocking me from loading it, despite I have my own implementation. Can we remove this guard, because it is not working anyway with wasm for now. And I think it will be cool and fun to reintroduce it if/when wasm builds will be actually supported.

P.S. Duplicate of https://github.com/Pumpkin-MC/Pumpkin/pull/827
Messed up with repos a bit

## Testing
WASM builds do not work anyway, I tested nothing
