### PR TITLE
Add macro for expanding tags to PumpkinBlock

### DIFF
--- a/pumpkin-macros/src/lib.rs
+++ b/pumpkin-macros/src/lib.rs
@@ -205,6 +205,35 @@ pub fn pumpkin_block(input: TokenStream, item: TokenStream) -> TokenStream {
     code.into()
 }
 
+#[proc_macro_attribute]
+pub fn pumpkin_block_from_tag(input: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: syn::DeriveInput = syn::parse(item.clone()).unwrap();
+    let name = &ast.ident;
+    let (impl_generics, ty_generics, _) = ast.generics.split_for_impl();
+
+    let input_string = input.to_string();
+    let packet_name = input_string.trim_matches('"');
+    let packet_name_split: Vec<&str> = packet_name.split(":").collect();
+
+    let namespace = packet_name_split[0];
+
+    let item: proc_macro2::TokenStream = item.into();
+
+    let code = quote! {
+        #item
+        impl #impl_generics crate::block::pumpkin_block::BlockMetadata for #name #ty_generics {
+            fn namespace(&self) -> &'static str {
+                #namespace
+            }
+            fn ids(&self) -> &'static [&'static str] {
+                get_tag_values(RegistryKey::Block, #packet_name).unwrap()
+            }
+        }
+    };
+
+    code.into()
+}
+
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn block_property(input: TokenStream, item: TokenStream) -> TokenStream {

--- a/pumpkin/src/block/blocks/anvil.rs
+++ b/pumpkin/src/block/blocks/anvil.rs
@@ -1,20 +1,12 @@
-use crate::block::pumpkin_block::{BlockMetadata, OnPlaceArgs, PumpkinBlock};
+use crate::block::pumpkin_block::{OnPlaceArgs, PumpkinBlock};
 use async_trait::async_trait;
 use pumpkin_data::block_properties::{BlockProperties, WallTorchLikeProperties};
 use pumpkin_data::tag::{RegistryKey, get_tag_values};
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_world::BlockStateId;
 
+#[pumpkin_block_from_tag("minecraft:anvil")]
 pub struct AnvilBlock;
-
-impl BlockMetadata for AnvilBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:anvil").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for AnvilBlock {

--- a/pumpkin/src/block/blocks/banners.rs
+++ b/pumpkin/src/block/blocks/banners.rs
@@ -1,21 +1,13 @@
-use crate::block::pumpkin_block::{BlockMetadata, OnPlaceArgs, PumpkinBlock};
+use crate::block::pumpkin_block::{OnPlaceArgs, PumpkinBlock};
 use crate::entity::EntityBase;
 use async_trait::async_trait;
 use pumpkin_data::block_properties::{BlockProperties, WhiteBannerLikeProperties};
 use pumpkin_data::tag::{RegistryKey, get_tag_values};
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_world::BlockStateId;
 
+#[pumpkin_block_from_tag("minecraft:banners")]
 pub struct BannerBlock;
-
-impl BlockMetadata for BannerBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:banners").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for BannerBlock {

--- a/pumpkin/src/block/blocks/bed.rs
+++ b/pumpkin/src/block/blocks/bed.rs
@@ -6,6 +6,7 @@ use pumpkin_data::block_properties::BedPart;
 use pumpkin_data::block_properties::BlockProperties;
 use pumpkin_data::entity::EntityType;
 use pumpkin_data::tag::{RegistryKey, get_tag_values};
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_registry::VanillaDimensionType;
 use pumpkin_util::GameMode;
 use pumpkin_util::math::position::BlockPos;
@@ -15,7 +16,7 @@ use pumpkin_world::block::entities::bed::BedBlockEntity;
 use pumpkin_world::world::BlockFlags;
 
 use crate::block::pumpkin_block::{
-    BlockMetadata, BrokenArgs, CanPlaceAtArgs, NormalUseArgs, OnPlaceArgs, PlacedArgs, PumpkinBlock,
+    BrokenArgs, CanPlaceAtArgs, NormalUseArgs, OnPlaceArgs, PlacedArgs, PumpkinBlock,
 };
 use crate::block::registry::BlockActionResult;
 use crate::entity::{Entity, EntityBase};
@@ -61,16 +62,8 @@ const NO_SLEEP_IDS: &[u16] = &[
     EntityType::ZOMBIFIED_PIGLIN.id,
 ];
 
+#[pumpkin_block_from_tag("minecraft:beds")]
 pub struct BedBlock;
-impl BlockMetadata for BedBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:beds").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for BedBlock {

--- a/pumpkin/src/block/blocks/candle_cakes.rs
+++ b/pumpkin/src/block/blocks/candle_cakes.rs
@@ -6,13 +6,14 @@ use pumpkin_data::{
     item::Item,
     tag::{RegistryKey, get_tag_values},
 };
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_util::{GameMode, math::position::BlockPos};
 use pumpkin_world::{item::ItemStack, world::BlockFlags};
 
 use crate::{
     block::{
         blocks::cake::CakeBlock,
-        pumpkin_block::{BlockMetadata, NormalUseArgs, PumpkinBlock, UseWithItemArgs},
+        pumpkin_block::{NormalUseArgs, PumpkinBlock, UseWithItemArgs},
         registry::BlockActionResult,
     },
     entity::player::Player,
@@ -59,17 +60,8 @@ pub fn candle_from_cake(block: &Block) -> &'static Item {
         )
 }
 
