### PR TITLE
fix: spawn player on top block instead of 200 y (#801)

### DIFF
--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -562,6 +562,11 @@ impl World {
                 true,
             ))
             .await;
+
+        // Spawn in initial chunks
+        // This is made before the player teleport so that the player doesn't glitch out when spawning
+        chunker::player_join(&player).await;
+
         // Permissions, i.e. the commands a player may use.
         player.send_permission_lvl_update().await;
         {
@@ -577,10 +582,12 @@ impl World {
 
             (position, yaw, pitch)
         } else {
+            let spawn_position = Vector2::new(self.level_info.spawn_x, self.level_info.spawn_z);
+            let pos_y = self.get_top_block(spawn_position).await + 1; // +1 to spawn on top of the block
             let info = &self.level_info;
             let position = Vector3::new(
                 f64::from(info.spawn_x),
-                f64::from(info.spawn_y) + 1.0,
+                f64::from(pos_y),
                 f64::from(info.spawn_z),
             );
             let yaw = info.spawn_angle;
@@ -784,9 +791,6 @@ impl World {
                 ))
                 .await;
         }
-
-        // Spawn in initial chunks
-        chunker::player_join(&player).await;
 
         // if let Some(bossbars) = self..lock().await.get_player_bars(&player.gameprofile.id) {
         //     for bossbar in bossbars {

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -563,16 +563,16 @@ impl World {
             ))
             .await;
 
-        // Spawn in initial chunks
-        // This is made before the player teleport so that the player doesn't glitch out when spawning
-        chunker::player_join(&player).await;
-
         // Permissions, i.e. the commands a player may use.
         player.send_permission_lvl_update().await;
         {
             let command_dispatcher = server.command_dispatcher.read().await;
             client_suggestions::send_c_commands_packet(&player, &command_dispatcher).await;
         };
+
+        // Spawn in initial chunks
+        // This is made before the player teleport so that the player doesn't glitch out when spawning
+        chunker::player_join(&player).await;
 
         // Teleport
         let (position, yaw, pitch) = if player.has_played_before.load(Ordering::Relaxed) {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

This PR was made to resolve [this issue](https://github.com/Pumpkin-MC/Pumpkin/issues/801).
When a player first spawns in a world, their y coordinate is set to 200, which typically results in their death on the first spawn. To address this issue, I modified the player’s spawning mechanism to ensure they spawn on the top block of the x and z coordinates. However, this modification, coupled with the current codebase, caused the player to spawn on the top block, but since the chunk generation occurred after the player spawned, the player would glitch out of the map. Consequently, I implemented a change to generate the chunk and send it to the client before the player spawns. 


## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
