### PR TITLE
Fix Resetting of Block States

### DIFF
--- a/pumpkin/src/item/items/ignite/ignition.rs
+++ b/pumpkin/src/item/items/ignite/ignition.rs
@@ -70,12 +70,10 @@ async fn get_ignite_result(block: &Block, world: &Arc<World>, location: &BlockPo
 
     let props = original_props
         .iter()
-        .filter_map(|(key, _value)| {
-            match key.as_str() {
-                "extinguished" => Some(("extinguished", "true")),
-                "lit" => Some(("lit", "true")),
-                _ => None, // Discard other keys
-            }
+        .map(|(key, value)| match (key.as_str(), value.as_str()) {
+            ("extinguished", "true") => ("extinguished", "false"),
+            ("lit", "false") => ("lit", "true"),
+            _ => (key.as_str(), value.as_str()),
         })
         .collect();
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

For some reason we were discarding the rest of the block state values when getting the new block state... which meant that for example the campfire rotation is reset.

## Testing

Ingame

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