+#[pumpkin_block_from_tag("minecraft:candle_cakes")]
 pub struct CandleCakeBlock;
-
-impl BlockMetadata for CandleCakeBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:candle_cakes").unwrap()
-    }
-}
 
 impl CandleCakeBlock {
     async fn consume_and_drop_candle(

--- a/pumpkin/src/block/blocks/candles.rs
+++ b/pumpkin/src/block/blocks/candles.rs
@@ -6,13 +6,14 @@ use pumpkin_data::{
     item::Item,
     tag::{RegistryKey, get_tag_values},
 };
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_world::{BlockStateId, world::BlockFlags};
 
 use crate::{
     block::{
         BlockIsReplacing,
         pumpkin_block::{
-            BlockMetadata, CanPlaceAtArgs, CanUpdateAtArgs, NormalUseArgs, OnPlaceArgs,
+            CanPlaceAtArgs, CanUpdateAtArgs, NormalUseArgs, OnPlaceArgs,
             PumpkinBlock, UseWithItemArgs,
         },
         registry::BlockActionResult,
@@ -20,17 +21,8 @@ use crate::{
     entity::EntityBase,
 };
 
+#[pumpkin_block_from_tag("minecraft:candles")]
 pub struct CandleBlock;
-
-impl BlockMetadata for CandleBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:candles").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for CandleBlock {

--- a/pumpkin/src/block/blocks/carpet.rs
+++ b/pumpkin/src/block/blocks/carpet.rs
@@ -1,25 +1,17 @@
 use crate::block::pumpkin_block::{
-    BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, OnScheduledTickArgs, PumpkinBlock,
+    CanPlaceAtArgs, GetStateForNeighborUpdateArgs, OnScheduledTickArgs, PumpkinBlock,
 };
 use async_trait::async_trait;
 use pumpkin_data::tag::{RegistryKey, get_tag_values};
-use pumpkin_macros::pumpkin_block;
+use pumpkin_macros::{pumpkin_block, pumpkin_block_from_tag};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::BlockStateId;
 use pumpkin_world::chunk::TickPriority;
 use pumpkin_world::world::{BlockAccessor, BlockFlags};
 
+#[pumpkin_block_from_tag("minecraft:wool_carpets")]
 pub struct CarpetBlock;
 
-impl BlockMetadata for CarpetBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:wool_carpets").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for CarpetBlock {

--- a/pumpkin/src/block/blocks/doors.rs
+++ b/pumpkin/src/block/blocks/doors.rs
@@ -12,6 +12,7 @@ use pumpkin_data::sound::SoundCategory;
 use pumpkin_data::tag::RegistryKey;
 use pumpkin_data::tag::Tagable;
 use pumpkin_data::tag::get_tag_values;
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::BlockStateId;
 use pumpkin_world::world::BlockAccessor;
@@ -25,7 +26,7 @@ use crate::block::pumpkin_block::NormalUseArgs;
 use crate::block::pumpkin_block::OnNeighborUpdateArgs;
 use crate::block::pumpkin_block::OnPlaceArgs;
 use crate::block::pumpkin_block::PlacedArgs;
-use crate::block::pumpkin_block::{BlockMetadata, PumpkinBlock};
+use crate::block::pumpkin_block::PumpkinBlock;
 use crate::block::registry::BlockActionResult;
 use crate::entity::player::Player;
 use pumpkin_protocol::java::server::play::SUseItemOn;
@@ -161,16 +162,8 @@ async fn get_hinge(
     }
 }
 
+#[pumpkin_block_from_tag("minecraft:doors")]
 pub struct DoorBlock;
-impl BlockMetadata for DoorBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:doors").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for DoorBlock {

--- a/pumpkin/src/block/blocks/fence_gates.rs
+++ b/pumpkin/src/block/blocks/fence_gates.rs
@@ -9,11 +9,12 @@ use pumpkin_data::block_properties::BlockProperties;
 use pumpkin_data::tag::RegistryKey;
 use pumpkin_data::tag::Tagable;
 use pumpkin_data::tag::get_tag_values;
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::BlockStateId;
 use pumpkin_world::world::BlockFlags;
 
-use crate::block::pumpkin_block::{BlockMetadata, PumpkinBlock};
+use crate::block::pumpkin_block::PumpkinBlock;
 use crate::block::registry::BlockActionResult;
 use crate::world::World;
 
@@ -52,16 +53,8 @@ pub async fn toggle_fence_gate(
     fence_gate_props.to_state_id(block)
 }
 
+#[pumpkin_block_from_tag("minecraft:fence_gates")]
 pub struct FenceGateBlock;
-impl BlockMetadata for FenceGateBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "c:fence_gates").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for FenceGateBlock {

--- a/pumpkin/src/block/blocks/flower_pots.rs
+++ b/pumpkin/src/block/blocks/flower_pots.rs
@@ -1,23 +1,15 @@
-use crate::block::pumpkin_block::{BlockMetadata, PumpkinBlock, RandomTickArgs, UseWithItemArgs};
+use crate::block::pumpkin_block::{PumpkinBlock, RandomTickArgs, UseWithItemArgs};
 use crate::block::registry::BlockActionResult;
 use async_trait::async_trait;
 use pumpkin_data::Block;
 use pumpkin_data::flower_pot_transformations::get_potted_item;
 use pumpkin_data::tag::{RegistryKey, get_tag_values};
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_registry::VanillaDimensionType;
 use pumpkin_world::world::BlockFlags;
 
+#[pumpkin_block_from_tag("minecraft:flower_pots")]
 pub struct FlowerPotBlock;
-
-impl BlockMetadata for FlowerPotBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:flower_pots").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for FlowerPotBlock {

--- a/pumpkin/src/block/blocks/logs.rs
+++ b/pumpkin/src/block/blocks/logs.rs
@@ -1,24 +1,16 @@
 use async_trait::async_trait;
 use pumpkin_data::block_properties::BlockProperties;
-use pumpkin_data::tag::RegistryKey;
-use pumpkin_data::tag::get_tag_values;
+use pumpkin_data::tag::{RegistryKey, get_tag_values};
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_world::BlockStateId;
 
 use crate::block::pumpkin_block::OnPlaceArgs;
-use crate::block::pumpkin_block::{BlockMetadata, PumpkinBlock};
+use crate::block::pumpkin_block::PumpkinBlock;
 
 type LogProperties = pumpkin_data::block_properties::PaleOakWoodLikeProperties;
 
+#[pumpkin_block_from_tag("minecraft:logs")]
 pub struct LogBlock;
-impl BlockMetadata for LogBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:logs").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for LogBlock {

--- a/pumpkin/src/block/blocks/plant/sapling.rs
+++ b/pumpkin/src/block/blocks/plant/sapling.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use pumpkin_data::block_properties::{BlockProperties, Integer0To1};
 use pumpkin_data::tag::{RegistryKey, get_tag_values};
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::BlockStateId;
 use pumpkin_world::world::BlockFlags;
@@ -8,12 +9,13 @@ use std::sync::Arc;
 
 use crate::block::blocks::plant::PlantBlockBase;
 use crate::block::pumpkin_block::{
-    BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, PumpkinBlock, RandomTickArgs,
+    CanPlaceAtArgs, GetStateForNeighborUpdateArgs, PumpkinBlock, RandomTickArgs,
 };
 use crate::world::World;
 
 type SaplingProperties = pumpkin_data::block_properties::OakSaplingLikeProperties;
 
+#[pumpkin_block_from_tag("minecraft:saplings")]
 pub struct SaplingBlock;
 
 impl SaplingBlock {
@@ -28,16 +30,6 @@ impl SaplingBlock {
         } else {
             //TODO generate tree
         }
-    }
-}
-
-impl BlockMetadata for SaplingBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:saplings").unwrap()
     }
 }
 

