### PR TITLE
fix: Do not generate fire block when use the flint and steel on tnt block

### DIFF
--- a/pumpkin/src/item/items/flint_and_steel.rs
+++ b/pumpkin/src/item/items/flint_and_steel.rs
@@ -26,9 +26,13 @@ impl PumpkinItem for FlintAndSteelItem {
         player: &Player,
         location: BlockPos,
         face: BlockDirection,
-        _block: &Block,
+        block: &Block,
         _server: &Server,
     ) {
+        if block.eq(&Block::TNT) {
+            // if use on tnt block, do not generate a new fire block
+            return;
+        }
         // TODO: check CampfireBlock, CandleBlock and CandleCakeBlock
         let world = player.world().await;
         let pos = location.offset(face.to_offset());


### PR DESCRIPTION
## Description

Do not generate fire block when use the flint and steel on tnt block.
Fixed #875 

## Testing

Tested manually.
