### PR TITLE
PluginAPI / Add `NamespacedKey` and `PersistentDataContainer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,6 +2011,7 @@ dependencies = [
  "bytes",
  "console-subscriber",
  "crossbeam",
+ "dashmap",
  "dhat",
  "flate2",
  "futures",

--- a/pumpkin-macros/src/lib.rs
+++ b/pumpkin-macros/src/lib.rs
@@ -3,7 +3,7 @@ use proc_macro::TokenStream;
 use proc_macro_error2::{abort, abort_call_site, proc_macro_error};
 use quote::quote;
 use syn::spanned::Spanned;
-use syn::{self};
+use syn::{self, DeriveInput};
 use syn::{
     Block, Expr, Field, Fields, ItemStruct, Stmt,
     parse::{Nothing, Parser},
@@ -351,4 +351,21 @@ pub fn block_property(input: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     code.into()
+}
+
+// Assumes the struct has a `container: PersistentDataContainer` field
+#[proc_macro_derive(PersistentDataHolder)]
+pub fn derive_persistent(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let expanded = quote! {
+        impl HasPersistentContainer for #name {
+            fn persistent_container(&self) -> &PersistentDataContainer {
+                &self.container
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
 }

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -35,6 +35,7 @@ rayon.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
 futures.workspace = true
+dashmap = "6.1"
 
 # config
 serde.workspace = true

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -32,7 +32,7 @@ use pumpkin_inventory::screen_handler::{
     ScreenHandlerListener,
 };
 use pumpkin_inventory::sync_handler::SyncHandler;
-use pumpkin_macros::send_cancellable;
+use pumpkin_macros::{PersistentDataHolder, send_cancellable};
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_nbt::tag::NbtTag;
 use pumpkin_protocol::IdOr;
@@ -64,25 +64,25 @@ use pumpkin_world::entity::entity_data_flags::{
 use pumpkin_world::item::ItemStack;
 use pumpkin_world::level::{SyncChunk, SyncEntityChunk};
 
-use crate::block::blocks::bed::BedBlock;
-use crate::command::client_suggestions;
-use crate::command::dispatcher::CommandDispatcher;
-use crate::data::op_data::OPERATOR_CONFIG;
-use crate::net::PlayerConfig;
-use crate::net::{ClientPlatform, GameProfile};
-use crate::plugin::player::player_change_world::PlayerChangeWorldEvent;
-use crate::plugin::player::player_gamemode_change::PlayerGamemodeChangeEvent;
-use crate::plugin::player::player_teleport::PlayerTeleportEvent;
-use crate::server::Server;
-use crate::world::World;
-use crate::{PERMISSION_MANAGER, block};
-
 use super::combat::{self, AttackType, player_attack_sound};
 use super::effect::Effect;
 use super::hunger::HungerManager;
 use super::item::ItemEntity;
 use super::living::LivingEntity;
 use super::{Entity, EntityBase, EntityId, NBTStorage};
+use crate::block::blocks::bed::BedBlock;
+use crate::command::client_suggestions;
+use crate::command::dispatcher::CommandDispatcher;
+use crate::data::op_data::OPERATOR_CONFIG;
+use crate::net::PlayerConfig;
+use crate::net::{ClientPlatform, GameProfile};
+use crate::plugin::persistence::{HasPersistentContainer, PersistentDataContainer};
+use crate::plugin::player::player_change_world::PlayerChangeWorldEvent;
+use crate::plugin::player::player_gamemode_change::PlayerGamemodeChangeEvent;
+use crate::plugin::player::player_teleport::PlayerTeleportEvent;
+use crate::server::Server;
+use crate::world::World;
+use crate::{PERMISSION_MANAGER, block};
 
 const MAX_CACHED_SIGNATURES: u8 = 128; // Vanilla: 128
 const MAX_PREVIOUS_MESSAGES: u8 = 20; // Vanilla: 20
@@ -186,6 +186,7 @@ impl ChunkManager {
 /// Represents a Minecraft player entity.
 ///
 /// A `Player` is a special type of entity that represents a human player connected to the server.
+#[derive(PersistentDataHolder)]
 pub struct Player {
     /// The underlying living entity object that represents the player.
     pub living_entity: LivingEntity,
@@ -266,6 +267,8 @@ pub struct Player {
     pub screen_handler_sync_id: AtomicU8,
     pub screen_handler_listener: Arc<dyn ScreenHandlerListener>,
     pub screen_handler_sync_handler: Arc<SyncHandler>,
+    /// The `PersistentDataContainer`
+    pub container: PersistentDataContainer,
 }
 
 impl Player {
@@ -368,6 +371,7 @@ impl Player {
             screen_handler_sync_id: AtomicU8::new(0),
             screen_handler_listener: Arc::new(ScreenListener {}),
             screen_handler_sync_handler: Arc::new(SyncHandler::new()),
+            container: PersistentDataContainer::new(),
         }
     }
 

--- a/pumpkin/src/plugin/api/mod.rs
+++ b/pumpkin/src/plugin/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod context;
 pub mod events;
+pub mod persistence;
 
 use async_trait::async_trait;
 pub use context::*;

--- a/pumpkin/src/plugin/api/persistence/mod.rs
+++ b/pumpkin/src/plugin/api/persistence/mod.rs
@@ -1,0 +1,162 @@
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+
+/// The `NamespacedKey` struct
+#[allow(dead_code)]
+#[derive(Eq, Hash, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub struct NamespacedKey {
+    namespace: String,
+    key: String,
+}
+
+#[derive(Debug)]
+pub enum NamespacedKeyError {
+    NonAsciiNamespace,
+    NonAsciiKey,
+}
+
+/// The `NamespacedKey` constructor
+///
+/// `new()` must only be called via the `ns_key!` macro.
+///
+/// # Parameters
+/// - `namespace`: namespace of the key, must be equal to the `CARGO_PKG_NAME`
+/// - `key`: The key as a String
+///
+/// # Returns
+/// - Self
+impl NamespacedKey {
+    #[allow(dead_code)]
+    pub(crate) fn new(namespace: &str, key: &str) -> Result<Self, NamespacedKeyError> {
+        if !namespace.is_ascii() {
+            log::error!("Invalid namespace: '{namespace}' is not pure ASCII.");
+            return Err(NamespacedKeyError::NonAsciiNamespace);
+        }
+        if !key.is_ascii() {
+            log::error!("Invalid key: '{key}' is not pure ASCII.");
+            return Err(NamespacedKeyError::NonAsciiKey);
+        }
+
+        Ok(Self {
+            namespace: namespace.to_ascii_lowercase(),
+            key: key.to_ascii_lowercase(),
+        })
+    }
+}
+
+/// A macro used to create a new `NamespacedKey` without having to manually pass the `CARGO_PKG_NAME` by using the `env!()` macro
+///
+/// # Parameters
+/// - `$value`: the key you want to create as a String.
+#[macro_export]
+macro_rules! ns_key {
+    ($value:expr) => {
+        match $crate::plugin::NamespacedKey::new(env!("CARGO_PKG_NAME"), $value) {
+            Ok(key) => key,
+            Err(e) => panic!("Invalid key: {:?}", e),
+        }
+    };
+}
+
+/// The `PersistentDataContainer` struct
+///
+/// This struct contains `NamespacedKey`s and associates them with `PersistentValue`s using a `DashMap` for maximum concurrency.
+#[allow(dead_code)]
+#[derive(Default, Debug)]
+pub struct PersistentDataContainer {
+    pub data: DashMap<NamespacedKey, PersistentValue>,
+}
+
+#[allow(dead_code)]
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+pub enum PersistentValue {
+    Bool(bool),
+    String(String),
+    Char(char),
+    I32(i32),
+    I64(i64),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    F32(f32),
+    F64(f64),
+    Bytes(Vec<u8>),
+    List(Vec<PersistentValue>),
+}
+
+impl PersistentDataContainer {
+    pub(crate) fn new() -> Self {
+        Self {
+            data: DashMap::new(),
+        }
+    }
+
+    pub fn clear(&self) {
+        self.data.clear();
+    }
+
+    #[must_use]
+    pub fn get(&self, key: &NamespacedKey) -> Option<PersistentValue> {
+        self.data.get(key).map(|v| v.clone())
+    }
+
+    pub fn insert(&self, key: &NamespacedKey, value: PersistentValue) {
+        self.data.insert(key.clone(), value);
+    }
+
+    #[must_use]
+    pub fn remove(&self, key: &NamespacedKey) -> Option<(NamespacedKey, PersistentValue)> {
+        self.data.remove(key)
+    }
+
+    #[must_use]
+    pub fn contains_key(&self, key: &NamespacedKey) -> bool {
+        self.data.contains_key(key)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (NamespacedKey, PersistentValue)> + '_ {
+        self.data
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+    }
+}
+
+pub trait HasPersistentContainer {
+    fn persistent_container(&self) -> &PersistentDataContainer;
+}
+
+pub trait PersistentDataHolder {
+    fn clear(&self);
+    fn get(&self, key: &NamespacedKey) -> Option<PersistentValue>;
+    fn insert(&self, key: &NamespacedKey, value: PersistentValue);
+    fn remove(&self, key: &NamespacedKey) -> Option<PersistentValue>;
+    fn contains_key(&self, key: &NamespacedKey) -> bool;
+    fn iter(&self) -> Box<dyn Iterator<Item = (NamespacedKey, PersistentValue)> + '_>;
+}
+
+impl<T: HasPersistentContainer> PersistentDataHolder for T {
+    fn clear(&self) {
+        self.persistent_container().clear();
+    }
+
+    fn get(&self, key: &NamespacedKey) -> Option<PersistentValue> {
+        self.persistent_container().get(key)
+    }
+
+    fn insert(&self, key: &NamespacedKey, value: PersistentValue) {
+        self.persistent_container().insert(key, value);
+    }
+
+    fn remove(&self, key: &NamespacedKey) -> Option<PersistentValue> {
+        self.persistent_container().remove(key).map(|(_, v)| v)
+    }
+
+    fn contains_key(&self, key: &NamespacedKey) -> bool {
+        self.persistent_container().contains_key(key)
+    }
+
+    fn iter(&self) -> Box<dyn Iterator<Item = (NamespacedKey, PersistentValue)> + '_> {
+        Box::new(self.persistent_container().iter())
+    }
+}


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This PR aims to add the covetted `PersitentDataContainer` feature to the Plugin API, but there are still some things I need to consider:
- [ ] Possibly convert `PersistentDataHolder` from a derive macro to an attribute macro for more flexibility
- [ ] Better way to "add" values to existing `NamespacedKey`, instead of overriding every time (automatic listing?)
- [ ] Add error handling when plugin dev tries to register an already existing key
- [ ] Implement for more types

## Testing
TODO

