### PR TITLE
build: nix user development simplification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [workspace]
 resolver = "2"
 members = [
-    "pumpkin-api-macros",
-    "pumpkin-config",
-    "pumpkin-util",
-    "pumpkin-inventory",
-    "pumpkin-macros/",
-    "pumpkin-protocol/",
-    "pumpkin-registry/",
-    "pumpkin-world",
-    "pumpkin/",
-    "pumpkin-data",
+  "pumpkin-api-macros",
+  "pumpkin-config",
+  "pumpkin-util",
+  "pumpkin-inventory",
+  "pumpkin-macros/",
+  "pumpkin-protocol/",
+  "pumpkin-registry/",
+  "pumpkin-world",
+  "pumpkin/",
+  "pumpkin-data",
 ]
 
 [workspace.package]
@@ -31,15 +31,15 @@ debug = true
 [workspace.dependencies]
 log = "0.4"
 tokio = { version = "1.47", features = [
-    "macros",
-    "net",
-    "rt-multi-thread",
-    "sync",
-    "io-std",
-    "signal",
-    "fs",
-    "io-util",
-    "time",
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "sync",
+  "io-std",
+  "signal",
+  "fs",
+  "io-util",
+  "time",
 ] }
 
 thiserror = "2.0"

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,12 @@
-(import
-  (
-    let
-      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-      nodeName = lock.nodes.root.inputs.flake-compat;
-    in
-    fetchTarball {
-      url = lock.nodes.${nodeName}.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
-      sha256 = lock.nodes.${nodeName}.locked.narHash;
-    }
-  )
-  { src = ./.; }
-).defaultNix
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1755153894,
-        "narHash": "sha256-DEKeIg3MQy5GMFiFRUzcx1hGGBN2ypUPTo0jrMAdmH4=",
+        "lastModified": 1755585599,
+        "narHash": "sha256-tl/0cnsqB/Yt7DbaGMel2RLa7QG5elA8lkaOXli6VdY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "f6874c6e512bc69d881d979a45379b988b80a338",
+        "rev": "6ed03ef4c8ec36d193c18e06b9ecddde78fb7e42",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -53,29 +53,52 @@
         "type": "github"
       }
     },
+    "naersk": {
+      "inputs": {
+        "fenix": [
+          "fenix"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752689277,
+        "narHash": "sha256-uldUBFkZe/E7qbvxa3mH1ItrWZyT6w1dBKJQF/3ZSsc=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "0e72363d0938b0208d6c646d10649164c43f4d64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751271578,
-        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "lastModified": 1755268003,
+        "narHash": "sha256-nNaeJjo861wFR0tjHDyCnHs1rbRtrMgxAKMoig9Sj/w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "rev": "32f313e49e42f715491e1ea7b306a87c16fe0388",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
         "type": "github"
       },
       "original": {
@@ -89,17 +112,18 @@
         "fenix": "fenix",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
+        "naersk": "naersk",
         "nixpkgs": "nixpkgs"
       }
     },
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1755004716,
-        "narHash": "sha256-TbhPR5Fqw5LjAeI3/FOPhNNFQCF3cieKCJWWupeZmiA=",
+        "lastModified": 1755504847,
+        "narHash": "sha256-VX0B9hwhJypCGqncVVLC+SmeMVd/GAYbJZ0MiiUn2Pk=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "b2a58b8c6eff3c3a2c8b5c70dbf69ead78284194",
+        "rev": "a905e3b21b144d77e1b304e49f3264f6f8d4db75",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,46 +1,40 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
     flake-parts.url = "github:hercules-ci/flake-parts";
+
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+
     fenix = {
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    naersk = {
+      url = "github:nix-community/naersk";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        fenix.follows = "fenix";
+      };
+    };
   };
 
