### PR TITLE
Implement string-based permission system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,8 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/pumpkin-util/Cargo.toml
+++ b/pumpkin-util/Cargo.toml
@@ -19,3 +19,6 @@ quote = "1.0"
 syn = "2.0"
 proc-macro2 = "1.0"
 enum_dispatch = "0.3.13"
+
+uuid.workspace = true
+tokio.workspace = true

--- a/pumpkin-util/src/permission.rs
+++ b/pumpkin-util/src/permission.rs
@@ -1,4 +1,223 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Describes the default behavior for permissions
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PermissionDefault {
+    /// Permission is not granted by default
+    Deny,
+    /// Permission is granted by default
+    Allow,
+    /// Permission is granted by default to operators
+    Op(PermissionLvl),
+}
+
+/// Defines a permission node in the system
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Permission {
+    /// The full node name (e.g., "minecraft:command.gamemode")
+    pub node: String,
+    /// Description of what this permission does
+    pub description: String,
+    /// The default value of this permission
+    pub default: PermissionDefault,
+    /// Children nodes that are affected by this permission
+    pub children: HashMap<String, bool>,
+}
+
+impl Permission {
+    pub fn new(node: &str, description: &str, default: PermissionDefault) -> Self {
+        Self {
+            node: node.to_string(),
+            description: description.to_string(),
+            default,
+            children: HashMap::new(),
+        }
+    }
+
+    /// Add a child permission with a specific value
+    pub fn add_child(&mut self, child: &str, value: bool) -> &mut Self {
+        self.children.insert(child.to_string(), value);
+        self
+    }
+}
+
+/// Repository for all registered permissions in the server
+#[derive(Default)]
+pub struct PermissionRegistry {
+    /// All registered permissions
+    permissions: HashMap<String, Permission>,
+}
+
+impl PermissionRegistry {
+    pub fn new() -> Self {
+        Self {
+            permissions: HashMap::new(),
+        }
+    }
+
+    /// Register a new permission
+    pub fn register_permission(&mut self, permission: Permission) -> Result<(), String> {
+        if self.permissions.contains_key(&permission.node) {
+            return Err(format!(
+                "Permission {} is already registered",
+                permission.node
+            ));
+        }
+        self.permissions.insert(permission.node.clone(), permission);
+        Ok(())
+    }
+
+    /// Get a registered permission by node
+    pub fn get_permission(&self, node: &str) -> Option<&Permission> {
+        self.permissions.get(node)
+    }
+
+    /// Check if a permission is registered
+    pub fn has_permission(&self, node: &str) -> bool {
+        self.permissions.contains_key(node)
+    }
+}
+
+/// Storage for player permissions
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct PermissionAttachment {
+    /// Directly assigned permissions
+    permissions: HashMap<String, bool>,
+}
+
+impl PermissionAttachment {
+    pub fn new() -> Self {
+        Self {
+            permissions: HashMap::new(),
+        }
+    }
+
+    /// Set a permission value
+    pub fn set_permission(&mut self, node: &str, value: bool) {
+        self.permissions.insert(node.to_string(), value);
+    }
+
+    /// Unset a permission
+    pub fn unset_permission(&mut self, node: &str) {
+        self.permissions.remove(node);
+    }
+
+    /// Check if a permission is directly set
+    pub fn has_permission_set(&self, node: &str) -> Option<bool> {
+        self.permissions.get(node).copied()
+    }
+
+    /// Get all directly set permissions
+    pub fn get_permissions(&self) -> &HashMap<String, bool> {
+        &self.permissions
+    }
+}
+
+/// Manager for player permissions
+#[derive(Default)]
+pub struct PermissionManager {
+    /// Global registry of permissions
+    registry: Arc<RwLock<PermissionRegistry>>,
+    /// Player permission attachments
+    attachments: HashMap<uuid::Uuid, Arc<RwLock<PermissionAttachment>>>,
+}
+
+impl PermissionManager {
+    pub fn new(registry: Arc<RwLock<PermissionRegistry>>) -> Self {
+        Self {
+            registry,
+            attachments: HashMap::new(),
+        }
+    }
+
+    /// Get or create a player's permission attachment
+    pub fn get_attachment(&mut self, player_id: uuid::Uuid) -> Arc<RwLock<PermissionAttachment>> {
+        self.attachments
+            .entry(player_id)
+            .or_insert_with(|| Arc::new(RwLock::new(PermissionAttachment::new())))
+            .clone()
+    }
+
+    /// Remove a player's permission attachment
+    pub fn remove_attachment(&mut self, player_id: &uuid::Uuid) {
+        self.attachments.remove(player_id);
+    }
+
+    /// Check if a player has a permission, considering defaults and op status
+    pub async fn has_permission(
+        &self,
+        player_id: &uuid::Uuid,
+        permission_node: &str,
+        player_op_level: PermissionLvl,
+    ) -> bool {
+        let reg = self.registry.read().await;
+
+        // Check explicitly set permissions
+        if let Some(attachment) = self.attachments.get(player_id) {
+            let attachment = attachment.read().await;
+
+            // Check for exact permission match
+            if let Some(value) = attachment.has_permission_set(permission_node) {
+                return value;
+            }
+
+            // Check parent nodes (for wildcard permissions)
+            let node_parts: Vec<&str> = permission_node.split(':').collect();
+            if node_parts.len() == 2 {
+                let namespace = node_parts[0];
+                let key_parts: Vec<&str> = node_parts[1].split('.').collect();
+
+                // Check wildcard permissions at each level
+                let mut current_node = namespace.to_string();
+                if let Some(value) = attachment.has_permission_set(&format!("{}:*", current_node)) {
+                    return value;
+                }
+
+                current_node.push(':');
+                for (i, part) in key_parts.iter().enumerate() {
+                    current_node.push_str(part);
+
+                    if let Some(value) = attachment.has_permission_set(&current_node) {
+                        return value;
+                    }
+
+                    if i < key_parts.len() - 1 {
+                        if let Some(value) =
+                            attachment.has_permission_set(&format!("{}.*", current_node))
+                        {
+                            return value;
+                        }
+                        current_node.push('.');
+                    }
+                }
+            }
+
+            // Check for inherited permissions from parent nodes
+            for (node, value) in attachment.get_permissions() {
+                if let Some(permission) = reg.get_permission(node) {
+                    if permission.children.contains_key(permission_node) {
+                        return *value && *permission.children.get(permission_node).unwrap();
+                    }
+                }
+            }
+        }
+
+        // Fall back to default permission value
+        if let Some(permission) = reg.get_permission(permission_node) {
+            match permission.default {
+                PermissionDefault::Allow => true,
+                PermissionDefault::Deny => false,
+                PermissionDefault::Op(required_level) => player_op_level >= required_level,
+            }
+        } else {
+            // If permission isn't registered, default to deny
+            false
+        }
+    }
+}
 
 /// Represents the player's permission level
 ///