--- a/pumpkin/src/block/blocks/redstone/buttons.rs
+++ b/pumpkin/src/block/blocks/redstone/buttons.rs
@@ -8,6 +8,7 @@ use pumpkin_data::block_properties::BlockFace;
 use pumpkin_data::block_properties::BlockProperties;
 use pumpkin_data::tag::RegistryKey;
 use pumpkin_data::tag::get_tag_values;
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::BlockStateId;
 use pumpkin_world::chunk::TickPriority;
@@ -24,7 +25,7 @@ use crate::block::pumpkin_block::GetStateForNeighborUpdateArgs;
 use crate::block::pumpkin_block::OnPlaceArgs;
 use crate::block::pumpkin_block::OnScheduledTickArgs;
 use crate::block::pumpkin_block::OnStateReplacedArgs;
-use crate::block::pumpkin_block::{BlockMetadata, NormalUseArgs, PumpkinBlock};
+use crate::block::pumpkin_block::{NormalUseArgs, PumpkinBlock};
 use crate::block::registry::BlockActionResult;
 use crate::world::World;
 
@@ -53,17 +54,8 @@ async fn click_button(world: &Arc<World>, block_pos: &BlockPos) {
     }
 }
 
+#[pumpkin_block_from_tag("minecraft:buttons")]
 pub struct ButtonBlock;
