### PR TITLE
fix: Prevent the server from binding to java or bedrock ports if they're configured to be disabled (fixes #1173)

### DIFF
--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -160,10 +160,18 @@ pub fn stop_server() {
     STOP_INTERRUPT.notify_waiters();
 }
 
+fn resolve_some<T: Future, D, F: FnOnce(D) -> T>(opt: Option<D>, func: F) -> futures::future::Either<T, std::future::Pending<T::Output>> {
+    use futures::future::Either;
+    match opt {
+        Some(val) => Either::Left(func(val)),
+        None => Either::Right(std::future::pending()),
+    }
+}
+
 pub struct PumpkinServer {
     pub server: Arc<Server>,
-    pub tcp_listener: TcpListener,
-    pub udp_socket: Arc<UdpSocket>,
+    pub tcp_listener: Option<TcpListener>,
+    pub udp_socket: Option<Arc<UdpSocket>>,
 }
 
 impl PumpkinServer {
@@ -199,26 +207,32 @@ impl PumpkinServer {
             });
         }
 
-        // Setup the TCP server socket.
-        let listener = tokio::net::TcpListener::bind(BASIC_CONFIG.java_edition_address)
-            .await
-            .expect("Failed to start `TcpListener`");
-        // In the event the user puts 0 for their port, this will allow us to know what port it is running on
-        let addr = listener
-            .local_addr()
-            .expect("Unable to get the address of the server!");
+        let mut tcp_listener = None;
 
-        if advanced_config().networking.query.enabled {
-            log::info!("Query protocol is enabled. Starting...");
-            server.spawn_task(query::start_query_handler(
-                server.clone(),
-                advanced_config().networking.query.address,
-            ));
-        }
+        if BASIC_CONFIG.java_edition {
+            // Setup the TCP server socket.
+            let listener = tokio::net::TcpListener::bind(BASIC_CONFIG.java_edition_address)
+                .await
+                .expect("Failed to start `TcpListener`");
+            // In the event the user puts 0 for their port, this will allow us to know what port it is running on
+            let addr = listener
+                .local_addr()
+                .expect("Unable to get the address of the server!");
 
-        if advanced_config().networking.lan_broadcast.enabled {
-            log::info!("LAN broadcast is enabled. Starting...");
-            server.spawn_task(lan_broadcast::start_lan_broadcast(addr));
+            if advanced_config().networking.query.enabled {
+                log::info!("Query protocol is enabled. Starting...");
+                server.spawn_task(query::start_query_handler(
+                    server.clone(),
+                    advanced_config().networking.query.address,
+                ));
+            }
+
+            if advanced_config().networking.lan_broadcast.enabled {
+                log::info!("LAN broadcast is enabled. Starting...");
+                server.spawn_task(lan_broadcast::start_lan_broadcast(addr));
+            }
+
+            tcp_listener = Some(listener);
         }
 
         if BASIC_CONFIG.allow_chat_reports {
@@ -234,14 +248,18 @@ impl PumpkinServer {
             });
         };
 
-        let udp_socket = UdpSocket::bind(BASIC_CONFIG.bedrock_edition_address)
-            .await
-            .expect("Failed to bind UDP Socket");
+        let mut udp_socket = None;
+
+        if BASIC_CONFIG.bedrock_edition {
+            udp_socket = Some(Arc::new(UdpSocket::bind(BASIC_CONFIG.bedrock_edition_address)
+                .await
+                .expect("Failed to bind UDP Socket")));
+        }
 
         Self {
             server: server.clone(),
-            tcp_listener: listener,
-            udp_socket: Arc::new(udp_socket),
+            tcp_listener,
+            udp_socket,
         }
     }
 
@@ -324,7 +342,7 @@ impl PumpkinServer {
 
         select! {
             // Branch for TCP connections (Java Edition)
-            tcp_result = self.tcp_listener.accept() => {
+            tcp_result = resolve_some(self.tcp_listener.as_ref(), |listener| listener.accept()) => {
                 match tcp_result {
                     Ok((connection, client_addr)) => {
                         if let Err(e) = connection.set_nodelay(true) {
@@ -378,7 +396,7 @@ impl PumpkinServer {
             },
 
             // Branch for UDP packets (Bedrock Edition)
-            udp_result = self.udp_socket.recv_from(&mut udp_buf) => {
+            udp_result = resolve_some(self.udp_socket.as_ref(), |sock: &Arc<UdpSocket>| sock.recv_from(&mut udp_buf)) => {
                 match udp_result {
                     Ok((len, client_addr)) => {
                         if len == 0 {
@@ -402,7 +420,7 @@ impl PumpkinServer {
                                 } else if let Ok(packet) = BedrockClient::is_connection_request(&mut Cursor::new(&udp_buf[4..len])) {
                                     *master_client_id_counter += 1;
 
-                                    let mut platform = BedrockClient::new(self.udp_socket.clone(), client_addr, be_clients);
+                                    let mut platform = BedrockClient::new(self.udp_socket.clone().unwrap(), client_addr, be_clients);
                                     platform.handle_connection_request(packet).await;
                                     platform.start_outgoing_packet_task();
 
@@ -415,7 +433,7 @@ impl PumpkinServer {
                                 // Please keep the function as simple as possible!
                                 // We dont care about the result, the client just resends the packet
                                 // Since offline packets are very small we dont need to move and clone the data
-                                let _ = BedrockClient::handle_offline_packet(&self.server, id, &mut Cursor::new(&udp_buf[1..len]), client_addr, &self.udp_socket).await;
+                                let _ = BedrockClient::handle_offline_packet(&self.server, id, &mut Cursor::new(&udp_buf[1..len]), client_addr, self.udp_socket.as_ref().unwrap()).await;
                             }
 
                         }

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -160,7 +160,10 @@ pub fn stop_server() {
     STOP_INTERRUPT.notify_waiters();
 }
 
-fn resolve_some<T: Future, D, F: FnOnce(D) -> T>(opt: Option<D>, func: F) -> futures::future::Either<T, std::future::Pending<T::Output>> {
+fn resolve_some<T: Future, D, F: FnOnce(D) -> T>(
+    opt: Option<D>,
+    func: F,
+) -> futures::future::Either<T, std::future::Pending<T::Output>> {
     use futures::future::Either;
     match opt {
         Some(val) => Either::Left(func(val)),
@@ -251,9 +254,11 @@ impl PumpkinServer {
         let mut udp_socket = None;
 
         if BASIC_CONFIG.bedrock_edition {
-            udp_socket = Some(Arc::new(UdpSocket::bind(BASIC_CONFIG.bedrock_edition_address)
-                .await
-                .expect("Failed to bind UDP Socket")));
+            udp_socket = Some(Arc::new(
+                UdpSocket::bind(BASIC_CONFIG.bedrock_edition_address)
+                    .await
+                    .expect("Failed to bind UDP Socket"),
+            ));
         }
 
         Self {


### PR DESCRIPTION


<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This change fixes the issue described in #1173 where the server would bind to the java or bedrock port even if they were configured to be disabled.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
