### PR TITLE
Add ArmorStandItem and ArmorStandEntity

### DIFF
--- a/pumpkin-protocol/src/java/client/play/spawn_entity.rs
+++ b/pumpkin-protocol/src/java/client/play/spawn_entity.rs
@@ -39,8 +39,8 @@ impl CSpawnEntity {
             r#type,
             position,
             pitch: (pitch * 256.0 / 360.0).floor() as u8,
-            yaw: (yaw * 256.0 / 360.0).floor() as u8,
-            head_yaw: (head_yaw * 256.0 / 360.0).floor() as u8,
+            yaw: (yaw.rem_euclid(360.0) * 256.0 / 360.0).floor() as u8,
+            head_yaw: (head_yaw.rem_euclid(360.0) * 256.0 / 360.0).floor() as u8,
             data,
             velocity: Vector3::new(
                 (velocity.x.clamp(-3.9, 3.9) * 8000.0) as i16,

--- a/pumpkin-util/src/math/euler_angle.rs
+++ b/pumpkin-util/src/math/euler_angle.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct EulerAngle {
+    pub pitch: f32,
+    pub yaw: f32,
+    pub roll: f32,
+}
+
+impl EulerAngle {
+    pub fn new(pitch: f32, yaw: f32, roll: f32) -> Self {
+        let pitch = if pitch.is_finite() { pitch % 360.0 } else { 0.0 };
+        let yaw = if yaw.is_finite() { yaw % 360.0 } else { 0.0 };
+        let roll = if roll.is_finite() { roll % 360.0 } else { 0.0 };
+
+        Self { pitch, yaw, roll }
+    }
+
+    pub const ZERO: EulerAngle = EulerAngle {
+        pitch: 0.0,
+        yaw: 0.0,
+        roll: 0.0,
+    };
+
+    //? Correct me if i am wrong with that or have better solutions
+    /// To NBT compatible ig
+    pub fn to_list(&self) -> Vec<f32> {
+        vec![self.pitch, self.yaw, self.roll]
+    }
+
+    //? Correct me if i am wrong with that or have better solutions
+    /// From NBT compatible list
+    pub fn from_list(list: &[f32]) -> Result<Self, String> {
+        if list.len() != 3 {
+            return Err(format!("Expected 3 floats, got {}", list.len()));
+        }
+        Ok(Self::new(list[0], list[1], list[2]))
+    }
+}
+
+/// AtomicCell default
+impl Default for EulerAngle {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl From<EulerAngle> for Vec<f32> {
+    fn from(angle: EulerAngle) -> Self {
+        angle.to_list()
+    }
+}
+
+impl TryFrom<Vec<f32>> for EulerAngle {
+    type Error = String;
+
+    fn try_from(value: Vec<f32>) -> Result<Self, Self::Error> {
+        Self::from_list(&value)
+    }
+}
+
+impl From<(f32, f32, f32)> for EulerAngle {
+    fn from((pitch, yaw, roll): (f32, f32, f32)) -> Self {
+        Self::new(pitch, yaw, roll)
+    }
+}

--- a/pumpkin-util/src/math/mod.rs
+++ b/pumpkin-util/src/math/mod.rs
@@ -9,6 +9,7 @@ pub mod position;
 pub mod vector2;
 pub mod vector3;
 pub mod vertical_surface_type;
+pub mod euler_angle;
 
 pub fn wrap_degrees(degrees: f32) -> f32 {
     let mut var1 = degrees % 360.0;

--- a/pumpkin/src/entity/decoration/armor_stand.rs
+++ b/pumpkin/src/entity/decoration/armor_stand.rs
@@ -1,0 +1,340 @@
+use std::sync::{atomic::{AtomicI32, AtomicU64, AtomicU8, Ordering}, Arc};
+
+use crate::entity::{living::LivingEntity, Entity, NBTStorage, EntityBase};
+use async_trait::async_trait;
+use crossbeam::atomic::AtomicCell;
+use pumpkin_data::{damage::DamageType, data_component_impl::{EquipmentSlot, EquipmentType}};
+use pumpkin_nbt::compound::NbtCompound;
+use pumpkin_util::math::{euler_angle::EulerAngle, vector3::Vector3};
+
+#[derive(Debug, Clone)]
+pub struct PackedRotation {
+    pub head: EulerAngle,
+    pub body: EulerAngle,
+    pub left_arm: EulerAngle,
+    pub right_arm: EulerAngle,
+    pub left_leg: EulerAngle,
+    pub right_leg: EulerAngle,
+}
+
+impl PackedRotation {
+    pub fn default() -> Self {
+        Self {
+            head: EulerAngle::new(0.0, 0.0, 0.0),
+            body: EulerAngle::new(0.0, 0.0, 0.0),
+            left_arm: EulerAngle::new(-10.0, 0.0, -10.0),
+            right_arm: EulerAngle::new(-15.0, 0.0, 10.0),
+            left_leg: EulerAngle::new(-1.0, 0.0, -1.0),
+            right_leg: EulerAngle::new(1.0, 0.0, 1.0),
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub struct ArmorStandEntity {
+    living_entity: LivingEntity,
+
+    armor_stand_flags: AtomicU8,
+    invisible: AtomicCell<bool>,
+    last_hit_time: AtomicU64,
+    disabled_slots: AtomicI32,
+
+    head_rotation: AtomicCell<EulerAngle>,
+    body_rotation: AtomicCell<EulerAngle>,
+    left_arm_rotation: AtomicCell<EulerAngle>,
+    right_arm_rotation: AtomicCell<EulerAngle>,
+    left_leg_rotation: AtomicCell<EulerAngle>,
+    right_leg_rotation: AtomicCell<EulerAngle>,
+}
+
+const SMALL_FLAG: u8 = 1;
+const SHOW_ARMS_FLAG: u8 = 4;
+const HIDE_BASE_PLATE_FLAG: u8 = 8;
+const MARKER_FLAG: u8 = 16;
+
+impl ArmorStandEntity {
+    pub fn new(entity: Entity) -> Self {
+        let living_entity = LivingEntity::new(entity);
+        let packed_rotation = PackedRotation::default();
+
+        Self {
+            living_entity,
+            armor_stand_flags: AtomicU8::new(0),
+            invisible: AtomicCell::new(false),
+            last_hit_time: AtomicU64::new(0),
+            disabled_slots: AtomicI32::new(0),
+            head_rotation: AtomicCell::new(packed_rotation.head),
+            body_rotation: AtomicCell::new(packed_rotation.body),
+            left_arm_rotation: AtomicCell::new(packed_rotation.left_arm),
+            right_arm_rotation: AtomicCell::new(packed_rotation.right_arm),
+            left_leg_rotation: AtomicCell::new(packed_rotation.left_leg),
+            right_leg_rotation: AtomicCell::new(packed_rotation.right_leg),
+        }
+    }
+
+    pub fn set_small(&self, small: bool) {
+        self.set_bit_field(SMALL_FLAG, small);
+    }
+
+    pub fn is_small(&self) -> bool {
+        (self.armor_stand_flags.load(Ordering::Relaxed) & SMALL_FLAG) != 0
+    }
+
+    pub fn set_show_arms(&self, show_arms: bool) {
+        self.set_bit_field(SHOW_ARMS_FLAG, show_arms);
+    }
+
+    pub fn should_show_arms(&self) -> bool {
+        (self.armor_stand_flags.load(Ordering::Relaxed) & SHOW_ARMS_FLAG) != 0
+    }
+
+    pub fn set_hide_base_plate(&self, hide_base_plate: bool) {
+        self.set_bit_field(HIDE_BASE_PLATE_FLAG, hide_base_plate);
+    }
+
+    pub fn should_show_base_plate(&self) -> bool {
+        (self.armor_stand_flags.load(Ordering::Relaxed) & HIDE_BASE_PLATE_FLAG) == 0
+    }
+
+    pub fn set_marker(&self, marker: bool) {
+        self.set_bit_field(MARKER_FLAG, marker);
+    }
+
+    pub fn is_marker(&self) -> bool {
+        (self.armor_stand_flags.load(Ordering::Relaxed) & MARKER_FLAG) != 0
+    }
+
+    fn set_bit_field(&self, bit_field: u8, set: bool) {
+        let current = self.armor_stand_flags.load(Ordering::Relaxed);
+        let new_value = if set {
+            current | bit_field
+        } else {
+            current & !bit_field
+        };
+        self.armor_stand_flags.store(new_value, Ordering::Relaxed);
+    }
+
+    pub fn can_use_slot(&self, slot: &EquipmentSlot) -> bool {
+        !matches!(slot, EquipmentSlot::Body(_) | EquipmentSlot::Saddle(_)) && !self.is_slot_disabled(slot)
+    }
+
+    pub fn is_slot_disabled(&self, slot: &EquipmentSlot) -> bool {
+        let disabled_slots = self.disabled_slots.load(Ordering::Relaxed);
+        let slot_bit = 1 << slot.get_offset_entity_slot_id(0);
+
+        (disabled_slots & slot_bit) != 0 ||
+        (slot.slot_type() == EquipmentType::Hand && !self.should_show_arms())
+    }
+
+    pub fn set_slot_disabled(&self, slot: &EquipmentSlot, disabled: bool) {
+        let slot_bit = 1 << slot.get_offset_entity_slot_id(0);
+        let current = self.disabled_slots.load(Ordering::Relaxed);
+
+        let new_val = if disabled {
+            current | slot_bit
+        } else {
+            current & !slot_bit
+        };
+
+        self.disabled_slots.store(new_val, Ordering::Relaxed);
+    }
+
+    pub fn set_head_rotation(&self, angle: EulerAngle) {
+        self.head_rotation.store(angle);
+    }
+
+    pub fn get_head_rotation(&self) -> EulerAngle {
+        self.head_rotation.load()
+    }
+
+    pub fn set_body_rotation(&self, angle: EulerAngle) {
+        self.body_rotation.store(angle);
+    }
+
+    pub fn get_body_rotation(&self) -> EulerAngle {
+        self.body_rotation.load()
+    }
+
+    pub fn set_left_arm_rotation(&self, angle: EulerAngle) {
+        self.left_arm_rotation.store(angle);
+    }
+
+    pub fn get_left_arm_rotation(&self) -> EulerAngle {
+        self.left_arm_rotation.load()
+    }
+
+    pub fn set_right_arm_rotation(&self, angle: EulerAngle) {
+        self.right_arm_rotation.store(angle);
+    }
+
+    pub fn get_right_arm_rotation(&self) -> EulerAngle {
+        self.right_arm_rotation.load()
+    }
+
+    pub fn set_left_leg_rotation(&self, angle: EulerAngle) {
+        self.left_leg_rotation.store(angle);
+    }
+
+    pub fn get_left_leg_rotation(&self) -> EulerAngle {
+        self.left_leg_rotation.load()
+    }
+
+    pub fn set_right_leg_rotation(&self, angle: EulerAngle) {
+        self.right_leg_rotation.store(angle);
+    }
+
+    pub fn get_right_leg_rotation(&self) -> EulerAngle {
+        self.right_leg_rotation.load()
+    }
+
+    pub fn pack_rotation(&self) -> PackedRotation {
+        PackedRotation {
+            head: self.get_head_rotation(),
+            body: self.get_body_rotation(),
+            left_arm: self.get_left_arm_rotation(),
+            right_arm: self.get_right_arm_rotation(),
+            left_leg: self.get_left_leg_rotation(),
+            right_leg: self.get_right_leg_rotation(),
+        }
+    }
+
+    pub fn unpack_rotation(&self, packed: &PackedRotation) {
+        self.set_head_rotation(packed.head);
+        self.set_body_rotation(packed.body);
+        self.set_left_arm_rotation(packed.left_arm);
+        self.set_right_arm_rotation(packed.right_arm);
+        self.set_left_leg_rotation(packed.left_leg);
+        self.set_right_leg_rotation(packed.right_leg);
+    }
+}
+
+#[async_trait]
+impl NBTStorage for ArmorStandEntity {
+    async fn write_nbt(&self, nbt: &mut NbtCompound) {
+        let disabled_slots = self.disabled_slots.load(Ordering::Relaxed);
+
+        // TODO: ADD `ArmorStandEntity`.is_invisible()
+        //nbt.put_bool("Invisible", self.is_invisible());
+        nbt.put_bool("Small", self.is_small());
+        nbt.put_bool("ShowArms", self.should_show_arms());
+        nbt.put_int("DisabledSlots", disabled_slots);
+        nbt.put_bool("NoBasePlate", !self.should_show_base_plate());
+        if self.is_marker() {
+            nbt.put_bool("Marker", true);
+        }
+
+        // TODO: Implement pose saving
+        //nbt.put("Pose", )
+    }
+
+    async fn read_nbt_non_mut(&self, nbt: &NbtCompound) {
+        let mut flags = 0u8;
+
+        if let Some(small) = nbt.get_bool("Small") {
+            if small {
+                flags |= 1;
+            }
+        }
+
+        if let Some(show_arms) = nbt.get_bool("ShowArms") {
+            if show_arms {
+                flags |= 4;
+            }
+        }
+
+        if let Some(no_base_plate) = nbt.get_bool("NoBasePlate") {
+            if !no_base_plate {
+                flags |= 8;
+            }
+        } else {
+            flags |= 8;
+        }
+
+        if let Some(marker) = nbt.get_bool("Marker") {
+            if marker {
+                flags |= 16;
+            }
+        }
+
+        self.armor_stand_flags.store(flags, Ordering::Relaxed);
+
+        if let Some(disabled_slots) = nbt.get_int("DisabledSlots") {
+            self.disabled_slots.store(disabled_slots, Ordering::Relaxed);
+        }
+    }
+}
+
+#[async_trait]
+impl EntityBase for ArmorStandEntity {
+    fn get_entity(&self) -> &Entity {
+        &self.living_entity.entity
+    }
+
+    fn get_living_entity(&self) -> Option<&LivingEntity> {
+        Some(&self.living_entity)
+    }
+
+    fn as_nbt_storage(&self) -> &dyn NBTStorage {
+        self
+    }
+
+    // TODO: Is this wrong here?
+    async fn damage_with_context(
+        &self,
+        _caller: Arc<dyn EntityBase>,
+        _amount: f32,
+        damage_type: DamageType,
+        _position: Option<Vector3<f64>>,
+        source: Option<&dyn EntityBase>,
+        cause: Option<&dyn EntityBase>,
+    ) -> bool {
+        let entity = self.get_entity();
+        if entity.is_removed() {
+            return false;
+        }
+
+        let world = &entity.world;
+        if let Some(server) = world.server.upgrade() {
+            let mob_griefing_gamerule = {
+                let game_rules = &server.level_info.read().await.game_rules;
+                game_rules.mob_griefing
+            };
+
+            if !mob_griefing_gamerule {
+                if let Some(attacker) = source {
+                    if attacker.get_player().is_none() {
+                        return false;
+                    }
+                }
+
+                if let Some(indirect_attacker) = cause {
+                    if indirect_attacker.get_player().is_none() {
+                        return false;
+                    }
+                }
+            }
+        };
+
+        // TODO: <DamageSource>.isIn(DamageTypeTags::BYPASSES_INVULNERABILITY)
+
+        if damage_type == DamageType::EXPLOSION {
+            // TODO: Implement Dropping Items that are in the Equipment Slots
+            entity.remove().await;
+            return false;
+        } // TODO: Implement <DamageSource>.isIn(DamageTypeTags::IGNITES_ARMOR_STANDS)
+
+        // TODO: Implement <DamageSource>.isIn(DamageTypeTags::BURNS_ARMOR_STANDS)
+
+        /* // TODO:
+        bl1: bool = <DamageSource>.isIn(DamageTypeTags.CAN_BREAK_ARMOR_STAND);
+        bl2: bool = <DamageSource>.isIn(DamageTypeTags.ALWAYS_KILLS_ARMOR_STANDS);
+
+        if !bl1 && !bl2 {
+            return false;
+        }
+        */
+
+
+        true
+    }
+}

--- a/pumpkin/src/entity/decoration/armor_stand.rs
+++ b/pumpkin/src/entity/decoration/armor_stand.rs
@@ -17,8 +17,8 @@ pub struct PackedRotation {
     pub right_leg: EulerAngle,
 }
 
-impl PackedRotation {
-    pub fn default() -> Self {
+impl Default for PackedRotation {
+    fn default() -> Self {
         Self {
             head: EulerAngle::new(0.0, 0.0, 0.0),
             body: EulerAngle::new(0.0, 0.0, 0.0),
@@ -230,17 +230,15 @@ impl NBTStorage for ArmorStandEntity {
     async fn read_nbt_non_mut(&self, nbt: &NbtCompound) {
         let mut flags = 0u8;
 
-        if let Some(small) = nbt.get_bool("Small") {
-            if small {
+        if let Some(small) = nbt.get_bool("Small")
+            && small {
                 flags |= 1;
             }
-        }
 
-        if let Some(show_arms) = nbt.get_bool("ShowArms") {
-            if show_arms {
+        if let Some(show_arms) = nbt.get_bool("ShowArms")
+            && show_arms {
                 flags |= 4;
             }
-        }
 
         if let Some(no_base_plate) = nbt.get_bool("NoBasePlate") {
             if !no_base_plate {
@@ -250,11 +248,10 @@ impl NBTStorage for ArmorStandEntity {
             flags |= 8;
         }
 
-        if let Some(marker) = nbt.get_bool("Marker") {
-            if marker {
+        if let Some(marker) = nbt.get_bool("Marker")
+            && marker {
                 flags |= 16;
             }
-        }
 
         self.armor_stand_flags.store(flags, Ordering::Relaxed);
 
@@ -301,19 +298,17 @@ impl EntityBase for ArmorStandEntity {
             };
 
             if !mob_griefing_gamerule {
-                if let Some(attacker) = source {
-                    if attacker.get_player().is_none() {
+                if let Some(attacker) = source
+                    && attacker.get_player().is_none() {
                         return false;
                     }
-                }
 
-                if let Some(indirect_attacker) = cause {
-                    if indirect_attacker.get_player().is_none() {
+                if let Some(indirect_attacker) = cause
+                    && indirect_attacker.get_player().is_none() {
                         return false;
                     }
-                }
             }
-        };
+        }
 
         // TODO: <DamageSource>.isIn(DamageTypeTags::BYPASSES_INVULNERABILITY)
 

--- a/pumpkin/src/entity/decoration/mod.rs
+++ b/pumpkin/src/entity/decoration/mod.rs
@@ -1,2 +1,3 @@
 pub mod end_crystal;
 pub mod painting;
+pub mod armor_stand;

--- a/pumpkin/src/entity/equipment_slot.rs
+++ b/pumpkin/src/entity/equipment_slot.rs
@@ -24,81 +24,76 @@ pub enum EquipmentSlot {
 impl EquipmentSlot {
     pub const NO_MAX_COUNT: i32 = 0;
 
-    pub fn slot_type(&self) -> EquipmentSlotType {
+    #[must_use] pub fn slot_type(&self) -> EquipmentSlotType {
         match self {
-            EquipmentSlot::MainHand | EquipmentSlot::OffHand => EquipmentSlotType::Hand,
-            EquipmentSlot::Feet | EquipmentSlot::Legs | EquipmentSlot::Chest | EquipmentSlot::Head => {
+            Self::MainHand | Self::OffHand => EquipmentSlotType::Hand,
+            Self::Feet | Self::Legs | Self::Chest | Self::Head => {
                 EquipmentSlotType::HumanoidArmor
             }
-            EquipmentSlot::Body => EquipmentSlotType::AnimalArmor,
-            EquipmentSlot::Saddle => EquipmentSlotType::Saddle,
+            Self::Body => EquipmentSlotType::AnimalArmor,
+            Self::Saddle => EquipmentSlotType::Saddle,
         }
     }
 
-    pub fn entity_slot_id(&self) -> i32 {
+    #[must_use] pub fn entity_slot_id(&self) -> i32 {
         match self {
-            EquipmentSlot::MainHand => 0,
-            EquipmentSlot::OffHand => 1,
-            EquipmentSlot::Feet => 0,
-            EquipmentSlot::Legs => 1,
-            EquipmentSlot::Chest => 2,
-            EquipmentSlot::Head => 3,
-            EquipmentSlot::Body => 0,
-            EquipmentSlot::Saddle => 0,
+            Self::MainHand | Self::Feet | Self::Body | Self::Saddle => 0,
+            Self::OffHand | Self::Legs => 1,
+            Self::Chest => 2,
+            Self::Head => 3,
         }
     }
 
-    pub fn max_count(&self) -> i32 {
+    #[must_use] pub fn max_count(&self) -> i32 {
         match self {
-            EquipmentSlot::MainHand => Self::NO_MAX_COUNT,
-            EquipmentSlot::OffHand => Self::NO_MAX_COUNT,
-            EquipmentSlot::Feet | EquipmentSlot::Legs | EquipmentSlot::Chest | EquipmentSlot::Head => 1,
-            EquipmentSlot::Body => 1,
-            EquipmentSlot::Saddle => 1,
+            Self::OffHand | Self::MainHand => Self::NO_MAX_COUNT,
+            Self::Feet | Self::Legs | Self::Chest | Self::Head | Self::Body | Self::Saddle => 1,
         }
     }
 
-    pub fn index(&self) -> i32 {
+    #[must_use] pub fn index(&self) -> i32 {
         match self {
-            EquipmentSlot::MainHand => 0,
-            EquipmentSlot::OffHand => 5,
-            EquipmentSlot::Feet => 1,
-            EquipmentSlot::Legs => 2,
-            EquipmentSlot::Chest => 3,
-            EquipmentSlot::Head => 4,
-            EquipmentSlot::Body => 6,
-            EquipmentSlot::Saddle => 7,
+            Self::MainHand => 0,
+            Self::OffHand => 5,
+            Self::Feet => 1,
+            Self::Legs => 2,
+            Self::Chest => 3,
+            Self::Head => 4,
+            Self::Body => 6,
+            Self::Saddle => 7,
         }
     }
 
-    pub fn name(&self) -> &'static str {
+    #[must_use] pub fn name(&self) -> &'static str {
         match self {
-            EquipmentSlot::MainHand => "mainhand",
-            EquipmentSlot::OffHand => "offhand",
-            EquipmentSlot::Feet => "feet",
-            EquipmentSlot::Legs => "legs",
-            EquipmentSlot::Chest => "chest",
-            EquipmentSlot::Head => "head",
-            EquipmentSlot::Body => "body",
-            EquipmentSlot::Saddle => "saddle",
+            Self::MainHand => "mainhand",
+            Self::OffHand => "offhand",
+            Self::Feet => "feet",
+            Self::Legs => "legs",
+            Self::Chest => "chest",
+            Self::Head => "head",
+            Self::Body => "body",
+            Self::Saddle => "saddle",
         }
     }
 
-    pub fn offset_entity_slot_id(&self, offset: i32) -> i32 {
+    #[must_use] pub fn offset_entity_slot_id(&self, offset: i32) -> i32 {
         offset + self.entity_slot_id()
     }
 
-    pub fn offset_index(&self, offset: i32) -> i32 {
+
+    #[must_use] pub fn offset_index(&self, offset: i32) -> i32 {
         self.index() + offset
     }
 
-    pub fn is_armor_slot(&self) -> bool {
+    #[must_use] pub fn is_armor_slot(&self) -> bool {
         matches!(
             self.slot_type(),
             EquipmentSlotType::HumanoidArmor | EquipmentSlotType::AnimalArmor
         )
     }
 
+    #[must_use]
     pub fn increases_dropped_experience(&self) -> bool {
         self.slot_type() != EquipmentSlotType::Saddle
     }
@@ -113,44 +108,46 @@ impl EquipmentSlot {
         }
     }
 
+    #[must_use]
     pub fn from_index(index: i32) -> Option<Self> {
         match index {
-            0 => Some(EquipmentSlot::MainHand),
-            1 => Some(EquipmentSlot::Feet),
-            2 => Some(EquipmentSlot::Legs),
-            3 => Some(EquipmentSlot::Chest),
-            4 => Some(EquipmentSlot::Head),
-            5 => Some(EquipmentSlot::OffHand),
-            6 => Some(EquipmentSlot::Body),
-            7 => Some(EquipmentSlot::Saddle),
+            0 => Some(Self::MainHand),
+            1 => Some(Self::Feet),
+            2 => Some(Self::Legs),
+            3 => Some(Self::Chest),
+            4 => Some(Self::Head),
+            5 => Some(Self::OffHand),
+            6 => Some(Self::Body),
+            7 => Some(Self::Saddle),
             _ => None,
         }
     }
 
     pub fn by_name(name: &str) -> Result<Self, String> {
         match name {
-            "mainhand" => Ok(EquipmentSlot::MainHand),
-            "offhand" => Ok(EquipmentSlot::OffHand),
-            "feet" => Ok(EquipmentSlot::Feet),
-            "legs" => Ok(EquipmentSlot::Legs),
-            "chest" => Ok(EquipmentSlot::Chest),
-            "head" => Ok(EquipmentSlot::Head),
-            "body" => Ok(EquipmentSlot::Body),
-            "saddle" => Ok(EquipmentSlot::Saddle),
-            _ => Err(format!("Invalid slot '{}'", name)),
+            "mainhand" => Ok(Self::MainHand),
+            "offhand" => Ok(Self::OffHand),
+            "feet" => Ok(Self::Feet),
+            "legs" => Ok(Self::Legs),
+            "chest" => Ok(Self::Chest),
+            "head" => Ok(Self::Head),
+            "body" => Ok(Self::Body),
+            "saddle" => Ok(Self::Saddle),
+            _ => Err(format!("Invalid slot '{name}'")),
         }
     }
 
-    pub fn all_values() -> &'static [EquipmentSlot] {
+    #[must_use]
+    pub fn all_values() -> &'static [Self] {
         &[
-            EquipmentSlot::MainHand,
-            EquipmentSlot::OffHand,
-            EquipmentSlot::Feet,
-            EquipmentSlot::Legs,
-            EquipmentSlot::Chest,
-            EquipmentSlot::Head,
-            EquipmentSlot::Body,
-            EquipmentSlot::Saddle,
+            Self::MainHand,
+            Self::OffHand,
+            Self::Feet,
+            Self::Legs,
+            Self::Chest,
+            Self::Head,
+            Self::Body,
+            Self::Saddle,
         ]
     }
 }

--- a/pumpkin/src/entity/equipment_slot.rs
+++ b/pumpkin/src/entity/equipment_slot.rs
@@ -1,0 +1,163 @@
+use std::{borrow::Cow, collections::HashMap};
+use pumpkin_world::item::ItemStack;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EquipmentSlotType {
+    Hand,
+    HumanoidArmor,
+    AnimalArmor,
+    Saddle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EquipmentSlot {
+    MainHand,
+    OffHand,
+    Feet,
+    Legs,
+    Chest,
+    Head,
+    Body,
+    Saddle,
+}
+
+impl EquipmentSlot {
+    pub const NO_MAX_COUNT: i32 = 0;
+
+    pub fn slot_type(&self) -> EquipmentSlotType {
+        match self {
+            EquipmentSlot::MainHand | EquipmentSlot::OffHand => EquipmentSlotType::Hand,
+            EquipmentSlot::Feet | EquipmentSlot::Legs | EquipmentSlot::Chest | EquipmentSlot::Head => {
+                EquipmentSlotType::HumanoidArmor
+            }
+            EquipmentSlot::Body => EquipmentSlotType::AnimalArmor,
+            EquipmentSlot::Saddle => EquipmentSlotType::Saddle,
+        }
+    }
+
+    pub fn entity_slot_id(&self) -> i32 {
+        match self {
+            EquipmentSlot::MainHand => 0,
+            EquipmentSlot::OffHand => 1,
+            EquipmentSlot::Feet => 0,
+            EquipmentSlot::Legs => 1,
+            EquipmentSlot::Chest => 2,
+            EquipmentSlot::Head => 3,
+            EquipmentSlot::Body => 0,
+            EquipmentSlot::Saddle => 0,
+        }
+    }
+
+    pub fn max_count(&self) -> i32 {
+        match self {
+            EquipmentSlot::MainHand => Self::NO_MAX_COUNT,
+            EquipmentSlot::OffHand => Self::NO_MAX_COUNT,
+            EquipmentSlot::Feet | EquipmentSlot::Legs | EquipmentSlot::Chest | EquipmentSlot::Head => 1,
+            EquipmentSlot::Body => 1,
+            EquipmentSlot::Saddle => 1,
+        }
+    }
+
+    pub fn index(&self) -> i32 {
+        match self {
+            EquipmentSlot::MainHand => 0,
+            EquipmentSlot::OffHand => 5,
+            EquipmentSlot::Feet => 1,
+            EquipmentSlot::Legs => 2,
+            EquipmentSlot::Chest => 3,
+            EquipmentSlot::Head => 4,
+            EquipmentSlot::Body => 6,
+            EquipmentSlot::Saddle => 7,
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            EquipmentSlot::MainHand => "mainhand",
+            EquipmentSlot::OffHand => "offhand",
+            EquipmentSlot::Feet => "feet",
+            EquipmentSlot::Legs => "legs",
+            EquipmentSlot::Chest => "chest",
+            EquipmentSlot::Head => "head",
+            EquipmentSlot::Body => "body",
+            EquipmentSlot::Saddle => "saddle",
+        }
+    }
+
+    pub fn offset_entity_slot_id(&self, offset: i32) -> i32 {
+        offset + self.entity_slot_id()
+    }
+
+    pub fn offset_index(&self, offset: i32) -> i32 {
+        self.index() + offset
+    }
+
+    pub fn is_armor_slot(&self) -> bool {
+        matches!(
+            self.slot_type(),
+            EquipmentSlotType::HumanoidArmor | EquipmentSlotType::AnimalArmor
+        )
+    }
+
+    pub fn increases_dropped_experience(&self) -> bool {
+        self.slot_type() != EquipmentSlotType::Saddle
+    }
+
+    pub fn split_item_stack<'a>(&self, stack: &'a mut ItemStack) -> Cow<'a, ItemStack> {
+        let max_count = self.max_count() as u8;
+
+        if max_count > 0 {
+            Cow::Owned(stack.split(max_count))
+        } else {
+            Cow::Borrowed(stack)
+        }
+    }
+
+    pub fn from_index(index: i32) -> Option<Self> {
+        match index {
+            0 => Some(EquipmentSlot::MainHand),
+            1 => Some(EquipmentSlot::Feet),
+            2 => Some(EquipmentSlot::Legs),
+            3 => Some(EquipmentSlot::Chest),
+            4 => Some(EquipmentSlot::Head),
+            5 => Some(EquipmentSlot::OffHand),
+            6 => Some(EquipmentSlot::Body),
+            7 => Some(EquipmentSlot::Saddle),
+            _ => None,
+        }
+    }
+
+    pub fn by_name(name: &str) -> Result<Self, String> {
+        match name {
+            "mainhand" => Ok(EquipmentSlot::MainHand),
+            "offhand" => Ok(EquipmentSlot::OffHand),
+            "feet" => Ok(EquipmentSlot::Feet),
+            "legs" => Ok(EquipmentSlot::Legs),
+            "chest" => Ok(EquipmentSlot::Chest),
+            "head" => Ok(EquipmentSlot::Head),
+            "body" => Ok(EquipmentSlot::Body),
+            "saddle" => Ok(EquipmentSlot::Saddle),
+            _ => Err(format!("Invalid slot '{}'", name)),
+        }
+    }
+
+    pub fn all_values() -> &'static [EquipmentSlot] {
+        &[
+            EquipmentSlot::MainHand,
+            EquipmentSlot::OffHand,
+            EquipmentSlot::Feet,
+            EquipmentSlot::Legs,
+            EquipmentSlot::Chest,
+            EquipmentSlot::Head,
+            EquipmentSlot::Body,
+            EquipmentSlot::Saddle,
+        ]
+    }
+}
+
+/// Equipment holder trait for entities that can have equipment (like a armorstand)
+pub trait HasEquipment {
+    fn get_equipment(&self, slot: EquipmentSlot) -> Option<&ItemStack>;
+    fn set_equipment(&mut self, slot: EquipmentSlot, item: Option<ItemStack>);
+    fn get_all_equipment(&self) -> HashMap<EquipmentSlot, ItemStack>;
+}

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -62,6 +62,7 @@ pub mod player;
 pub mod projectile;
 pub mod tnt;
 pub mod r#type;
+pub mod equipment_slot;
 
 mod combat;
 pub mod predicate;

--- a/pumpkin/src/item/items/armor_stand.rs
+++ b/pumpkin/src/item/items/armor_stand.rs
@@ -10,6 +10,7 @@ use pumpkin_data::entity::EntityType;
 use pumpkin_data::item::Item;
 use pumpkin_data::sound::{Sound, SoundCategory};
 use pumpkin_data::{Block, BlockDirection};
+use pumpkin_util::math::boundingbox::BoundingBox;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::math::wrap_degrees;
@@ -51,25 +52,49 @@ impl ItemBehaviour for ArmorStandItem {
         let world = player.world();
         let position = Self::calculate_placement_position(&location, &face).to_f64();
 
-        let (player_yaw, _) = player.rotation();
-        let rotation = ((wrap_degrees(player_yaw - 180.0) + 22.5) / 45.0).floor() * 45.0;
-
-        let entity = Entity::new(
-            Uuid::new_v4(),
-            world.clone(),
-            position,
-            &EntityType::ARMOR_STAND,
-            false
+        let bottom_center = Vector3::new(
+            position.x,
+            position.y,
+            position.z
         );
 
-        // TODO: There's a problem with the entity's rotation at East -90. Other people can also replicate it
-        entity.set_rotation(rotation, 0.0);
+        let armor_stand_dimensions = EntityType::ARMOR_STAND.dimension;
+        let width = armor_stand_dimensions[0] as f64;
+        let height = armor_stand_dimensions[1] as f64;
 
-        world.play_sound(Sound::EntityArmorStandPlace, SoundCategory::Blocks, &entity.pos.load()).await;
+        let bounding_box = BoundingBox::new(
+            Vector3::new(
+                bottom_center.x - width / 2.0,
+                bottom_center.y,
+                bottom_center.z - width / 2.0
+            ),
+            Vector3::new(
+                bottom_center.x + width / 2.0,
+                bottom_center.y + height,
+                bottom_center.z + width / 2.0
+            )
+        );
 
-        let armor_stand = ArmorStandEntity::new(entity);
+        if world.is_space_empty(bounding_box.clone()).await && world.get_entities_at_box(&bounding_box).await.is_empty() {
+            let (player_yaw, _) = player.rotation();
+            let rotation = ((wrap_degrees(player_yaw - 180.0) + 22.5) / 45.0).floor() * 45.0;
 
-        world.spawn_entity(Arc::new(armor_stand)).await;
+            let entity = Entity::new(
+                Uuid::new_v4(),
+                world.clone(),
+                position,
+                &EntityType::ARMOR_STAND,
+                false
+            );
+
+            entity.set_rotation(rotation, 0.0);
+
+            world.play_sound(Sound::EntityArmorStandPlace, SoundCategory::Blocks, &entity.pos.load()).await;
+
+            let armor_stand = ArmorStandEntity::new(entity);
+
+            world.spawn_entity(Arc::new(armor_stand)).await;
+        }
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/pumpkin/src/item/items/armor_stand.rs
+++ b/pumpkin/src/item/items/armor_stand.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 pub struct ArmorStandItem;
 
 impl ArmorStandItem {
-    fn calculate_placement_position(location: &BlockPos, face: &BlockDirection) -> BlockPos {
+    fn calculate_placement_position(location: &BlockPos, face: BlockDirection) -> BlockPos {
         match face {
             BlockDirection::Up => location.offset(Vector3::new(0, 1, 0)),
             BlockDirection::Down => location.offset(Vector3::new(0, -1, 0)),
@@ -50,7 +50,7 @@ impl ItemBehaviour for ArmorStandItem {
         _server: &Server
     ) {
         let world = player.world();
-        let position = Self::calculate_placement_position(&location, &face).to_f64();
+        let position = Self::calculate_placement_position(&location, face).to_f64();
 
         let bottom_center = Vector3::new(
             position.x,
@@ -59,8 +59,8 @@ impl ItemBehaviour for ArmorStandItem {
         );
 
         let armor_stand_dimensions = EntityType::ARMOR_STAND.dimension;
-        let width = armor_stand_dimensions[0] as f64;
-        let height = armor_stand_dimensions[1] as f64;
+        let width = f64::from(armor_stand_dimensions[0]);
+        let height = f64::from(armor_stand_dimensions[1]);
 
         let bounding_box = BoundingBox::new(
             Vector3::new(
@@ -75,7 +75,7 @@ impl ItemBehaviour for ArmorStandItem {
             )
         );
 
-        if world.is_space_empty(bounding_box.clone()).await && world.get_entities_at_box(&bounding_box).await.is_empty() {
+        if world.is_space_empty(bounding_box).await && world.get_entities_at_box(&bounding_box).await.is_empty() {
             let (player_yaw, _) = player.rotation();
             let rotation = ((wrap_degrees(player_yaw - 180.0) + 22.5) / 45.0).floor() * 45.0;
 

--- a/pumpkin/src/item/items/armor_stand.rs
+++ b/pumpkin/src/item/items/armor_stand.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use crate::entity::decoration::armor_stand::ArmorStandEntity;
+use crate::entity::Entity;
+use crate::entity::player::Player;
+use crate::server::Server;
+use crate::item::{ItemBehaviour, ItemMetadata};
+use async_trait::async_trait;
+use pumpkin_data::entity::EntityType;
+use pumpkin_data::item::Item;
+use pumpkin_data::sound::{Sound, SoundCategory};
+use pumpkin_data::{Block, BlockDirection};
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::vector3::Vector3;
+use pumpkin_util::math::wrap_degrees;
+use pumpkin_world::item::ItemStack;
+use uuid::Uuid;
+
+pub struct ArmorStandItem;
+
+impl ArmorStandItem {
+    fn calculate_placement_position(location: &BlockPos, face: &BlockDirection) -> BlockPos {
+        match face {
+            BlockDirection::Up => location.offset(Vector3::new(0, 1, 0)),
+            BlockDirection::Down => location.offset(Vector3::new(0, -1, 0)),
+            BlockDirection::North => location.offset(Vector3::new(0, 0, -1)),
+            BlockDirection::South => location.offset(Vector3::new(0, 0, 1)),
+            BlockDirection::West => location.offset(Vector3::new(-1, 0, 0)),
+            BlockDirection::East => location.offset(Vector3::new(1, 0, 0)),
+        }
+    }
+}
+
+impl ItemMetadata for ArmorStandItem {
+    fn ids() -> Box<[u16]> {
+        [Item::ARMOR_STAND.id].into()
+    }
+}
+
+#[async_trait]
+impl ItemBehaviour for ArmorStandItem {
+    async fn use_on_block(
+        &self,
+        _item: &mut ItemStack,
+        player: &Player,
+        location: BlockPos,
+        face: BlockDirection,
+        _block: &Block,
+        _server: &Server
+    ) {
+        let world = player.world();
+        let position = Self::calculate_placement_position(&location, &face).to_f64();
+
+        let (player_yaw, _) = player.rotation();
+        let rotation = ((wrap_degrees(player_yaw - 180.0) + 22.5) / 45.0).floor() * 45.0;
+
+        let entity = Entity::new(
+            Uuid::new_v4(),
+            world.clone(),
+            position,
+            &EntityType::ARMOR_STAND,
+            false
+        );
+
+        // TODO: There's a problem with the entity's rotation at East -90. Other people can also replicate it
+        entity.set_rotation(rotation, 0.0);
+
+        world.play_sound(Sound::EntityArmorStandPlace, SoundCategory::Blocks, &entity.pos.load()).await;
+
+        let armor_stand = ArmorStandEntity::new(entity);
+
+        world.spawn_entity(Arc::new(armor_stand)).await;
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/pumpkin/src/item/items/mod.rs
+++ b/pumpkin/src/item/items/mod.rs
@@ -17,7 +17,9 @@ pub mod snowball;
 pub mod spawn_egg;
 pub mod swords;
 pub mod trident;
+pub mod armor_stand;
 
+use crate::item::items::armor_stand::ArmorStandItem;
 use crate::item::items::end_crystal::EndCrystalItem;
 use crate::item::items::minecart::MinecartItem;
 use crate::item::items::name_tag::NameTagItem;
@@ -67,6 +69,7 @@ pub fn default_registry() -> Arc<ItemRegistry> {
     manager.register(DyeItem);
     manager.register(InkSacItem);
     manager.register(GlowingInkSacItem);
+    manager.register(ArmorStandItem);
 
     Arc::new(manager)
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This pull request introduces comprehensive support for armor stands, including their entity logic, item behavior, rotation handling, and equipment slot management. The changes add new modules and types to handle armor stand entities and their  rotations (not fully done yet :C). Also added EulerAngle cause it was missing.

**Armor Stand Entity & Item Support**

* Added `ArmorStandEntity` implementation with full support for flags, equipment slots, rotation management, NBT data, and damage handling in `armor_stand.rs`.
* Implemented `ArmorStandItem` behavior, allowing players to place armor stands in the world with correct rotation and sound effects in `armor_stand.rs` and registered it in the item registry. [[1]](diffhunk://#diff-1f5ee7d7f2332422dd007f01c9d1779768169f271c5a15baa32f90ee861b8ef1R1-R78) [[2]](diffhunk://#diff-b02ff91b26a4ef533ceaa0d2669f12824dd9143b6569a2d17aed714241661edeR20-R22) [[3]](diffhunk://#diff-b02ff91b26a4ef533ceaa0d2669f12824dd9143b6569a2d17aed714241661edeR72)

**Rotation & Math Utilities**
* Improved rotation normalization for entity spawning by using `rem_euclid` to ensure angles are within [0, 360) degrees in `spawn_entity.rs` thanks to @teknostom for helping me with this one.
* 
## Testing
![placement](https://cdn.discordapp.com/attachments/1268611318617866261/1410510679219245126/2025-08-27_21.06.28.png?ex=68b147ef&is=68aff66f&hm=aeb5dad3012353475fc3e33a4449a57807bb049a15e07b21f9c21d94974b3406&)
- clippy passed
- and every test also passed

just get a armor stand in your inventory and place it down.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
