### PR TITLE
Fix Breaking the Block below Vegetation

### DIFF
--- a/pumpkin/src/block/blocks/plant/bush.rs
+++ b/pumpkin/src/block/blocks/plant/bush.rs
@@ -1,8 +1,11 @@
 use async_trait::async_trait;
 use pumpkin_data::Block;
+use pumpkin_world::BlockStateId;
 
 use crate::block::blocks::plant::PlantBlockBase;
-use crate::block::pumpkin_block::{BlockMetadata, CanPlaceAtArgs, PumpkinBlock};
+use crate::block::pumpkin_block::{
+    BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, PumpkinBlock,
+};
 
 pub struct BushBlock;
 
@@ -20,6 +23,19 @@ impl BlockMetadata for BushBlock {
 impl PumpkinBlock for BushBlock {
     async fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
         <Self as PlantBlockBase>::can_place_at(self, args.block_accessor, args.position).await
+    }
+
+    async fn get_state_for_neighbor_update(
+        &self,
+        args: GetStateForNeighborUpdateArgs<'_>,
+    ) -> BlockStateId {
+        <Self as PlantBlockBase>::get_state_for_neighbor_update(
+            self,
+            args.world,
+            args.position,
+            args.state_id,
+        )
+        .await
     }
 }
 

--- a/pumpkin/src/block/blocks/plant/dry_vegetation.rs
+++ b/pumpkin/src/block/blocks/plant/dry_vegetation.rs
@@ -1,8 +1,13 @@
 use async_trait::async_trait;
 use pumpkin_data::tag;
 use pumpkin_data::tag::Taggable;
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_world::{BlockStateId, world::BlockAccessor};
 
-use crate::block::pumpkin_block::{BlockMetadata, CanPlaceAtArgs, PumpkinBlock};
+use crate::block::{
+    blocks::plant::PlantBlockBase,
+    pumpkin_block::{BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, PumpkinBlock},
+};
 
 pub struct DryVegetationBlock;
 
@@ -19,7 +24,30 @@ impl BlockMetadata for DryVegetationBlock {
 #[async_trait]
 impl PumpkinBlock for DryVegetationBlock {
     async fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
-        let block_below = args.block_accessor.get_block(&args.position.down()).await;
+        <Self as PlantBlockBase>::can_place_at(self, args.block_accessor, args.position).await
+    }
+
+    async fn get_state_for_neighbor_update(
+        &self,
+        args: GetStateForNeighborUpdateArgs<'_>,
+    ) -> BlockStateId {
+        <Self as PlantBlockBase>::get_state_for_neighbor_update(
+            self,
+            args.world,
+            args.position,
+            args.state_id,
+        )
+        .await
+    }
+}
+
+impl PlantBlockBase for DryVegetationBlock {
+    async fn can_plant_on_top(
+        &self,
+        block_accessor: &dyn BlockAccessor,
+        block_pos: &BlockPos,
+    ) -> bool {
+        let block_below = block_accessor.get_block(block_pos).await;
         block_below.is_tagged_with_by_tag(&tag::Block::MINECRAFT_DRY_VEGETATION_MAY_PLACE_ON)
     }
 }

--- a/pumpkin/src/block/blocks/plant/mushroom_plant.rs
+++ b/pumpkin/src/block/blocks/plant/mushroom_plant.rs
@@ -1,8 +1,13 @@
 use async_trait::async_trait;
 use pumpkin_data::tag;
 use pumpkin_data::tag::Taggable;
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_world::{BlockStateId, world::BlockAccessor};
 
-use crate::block::pumpkin_block::{BlockMetadata, CanPlaceAtArgs, PumpkinBlock};
+use crate::block::{
+    blocks::plant::PlantBlockBase,
+    pumpkin_block::{BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, PumpkinBlock},
+};
 
 pub struct MushroomPlantBlock;
 
@@ -19,11 +24,27 @@ impl BlockMetadata for MushroomPlantBlock {
 #[async_trait]
 impl PumpkinBlock for MushroomPlantBlock {
     async fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
-        let block_below = args.block_accessor.get_block(&args.position.down()).await;
-        if block_below.is_tagged_with_by_tag(&tag::Block::MINECRAFT_MUSHROOM_GROW_BLOCK) {
-            return true;
-        }
+        <Self as PlantBlockBase>::can_place_at(self, args.block_accessor, args.position).await
+    }
+
+    async fn get_state_for_neighbor_update(
+        &self,
+        args: GetStateForNeighborUpdateArgs<'_>,
+    ) -> BlockStateId {
+        <Self as PlantBlockBase>::get_state_for_neighbor_update(
+            self,
+            args.world,
+            args.position,
+            args.state_id,
+        )
+        .await
+    }
+}
+
+impl PlantBlockBase for MushroomPlantBlock {
+    async fn can_plant_on_top(&self, block_accessor: &dyn BlockAccessor, pos: &BlockPos) -> bool {
+        let block = block_accessor.get_block(pos).await;
+        block.is_tagged_with_by_tag(&tag::Block::MINECRAFT_MUSHROOM_GROW_BLOCK)
         // TODO: Check light level and isOpaqueFullCube
-        false
     }
 }

