### PR TITLE
Custom apis

### DIFF
--- a/pumpkin-macros/src/lib.rs
+++ b/pumpkin-macros/src/lib.rs
@@ -100,8 +100,6 @@ pub fn send_cancellable(input: TokenStream) -> TokenStream {
             if let Some(cancelled_block) = cancelled_block {
                 quote! {
                     let event = crate::PLUGIN_MANAGER
-                        .read()
-                        .await
                         .fire(#event)
                         .await;
 
@@ -115,8 +113,6 @@ pub fn send_cancellable(input: TokenStream) -> TokenStream {
             } else {
                 quote! {
                     let event = crate::PLUGIN_MANAGER
-                        .read()
-                        .await
                         .fire(#event)
                         .await;
 
@@ -129,8 +125,6 @@ pub fn send_cancellable(input: TokenStream) -> TokenStream {
         } else if let Some(cancelled_block) = cancelled_block {
             quote! {
                 let event = crate::PLUGIN_MANAGER
-                    .read()
-                    .await
                     .fire(#event)
                     .await;
 
@@ -142,8 +136,6 @@ pub fn send_cancellable(input: TokenStream) -> TokenStream {
         } else {
             quote! {
                 let event = crate::PLUGIN_MANAGER
-                    .read()
-                    .await
                     .fire(#event)
                     .await;
             }

--- a/pumpkin/src/command/commands/plugin.rs
+++ b/pumpkin/src/command/commands/plugin.rs
@@ -36,8 +36,7 @@ impl CommandExecutor for ListExecutor {
         _server: &crate::server::Server,
         _args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let plugin_manager = PLUGIN_MANAGER.read().await;
-        let plugins = plugin_manager.active_plugins();
+        let plugins = PLUGIN_MANAGER.active_plugins().await;
 
         let message_text = if plugins.is_empty() {
             "There are no loaded plugins.".to_string()
@@ -84,9 +83,8 @@ impl CommandExecutor for LoadExecutor {
         let Some(Arg::Simple(plugin_name)) = args.get(PLUGIN_NAME) else {
             return Err(InvalidConsumption(Some(PLUGIN_NAME.into())));
         };
-        let mut plugin_manager = PLUGIN_MANAGER.write().await;
 
-        if plugin_manager.is_plugin_active(plugin_name) {
+        if PLUGIN_MANAGER.is_plugin_active(plugin_name).await {
             sender
                 .send_message(
                     TextComponent::text(format!("Plugin {plugin_name} is already loaded"))
@@ -96,7 +94,7 @@ impl CommandExecutor for LoadExecutor {
             return Ok(());
         }
 
-        let result = plugin_manager.try_load_plugin(Path::new(plugin_name)).await;
+        let result = PLUGIN_MANAGER.try_load_plugin(Path::new(plugin_name)).await;
 
         match result {
             Ok(()) => {
@@ -134,9 +132,8 @@ impl CommandExecutor for UnloadExecutor {
         let Some(Arg::Simple(plugin_name)) = args.get(PLUGIN_NAME) else {
             return Err(InvalidConsumption(Some(PLUGIN_NAME.into())));
         };
-        let mut plugin_manager = PLUGIN_MANAGER.write().await;
 
-        if !plugin_manager.is_plugin_active(plugin_name) {
+        if !PLUGIN_MANAGER.is_plugin_active(plugin_name).await {
             sender
                 .send_message(
                     TextComponent::text(format!("Plugin {plugin_name} is not loaded"))
@@ -146,7 +143,7 @@ impl CommandExecutor for UnloadExecutor {
             return Ok(());
         }
 
-        let result = plugin_manager.unload_plugin(plugin_name).await;
+        let result = PLUGIN_MANAGER.unload_plugin(plugin_name).await;
 
         match result {
             Ok(()) => {

--- a/pumpkin/src/command/commands/plugins.rs
+++ b/pumpkin/src/command/commands/plugins.rs
@@ -22,8 +22,7 @@ impl CommandExecutor for Executor {
         _server: &crate::server::Server,
         _args: &ConsumedArgs<'a>,
     ) -> Result<(), CommandError> {
-        let plugin_manager = PLUGIN_MANAGER.read().await;
-        let plugins = plugin_manager.active_plugins();
+        let plugins = PLUGIN_MANAGER.active_plugins().await;
 
         let message_text = if plugins.is_empty() {
             "There are no loaded plugins.".to_string()

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -75,15 +75,8 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 #[cfg(feature = "dhat-heap")]
 use pumpkin::HEAP_PROFILER;
 
-pub static PLUGIN_MANAGER: LazyLock<Arc<RwLock<PluginManager>>> = LazyLock::new(|| {
-    let manager = PluginManager::new();
-    let arc_manager = Arc::new(RwLock::new(manager));
-    let clone = Arc::clone(&arc_manager);
-    let arc_manager_clone = arc_manager.clone();
-    let mut manager = futures::executor::block_on(arc_manager_clone.write());
-    manager.set_self_ref(clone);
-    arc_manager
-});
+pub static PLUGIN_MANAGER: LazyLock<Arc<PluginManager>> =
+    LazyLock::new(|| Arc::new(PluginManager::new()));
 
 pub static PERMISSION_REGISTRY: LazyLock<Arc<RwLock<PermissionRegistry>>> =
     LazyLock::new(|| Arc::new(RwLock::new(PermissionRegistry::new())));

--- a/pumpkin/src/net/query.rs
+++ b/pumpkin/src/net/query.rs
@@ -14,7 +14,7 @@ use rand::Rng;
 use tokio::{net::UdpSocket, sync::RwLock, time};
 
 use crate::{
-    SHOULD_STOP, STOP_INTERRUPT,
+    PLUGIN_MANAGER, SHOULD_STOP, STOP_INTERRUPT,
     server::{CURRENT_MC_VERSION, Server},
 };
 
@@ -140,9 +140,9 @@ async fn handle_packet(
                                 }
                             }
 
-                            let plugin_manager = crate::PLUGIN_MANAGER.read().await;
-                            let plugins = plugin_manager
+                            let plugins = PLUGIN_MANAGER
                                 .active_plugins()
+                                .await
                                 .into_iter()
                                 .map(|meta| meta.name.to_string())
                                 .reduce(|acc, name| format!("{acc}, {name}"))

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -1,4 +1,9 @@
-use std::{fs, path::Path, path::PathBuf, sync::Arc};
+use std::{
+    any::Any,
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use crate::command::client_suggestions;
 use pumpkin_util::{
@@ -78,6 +83,55 @@ impl Context {
     /// An optional reference to the player if found, or `None` if not.
     pub async fn get_player_by_name(&self, player_name: String) -> Option<Arc<Player>> {
         self.server.get_player_by_name(&player_name).await
+    }
+
+    /// Registers a service with the plugin context.
+    ///
+    /// This method allows you to associate a service instance with a given name,
+    /// making it available for retrieval by plugins or other components.
+    /// The service must be wrapped in an `Arc` and implement `Any`, `Send`, and `Sync`.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The unique name to register the service under.
+    /// * `service` - The service instance to register, wrapped in an `Arc`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// context.register_service("my_service".to_string(), Arc::new(MyService::new())).await;
+    /// ```
+    pub async fn register_service<T: Any + Send + Sync>(&self, name: String, service: Arc<T>) {
+        let manager = self.plugin_manager.read().await;
+        let mut services = manager.services.write().await;
+        services.insert(name, service);
+    }
+
+    /// Retrieves a registered service by name and type.
+    ///
+    /// This method attempts to fetch a service previously registered under the given name,
+    /// and downcasts it to the requested type. Returns `Some(Arc<T>)` if the service exists
+    /// and the type matches, or `None` otherwise.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the service to retrieve.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<Arc<T>>` containing the service if found and type matches, or `None`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// if let Some(service) = context.get_service::<MyService>("my_service").await {
+    ///     // Use the service
+    /// }
+    /// ```
+    pub async fn get_service<T: Any + Send + Sync>(&self, name: &str) -> Option<Arc<T>> {
+        let manager = self.plugin_manager.read().await;
+        let services = manager.services.read().await;
+        services.get(name)?.clone().downcast::<T>().ok()
     }
 
     /// Asynchronously registers a command with the server.

--- a/pumpkin/src/plugin/api/mod.rs
+++ b/pumpkin/src/plugin/api/mod.rs
@@ -1,6 +1,8 @@
 pub mod context;
 pub mod events;
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 pub use context::*;
 pub use events::*;
@@ -38,7 +40,7 @@ pub trait Plugin: Send + Sync + 'static {
     ///
     /// # Returns
     /// - `Ok(())` on success, or `Err(String)` on failure.
-    async fn on_load(&mut self, _server: &Context) -> Result<(), String> {
+    async fn on_load(&mut self, _server: Arc<Context>) -> Result<(), String> {
         Ok(())
     }
 
@@ -51,7 +53,7 @@ pub trait Plugin: Send + Sync + 'static {
     ///
     /// # Returns
     /// - `Ok(())` on success, or `Err(String)` on failure.
-    async fn on_unload(&mut self, _server: &Context) -> Result<(), String> {
+    async fn on_unload(&mut self, _server: Arc<Context>) -> Result<(), String> {
         Ok(())
     }
 }

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -137,6 +137,7 @@ pub struct PluginManager {
     unloaded_files: HashSet<PathBuf>,
     // Self-reference for sharing with contexts
     self_ref: Option<Arc<RwLock<PluginManager>>>,
+    services: Arc<RwLock<HashMap<String, Arc<dyn Any + Send + Sync>>>>,
 }
 
 /// Represents a successfully loaded plugin
@@ -180,6 +181,7 @@ impl Default for PluginManager {
             handlers: Arc::new(RwLock::new(HashMap::new())),
             unloaded_files: HashSet::new(),
             self_ref: None,
+            services: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1732,7 +1732,7 @@ impl World {
             .color_named(NamedColor::Yellow);
             let event = PlayerJoinEvent::new(player.clone(), msg_comp);
 
-            let event = PLUGIN_MANAGER.read().await.fire(event).await;
+            let event = PLUGIN_MANAGER.fire(event).await;
 
             if !event.cancelled {
                 let current_players = current_players.clone();
@@ -1785,7 +1785,7 @@ impl World {
             .color_named(NamedColor::Yellow);
             let event = PlayerLeaveEvent::new(player.clone(), msg_comp);
 
-            let event = PLUGIN_MANAGER.read().await.fire(event).await;
+            let event = PLUGIN_MANAGER.fire(event).await;
 
             if !event.cancelled {
                 let players = self.players.read().await;
@@ -2010,11 +2010,7 @@ impl World {
         let (broken_block, broken_block_state) = self.get_block_and_state_id(position).await;
         let event = BlockBreakEvent::new(cause.clone(), broken_block, *position, 0, false);
 
-        let event = PLUGIN_MANAGER
-            .read()
-            .await
-            .fire::<BlockBreakEvent>(event)
-            .await;
+        let event = PLUGIN_MANAGER.fire::<BlockBreakEvent>(event).await;
 
         if !event.cancelled {
             let new_state_id = if broken_block


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This PR contains several substantial changes to the plugin API.

### Move `Context` behind an `Arc`
The plugin's `on_load` and `on_unload` methods traditionally received a reference to the Context object (`&Context`), I have replaced this with a `Arc<Context>`, which allows both the use of the same instance of the Context for both the loading an unloading of the plugin, as well as copying the Context object and using it across threads from within the plugin. 

Previously if a plugin wanted to use the Server, or PermissionManager, or any other field contained in the Context, the plugin either needed to use the field directly from the `on_load` method, or a method directly called from `on_load`. If the plugin wanted to use it in another thread, it would have to make clones of each of the field that it wanted to access. Now it is possible to just clone the Context itself, without having to clone each field individually. Also this allows using the Context's helper methods in other threads.

### Move `PluginManager` outside of `RwLock`
Since plugins will now require access to certain fields in the PluginManager while loading, I have decided to move the manager itself out of the RwLock, and instead put all fields that require mutation inside their own RwLocks. This means that plugins can access certain methods and fields of the PluginManager while they are being loaded, without causing a deadlock.

This also allows plugins to fire events, including their own custom events.

### Custom APIs
This change adds a `services` field to the PluginManager, where plugins can submit instances of their own structs, which can be accessed by other plugins. This allows for plugins to expose custom APIs to each other for easier interaction and sharing data between plugins. Provided below is a hypothetical example situation:
<details>
  <summary>Code sample</summary>
  
  Here are examples of two plugins, the first one being a API provider and the second a API consumer.
  #### API Provider
```rs
#[derive(Clone)]
pub struct EconomyApi {
    // internal state
}

impl EconomyApi {
    pub async fn get_balance(&self, player_uuid: &str) -> Result<f64, String> {
        // implementation
    }
    
    pub async fn withdraw(&self, player_uuid: &str, amount: f64) -> Result<(), String> {
        // implementation
    }
}

#[plugin_method]
async fn on_load(&mut self, server: &Context) -> Result<(), String> {
    let economy_api = EconomyApi::new();
    
    // Register API service
    server.register_api_service("economy", Box::new(economy_api)).await?;
    
    Ok(())
}
```

  #### API Consumer
```rs
#[plugin_method]
async fn on_load(&mut self, server: &Context) -> Result<(), String> {
    // Wait for economy plugin to be available
    let economy_api = server.get_api_service::<EconomyApi>("economy").await
        .ok_or("Economy plugin not found")?;
    
    // Store reference for later use
    self.economy = Some(economy_api);
    
    Ok(())
}

// In command executor
async fn execute(&self, sender: &mut CommandSender, server: &Server, args: &ConsumedArgs) -> Result<(), CommandError> {
    if let Some(economy) = &self.economy {
        let balance = economy.get_balance(&player_uuid).await?;
        // use balance...
    }
}
```
  
</details>

### Asynchronous plugin loading and dependency awaiting
This addition changes how plugins are loaded. When the plugin is first picked up by a loader (any loader returns `true` from `can_load()`), the plugin is added to a state map with a state of `PluginState::Loading`. After that, the `on_load` method is called from a separate task so that multiple plugins can load at once without the whole server having to wait for one plugin to fully load before another one starts loading. 

Once the plugin's `on_load` method has completed, the state changes to either `PluginState::Loaded` if the method completed successfully, or to `PluginState::Failed(String)` with the error returned.

The PluginManager also has several new methods to go with this new loading system and to allow plugins to wait for other plugins to fully load. For example, the new `wait_for_plugin` method allows a plugin to wait until another plugin is fully loaded:
```rs
#[plugin_method]
async fn on_load(&mut self, context: Arc<Context>) -> Result<(), String> {
    pumpkin::init_log!();

    log::info!("Waiting for PLua to load...");

    context.plugin_manager.wait_for_plugin("plua").await?; // Use the plugin's package name as specified in it's Cargo.toml
    
    log::info!("PLua loaded!");

    Ok(())
}
```