### PR TITLE
Add components to ItemStack; Handle armour items more elegantly

### DIFF
--- a/pumpkin-inventory/src/equipment_slot.rs
+++ b/pumpkin-inventory/src/equipment_slot.rs
@@ -101,6 +101,20 @@ impl EquipmentSlot {
         }
     }
 
+    pub fn get_from_name(name: &str) -> Option<Self> {
+        match name {
+            "mainhand" => Some(Self::MAIN_HAND),
+            "offhand" => Some(Self::OFF_HAND),
+            "feet" => Some(Self::FEET),
+            "legs" => Some(Self::LEGS),
+            "chest" => Some(Self::CHEST),
+            "head" => Some(Self::HEAD),
+            "body" => Some(Self::BODY),
+            "saddle" => Some(Self::SADDLE),
+            _ => None,
+        }
+    }
+
     pub fn get_offset_entity_slot_id(&self, offset: i32) -> i32 {
         self.get_entity_slot_id() + offset
     }

--- a/pumpkin-inventory/src/player/player_screen_handler.rs
+++ b/pumpkin-inventory/src/player/player_screen_handler.rs
@@ -1,14 +1,15 @@
-use async_trait::async_trait;
-use pumpkin_data::screen::WindowType;
-use pumpkin_world::inventory::Inventory;
-use pumpkin_world::item::ItemStack;
-
 use crate::crafting::crafting_inventory::CraftingInventory;
 use crate::crafting::crafting_screen_handler::CraftingScreenHandler;
 use crate::crafting::recipes::{RecipeFinderScreenHandler, RecipeInputInventory};
 use crate::equipment_slot::{EquipmentSlot, EquipmentType};
 use crate::screen_handler::{InventoryPlayer, ScreenHandler, ScreenHandlerBehaviour};
 use crate::slot::{ArmorSlot, NormalSlot, Slot};
+use async_trait::async_trait;
+use pumpkin_data::screen::WindowType;
+use pumpkin_world::inventory::Inventory;
+use pumpkin_world::item::ItemStack;
+use std::any::Any;
+use std::sync::Arc;
 
 use super::player_inventory::PlayerInventory;
 

--- a/pumpkin-inventory/src/player/player_screen_handler.rs
+++ b/pumpkin-inventory/src/player/player_screen_handler.rs
@@ -75,42 +75,6 @@ impl PlayerScreenHandler {
 
         player_screen_handler
     }
-
-    async fn try_move_one_to_armor_slot(&mut self, stack: &ItemStack) -> bool {
-        if stack.item_count == 0 {
-            return false;
-        }
-
-        let one_item = stack.copy_with_count(1);
-
-        for armor_slot_index in 5..9 {
-            let armor_slot = self.get_slot(armor_slot_index).await;
-            if !armor_slot.has_stack().await && armor_slot.can_insert(&one_item).await {
-                armor_slot.set_stack(one_item).await;
-                return true;
-            }
-        }
-        false
-    }
-
-    async fn handle_inventory_move(&mut self, slot_index: i32, slot_stack: &mut ItemStack) -> bool {
-        if !slot_stack.is_empty() && self.try_move_one_to_armor_slot(slot_stack).await {
-            slot_stack.item_count -= 1;
-            if slot_stack.item_count == 0 {
-                *slot_stack = ItemStack::EMPTY;
-            }
-        }
-
-        if slot_stack.is_empty() {
-            true
-        } else {
-            match slot_index {
-                9..=35 => self.insert_item(slot_stack, 36, 45, false).await, // Main → Hotbar
-                36..=44 => self.insert_item(slot_stack, 9, 36, false).await, // Hotbar → Main
-                _ => false,
-            }
-        }
-    }
 }
 
 #[async_trait]
@@ -163,11 +127,12 @@ impl ScreenHandler for PlayerScreenHandler {
                 if !self.insert_item(&mut slot_stack, 9, 45, false).await {
                     return ItemStack::EMPTY;
                 }
-            } else if (9..45).contains(&slot_index) {
-                if !self
-                    .handle_inventory_move(slot_index, &mut slot_stack)
-                    .await
-                {
+            } else if (9..36).contains(&slot_index) {
+                if !self.insert_item(&mut slot_stack, 36, 45, false).await {
+                    return ItemStack::EMPTY;
+                }
+            } else if (36..45).contains(&slot_index) {
+                if !self.insert_item(&mut slot_stack, 9, 36, false).await {
                     return ItemStack::EMPTY;
                 }
             } else if !self.insert_item(&mut slot_stack, 9, 45, false).await {

--- a/pumpkin-inventory/src/slot.rs
+++ b/pumpkin-inventory/src/slot.rs
@@ -5,13 +5,12 @@ use std::{
     time::Duration,
 };
 
+use crate::{equipment_slot::EquipmentSlot, screen_handler::InventoryPlayer};
 use async_trait::async_trait;
 use pumpkin_data::item::Item;
 use pumpkin_world::inventory::Inventory;
 use pumpkin_world::item::ItemStack;
 use tokio::{sync::Mutex, time::timeout};
-
-use crate::{equipment_slot::EquipmentSlot, screen_handler::InventoryPlayer};
 
 // Slot.java
 // This is a trait due to crafting slots being a thing
@@ -283,6 +282,7 @@ impl Slot for ArmorSlot {
             _ => true,
         }
     }
+
     async fn can_take_items(&self, _player: &dyn InventoryPlayer) -> bool {
         // TODO: Check enchantments
         true

--- a/pumpkin-world/src/item/mod.rs
+++ b/pumpkin-world/src/item/mod.rs
@@ -1,4 +1,4 @@
-use pumpkin_data::item::Item;
+use pumpkin_data::item::{Item, ItemComponents};
 use pumpkin_data::recipes::RecipeResultStruct;
 use pumpkin_data::tag::{RegistryKey, get_tag_values};
 use pumpkin_nbt::compound::NbtCompound;
@@ -21,6 +21,7 @@ pub enum Rarity {
 pub struct ItemStack {
     pub item_count: u8,
     pub item: &'static Item,
+    pub components: ItemComponents,
 }
 
 impl Hash for ItemStack {
@@ -41,10 +42,15 @@ impl ItemStack {
     pub const EMPTY: ItemStack = ItemStack {
         item_count: 0,
         item: &Item::AIR,
+        components: Item::AIR.components,
     };
 
     pub fn new(item_count: u8, item: &'static Item) -> Self {
-        Self { item_count, item }
+        Self {
+            item_count,
+            item,
+            components: item.components,
+        }
     }
 
     pub fn get_max_stack_size(&self) -> u8 {
@@ -221,8 +227,8 @@ impl From<&RecipeResultStruct> for ItemStack {
     fn from(value: &RecipeResultStruct) -> Self {
         Self {
             item_count: value.count,
-            item: Item::from_registry_key(value.id.strip_prefix("minecraft:").unwrap_or(value.id))
-                .expect("Crafting recipe gives invalid item"),
+            item: Item::from_registry_key(value.id).expect("Crafting recipe gives invalid item"),
+            components: Item::from_registry_key(value.id).unwrap().components,
         }
     }
 }


### PR DESCRIPTION
## Description

`try_move_one_to_armor_slot` in #1008 iterates over 4 slots to find the correct armor slot, splits logic into two functions (also different from vanilla structure), not handling offhand (shield), and has some useless check. These are fixed in this PR by parsing `equippable` item component.

## Refactor

Added components to ItemStack

## Testing

- Shield ✅ 
- Helmet ✅ 
- Skull ✅ 