-
-impl BlockMetadata for ButtonBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:buttons").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for ButtonBlock {

--- a/pumpkin/src/block/blocks/signs.rs
+++ b/pumpkin/src/block/blocks/signs.rs
@@ -4,28 +4,20 @@ use async_trait::async_trait;
 use pumpkin_data::block_properties::BlockProperties;
 use pumpkin_data::tag::RegistryKey;
 use pumpkin_data::tag::get_tag_values;
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_world::block::entities::sign::SignBlockEntity;
 
 use crate::block::pumpkin_block::OnPlaceArgs;
 use crate::block::pumpkin_block::OnStateReplacedArgs;
 use crate::block::pumpkin_block::PlacedArgs;
 use crate::block::pumpkin_block::PlayerPlacedArgs;
-use crate::block::pumpkin_block::{BlockMetadata, PumpkinBlock};
+use crate::block::pumpkin_block::PumpkinBlock;
 use crate::entity::EntityBase;
 
 type SignProperties = pumpkin_data::block_properties::OakSignLikeProperties;
 
+#[pumpkin_block_from_tag("minecraft:signs")]
 pub struct SignBlock;
-
-impl BlockMetadata for SignBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:signs").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for SignBlock {

--- a/pumpkin/src/block/blocks/slabs.rs
+++ b/pumpkin/src/block/blocks/slabs.rs
@@ -4,26 +4,18 @@ use pumpkin_data::block_properties::BlockProperties;
 use pumpkin_data::block_properties::SlabType;
 use pumpkin_data::tag::RegistryKey;
 use pumpkin_data::tag::get_tag_values;
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_world::BlockStateId;
 
 use crate::block::BlockIsReplacing;
 use crate::block::pumpkin_block::CanUpdateAtArgs;
 use crate::block::pumpkin_block::OnPlaceArgs;
-use crate::block::pumpkin_block::{BlockMetadata, PumpkinBlock};
+use crate::block::pumpkin_block::PumpkinBlock;
 
 type SlabProperties = pumpkin_data::block_properties::ResinBrickSlabLikeProperties;
 
+#[pumpkin_block_from_tag("minecraft:slabs")]
 pub struct SlabBlock;
-
-impl BlockMetadata for SlabBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:slabs").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for SlabBlock {

