### PR TITLE
fix: Make all client packet members public.

### DIFF
--- a/pumpkin-protocol/src/java/client/config/add_resource_pack.rs
+++ b/pumpkin-protocol/src/java/client/config/add_resource_pack.rs
@@ -9,11 +9,11 @@ use pumpkin_data::packet::clientbound::CONFIG_RESOURCE_PACK_PUSH;
 #[packet(CONFIG_RESOURCE_PACK_PUSH)]
 pub struct CConfigAddResourcePack<'a> {
     #[serde(with = "uuid::serde::compact")]
-    uuid: &'a uuid::Uuid,
-    url: &'a str,
-    hash: &'a str, // max 40
-    forced: bool,
-    prompt_message: Option<TextComponent>,
+    pub uuid: &'a uuid::Uuid,
+    pub url: &'a str,
+    pub hash: &'a str, // max 40
+    pub forced: bool,
+    pub prompt_message: Option<TextComponent>,
 }
 
 impl<'a> CConfigAddResourcePack<'a> {

--- a/pumpkin-protocol/src/java/client/config/server_links.rs
+++ b/pumpkin-protocol/src/java/client/config/server_links.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(CONFIG_SERVER_LINKS)]
 pub struct CConfigServerLinks<'a> {
-    links: &'a [Link<'a>],
+    pub links: &'a [Link<'a>],
 }
 
 impl<'a> CConfigServerLinks<'a> {

--- a/pumpkin-protocol/src/java/client/config/store_cookie.rs
+++ b/pumpkin-protocol/src/java/client/config/store_cookie.rs
@@ -7,8 +7,8 @@ use pumpkin_util::resource_location::ResourceLocation;
 /// Stores some arbitrary data on the client, which persists between server transfers.
 /// The Notchian (vanilla) client only accepts cookies of up to 5 KiB in size.
 pub struct CStoreCookie<'a> {
-    key: &'a ResourceLocation,
-    payload: &'a [u8], // 5120,
+    pub key: &'a ResourceLocation,
+    pub payload: &'a [u8], // 5120,
 }
 
 impl<'a> CStoreCookie<'a> {

--- a/pumpkin-protocol/src/java/client/config/update_tags.rs
+++ b/pumpkin-protocol/src/java/client/config/update_tags.rs
@@ -13,7 +13,7 @@ use pumpkin_util::resource_location::ResourceLocation;
 
 #[packet(CONFIG_UPDATE_TAGS)]
 pub struct CUpdateTags<'a> {
-    tags: &'a [pumpkin_data::tag::RegistryKey],
+    pub tags: &'a [pumpkin_data::tag::RegistryKey],
 }
 
 impl<'a> CUpdateTags<'a> {

--- a/pumpkin-protocol/src/java/client/login/cookie_request.rs
+++ b/pumpkin-protocol/src/java/client/login/cookie_request.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 #[packet(LOGIN_COOKIE_REQUEST)]
 /// Requests a cookie that was previously stored.
 pub struct CLoginCookieRequest<'a> {
-    key: &'a ResourceLocation,
+    pub key: &'a ResourceLocation,
 }
 
 impl<'a> CLoginCookieRequest<'a> {

--- a/pumpkin-protocol/src/java/client/play/actionbar.rs
+++ b/pumpkin-protocol/src/java/client/play/actionbar.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SET_ACTION_BAR_TEXT)]
 pub struct CActionBar<'a> {
-    action_bar: &'a TextComponent,
+    pub action_bar: &'a TextComponent,
 }
 
 impl<'a> CActionBar<'a> {

--- a/pumpkin-protocol/src/java/client/play/block_destroy_stage.rs
+++ b/pumpkin-protocol/src/java/client/play/block_destroy_stage.rs
@@ -9,9 +9,9 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_BLOCK_DESTRUCTION)]
 pub struct CSetBlockDestroyStage {
-    entity_id: VarInt,
-    location: BlockPos,
-    destroy_stage: i8,
+    pub entity_id: VarInt,
+    pub location: BlockPos,
+    pub destroy_stage: i8,
 }
 
 impl CSetBlockDestroyStage {

--- a/pumpkin-protocol/src/java/client/play/block_entity_data.rs
+++ b/pumpkin-protocol/src/java/client/play/block_entity_data.rs
@@ -8,10 +8,10 @@ use crate::{VarInt, ser::network_serialize_no_prefix};
 #[derive(Serialize)]
 #[packet(PLAY_BLOCK_ENTITY_DATA)]
 pub struct CBlockEntityData {
-    location: BlockPos,
-    r#type: VarInt,
+    pub location: BlockPos,
+    pub r#type: VarInt,
     #[serde(serialize_with = "network_serialize_no_prefix")]
-    nbt_data: Box<[u8]>,
+    pub nbt_data: Box<[u8]>,
 }
 
 impl CBlockEntityData {

--- a/pumpkin-protocol/src/java/client/play/block_event.rs
+++ b/pumpkin-protocol/src/java/client/play/block_event.rs
@@ -9,10 +9,10 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_BLOCK_EVENT)]
 pub struct CBlockEvent {
-    location: BlockPos,
-    action_id: u8,
-    action_parameter: u8,
-    block_type: VarInt,
+    pub location: BlockPos,
+    pub action_id: u8,
+    pub action_parameter: u8,
+    pub block_type: VarInt,
 }
 
 impl CBlockEvent {

--- a/pumpkin-protocol/src/java/client/play/block_update.rs
+++ b/pumpkin-protocol/src/java/client/play/block_update.rs
@@ -9,8 +9,8 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_BLOCK_UPDATE)]
 pub struct CBlockUpdate {
-    location: BlockPos,
-    block_id: VarInt,
+    pub location: BlockPos,
+    pub block_id: VarInt,
 }
 
 impl CBlockUpdate {

--- a/pumpkin-protocol/src/java/client/play/change_difficulty.rs
+++ b/pumpkin-protocol/src/java/client/play/change_difficulty.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_CHANGE_DIFFICULTY)]
 pub struct CChangeDifficulty {
-    difficulty: u8,
-    locked: bool,
+    pub difficulty: u8,
+    pub locked: bool,
 }
 
 impl CChangeDifficulty {

--- a/pumpkin-protocol/src/java/client/play/chunk_batch_end.rs
+++ b/pumpkin-protocol/src/java/client/play/chunk_batch_end.rs
@@ -7,7 +7,7 @@ use crate::codec::var_int::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_CHUNK_BATCH_FINISHED)]
 pub struct CChunkBatchEnd {
-    batch_size: VarInt,
+    pub batch_size: VarInt,
 }
 
 impl CChunkBatchEnd {

--- a/pumpkin-protocol/src/java/client/play/clear_title.rs
+++ b/pumpkin-protocol/src/java/client/play/clear_title.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_CLEAR_TITLES)]
 pub struct CClearTitle {
-    reset: bool,
+    pub reset: bool,
 }
 
 impl CClearTitle {

--- a/pumpkin-protocol/src/java/client/play/close_container.rs
+++ b/pumpkin-protocol/src/java/client/play/close_container.rs
@@ -7,7 +7,7 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_CONTAINER_CLOSE)]
 pub struct CCloseContainer {
-    sync_id: VarInt,
+    pub sync_id: VarInt,
 }
 
 impl CCloseContainer {

--- a/pumpkin-protocol/src/java/client/play/combat_death.rs
+++ b/pumpkin-protocol/src/java/client/play/combat_death.rs
@@ -8,8 +8,8 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_PLAYER_COMBAT_KILL)]
 pub struct CCombatDeath<'a> {
