### PR TITLE
build: Make file generation deterministic & skip unchanged files

### DIFF
--- a/pumpkin-data/Clippy.toml
+++ b/pumpkin-data/Clippy.toml
@@ -1,0 +1,3 @@
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "If you need a map, use BTreeMap for deterministic ordering. Otherwise it forces a rebuild after every change.", replacement = "std::collections::BTreeMap" }
+]

--- a/pumpkin-data/build/attributes.rs
+++ b/pumpkin-data/build/attributes.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs;
 
 #[derive(Deserialize)]
@@ -13,7 +13,7 @@ struct Attributes {
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/attributes.json");
 
-    let attributes: HashMap<String, Attributes> =
+    let attributes: BTreeMap<String, Attributes> =
         serde_json::from_str(&fs::read_to_string("../assets/attributes.json").unwrap())
             .expect("Failed to parse attributes.json");
 

--- a/pumpkin-data/build/biome.rs
+++ b/pumpkin-data/build/biome.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use heck::ToShoutySnakeCase;
 use proc_macro2::{Span, TokenStream};
@@ -16,7 +16,7 @@ pub struct Biome {
     features: Vec<Vec<String>>,
     creature_spawn_probability: Option<f32>,
     spawners: SpawnGroups,
-    spawn_costs: HashMap<String, SpawnCosts>,
+    spawn_costs: BTreeMap<String, SpawnCosts>,
     pub id: u8,
 }
 
@@ -161,7 +161,7 @@ pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/biome.json");
     println!("cargo:rerun-if-changed=../assets/multi_noise_biome_tree.json");
 
-    let biomes: HashMap<String, Biome> =
+    let biomes: BTreeMap<String, Biome> =
         serde_json::from_str(&fs::read_to_string("../assets/biome.json").unwrap())
             .expect("Failed to parse biome.json");
     let biome_trees: MultiNoiseBiomeSuppliers =

--- a/pumpkin-data/build/block.rs
+++ b/pumpkin-data/build/block.rs
@@ -4,7 +4,7 @@ use pumpkin_util::math::{experience::Experience, vector3::Vector3};
 use quote::{ToTokens, format_ident, quote};
 use serde::Deserialize;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     fs,
     io::{Cursor, Read},
     panic,
@@ -675,11 +675,11 @@ pub(crate) fn build() -> TokenStream {
     let mut block_state_to_bedrock = Vec::new();
 
     // Used to create property `enum`s.
-    let mut property_enums: HashMap<String, PropertyStruct> = HashMap::new();
+    let mut property_enums: BTreeMap<String, PropertyStruct> = BTreeMap::new();
     // Property implementation for a block.
     let mut block_properties: Vec<BlockPropertyStruct> = Vec::new();
     // Mapping of a collection of property hashes -> blocks that have these properties.
-    let mut property_collection_map: HashMap<Vec<i32>, PropertyCollectionData> = HashMap::new();
+    let mut property_collection_map: BTreeMap<Vec<i32>, PropertyCollectionData> = BTreeMap::new();
     // Validator that we have no `enum` collisions.
     let mut optimized_blocks: Vec<Block> = Vec::new();
     for block in blocks_assets.blocks.clone() {
@@ -910,7 +910,7 @@ pub(crate) fn build() -> TokenStream {
         use pumpkin_util::loot_table::*;
         use pumpkin_util::math::experience::Experience;
         use pumpkin_util::math::vector3::Vector3;
-        use std::collections::HashMap;
+        use std::collections::BTreeMap;
         use phf;
 
 
@@ -1169,8 +1169,8 @@ pub(crate) fn build() -> TokenStream {
     }
 }
 
-fn get_be_data_from_nbt<R: Read>(reader: &mut R) -> HashMap<String, (u32, u32)> {
-    let mut block_data: HashMap<String, (u32, u32)> = HashMap::new();
+fn get_be_data_from_nbt<R: Read>(reader: &mut R) -> BTreeMap<String, (u32, u32)> {
+    let mut block_data: BTreeMap<String, (u32, u32)> = BTreeMap::new();
     let mut current_id = 0;
 
     while read_byte(reader) == 10 {

--- a/pumpkin-data/build/build.rs
+++ b/pumpkin-data/build/build.rs
@@ -120,9 +120,10 @@ pub fn write_generated_file(new_code: &str, out_file: &str) {
 
     if path.exists()
         && let Ok(existing_code) = fs::read_to_string(&path)
-            && existing_code == new_code {
-                return; // No changes, so we skip writing.
-            }
+        && existing_code == new_code
+    {
+        return; // No changes, so we skip writing.
+    }
 
     fs::write(&path, new_code)
         .unwrap_or_else(|_| panic!("Failed to write to file: {}", path.display()));

--- a/pumpkin-data/build/composter_increase_chance.rs
+++ b/pumpkin-data/build/composter_increase_chance.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -6,7 +6,7 @@ use quote::quote;
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/composter_increase_chance.json");
 
-    let composter_increase_chance: HashMap<u16, f32> = serde_json::from_str(
+    let composter_increase_chance: BTreeMap<u16, f32> = serde_json::from_str(
         &fs::read_to_string("../assets/composter_increase_chance.json").unwrap(),
     )
     .expect("Failed to parse composter_increase_chance.json");

--- a/pumpkin-data/build/damage_type.rs
+++ b/pumpkin-data/build/damage_type.rs
@@ -2,7 +2,7 @@ use heck::ToShoutySnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use serde::Deserialize;
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 use syn::{Ident, LitInt};
 
 #[derive(Deserialize)]
@@ -50,7 +50,7 @@ pub enum DeathMessageType {
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/damage_type.json");
 
-    let damage_types: HashMap<String, DamageTypeEntry> =
+    let damage_types: BTreeMap<String, DamageTypeEntry> =
         serde_json::from_str(&fs::read_to_string("../assets/damage_type.json").unwrap())
             .expect("Failed to parse damage_type.json");
 

--- a/pumpkin-data/build/data_component.rs
+++ b/pumpkin-data/build/data_component.rs
@@ -1,13 +1,13 @@
 use heck::ToPascalCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs;
 
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/data_component.json");
 
-    let data_component: HashMap<String, u8> =
+    let data_component: BTreeMap<String, u8> =
         serde_json::from_str(&fs::read_to_string("../assets/data_component.json").unwrap())
             .expect("Failed to parse data_component.json");
 

--- a/pumpkin-data/build/effect.rs
+++ b/pumpkin-data/build/effect.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use heck::{ToPascalCase, ToShoutySnakeCase};
 use proc_macro2::TokenStream;
@@ -61,7 +61,7 @@ impl MobEffectCategory {
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/effect.json");
 
-    let effects: HashMap<String, Effect> =
+    let effects: BTreeMap<String, Effect> =
         serde_json::from_str(&fs::read_to_string("../assets/effect.json").unwrap())
             .expect("Failed to parse effect.json");
 

--- a/pumpkin-data/build/enchantments.rs
+++ b/pumpkin-data/build/enchantments.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use heck::ToShoutySnakeCase;
 use proc_macro2::TokenStream;
@@ -50,7 +50,7 @@ impl AttributeModifierSlot {
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/enchantments.json");
 
-    let enchantments: HashMap<String, Enchantment> =
+    let enchantments: BTreeMap<String, Enchantment> =
         serde_json::from_str(&fs::read_to_string("../assets/enchantments.json").unwrap())
             .expect("Failed to parse enchantments.json");
 

--- a/pumpkin-data/build/entity_status.rs
+++ b/pumpkin-data/build/entity_status.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use heck::ToPascalCase;
 use proc_macro2::TokenStream;
@@ -7,7 +7,7 @@ use quote::{format_ident, quote};
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/entity_statuses.json");
 
-    let events: HashMap<String, u8> =
+    let events: BTreeMap<String, u8> =
         serde_json::from_str(&fs::read_to_string("../assets/entity_statuses.json").unwrap())
             .expect("Failed to parse entity_statuses.json");
     let mut variants = TokenStream::new();

--- a/pumpkin-data/build/entity_type.rs
+++ b/pumpkin-data/build/entity_type.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use proc_macro2::TokenStream;
 use pumpkin_util::HeightMap;
@@ -154,7 +154,7 @@ impl ToTokens for NamedEntityType<'_> {
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/entities.json");
 
-    let json: HashMap<String, EntityType> =
+    let json: BTreeMap<String, EntityType> =
         serde_json::from_str(&fs::read_to_string("../assets/entities.json").unwrap())
             .expect("Failed to parse entities.json");
 

--- a/pumpkin-data/build/flower_pot_transformations.rs
+++ b/pumpkin-data/build/flower_pot_transformations.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/flower_pot_transformations.json");
 
-    let flower_pot_transformation: HashMap<u16, u16> = serde_json::from_str(
+    let flower_pot_transformation: BTreeMap<u16, u16> = serde_json::from_str(
         &fs::read_to_string("../assets/flower_pot_transformations.json").unwrap(),
     )
     .expect("Failed to parse flower_pot_transformations.json");

--- a/pumpkin-data/build/fluid.rs
+++ b/pumpkin-data/build/fluid.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, format_ident, quote};
 use serde::Deserialize;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     fs,
 };
 use syn::{Ident, LitInt, LitStr};
@@ -357,13 +357,14 @@ pub(crate) fn build() -> TokenStream {
     let mut fluid_properties_from_props_and_name = TokenStream::new();
 
     // Used to create property `enum`s.
-    let mut property_enums: HashMap<String, PropertyStruct> = HashMap::new();
+    let mut property_enums: BTreeMap<String, PropertyStruct> = BTreeMap::new();
     // Property implementation for a fluid.
     let mut fluid_properties: Vec<FluidPropertyStruct> = Vec::new();
     // Mapping of a collection of property names -> fluids that have these properties.
-    let mut property_collection_map: HashMap<Vec<String>, PropertyCollectionData> = HashMap::new();
+    let mut property_collection_map: BTreeMap<Vec<String>, PropertyCollectionData> =
+        BTreeMap::new();
     // Validator that we have no `enum` collisions.
-    let mut enum_to_values: HashMap<String, Vec<String>> = HashMap::new();
+    let mut enum_to_values: BTreeMap<String, Vec<String>> = BTreeMap::new();
 
     // Collect unique fluid states to create partial states
     let mut unique_states = Vec::new();

--- a/pumpkin-data/build/fuels.rs
+++ b/pumpkin-data/build/fuels.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/fuels.json");
 
-    let fuels: HashMap<u16, u16> =
+    let fuels: BTreeMap<u16, u16> =
         serde_json::from_str(&fs::read_to_string("../assets/fuels.json").unwrap())
             .expect("Failed to parse fuels.json");
 

--- a/pumpkin-data/build/game_rules.rs
+++ b/pumpkin-data/build/game_rules.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use heck::{ToPascalCase, ToSnakeCase};
 use proc_macro2::TokenStream;
@@ -8,7 +8,7 @@ use serde_json::Value;
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/game_rules.json");
 
-    let game_rules: HashMap<String, Value> =
+    let game_rules: BTreeMap<String, Value> =
         serde_json::from_str(&fs::read_to_string("../assets/game_rules.json").unwrap())
             .expect("Failed to parse game_rules.json");
 

--- a/pumpkin-data/build/item.rs
+++ b/pumpkin-data/build/item.rs
@@ -6,7 +6,7 @@ use pumpkin_util::text::TextContent;
 use pumpkin_util::{registry::RegistryEntryList, text::TextComponent};
 use quote::{ToTokens, format_ident, quote};
 use serde::Deserialize;
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 use syn::{Ident, LitBool, LitFloat, LitInt, LitStr};
 
 #[derive(Deserialize, Clone)]
@@ -406,7 +406,7 @@ pub enum Operation {
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/items.json");
 
-    let items: HashMap<String, Item> =
+    let items: BTreeMap<String, Item> =
         serde_json::from_str(&fs::read_to_string("../assets/items.json").unwrap())
             .expect("Failed to parse items.json");
 

--- a/pumpkin-data/build/loot.rs
+++ b/pumpkin-data/build/loot.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use proc_macro2::{Span, TokenStream};
 use pumpkin_util::loot_table::LootNumberProviderTypes;
@@ -174,7 +174,7 @@ pub enum LootConditionStruct {
     #[serde(rename = "minecraft:block_state_property")]
     BlockStateProperty {
         block: String,
-        properties: HashMap<String, String>,
+        properties: BTreeMap<String, String>,
     },
     #[serde(rename = "minecraft:match_tool")]
     MatchTool,

--- a/pumpkin-data/build/message_type.rs
+++ b/pumpkin-data/build/message_type.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use proc_macro2::TokenStream;
 use pumpkin_util::text::style::Style;
@@ -28,7 +28,7 @@ pub struct Decoration {
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/message_type.json");
 
-    let json: HashMap<String, RawChatType> =
+    let json: BTreeMap<String, RawChatType> =
         serde_json::from_str(&fs::read_to_string("../assets/message_type.json").unwrap())
             .expect("Failed to parse message_type.json");
     let mut variants = TokenStream::new();

--- a/pumpkin-data/build/noise_parameter.rs
+++ b/pumpkin-data/build/noise_parameter.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use proc_macro2::TokenStream;
 use pumpkin_util::DoublePerlinNoiseParametersCodec;
@@ -7,7 +7,7 @@ use quote::{format_ident, quote};
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/noise_parameters.json");
 
-    let json: HashMap<String, DoublePerlinNoiseParametersCodec> =
+    let json: BTreeMap<String, DoublePerlinNoiseParametersCodec> =
         serde_json::from_str(&fs::read_to_string("../assets/noise_parameters.json").unwrap())
             .expect("Failed to parse noise_parameters.json");
     let mut variants = TokenStream::new();

--- a/pumpkin-data/build/noise_router.rs
+++ b/pumpkin-data/build/noise_router.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fs,
     hash::{DefaultHasher, Hash, Hasher},
 };
@@ -100,7 +100,7 @@ impl SplineRepr {
     fn into_token_stream(
         self,
         stack: &mut Vec<TokenStream>,
-        hash_to_index_map: &mut HashMap<u64, usize>,
+        hash_to_index_map: &mut BTreeMap<u64, usize>,
     ) -> TokenStream {
         match self {
             Self::Fixed { value } => {
@@ -564,7 +564,7 @@ impl DensityFunctionRepr {
     fn get_index_for_component(
         self,
         stack: &mut Vec<TokenStream>,
-        hash_to_index_map: &mut HashMap<u64, usize>,
+        hash_to_index_map: &mut BTreeMap<u64, usize>,
     ) -> usize {
         if let Some(index) = hash_to_index_map.get(&self.unique_id()) {
             *index
@@ -581,7 +581,7 @@ impl DensityFunctionRepr {
     fn into_token_stream(
         self,
         stack: &mut Vec<TokenStream>,
-        hash_to_index_map: &mut HashMap<u64, usize>,
+        hash_to_index_map: &mut BTreeMap<u64, usize>,
     ) -> TokenStream {
         match self {
             Self::Spline { spline, data } => {
@@ -885,7 +885,7 @@ struct NoiseRouterRepr {
 impl NoiseRouterRepr {
     fn into_token_stream(self) -> TokenStream {
         let mut noise_component_stack = Vec::new();
-        let mut noise_lookup_map = HashMap::new();
+        let mut noise_lookup_map = BTreeMap::new();
 
         // The aquifer sampler is called most often
         let final_density = self
@@ -926,13 +926,13 @@ impl NoiseRouterRepr {
             .get_index_for_component(&mut noise_component_stack, &mut noise_lookup_map);
 
         let mut surface_component_stack = Vec::new();
-        let mut surface_lookup_map = HashMap::new();
+        let mut surface_lookup_map = BTreeMap::new();
         let _ = self
             .initial_density_without_jaggedness
             .get_index_for_component(&mut surface_component_stack, &mut surface_lookup_map);
 
         let mut multinoise_component_stack = Vec::new();
-        let mut multinoise_lookup_map = HashMap::new();
+        let mut multinoise_lookup_map = BTreeMap::new();
         let ridges = self
             .ridges
             .get_index_for_component(&mut multinoise_component_stack, &mut multinoise_lookup_map);

--- a/pumpkin-data/build/packet.rs
+++ b/pumpkin-data/build/packet.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -7,8 +7,8 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 pub struct Packets {
     version: u32,
-    serverbound: HashMap<String, Vec<String>>,
-    clientbound: HashMap<String, Vec<String>>,
+    serverbound: BTreeMap<String, Vec<String>>,
+    clientbound: BTreeMap<String, Vec<String>>,
 }
 
 pub(crate) fn build() -> TokenStream {
@@ -35,7 +35,7 @@ pub(crate) fn build() -> TokenStream {
     )
 }
 
-pub(crate) fn parse_packets(packets: HashMap<String, Vec<String>>) -> proc_macro2::TokenStream {
+pub(crate) fn parse_packets(packets: BTreeMap<String, Vec<String>>) -> proc_macro2::TokenStream {
     let mut consts = TokenStream::new();
 
     for packet in packets {

--- a/pumpkin-data/build/potion.rs
+++ b/pumpkin-data/build/potion.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use heck::ToShoutySnakeCase;
 use proc_macro2::TokenStream;
@@ -52,7 +52,7 @@ impl Effect {
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/potion.json");
 
-    let potions: HashMap<String, Potion> =
+    let potions: BTreeMap<String, Potion> =
         serde_json::from_str(&fs::read_to_string("../assets/potion.json").unwrap())
             .expect("Failed to parse potion.json");
 

--- a/pumpkin-data/build/recipe_remainder.rs
+++ b/pumpkin-data/build/recipe_remainder.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/recipe_remainder.json");
 
-    let remainder: HashMap<u16, u16> =
+    let remainder: BTreeMap<u16, u16> =
         serde_json::from_str(&fs::read_to_string("../assets/recipe_remainder.json").unwrap())
             .expect("Failed to parse recipe_remainder.json");
     let mut variants = TokenStream::new();

--- a/pumpkin-data/build/recipes.rs
+++ b/pumpkin-data/build/recipes.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
@@ -77,7 +77,7 @@ pub struct CraftingShapedRecipeStruct {
     category: Option<RecipeCategoryTypes>,
     group: Option<String>,
     show_notification: Option<bool>,
-    key: HashMap<String, RecipeIngredientTypes>,
+    key: BTreeMap<String, RecipeIngredientTypes>,
     pattern: Vec<String>,
     result: RecipeResultStruct,
 }

--- a/pumpkin-data/build/spawn_egg.rs
+++ b/pumpkin-data/build/spawn_egg.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use heck::ToShoutySnakeCase;
 use proc_macro2::TokenStream;
@@ -7,7 +7,7 @@ use quote::{format_ident, quote};
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/spawn_egg.json");
 
-    let eggs: HashMap<u16, String> =
+    let eggs: BTreeMap<u16, String> =
         serde_json::from_str(&fs::read_to_string("../assets/spawn_egg.json").unwrap())
             .expect("Failed to parse spawn_egg.json");
     let mut names = TokenStream::new();

--- a/pumpkin-data/build/tag.rs
+++ b/pumpkin-data/build/tag.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use crate::biome::Biome;
 use crate::block::BlockAssets;
@@ -38,7 +38,7 @@ pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/biome.json");
     println!("cargo:rerun-if-changed=../assets/fluids.json");
 
-    let tags: HashMap<String, HashMap<String, Vec<String>>> =
+    let tags: BTreeMap<String, BTreeMap<String, Vec<String>>> =
         serde_json::from_str(&fs::read_to_string("../assets/tags.json").unwrap())
             .expect("Failed to parse tags.json");
 
@@ -46,11 +46,11 @@ pub(crate) fn build() -> TokenStream {
         serde_json::from_str(&fs::read_to_string("../assets/blocks.json").unwrap())
             .expect("Failed to parse blocks.json");
 
-    let items: HashMap<String, Item> =
+    let items: BTreeMap<String, Item> =
         serde_json::from_str(&fs::read_to_string("../assets/items.json").unwrap())
             .expect("Failed to parse items.json");
 
-    let biomes: HashMap<String, Biome> =
+    let biomes: BTreeMap<String, Biome> =
         serde_json::from_str(&fs::read_to_string("../assets/biome.json").unwrap())
             .expect("Failed to parse biome.json");
 
@@ -77,7 +77,7 @@ pub(crate) fn build() -> TokenStream {
         let key_pascal = format_ident!("{}", key.to_pascal_case());
         let dict_name = format_ident!("{}_TAGS", key.to_pascal_case().to_uppercase());
 
-        // Create a HashMap to store tag name -> index mapping
+        // Create a BTreeMap to store tag name -> index mapping
         let mut tag_values = Vec::new();
 
         // Collect all unique tags

--- a/pumpkin-data/build/world_event.rs
+++ b/pumpkin-data/build/world_event.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 use heck::ToPascalCase;
 use proc_macro2::TokenStream;
@@ -7,7 +7,7 @@ use quote::{format_ident, quote};
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/world_event.json");
 
-    let events: HashMap<String, u16> =
+    let events: BTreeMap<String, u16> =
         serde_json::from_str(&fs::read_to_string("../assets/world_event.json").unwrap())
             .expect("Failed to parse world_event.json");
     let mut variants = TokenStream::new();


### PR DESCRIPTION
## Description
I noticed that running `cargo check`, `cargo build`, and `cargo clippy` back-to-back would always rewrite the generated files. This slowed down incremental builds because crates that depended on those files had to be recompiled every time.

This was happening for three main reasons:
- Changing tools doesn't honor `cargo:rerun-if-changed`
-  We used HashMaps, which don't guarantee a consistent order.
-  We always rewrote the output file, even if the content was identical.

This PR fixes this by switching all the HashMaps in the build functions to BTreeMaps to ensure the output is always in the same order. I also added a lint to prevent anyone from accidentally using a HashMap here again.

Additionally, the script now checks if the file content has actually changed before writing. If it's the same, we skip the write.

I also did some minor refactoring around the `rustfmt` formatting logic.

## Testing

I've tested this on Linux and it fixes the issue for me.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
