### PR TITLE
Allow creative mode players to pick up items regardless of if they have enough inventory room

### DIFF
--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -380,10 +380,11 @@ impl EntityBase for ItemEntity {
 
         if can_pickup
             && player.living_entity.health.load() > 0.0
-            && player
+            && (player
                 .inventory
                 .insert_stack_anywhere(&mut *self.item_stack.lock().await)
                 .await
+                || player.is_creative())
         {
             player
                 .client


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
In vanilla, players in creative mode can pick up items even if they have a full inventory.
This is a simple PR to add that functionality to Pumpkin.

## Testing
1. Go into creative mode with a full inventory
2. Try to pick up items from the ground

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
