### PR TITLE
Skip unloadable plugins and log loaded plugins

### DIFF
--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -260,7 +260,9 @@ impl PluginManager {
                 continue;
             }
 
-            self.try_load_plugin(&path).await?;
+            if let Err(err) = self.try_load_plugin(&path).await {
+                log::error!("{err}");
+            }
         }
 
         Ok(())
@@ -272,6 +274,7 @@ impl PluginManager {
             if loader.can_load(path) {
                 match self.load_with_loader(loader, path).await {
                     Ok(plugin) => {
+                        log::info!("Loaded {} ({})", plugin.metadata.name, plugin.metadata.version);
                         self.plugins.push(plugin);
                         // Remove from unloaded files if it was there
                         self.unloaded_files.remove(path);

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -274,7 +274,11 @@ impl PluginManager {
             if loader.can_load(path) {
                 match self.load_with_loader(loader, path).await {
                     Ok(plugin) => {
-                        log::info!("Loaded {} ({})", plugin.metadata.name, plugin.metadata.version);
+                        log::info!(
+                            "Loaded {} ({})",
+                            plugin.metadata.name,
+                            plugin.metadata.version
+                        );
                         self.plugins.push(plugin);
                         // Remove from unloaded files if it was there
                         self.unloaded_files.remove(path);


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

- When loading all Plugins make it so that when try_load_plugin fails that other plugins will still be loaded.
- Log loaded plugins

## Testing
![grafik](https://github.com/user-attachments/assets/143d29e3-6aa0-42e1-a33e-4aeef579ea41)

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
