### PR TITLE
Refactor: Entity::world() helper

### DIFF
--- a/pumpkin/src/command/commands/rotate.rs
+++ b/pumpkin/src/command/commands/rotate.rs
@@ -79,7 +79,7 @@ async fn rotate_entity(
     // Use teleport with same position to update rotation
     // This properly handles both players (sends CPlayerPosition) and other entities
     let pos = entity.pos.load();
-    let world = entity.world.load_full();
+    let world = entity.world();
     target
         .teleport(pos, Some(final_yaw), Some(final_pitch), world)
         .await;

--- a/pumpkin/src/command/commands/seed.rs
+++ b/pumpkin/src/command/commands/seed.rs
@@ -23,7 +23,7 @@ impl CommandExecutor for Executor {
         Box::pin(async move {
             let seed = match sender {
                 CommandSender::Player(player) => {
-                    player.living_entity.entity.world.load().level.seed.0
+                    player.living_entity.entity.world().level.seed.0
                 }
                 // TODO: Maybe ask player for world, or get the current world
                 _ => match server.worlds.load().first() {

--- a/pumpkin/src/command/commands/seed.rs
+++ b/pumpkin/src/command/commands/seed.rs
@@ -22,9 +22,7 @@ impl CommandExecutor for Executor {
     ) -> CommandResult<'a> {
         Box::pin(async move {
             let seed = match sender {
-                CommandSender::Player(player) => {
-                    player.living_entity.entity.world().level.seed.0
-                }
+                CommandSender::Player(player) => player.living_entity.entity.world().level.seed.0,
                 // TODO: Maybe ask player for world, or get the current world
                 _ => match server.worlds.load().first() {
                     Some(world) => world.level.seed.0,

--- a/pumpkin/src/command/commands/teleport.rs
+++ b/pumpkin/src/command/commands/teleport.rs
@@ -76,7 +76,7 @@ impl CommandExecutor for EntitiesToEntityExecutor {
                 let base_entity = target.get_entity();
                 let yaw = base_entity.yaw.load();
                 let pitch = base_entity.pitch.load();
-                let world = base_entity.world.load_full();
+                let world = base_entity.world();
                 target
                     .clone()
                     .teleport(pos, yaw.into(), pitch.into(), world)
@@ -160,7 +160,7 @@ impl CommandExecutor for EntitiesToPosFacingEntityExecutor {
                         pos,
                         Some(yaw),
                         Some(pitch),
-                        facing_entity.get_entity().world.load_full(),
+                        facing_entity.get_entity().world(),
                     )
                     .await;
             }
@@ -260,7 +260,7 @@ impl CommandExecutor for SelfToEntityExecutor {
         Box::pin(async move {
             let destination = EntityArgumentConsumer::find_arg(args, ARG_DESTINATION)?;
             let pos = destination.get_entity().pos.load();
-            let world = destination.get_entity().world.load_full();
+            let world = destination.get_entity().world();
 
             match sender {
                 CommandSender::Player(player) => {

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -173,7 +173,7 @@ impl CommandSender {
         match self {
             // TODO: maybe return first world when console
             Self::Console | Self::Rcon(..) | Self::Dummy => None,
-            Self::Player(p) => Some(p.living_entity.entity.world.load_full()),
+            Self::Player(p) => Some(p.living_entity.entity.world()),
             Self::CommandBlock(_, w) => Some(w.clone()),
         }
     }

--- a/pumpkin/src/entity/ai/goal/active_target.rs
+++ b/pumpkin/src/entity/ai/goal/active_target.rs
@@ -72,7 +72,7 @@ impl ActiveTargetGoal {
     }
 
     fn find_closest_target(&mut self, mob: &MobEntity) {
-        let world = mob.living_entity.entity.world.load();
+        let world = mob.living_entity.entity.world();
         if self.target_type == &EntityType::PLAYER {
             let potential_player = world
                 .get_closest_player(

--- a/pumpkin/src/entity/ai/goal/avoid_entity.rs
+++ b/pumpkin/src/entity/ai/goal/avoid_entity.rs
@@ -42,7 +42,7 @@ impl AvoidEntityGoal {
     fn find_threat(&self, mob: &dyn Mob) -> Option<Arc<dyn EntityBase>> {
         let entity = &mob.get_mob_entity().living_entity.entity;
         let pos = entity.pos.load();
-        let world = entity.world.load();
+        let world = entity.world();
 
         if self.flee_type == &EntityType::PLAYER {
             world
@@ -58,7 +58,7 @@ impl AvoidEntityGoal {
     async fn find_flee_position(mob: &dyn Mob, threat_pos: &Vector3<f64>) -> Option<Vector3<f64>> {
         let entity = &mob.get_mob_entity().living_entity.entity;
         let mob_pos = entity.pos.load();
-        let world = entity.world.load();
+        let world = entity.world();
 
         let candidates = {
             let mut rng = mob.get_random();

--- a/pumpkin/src/entity/ai/goal/beg.rs
+++ b/pumpkin/src/entity/ai/goal/beg.rs
@@ -66,7 +66,7 @@ impl Goal for BegGoal {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async {
             let entity = &mob.get_mob_entity().living_entity.entity;
-            let world = entity.world.load_full();
+            let world = entity.world();
             let pos = entity.pos.load();
             let radius = self.beg_distance_sq.sqrt();
 

--- a/pumpkin/src/entity/ai/goal/breed.rs
+++ b/pumpkin/src/entity/ai/goal/breed.rs
@@ -30,7 +30,7 @@ impl BreedGoal {
 
         let entity = mob.get_entity();
         let pos = entity.pos.load();
-        let world = entity.world.load();
+        let world = entity.world();
         let my_type = entity.entity_type;
         let my_uuid = entity.entity_uuid;
 
@@ -63,7 +63,7 @@ impl BreedGoal {
     async fn breed(mob: &dyn Mob, mate: &dyn EntityBase) {
         let mob_entity = mob.get_mob_entity();
         let entity = mob.get_entity();
-        let world = entity.world.load();
+        let world = entity.world();
 
         mob_entity.reset_love_ticks();
         mob_entity

--- a/pumpkin/src/entity/ai/goal/chase_player.rs
+++ b/pumpkin/src/entity/ai/goal/chase_player.rs
@@ -49,7 +49,7 @@ impl Goal for ChasePlayerGoal {
                 return false;
             }
 
-            let world = entity.world.load();
+            let world = entity.world();
             let closest = world.get_closest_player(mob_pos, 256.0);
             if let Some(p) = closest
                 && p.get_entity().entity_id == target.get_entity().entity_id

--- a/pumpkin/src/entity/ai/goal/eat_grass.rs
+++ b/pumpkin/src/entity/ai/goal/eat_grass.rs
@@ -37,7 +37,7 @@ impl Goal for EatGrassGoal {
 
             let entity = &mob.get_mob_entity().living_entity.entity;
             let block_pos = entity.block_pos.load();
-            let world = entity.world.load();
+            let world = entity.world();
 
             let block_at_pos = world.get_block(&block_pos).await;
             if block_at_pos.has_tag(&tag::Block::MINECRAFT_EDIBLE_FOR_SHEEP) {
@@ -68,7 +68,7 @@ impl Goal for EatGrassGoal {
             if self.timer == 4 {
                 let entity = &mob.get_mob_entity().living_entity.entity;
                 let block_pos = entity.block_pos.load();
-                let world = entity.world.load_full();
+                let world = entity.world();
 
                 let block_at_pos = world.get_block(&block_pos).await;
                 if block_at_pos.has_tag(&tag::Block::MINECRAFT_EDIBLE_FOR_SHEEP) {

--- a/pumpkin/src/entity/ai/goal/follow_owner.rs
+++ b/pumpkin/src/entity/ai/goal/follow_owner.rs
@@ -36,7 +36,7 @@ impl FollowOwnerGoal {
 
     fn find_owner(mob: &dyn Mob) -> Option<Arc<Player>> {
         let owner_uuid = mob.get_owner_uuid()?;
-        let world = mob.get_mob_entity().living_entity.entity.world.load_full();
+        let world = mob.get_mob_entity().living_entity.entity.world();
         let player = world.get_player_by_uuid(owner_uuid)?;
         if player.is_spectator() {
             return None;
@@ -53,7 +53,7 @@ impl FollowOwnerGoal {
     async fn try_teleport_to_owner(mob: &dyn Mob, owner: &Player) {
         let owner_pos = owner.living_entity.entity.pos.load();
         let mob_entity = &mob.get_mob_entity().living_entity.entity;
-        let world = mob_entity.world.load_full();
+        let world = mob_entity.world();
 
         let offsets: [(i32, i32, i32); 10] = {
             let mut rng = mob.get_random();

--- a/pumpkin/src/entity/ai/goal/follow_parent.rs
+++ b/pumpkin/src/entity/ai/goal/follow_parent.rs
@@ -31,7 +31,7 @@ impl FollowParentGoal {
         let entity = &mob_entity.living_entity.entity;
         let pos = entity.pos.load();
         let my_type = entity.entity_type;
-        let world = entity.world.load();
+        let world = entity.world();
 
         let nearby = world.get_nearby_entities(pos, SEARCH_RADIUS);
         let mut closest: Option<(f64, Arc<dyn EntityBase>)> = None;

--- a/pumpkin/src/entity/ai/goal/look_at_entity.rs
+++ b/pumpkin/src/entity/ai/goal/look_at_entity.rs
@@ -92,7 +92,7 @@ impl Goal for LookAtEntityGoal {
                 }
             }
 
-            let world = mob_entity.living_entity.entity.world.load();
+            let world = mob_entity.living_entity.entity.world();
             let mob_pos = mob_entity.living_entity.entity.pos.load();
 
             if *self.target_type == EntityType::PLAYER {

--- a/pumpkin/src/entity/ai/goal/melee_attack.rs
+++ b/pumpkin/src/entity/ai/goal/melee_attack.rs
@@ -50,7 +50,7 @@ impl Goal for MeleeAttackGoal {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async {
             let time = {
-                let world = mob.get_entity().world.load();
+                let world = mob.get_entity().world();
                 let level_time = world.level_time.lock().await;
                 level_time.world_age
             };

--- a/pumpkin/src/entity/ai/goal/move_to_target_pos.rs
+++ b/pumpkin/src/entity/ai/goal/move_to_target_pos.rs
@@ -75,7 +75,7 @@ impl<M: MoveToTargetPos> MoveToTargetPosGoal<M> {
                         block_pos_mut.0.z = block_pos.0.z + n;
                         // Make sure the world lock is dropped
                         {
-                            let world = mob.get_entity().world.load_full();
+                            let world = mob.get_entity().world();
 
                             let can_target =
                                 if let Some(move_to_target_pos) = self.move_to_target_pos.get() {
@@ -145,7 +145,7 @@ impl<M: MoveToTargetPos> Goal for MoveToTargetPosGoal<M> {
 
     fn should_continue<'a>(&'a self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async {
-            let world = mob.get_entity().world.load_full();
+            let world = mob.get_entity().world();
             let can_target = if let Some(x) = self.move_to_target_pos.get() {
                 x.is_target_pos(world, self.target_pos).await
             } else {

--- a/pumpkin/src/entity/ai/goal/owner_hurt_by_target.rs
+++ b/pumpkin/src/entity/ai/goal/owner_hurt_by_target.rs
@@ -33,7 +33,7 @@ impl Goal for OwnerHurtByTargetGoal {
             };
 
             let entity = &mob.get_mob_entity().living_entity.entity;
-            let world = entity.world.load_full();
+            let world = entity.world();
             let Some(owner) = world.get_player_by_uuid(owner_uuid) else {
                 return false;
             };
@@ -86,7 +86,7 @@ impl Goal for OwnerHurtByTargetGoal {
             *mob_entity.target.lock().await = self.target.clone();
 
             if let Some(owner_uuid) = mob.get_owner_uuid() {
-                let world = mob_entity.living_entity.entity.world.load_full();
+                let world = mob_entity.living_entity.entity.world();
                 if let Some(owner) = world.get_player_by_uuid(owner_uuid) {
                     self.last_attacked_time = owner.living_entity.last_attacked_time.load(Relaxed);
                 }

--- a/pumpkin/src/entity/ai/goal/owner_hurt_target.rs
+++ b/pumpkin/src/entity/ai/goal/owner_hurt_target.rs
@@ -33,7 +33,7 @@ impl Goal for OwnerHurtTargetGoal {
             };
 
             let entity = &mob.get_mob_entity().living_entity.entity;
-            let world = entity.world.load_full();
+            let world = entity.world();
             let Some(owner) = world.get_player_by_uuid(owner_uuid) else {
                 return false;
             };
@@ -86,7 +86,7 @@ impl Goal for OwnerHurtTargetGoal {
             *mob_entity.target.lock().await = self.target.clone();
 
             if let Some(owner_uuid) = mob.get_owner_uuid() {
-                let world = mob_entity.living_entity.entity.world.load_full();
+                let world = mob_entity.living_entity.entity.world();
                 if let Some(owner) = world.get_player_by_uuid(owner_uuid) {
                     self.last_attack_time = owner.living_entity.last_attack_time.load(Relaxed);
                 }

--- a/pumpkin/src/entity/ai/goal/pick_up_block.rs
+++ b/pumpkin/src/entity/ai/goal/pick_up_block.rs
@@ -26,7 +26,7 @@ impl Goal for PickUpBlockGoal {
             }
 
             let entity = &mob.get_mob_entity().living_entity.entity;
-            let world = entity.world.load();
+            let world = entity.world();
             if !world.level_info.load().game_rules.mob_griefing {
                 return false;
             }
@@ -53,7 +53,7 @@ impl Goal for PickUpBlockGoal {
                 )
             };
 
-            let world = entity.world.load();
+            let world = entity.world();
             let target_pos = BlockPos::new(bx, by, bz);
 
             let (block, _state_id) = world.get_block_and_state_id(&target_pos).await;

--- a/pumpkin/src/entity/ai/goal/place_block.rs
+++ b/pumpkin/src/entity/ai/goal/place_block.rs
@@ -27,7 +27,7 @@ impl Goal for PlaceBlockGoal {
             }
 
             let entity = &mob.get_mob_entity().living_entity.entity;
-            let world = entity.world.load();
+            let world = entity.world();
             if !world.level_info.load().game_rules.mob_griefing {
                 return false;
             }
@@ -58,7 +58,7 @@ impl Goal for PlaceBlockGoal {
                 )
             };
 
-            let world = entity.world.load();
+            let world = entity.world();
             let target_pos = BlockPos::new(bx, by, bz);
 
             let state_id = world.get_block_state_id(&target_pos).await;

--- a/pumpkin/src/entity/ai/goal/revenge.rs
+++ b/pumpkin/src/entity/ai/goal/revenge.rs
@@ -46,7 +46,7 @@ impl Goal for RevengeGoal {
                 return false;
             }
 
-            let world = living.entity.world.load();
+            let world = living.entity.world();
             let Some(attacker) = world.get_entity_by_id(attacker_id) else {
                 return false;
             };

--- a/pumpkin/src/entity/ai/goal/step_and_destroy_block.rs
+++ b/pumpkin/src/entity/ai/goal/step_and_destroy_block.rs
@@ -89,7 +89,7 @@ impl<S: Stepping + Send + Sync, M: MoveToTargetPos + Send + Sync> Goal
 {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async {
-            let world = mob.get_entity().world.load();
+            let world = mob.get_entity().world();
             let level_info = world.level_info.load();
             if !level_info.game_rules.mob_griefing {
                 false
@@ -128,7 +128,7 @@ impl<S: Stepping + Send + Sync, M: MoveToTargetPos + Send + Sync> Goal
         Box::pin(async {
             self.move_to_target_pos_goal.tick(mob).await;
             let mob_entity = mob.get_mob_entity();
-            let world = mob.get_entity().world.load_full();
+            let world = mob.get_entity().world();
             let block_pos = mob.get_entity().block_pos.load();
 
             let tweak_pos = self.tweak_to_proper_pos(block_pos, world.clone()).await;

--- a/pumpkin/src/entity/ai/goal/teleport_towards_player.rs
+++ b/pumpkin/src/entity/ai/goal/teleport_towards_player.rs
@@ -43,7 +43,7 @@ impl TeleportTowardsPlayerGoal {
 
     async fn find_staring_player(&self) -> Option<Arc<Player>> {
         let entity = &self.enderman.mob_entity.living_entity.entity;
-        let world = entity.world.load();
+        let world = entity.world();
         let pos = entity.pos.load();
         let follow_range = self
             .enderman

--- a/pumpkin/src/entity/ai/goal/tempt.rs
+++ b/pumpkin/src/entity/ai/goal/tempt.rs
@@ -43,7 +43,7 @@ impl TemptGoal {
     async fn find_tempting_player(&self, mob: &dyn Mob) -> Option<Arc<Player>> {
         let mob_entity = mob.get_mob_entity();
         let pos = mob_entity.living_entity.entity.pos.load();
-        let world = mob_entity.living_entity.entity.world.load();
+        let world = mob_entity.living_entity.entity.world();
 
         for player in world.get_nearby_players(pos, TEMPT_RANGE) {
             if self.is_holding_tempt_item(&player).await {

--- a/pumpkin/src/entity/ai/goal/track_target.rs
+++ b/pumpkin/src/entity/ai/goal/track_target.rs
@@ -59,7 +59,7 @@ impl TrackTargetGoal {
         }
         let mob_entity = mob.get_mob_entity();
         let target = target.unwrap();
-        let world = mob_entity.living_entity.entity.world.load_full();
+        let world = mob_entity.living_entity.entity.world();
         if !target_predicate.test(&world, Some(&mob_entity.living_entity), target) {
             return false;
         }

--- a/pumpkin/src/entity/ai/pathfinder/mod.rs
+++ b/pumpkin/src/entity/ai/pathfinder/mod.rs
@@ -123,7 +123,7 @@ impl Navigator {
         let start_block_vec = start_pos_f.to_i32();
         let mob_position = Vector3::new(start_block_vec.x, start_block_vec.y, start_block_vec.z);
 
-        let context = PathfindingContext::new(mob_position, entity.entity.world.load_full());
+        let context = PathfindingContext::new(mob_position, entity.entity.world());
         let mut mob_data = MobData::new(start_pos_f, self.mob_width, self.mob_height, 1.0);
         mob_data.on_ground = entity.entity.on_ground.load(Ordering::Relaxed);
         mob_data.set_pathfinding_malus(PathType::DangerFire, 16.0);

--- a/pumpkin/src/entity/attributes.rs
+++ b/pumpkin/src/entity/attributes.rs
@@ -172,8 +172,7 @@ pub async fn send_attribute_updates_for_living(
 
     living
         .entity
-        .world
-        .load()
+        .world()
         .broadcast_editioned(&je_packet, &be_packet)
         .await;
 }

--- a/pumpkin/src/entity/decoration/armor_stand.rs
+++ b/pumpkin/src/entity/decoration/armor_stand.rs
@@ -194,8 +194,7 @@ impl ArmorStandEntity {
         //TODO: i am stupid! let armor_stand_item = ItemStack::new_with_component(1, &Item::ARMOR_STAND, vec![(DataComponent::CustomName, self.get_custom_name())]);
         let armor_stand_item = ItemStack::new(1, &Item::ARMOR_STAND);
         entity
-            .world
-            .load()
+            .world()
             .drop_stack(&entity.block_pos.load(), armor_stand_item)
             .await;
 

--- a/pumpkin/src/entity/decoration/armor_stand.rs
+++ b/pumpkin/src/entity/decoration/armor_stand.rs
@@ -203,7 +203,7 @@ impl ArmorStandEntity {
     }
 
     async fn on_break(&self, entity: &Entity) {
-        let world = entity.world.load();
+        let world = entity.world();
         world
             .play_sound(
                 Sound::EntityArmorStandBreak,
@@ -218,7 +218,7 @@ impl ArmorStandEntity {
     /// Spawns break particles at the armor stand's position.
     // TODO: use oak plank block particles like vanilla (requires block state data in particle system)
     async fn spawn_break_particles(&self, entity: &Entity) {
-        let world = entity.world.load();
+        let world = entity.world();
         let pos = entity.pos.load();
         let width = entity.width();
         let height = entity.height();
@@ -339,7 +339,7 @@ impl EntityBase for ArmorStandEntity {
                 return false;
             }
 
-            let world = entity.world.load();
+            let world = entity.world();
 
             let mob_griefing_gamerule = {
                 let game_rules = &world.level_info.load().game_rules;

--- a/pumpkin/src/entity/decoration/end_crystal.rs
+++ b/pumpkin/src/entity/decoration/end_crystal.rs
@@ -50,8 +50,7 @@ impl EntityBase for EndCrystalEntity {
         Box::pin(async move {
             if damage_type != DamageType::EXPLOSION {
                 self.entity
-                    .world
-                    .load()
+                    .world()
                     .explode(self.entity.pos.load(), 6.0)
                     .await;
             }

--- a/pumpkin/src/entity/experience_orb.rs
+++ b/pumpkin/src/entity/experience_orb.rs
@@ -84,8 +84,7 @@ impl EntityBase for ExperienceOrbEntity {
 
             let no_clip = !self
                 .entity
-                .world
-                .load()
+                .world()
                 .is_space_empty(bounding_box.expand(-1.0e-7, -1.0e-7, -1.0e-7))
                 .await;
             // TODO: isSubmergedIn

--- a/pumpkin/src/entity/falling.rs
+++ b/pumpkin/src/entity/falling.rs
@@ -68,8 +68,7 @@ impl EntityBase for FallingEntity {
             if entity.on_ground.load(Ordering::Relaxed) {
                 entity.velocity.store(velo.multiply(0.7, -0.5, 0.7));
                 entity
-                    .world
-                    .load()
+                    .world()
                     .set_block_state(
                         &self.entity.block_pos.load(),
                         self.block_state_id,

--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -235,8 +235,7 @@ impl ItemEntity {
         let bounding_box = entity.bounding_box.load();
 
         let no_clip = !entity
-            .world
-            .load()
+            .world()
             .is_space_empty(bounding_box.expand(-1.0e-7, -1.0e-7, -1.0e-7))
             .await;
 

--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -105,7 +105,7 @@ impl ItemEntity {
     async fn try_merge(&self) {
         let bounding_box = self.entity.bounding_box.load().expand(0.5, 0.0, 0.5);
 
-        let world = self.entity.world.load();
+        let world = self.entity.world();
         let entities = world.entities.load();
         let items = entities.iter().filter_map(|entity: &Arc<dyn EntityBase>| {
             entity.clone().get_item_entity().filter(|item| {

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -185,8 +185,7 @@ impl LivingEntity {
             })
             .collect();
         self.entity
-            .world
-            .load()
+            .world()
             .broadcast_packet_except(
                 &[self.entity.entity_uuid],
                 &CSetEquipment::new(self.entity_id().into(), equipment),
@@ -198,8 +197,7 @@ impl LivingEntity {
     pub async fn pickup(&self, item: &Entity, stack_amount: u32) {
         // TODO: Only nearby
         self.entity
-            .world
-            .load()
+            .world()
             .broadcast_packet_all(&CTakeItemEntity::new(
                 item.entity_id.into(),
                 self.entity.entity_id.into(),
@@ -409,12 +407,7 @@ impl LivingEntity {
             self.heal(heal_amount).await;
         } else if effect.effect_type == &StatusEffect::INSTANT_DAMAGE {
             let damage_amount = 6.0 * (1 << effect.amplifier) as f32;
-            if let Some(dyn_self) = self
-                .entity
-                .world
-                .load()
-                .get_entity_by_id(self.entity.entity_id)
-            {
+            if let Some(dyn_self) = self.entity.world().get_entity_by_id(self.entity.entity_id) {
                 dyn_self
                     .damage(&*dyn_self, damage_amount, DamageType::MAGIC)
                     .await;
@@ -522,8 +515,7 @@ impl LivingEntity {
 
         // Broadcast effect removal
         self.entity
-            .world
-            .load()
+            .world()
             .send_remove_mob_effect(&self.entity, effect_type)
             .await;
 
@@ -700,8 +692,7 @@ impl LivingEntity {
     pub async fn swing_hand(&self) {
         // TODO: radius
         self.entity
-            .world
-            .load()
+            .world()
             .broadcast_packet_all(&CEntityAnimation::new(
                 self.entity_id().into(),
                 Animation::SwingMainArm,
@@ -952,8 +943,7 @@ impl LivingEntity {
         if self.entity.horizontal_collision.load(SeqCst)
             && !self
                 .entity
-                .world
-                .load()
+                .world()
                 .check_fluid_collision(self.entity.bounding_box.load().shift(velo))
                 .await
         {
@@ -1402,11 +1392,7 @@ impl LivingEntity {
         } else if effect_type == &StatusEffect::POISON {
             let current_health = self.health.load();
             if current_health > 1.0
-                && let Some(dyn_self) = self
-                    .entity
-                    .world
-                    .load()
-                    .get_entity_by_id(self.entity.entity_id)
+                && let Some(dyn_self) = self.entity.world().get_entity_by_id(self.entity.entity_id)
             {
                 let damage_amount = (current_health - 1.0).min(1.0);
                 if damage_amount > 0.0 {
@@ -1417,12 +1403,7 @@ impl LivingEntity {
             }
         } else if effect_type == &StatusEffect::WITHER {
             let damage_amount = 1.0;
-            if let Some(dyn_self) = self
-                .entity
-                .world
-                .load()
-                .get_entity_by_id(self.entity.entity_id)
-            {
+            if let Some(dyn_self) = self.entity.world().get_entity_by_id(self.entity.entity_id) {
                 dyn_self
                     .damage(&*dyn_self, damage_amount, DamageType::WITHER)
                     .await;
@@ -1461,8 +1442,7 @@ impl LivingEntity {
                 stack.clear();
                 self.set_health(1.0).await;
                 self.entity
-                    .world
-                    .load()
+                    .world()
                     .send_entity_status(&self.entity, EntityStatus::UseTotemOfUndying)
                     .await;
 
@@ -2075,8 +2055,7 @@ impl EntityBase for LivingEntity {
                 if time >= 20 && self.entity.is_alive() {
                     // Spawn Death particles
                     self.entity
-                        .world
-                        .load()
+                        .world()
                         .send_entity_status(&self.entity, EntityStatus::AddDeathParticles)
                         .await;
                     self.entity.remove().await;

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -508,7 +508,7 @@ impl LivingEntity {
             flag,
         );
 
-        self.entity.world.load().broadcast_packet_all(&packet).await;
+        self.entity.world().broadcast_packet_all(&packet).await;
     }
 
     pub async fn remove_effect(&self, effect_type: &'static StatusEffect) -> bool {
@@ -594,7 +594,7 @@ impl LivingEntity {
 
     pub async fn is_in_fall_damage_resetting(&self) -> (bool, &Block) {
         let block_pos = self.entity.block_pos.load();
-        let block = self.entity.world.load().get_block(&block_pos).await;
+        let block = self.entity.world().get_block(&block_pos).await;
         (
             block.has_tag(&tag::Block::MINECRAFT_FALL_DAMAGE_RESETTING),
             block,
@@ -604,13 +604,13 @@ impl LivingEntity {
     // Check if the entity is in water
     pub async fn is_in_water(&self) -> bool {
         let block_pos = self.entity.block_pos.load();
-        self.entity.world.load().get_block(&block_pos).await == &Block::WATER
+        self.entity.world().get_block(&block_pos).await == &Block::WATER
     }
 
     // Check if the entity is in powder snow
     pub async fn is_in_powder_snow(&self) -> bool {
         let block_pos = self.entity.block_pos.load();
-        self.entity.world.load().get_block(&block_pos).await == &Block::POWDER_SNOW
+        self.entity.world().get_block(&block_pos).await == &Block::POWDER_SNOW
     }
 
     pub async fn should_prevent_fall_damage(&self) -> bool {
@@ -630,7 +630,7 @@ impl LivingEntity {
             }
 
             if block == &Block::NETHER_PORTAL {
-                let world = self.entity.world.load();
+                let world = self.entity.world();
                 let level_info = world.level_info.load();
 
                 return level_info.game_rules.players_nether_portal_default_delay == 0;
@@ -641,7 +641,7 @@ impl LivingEntity {
     }
 
     pub async fn should_prevent_fall_damage_in_area(&self) -> bool {
-        let world = self.entity.world.load();
+        let world = self.entity.world();
         let block_pos = self.entity.block_pos.load().down();
         let entity_pos = self.entity.pos.load();
 
@@ -1146,7 +1146,7 @@ impl LivingEntity {
             {
                 return;
             }
-            let world = self.entity.world.load();
+            let world = self.entity.world();
             let block = world
                 .get_block(&self.entity.get_pos_with_y_offset(0.2).await.0)
                 .await;
@@ -1255,7 +1255,7 @@ impl LivingEntity {
         source: Option<&dyn EntityBase>,
         cause: Option<&dyn EntityBase>,
     ) {
-        let world = self.entity.world.load();
+        let world = self.entity.world();
         let dyn_self = world
             .get_entity_by_id(self.entity.entity_id)
             .expect("Entity not found in world");
@@ -1316,7 +1316,7 @@ impl LivingEntity {
         if let Some(loot_table) = &self.get_entity().entity_type.loot_table {
             let pos = self.entity.block_pos.load();
             for stack in loot_table.get_loot(params) {
-                self.entity.world.load().drop_stack(&pos, stack).await;
+                self.entity.world().drop_stack(&pos, stack).await;
             }
         }
     }
@@ -1428,7 +1428,7 @@ impl LivingEntity {
                     .await;
             }
         } else if effect_type == &StatusEffect::HUNGER {
-            let world = self.entity.world.load();
+            let world = self.entity.world();
             if let Some(entity) = world.get_entity_by_id(self.entity.entity_id)
                 && let Some(player) = entity.get_player()
             {
@@ -1438,7 +1438,7 @@ impl LivingEntity {
             }
             drop(world);
         } else if effect_type == &StatusEffect::SATURATION {
-            let world = self.entity.world.load();
+            let world = self.entity.world();
             if let Some(entity) = world.get_entity_by_id(self.entity.entity_id)
                 && let Some(player) = entity.get_player()
             {
@@ -1623,7 +1623,7 @@ impl LivingEntity {
         self.jumping.store(false, Relaxed);
 
         // If this LivingEntity corresponds to a Player, reset their hunger manager
-        let world = self.entity.world.load();
+        let world = self.entity.world();
         if let Some(player) = world.get_player_by_id(self.entity.entity_id) {
             player.hunger_manager.restart();
         }
@@ -1645,7 +1645,7 @@ impl LivingEntity {
             return;
         }
 
-        let world = self.entity.world.load();
+        let world = self.entity.world();
 
         // 10% chance
         if rand::rng().random::<f32>() <= 0.1 {
@@ -1692,7 +1692,7 @@ impl LivingEntity {
     }
 
     pub fn is_player(&self) -> bool {
-        let world = self.entity.world.load();
+        let world = self.entity.world();
         world.get_player_by_id(self.entity.entity_id).is_some()
     }
 
@@ -1800,7 +1800,7 @@ impl EntityBase for LivingEntity {
                 return false;
             }
 
-            let world = self.entity.world.load();
+            let world = self.entity.world();
             let is_fire_damage = damage_type == DamageType::IN_FIRE
                 || damage_type == DamageType::ON_FIRE
                 || damage_type == DamageType::LAVA
@@ -2001,7 +2001,7 @@ impl EntityBase for LivingEntity {
 
             // Notify the block under the entity each tick if a supporting block position is found
             if let Some(supporting) = supporting_pos {
-                let world = self.entity.world.load();
+                let world = self.entity.world();
                 let (block, state) = world.get_block_and_state(&supporting).await;
 
                 world

--- a/pumpkin/src/entity/mob/bat.rs
+++ b/pumpkin/src/entity/mob/bat.rs
@@ -106,7 +106,7 @@ impl Mob for BatEntity {
             let entity = &self.mob_entity.living_entity.entity;
             let block_pos = entity.block_pos.load();
             let above_pos = BlockPos::new(block_pos.0.x, block_pos.0.y + 1, block_pos.0.z);
-            let world = entity.world.load();
+            let world = entity.world();
 
             // Ambient idle sound (vanilla: MobEntity.mobTick → playAmbientSound)
             let chance = self.ambient_sound_chance.fetch_sub(1, Relaxed);

--- a/pumpkin/src/entity/mob/creeper.rs
+++ b/pumpkin/src/entity/mob/creeper.rs
@@ -111,7 +111,7 @@ impl CreeperEntity {
             .living_entity
             .dead
             .store(true, Ordering::Relaxed);
-        let world = entity.world.load();
+        let world = entity.world();
         let pos = entity.pos.load();
         world.explode(pos, radius * multiplier).await;
         // TODO: spawn area effect cloud with potion effects
@@ -187,7 +187,7 @@ impl Mob for CreeperEntity {
             let current = self.current_fuse_time.load(Ordering::Relaxed);
 
             if fuse_speed > 0 && current == 0 {
-                let world = entity.world.load();
+                let world = entity.world();
                 world
                     .play_sound_fine(
                         Sound::EntityCreeperPrimed,
@@ -221,7 +221,7 @@ impl Mob for CreeperEntity {
             }
 
             let entity = &self.mob_entity.living_entity.entity;
-            let world = entity.world.load();
+            let world = entity.world();
             let pos = entity.pos.load();
 
             world

--- a/pumpkin/src/entity/mob/enderman.rs
+++ b/pumpkin/src/entity/mob/enderman.rs
@@ -173,7 +173,7 @@ impl EndermanEntity {
     pub async fn teleport_to(&self, x: f64, y: f64, z: f64) -> bool {
         let entity = &self.mob_entity.living_entity.entity;
         let origin = entity.pos.load();
-        let world = entity.world.load();
+        let world = entity.world();
 
         let min_y = f64::from(world.dimension.min_y);
         let max_y = f64::from(world.dimension.min_y + world.dimension.height - 1);
@@ -394,7 +394,7 @@ impl EndermanEntity {
 
         let enderman_eye_pos = Vector3::new(enderman_pos.x, enderman_eye_y, enderman_pos.z);
         let player_eye_pos = Vector3::new(player_pos.x, player_eye_y, player_pos.z);
-        let world = entity.world.load();
+        let world = entity.world();
         world
             .raycast(enderman_eye_pos, player_eye_pos, async |block_pos, w| {
                 let state = w.get_block_state(block_pos).await;
@@ -451,7 +451,7 @@ impl Mob for EndermanEntity {
             }
 
             let pos = entity.pos.load();
-            let world = entity.world.load();
+            let world = entity.world();
             let particles = {
                 let mut rng = self.get_random();
                 std::array::from_fn::<_, 2, _>(|_| {

--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -366,7 +366,7 @@ impl<T: Mob + Send + 'static> EntityBase for T {
             let last_head_yaw = mob_entity.last_sent_head_yaw.load(Relaxed);
 
             if yaw.abs_diff(last_yaw) >= 1 || pitch.abs_diff(last_pitch) >= 1 {
-                let world = entity.world.load();
+                let world = entity.world();
                 world
                     .broadcast_packet_all(&CUpdateEntityRot::new(
                         entity.entity_id.into(),
@@ -380,7 +380,7 @@ impl<T: Mob + Send + 'static> EntityBase for T {
             }
 
             if head_yaw.abs_diff(last_head_yaw) >= 1 {
-                let world = entity.world.load();
+                let world = entity.world();
                 world
                     .broadcast_packet_all(&CHeadRot::new(entity.entity_id.into(), head_yaw))
                     .await;
@@ -525,7 +525,7 @@ pub trait SunSensitive: Mob + Send + Sync {
                 return;
             }
 
-            let world_arc = entity.world.load();
+            let world_arc = entity.world();
             let world = world_arc.as_ref();
 
             if world.level_time.lock().await.is_night() {

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -470,6 +470,12 @@ impl Entity {
         position: Vector3<f64>,
         entity_type: &'static EntityType,
     ) -> Self {
+        let weak_world = {
+            let weak = Arc::downgrade(&world);
+            drop(world);
+            weak
+        };
+
         let floor_x = position.x.floor() as i32;
         let floor_y = position.y.floor() as i32;
         let floor_z = position.z.floor() as i32;
@@ -502,7 +508,7 @@ impl Entity {
             sneaking: AtomicBool::new(false),
             invisible: AtomicBool::new(false),
             glowing: AtomicBool::new(false),
-            world: RwLock::new(Arc::downgrade(&world)),
+            world: RwLock::new(weak_world),
             sprinting: AtomicBool::new(false),
             fall_flying: AtomicBool::new(false),
             yaw: AtomicCell::new(0.0),
@@ -555,14 +561,22 @@ impl Entity {
     /// Updates the world reference for this entity.
     /// Called when the entity changes dimensions (e.g., through a nether portal).
     pub fn set_world(&self, world: Arc<World>) {
-        *self.world.write().unwrap_or_else(|e| e.into_inner()) = Arc::downgrade(&world);
+        let weak_world = {
+            let weak = Arc::downgrade(&world);
+            drop(world);
+            weak
+        };
+        *self
+            .world
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = weak_world;
     }
 
     /// Returns the world this entity belongs to.
     pub fn world(&self) -> Arc<World> {
         self.world
             .read()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .upgrade()
             .expect("Entity outlived its World")
     }

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -559,6 +559,11 @@ impl Entity {
         self.world.store(world);
     }
 
+    /// Returns the world this entity belongs to.
+    pub fn world(&self) -> Arc<World> {
+        self.world.load_full()
+    }
+
     /// Sets the entity's age in ticks.
     /// Negative values indicate that the entity is a baby.
     pub fn set_age(&self, age: i32) {
@@ -950,7 +955,7 @@ impl Entity {
         eye_level_box.max.y = eye_level_box.min.y;
 
         let mut suffocating = false;
-        let world = self.world.load();
+        let world = self.world();
 
         for pos in BlockPos::iterate(min, max) {
             let (block, state) = world.get_block_and_state(&pos).await;
@@ -1085,7 +1090,7 @@ impl Entity {
 
         let max = bounding_box.max_block_pos();
 
-        let world = self.world.load();
+        let world = self.world();
 
         for x in min.0.x..=max.0.x {
             for y in min.0.y..=max.0.y {
@@ -1262,7 +1267,7 @@ impl Entity {
         if let (Some(b), Some(s)) = (block, state) {
             (pos, b, s)
         } else {
-            let (b, s) = self.world.load().get_block_and_state(&pos).await;
+            let (b, s) = self.world().get_block_and_state(&pos).await;
 
             (pos, b, s)
         }
@@ -1306,7 +1311,7 @@ impl Entity {
 
     #[expect(clippy::float_cmp)]
     async fn get_velocity_multiplier(&self) -> f32 {
-        let block = self.world.load().get_block(&self.block_pos.load()).await;
+        let block = self.world().get_block(&self.block_pos.load()).await;
 
         let multiplier = block.velocity_multiplier;
 
@@ -1387,7 +1392,7 @@ impl Entity {
         }
 
         if motion.y != final_move.y {
-            let world = self.world.load();
+            let world = self.world();
             let block = self.get_block_with_y_offset(0.2).await.1;
             world
                 .block_registry
@@ -1467,7 +1472,7 @@ impl Entity {
                 let current_yaw = self.yaw.load();
                 let dimensions = self.entity_dimension.load();
                 let scale_factor_new = portal_manager.portal_world.dimension.coordinate_scale;
-                let scale_factor_current = self.world.load().dimension.coordinate_scale;
+                let scale_factor_current = self.world().dimension.coordinate_scale;
 
                 let scale_factor = scale_factor_current / scale_factor_new;
                 let target_pos =
@@ -1614,7 +1619,7 @@ impl Entity {
         }
 
         let mut manager = self.portal_manager.lock().await;
-        let world = self.world.load();
+        let world = self.world();
         if manager.is_none() {
             let mut new_manager = PortalManager::new(portal_delay, portal_world, pos);
 
@@ -1684,7 +1689,7 @@ impl Entity {
     /// Check if the entity is currently in powder snow
     pub async fn is_in_powder_snow(&self) -> bool {
         let block_pos = self.block_pos.load();
-        self.world.load().get_block(&block_pos).await == &Block::POWDER_SNOW
+        self.world().get_block(&block_pos).await == &Block::POWDER_SNOW
     }
 
     /// Check if this entity type is immune to freezing
@@ -1746,7 +1751,7 @@ impl Entity {
 
     /// Removes the `Entity` from their current `World`
     pub async fn remove(&self) {
-        self.world.load().remove_entity(self).await;
+        self.world().remove_entity(self).await;
     }
 
     pub fn create_spawn_packet(&self) -> CSpawnEntity {
@@ -1999,7 +2004,7 @@ impl Entity {
             meta.write(&mut buf, &MinecraftVersion::V_1_21_11).unwrap();
         }
         buf.put_u8(255);
-        let world = self.world.load();
+        let world = self.world();
         for player in world.players.load().iter() {
             if let ClientPlatform::Java(client) = &player.client {
                 let mut buf = Vec::new();
@@ -2057,7 +2062,7 @@ impl Entity {
             (aabb.max.y - 0.001).floor() as i32,
             (aabb.max.z - 0.001).floor() as i32,
         );
-        let world = entity.get_entity().world.load();
+        let world = entity.get_entity().world();
 
         for x in blockpos.0.x..=blockpos1.0.x {
             for y in blockpos.0.y..=blockpos1.0.y {
@@ -2172,7 +2177,7 @@ impl Entity {
             .map(|p| VarInt(p.get_entity().entity_id))
             .collect();
 
-        let world = self.world.load();
+        let world = self.world();
         world
             .broadcast_packet_all(&CSetPassengers::new(VarInt(self.entity_id), &passenger_ids))
             .await;
@@ -2230,7 +2235,7 @@ impl Entity {
             // Now send CSetPassengers — client movement is already blocked.
             // Vanilla sends this directly to the dismounting player's connection,
             // then broadcasts to other players separately.
-            let world = self.world.load();
+            let world = self.world();
             let passengers_packet = CSetPassengers::new(VarInt(self.entity_id), &passenger_ids);
             if let Some(player) = passenger.get_player() {
                 player.client.enqueue_packet(&passengers_packet).await;
@@ -2354,7 +2359,7 @@ impl Entity {
             }
         } else {
             // No passenger was removed, still need to broadcast the passenger list
-            let world = self.world.load();
+            let world = self.world();
             world
                 .broadcast_packet_all(&CSetPassengers::new(VarInt(self.entity_id), &passenger_ids))
                 .await;
@@ -2362,7 +2367,7 @@ impl Entity {
     }
 
     pub async fn check_out_of_world(&self, dyn_self: &dyn EntityBase) {
-        if self.pos.load().y < f64::from(self.world.load().dimension.min_y) - 64.0 {
+        if self.pos.load().y < f64::from(self.world().dimension.min_y) - 64.0 {
             dyn_self.tick_in_void(dyn_self).await;
         }
     }

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -5,7 +5,6 @@ use crate::{
     server::Server,
     world::portal::{NetherPortal, PortalManager, PortalSearchResult, SourcePortalInfo},
 };
-use arc_swap::ArcSwap;
 use bytes::BufMut;
 use crossbeam::atomic::AtomicCell;
 use living::LivingEntity;
@@ -51,7 +50,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use std::pin::Pin;
 use std::sync::{
-    Arc,
+    Arc, RwLock, Weak,
     atomic::{
         AtomicBool, AtomicI32, AtomicU32,
         Ordering::{self, Relaxed},
@@ -360,8 +359,8 @@ pub struct Entity {
     /// The type of entity (e.g., player, zombie, item)
     pub entity_type: &'static EntityType,
     /// The world in which the entity exists.
-    /// Uses `ArcSwap` to allow atomic updates when changing dimensions.
-    pub world: ArcSwap<World>,
+    /// Stored weakly to avoid an `Arc<World> <-> Arc<Entity>` reference cycle.
+    pub world: RwLock<Weak<World>>,
     /// The entity's current position in the world
     pub pos: AtomicCell<Vector3<f64>>,
     /// The last known position of the entity.
@@ -503,7 +502,7 @@ impl Entity {
             sneaking: AtomicBool::new(false),
             invisible: AtomicBool::new(false),
             glowing: AtomicBool::new(false),
-            world: ArcSwap::new(world),
+            world: RwLock::new(Arc::downgrade(&world)),
             sprinting: AtomicBool::new(false),
             fall_flying: AtomicBool::new(false),
             yaw: AtomicCell::new(0.0),
@@ -556,12 +555,16 @@ impl Entity {
     /// Updates the world reference for this entity.
     /// Called when the entity changes dimensions (e.g., through a nether portal).
     pub fn set_world(&self, world: Arc<World>) {
-        self.world.store(world);
+        *self.world.write().unwrap_or_else(|e| e.into_inner()) = Arc::downgrade(&world);
     }
 
     /// Returns the world this entity belongs to.
     pub fn world(&self) -> Arc<World> {
-        self.world.load_full()
+        self.world
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .upgrade()
+            .expect("Entity outlived its World")
     }
 
     /// Sets the entity's age in ticks.
@@ -582,8 +585,7 @@ impl Entity {
 
     pub async fn send_velocity(&self) {
         let velocity = self.velocity.load();
-        self.world
-            .load()
+        self.world()
             .broadcast_packet_all(&CEntityVelocity::new(self.entity_id.into(), velocity))
             .await;
     }
@@ -683,8 +685,7 @@ impl Entity {
 
         let pitch = (pitch * 256.0 / 360.0).rem_euclid(256.0);
 
-        self.world
-            .load()
+        self.world()
             .broadcast_packet_all(&CUpdateEntityRot::new(
                 self.entity_id.into(),
                 yaw,
@@ -697,8 +698,7 @@ impl Entity {
     }
 
     pub async fn send_head_rot(&self, head_yaw: u8) {
-        self.world
-            .load()
+        self.world()
             .broadcast_packet_all(&CHeadRot::new(self.entity_id.into(), head_yaw))
             .await;
     }
@@ -734,8 +734,7 @@ impl Entity {
         let bounding_box = self.bounding_box.load();
 
         let (collisions, block_positions) = self
-            .world
-            .load()
+            .world()
             .get_block_collisions(bounding_box.stretch(movement))
             .await;
 
@@ -1019,8 +1018,7 @@ impl Entity {
 
         let pitch = (pitch * 256.0 / 360.0).rem_euclid(256.0);
 
-        self.world
-            .load()
+        self.world()
             .broadcast_packet_all(&CUpdateEntityPosRot::new(
                 self.entity_id.into(),
                 Vector3::new(converted.x, converted.y, converted.z),
@@ -1050,8 +1048,7 @@ impl Entity {
             new.z.mul_add(4096.0, -(old.z * 4096.0)) as i16,
         );
 
-        self.world
-            .load()
+        self.world()
             .broadcast_packet_all(&CUpdateEntityPos::new(
                 self.entity_id.into(),
                 Vector3::new(converted.x, converted.y, converted.z),
@@ -1223,11 +1220,7 @@ impl Entity {
     ) {
         if let Some(mut supporting_block) = self.supporting_block_pos.load() {
             if offset > 1.0e-5 {
-                let (block, state) = self
-                    .world
-                    .load()
-                    .get_block_and_state(&supporting_block)
-                    .await;
+                let (block, state) = self.world().get_block_and_state(&supporting_block).await;
 
                 // if let Some(props) = block.properties(state.id) {
                 //     let name = props.;
@@ -1327,8 +1320,7 @@ impl Entity {
     #[expect(clippy::float_cmp)]
     async fn get_jump_velocity_multiplier(&self) -> f32 {
         let f = self
-            .world
-            .load()
+            .world()
             .get_block(&self.block_pos.load())
             .await
             .jump_velocity_multiplier;
@@ -1418,8 +1410,7 @@ impl Entity {
             let offset = dir.to_offset();
 
             if self
-                .world
-                .load()
+                .world()
                 .get_block_state(&block_pos.offset(offset))
                 .await
                 .is_full_cube()
@@ -1992,8 +1983,7 @@ impl Entity {
 
     /// Plays sound at this entity's position with the entity's sound category
     pub async fn play_sound(&self, sound: Sound) {
-        self.world
-            .load()
+        self.world()
             .play_sound(sound, SoundCategory::Neutral, &self.pos.load())
             .await;
     }
@@ -2024,12 +2014,7 @@ impl Entity {
         let dimension = Self::get_entity_dimensions(pose);
         let position = self.pos.load();
         let aabb = BoundingBox::new_from_pos(position.x, position.y, position.z, &dimension);
-        if self
-            .world
-            .load()
-            .is_space_empty(aabb.contract_all(1.0E-7))
-            .await
-        {
+        if self.world().is_space_empty(aabb.contract_all(1.0E-7)).await {
             self.pose.store(pose);
             let dimension = Self::get_entity_dimensions(pose);
             self.bounding_box.store(aabb);
@@ -2118,8 +2103,7 @@ impl Entity {
         if let Some(pitch) = pitch {
             self.set_pitch(pitch);
         }
-        self.world
-            .load()
+        self.world()
             .broadcast_packet_all(&CEntityPositionSync::new(
                 self.entity_id.into(),
                 position,

--- a/pumpkin/src/entity/passive/chicken.rs
+++ b/pumpkin/src/entity/passive/chicken.rs
@@ -87,7 +87,7 @@ impl Mob for ChickenEntity {
             if self.egg_lay_time.fetch_sub(1, Ordering::Relaxed) <= 1 {
                 let next_time = rand::rng().random_range(6000..12000);
                 let entity = &self.mob_entity.living_entity.entity;
-                let world = entity.world.load_full();
+                let world = entity.world();
                 let pos = entity.block_pos.load();
                 world.drop_stack(&pos, ItemStack::new(1, &Item::EGG)).await;
                 self.egg_lay_time.store(next_time, Ordering::Relaxed);

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1614,7 +1614,7 @@ impl Player {
     }
 
     pub fn world(&self) -> Arc<World> {
-        self.living_entity.entity.world.load_full()
+        self.living_entity.entity.world()
     }
 
     pub fn position(&self) -> Vector3<f64> {
@@ -1829,7 +1829,7 @@ impl Player {
         yaw: Option<f32>,
         pitch: Option<f32>,
     ) {
-        let current_world = self.living_entity.entity.world.load_full();
+        let current_world = self.living_entity.entity.world();
         let yaw = yaw.unwrap_or(new_world.level_info.load().spawn_yaw);
         let pitch = pitch.unwrap_or(new_world.level_info.load().spawn_pitch);
 

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1244,8 +1244,7 @@ impl Player {
         let position = entity.pos.load();
         let aabb = BoundingBox::new_from_pos(position.x, position.y, position.z, &dimensions);
         entity
-            .world
-            .load()
+            .world()
             .is_space_empty(aabb.contract_all(1.0E-7))
             .await
     }
@@ -2120,8 +2119,7 @@ impl Player {
                 );
                 self.living_entity
                     .entity
-                    .world
-                    .load()
+                    .world()
                     .broadcast_packet_all(&CPlayerInfoUpdate::new(
                         PlayerInfoFlags::UPDATE_GAME_MODE.bits(),
                         &[pumpkin_protocol::java::client::play::Player {
@@ -3195,8 +3193,7 @@ impl EntityBase for Player {
                         let entity = self.get_entity();
                         self.request_teleport(position, yaw, pitch).await;
                         entity
-                            .world
-                            .load()
+                            .world()
                             .broadcast_packet_except(&[self.gameprofile.id], &CEntityPositionSync::new(
                                 self.living_entity.entity.entity_id.into(),
                                 position,

--- a/pumpkin/src/entity/projectile/egg.rs
+++ b/pumpkin/src/entity/projectile/egg.rs
@@ -106,7 +106,7 @@ impl EntityBase for EggEntity {
 
     fn on_hit(&self, hit: crate::entity::projectile::ProjectileHit) -> EntityBaseFuture<'_, ()> {
         Box::pin(async move {
-            let world = self.get_entity().world.load();
+            let world = self.get_entity().world();
             let hit_pos = hit.hit_pos();
             let normal = hit.normal();
 

--- a/pumpkin/src/entity/projectile/firework_rocket.rs
+++ b/pumpkin/src/entity/projectile/firework_rocket.rs
@@ -110,7 +110,7 @@ impl EntityBase for FireworkRocketEntity {
             self.entity.process_tick(caller, server).await;
 
             let entity = self.get_entity();
-            let world = entity.world.load();
+            let world = entity.world();
             let mut velocity = entity.velocity.load();
 
             if let Some(shooter_id) = self.shooter_id {

--- a/pumpkin/src/entity/projectile/mod.rs
+++ b/pumpkin/src/entity/projectile/mod.rs
@@ -96,7 +96,7 @@ impl ThrownItemEntity {
     /// Process a tick for projectile movement and collisions
     pub async fn process_tick(&self, caller: Arc<dyn EntityBase>, _server: &Server) {
         let entity = self.get_entity();
-        let world = entity.world.load();
+        let world = entity.world();
 
         // Apply gravity and inertia
         let mut velocity = entity.velocity.load();

--- a/pumpkin/src/entity/projectile/snowball.rs
+++ b/pumpkin/src/entity/projectile/snowball.rs
@@ -65,7 +65,7 @@ impl EntityBase for SnowballEntity {
 
     fn on_hit(&self, hit: crate::entity::projectile::ProjectileHit) -> EntityBaseFuture<'_, ()> {
         Box::pin(async move {
-            let world = self.get_entity().world.load();
+            let world = self.get_entity().world();
 
             // Always send particle status regardless of what was hit
             world

--- a/pumpkin/src/entity/projectile/wind_charge.rs
+++ b/pumpkin/src/entity/projectile/wind_charge.rs
@@ -44,8 +44,7 @@ impl WindChargeEntity {
 
     pub async fn create_explosion(&self, position: Vector3<f64>) {
         self.get_entity()
-            .world
-            .load()
+            .world()
             .explode(position, EXPLOSION_POWER)
             .await;
     }

--- a/pumpkin/src/entity/tnt.rs
+++ b/pumpkin/src/entity/tnt.rs
@@ -66,8 +66,7 @@ impl EntityBase for TNTEntity {
                 // TNT explodes now
                 self.entity.remove().await;
                 self.entity
-                    .world
-                    .load()
+                    .world()
                     .explode(self.entity.pos.load(), self.power)
                     .await;
             } else {

--- a/pumpkin/src/entity/vehicle/boat.rs
+++ b/pumpkin/src/entity/vehicle/boat.rs
@@ -84,7 +84,7 @@ impl BoatEntity {
     }
 
     async fn kill_and_drop_self(&self) {
-        let world = self.entity.world.load();
+        let world = self.entity.world();
         let entity_drops = world.level_info.load().game_rules.entity_drops;
 
         if entity_drops && let Some(loot_table) = &self.entity.entity_type.loot_table {
@@ -213,7 +213,7 @@ impl EntityBase for BoatEntity {
                 return false;
             }
 
-            let world = self.entity.world.load();
+            let world = self.entity.world();
             let Some(vehicle) = world.get_entity_by_id(self.entity.entity_id) else {
                 return false;
             };

--- a/pumpkin/src/net/bedrock/play.rs
+++ b/pumpkin/src/net/bedrock/play.rs
@@ -173,7 +173,7 @@ impl BedrockClient {
                         message, gameprofile.name.clone()
                     );
 
-                    entity.world.load().broadcast_editioned(&je_packet, &be_packet).await;
+                    entity.world().broadcast_editioned(&je_packet, &be_packet).await;
                 }
             }
         }}

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -467,7 +467,7 @@ impl JavaClient {
                 let yaw = (entity.yaw.load() * 256.0 / 360.0).rem_euclid(256.0);
                 let pitch = (entity.pitch.load() * 256.0 / 360.0).rem_euclid(256.0);
                 // let head_yaw = (entity.head_yaw * 256.0 / 360.0).floor();
-                let world = entity.world.load_full();
+                let world = entity.world();
 
                 // TODO: Warn when player moves to quickly
                 if !self
@@ -570,7 +570,7 @@ impl JavaClient {
         let pitch = (entity.pitch.load() * 256.0 / 360.0).rem_euclid(256.0);
         // let head_yaw = modulus(entity.head_yaw * 256.0 / 360.0, 256.0);
 
-        let world = entity.world.load_full();
+        let world = entity.world();
         let packet =
             CUpdateEntityRot::new(entity_id.into(), yaw as u8, pitch as u8, rotation.ground);
         world
@@ -963,7 +963,7 @@ impl JavaClient {
                 );
 
                 let entity = &player.living_entity.entity;
-                let world = entity.world.load_full();
+                let world = entity.world();
                 if server.basic_config.allow_chat_reports {
                     world.broadcast_secure_player_chat(player, &chat_message, &decorated_message).await;
                 } else {
@@ -1270,7 +1270,7 @@ impl JavaClient {
         };
 
         // Resolve the target entity for the event
-        let world = player_entity.world.load_full();
+        let world = player_entity.world();
         let player_target = world.get_player_by_id(entity_id.0);
         let target: Option<Arc<dyn EntityBase>> = player_target
             .as_ref()
@@ -1385,7 +1385,7 @@ impl JavaClient {
                     }
                     let position = player_action.position;
                     let entity = &player.living_entity.entity;
-                    let world = entity.world.load_full();
+                    let world = entity.world();
                     let (block, state) = world.get_block_and_state(&position).await;
 
                     let inventory = player.inventory();
@@ -1492,7 +1492,7 @@ impl JavaClient {
 
                     // Block break & play sound
                     let entity = &player.living_entity.entity;
-                    let world = entity.world.load_full();
+                    let world = entity.world();
 
                     player.mining.store(false, Ordering::Relaxed);
                     world.set_block_breaking(entity, location, -1).await;
@@ -1646,7 +1646,7 @@ impl JavaClient {
         };
 
         let entity = &player.living_entity.entity;
-        let world = entity.world.load_full();
+        let world = entity.world();
         let block = world.get_block(&position).await;
 
         let sneaking = player.living_entity.entity.sneaking.load(Ordering::Relaxed);
@@ -1775,7 +1775,7 @@ impl JavaClient {
     }
 
     pub async fn handle_sign_update(&self, player: &Player, sign_data: SUpdateSign) {
-        let world = player.living_entity.entity.world.load_full();
+        let world = player.living_entity.entity.world();
         let Some(block_entity) = world.get_block_entity(&sign_data.location).await else {
             return;
         };
@@ -2176,7 +2176,7 @@ impl JavaClient {
         }
 
         let clicked_block_pos = BlockPos(location.0);
-        let world = entity.world.load_full();
+        let world = entity.world();
 
         // Check if the block is under the world
         if location.0.y + face.to_offset().y < world.get_bottom_y() {

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -1472,8 +1472,7 @@ impl JavaClient {
                     player.mining.store(false, Ordering::Relaxed);
                     let entity = &player.living_entity.entity;
                     entity
-                        .world
-                        .load()
+                        .world()
                         .set_block_breaking(entity, player_action.position, -1)
                         .await;
                     self.update_sequence(player, player_action.sequence.0);


### PR DESCRIPTION
## Description

Replace `ArcSwap<World>` with `RwLock<Weak<World>>` — entities now hold a Weak reference to their world, breaking the cycle. The Arc is explicitly dropped before storing the Weak to ensure the strong count decreases immediately.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