-    player_id: VarInt,
-    message: &'a TextComponent,
+    pub player_id: VarInt,
+    pub message: &'a TextComponent,
 }
 
 impl<'a> CCombatDeath<'a> {

--- a/pumpkin-protocol/src/java/client/play/command_suggestions.rs
+++ b/pumpkin-protocol/src/java/client/play/command_suggestions.rs
@@ -8,10 +8,10 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_COMMAND_SUGGESTIONS)]
 pub struct CCommandSuggestions {
-    id: VarInt,
-    start: VarInt,
-    length: VarInt,
-    matches: Box<[CommandSuggestion]>,
+    pub id: VarInt,
+    pub start: VarInt,
+    pub length: VarInt,
+    pub matches: Box<[CommandSuggestion]>,
 }
 
 impl CCommandSuggestions {

--- a/pumpkin-protocol/src/java/client/play/cookie_request.rs
+++ b/pumpkin-protocol/src/java/client/play/cookie_request.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 #[packet(PLAY_COOKIE_REQUEST)]
 /// Requests a cookie that was previously stored.
 pub struct CPlayCookieRequest<'a> {
-    key: &'a ResourceLocation,
+    pub key: &'a ResourceLocation,
 }
 
 impl<'a> CPlayCookieRequest<'a> {

--- a/pumpkin-protocol/src/java/client/play/damage_event.rs
+++ b/pumpkin-protocol/src/java/client/play/damage_event.rs
@@ -8,11 +8,11 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_DAMAGE_EVENT)]
 pub struct CDamageEvent {
-    entity_id: VarInt,
-    source_type_id: VarInt,
-    source_cause_id: VarInt,
-    source_direct_id: VarInt,
-    source_position: Option<Vector3<f64>>,
+    pub entity_id: VarInt,
+    pub source_type_id: VarInt,
+    pub source_cause_id: VarInt,
+    pub source_direct_id: VarInt,
+    pub source_position: Option<Vector3<f64>>,
 }
 
 impl CDamageEvent {

--- a/pumpkin-protocol/src/java/client/play/disguised_chat_message.rs
+++ b/pumpkin-protocol/src/java/client/play/disguised_chat_message.rs
@@ -9,10 +9,10 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_DISGUISED_CHAT)]
 pub struct CDisguisedChatMessage<'a> {
