### PR TITLE
Fix world max height

### DIFF
--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -1548,7 +1548,7 @@ impl Player {
     }
 
     const WORLD_LOWEST_Y: i8 = -64;
-    const WORLD_MAX_Y: u16 = 384;
+    const WORLD_MAX_Y: u16 = 320;
 
     #[allow(clippy::too_many_lines)]
     async fn run_is_block_place(


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Change max world height from 384 to 320.
[Vanilla max height is 320](https://minecraft.wiki/w/Altitude)

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