--- a/pumpkin/src/block/blocks/plant/roots.rs
+++ b/pumpkin/src/block/blocks/plant/roots.rs
@@ -1,8 +1,13 @@
 use async_trait::async_trait;
 use pumpkin_data::tag::Taggable;
 use pumpkin_data::{Block, tag};
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_world::{BlockStateId, world::BlockAccessor};
 
-use crate::block::pumpkin_block::{BlockMetadata, CanPlaceAtArgs, PumpkinBlock};
+use crate::block::{
+    blocks::plant::PlantBlockBase,
+    pumpkin_block::{BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, PumpkinBlock},
+};
 
 pub struct RootsBlock;
 
@@ -19,10 +24,34 @@ impl BlockMetadata for RootsBlock {
 #[async_trait]
 impl PumpkinBlock for RootsBlock {
     async fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
-        let block_below = args.block_accessor.get_block(&args.position.down()).await;
+        <Self as PlantBlockBase>::can_place_at(self, args.block_accessor, args.position).await
+    }
+
+    async fn get_state_for_neighbor_update(
+        &self,
+        args: GetStateForNeighborUpdateArgs<'_>,
+    ) -> BlockStateId {
+        <Self as PlantBlockBase>::get_state_for_neighbor_update(
+            self,
+            args.world,
+            args.position,
+            args.state_id,
+        )
+        .await
+    }
+}
+
+impl PlantBlockBase for RootsBlock {
+    async fn can_plant_on_top(&self, block_accessor: &dyn BlockAccessor, pos: &BlockPos) -> bool {
+        let block_below = block_accessor.get_block(pos).await;
         block_below.is_tagged_with_by_tag(&tag::Block::MINECRAFT_NYLIUM)
             || block_below == &Block::SOUL_SOIL
             || block_below.is_tagged_with_by_tag(&tag::Block::MINECRAFT_DIRT)
             || block_below == &Block::FARMLAND
+    }
+
+    async fn can_place_at(&self, block_accessor: &dyn BlockAccessor, block_pos: &BlockPos) -> bool {
+        self.can_plant_on_top(block_accessor, &block_pos.down())
+            .await
     }
 }

--- a/pumpkin/src/block/blocks/plant/short_plant.rs
+++ b/pumpkin/src/block/blocks/plant/short_plant.rs
@@ -1,8 +1,12 @@
 use async_trait::async_trait;
 use pumpkin_data::tag::Taggable;
 use pumpkin_data::{Block, tag};
+use pumpkin_world::BlockStateId;
 
-use crate::block::pumpkin_block::{BlockMetadata, CanPlaceAtArgs, PumpkinBlock};
+use crate::block::{
+    blocks::plant::PlantBlockBase,
+    pumpkin_block::{BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, PumpkinBlock},
+};
 
 pub struct ShortPlantBlock;
 
@@ -23,4 +27,19 @@ impl PumpkinBlock for ShortPlantBlock {
         block_below.is_tagged_with_by_tag(&tag::Block::MINECRAFT_DIRT)
             || block_below == &Block::FARMLAND
     }
+
+    async fn get_state_for_neighbor_update(
+        &self,
+        args: GetStateForNeighborUpdateArgs<'_>,
+    ) -> BlockStateId {
+        <Self as PlantBlockBase>::get_state_for_neighbor_update(
+            self,
+            args.world,
+            args.position,
+            args.state_id,
+        )
+        .await
+    }
 }
+
+impl PlantBlockBase for ShortPlantBlock {}

--- a/pumpkin/src/block/blocks/plant/tall_plant.rs
+++ b/pumpkin/src/block/blocks/plant/tall_plant.rs
@@ -1,8 +1,14 @@
 use async_trait::async_trait;
