### PR TITLE
feat(protocol): Add resource pack info, improve Ack limits & handle slot errors

### DIFF
--- a/pumpkin-protocol/src/bedrock/client/resource_packs_info.rs
+++ b/pumpkin-protocol/src/bedrock/client/resource_packs_info.rs
@@ -1,6 +1,5 @@
-use pumpkin_macros::packet;
-
 use crate::serial::PacketWrite;
+use pumpkin_macros::packet;
 
 #[derive(PacketWrite)]
 #[packet(6)]
@@ -11,7 +10,22 @@ pub struct CResourcePacksInfo {
     is_vibrant_visuals_force_disabled: bool,
     world_template_id: uuid::Uuid,
     world_template_version: String,
-    resource_packs_size: u16, // TODO: Add more
+    resource_packs_size: u16,
+    resource_packs: Vec<ResourcePack>,
+}
+
+#[derive(PacketWrite)]
+pub struct ResourcePack {
+    pack_id: uuid::Uuid,
+    version: String,
+    size: u64,
+    content_key: String,
+    subpack_name: String,
+    content_identity: String,
+    has_scripts: bool,
+    is_addon_pack: bool,
+    is_raytracing_capable: bool,
+    cdn_url: String,
 }
 
 impl CResourcePacksInfo {
@@ -22,6 +36,7 @@ impl CResourcePacksInfo {
         is_vibrant_visuals_force_disabled: bool,
         world_template_id: uuid::Uuid,
         world_template_version: String,
+        resource_packs: Vec<ResourcePack>,
     ) -> Self {
         Self {
             resource_pack_required,
@@ -30,8 +45,8 @@ impl CResourcePacksInfo {
             is_vibrant_visuals_force_disabled,
             world_template_id,
             world_template_version,
-            // TODO
-            resource_packs_size: 0,
+            resource_packs_size: resource_packs.len() as u16,
+            resource_packs,
         }
     }
 }

--- a/pumpkin-protocol/src/java/server/play/click_container.rs
+++ b/pumpkin-protocol/src/java/server/play/click_container.rs
@@ -63,13 +63,15 @@ impl<'de> Deserialize<'de> for SClickSlot {
                     .next_element::<OptionalItemStackHash>()?
                     .ok_or(de::Error::custom("Failed to decode carried item"))?;
 
+                let mode: SlotActionType = SlotActionType::try_from(mode.0)
+                    .map_err(|_| de::Error::custom("Invalid slot action type"))?;
+
                 Ok(SClickSlot {
                     sync_id,
                     revision,
                     slot,
                     button,
-                    mode: SlotActionType::try_from(mode.0)
-                        .expect("Invalid slot action, TODO better error handling ;D"),
+                    mode,
                     length_of_array,
                     array_of_changed_slots,
                     carried_item,

--- a/pumpkin/src/net/bedrock/login.rs
+++ b/pumpkin/src/net/bedrock/login.rs
@@ -91,6 +91,7 @@ impl BedrockClient {
                 false,
                 uuid::Uuid::default(),
                 String::new(),
+                Vec::new(),
             ),
             &mut frame_set,
         )


### PR DESCRIPTION
1. bc0556a11a247dcc487df619fcc86ade4d110a60 Handled error for invalid slot action type for java.
2. 1da4572fe89ac20ad51394cfa9940f142a43c75d Added a size check for the bedrock ack read function.
3. ba9a3cfdfb03c4913b14c99159c351810720e0ba Added the missing resource pack fields using the [ResourcePacksInfoPacket Docs](https://mojang.github.io/bedrock-protocol-docs/html/ResourcePacksInfoPacket.html)

## Testing
Tested only on Java.