### PR TITLE
fix: Server and client inventories out of sync after respawn_player

### DIFF
--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -988,6 +988,10 @@ impl Player {
                 }
                 self.world().await.respawn_player(self, false).await;
 
+                let screen_handler = self.current_screen_handler.lock().await;
+                let mut screen_handler = screen_handler.lock().await;
+                screen_handler.sync_state().await;
+
                 // Restore abilities based on gamemode after respawn
                 let mut abilities = self.abilities.lock().await;
                 abilities.set_for_gamemode(self.gamemode.load());


### PR DESCRIPTION
## Description
After the player respawns, items that were originally in the backpack are not visible in the client's hotbar. However, they can still be placed by right-clicking. 
This bug is mentioned in the issue: https://github.com/Pumpkin-MC/Pumpkin/issues/876