### PR TITLE
fixed assert for valid y coordinate

### DIFF
--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -224,7 +224,7 @@ impl ChunkSections {
         block_state: BlockStateId,
     ) {
         let y = y - self.min_y;
-        debug_assert!(y > 0);
+        debug_assert!(y >= 0);
         let relative_y = y as usize;
 
         self.set_relative_block(relative_x, relative_y, relative_z, block_state);


### PR DESCRIPTION
## Description
Breaking lowest bedrock block triggers this assert. This does not make sence. Lets not trigger it. Breaking lowest block should be fine

## Testing
It seems to work fine
