### PR TITLE
PluginAPI / Add schedulers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,6 +1905,7 @@ dependencies = [
  "libloading",
  "log",
  "num-bigint",
+ "once_cell",
  "png",
  "pumpkin-config",
  "pumpkin-data",

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -35,6 +35,7 @@ rayon.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
 futures.workspace = true
+once_cell = "1.21.3"
 
 # config
 serde.workspace = true

--- a/pumpkin/src/plugin/api/mod.rs
+++ b/pumpkin/src/plugin/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod context;
 pub mod events;
+pub mod task;
 
 use async_trait::async_trait;
 pub use context::*;

--- a/pumpkin/src/plugin/api/task/mod.rs
+++ b/pumpkin/src/plugin/api/task/mod.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use tokio::time::{Duration, sleep};
+use once_cell::sync::Lazy;
+
+pub static TOKIO_RUNTIME: Lazy<Runtime> =
+    Lazy::new(|| Runtime::new().expect("Failed to create global Tokio Runtime"));
+
+#[async_trait::async_trait]
+pub trait TaskHandler: Send + Sync {
+    async fn run(&self);
+    async fn cancel(&self);
+}
+
+pub fn start_loop<H>(delay: Duration, handler: Arc<H>)
+where
+    H: TaskHandler + 'static,
+{
+    TOKIO_RUNTIME.spawn(run_task_timer(delay, handler));
+}
+
+async fn run_task_timer<H>(delay: Duration, handler: Arc<H>)
+where
+    H: TaskHandler + 'static,
+{
+    loop {
+        sleep(delay).await;
+        handler.run().await;
+    }
+}
+
+async fn run_task_later<H>(delay: Duration, handler: Arc<H>)
+where
+    H: TaskHandler + 'static,
+{
+    sleep(delay).await;
+    handler.run().await;
+}
+
+#[macro_export]
+macro_rules! run_task_timer {
+    ($delay:expr, $body:block) => {{
+        use std::sync::Arc;
+        use $crate::task::{start_loop, TaskHandler};
+
+        struct InlineHandler;
+
+        #[async_trait::async_trait]
+        impl TaskHandler for InlineHandler {
+            async fn run(&self) $body
+        }
+
+        let handler = Arc::new(InlineHandler);
+        start_loop($delay, handler);
+    }};
+}
+
+#[macro_export]
+macro_rules! run_task_later {
+    ($delay:expr, $body:block) => {{
+        use std::sync::Arc;
+        use $crate::task::{run_task_later, TaskHandler};
+        use async_trait::async_trait;
+
+        struct InlineHandler;
+
+        #[async_trait]
+        impl TaskHandler for InlineHandler {
+            async fn run(&self) $body
+        }
+
+        let handler = Arc::new(InlineHandler);
+
+        $crate::TOKIO_RUNTIME.spawn(run_task_later($delay, handler));
+    }};
+}
+


### PR DESCRIPTION
## Description
This PR aims to add the usefull makros `run_task_later!` and `run_task_timer!` to mimic the behaviour of bukkit runnables, which are frequently used in bukkit plugins.

