### PR TITLE
Fix Nightly Clippy Warnings

### DIFF
--- a/pumpkin-macros/src/lib.rs
+++ b/pumpkin-macros/src/lib.rs
@@ -85,13 +85,13 @@ pub fn send_cancellable(input: TokenStream) -> TokenStream {
         if let Stmt::Expr(expr, _) = stmt {
             if event.is_none() {
                 event = Some(expr);
-            } else if let Expr::Block(b) = expr {
-                if let Some(ref label) = b.label {
-                    if label.name.ident == "after" {
-                        after_block = Some(b);
-                    } else if label.name.ident == "cancelled" {
-                        cancelled_block = Some(b);
-                    }
+            } else if let Expr::Block(b) = expr
+                && let Some(ref label) = b.label
+            {
+                if label.name.ident == "after" {
+                    after_block = Some(b);
+                } else if label.name.ident == "cancelled" {
+                    cancelled_block = Some(b);
                 }
             }
         }

--- a/pumpkin-protocol/src/codec/var_uint.rs
+++ b/pumpkin-protocol/src/codec/var_uint.rs
@@ -118,11 +118,9 @@ gen_from!(u32);
 
 macro_rules! gen_try_from {
     ($ty: ty) => {
-        impl TryFrom<$ty> for VarUInt {
-            type Error = <i32 as TryFrom<$ty>>::Error;
-
-            fn try_from(value: $ty) -> Result<Self, Self::Error> {
-                Ok(VarUInt(value as u32))
+        impl From<$ty> for VarUInt {
+            fn from(value: $ty) -> VarUInt {
+                VarUInt(value as u32)
             }
         }
     };

--- a/pumpkin-protocol/src/codec/var_uint.rs
+++ b/pumpkin-protocol/src/codec/var_uint.rs
@@ -118,9 +118,11 @@ gen_from!(u32);
 
 macro_rules! gen_try_from {
     ($ty: ty) => {
-        impl From<$ty> for VarUInt {
-            fn from(value: $ty) -> VarUInt {
-                VarUInt(value as u32)
+        impl TryFrom<$ty> for VarUInt {
+            type Error = <i32 as TryFrom<$ty>>::Error;
+
+            fn try_from(value: $ty) -> Result<Self, Self::Error> {
+                Ok(VarUInt(value as u32))
             }
         }
     };

--- a/pumpkin-util/src/math/vector3.rs
+++ b/pumpkin-util/src/math/vector3.rs
@@ -303,12 +303,11 @@ impl<'de> serde::Deserialize<'de> for Vector3<i32> {
             where
                 A: serde::de::SeqAccess<'de>,
             {
-                if let Some(x) = seq.next_element::<i32>()? {
-                    if let Some(y) = seq.next_element::<i32>()? {
-                        if let Some(z) = seq.next_element::<i32>()? {
-                            return Ok(Vector3::new(x, y, z));
-                        }
-                    }
+                if let Some(x) = seq.next_element::<i32>()?
+                    && let Some(y) = seq.next_element::<i32>()?
+                    && let Some(z) = seq.next_element::<i32>()?
+                {
+                    return Ok(Vector3::new(x, y, z));
                 }
                 Err(serde::de::Error::custom("Failed to read Vector<i32>"))
             }
@@ -336,12 +335,11 @@ impl<'de> serde::Deserialize<'de> for Vector3<f32> {
             where
                 A: serde::de::SeqAccess<'de>,
             {
-                if let Some(x) = seq.next_element::<f32>()? {
-                    if let Some(y) = seq.next_element::<f32>()? {
-                        if let Some(z) = seq.next_element::<f32>()? {
-                            return Ok(Vector3::new(x, y, z));
-                        }
-                    }
+                if let Some(x) = seq.next_element::<f32>()?
+                    && let Some(y) = seq.next_element::<f32>()?
+                    && let Some(z) = seq.next_element::<f32>()?
+                {
+                    return Ok(Vector3::new(x, y, z));
                 }
                 Err(serde::de::Error::custom("Failed to read Vector<f32>"))
             }
@@ -369,12 +367,11 @@ impl<'de> serde::Deserialize<'de> for Vector3<f64> {
             where
                 A: serde::de::SeqAccess<'de>,
             {
-                if let Some(x) = seq.next_element::<f64>()? {
-                    if let Some(y) = seq.next_element::<f64>()? {
-                        if let Some(z) = seq.next_element::<f64>()? {
-                            return Ok(Vector3::new(x, y, z));
-                        }
-                    }
+                if let Some(x) = seq.next_element::<f64>()?
+                    && let Some(y) = seq.next_element::<f64>()?
+                    && let Some(z) = seq.next_element::<f64>()?
+                {
+                    return Ok(Vector3::new(x, y, z));
                 }
                 Err(serde::de::Error::custom("Failed to read Vector<f64>"))
             }

--- a/pumpkin-util/src/permission.rs
+++ b/pumpkin-util/src/permission.rs
@@ -197,10 +197,10 @@ impl PermissionManager {
 
             // Check for inherited permissions from parent nodes
             for (node, value) in attachment.get_permissions() {
-                if let Some(permission) = reg.get_permission(node) {
-                    if permission.children.contains_key(permission_node) {
-                        return *value && *permission.children.get(permission_node).unwrap();
-                    }
+                if let Some(permission) = reg.get_permission(node)
+                    && permission.children.contains_key(permission_node)
+                {
+                    return *value && *permission.children.get(permission_node).unwrap();
                 }
             }
         }

--- a/pumpkin-world/src/block/entities/dropper.rs
+++ b/pumpkin-world/src/block/entities/dropper.rs
@@ -69,7 +69,7 @@ impl DropperBlockEntity {
             dirty: AtomicBool::new(false),
         }
     }
-    pub async fn get_random_slot(&self) -> Option<MutexGuard<ItemStack>> {
+    pub async fn get_random_slot(&self) -> Option<MutexGuard<'_, ItemStack>> {
         // this.unpackLootTable(null);
         let mut ret = None;
         let mut j = 0;

--- a/pumpkin-world/src/data/player_data.rs
+++ b/pumpkin-world/src/data/player_data.rs
@@ -28,10 +28,10 @@ impl PlayerDataStorage {
     /// Creates a new `PlayerDataStorage` with the specified data path and cache expiration time.
     pub fn new(data_path: impl Into<PathBuf>) -> Self {
         let path = data_path.into();
-        if !path.exists() {
-            if let Err(e) = create_dir_all(&path) {
-                log::error!("Failed to create player data directory at {path:?}: {e}");
-            }
+        if !path.exists()
+            && let Err(e) = create_dir_all(&path)
+        {
+            log::error!("Failed to create player data directory at {path:?}: {e}");
         }
 
         Self {
@@ -126,11 +126,11 @@ impl PlayerDataStorage {
         let path = self.get_player_data_path(uuid);
 
         // Ensure parent directory exists
-        if let Some(parent) = path.parent() {
-            if let Err(e) = create_dir_all(parent) {
-                log::error!("Failed to create player data directory for {uuid}: {e}");
-                return Err(PlayerDataError::Io(e));
-            }
+        if let Some(parent) = path.parent()
+            && let Err(e) = create_dir_all(parent)
+        {
+            log::error!("Failed to create player data directory for {uuid}: {e}");
+            return Err(PlayerDataError::Io(e));
         }
 
         // Create the file and write directly with GZip compression

--- a/pumpkin-world/src/inventory/inventory.rs
+++ b/pumpkin-world/src/inventory/inventory.rs
@@ -63,15 +63,15 @@ pub trait Inventory: Send + Sync + Debug + Clearable {
     ) {
         if let Some(inventory_list) = nbt.get_list("Items") {
             for tag in inventory_list {
-                if let Some(item_compound) = tag.extract_compound() {
-                    if let Some(slot_byte) = item_compound.get_byte("Slot") {
-                        let slot = slot_byte as usize;
-                        if slot < stacks.len() {
-                            if let Some(item_stack) = ItemStack::read_item_stack(item_compound) {
-                                // This won't error cause it's only called on initialization
-                                *stacks[slot].try_lock().unwrap() = item_stack;
-                            }
-                        }
+                if let Some(item_compound) = tag.extract_compound()
+                    && let Some(slot_byte) = item_compound.get_byte("Slot")
+                {
+                    let slot = slot_byte as usize;
+                    if slot < stacks.len()
+                        && let Some(item_stack) = ItemStack::read_item_stack(item_compound)
+                    {
+                        // This won't error cause it's only called on initialization
+                        *stacks[slot].try_lock().unwrap() = item_stack;
                     }
                 }
             }

--- a/pumpkin-world/src/item/mod.rs
+++ b/pumpkin-world/src/item/mod.rs
@@ -133,10 +133,9 @@ impl ItemStack {
                     // Check if block is in the tag group
                     if let Some(blocks) =
                         get_tag_values(RegistryKey::Block, entry.strip_prefix('#').unwrap())
+                        && blocks.contains(&block)
                     {
-                        if blocks.contains(&block) {
-                            return speed;
-                        }
+                        return speed;
                     }
                 }
             }
@@ -168,10 +167,9 @@ impl ItemStack {
                     // Check if block exists within the tag group
                     if let Some(blocks) =
                         get_tag_values(RegistryKey::Block, entry.strip_prefix('#').unwrap())
+                        && blocks.contains(&block)
                     {
-                        if blocks.contains(&block) {
-                            return correct_for_drops;
-                        }
+                        return correct_for_drops;
                     }
                 }
             }

--- a/pumpkin/src/command/args/block.rs
+++ b/pumpkin/src/command/args/block.rs
@@ -17,7 +17,7 @@ use super::{
 pub struct BlockArgumentConsumer;
 
 impl GetClientSideArgParser for BlockArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::BlockState
     }
 
@@ -92,7 +92,7 @@ pub enum BlockPredicate {
 }
 
 impl GetClientSideArgParser for BlockPredicateArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::BlockPredicate
     }
 

--- a/pumpkin/src/command/args/bool.rs
+++ b/pumpkin/src/command/args/bool.rs
@@ -9,7 +9,7 @@ use pumpkin_protocol::java::client::play::{ArgumentType, CommandSuggestion, Sugg
 pub struct BoolArgConsumer;
 
 impl GetClientSideArgParser for BoolArgConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Bool
     }
 

--- a/pumpkin/src/command/args/bossbar_color.rs
+++ b/pumpkin/src/command/args/bossbar_color.rs
@@ -12,7 +12,7 @@ use pumpkin_protocol::java::client::play::{ArgumentType, CommandSuggestion, Sugg
 pub struct BossbarColorArgumentConsumer;
 
 impl GetClientSideArgParser for BossbarColorArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         // Not sure if this is right...
         ArgumentType::ResourceLocation
     }

--- a/pumpkin/src/command/args/bossbar_style.rs
+++ b/pumpkin/src/command/args/bossbar_style.rs
@@ -12,7 +12,7 @@ use pumpkin_protocol::java::client::play::{ArgumentType, CommandSuggestion, Sugg
 pub struct BossbarStyleArgumentConsumer;
 
 impl GetClientSideArgParser for BossbarStyleArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         // Not sure if this is right...
         ArgumentType::ResourceLocation
     }

--- a/pumpkin/src/command/args/bounded_num.rs
+++ b/pumpkin/src/command/args/bounded_num.rs
@@ -198,7 +198,7 @@ impl ToFromNumber for f64 {
 }
 
 impl GetClientSideArgParser for BoundedNumArgumentConsumer<f64> {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Double {
             min: self.min_inclusive,
             max: self.max_inclusive,
@@ -226,7 +226,7 @@ impl ToFromNumber for f32 {
 }
 
 impl GetClientSideArgParser for BoundedNumArgumentConsumer<f32> {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Float {
             min: self.min_inclusive,
             max: self.max_inclusive,
@@ -254,7 +254,7 @@ impl ToFromNumber for i32 {
 }
 
 impl GetClientSideArgParser for BoundedNumArgumentConsumer<i32> {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Integer {
             min: self.min_inclusive,
             max: self.max_inclusive,
@@ -282,7 +282,7 @@ impl ToFromNumber for i64 {
 }
 
 impl GetClientSideArgParser for BoundedNumArgumentConsumer<i64> {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Long {
             min: self.min_inclusive,
             max: self.max_inclusive,

--- a/pumpkin/src/command/args/command.rs
+++ b/pumpkin/src/command/args/command.rs
@@ -18,7 +18,7 @@ use super::{Arg, ArgumentConsumer, DefaultNameArgConsumer, FindArg, GetClientSid
 pub struct CommandTreeArgumentConsumer;
 
 impl GetClientSideArgParser for CommandTreeArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::String(StringProtoArgBehavior::SingleWord)
     }
 

--- a/pumpkin/src/command/args/difficulty.rs
+++ b/pumpkin/src/command/args/difficulty.rs
@@ -14,7 +14,7 @@ use super::{Arg, ArgumentConsumer, DefaultNameArgConsumer, FindArg, GetClientSid
 pub struct DifficultyArgumentConsumer;
 
 impl GetClientSideArgParser for DifficultyArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::String(
             pumpkin_protocol::java::client::play::StringProtoArgBehavior::SingleWord,
         )

--- a/pumpkin/src/command/args/entities.rs
+++ b/pumpkin/src/command/args/entities.rs
@@ -19,7 +19,7 @@ use super::{Arg, DefaultNameArgConsumer, FindArg, GetClientSideArgParser};
 pub struct EntitiesArgumentConsumer;
 
 impl GetClientSideArgParser for EntitiesArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         // todo: investigate why this does not accept target selectors
         ArgumentType::Entity { flags: 0 }
     }

--- a/pumpkin/src/command/args/entity.rs
+++ b/pumpkin/src/command/args/entity.rs
@@ -20,7 +20,7 @@ use super::{Arg, DefaultNameArgConsumer, FindArg, GetClientSideArgParser};
 pub struct EntityArgumentConsumer;
 
 impl GetClientSideArgParser for EntityArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         // todo: investigate why this does not accept target selectors
         ArgumentType::Entity {
             flags: ArgumentType::ENTITY_FLAG_ONLY_SINGLE,

--- a/pumpkin/src/command/args/gamemode.rs
+++ b/pumpkin/src/command/args/gamemode.rs
@@ -14,7 +14,7 @@ use super::{Arg, ArgumentConsumer, DefaultNameArgConsumer, FindArg, GetClientSid
 pub struct GamemodeArgumentConsumer;
 
 impl GetClientSideArgParser for GamemodeArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Gamemode
     }
 

--- a/pumpkin/src/command/args/message.rs
+++ b/pumpkin/src/command/args/message.rs
@@ -17,7 +17,7 @@ use super::{
 pub struct MsgArgConsumer;
 
 impl GetClientSideArgParser for MsgArgConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::String(StringProtoArgBehavior::GreedyPhrase)
     }
 

--- a/pumpkin/src/command/args/mod.rs
+++ b/pumpkin/src/command/args/mod.rs
@@ -72,7 +72,7 @@ pub trait ArgumentConsumer: Sync + GetClientSideArgParser {
 
 pub trait GetClientSideArgParser {
     /// Return the parser the client should use while typing a command in chat.
-    fn get_client_side_parser(&self) -> ArgumentType;
+    fn get_client_side_parser(&self) -> ArgumentType<'_>;
     /// Usually this should return None. This can be used to force suggestions to be processed on serverside.
     fn get_client_side_suggestion_type_override(&self) -> Option<SuggestionProviders>;
 }

--- a/pumpkin/src/command/args/players.rs
+++ b/pumpkin/src/command/args/players.rs
@@ -16,7 +16,7 @@ use super::{Arg, DefaultNameArgConsumer, FindArg, GetClientSideArgParser};
 pub struct PlayersArgumentConsumer;
 
 impl GetClientSideArgParser for PlayersArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         // todo: investigate why this does not accept target selectors
         ArgumentType::Entity {
             flags: ArgumentType::ENTITY_FLAG_PLAYERS_ONLY,

--- a/pumpkin/src/command/args/position_2d.rs
+++ b/pumpkin/src/command/args/position_2d.rs
@@ -18,7 +18,7 @@ use super::{Arg, DefaultNameArgConsumer, FindArg, GetClientSideArgParser};
 pub struct Position2DArgumentConsumer;
 
 impl GetClientSideArgParser for Position2DArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Vec2
     }
 

--- a/pumpkin/src/command/args/position_3d.rs
+++ b/pumpkin/src/command/args/position_3d.rs
@@ -15,7 +15,7 @@ use super::{Arg, DefaultNameArgConsumer, FindArg, GetClientSideArgParser};
 pub struct Position3DArgumentConsumer;
 
 impl GetClientSideArgParser for Position3DArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Vec3
     }
 

--- a/pumpkin/src/command/args/position_block.rs
+++ b/pumpkin/src/command/args/position_block.rs
@@ -16,7 +16,7 @@ use super::{Arg, DefaultNameArgConsumer, FindArg, GetClientSideArgParser};
 pub struct BlockPosArgumentConsumer;
 
 impl GetClientSideArgParser for BlockPosArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::BlockPos
     }
 

--- a/pumpkin/src/command/args/resource/damage_type.rs
+++ b/pumpkin/src/command/args/resource/damage_type.rs
@@ -16,7 +16,7 @@ use crate::server::Server;
 pub struct DamageTypeArgumentConsumer;
 
 impl GetClientSideArgParser for DamageTypeArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Resource {
             identifier: "damage_type",
         }

--- a/pumpkin/src/command/args/resource/effect.rs
+++ b/pumpkin/src/command/args/resource/effect.rs
@@ -16,7 +16,7 @@ use crate::server::Server;
 pub struct EffectTypeArgumentConsumer;
 
 impl GetClientSideArgParser for EffectTypeArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Resource {
             identifier: "mob_effect",
         }

--- a/pumpkin/src/command/args/resource/enchantment.rs
+++ b/pumpkin/src/command/args/resource/enchantment.rs
@@ -16,7 +16,7 @@ use crate::server::Server;
 pub struct EnchantmentArgumentConsumer;
 
 impl GetClientSideArgParser for EnchantmentArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Resource {
             identifier: "enchantment",
         }

--- a/pumpkin/src/command/args/resource/item.rs
+++ b/pumpkin/src/command/args/resource/item.rs
@@ -17,7 +17,7 @@ use crate::server::Server;
 pub struct ItemArgumentConsumer;
 
 impl GetClientSideArgParser for ItemArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Resource { identifier: "item" }
     }
 

--- a/pumpkin/src/command/args/resource/particle.rs
+++ b/pumpkin/src/command/args/resource/particle.rs
@@ -16,7 +16,7 @@ use crate::server::Server;
 pub struct ParticleArgumentConsumer;
 
 impl GetClientSideArgParser for ParticleArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Resource {
             identifier: "particle_type",
         }

--- a/pumpkin/src/command/args/resource_location.rs
+++ b/pumpkin/src/command/args/resource_location.rs
@@ -13,7 +13,7 @@ pub struct ResourceLocationArgumentConsumer {
 }
 
 impl GetClientSideArgParser for ResourceLocationArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::ResourceLocation
     }
 

--- a/pumpkin/src/command/args/rotation.rs
+++ b/pumpkin/src/command/args/rotation.rs
@@ -13,7 +13,7 @@ use super::{Arg, DefaultNameArgConsumer, FindArg, GetClientSideArgParser};
 pub struct RotationArgumentConsumer;
 
 impl GetClientSideArgParser for RotationArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Rotation
     }
 

--- a/pumpkin/src/command/args/simple.rs
+++ b/pumpkin/src/command/args/simple.rs
@@ -18,7 +18,7 @@ use super::{
 pub struct SimpleArgConsumer;
 
 impl GetClientSideArgParser for SimpleArgConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::String(StringProtoArgBehavior::SingleWord)
     }
 

--- a/pumpkin/src/command/args/sound.rs
+++ b/pumpkin/src/command/args/sound.rs
@@ -16,7 +16,7 @@ use super::{
 pub struct SoundArgumentConsumer;
 
 impl GetClientSideArgParser for SoundArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::ResourceLocation
     }
 

--- a/pumpkin/src/command/args/sound_category.rs
+++ b/pumpkin/src/command/args/sound_category.rs
@@ -13,7 +13,7 @@ use pumpkin_protocol::java::client::play::{ArgumentType, CommandSuggestion, Sugg
 pub struct SoundCategoryArgumentConsumer;
 
 impl GetClientSideArgParser for SoundCategoryArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         // ResourceLocation is used for enumerated string values
         ArgumentType::ResourceLocation
     }

--- a/pumpkin/src/command/args/summonable_entities.rs
+++ b/pumpkin/src/command/args/summonable_entities.rs
@@ -16,7 +16,7 @@ use super::{
 pub struct SummonableEntitiesArgumentConsumer;
 
 impl GetClientSideArgParser for SummonableEntitiesArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::ResourceLocation
     }
 

--- a/pumpkin/src/command/args/textcomponent.rs
+++ b/pumpkin/src/command/args/textcomponent.rs
@@ -10,7 +10,7 @@ use pumpkin_util::text::TextComponent;
 pub struct TextComponentArgConsumer;
 
 impl GetClientSideArgParser for TextComponentArgConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Component
     }
 

--- a/pumpkin/src/command/args/time.rs
+++ b/pumpkin/src/command/args/time.rs
@@ -12,7 +12,7 @@ use crate::server::Server;
 pub struct TimeArgumentConsumer;
 
 impl GetClientSideArgParser for TimeArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
         ArgumentType::Time { min: 0 }
     }
 

--- a/pumpkin/src/item/items/honeycomb.rs
+++ b/pumpkin/src/item/items/honeycomb.rs
@@ -35,11 +35,11 @@ impl PumpkinItem for HoneyCombItem {
         // First we try to strip the block. by getting his equivalent and applying it the axis.
         let replacement_block = get_waxed_equivalent(block);
         // If there is a strip equivalent.
-        if replacement_block.is_some() {
+        if let Some(replacement_block) = replacement_block {
             // get block state of the old log.
             // get the log properties
             // create new properties for the new log.
-            let new_block = &Block::from_id(replacement_block.unwrap());
+            let new_block = &Block::from_id(replacement_block);
 
             let new_state_id = if block.is_tagged_with("#minecraft:doors").is_some()
                 && block.is_tagged_with("#minecraft:doors").unwrap()

--- a/pumpkin/src/net/bedrock/connection.rs
+++ b/pumpkin/src/net/bedrock/connection.rs
@@ -22,7 +22,7 @@ impl BedrockClientPlatform {
                 SocketAddress(self.address),
                 0,
                 [SocketAddress(SocketAddr::V4(SocketAddrV4::new(
-                    Ipv4Addr::new(0, 0, 0, 0),
+                    Ipv4Addr::UNSPECIFIED,
                     19132,
                 ))); 10],
                 packet.time,

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -357,7 +357,7 @@ impl PluginManager {
 
     /// Get list of active plugins
     #[must_use]
-    pub fn active_plugins(&self) -> Vec<&PluginMetadata> {
+    pub fn active_plugins(&self) -> Vec<&PluginMetadata<'_>> {
         self.plugins
             .iter()
             .filter(|p| p.is_active)
@@ -373,7 +373,7 @@ impl PluginManager {
 
     /// Get list of loaded plugins
     #[must_use]
-    pub fn loaded_plugins(&self) -> Vec<&PluginMetadata> {
+    pub fn loaded_plugins(&self) -> Vec<&PluginMetadata<'_>> {
         self.plugins.iter().map(|p| &p.metadata).collect()
     }
 

--- a/pumpkin/src/server/connection_cache.rs
+++ b/pumpkin/src/server/connection_cache.rs
@@ -46,7 +46,7 @@ impl CachedBranding {
             cached_server_brand,
         }
     }
-    pub fn get_branding(&self) -> CPluginMessage {
+    pub fn get_branding(&self) -> CPluginMessage<'_> {
         CPluginMessage::new("minecraft:brand", &self.cached_server_brand)
     }
     const BRAND: &str = "Pumpkin";

--- a/pumpkin/src/world/custom_bossbar.rs
+++ b/pumpkin/src/world/custom_bossbar.rs
@@ -108,7 +108,7 @@ impl CustomBossbars {
         &mut self,
         server: &Server,
         resource_location: String,
-    ) -> Result<(), BossbarUpdateError> {
+    ) -> Result<(), BossbarUpdateError<'_>> {
         let bossbar = self.custom_bossbars.get_cloned(&resource_location);
         if let Some(bossbar) = bossbar {
             self.custom_bossbars.remove(&resource_location);
@@ -144,7 +144,7 @@ impl CustomBossbars {
         resource_location: String,
         max_value: u32,
         value: u32,
-    ) -> Result<(), BossbarUpdateError> {
+    ) -> Result<(), BossbarUpdateError<'_>> {
         let bossbar = self.custom_bossbars.get_mut(&resource_location);
         if let Some(bossbar) = bossbar {
             if bossbar.value == value && bossbar.max == max_value {
@@ -193,7 +193,7 @@ impl CustomBossbars {
         server: &Server,
         resource_location: String,
         new_visibility: bool,
-    ) -> Result<(), BossbarUpdateError> {
+    ) -> Result<(), BossbarUpdateError<'_>> {
         let bossbar = self.custom_bossbars.get_mut(&resource_location);
         if let Some(bossbar) = bossbar {
             if bossbar.visible == new_visibility && new_visibility {
@@ -232,7 +232,7 @@ impl CustomBossbars {
         server: &Server,
         resource_location: &str,
         new_title: TextComponent,
-    ) -> Result<(), BossbarUpdateError> {
+    ) -> Result<(), BossbarUpdateError<'_>> {
         let bossbar = self.custom_bossbars.get_mut(resource_location);
         if let Some(bossbar) = bossbar {
             if bossbar.bossbar_data.title == new_title {
@@ -271,7 +271,7 @@ impl CustomBossbars {
         server: &Server,
         resource_location: String,
         new_color: BossbarColor,
-    ) -> Result<(), BossbarUpdateError> {
+    ) -> Result<(), BossbarUpdateError<'_>> {
         let bossbar = self.custom_bossbars.get_mut(&resource_location);
         if let Some(bossbar) = bossbar {
             if bossbar.bossbar_data.color == new_color {
@@ -311,7 +311,7 @@ impl CustomBossbars {
         server: &Server,
         resource_location: String,
         new_division: BossbarDivisions,
-    ) -> Result<(), BossbarUpdateError> {
+    ) -> Result<(), BossbarUpdateError<'_>> {
         let bossbar = self.custom_bossbars.get_mut(&resource_location);
         if let Some(bossbar) = bossbar {
             if bossbar.bossbar_data.division == new_division {
@@ -351,7 +351,7 @@ impl CustomBossbars {
         server: &Server,
         resource_location: String,
         new_players: Vec<Uuid>,
-    ) -> Result<(), BossbarUpdateError> {
+    ) -> Result<(), BossbarUpdateError<'_>> {
         let bossbar = self.custom_bossbars.get_mut(&resource_location);
         if let Some(bossbar) = bossbar {
             // Get the difference between the old and new player list and remove bossbars from old players.


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

Become mostly nightly clippy compliant. DataPool, Music and MilkBucketItem are problems that cannot easily be resolved.

```
warning: struct `DataPool` is never constructed
  --> pumpkin-registry/src/lib.rs:77:8
   |
77 | struct DataPool<T> {
   |        ^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: struct `Music` is never constructed
  --> pumpkin-registry/src/biome.rs:65:8
   |
65 | struct Music {
   |        ^^^^^

warning: `pumpkin-registry` (lib) generated 2 warnings
    Checking pumpkin v0.1.0-dev+1.21.7 (/workspaces/Pumpkin/pumpkin)
warning: struct `MilkBucketItem` is never constructed
  --> pumpkin/src/item/items/bucket.rs:23:12
   |
23 | pub struct MilkBucketItem;
   |            ^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `pumpkin` (lib) generated 1 warning
```
## Testing

None but should only be syntactical changes, not logic ones.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
