### PR TITLE
copper chains have now the same behavior then iron chains

### DIFF
--- a/pumpkin/src/block/blocks/chain.rs
+++ b/pumpkin/src/block/blocks/chain.rs
@@ -3,10 +3,12 @@ use async_trait::async_trait;
 use pumpkin_data::BlockDirection;
 use pumpkin_data::block_properties::Axis;
 use pumpkin_data::block_properties::BlockProperties;
-use pumpkin_macros::pumpkin_block;
 use pumpkin_world::BlockStateId;
+use pumpkin_macros::pumpkin_block_from_tag;
+use pumpkin_data::tag::get_tag_values;
+use pumpkin_data::tag::RegistryKey;
 
-#[pumpkin_block("minecraft:iron_chain")]
+#[pumpkin_block_from_tag("minecraft:chains")]
 pub struct ChainBlock;
 
 #[async_trait]


### PR DESCRIPTION
## Description
changed pumpkin_block macro to pumpkin_block_from_tag macro to get also for copper chains the same behavior

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