-    message: &'a TextComponent,
-    chat_type: VarInt,
-    sender_name: &'a TextComponent,
-    target_name: Option<&'a TextComponent>,
+    pub message: &'a TextComponent,
+    pub chat_type: VarInt,
+    pub sender_name: &'a TextComponent,
+    pub target_name: Option<&'a TextComponent>,
 }
 
 impl<'a> CDisguisedChatMessage<'a> {

--- a/pumpkin-protocol/src/java/client/play/display_objective.rs
+++ b/pumpkin-protocol/src/java/client/play/display_objective.rs
@@ -9,8 +9,8 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_SET_DISPLAY_OBJECTIVE)]
 pub struct CDisplayObjective {
-    position: VarInt,
-    score_name: String,
+    pub position: VarInt,
+    pub score_name: String,
 }
 
 impl CDisplayObjective {

--- a/pumpkin-protocol/src/java/client/play/entity_animation.rs
+++ b/pumpkin-protocol/src/java/client/play/entity_animation.rs
@@ -7,9 +7,9 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_ANIMATE)]
 pub struct CEntityAnimation {
-    entity_id: VarInt,
+    pub entity_id: VarInt,
     /// See `Animation`
-    animation: u8,
+    pub animation: u8,
 }
 
 impl CEntityAnimation {

--- a/pumpkin-protocol/src/java/client/play/entity_metadata.rs
+++ b/pumpkin-protocol/src/java/client/play/entity_metadata.rs
@@ -7,10 +7,10 @@ use crate::{VarInt, ser::network_serialize_no_prefix};
 #[derive(Serialize)]
 #[packet(PLAY_SET_ENTITY_DATA)]
 pub struct CSetEntityMetadata {
-    entity_id: VarInt,
+    pub entity_id: VarInt,
     // TODO: We should migrate the serialization of this into this file
     #[serde(serialize_with = "network_serialize_no_prefix")]
-    metadata: Box<[u8]>,
+    pub metadata: Box<[u8]>,
 }
 
 impl CSetEntityMetadata {

--- a/pumpkin-protocol/src/java/client/play/entity_position_sync.rs
+++ b/pumpkin-protocol/src/java/client/play/entity_position_sync.rs
@@ -10,12 +10,12 @@ use crate::VarInt;
 #[packet(PLAY_ENTITY_POSITION_SYNC)]
 #[derive(Serialize)]
 pub struct CEntityPositionSync {
-    entity_id: VarInt,
-    position: Vector3<f64>,
-    delta: Vector3<f64>,
-    yaw: f32,
-    pitch: f32,
-    on_ground: bool,
+    pub entity_id: VarInt,
+    pub position: Vector3<f64>,
+    pub delta: Vector3<f64>,
+    pub yaw: f32,
+    pub pitch: f32,
+    pub on_ground: bool,
 }
 
 impl CEntityPositionSync {

--- a/pumpkin-protocol/src/java/client/play/entity_sound_effect.rs
+++ b/pumpkin-protocol/src/java/client/play/entity_sound_effect.rs
@@ -8,12 +8,12 @@ use crate::{IdOr, SoundEvent, VarInt};
 #[derive(Deserialize)]
 #[packet(PLAY_SOUND_ENTITY)]
 pub struct CEntitySoundEffect {
-    sound_event: IdOr<SoundEvent>,
-    sound_category: VarInt,
-    entity_id: VarInt,
-    volume: f32,
-    pitch: f32,
-    seed: f64,
+    pub sound_event: IdOr<SoundEvent>,
+    pub sound_category: VarInt,
+    pub entity_id: VarInt,
+    pub volume: f32,
+    pub pitch: f32,
+    pub seed: f64,
 }
 
 impl CEntitySoundEffect {

--- a/pumpkin-protocol/src/java/client/play/entity_status.rs
+++ b/pumpkin-protocol/src/java/client/play/entity_status.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 #[packet(PLAY_ENTITY_EVENT)]
 pub struct CEntityStatus {
-    entity_id: i32,
-    entity_status: i8,
+    pub entity_id: i32,
+    pub entity_status: i8,
 }
 
 impl CEntityStatus {

--- a/pumpkin-protocol/src/java/client/play/entity_velocity.rs
+++ b/pumpkin-protocol/src/java/client/play/entity_velocity.rs
@@ -8,8 +8,8 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_SET_ENTITY_MOTION)]
 pub struct CEntityVelocity {
-    entity_id: VarInt,
-    velocity: Vector3<i16>,
+    pub entity_id: VarInt,
+    pub velocity: Vector3<i16>,
 }
 
 impl CEntityVelocity {

--- a/pumpkin-protocol/src/java/client/play/explode.rs
+++ b/pumpkin-protocol/src/java/client/play/explode.rs
@@ -8,10 +8,10 @@ use crate::{IdOr, SoundEvent, codec::var_int::VarInt};
 #[derive(Serialize)]
 #[packet(PLAY_EXPLODE)]
 pub struct CExplosion {
-    center: Vector3<f64>,
-    knockback: Option<Vector3<f64>>,
-    particle: VarInt,
-    sound: IdOr<SoundEvent>,
+    pub center: Vector3<f64>,
+    pub knockback: Option<Vector3<f64>>,
+    pub particle: VarInt,
+    pub sound: IdOr<SoundEvent>,
 }
 
 impl CExplosion {

--- a/pumpkin-protocol/src/java/client/play/game_event.rs
+++ b/pumpkin-protocol/src/java/client/play/game_event.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 #[packet(PLAY_GAME_EVENT)]
 pub struct CGameEvent {
-    event: u8,
-    value: f32,
+    pub event: u8,
+    pub value: f32,
 }
 
 /// You need to implement all the random stuff somewhere, right?

--- a/pumpkin-protocol/src/java/client/play/head_rot.rs
+++ b/pumpkin-protocol/src/java/client/play/head_rot.rs
@@ -7,8 +7,8 @@ use crate::VarInt;
 #[derive(Serialize, Deserialize)]
 #[packet(PLAY_ROTATE_HEAD)]
 pub struct CHeadRot {
-    entity_id: VarInt,
-    head_yaw: u8,
+    pub entity_id: VarInt,
+    pub head_yaw: u8,
 }
 
 impl CHeadRot {

--- a/pumpkin-protocol/src/java/client/play/hurt_animation.rs
+++ b/pumpkin-protocol/src/java/client/play/hurt_animation.rs
@@ -7,8 +7,8 @@ use crate::VarInt;
 #[derive(Serialize, Deserialize)]
 #[packet(PLAY_HURT_ANIMATION)]
 pub struct CHurtAnimation {
-    entity_id: VarInt,
-    yaw: f32,
+    pub entity_id: VarInt,
+    pub yaw: f32,
 }
 
 impl CHurtAnimation {

--- a/pumpkin-protocol/src/java/client/play/initialize_world_border.rs
+++ b/pumpkin-protocol/src/java/client/play/initialize_world_border.rs
@@ -7,14 +7,14 @@ use crate::{VarInt, codec::var_long::VarLong};
 #[derive(Serialize)]
 #[packet(PLAY_INITIALIZE_BORDER)]
 pub struct CInitializeWorldBorder {
-    x: f64,
-    z: f64,
-    old_diameter: f64,
-    new_diameter: f64,
-    speed: VarLong,
-    portal_teleport_boundary: VarInt,
-    warning_blocks: VarInt,
-    warning_time: VarInt,
+    pub x: f64,
+    pub z: f64,
+    pub old_diameter: f64,
+    pub new_diameter: f64,
+    pub speed: VarLong,
+    pub portal_teleport_boundary: VarInt,
+    pub warning_blocks: VarInt,
+    pub warning_time: VarInt,
 }
 
 impl CInitializeWorldBorder {

--- a/pumpkin-protocol/src/java/client/play/level_event.rs
+++ b/pumpkin-protocol/src/java/client/play/level_event.rs
@@ -6,10 +6,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 #[packet(PLAY_LEVEL_EVENT)]
 pub struct CLevelEvent {
-    event: i32,
-    location: BlockPos,
-    data: i32,
-    disable_relative_volume: bool,
+    pub event: i32,
+    pub location: BlockPos,
+    pub data: i32,
+    pub disable_relative_volume: bool,
 }
 
 impl CLevelEvent {

--- a/pumpkin-protocol/src/java/client/play/login.rs
+++ b/pumpkin-protocol/src/java/client/play/login.rs
@@ -9,28 +9,28 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_LOGIN)]
 pub struct CLogin<'a> {
-    entity_id: i32,
-    is_hardcore: bool,
-    dimension_names: &'a [ResourceLocation],
-    max_players: VarInt,
-    view_distance: VarInt,
-    simulated_distance: VarInt,
-    reduced_debug_info: bool,
-    enabled_respawn_screen: bool,
-    limited_crafting: bool,
+    pub entity_id: i32,
+    pub is_hardcore: bool,
+    pub dimension_names: &'a [ResourceLocation],
+    pub max_players: VarInt,
+    pub view_distance: VarInt,
+    pub simulated_distance: VarInt,
+    pub reduced_debug_info: bool,
+    pub enabled_respawn_screen: bool,
+    pub limited_crafting: bool,
     // Spawn info
-    dimension_type: VarInt,
-    dimension_name: ResourceLocation,
+    pub dimension_type: VarInt,
+    pub dimension_name: ResourceLocation,
     /// First 8 bytes of the SHA-256 hash of the world's seed. Used client side for biome noise
-    hashed_seed: i64,
-    game_mode: u8,
-    previous_gamemode: i8,
-    debug: bool,
-    is_flat: bool,
-    death_dimension_name: Option<(ResourceLocation, BlockPos)>,
-    portal_cooldown: VarInt,
-    sealevel: VarInt,
-    enforce_secure_chat: bool,
+    pub hashed_seed: i64,
+    pub game_mode: u8,
+    pub previous_gamemode: i8,
+    pub debug: bool,
+    pub is_flat: bool,
+    pub death_dimension_name: Option<(ResourceLocation, BlockPos)>,
+    pub portal_cooldown: VarInt,
+    pub sealevel: VarInt,
+    pub enforce_secure_chat: bool,
 }
 
 impl<'a> CLogin<'a> {

--- a/pumpkin-protocol/src/java/client/play/multi_block_update.rs
+++ b/pumpkin-protocol/src/java/client/play/multi_block_update.rs
@@ -11,8 +11,8 @@ use crate::codec::{var_int::VarInt, var_long::VarLong};
 
 #[packet(PLAY_SECTION_BLOCKS_UPDATE)]
 pub struct CMultiBlockUpdate {
-    chunk_section: Vector3<i32>,
-    positions_to_state_ids: Vec<(i16, i32)>,
+    pub chunk_section: Vector3<i32>,
+    pub positions_to_state_ids: Vec<(i16, i32)>,
 }
 
 impl CMultiBlockUpdate {

--- a/pumpkin-protocol/src/java/client/play/open_screen.rs
+++ b/pumpkin-protocol/src/java/client/play/open_screen.rs
@@ -9,9 +9,9 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_OPEN_SCREEN)]
 pub struct COpenScreen<'a> {
-    sync_id: VarInt,
-    window_type: VarInt,
-    window_title: &'a TextComponent,
+    pub sync_id: VarInt,
+    pub window_type: VarInt,
+    pub window_title: &'a TextComponent,
 }
 
 impl<'a> COpenScreen<'a> {

--- a/pumpkin-protocol/src/java/client/play/open_sign_editor.rs
+++ b/pumpkin-protocol/src/java/client/play/open_sign_editor.rs
@@ -6,8 +6,8 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_OPEN_SIGN_EDITOR)]
 pub struct COpenSignEditor {
-    location: BlockPos,
-    is_front_text: bool,
+    pub location: BlockPos,
+    pub is_front_text: bool,
 }
 
 impl COpenSignEditor {

--- a/pumpkin-protocol/src/java/client/play/particle.rs
+++ b/pumpkin-protocol/src/java/client/play/particle.rs
@@ -8,16 +8,16 @@ use crate::{VarInt, ser::network_serialize_no_prefix};
 #[derive(Serialize)]
 #[packet(PLAY_LEVEL_PARTICLES)]
 pub struct CParticle<'a> {
-    force_spawn: bool,
+    pub force_spawn: bool,
     /// If true, particle distance increases from 256 to 65536.
-    important: bool,
-    position: Vector3<f64>,
-    offset: Vector3<f32>,
-    max_speed: f32,
-    particle_count: i32,
-    particle_id: VarInt,
+    pub important: bool,
+    pub position: Vector3<f64>,
+    pub offset: Vector3<f32>,
+    pub max_speed: f32,
+    pub particle_count: i32,
+    pub particle_id: VarInt,
     #[serde(serialize_with = "network_serialize_no_prefix")]
-    data: &'a [u8],
+    pub data: &'a [u8],
 }
 
 impl<'a> CParticle<'a> {

--- a/pumpkin-protocol/src/java/client/play/player_abilities.rs
+++ b/pumpkin-protocol/src/java/client/play/player_abilities.rs
@@ -5,9 +5,9 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_PLAYER_ABILITIES)]
 pub struct CPlayerAbilities {
-    flags: i8,
-    flying_speed: f32,
-    field_of_view: f32,
+    pub flags: i8,
+    pub flying_speed: f32,
+    pub field_of_view: f32,
 }
 
 impl CPlayerAbilities {

--- a/pumpkin-protocol/src/java/client/play/player_chat_message.rs
+++ b/pumpkin-protocol/src/java/client/play/player_chat_message.rs
@@ -13,21 +13,21 @@ use crate::{
 #[packet(PLAY_PLAYER_CHAT)]
 pub struct CPlayerChatMessage {
     /// An index that increases for every message sent TO the client
-    global_index: VarInt,
-    sender: uuid::Uuid,
+    pub global_index: VarInt,
+    pub sender: uuid::Uuid,
     /// An index that increases for every message sent BY the client
-    index: VarInt,
-    message_signature: Option<Box<[u8]>>, // always 256
-    message: String,
-    timestamp: i64,
-    salt: i64,
-    previous_messages: Box<[PreviousMessage]>, // max 20
-    unsigned_content: Option<TextComponent>,
-    filter_type: FilterType,
+    pub index: VarInt,
+    pub message_signature: Option<Box<[u8]>>, // always 256
+    pub message: String,
+    pub timestamp: i64,
+    pub salt: i64,
+    pub previous_messages: Box<[PreviousMessage]>, // max 20
+    pub unsigned_content: Option<TextComponent>,
+    pub filter_type: FilterType,
     /// This should not be zero, (index + 1)
-    chat_type: VarInt,
-    sender_name: TextComponent,
-    target_name: Option<TextComponent>,
+    pub chat_type: VarInt,
+    pub sender_name: TextComponent,
+    pub target_name: Option<TextComponent>,
 }
 
 impl CPlayerChatMessage {

--- a/pumpkin-protocol/src/java/client/play/player_remove.rs
+++ b/pumpkin-protocol/src/java/client/play/player_remove.rs
@@ -6,7 +6,7 @@ use serde::{Serialize, ser::SerializeSeq};
 #[packet(PLAY_PLAYER_INFO_REMOVE)]
 pub struct CRemovePlayerInfo<'a> {
     #[serde(serialize_with = "serialize_slice_uuids")]
-    players: &'a [uuid::Uuid],
+    pub players: &'a [uuid::Uuid],
 }
 
 impl<'a> CRemovePlayerInfo<'a> {

--- a/pumpkin-protocol/src/java/client/play/remove_entities.rs
+++ b/pumpkin-protocol/src/java/client/play/remove_entities.rs
@@ -7,7 +7,7 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_REMOVE_ENTITIES)]
 pub struct CRemoveEntities<'a> {
-    entity_ids: &'a [VarInt],
+    pub entity_ids: &'a [VarInt],
 }
 
 impl<'a> CRemoveEntities<'a> {

--- a/pumpkin-protocol/src/java/client/play/reset_score.rs
+++ b/pumpkin-protocol/src/java/client/play/reset_score.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_RESET_SCORE)]
 pub struct CResetScore {
-    entity_name: String,
-    objective_name: Option<String>,
+    pub entity_name: String,
+    pub objective_name: Option<String>,
 }
 
 impl CResetScore {

--- a/pumpkin-protocol/src/java/client/play/respawn.rs
+++ b/pumpkin-protocol/src/java/client/play/respawn.rs
@@ -8,17 +8,17 @@ use crate::VarInt;
 #[derive(Serialize, Deserialize)]
 #[packet(PLAY_RESPAWN)]
 pub struct CRespawn {
-    dimension_type: VarInt,
-    dimension_name: ResourceLocation,
-    hashed_seed: i64,
-    game_mode: u8,
-    previous_gamemode: i8,
-    debug: bool,
-    is_flat: bool,
-    death_dimension_name: Option<(ResourceLocation, BlockPos)>,
-    portal_cooldown: VarInt,
-    sealevel: VarInt,
-    data_kept: u8,
+    pub dimension_type: VarInt,
+    pub dimension_name: ResourceLocation,
+    pub hashed_seed: i64,
+    pub game_mode: u8,
+    pub previous_gamemode: i8,
+    pub debug: bool,
+    pub is_flat: bool,
+    pub death_dimension_name: Option<(ResourceLocation, BlockPos)>,
+    pub portal_cooldown: VarInt,
+    pub sealevel: VarInt,
+    pub data_kept: u8,
 }
 
 impl CRespawn {

--- a/pumpkin-protocol/src/java/client/play/server_links.rs
+++ b/pumpkin-protocol/src/java/client/play/server_links.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SERVER_LINKS)]
 pub struct CPlayServerLinks<'a> {
-    links: &'a [Link<'a>],
+    pub links: &'a [Link<'a>],
 }
 
 impl<'a> CPlayServerLinks<'a> {

--- a/pumpkin-protocol/src/java/client/play/set_border_center.rs
+++ b/pumpkin-protocol/src/java/client/play/set_border_center.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SET_BORDER_CENTER)]
 pub struct CSetBorderCenter {
-    x: f64,
-    z: f64,
+    pub x: f64,
+    pub z: f64,
 }
 
 impl CSetBorderCenter {

--- a/pumpkin-protocol/src/java/client/play/set_border_lerp_size.rs
+++ b/pumpkin-protocol/src/java/client/play/set_border_lerp_size.rs
@@ -7,9 +7,9 @@ use crate::codec::var_long::VarLong;
 #[derive(Serialize)]
 #[packet(PLAY_SET_BORDER_LERP_SIZE)]
 pub struct CSetBorderLerpSize {
-    old_diameter: f64,
-    new_diameter: f64,
-    speed: VarLong,
+    pub old_diameter: f64,
+    pub new_diameter: f64,
+    pub speed: VarLong,
 }
 
 impl CSetBorderLerpSize {

--- a/pumpkin-protocol/src/java/client/play/set_border_size.rs
+++ b/pumpkin-protocol/src/java/client/play/set_border_size.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SET_BORDER_SIZE)]
 pub struct CSetBorderSize {
-    diameter: f64,
+    pub diameter: f64,
 }
 
 impl CSetBorderSize {

--- a/pumpkin-protocol/src/java/client/play/set_border_warning_delay.rs
+++ b/pumpkin-protocol/src/java/client/play/set_border_warning_delay.rs
@@ -7,7 +7,7 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_SET_BORDER_WARNING_DELAY)]
 pub struct CSetBorderWarningDelay {
-    warning_time: VarInt,
+    pub warning_time: VarInt,
 }
 
 impl CSetBorderWarningDelay {

--- a/pumpkin-protocol/src/java/client/play/set_border_warning_distance.rs
+++ b/pumpkin-protocol/src/java/client/play/set_border_warning_distance.rs
@@ -7,7 +7,7 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_SET_BORDER_WARNING_DISTANCE)]
 pub struct CSetBorderWarningDistance {
-    warning_blocks: VarInt,
+    pub warning_blocks: VarInt,
 }
 
 impl CSetBorderWarningDistance {

--- a/pumpkin-protocol/src/java/client/play/set_container_content.rs
+++ b/pumpkin-protocol/src/java/client/play/set_container_content.rs
@@ -8,10 +8,10 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_CONTAINER_SET_CONTENT)]
 pub struct CSetContainerContent<'a> {
