### PR TITLE
create gh release on each push

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,9 +68,11 @@ jobs:
       - name: Export executable
         uses: actions/upload-artifact@v4
         with:
-          name: pumpkin-${{ matrix.os }}
+          name: pumpkin-${{ runner.arch }}-${{ runner.os }}
           compression-level: 9
-          path: target/${{ matrix.target }}/release/pumpkin*
+          path: |
+           target/release/pumpkin
+           target/release/pumpkin.exe
   clippy_release:
     name: Run lints in release mode
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,3 +84,26 @@ jobs:
       - run: rustup component add clippy rustfmt --toolchain ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --release --all-targets --all-features
+  draft_release:
+    permissions:
+      contents: write
+    needs: [build_release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download prebuilt binary artifacts
+        uses: actions/download-artifact@v5
+        with:
+          merge-mulitple: true
+      - name: Generate release notes
+        run: |
+          tree
+          echo "From commit: ${GITHUB_SHA:0:8}" > RELEASE.md
+          echo "Generated on: $(date -u +"%Y-%m-%d %H:%M") UTC" >> RELEASE.md
+
+      - name: Draft a nightly github release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true
+          files: pumpkin-*
+          name: Nightly Build
+          body_path: RELEASE.md


### PR DESCRIPTION
# pr

## commits

- **ci: pre-release a nightly build on every push**
- **ci: upload only bin, with name `pumpkin-<arch>-<os>`**

## Description

creates a `Nightly Build` named GitHub Release on each push to `master`
also, the uploaded and now released artifacts are renamed by the template defined above, eg: `pumpkin-X64-Linux`