--- a/pumpkin/src/block/blocks/stairs.rs
+++ b/pumpkin/src/block/blocks/stairs.rs
@@ -7,28 +7,20 @@ use pumpkin_data::block_properties::StairShape;
 use pumpkin_data::tag::RegistryKey;
 use pumpkin_data::tag::Tagable;
 use pumpkin_data::tag::get_tag_values;
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::BlockStateId;
 use pumpkin_world::world::BlockFlags;
 
 use crate::block::pumpkin_block::OnNeighborUpdateArgs;
 use crate::block::pumpkin_block::OnPlaceArgs;
-use crate::block::pumpkin_block::{BlockMetadata, PumpkinBlock};
+use crate::block::pumpkin_block::PumpkinBlock;
 use crate::world::World;
 
 type StairsProperties = pumpkin_data::block_properties::OakStairsLikeProperties;
 
+#[pumpkin_block_from_tag("minecraft:stairs")]
 pub struct StairBlock;
-
-impl BlockMetadata for StairBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:stairs").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for StairBlock {

--- a/pumpkin/src/block/blocks/trapdoor.rs
+++ b/pumpkin/src/block/blocks/trapdoor.rs
@@ -1,6 +1,6 @@
 use crate::block::blocks::redstone::block_receives_redstone_power;
 use crate::block::pumpkin_block::{
-    BlockMetadata, NormalUseArgs, OnNeighborUpdateArgs, OnPlaceArgs, PumpkinBlock,
+    NormalUseArgs, OnNeighborUpdateArgs, OnPlaceArgs, PumpkinBlock,
 };
 use crate::block::registry::BlockActionResult;
 use crate::entity::player::Player;
@@ -11,6 +11,7 @@ use pumpkin_data::BlockDirection;
 use pumpkin_data::block_properties::{BlockHalf, BlockProperties};
 use pumpkin_data::sound::{Sound, SoundCategory};
 use pumpkin_data::tag::{RegistryKey, Tagable, get_tag_values};
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::BlockStateId;
 use pumpkin_world::world::BlockFlags;
@@ -66,16 +67,9 @@ fn get_sound(block: &Block, open: bool) -> Sound {
         Sound::BlockCopperTrapdoorClose
     }
 }
-pub struct TrapDoorBlock;
-impl BlockMetadata for TrapDoorBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
 
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:trapdoors").unwrap()
-    }
-}
+#[pumpkin_block_from_tag("minecraft:trapdoors")]
+pub struct TrapDoorBlock;
 
 #[async_trait]
 impl PumpkinBlock for TrapDoorBlock {

--- a/pumpkin/src/block/blocks/walls.rs
+++ b/pumpkin/src/block/blocks/walls.rs
@@ -13,25 +13,18 @@ use pumpkin_data::block_properties::WestWallShape;
 use pumpkin_data::tag::RegistryKey;
 use pumpkin_data::tag::Tagable;
 use pumpkin_data::tag::get_tag_values;
+use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::BlockStateId;
 
-use crate::block::pumpkin_block::{BlockMetadata, PumpkinBlock};
+use crate::block::pumpkin_block::PumpkinBlock;
 use crate::world::World;
 type FenceGateProperties = pumpkin_data::block_properties::OakFenceGateLikeProperties;
 type FenceLikeProperties = pumpkin_data::block_properties::OakFenceLikeProperties;
 type WallProperties = pumpkin_data::block_properties::ResinBrickWallLikeProperties;
 
+#[pumpkin_block_from_tag("minecraft:walls")]
 pub struct WallBlock;
-impl BlockMetadata for WallBlock {
-    fn namespace(&self) -> &'static str {
-        "minecraft"
-    }
-
-    fn ids(&self) -> &'static [&'static str] {
-        get_tag_values(RegistryKey::Block, "minecraft:walls").unwrap()
-    }
-}
 
 #[async_trait]
 impl PumpkinBlock for WallBlock {

--- a/pumpkin/src/block/registry.rs
+++ b/pumpkin/src/block/registry.rs
@@ -80,6 +80,7 @@ impl BlockRegistry {
         let val = Arc::new(block);
         self.blocks.reserve(names.len());
         for i in names {
+            log::info!("{i}");
             self.blocks.insert(
                 block_properties::get_block(i.as_str()).unwrap(),
                 val.clone(),


### PR DESCRIPTION
## Description

Right now, many blocks are implementing the `tag -> blocks` logic every time, so i added a macro to do this automatically.

## Testing
 Manual
