### PR TITLE
hopefully fix for miss generating files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,13 @@ jobs:
       id-token: write
 
     steps:
+      - name: Check Repository
+        run: |
+          if [ "${{ github.repository }}" != "Pumpkin-MC/Pumpkin" ]; then
+            echo "Not the target repository. Exiting successfully."
+            exit 0
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/pumpkin-data/build/build.rs
+++ b/pumpkin-data/build/build.rs
@@ -1,5 +1,5 @@
 use quote::{format_ident, quote};
-use std::{fs, path::Path, process::Command};
+use std::{fs, io::Write, path::Path, process::Command};
 
 use heck::ToPascalCase;
 use proc_macro2::TokenStream;
@@ -76,7 +76,10 @@ pub fn write_generated_file(content: TokenStream, out_file: &str) {
     let path = Path::new(OUT_DIR).join(out_file);
     let code = content.to_string();
 
-    fs::write(&path, code).expect("Failed to write to fs");
+    let mut file = fs::File::create(&path).unwrap();
+    if let Err(e) = file.write_all(code.as_bytes()) {
+        println!("cargo::error={}", e);
+    }
 
     // Try to format the output for debugging purposes.
     // Doesn't matter if rustfmt is unavailable.


### PR DESCRIPTION
## Description
This should fix the problem that the pumpkin-data build script can sometimes produce empty files.
added a hard error if writing to a file returns an error other than interrupted.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
