### PR TITLE
Fix permissions not being registered from plugins

### DIFF
--- a/pumpkin-util/src/permission.rs
+++ b/pumpkin-util/src/permission.rs
@@ -120,9 +120,9 @@ impl PermissionAttachment {
 #[derive(Default)]
 pub struct PermissionManager {
     /// Global registry of permissions
-    registry: Arc<RwLock<PermissionRegistry>>,
+    pub registry: Arc<RwLock<PermissionRegistry>>,
     /// Player permission attachments
-    attachments: HashMap<uuid::Uuid, Arc<RwLock<PermissionAttachment>>>,
+    pub attachments: HashMap<uuid::Uuid, Arc<RwLock<PermissionAttachment>>>,
 }
 
 impl PermissionManager {

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -56,8 +56,11 @@ pub static PLUGIN_MANAGER: LazyLock<Arc<RwLock<PluginManager>>> = LazyLock::new(
 pub static PERMISSION_REGISTRY: LazyLock<Arc<RwLock<PermissionRegistry>>> =
     LazyLock::new(|| Arc::new(RwLock::new(PermissionRegistry::new())));
 
-pub static PERMISSION_MANAGER: LazyLock<RwLock<PermissionManager>> =
-    LazyLock::new(|| RwLock::new(PermissionManager::new(PERMISSION_REGISTRY.clone())));
+pub static PERMISSION_MANAGER: LazyLock<Arc<RwLock<PermissionManager>>> = LazyLock::new(|| {
+    Arc::new(RwLock::new(PermissionManager::new(
+        PERMISSION_REGISTRY.clone(),
+    )))
+});
 
 /// A wrapper for our logger to hold the terminal input while no input is expected in order to
 /// properly flush logs to the output while they happen instead of batched

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -88,8 +88,11 @@ pub static PLUGIN_MANAGER: LazyLock<Arc<RwLock<PluginManager>>> = LazyLock::new(
 pub static PERMISSION_REGISTRY: LazyLock<Arc<RwLock<PermissionRegistry>>> =
     LazyLock::new(|| Arc::new(RwLock::new(PermissionRegistry::new())));
 
-pub static PERMISSION_MANAGER: LazyLock<RwLock<PermissionManager>> =
-    LazyLock::new(|| RwLock::new(PermissionManager::new(PERMISSION_REGISTRY.clone())));
+pub static PERMISSION_MANAGER: LazyLock<Arc<RwLock<PermissionManager>>> = LazyLock::new(|| {
+    Arc::new(RwLock::new(PermissionManager::new(
+        PERMISSION_REGISTRY.clone(),
+    )))
+});
 
 const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const GIT_VERSION: &str = env!("GIT_VERSION");

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -1,7 +1,10 @@
 use std::{fs, path::Path, sync::Arc};
 
 use crate::{PERMISSION_MANAGER, PERMISSION_REGISTRY, command::client_suggestions};
-use pumpkin_util::{PermissionLvl, permission::Permission};
+use pumpkin_util::{
+    PermissionLvl,
+    permission::{Permission, PermissionManager},
+};
 use tokio::sync::RwLock;
 
 use crate::{
@@ -24,6 +27,7 @@ pub struct Context {
     pub server: Arc<Server>,
     pub handlers: Arc<RwLock<HandlerMap>>,
     pub plugin_manager: Arc<RwLock<PluginManager>>,
+    pub permission_manager: Arc<RwLock<PermissionManager>>,
 }
 impl Context {
     /// Creates a new instance of `Context`.
@@ -41,12 +45,14 @@ impl Context {
         server: Arc<Server>,
         handlers: Arc<RwLock<HandlerMap>>,
         plugin_manager: Arc<RwLock<PluginManager>>,
+        permission_manager: Arc<RwLock<PermissionManager>>,
     ) -> Self {
         Self {
             metadata,
             server,
             handlers,
             plugin_manager,
+            permission_manager,
         }
     }
 
@@ -134,13 +140,14 @@ impl Context {
             ));
         }
 
-        let mut registry = PERMISSION_REGISTRY.write().await;
+        let manager = self.permission_manager.read().await;
+        let mut registry = manager.registry.write().await;
         registry.register_permission(permission)
     }
 
     /// Check if a player has a permission
     pub async fn player_has_permission(&self, player_uuid: &uuid::Uuid, permission: &str) -> bool {
-        let permission_manager = PERMISSION_MANAGER.read().await;
+        let permission_manager = self.permission_manager.read().await;
 
         // If the player isn't online, we need to find their op level
         let player_op_level = (self.server.get_player_by_uuid(*player_uuid).await)

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -13,7 +13,7 @@ use tokio::sync::RwLock;
 pub mod api;
 pub mod loader;
 
-use crate::server::Server;
+use crate::{PERMISSION_MANAGER, server::Server};
 pub use api::*;
 
 /// A trait for handling events dynamically.
@@ -316,6 +316,7 @@ impl PluginManager {
             Arc::clone(server),
             Arc::clone(&self.handlers),
             Arc::clone(self_ref),
+            Arc::clone(&PERMISSION_MANAGER),
         );
 
         if let Err(e) = instance.on_load(&context).await {
@@ -394,6 +395,7 @@ impl PluginManager {
             Arc::clone(server),
             Arc::clone(&self.handlers),
             Arc::clone(self_ref),
+            Arc::clone(&PERMISSION_MANAGER),
         );
 
         plugin.instance.on_unload(&context).await.ok();


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Fixes the issue where plugins are unable to register permissions by passing a clone of the permission manager to the plugin's context.

The original issue is caused by the fact that both the `main.rs` and `lib.rs` files define a `PERMISSION_MANAGER`, and plugins use the instance created by `lib.rs` whereas the internal server uses the instance created from `main.rs`.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
