### PR TITLE
Fixed weird behavior of fall damage when player is in water #507

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -238,14 +238,15 @@ impl LivingEntity {
                     .await;
             }
         } else if height_difference < 0.0 {
-            let mut new_fall_distance = 0f32;
+            let new_fall_distance = if !self.is_in_water().await && !self.is_in_powder_snow().await
+            {
+                let distance = self.fall_distance.load();
+                distance - (height_difference as f32)
+            } else {
+                0f32
+            };
 
             // Reset fall distance if is in water or powder_snow
-            if !self.is_in_water().await && !self.is_in_powder_snow().await {
-                let distance = self.fall_distance.load();
-                new_fall_distance = distance - (height_difference as f32);
-            }
-
             self.fall_distance.store(new_fall_distance);
         }
     }

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -239,16 +239,14 @@ impl LivingEntity {
             }
         } else if height_difference < 0.0 {
             let mut new_fall_distance = 0f32;
-            
+
             // Reset fall distance if is in water or powder_snow
             if !self.is_in_water().await && !self.is_in_powder_snow().await {
                 let distance = self.fall_distance.load();
                 new_fall_distance = distance - (height_difference as f32)
-            
             }
 
-            self.fall_distance
-                .store(new_fall_distance);
+            self.fall_distance.store(new_fall_distance);
         }
     }
 

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -238,9 +238,17 @@ impl LivingEntity {
                     .await;
             }
         } else if height_difference < 0.0 {
-            let distance = self.fall_distance.load();
+            let mut new_fall_distance = 0f32;
+            
+            // Reset fall distance if is in water or powder_snow
+            if !self.is_in_water().await && !self.is_in_powder_snow().await {
+                let distance = self.fall_distance.load();
+                new_fall_distance = distance - (height_difference as f32)
+            
+            }
+
             self.fall_distance
-                .store(distance - (height_difference as f32));
+                .store(new_fall_distance);
         }
     }
 

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -243,7 +243,7 @@ impl LivingEntity {
             // Reset fall distance if is in water or powder_snow
             if !self.is_in_water().await && !self.is_in_powder_snow().await {
                 let distance = self.fall_distance.load();
-                new_fall_distance = distance - (height_difference as f32)
+                new_fall_distance = distance - (height_difference as f32);
             }
 
             self.fall_distance.store(new_fall_distance);


### PR DESCRIPTION
## Description
The fall distance was not reset when the player fell into water or powder snow, causing the player to take damage when returning to the ground. 

The bug wasn't really in #507 but is similar.

## Testing
In-Game testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