-  outputs = inputs @ {
-    nixpkgs,
-    flake-parts,
-    fenix,
-    ...
-  }:
-    flake-parts.lib.mkFlake {inherit inputs;} {
+  outputs =
+    inputs@{
+      flake-parts,
+      naersk,
+      nixpkgs,
+      ...
+    }:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = nixpkgs.lib.systems.flakeExposed;
-      perSystem = {
-        pkgs,
-        system,
-        ...
-      }: let
-        toolchain = fenix.packages.${system}.stable.toolchain;
-        manifest = (pkgs.lib.importTOML ./pumpkin/Cargo.toml).package;
-        workspace-manifest =
-          (pkgs.lib.importTOML ./Cargo.toml).workspace.package;
-      in {
-        _module.args.pkgs = import nixpkgs {
-          inherit system;
-        };
 
-        devShells.default =
-          pkgs.mkShell
-          {
-            nativeBuildInputs = with pkgs; [
-              toolchain
-              pkg-config
-            ];
       imports = [ flake-parts.flakeModules.partitions ];
 
       partitionedAttrs = {
+        checks = "dev";
+        devShells = "dev";
         formatter = "dev";
       };
 
@@ -49,23 +43,53 @@
         module.imports = [ ./nix/dev ];
       };
 
+      perSystem =
+        {
+          inputs',
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          toolchain = inputs'.fenix.packages.fromToolchainFile {
+            file = ./rust-toolchain.toml;
+            sha256 = "sha256-+9FmLhAOezBZCOziO0Qct1NOrfpjNsXxc/8I0c7BdKE=";
           };
 
-        packages.default =
-          (pkgs.makeRustPlatform {
-            rustc = toolchain;
+          naersk' = pkgs.callPackage naersk {
             cargo = toolchain;
-          }).buildRustPackage {
+            rustc = toolchain;
+          };
+
+          manifest = (lib.importTOML ./pumpkin/Cargo.toml).package;
+          workspace-manifest = (lib.importTOML ./Cargo.toml).workspace.package;
+        in
+        {
+          packages.default = naersk'.buildPackage {
             pname = manifest.name;
-            version = workspace-manifest.version;
+            inherit (workspace-manifest) version;
+            src = lib.fileset.toSource {
+              root = ./.;
+              fileset = lib.fileset.unions [
+                ./Cargo.lock
+                ./Cargo.toml
 
-            src = ./.;
-
-            useFetchCargoVendor = true;
-            cargoLock = {
-              lockFile = ./Cargo.lock;
+                ./assets
+                ./pumpkin
+                ./pumpkin-api-macros
+                ./pumpkin-config
+                ./pumpkin-data
+                ./pumpkin-inventory
+                ./pumpkin-inventory
+                ./pumpkin-macros
+                ./pumpkin-nbt
+                ./pumpkin-protocol
+                ./pumpkin-registry
+                ./pumpkin-util
+                ./pumpkin-world
+              ];
             };
           };
-      };
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
         workspace-manifest =
           (pkgs.lib.importTOML ./Cargo.toml).workspace.package;
       in {
-        formatter = pkgs.nixfmt-rfc-style;
         _module.args.pkgs = import nixpkgs {
           inherit system;
         };
@@ -39,6 +38,17 @@
               toolchain
               pkg-config
             ];
+      imports = [ flake-parts.flakeModules.partitions ];
+
+      partitionedAttrs = {
+        formatter = "dev";
+      };
+
+      partitions.dev = {
+        extraInputsFlake = ./nix/dev;
+        module.imports = [ ./nix/dev ];
+      };
+
           };
 
         packages.default =

--- a/nix/dev/default.nix
+++ b/nix/dev/default.nix
@@ -23,5 +23,15 @@
         # TOML
         taplo.enable = true;
       };
+
+      checks = self'.packages;
+
+      devShells.default = pkgs.mkShell {
+        name = "pumpkin";
+
+        inputsFrom = [ self'.packages.default ];
+
+        packages = [ pkgs.nil ];
+      };
     };
 }