-    window_id: VarInt,
-    state_id: VarInt,
-    slot_data: &'a [ItemStackSerializer<'a>],
-    carried_item: &'a ItemStackSerializer<'a>,
+    pub window_id: VarInt,
+    pub state_id: VarInt,
+    pub slot_data: &'a [ItemStackSerializer<'a>],
+    pub carried_item: &'a ItemStackSerializer<'a>,
 }
 
 impl<'a> CSetContainerContent<'a> {

--- a/pumpkin-protocol/src/java/client/play/set_container_property.rs
+++ b/pumpkin-protocol/src/java/client/play/set_container_property.rs
@@ -7,9 +7,9 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_CONTAINER_SET_DATA)]
 pub struct CSetContainerProperty {
-    window_id: VarInt,
-    property: i16,
-    value: i16,
+    pub window_id: VarInt,
+    pub property: i16,
+    pub value: i16,
 }
 
 impl CSetContainerProperty {

--- a/pumpkin-protocol/src/java/client/play/set_container_slot.rs
+++ b/pumpkin-protocol/src/java/client/play/set_container_slot.rs
@@ -8,10 +8,10 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_CONTAINER_SET_SLOT)]
 pub struct CSetContainerSlot<'a> {
-    window_id: i8,
-    state_id: VarInt,
-    slot: i16,
-    slot_data: &'a ItemStackSerializer<'a>,
+    pub window_id: i8,
+    pub state_id: VarInt,
+    pub slot: i16,
+    pub slot_data: &'a ItemStackSerializer<'a>,
 }
 
 impl<'a> CSetContainerSlot<'a> {

--- a/pumpkin-protocol/src/java/client/play/set_cursor_slot.rs
+++ b/pumpkin-protocol/src/java/client/play/set_cursor_slot.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SET_CURSOR_ITEM)]
 pub struct CSetCursorItem<'a> {
