### PR TITLE
Tick block entities

### DIFF
--- a/pumpkin/src/block/blocks/piston/mod.rs
+++ b/pumpkin/src/block/blocks/piston/mod.rs
@@ -50,13 +50,7 @@ impl<'a> PistonHandler<'a> {
         self.moved_blocks.clear();
         self.broken_blocks.clear();
         let (block, block_state) = self.world.get_block_and_block_state(&self.pos_to).await;
-        dbg!(PistonBlock::is_movable(
-            &block,
-            &block_state,
-            self.motion_direction,
-            false,
-            self.piston_direction,
-        ));
+
         if !PistonBlock::is_movable(
             &block,
             &block_state,

--- a/pumpkin/src/block/blocks/piston/piston.rs
+++ b/pumpkin/src/block/blocks/piston/piston.rs
@@ -363,7 +363,6 @@ async fn move_piston(
 
     let mut moved_blocks_map: HashMap<BlockPos, BlockState> = HashMap::new();
     let moved_blocks: Vec<BlockPos> = handler.moved_blocks;
-    dbg!(&moved_blocks);
 
     let mut moved_block_states: Vec<BlockState> = Vec::new();
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -386,9 +386,6 @@ impl World {
 
     pub async fn tick(self: &Arc<Self>, server: &Server) {
         self.flush_block_updates().await;
-        // tick block entities
-        // TODO: fix dead lock
-        // self.level.tick_block_entities(self.clone()).await;
         self.flush_synced_block_events().await;
 
         // world ticks

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -71,6 +71,7 @@ use pumpkin_util::{
     Difficulty,
     math::{boundingbox::BoundingBox, position::BlockPos, vector3::Vector3},
 };
+use pumpkin_world::world::SimpleWorld;
 use pumpkin_world::{
     BlockStateId, GENERATION_SETTINGS, GeneratorSetting, biome, block::entities::BlockEntity,
 };
@@ -433,6 +434,10 @@ impl World {
                 }
             }
         }
+
+        self.level
+            .tick_block_entities(self.clone() as Arc<dyn SimpleWorld>)
+            .await;
     }
 
     pub async fn flush_block_updates(&self) {


### PR DESCRIPTION
## Description

Block entities should be ticked at the end of every tick.

There was an old comment about this causing a deadlock when done at the beginning of the tick,
when testing this change i did not encounter any deadlocks.

Currently piston are the only block entities that tick and they work a lot better with this change, but still have some issues.

I also removed two annoying dbg! statements from the piston implementation, that messed up the console log.

## Testing

Passed all tests