### PR TITLE
Fix broken nix flake, add rust-analyzer to devshell and move to fenix from rust-overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1755153894,
+        "narHash": "sha256-DEKeIg3MQy5GMFiFRUzcx1hGGBN2ypUPTo0jrMAdmH4=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f6874c6e512bc69d881d979a45379b988b80a338",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "locked": {
         "lastModified": 1733328505,
@@ -65,29 +86,26 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "nixpkgs": "nixpkgs"
       }
     },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
+    "rust-analyzer-src": {
+      "flake": false,
       "locked": {
-        "lastModified": 1751423951,
-        "narHash": "sha256-AowKhJGplXRkAngSvb+32598DTiI6LOzhAnzgvbCtYM=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "1684ed5b15859b655caf41b467d046e29a994d04",
+        "lastModified": 1755004716,
+        "narHash": "sha256-TbhPR5Fqw5LjAeI3/FOPhNNFQCF3cieKCJWWupeZmiA=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "b2a58b8c6eff3c3a2c8b5c70dbf69ead78284194",
         "type": "github"
       },
       "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,52 +3,59 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
+    fenix = {
+      url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = inputs@{ nixpkgs, flake-parts, ... }:
+  outputs = inputs @ {
+    nixpkgs,
+    flake-parts,
+    fenix,
+    ...
+  }:
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = nixpkgs.lib.systems.flakeExposed;
       perSystem = {
         pkgs,
         system,
         ...
-      }:
-      let
-        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      }: let
+        toolchain = fenix.packages.${system}.stable.toolchain;
         manifest = (pkgs.lib.importTOML ./pumpkin/Cargo.toml).package;
-      in
-      {
+        workspace-manifest =
+          (pkgs.lib.importTOML ./Cargo.toml).workspace.package;
+      in {
         formatter = pkgs.nixfmt-rfc-style;
         _module.args.pkgs = import nixpkgs {
           inherit system;
-          overlays = [
-            (import inputs.rust-overlay)
-          ];
         };
 
-        devShells.default = pkgs.mkShell
-        {
-          nativeBuildInputs = with pkgs; [
-            (rustToolchain.override {
-                extensions = ["rust-src"];
-            })
-            pkg-config
-          ];
-        };
+        devShells.default =
+          pkgs.mkShell
+          {
+            nativeBuildInputs = with pkgs; [
+              toolchain
+              pkg-config
+            ];
+          };
 
-        packages.default = (pkgs.makeRustPlatform {rustc = rustToolchain; cargo = rustToolchain;}).buildRustPackage {
+        packages.default =
+          (pkgs.makeRustPlatform {
+            rustc = toolchain;
+            cargo = toolchain;
+          }).buildRustPackage {
             pname = manifest.name;
-            version = manifest.version;
+            version = workspace-manifest.version;
+
+            src = ./.;
 
             useFetchCargoVendor = true;
             cargoLock = {
-                lockFile = ./Cargo.lock;
+              lockFile = ./Cargo.lock;
             };
-        };
+          };
       };
     };
 }


### PR DESCRIPTION
## Description
Like the title says, this fixes the flake that previously didn't break, adds rust-analyzer to the nix devshell and moves to fenix (a rust toolchain provider) from rust-overlay.

## Testing
This doesn't affect any of the code and I have successfully built the nix package which should be reproducible.