-    stack: &'a ItemStackSerializer<'a>,
+    pub stack: &'a ItemStackSerializer<'a>,
 }
 
 impl<'a> CSetCursorItem<'a> {

--- a/pumpkin-protocol/src/java/client/play/set_equipment.rs
+++ b/pumpkin-protocol/src/java/client/play/set_equipment.rs
@@ -15,8 +15,8 @@ use crate::{
 
 #[packet(PLAY_SET_EQUIPMENT)]
 pub struct CSetEquipment {
-    entity_id: VarInt,
-    equipment: Vec<(i8, ItemStackSerializer<'static>)>,
+    pub entity_id: VarInt,
+    pub equipment: Vec<(i8, ItemStackSerializer<'static>)>,
 }
 
 impl CSetEquipment {

--- a/pumpkin-protocol/src/java/client/play/set_experience.rs
+++ b/pumpkin-protocol/src/java/client/play/set_experience.rs
@@ -7,9 +7,9 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_SET_EXPERIENCE)]
 pub struct CSetExperience {
-    progress: f32,
-    total_experience: VarInt,
-    level: VarInt,
+    pub progress: f32,
+    pub total_experience: VarInt,
+    pub level: VarInt,
 }
 
 impl CSetExperience {

--- a/pumpkin-protocol/src/java/client/play/set_health.rs
+++ b/pumpkin-protocol/src/java/client/play/set_health.rs
@@ -7,9 +7,9 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_SET_HEALTH)]
 pub struct CSetHealth {
-    health: f32,
-    food: VarInt,
-    food_saturation: f32,
+    pub health: f32,
+    pub food: VarInt,
+    pub food_saturation: f32,
 }
 
 impl CSetHealth {

--- a/pumpkin-protocol/src/java/client/play/set_held_item.rs
+++ b/pumpkin-protocol/src/java/client/play/set_held_item.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SET_HELD_SLOT)]
 pub struct CSetSelectedSlot {
-    slot: i8,
+    pub slot: i8,
 }
 
 impl CSetSelectedSlot {

--- a/pumpkin-protocol/src/java/client/play/set_player_inventory.rs
+++ b/pumpkin-protocol/src/java/client/play/set_player_inventory.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SET_PLAYER_INVENTORY)]
 pub struct CSetPlayerInventory<'a> {
