### PR TITLE
Replace some statics with consts

### DIFF
--- a/pumpkin-data/build/block.rs
+++ b/pumpkin-data/build/block.rs
@@ -953,15 +953,15 @@ pub(crate) fn build() -> TokenStream {
             fn from_value(value: &str) -> Self;
         }
 
-        pub static COLLISION_SHAPES: &[CollisionShape] = &[
+        pub const COLLISION_SHAPES: &[CollisionShape] = &[
             #(#shapes),*
         ];
 
-        //pub static BLOCK_STATES: &[BlockState] = &[
+        //pub const BLOCK_STATES: &[BlockState] = &[
         //    #(#unique_states_tokens),*
         //];
 
-        pub static BLOCK_ENTITY_TYPES: &[&str] = &[
+        pub const BLOCK_ENTITY_TYPES: &[&str] = &[
             #(#block_entity_types),*
         ];
 

--- a/pumpkin-data/build/fluid.rs
+++ b/pumpkin-data/build/fluid.rs
@@ -655,7 +655,7 @@ pub(crate) fn build() -> TokenStream {
 
         impl Eq for Fluid {}
 
-        pub static FLUID_STATES: &[PartialFluidState] = &[
+        pub const FLUID_STATES: &[PartialFluidState] = &[
             #(#unique_fluid_states),*
         ];
 

--- a/pumpkin-data/build/fuels.rs
+++ b/pumpkin-data/build/fuels.rs
@@ -28,7 +28,7 @@ pub(crate) fn build() -> TokenStream {
         .collect::<Vec<_>>();
 
     quote! {
-        pub static FUELS: [(u16,u16); #fuel_list_len] = [
+        pub const FUELS: [(u16,u16); #fuel_list_len] = [
                 #(#fuel_list_tokens),*
         ];
 

--- a/pumpkin-protocol/src/java/server/play/player_position_rotation.rs
+++ b/pumpkin-protocol/src/java/server/play/player_position_rotation.rs
@@ -2,8 +2,8 @@ use pumpkin_data::packet::serverbound::PLAY_MOVE_PLAYER_POS_ROT;
 use pumpkin_macros::packet;
 use pumpkin_util::math::vector3::Vector3;
 
-pub static FLAG_ON_GROUND: u8 = 0x01;
-pub static FLAG_IN_WALL: u8 = 0x02;
+pub const FLAG_ON_GROUND: u8 = 0x01;
+pub const FLAG_IN_WALL: u8 = 0x02;
 
 #[derive(serde::Deserialize)]
 #[packet(PLAY_MOVE_PLAYER_POS_ROT)]


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

These instances of `static` can be replaced with `const`, which is the appropriate choice for immutable, inlined constants.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
