### PR TITLE
Fix typo: Rename 'Aquifier' to 'Aquifer' in generation module

### DIFF
--- a/pumpkin-world/src/generation/aquifer_sampler.rs
+++ b/pumpkin-world/src/generation/aquifer_sampler.rs
@@ -74,7 +74,7 @@ pub trait FluidLevelSamplerImpl {
 #[enum_dispatch(AquiferSamplerImpl)]
 pub enum AquiferSampler {
     SeaLevel(SeaLevelAquiferSampler),
-    Aquifier(WorldAquiferSampler),
+    Aquifer(WorldAquiferSampler),
 }
 
 macro_rules! local_xz {
@@ -729,7 +729,7 @@ mod test {
             _ => unreachable!(),
         };
         let aquifer = match sampler {
-            AquiferSampler::Aquifier(aquifer) => aquifer,
+            AquiferSampler::Aquifer(aquifer) => aquifer,
             _ => unreachable!(),
         };
 

--- a/pumpkin-world/src/generation/chunk_noise.rs
+++ b/pumpkin-world/src/generation/chunk_noise.rs
@@ -210,9 +210,9 @@ impl<'a> ChunkNoiseGenerator<'a> {
         let aquifer_sampler = if aquifers {
             let section_x = section_coords::block_to_section(start_block_x);
             let section_z = section_coords::block_to_section(start_block_z);
-            AquiferSampler::Aquifier(WorldAquiferSampler::new(
+            AquiferSampler::Aquifer(WorldAquiferSampler::new(
                 Vector2::new(section_x, section_z),
-                random_config.aquifier_random_deriver.clone(),
+                random_config.aquifer_random_deriver.clone(),
                 generation_shape.min_y,
                 generation_shape.height,
                 level_sampler,

--- a/pumpkin-world/src/generation/mod.rs
+++ b/pumpkin-world/src/generation/mod.rs
@@ -40,7 +40,7 @@ pub fn get_world_gen(seed: Seed, dimension: Dimension) -> Box<dyn WorldGenerator
 pub struct GlobalRandomConfig {
     seed: u64,
     base_random_deriver: RandomDeriver,
-    aquifier_random_deriver: RandomDeriver,
+    aquifer_random_deriver: RandomDeriver,
     ore_random_deriver: RandomDeriver,
 }
 
@@ -59,7 +59,7 @@ impl GlobalRandomConfig {
         Self {
             seed,
             base_random_deriver: random_deriver,
-            aquifier_random_deriver: aquifer_deriver,
+            aquifer_random_deriver: aquifer_deriver,
             ore_random_deriver: ore_deriver,
         }
     }


### PR DESCRIPTION
### What was changed?
Renamed instances of the misspelled term `Aquifier` to the correct spelling `Aquifer` across the `pumpkin-world/src/generation` module. Specifically updated:
- `mod.rs`
- `aquifer_sampler.rs`
- `chunk_noise.rs`

### Why were these changes necessary?
The term `Aquifier` appears to be a typo, as `Aquifer` is used consistently throughout the rest of the codebase (33 times vs. 4 instances of the typo). This fix improves clarity and consistency in the code.

### What is the impact of this change?
Only identifier names were updated to correct the spelling. No functional changes were made. Should not affect runtime behavior.

### Known issues or limitations
None.

Fixes #832