@@ -9,7 +228,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// - `Two`: `gamemaster`: Player or executor can use more commands and player can use command blocks.
 /// - `Three`:  `admin`: Player or executor can use commands related to multiplayer management.
 /// - `Four`: `owner`: Player or executor can use all of the commands, including commands related to server management.
-#[derive(Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum PermissionLvl {
     #[default]
     Zero = 0,

--- a/pumpkin/src/command/client_suggestions.rs
+++ b/pumpkin/src/command/client_suggestions.rs
@@ -18,11 +18,11 @@ pub async fn send_c_commands_packet(player: &Arc<Player>, dispatcher: &CommandDi
             continue;
         };
 
-        let Some(permission) = dispatcher.get_permission_lvl(key) else {
+        let Some(permission) = dispatcher.get_permission(key) else {
             continue;
         };
 
-        if !cmd_src.has_permission_lvl(permission) {
+        if !cmd_src.has_permission(permission.as_str()).await {
             continue;
         }
 

--- a/pumpkin/src/command/commands/help.rs
+++ b/pumpkin/src/command/commands/help.rs
@@ -139,7 +139,7 @@ impl CommandExecutor for BaseHelpExecutor {
                 if let Some(perm) = dispatcher.permissions.get(&tree.names[0]) {
                     return sender.has_permission(perm.as_str()).await;
                 }
-                return false;
+                false
             })
             .collect()
             .await;

--- a/pumpkin/src/command/commands/help.rs
+++ b/pumpkin/src/command/commands/help.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures::StreamExt;
 use pumpkin_util::text::TextComponent;
 use pumpkin_util::text::click::ClickEvent;
 use pumpkin_util::text::color::{Color, NamedColor};
@@ -124,20 +125,24 @@ impl CommandExecutor for BaseHelpExecutor {
         };
 
         let dispatcher = server.command_dispatcher.read().await;
-        let mut commands: Vec<&CommandTree> = dispatcher
+        let commands: Vec<&CommandTree> = dispatcher
             .commands
             .values()
             .filter_map(|cmd| match cmd {
                 Command::Tree(tree) => Some(tree),
                 Command::Alias(_) => None,
             })
-            .filter(|tree| {
-                dispatcher
-                    .permissions
-                    .get(&tree.names[0])
-                    .is_none_or(|perm| sender.has_permission_lvl(*perm))
-            })
             .collect();
+
+        let mut commands: Vec<&CommandTree> = futures::stream::iter(commands.iter())
+            .filter(|tree| async {
+                if let Some(perm) = dispatcher.permissions.get(&tree.names[0]) {
+                    return sender.has_permission(perm.as_str()).await;
+                }
+                return false;
+            })
+            .collect()
+            .await;
 
         commands.sort_by(|a, b| a.names[0].cmp(&b.names[0]));
 

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -1,4 +1,9 @@
-use pumpkin_util::PermissionLvl;
+use pumpkin_util::{
+    PermissionLvl,
+    permission::{Permission, PermissionDefault, PermissionRegistry},
+};
+
+use crate::PERMISSION_REGISTRY;
 
 use super::dispatcher::CommandDispatcher;
 
@@ -48,57 +53,510 @@ mod profile;
 mod tellraw;
 
 #[must_use]
-pub fn default_dispatcher() -> CommandDispatcher {
+pub async fn default_dispatcher() -> CommandDispatcher {
     let mut dispatcher = CommandDispatcher::default();
 
+    register_permissions().await;
+
     // Zero
-    dispatcher.register(pumpkin::init_command_tree(), PermissionLvl::Zero);
-    dispatcher.register(help::init_command_tree(), PermissionLvl::Zero);
-    dispatcher.register(list::init_command_tree(), PermissionLvl::Zero);
-    dispatcher.register(transfer::init_command_tree(), PermissionLvl::Zero);
-    dispatcher.register(me::init_command_tree(), PermissionLvl::Zero);
-    dispatcher.register(msg::init_command_tree(), PermissionLvl::Zero);
+    dispatcher.register(
+        pumpkin::init_command_tree(),
+        "pumpkin:command.pumpkin".to_string(),
+    );
+    dispatcher.register(
+        help::init_command_tree(),
+        "minecraft:command.help".to_string(),
+    );
+    dispatcher.register(
+        list::init_command_tree(),
+        "minecraft:command.list".to_string(),
+    );
+    dispatcher.register(
+        transfer::init_command_tree(),
+        "minecraft:command.transfer".to_string(),
+    );
+    dispatcher.register(me::init_command_tree(), "minecraft:command.me".to_string());
+    dispatcher.register(
+        msg::init_command_tree(),
+        "minecraft:command.msg".to_string(),
+    );
     // Two
-    dispatcher.register(kill::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(worldborder::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(effect::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(teleport::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(time::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(give::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(clear::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(setblock::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(seed::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(fill::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(playsound::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(tellraw::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(title::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(summon::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(experience::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(weather::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(particle::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(damage::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(bossbar::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(say::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(gamemode::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(stopsound::init_command_tree(), PermissionLvl::Two);
-    dispatcher.register(defaultgamemode::init_command_tree(), PermissionLvl::Two);
+    dispatcher.register(
+        kill::init_command_tree(),
+        "minecraft:command.kill".to_string(),
+    );
+    dispatcher.register(
+        worldborder::init_command_tree(),
+        "minecraft:command.worldborder".to_string(),
+    );
+    dispatcher.register(
+        effect::init_command_tree(),
+        "minecraft:command.effect".to_string(),
+    );
+    dispatcher.register(
+        teleport::init_command_tree(),
+        "minecraft:command.teleport".to_string(),
+    );
+    dispatcher.register(
+        time::init_command_tree(),
+        "minecraft:command.time".to_string(),
+    );
+    dispatcher.register(
+        give::init_command_tree(),
+        "minecraft:command.give".to_string(),
+    );
+    dispatcher.register(
+        clear::init_command_tree(),
+        "minecraft:command.clear".to_string(),
+    );
+    dispatcher.register(
+        setblock::init_command_tree(),
+        "minecraft:command.setblock".to_string(),
+    );
+    dispatcher.register(
+        seed::init_command_tree(),
+        "minecraft:command.seed".to_string(),
+    );
+    dispatcher.register(
+        fill::init_command_tree(),
+        "minecraft:command.fill".to_string(),
+    );
+    dispatcher.register(
+        playsound::init_command_tree(),
+        "minecraft:command.playsound".to_string(),
+    );
+    dispatcher.register(
+        tellraw::init_command_tree(),
+        "minecraft:command.tellraw".to_string(),
+    );
+    dispatcher.register(
+        title::init_command_tree(),
+        "minecraft:command.title".to_string(),
+    );
+    dispatcher.register(
+        summon::init_command_tree(),
+        "minecraft:command.summon".to_string(),
+    );
+    dispatcher.register(
+        experience::init_command_tree(),
+        "minecraft:command.experience".to_string(),
+    );
+    dispatcher.register(
+        weather::init_command_tree(),
+        "minecraft:command.weather".to_string(),
+    );
+    dispatcher.register(
+        particle::init_command_tree(),
+        "minecraft:command.particle".to_string(),
+    );
+    dispatcher.register(
+        damage::init_command_tree(),
+        "minecraft:command.damage".to_string(),
+    );
+    dispatcher.register(
+        bossbar::init_command_tree(),
+        "minecraft:command.bossbar".to_string(),
+    );
+    dispatcher.register(
+        say::init_command_tree(),
+        "minecraft:command.say".to_string(),
+    );
+    dispatcher.register(
+        gamemode::init_command_tree(),
+        "minecraft:command.gamemode".to_string(),
+    );
+    dispatcher.register(
+        stopsound::init_command_tree(),
+        "minecraft:command.stopsound".to_string(),
+    );
+    dispatcher.register(
+        defaultgamemode::init_command_tree(),
+        "minecraft:command.defaultgamemode".to_string(),
+    );
     // Three
-    dispatcher.register(op::init_command_tree(), PermissionLvl::Three);
-    dispatcher.register(deop::init_command_tree(), PermissionLvl::Three);
-    dispatcher.register(kick::init_command_tree(), PermissionLvl::Three);
-    dispatcher.register(plugin::init_command_tree(), PermissionLvl::Three);
-    dispatcher.register(plugins::init_command_tree(), PermissionLvl::Three);
-    dispatcher.register(ban::init_command_tree(), PermissionLvl::Three);
-    dispatcher.register(banip::init_command_tree(), PermissionLvl::Three);
-    dispatcher.register(banlist::init_command_tree(), PermissionLvl::Three);
-    dispatcher.register(pardon::init_command_tree(), PermissionLvl::Three);
-    dispatcher.register(pardonip::init_command_tree(), PermissionLvl::Three);
-    dispatcher.register(whitelist::init_command_tree(), PermissionLvl::Three);
+    dispatcher.register(
+        op::init_command_tree(),
+        "minecraft:command.op".to_string(),
+    );
+    dispatcher.register(
+        deop::init_command_tree(),
+        "minecraft:command.deop".to_string(),
+    );
+    dispatcher.register(
+        kick::init_command_tree(),
+        "minecraft:command.kick".to_string(),
+    );
+    dispatcher.register(
+        plugin::init_command_tree(),
+        "pumpkin:command.plugin".to_string(),
+    );
+    dispatcher.register(
+        plugins::init_command_tree(),
+        "pumpkin:command.plugins".to_string(),
+    );
+    dispatcher.register(
+        ban::init_command_tree(),
+        "minecraft:command.ban".to_string(),
+    );
+    dispatcher.register(
+        banip::init_command_tree(),
+        "minecraft:command.banip".to_string(),
+    );
+    dispatcher.register(
+        banlist::init_command_tree(),
+        "minecraft:command.banlist".to_string(),
+    );
+    dispatcher.register(
+        pardon::init_command_tree(),
+        "minecraft:command.pardon".to_string(),
+    );
+    dispatcher.register(
+        pardonip::init_command_tree(),
+        "minecraft:command.pardonip".to_string(),
+    );
+    dispatcher.register(
+        whitelist::init_command_tree(),
+        "minecraft:command.whitelist".to_string(),
+    );
     // Four
-    dispatcher.register(stop::init_command_tree(), PermissionLvl::Four);
+    dispatcher.register(
+        stop::init_command_tree(),
+        "minecraft:command.stop".to_string(),
+    );
 
     #[cfg(feature = "dhat-heap")]
-    dispatcher.register(profile::init_command_tree(), PermissionLvl::Four);
+    dispatcher.register(
+        profile::init_command_tree(),
+        "pumpkin:command.profile".to_string(),
+    );
 
     dispatcher
+}
+
+async fn register_permissions() {
+    let mut registry = PERMISSION_REGISTRY.write().await;
+
+    // Register level 0 permissions (allowed by default)
+    register_level_0_permissions(&mut registry);
+
+    // Register level 2 permissions (OP level 2)
+    register_level_2_permissions(&mut registry);
+
+    // Register level 3 permissions (OP level 3)
+    register_level_3_permissions(&mut registry);
+
+    // Register level 4 permissions (OP level 4)
+    register_level_4_permissions(&mut registry);
+}
+
+fn register_level_0_permissions(registry: &mut PermissionRegistry) {
+    // Register permissions for builtin commands that are allowed for everyone
+    registry
+        .register_permission(Permission::new(
+            "pumpkin:command.pumpkin",
+            "Shows information about the Pumpkin server",
+            PermissionDefault::Allow,
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.help",
+            "Lists available commands and their usage",
+            PermissionDefault::Allow,
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.list",
+            "Lists players that are currently online",
+            PermissionDefault::Allow,
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.transfer",
+            "Transfers the player to another server",
+            PermissionDefault::Allow,
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.me",
+            "Broadcasts a narrative message about the player",
+            PermissionDefault::Allow,
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.msg",
+            "Sends a private message to another player",
+            PermissionDefault::Allow,
+        ))
+        .unwrap();
+}
+
+fn register_level_2_permissions(registry: &mut PermissionRegistry) {
+    // Register permissions for commands with PermissionLvl::Two
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.kill",
+            "Kills entities (players, mobs, items, etc.)",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.worldborder",
+            "Manages the world border",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.effect",
+            "Adds or removes status effects",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.teleport",
+            "Teleports entities to other locations",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.time",
+            "Changes or queries the world's game time",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.give",
+            "Gives an item to a player",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.clear",
+            "Clears items from player inventory",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.setblock",
+            "Changes a block to another block",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.seed",
+            "Displays the world seed",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.fill",
+            "Fills a region with a specific block",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.playsound",
+            "Plays a sound to players",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.tellraw",
+            "Displays a JSON message to players",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.title",
+            "Controls screen titles displayed to players",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.summon",
+            "Summons an entity",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.experience",
+            "Adds, removes or queries player experience",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.weather",
+            "Sets the weather in the server",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.particle",
+            "Creates particles in the world",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.damage",
+            "Damages entities",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.bossbar",
+            "Creates and manages boss bars",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.say",
+            "Broadcasts a message to multiple players",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.gamemode",
+            "Sets a player's game mode",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.stopsound",
+            "Stops sounds from playing",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.defaultgamemode",
+            "Sets the default game mode for new players",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+}
+
+fn register_level_3_permissions(registry: &mut PermissionRegistry) {
+    // Register permissions for commands with PermissionLvl::Three
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.op",
+            "Grants operator status to a player",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.deop",
+            "Revokes operator status from a player",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.kick",
+            "Removes players from the server",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "pumpkin:command.plugin",
+            "Manages server plugins",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "pumpkin:command.plugins",
+            "Lists all plugins loaded on the server",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.ban",
+            "Adds players to banlist",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.banip",
+            "Adds IP addresses to banlist",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.banlist",
+            "Displays banned players or IP addresses",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.pardon",
+            "Removes entries from the player banlist",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.pardonip",
+            "Removes entries from the IP banlist",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.whitelist",
+            "Manages server whitelist",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
+}
+
+fn register_level_4_permissions(registry: &mut PermissionRegistry) {
+    // Register permissions for commands with PermissionLvl::Four
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.stop",
+            "Stops the server",
+            PermissionDefault::Op(PermissionLvl::Four),
+        ))
+        .unwrap();
+
+    #[cfg(feature = "dhat-heap")]
+    registry
+        .register_permission(Permission::new(
+            "pumpkin:command.profile",
+            "Controls heap profiling",
+            PermissionDefault::Op(PermissionLvl::Four),
+        ))
+        .unwrap();
 }

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -59,176 +59,71 @@ pub async fn default_dispatcher() -> CommandDispatcher {
     register_permissions().await;
 
     // Zero
-    dispatcher.register(
-        pumpkin::init_command_tree(),
-        "pumpkin:command.pumpkin".to_string(),
-    );
-    dispatcher.register(
-        help::init_command_tree(),
-        "minecraft:command.help".to_string(),
-    );
-    dispatcher.register(
-        list::init_command_tree(),
-        "minecraft:command.list".to_string(),
-    );
-    dispatcher.register(
-        transfer::init_command_tree(),
-        "minecraft:command.transfer".to_string(),
-    );
-    dispatcher.register(me::init_command_tree(), "minecraft:command.me".to_string());
-    dispatcher.register(
-        msg::init_command_tree(),
-        "minecraft:command.msg".to_string(),
-    );
+    dispatcher.register(pumpkin::init_command_tree(), "pumpkin:command.pumpkin");
+    dispatcher.register(help::init_command_tree(), "minecraft:command.help");
+    dispatcher.register(list::init_command_tree(), "minecraft:command.list");
+    dispatcher.register(transfer::init_command_tree(), "minecraft:command.transfer");
+    dispatcher.register(me::init_command_tree(), "minecraft:command.me");
+    dispatcher.register(msg::init_command_tree(), "minecraft:command.msg");
     // Two
-    dispatcher.register(
-        kill::init_command_tree(),
-        "minecraft:command.kill".to_string(),
-    );
+    dispatcher.register(kill::init_command_tree(), "minecraft:command.kill");
     dispatcher.register(
         worldborder::init_command_tree(),
-        "minecraft:command.worldborder".to_string(),
+        "minecraft:command.worldborder",
     );
-    dispatcher.register(
-        effect::init_command_tree(),
-        "minecraft:command.effect".to_string(),
-    );
-    dispatcher.register(
-        teleport::init_command_tree(),
-        "minecraft:command.teleport".to_string(),
-    );
-    dispatcher.register(
-        time::init_command_tree(),
-        "minecraft:command.time".to_string(),
-    );
-    dispatcher.register(
-        give::init_command_tree(),
-        "minecraft:command.give".to_string(),
-    );
-    dispatcher.register(
-        clear::init_command_tree(),
-        "minecraft:command.clear".to_string(),
-    );
-    dispatcher.register(
-        setblock::init_command_tree(),
-        "minecraft:command.setblock".to_string(),
-    );
-    dispatcher.register(
-        seed::init_command_tree(),
-        "minecraft:command.seed".to_string(),
-    );
-    dispatcher.register(
-        fill::init_command_tree(),
-        "minecraft:command.fill".to_string(),
-    );
+    dispatcher.register(effect::init_command_tree(), "minecraft:command.effect");
+    dispatcher.register(teleport::init_command_tree(), "minecraft:command.teleport");
+    dispatcher.register(time::init_command_tree(), "minecraft:command.time");
+    dispatcher.register(give::init_command_tree(), "minecraft:command.give");
+    dispatcher.register(clear::init_command_tree(), "minecraft:command.clear");
+    dispatcher.register(setblock::init_command_tree(), "minecraft:command.setblock");
+    dispatcher.register(seed::init_command_tree(), "minecraft:command.seed");
+    dispatcher.register(fill::init_command_tree(), "minecraft:command.fill");
     dispatcher.register(
         playsound::init_command_tree(),
-        "minecraft:command.playsound".to_string(),
+        "minecraft:command.playsound",
     );
-    dispatcher.register(
-        tellraw::init_command_tree(),
-        "minecraft:command.tellraw".to_string(),
-    );
-    dispatcher.register(
-        title::init_command_tree(),
-        "minecraft:command.title".to_string(),
-    );
-    dispatcher.register(
-        summon::init_command_tree(),
-        "minecraft:command.summon".to_string(),
-    );
+    dispatcher.register(tellraw::init_command_tree(), "minecraft:command.tellraw");
+    dispatcher.register(title::init_command_tree(), "minecraft:command.title");
+    dispatcher.register(summon::init_command_tree(), "minecraft:command.summon");
     dispatcher.register(
         experience::init_command_tree(),
-        "minecraft:command.experience".to_string(),
+        "minecraft:command.experience",
     );
-    dispatcher.register(
-        weather::init_command_tree(),
-        "minecraft:command.weather".to_string(),
-    );
-    dispatcher.register(
-        particle::init_command_tree(),
-        "minecraft:command.particle".to_string(),
-    );
-    dispatcher.register(
-        damage::init_command_tree(),
-        "minecraft:command.damage".to_string(),
-    );
-    dispatcher.register(
-        bossbar::init_command_tree(),
-        "minecraft:command.bossbar".to_string(),
-    );
-    dispatcher.register(
-        say::init_command_tree(),
-        "minecraft:command.say".to_string(),
-    );
-    dispatcher.register(
-        gamemode::init_command_tree(),
-        "minecraft:command.gamemode".to_string(),
-    );
+    dispatcher.register(weather::init_command_tree(), "minecraft:command.weather");
+    dispatcher.register(particle::init_command_tree(), "minecraft:command.particle");
+    dispatcher.register(damage::init_command_tree(), "minecraft:command.damage");
+    dispatcher.register(bossbar::init_command_tree(), "minecraft:command.bossbar");
+    dispatcher.register(say::init_command_tree(), "minecraft:command.say");
+    dispatcher.register(gamemode::init_command_tree(), "minecraft:command.gamemode");
     dispatcher.register(
         stopsound::init_command_tree(),
-        "minecraft:command.stopsound".to_string(),
+        "minecraft:command.stopsound",
     );
     dispatcher.register(
         defaultgamemode::init_command_tree(),
-        "minecraft:command.defaultgamemode".to_string(),
+        "minecraft:command.defaultgamemode",
     );
     // Three
-    dispatcher.register(
-        op::init_command_tree(),
-        "minecraft:command.op".to_string(),
-    );
-    dispatcher.register(
-        deop::init_command_tree(),
-        "minecraft:command.deop".to_string(),
-    );
-    dispatcher.register(
-        kick::init_command_tree(),
-        "minecraft:command.kick".to_string(),
-    );
-    dispatcher.register(
-        plugin::init_command_tree(),
-        "pumpkin:command.plugin".to_string(),
-    );
-    dispatcher.register(
-        plugins::init_command_tree(),
-        "pumpkin:command.plugins".to_string(),
-    );
-    dispatcher.register(
-        ban::init_command_tree(),
-        "minecraft:command.ban".to_string(),
-    );
-    dispatcher.register(
-        banip::init_command_tree(),
-        "minecraft:command.banip".to_string(),
-    );
-    dispatcher.register(
-        banlist::init_command_tree(),
-        "minecraft:command.banlist".to_string(),
-    );
-    dispatcher.register(
-        pardon::init_command_tree(),
-        "minecraft:command.pardon".to_string(),
-    );
-    dispatcher.register(
-        pardonip::init_command_tree(),
-        "minecraft:command.pardonip".to_string(),
-    );
+    dispatcher.register(op::init_command_tree(), "minecraft:command.op");
+    dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");
+    dispatcher.register(kick::init_command_tree(), "minecraft:command.kick");
+    dispatcher.register(plugin::init_command_tree(), "pumpkin:command.plugin");
+    dispatcher.register(plugins::init_command_tree(), "pumpkin:command.plugins");
+    dispatcher.register(ban::init_command_tree(), "minecraft:command.ban");
+    dispatcher.register(banip::init_command_tree(), "minecraft:command.banip");
+    dispatcher.register(banlist::init_command_tree(), "minecraft:command.banlist");
+    dispatcher.register(pardon::init_command_tree(), "minecraft:command.pardon");
+    dispatcher.register(pardonip::init_command_tree(), "minecraft:command.pardonip");
     dispatcher.register(
         whitelist::init_command_tree(),
-        "minecraft:command.whitelist".to_string(),
+        "minecraft:command.whitelist",
     );
     // Four
-    dispatcher.register(
-        stop::init_command_tree(),
-        "minecraft:command.stop".to_string(),
-    );
+    dispatcher.register(stop::init_command_tree(), "minecraft:command.stop");
 
     #[cfg(feature = "dhat-heap")]
-    dispatcher.register(
-        profile::init_command_tree(),
-        "pumpkin:command.profile".to_string(),
-    );
+    dispatcher.register(profile::init_command_tree(), "pumpkin:command.profile");
 
     dispatcher
 }
@@ -295,6 +190,7 @@ fn register_level_0_permissions(registry: &mut PermissionRegistry) {
         .unwrap();
 }
 
+#[allow(clippy::too_many_lines)]
 fn register_level_2_permissions(registry: &mut PermissionRegistry) {
     // Register permissions for commands with PermissionLvl::Two
     registry

--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -411,8 +411,9 @@ impl CommandDispatcher {
     }
 
     /// Register a command with the dispatcher.
-    pub(crate) fn register(&mut self, tree: CommandTree, permission: String) {
+    pub(crate) fn register(&mut self, tree: CommandTree, permission: &str) {
         let mut names = tree.names.iter();
+        let permission = permission.to_string();
 
         let primary_name = names.next().expect("at least one name must be provided");
 
@@ -456,6 +457,6 @@ mod test {
     async fn test_dynamic_command() {
         let mut dispatcher = default_dispatcher().await;
         let tree = CommandTree::new(["test"], "test_desc");
-        dispatcher.register(tree, "minecraft:test".to_string());
+        dispatcher.register(tree, "minecraft:test");
     }
 }

--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -1,5 +1,4 @@
 use pumpkin_protocol::client::play::CommandSuggestion;
-use pumpkin_util::permission::PermissionLvl;
 use pumpkin_util::text::TextComponent;
 
 use super::args::ConsumedArgs;
@@ -59,7 +58,7 @@ impl CommandError {
 #[derive(Default)]
 pub struct CommandDispatcher {
     pub(crate) commands: HashMap<String, Command>,
-    pub(crate) permissions: HashMap<String, PermissionLvl>,
+    pub(crate) permissions: HashMap<String, String>,
 }
 
 /// Stores registered [`CommandTree`]s and dispatches commands to them.
@@ -267,7 +266,7 @@ impl CommandDispatcher {
             ));
         };
 
-        if !src.has_permission_lvl(*permission) {
+        if !src.has_permission(permission.as_str()).await {
             return Err(PermissionDenied);
         }
 
@@ -306,8 +305,8 @@ impl CommandDispatcher {
         }
     }
 
-    pub(crate) fn get_permission_lvl(&self, key: &str) -> Option<PermissionLvl> {
-        self.permissions.get(key).copied()
+    pub(crate) fn get_permission(&self, key: &str) -> Option<&String> {
+        self.permissions.get(key)
     }
 
     async fn try_is_fitting_path<'a>(
@@ -412,7 +411,7 @@ impl CommandDispatcher {
     }
 
     /// Register a command with the dispatcher.
-    pub(crate) fn register(&mut self, tree: CommandTree, permission: PermissionLvl) {
+    pub(crate) fn register(&mut self, tree: CommandTree, permission: String) {
         let mut names = tree.names.iter();
 
         let primary_name = names.next().expect("at least one name must be provided");
@@ -420,7 +419,8 @@ impl CommandDispatcher {
         for name in names {
             self.commands
                 .insert(name.to_string(), Command::Alias(primary_name.to_string()));
-            self.permissions.insert(name.to_string(), permission);
+            self.permissions
+                .insert(name.to_string(), permission.clone());
         }
 
         self.permissions
@@ -452,11 +452,10 @@ impl CommandDispatcher {
 #[cfg(test)]
 mod test {
     use crate::command::{commands::default_dispatcher, tree::CommandTree};
-    use pumpkin_util::permission::PermissionLvl;
-    #[test]
-    fn test_dynamic_command() {
-        let mut dispatcher = default_dispatcher();
+    #[tokio::test]
+    async fn test_dynamic_command() {
+        let mut dispatcher = default_dispatcher().await;
         let tree = CommandTree::new(["test"], "test_desc");
-        dispatcher.register(tree, PermissionLvl::Zero);
+        dispatcher.register(tree, "minecraft:test".to_string());
     }
 }

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -81,6 +81,14 @@ impl CommandSender {
         }
     }
 
+    /// Check if the sender has a specific permission
+    pub async fn has_permission(&self, node: &str) -> bool {
+        match self {
+            Self::Console | Self::Rcon(_) => true, // Console and RCON always have all permissions
+            Self::Player(p) => p.has_permission(node).await,
+        }
+    }
+
     #[must_use]
     pub fn position(&self) -> Option<Vector3<f64>> {
         match self {

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -22,7 +22,7 @@ use super::{
     item::ItemEntity,
 };
 use crate::{
-    block,
+    PERMISSION_MANAGER, block,
     command::{client_suggestions, dispatcher::CommandDispatcher},
     data::op_data::OPERATOR_CONFIG,
     net::{Client, PlayerConfig},
@@ -1711,6 +1711,14 @@ impl Player {
         } else {
             screen_handler.send_content_updates().await;
         }
+    }
+
+    /// Check if the player has a specific permission
+    pub async fn has_permission(&self, node: &str) -> bool {
+        let perm_manager = PERMISSION_MANAGER.read().await;
+        perm_manager
+            .has_permission(&self.gameprofile.id, node, self.permission_lvl.load())
+            .await
     }
 }
 

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -40,17 +40,20 @@ use plugin::PluginManager;
 use pumpkin_data::packet::CURRENT_MC_PROTOCOL;
 use std::{
     io::{self},
-    sync::LazyLock,
+    sync::{Arc, LazyLock},
 };
 #[cfg(not(unix))]
 use tokio::signal::ctrl_c;
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::server::CURRENT_MC_VERSION;
 use pumpkin::{PumpkinServer, SHOULD_STOP, STOP_INTERRUPT, init_log, stop_server};
-use pumpkin_util::text::{TextComponent, color::NamedColor};
+use pumpkin_util::{
+    permission::{PermissionManager, PermissionRegistry},
+    text::{TextComponent, color::NamedColor},
+};
 use std::time::Instant;
 // Setup some tokens to allow us to identify which event is for which socket.
 
@@ -74,6 +77,12 @@ use pumpkin::HEAP_PROFILER;
 
 pub static PLUGIN_MANAGER: LazyLock<Mutex<PluginManager>> =
     LazyLock::new(|| Mutex::new(PluginManager::new()));
+
+pub static PERMISSION_REGISTRY: LazyLock<Arc<RwLock<PermissionRegistry>>> =
+    LazyLock::new(|| Arc::new(RwLock::new(PermissionRegistry::new())));
+
+pub static PERMISSION_MANAGER: LazyLock<RwLock<PermissionManager>> =
+    LazyLock::new(|| RwLock::new(PermissionManager::new(PERMISSION_REGISTRY.clone())));
 
 const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const GIT_VERSION: &str = env!("GIT_VERSION");

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::Path, sync::Arc};
 
-use crate::command::client_suggestions;
-use pumpkin_util::PermissionLvl;
+use crate::{PERMISSION_MANAGER, PERMISSION_REGISTRY, command::client_suggestions};
+use pumpkin_util::{PermissionLvl, permission::Permission};
 use tokio::sync::RwLock;
 
 use crate::{
@@ -79,11 +79,18 @@ impl Context {
     pub async fn register_command(
         &self,
         tree: crate::command::tree::CommandTree,
-        permission: PermissionLvl,
+        permission_node: &str,
     ) {
+        let plugin_name = self.metadata.name;
+        let full_permission_node = if !permission_node.contains(':') {
+            format!("{}:{}", plugin_name, permission_node)
+        } else {
+            permission_node.to_string()
+        };
+
         {
             let mut dispatcher_lock = self.server.command_dispatcher.write().await;
-            dispatcher_lock.register(tree, permission);
+            dispatcher_lock.register(tree, full_permission_node);
         };
 
         for world in self.server.worlds.read().await.iter() {
@@ -110,6 +117,39 @@ impl Context {
                 client_suggestions::send_c_commands_packet(player, &command_dispatcher).await;
             }
         }
+    }
+
+    /// Register a permission for this plugin
+    pub async fn register_permission(&self, permission: Permission) -> Result<(), String> {
+        // Ensure the permission has the correct namespace
+        let plugin_name = self.metadata.name;
+
+        if !permission.node.starts_with(&format!("{}:", plugin_name)) {
+            return Err(format!(
+                "Permission {} must use the plugin's namespace ({})",
+                permission.node, plugin_name
+            ));
+        }
+
+        let mut registry = PERMISSION_REGISTRY.write().await;
+        registry.register_permission(permission)
+    }
+
+    /// Check if a player has a permission
+    pub async fn player_has_permission(&self, player_uuid: &uuid::Uuid, permission: &str) -> bool {
+        let permission_manager = PERMISSION_MANAGER.read().await;
+
+        // If the player isn't online, we need to find their op level
+        let player_op_level =
+            if let Some(player) = self.server.get_player_by_uuid(player_uuid.clone()).await {
+                player.permission_lvl.load()
+            } else {
+                PermissionLvl::Zero // Default to zero if player not found
+            };
+
+        permission_manager
+            .has_permission(player_uuid, permission, player_op_level)
+            .await
     }
 
     /// Asynchronously registers an event handler for a specific event type.

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -97,7 +97,7 @@ pub struct Server {
 impl Server {
     #[allow(clippy::new_without_default)]
     #[must_use]
-    pub fn new() -> Self {
+    pub async fn new() -> Self {
         let auth_client = BASIC_CONFIG.online_mode.then(|| {
             reqwest::Client::builder()
                 .connect_timeout(Duration::from_millis(u64::from(
@@ -111,7 +111,7 @@ impl Server {
         });
 
         // First register the default commands. After that, plugins can put in their own.
-        let command_dispatcher = RwLock::new(default_dispatcher());
+        let command_dispatcher = RwLock::new(default_dispatcher().await);
         let world_path = BASIC_CONFIG.get_world_path();
 
         let block_registry = super::block::default_registry();


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This PR implements a string-based, namespaced permission system (not only) for commands.
Permissions are prefixed with a namespace, that can either be:
- `minecraft:` for vanilla builtin commands
- `pumpkin:` for builtin commands that have been added on top of vanilla
- or when used with plugins, the plugin identifier is used (plugins may only register permissions within their namespace, there is a workaround, but it is only intended for advanced use cases)

The value of each permission is a list of identifiers separated by the `.` character. There can be as many identifiers as necessary.

When registering a permission, the default value must be provided. This can be one of:
- `PermissionDefault::Allow` - which will allow the permission by default
- `PermissionDefault::Deny` - which will deny the permission by default
- `PermissionDefault::Op(PermissionLvl)` - will allow the permission for any player with a minimum PermissionLvl

Permissions can also have children. Children are a list of other permissions, which the player will be granted if they are granted the base permission. Example: if the permission `minecraft:command.teleport` has `minecraft:command.teleport.self = true` and `minecraft:command.teleport.other = true`, any player that is granted the `minecraft:command.teleport` permission will also be granted both of the child permissions.

Similarly to how other mc server software works, the permission system will only store the permissions (and any changes to them) in memory while the server is running. This means that plugins will be in charge of storing permissions in some non-volatile location.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
