### PR TITLE
Fix issue with Level::is_block_tick_scheduled, related to problems with redstone.

### DIFF
--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -101,7 +101,7 @@ impl From<i32> for TickPriority {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ScheduledTick {
     pub block_pos: BlockPos,
     pub delay: u16,

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -1,17 +1,17 @@
-use std::{
-    path::PathBuf,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-};
-
 use dashmap::{DashMap, Entry};
 use log::trace;
 use num_traits::Zero;
 use pumpkin_config::{advanced_config, chunk::ChunkFormat};
 use pumpkin_data::Block;
 use pumpkin_util::math::{position::BlockPos, vector2::Vector2};
+use std::{
+    collections::VecDeque,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    }
+};
 use tokio::{
     select,
     sync::{
@@ -63,6 +63,7 @@ pub struct Level {
     world_gen: Arc<dyn WorldGenerator>,
 
     block_ticks: Arc<Mutex<Vec<ScheduledTick>>>,
+    remaining_block_ticks_this_tick: Arc<Mutex<VecDeque<ScheduledTick>>>,
     fluid_ticks: Arc<Mutex<Vec<ScheduledTick>>>,
     /// Tracks tasks associated with this world instance
     tasks: TaskTracker,
@@ -116,6 +117,7 @@ impl Level {
             tasks: TaskTracker::new(),
             shutdown_notifier: Notify::new(),
             block_ticks: Arc::new(Mutex::new(Vec::new())),
+            remaining_block_ticks_this_tick: Arc::new(Mutex::new(VecDeque::new())),
             fluid_ticks: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -430,7 +432,7 @@ impl Level {
                 let (chunk_coord, _relative_coord) =
                     tick.block_pos.chunk_and_chunk_relative_position();
                 if chunk_coord == *coord {
-                    chunk_data.block_ticks.push(tick.clone());
+                    chunk_data.block_ticks.push(*tick);
                     false
                 } else {
                     true
@@ -440,7 +442,7 @@ impl Level {
                 let (chunk_coord, _relative_coord) =
                     tick.block_pos.chunk_and_chunk_relative_position();
                 if chunk_coord == *coord {
-                    chunk_data.fluid_ticks.push(tick.clone());
+                    chunk_data.fluid_ticks.push(*tick);
                     false
                 } else {
                     true
@@ -653,22 +655,23 @@ impl Level {
         self.loaded_chunks.try_get(&coordinates).try_unwrap()
     }
 
-    pub async fn get_and_tick_block_ticks(&self) -> Vec<ScheduledTick> {
+    pub async fn get_and_tick_block_ticks(&self) -> Arc<Mutex<VecDeque<ScheduledTick>>> {
         let mut block_ticks = self.block_ticks.lock().await;
-        let mut ticks = Vec::new();
+        let mut ticks = VecDeque::new();
         let mut remaining_ticks = Vec::new();
         for mut tick in block_ticks.drain(..) {
             tick.delay = tick.delay.saturating_sub(1);
             if tick.delay == 0 {
-                ticks.push(tick);
+                ticks.push_back(tick);
             } else {
                 remaining_ticks.push(tick);
             }
         }
 
         *block_ticks = remaining_ticks;
-        ticks.sort_by_key(|tick| tick.priority);
-        ticks
+        ticks.make_contiguous().sort_by_key(|tick| tick.priority);
+        *self.remaining_block_ticks_this_tick.lock().await = ticks;
+        self.remaining_block_ticks_this_tick.clone()
     }
 
     pub async fn get_and_tick_fluid_ticks(&self) -> Vec<ScheduledTick> {
@@ -677,7 +680,7 @@ impl Level {
         fluid_ticks.retain_mut(|tick| {
             tick.delay = tick.delay.saturating_sub(1);
             if tick.delay == 0 {
-                ticks.push(tick.clone());
+                ticks.push(*tick);
                 false
             } else {
                 true
@@ -688,8 +691,10 @@ impl Level {
 
     pub async fn is_block_tick_scheduled(&self, block_pos: &BlockPos, block_id: u16) -> bool {
         let block_ticks = self.block_ticks.lock().await;
+        let remaining_block_ticks_this_tick = self.remaining_block_ticks_this_tick.lock().await;
         block_ticks
             .iter()
+            .chain(remaining_block_ticks_this_tick.iter())
             .any(|tick| tick.block_pos == *block_pos && tick.target_block_id == block_id)
     }
 

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -10,7 +10,7 @@ use std::{
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
-    }
+    },
 };
 use tokio::{
     select,

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -469,7 +469,7 @@ impl World {
         let blocks_to_tick = self.level.get_and_tick_block_ticks().await;
         let fluids_to_tick = self.level.get_and_tick_fluid_ticks().await;
 
-        for scheduled_tick in blocks_to_tick {
+        while let Some(scheduled_tick) = { blocks_to_tick.lock().await.pop_front() } {
             let block = self.get_block(&scheduled_tick.block_pos).await;
             if scheduled_tick.target_block_id != block.id {
                 continue;


### PR DESCRIPTION
## Description

Level::is_block_tick_scheduled did not detect block-ticks that will be executed later in the current tick,
leading to incorrect behavior of redstone torches and repeaters, like redstone torches
reacting to 2 gametick pulses, and repeaters in some cases flashing when being turned off. 

is_block_tick_scheduled should detect block-ticks that will be executed later in the current tick,
but not detect block-ticks that were already processed.

To implement this, is_block_tick_scheduled needs to know which block-ticks were already executed
by the World::tick_scheduled_block_ticks function in the current tick, therefore we store the block-ticks,
that still need to be processed in a field in the Level called "remaining_block_ticks_this_tick", where both
methods can access it.

This is to kind of related to #766, however the redstone problems fixed with this PR are not mentioned there explicitly.

The same could also be done with fluid-ticks, however is_fluid_tick_scheduled is currently not used
anywhere, and i don't know of any case where this matters with fluids.

## Testing

Passed all tests.
