### PR TITLE
Fix deadlock when throwing items (#865)

### DIFF
--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -165,7 +165,7 @@ pub trait ScreenHandler: Send + Sync {
         }
     }
 
-    async fn set_received_hash(&mut self, slot: usize, hash: OptionalItemStackHash) {
+    fn set_received_hash(&mut self, slot: usize, hash: OptionalItemStackHash) {
         let behaviour = self.get_behaviour_mut();
         if slot < behaviour.previous_tracked_stacks.len() {
             behaviour.previous_tracked_stacks[slot].set_received_hash(hash);
@@ -178,12 +178,12 @@ pub trait ScreenHandler: Send + Sync {
         }
     }
 
-    async fn set_received_stack(&mut self, slot: usize, stack: ItemStack) {
+    fn set_received_stack(&mut self, slot: usize, stack: ItemStack) {
         let behaviour = self.get_behaviour_mut();
         behaviour.previous_tracked_stacks[slot].set_received_stack(stack);
     }
 
-    async fn set_received_cursor_hash(&mut self, hash: OptionalItemStackHash) {
+    fn set_received_cursor_hash(&mut self, hash: OptionalItemStackHash) {
         let behaviour = self.get_behaviour_mut();
         behaviour.previous_cursor_stack.set_received_hash(hash);
     }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1454,6 +1454,8 @@ impl Player {
     }
 
     pub async fn drop_held_item(&self, drop_stack: bool) {
+        // should be locked first otherwise cause deadlock in tick() (this thread lock stack, that thread lock screen_handler)
+        let screen_binding = self.current_screen_handler.lock().await;
         let binding = self.inventory.held_item();
         let mut item_stack = binding.lock().await;
 
@@ -1464,8 +1466,7 @@ impl Player {
             item_stack.decrement(drop_amount);
             let selected_slot = self.inventory.get_selected_slot();
             let inv: Arc<dyn Inventory> = self.inventory.clone();
-            let binding = self.current_screen_handler.lock().await;
-            let mut screen_handler = binding.lock().await;
+            let mut screen_handler = screen_binding.lock().await;
             let slot_index = screen_handler
                 .get_slot_index(&inv, selected_slot as usize)
                 .await;

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1472,9 +1472,7 @@ impl Player {
                 .await;
 
             if let Some(slot_index) = slot_index {
-                screen_handler
-                    .set_received_stack(slot_index, *item_stack)
-                    .await;
+                screen_handler.set_received_stack(slot_index, *item_stack);
             }
         }
     }
@@ -1822,12 +1820,10 @@ impl Player {
             .await;
 
         for (key, value) in packet.array_of_changed_slots {
-            screen_handler.set_received_hash(key as usize, value).await;
+            screen_handler.set_received_hash(key as usize, value);
         }
 
-        screen_handler
-            .set_received_cursor_hash(packet.carried_item)
-            .await;
+        screen_handler.set_received_cursor_hash(packet.carried_item);
         screen_handler.enable_sync().await;
 
         if not_in_sync {

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -1459,9 +1459,7 @@ impl Player {
                 .await
                 .set_stack(item_stack)
                 .await;
-            player_screen_handler
-                .set_received_stack(packet.slot as usize, item_stack)
-                .await;
+            player_screen_handler.set_received_stack(packet.slot as usize, item_stack);
             player_screen_handler.send_content_updates().await;
         } else if is_negative && is_legal {
             // Item drop


### PR DESCRIPTION
## Description

Fix deadlock when throwing items #865
`self.current_screen_handler.lock().await;` should do first otherwise cause deadlock in tick() (this thread lock stack and wait screen_handler. that thread lock screen_handler and wait stack)

In addition, i notice `screen_handler.get_slot_index` and `screen_handler.set_received_stack` don't use any async fn in them but are marked as async. Should i remove async mark of the two fn?

## Testing

![1](https://github.com/user-attachments/assets/b1f2e92e-4cc6-4a9b-a583-9ab8c024d882)

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
