### PR TITLE
Arc context for plugins

### DIFF
--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -20,9 +20,9 @@ use super::{Event, EventPriority, PluginMetadata};
 /// - `server`: A reference to the server on which the plugin operates.
 /// - `handlers`: A map of event handlers, protected by a read-write lock for safe access across threads.
 pub struct Context {
-    metadata: PluginMetadata<'static>,
+    pub metadata: PluginMetadata<'static>,
     pub server: Arc<Server>,
-    handlers: Arc<RwLock<HandlerMap>>,
+    pub handlers: Arc<RwLock<HandlerMap>>,
 }
 impl Context {
     /// Creates a new instance of `Context`.

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -5,7 +5,6 @@ use pumpkin_util::PermissionLvl;
 use tokio::sync::RwLock;
 
 use crate::{
-    entity::player::Player,
     plugin::{EventHandler, HandlerMap, TypedEventHandler},
     server::Server,
 };
@@ -58,17 +57,6 @@ impl Context {
             fs::create_dir_all(&path).unwrap();
         }
         path
-    }
-
-    /// Asynchronously retrieves a player by their name.
-    ///
-    /// # Arguments
-    /// - `player_name`: The name of the player to retrieve.
-    ///
-    /// # Returns
-    /// An optional reference to the player if found, or `None` if not.
-    pub async fn get_player_by_name(&self, player_name: String) -> Option<Arc<Player>> {
-        self.server.get_player_by_name(&player_name).await
     }
 
     /// Asynchronously registers a command with the server.

--- a/pumpkin/src/plugin/api/mod.rs
+++ b/pumpkin/src/plugin/api/mod.rs
@@ -1,6 +1,8 @@
 pub mod context;
 pub mod events;
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 pub use context::*;
 pub use events::*;
@@ -34,11 +36,11 @@ pub trait Plugin: Send + Sync + 'static {
     /// This method initializes the plugin within the server context.
     ///
     /// # Parameters
-    /// - `_server`: Reference to the server's context.
+    /// - `_context`: Reference to the server's context.
     ///
     /// # Returns
     /// - `Ok(())` on success, or `Err(String)` on failure.
-    async fn on_load(&mut self, _server: &Context) -> Result<(), String> {
+    async fn on_load(&mut self, _context: Arc<Context>) -> Result<(), String> {
         Ok(())
     }
 
@@ -47,11 +49,11 @@ pub trait Plugin: Send + Sync + 'static {
     /// This method cleans up resources when the plugin is removed from the server context.
     ///
     /// # Parameters
-    /// - `_server`: Reference to the server's context.
+    /// - `_context`: Reference to the server's context.
     ///
     /// # Returns
     /// - `Ok(())` on success, or `Err(String)` on failure.
-    async fn on_unload(&mut self, _server: &Context) -> Result<(), String> {
+    async fn on_unload(&mut self, _context: Arc<Context>) -> Result<(), String> {
         Ok(())
     }
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Until now, plugins only received a `&Context` in the `on_load()` and `on_unload()` methods. This PR changes the `&Context` to a `Arc<Context>` so that plugins can store the context to use later. This will allow plugins to interact with the server at any time, not only when the server requests interaction.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
