### PR TITLE
fix: could not find en_us.json

### DIFF
--- a/pumpkin-util/src/translation.rs
+++ b/pumpkin-util/src/translation.rs
@@ -1,14 +1,12 @@
-use std::{collections::HashMap, fs, sync::LazyLock};
+use std::{collections::HashMap, sync::LazyLock};
 
 use crate::text::TextComponentBase;
 
+static EN_US_JSON: &str = include_str!("../../assets/en_us.json");
+
 // The path is different for the build script!
-pub static EN_US: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
-    let content = fs::read_to_string("assets/en_us.json")
-        .or_else(|_| fs::read_to_string("../assets/en_us.json"))
-        .expect("Could not find en_us.json!");
-    serde_json::from_str(&content).expect("Could not parse en_us.json.")
-});
+pub static EN_US: LazyLock<HashMap<String, String>> =
+    LazyLock::new(|| serde_json::from_str(EN_US_JSON).expect("Could not parse en_us.json."));
 
 pub fn get_translation_en_us(key: &str, with: &[TextComponentBase]) -> Option<String> {
     let mut translation = EN_US.get(key)?.clone();


### PR DESCRIPTION
## Description
https://github.com/Pumpkin-MC/Pumpkin/issues/1077

When I placed the assets/en_us.json file from the source code into the assets directory relative to the pumpkin binary, it worked correctly.
So I used include_str!() to handle it.