--- a/nix/dev/default.nix
+++ b/nix/dev/default.nix
@@ -1,0 +1,27 @@
+{ inputs, ... }:
+{
+  imports = [ inputs.treefmt-nix.flakeModule ];
+
+  perSystem =
+    { self', pkgs, ... }:
+    {
+      treefmt.programs = {
+        # Docker
+        dockerfmt.enable = true;
+
+        # Nix
+        deadnix.enable = true;
+        statix.enable = true;
+        nixfmt = {
+          enable = true;
+          strict = true;
+        };
+
+        # Rust
+        rustfmt.enable = true;
+
+        # TOML
+        taplo.enable = true;
+      };
+    };
+}

--- a/nix/dev/flake.lock
+++ b/nix/dev/flake.lock
@@ -1,0 +1,45 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1754847726,
+        "narHash": "sha256-2vX8QjO5lRsDbNYvN9hVHXLU6oMl+V/PsmIiJREG4rE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "7d81f6fb2e19bf84f1c65135d1060d829fae2408",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/dev/flake.nix
+++ b/nix/dev/flake.nix
@@ -1,0 +1,12 @@
+{
+  description = ''
+    Private inputs for development purposes.
+    These are used by the top level flake in the `dev` partition,
+    but do not appear in consumers' lock files.
+  '';
+
+  inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
+
+  # This flake is only used for its inputs.
+  outputs = _: { };
+}

--- a/pumpkin-data/Clippy.toml
+++ b/pumpkin-data/Clippy.toml
@@ -1,3 +1,3 @@
 disallowed-types = [
-    { path = "std::collections::HashMap", reason = "If you need a map, use BTreeMap for deterministic ordering. Otherwise it forces a rebuild after every change.", replacement = "std::collections::BTreeMap" }
+  { path = "std::collections::HashMap", reason = "If you need a map, use BTreeMap for deterministic ordering. Otherwise it forces a rebuild after every change.", replacement = "std::collections::BTreeMap" },
 ]

--- a/pumpkin-inventory/Cargo.toml
+++ b/pumpkin-inventory/Cargo.toml
@@ -16,4 +16,3 @@ tokio.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
 crossbeam-utils = "0.8.21"
-

--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -49,7 +49,10 @@ rand = "0.9.2"
 num_cpus = "1.17.0"
 
 [dev-dependencies]
-criterion = { version = "0.7", default-features = false, features = ["html_reports", "async_tokio"] }
+criterion = { version = "0.7", default-features = false, features = [
+  "html_reports",
+  "async_tokio",
+] }
 temp-dir = "0.1.16"
 # Print log info inside tests when needed
 env_logger = "0.11.8"

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -54,9 +54,7 @@ rsa = { version = "=0.10.0-rc.4", features = ["sha1"] }
 rsa-der = "0.3"
 
 # authentication
-ureq = { version = "3.1.0", features = [
-    "json",
-] }
+ureq = { version = "3.1.0", features = ["json"] }
 
 sha1 = "=0.11.0-rc.0"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 # Anything in the latest stable version of Rust is fine to use.
 channel = "stable"
+components = ["rust-analyzer", "rust-src"]

--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,12 @@
-(import
-  (
-    let
-      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-      nodeName = lock.nodes.root.inputs.flake-compat;
-    in
-    fetchTarball {
-      url = lock.nodes.${nodeName}.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
-      sha256 = lock.nodes.${nodeName}.locked.narHash;
-    }
-  )
-  { src = ./.; }
-).shellNix
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
## Description

This PR simplifies the development for Nix users, by:

1. adding the ability to format the whole repository instead of just `.nix` files
2. allowing Nix to cache build instead of rebuild everything on any file change
3. syncing the "nixified rust toolchain" with the one specified by the `rust-toolchain.toml` file

## Testing

The Project was built & run twice, once via Cargo and once via Nix, to ensure that everything still works.