-    slot: VarInt,
-    item: &'a ItemStackSerializer<'a>,
+    pub slot: VarInt,
+    pub item: &'a ItemStackSerializer<'a>,
 }
 
 impl<'a> CSetPlayerInventory<'a> {

--- a/pumpkin-protocol/src/java/client/play/set_time.rs
+++ b/pumpkin-protocol/src/java/client/play/set_time.rs
@@ -5,9 +5,9 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SET_TIME)]
 pub struct CUpdateTime {
-    world_age: i64,
-    time_of_day: i64,
-    time_of_day_increasing: bool,
+    pub world_age: i64,
+    pub time_of_day: i64,
+    pub time_of_day_increasing: bool,
 }
 
 impl CUpdateTime {

--- a/pumpkin-protocol/src/java/client/play/set_title.rs
+++ b/pumpkin-protocol/src/java/client/play/set_title.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SET_TITLE_TEXT)]
 pub struct CTitleText<'a> {
-    title: &'a TextComponent,
+    pub title: &'a TextComponent,
 }
 
 impl<'a> CTitleText<'a> {

--- a/pumpkin-protocol/src/java/client/play/sound_effect.rs
+++ b/pumpkin-protocol/src/java/client/play/sound_effect.rs
@@ -8,12 +8,12 @@ use crate::{IdOr, SoundEvent, VarInt};
 #[derive(Serialize)]
 #[packet(PLAY_SOUND)]
 pub struct CSoundEffect {
-    sound_event: IdOr<SoundEvent>,
-    sound_category: VarInt,
-    position: Vector3<i32>,
-    volume: f32,
-    pitch: f32,
-    seed: f64,
+    pub sound_event: IdOr<SoundEvent>,
+    pub sound_category: VarInt,
+    pub position: Vector3<i32>,
+    pub volume: f32,
+    pub pitch: f32,
+    pub seed: f64,
 }
 
 impl CSoundEffect {

--- a/pumpkin-protocol/src/java/client/play/spawn_entity.rs
+++ b/pumpkin-protocol/src/java/client/play/spawn_entity.rs
@@ -8,16 +8,16 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_ADD_ENTITY)]
 pub struct CSpawnEntity {
-    entity_id: VarInt,
+    pub entity_id: VarInt,
     #[serde(with = "uuid::serde::compact")]
-    entity_uuid: uuid::Uuid,
-    r#type: VarInt,
-    position: Vector3<f64>,
-    pitch: u8,    // angle
-    yaw: u8,      // angle
-    head_yaw: u8, // angle
-    data: VarInt,
-    velocity: Vector3<i16>,
+    pub entity_uuid: uuid::Uuid,
+    pub r#type: VarInt,
+    pub position: Vector3<f64>,
+    pub pitch: u8,    // angle
+    pub yaw: u8,      // angle
+    pub head_yaw: u8, // angle
+    pub data: VarInt,
+    pub velocity: Vector3<i16>,
 }
 
 impl CSpawnEntity {

--- a/pumpkin-protocol/src/java/client/play/stop_sound.rs
+++ b/pumpkin-protocol/src/java/client/play/stop_sound.rs
@@ -9,8 +9,8 @@ use pumpkin_util::resource_location::ResourceLocation;
 
 #[packet(PLAY_STOP_SOUND)]
 pub struct CStopSound {
-    sound_id: Option<ResourceLocation>,
-    category: Option<SoundCategory>,
+    pub sound_id: Option<ResourceLocation>,
+    pub category: Option<SoundCategory>,
 }
 
 impl CStopSound {

--- a/pumpkin-protocol/src/java/client/play/store_cookie.rs
+++ b/pumpkin-protocol/src/java/client/play/store_cookie.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_STORE_COOKIE)]
 pub struct CStoreCookie<'a> {