-use pumpkin_data::tag::Taggable;
-use pumpkin_data::{Block, tag};
+use pumpkin_data::{Block, BlockDirection};
+use pumpkin_data::block_properties::{BlockProperties, DoubleBlockHalf, TallSeagrassLikeProperties};
+use pumpkin_world::BlockStateId;
+use pumpkin_world::world::BlockFlags;
 
-use crate::block::pumpkin_block::{BlockMetadata, CanPlaceAtArgs, PumpkinBlock};
+use crate::block::pumpkin_block::GetStateForNeighborUpdateArgs;
+use crate::block::{
+    blocks::plant::PlantBlockBase,
+    pumpkin_block::{BlockMetadata, CanPlaceAtArgs, PlacedArgs, PumpkinBlock},
+};
 
 pub struct TallPlantBlock;
 
@@ -27,27 +33,53 @@ impl BlockMetadata for TallPlantBlock {
 
 #[async_trait]
 impl PumpkinBlock for TallPlantBlock {
+    async fn placed(&self, args: PlacedArgs<'_>) {
+        let mut tall_plant_props =
+            TallSeagrassLikeProperties::from_state_id(args.state_id, args.block);
+        tall_plant_props.half = DoubleBlockHalf::Upper;
+
+        args.world
+            .set_block_state(
+                &args.position.offset(BlockDirection::Up.to_offset()),
+                tall_plant_props.to_state_id(args.block),
+                BlockFlags::NOTIFY_ALL | BlockFlags::SKIP_BLOCK_ADDED_CALLBACK,
+            )
+            .await;
+    }
+
     async fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
-        let (block, state) = args.block_accessor.get_block_and_state(args.position).await;
-        if let Some(props) = block.properties(state.id).map(|s| s.to_props()) {
-            if props
-                .iter()
-                .any(|(key, value)| key == "half" && value == "upper")
-            {
-                let (block, below_state) = args
-                    .block_accessor
-                    .get_block_and_state(&args.position.down())
-                    .await;
-                if let Some(props) = block.properties(below_state.id).map(|s| s.to_props()) {
-                    let is_lower = props
-                        .iter()
-                        .any(|(key, value)| key == "half" && value == "lower");
-                    return below_state.id == state.id && is_lower;
-                }
+        let upper_state = args
+            .block_accessor
+            .get_block_state(&args.position.up())
+            .await;
+        <Self as PlantBlockBase>::can_place_at(self, args.block_accessor, args.position).await
+            && upper_state.is_air()
+    }
+
+    async fn get_state_for_neighbor_update(
+        &self,
+        args: GetStateForNeighborUpdateArgs<'_>,
+    ) -> BlockStateId {
+        let tall_plant_props = TallSeagrassLikeProperties::from_state_id(args.state_id, args.block);
+        let other_block_pos = match tall_plant_props.half {
+            DoubleBlockHalf::Upper => args.position.down(),
+            DoubleBlockHalf::Lower => args.position.up(),
+        };
+        let (other_block, other_state_id) =
+            args.world.get_block_and_state_id(&other_block_pos).await;
+        if self.ids().contains(&other_block.name) {
+            let other_props =
+                TallSeagrassLikeProperties::from_state_id(other_state_id, other_block);
+            let opposite_half = match tall_plant_props.half {
+                DoubleBlockHalf::Upper => DoubleBlockHalf::Lower,
+                DoubleBlockHalf::Lower => DoubleBlockHalf::Upper,
+            };
+            if other_props.half == opposite_half {
+                return args.state_id;
             }
         }
-        let block_below = args.block_accessor.get_block(&args.position.down()).await;
-        block_below.is_tagged_with_by_tag(&tag::Block::MINECRAFT_DIRT)
-            || block_below == &Block::FARMLAND
+        return Block::AIR.default_state.id;
     }
 }
+
+impl PlantBlockBase for TallPlantBlock {}

--- a/pumpkin/src/block/blocks/plant/tall_plant.rs
+++ b/pumpkin/src/block/blocks/plant/tall_plant.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
+use pumpkin_data::block_properties::{
+    BlockProperties, DoubleBlockHalf, TallSeagrassLikeProperties,
+};
 use pumpkin_data::{Block, BlockDirection};
-use pumpkin_data::block_properties::{BlockProperties, DoubleBlockHalf, TallSeagrassLikeProperties};
 use pumpkin_world::BlockStateId;
 use pumpkin_world::world::BlockFlags;
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

PlantBlockBase was added but not implemented for all types of foliage.

These two still have to be fixed but probably not in this pr:

- [ ] Lily Pad placement
- [ ] Sea Grass and Tall Sea Grass

## Testing

Yea

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