-    key: &'a ResourceLocation,
-    payload: &'a [u8], // 5120,
+    pub key: &'a ResourceLocation,
+    pub payload: &'a [u8], // 5120,
 }
 
 impl<'a> CStoreCookie<'a> {

--- a/pumpkin-protocol/src/java/client/play/subtitle.rs
+++ b/pumpkin-protocol/src/java/client/play/subtitle.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SET_SUBTITLE_TEXT)]
 pub struct CSubtitle<'a> {
-    subtitle: &'a TextComponent,
+    pub subtitle: &'a TextComponent,
 }
 
 impl<'a> CSubtitle<'a> {

--- a/pumpkin-protocol/src/java/client/play/system_chat_message.rs
+++ b/pumpkin-protocol/src/java/client/play/system_chat_message.rs
@@ -7,8 +7,8 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_SYSTEM_CHAT)]
 pub struct CSystemChatMessage<'a> {
-    content: &'a TextComponent,
-    overlay: bool,
+    pub content: &'a TextComponent,
+    pub overlay: bool,
 }
 
 impl<'a> CSystemChatMessage<'a> {

--- a/pumpkin-protocol/src/java/client/play/take_item.rs
+++ b/pumpkin-protocol/src/java/client/play/take_item.rs
@@ -7,11 +7,11 @@ use serde::Serialize;
 #[packet(PLAY_TAKE_ITEM_ENTITY)]
 pub struct CTakeItemEntity {
     /// The entity id of the item entity.
-    entity_id: VarInt,
+    pub entity_id: VarInt,
     /// The entity id of the entity who is collecting the item.
-    collector_entity_id: VarInt,
+    pub collector_entity_id: VarInt,
     /// The Number of items in the Stack
-    stack_amount: VarInt,
+    pub stack_amount: VarInt,
 }
 
 impl CTakeItemEntity {

--- a/pumpkin-protocol/src/java/client/play/teleport_entity.rs
+++ b/pumpkin-protocol/src/java/client/play/teleport_entity.rs
@@ -9,13 +9,13 @@ use crate::{ClientPacket, PositionFlag, VarInt, WritingError, ser::NetworkWriteE
 /// Only used when teleporting a player's vehicle, this packet is sent to the player.
 #[packet(PLAY_TELEPORT_ENTITY)]
 pub struct CTeleportEntity<'a> {
-    entity_id: VarInt,
-    position: Vector3<f64>,
-    delta: Vector3<f64>,
-    yaw: f32,
-    pitch: f32,
-    relatives: &'a [PositionFlag],
-    on_ground: bool,
+    pub entity_id: VarInt,
+    pub position: Vector3<f64>,
+    pub delta: Vector3<f64>,
+    pub yaw: f32,
+    pub pitch: f32,
+    pub relatives: &'a [PositionFlag],
+    pub on_ground: bool,
 }
 
 impl<'a> CTeleportEntity<'a> {

--- a/pumpkin-protocol/src/java/client/play/ticking_state.rs
+++ b/pumpkin-protocol/src/java/client/play/ticking_state.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_TICKING_STATE)]
 pub struct CTickingState {
-    tick_rate: f32,
-    is_frozen: bool,
+    pub tick_rate: f32,
+    pub is_frozen: bool,
 }
 
 impl CTickingState {

--- a/pumpkin-protocol/src/java/client/play/ticking_step.rs
+++ b/pumpkin-protocol/src/java/client/play/ticking_step.rs
@@ -7,7 +7,7 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_TICKING_STEP)]
 pub struct CTickingStep {
-    tick_steps: VarInt,
+    pub tick_steps: VarInt,
 }
 
 impl CTickingStep {

--- a/pumpkin-protocol/src/java/client/play/transfer.rs
+++ b/pumpkin-protocol/src/java/client/play/transfer.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 #[packet(PLAY_TRANSFER)]
 pub struct CTransfer<'a> {
-    host: &'a str,
-    port: VarInt,
+    pub host: &'a str,
+    pub port: VarInt,
 }
 
 impl<'a> CTransfer<'a> {

--- a/pumpkin-protocol/src/java/client/play/unload_chunk.rs
+++ b/pumpkin-protocol/src/java/client/play/unload_chunk.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_FORGET_LEVEL_CHUNK)]
 pub struct CUnloadChunk {
-    z: i32,
-    x: i32,
+    pub z: i32,
+    pub x: i32,
 }
 
 impl CUnloadChunk {

--- a/pumpkin-protocol/src/java/client/play/update_entity_pos.rs
+++ b/pumpkin-protocol/src/java/client/play/update_entity_pos.rs
@@ -8,9 +8,9 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_MOVE_ENTITY_POS)]
 pub struct CUpdateEntityPos {
-    entity_id: VarInt,
-    delta: Vector3<i16>,
-    on_ground: bool,
+    pub entity_id: VarInt,
+    pub delta: Vector3<i16>,
+    pub on_ground: bool,
 }
 
 impl CUpdateEntityPos {

--- a/pumpkin-protocol/src/java/client/play/update_entity_pos_rot.rs
+++ b/pumpkin-protocol/src/java/client/play/update_entity_pos_rot.rs
@@ -8,11 +8,11 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_MOVE_ENTITY_POS_ROT)]
 pub struct CUpdateEntityPosRot {
-    entity_id: VarInt,
-    delta: Vector3<i16>,
-    yaw: u8,
-    pitch: u8,
-    on_ground: bool,
+    pub entity_id: VarInt,
+    pub delta: Vector3<i16>,
+    pub yaw: u8,
+    pub pitch: u8,
+    pub on_ground: bool,
 }
 
 impl CUpdateEntityPosRot {

--- a/pumpkin-protocol/src/java/client/play/update_entity_rot.rs
+++ b/pumpkin-protocol/src/java/client/play/update_entity_rot.rs
@@ -7,10 +7,10 @@ use crate::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_MOVE_ENTITY_ROT)]
 pub struct CUpdateEntityRot {
-    entity_id: VarInt,
-    yaw: u8,
-    pitch: u8,
-    on_ground: bool,
+    pub entity_id: VarInt,
+    pub yaw: u8,
+    pub pitch: u8,
+    pub on_ground: bool,
 }
 
 impl CUpdateEntityRot {

--- a/pumpkin-protocol/src/java/client/play/update_mob_effect.rs
+++ b/pumpkin-protocol/src/java/client/play/update_mob_effect.rs
@@ -7,11 +7,11 @@ use crate::codec::var_int::VarInt;
 #[derive(Serialize)]
 #[packet(PLAY_UPDATE_MOB_EFFECT)]
 pub struct CUpdateMobEffect {
-    entity_id: VarInt,
-    effect_id: VarInt,
-    amplifier: VarInt,
-    duration: VarInt,
-    flags: i8,
+    pub entity_id: VarInt,
+    pub effect_id: VarInt,
+    pub amplifier: VarInt,
+    pub duration: VarInt,
+    pub flags: i8,
 }
 
 impl CUpdateMobEffect {

--- a/pumpkin-protocol/src/java/client/play/update_objectives.rs
+++ b/pumpkin-protocol/src/java/client/play/update_objectives.rs
@@ -8,11 +8,11 @@ use crate::{ClientPacket, NumberFormat, VarInt, WritingError, ser::NetworkWriteE
 
 #[packet(PLAY_SET_OBJECTIVE)]
 pub struct CUpdateObjectives {
-    objective_name: String,
-    mode: u8,
-    display_name: TextComponent,
-    render_type: VarInt,
-    number_format: Option<NumberFormat>,
+    pub objective_name: String,
+    pub mode: u8,
+    pub display_name: TextComponent,
+    pub render_type: VarInt,
+    pub number_format: Option<NumberFormat>,
 }
 
 impl CUpdateObjectives {

--- a/pumpkin-protocol/src/java/client/play/update_score.rs
+++ b/pumpkin-protocol/src/java/client/play/update_score.rs
@@ -9,11 +9,11 @@ use crate::{NumberFormat, VarInt};
 #[derive(Serialize)]
 #[packet(PLAY_SET_SCORE)]
 pub struct CUpdateScore {
-    entity_name: String,
-    objective_name: String,
-    value: VarInt,
-    display_name: Option<TextComponent>,
-    number_format: Option<NumberFormat>,
+    pub entity_name: String,
+    pub objective_name: String,
+    pub value: VarInt,
+    pub display_name: Option<TextComponent>,
+    pub number_format: Option<NumberFormat>,
 }
 
 impl CUpdateScore {

--- a/pumpkin-protocol/src/java/client/play/worldevent.rs
+++ b/pumpkin-protocol/src/java/client/play/worldevent.rs
@@ -7,10 +7,10 @@ use serde::Serialize;
 #[derive(Serialize)]
 #[packet(PLAY_LEVEL_EVENT)]
 pub struct CWorldEvent {
-    event: i32,
-    location: BlockPos,
-    data: i32,
-    disable_relative_volume: bool,
+    pub event: i32,
+    pub location: BlockPos,
+    pub data: i32,
+    pub disable_relative_volume: bool,
 }
 
 impl CWorldEvent {

--- a/pumpkin-protocol/src/java/client/status/ping_response.rs
+++ b/pumpkin-protocol/src/java/client/status/ping_response.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 #[packet(STATUS_PONG_RESPONSE)]
 pub struct CPingResponse {
-    payload: i64, // must respond with the same as in `SPingRequest`
+    pub payload: i64, // must respond with the same as in `SPingRequest`
 }
 
 impl CPingResponse {

--- a/pumpkin-protocol/src/java/client/status/status_response.rs
+++ b/pumpkin-protocol/src/java/client/status/status_response.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 #[packet(STATUS_STATUS_RESPONSE)]
 pub struct CStatusResponse<'a> {
-    json_response: &'a str, // 32767
+    pub json_response: &'a str, // 32767
 }
 impl<'a> CStatusResponse<'a> {
     pub fn new(json_response: &'a str) -> Self {


### PR DESCRIPTION
## Description
This pull request makes all parameters of client packets public and accessible to any projects that may use pumpkin for the client protocol. BotMark makes use of the protocol but does not currently need access to any of these packets, but it should open the opportunity for people to use it that way.

