### PR TITLE
feat: Combat enchantments, sweep attack area damage, and critical particles

### DIFF
--- a/pumpkin/src/entity/combat.rs
+++ b/pumpkin/src/entity/combat.rs
@@ -1,13 +1,18 @@
 use std::sync::atomic::Ordering;
 
 use pumpkin_data::{
+    Enchantment,
+    attributes::Attributes,
+    damage::DamageType,
+    entity::EntityType,
     particle::Particle,
     sound::{Sound, SoundCategory},
+    tag::{self, Taggable},
 };
 use pumpkin_util::math::vector3::Vector3;
 
 use crate::{
-    entity::{Entity, player::Player},
+    entity::{Entity, EntityBase, player::Player},
     world::World,
 };
 
@@ -34,15 +39,11 @@ impl AttackType {
             return Self::Knockback;
         }
 
-        // TODO: even more checks
-        if is_strong && !on_ground && fall_distance > 0.0 {
-            // !sprinting omitted
+        if is_strong && !on_ground && fall_distance > 0.0 && !sprinting {
             return Self::Critical;
         }
 
-        // TODO: movement speed check
-        if sword && is_strong {
-            // !is_crit, !is_knockback_hit, on_ground omitted
+        if sword && is_strong && on_ground && !sprinting {
             return Self::Sweeping;
         }
 
@@ -50,16 +51,159 @@ impl AttackType {
     }
 }
 
-pub fn handle_knockback(attacker: &Entity, victim: &Entity, strength: f64) {
+pub fn handle_knockback(
+    attacker: &Entity,
+    victim: &Entity,
+    strength: f64,
+    victim_knockback_resistance: f64,
+) {
+    // Apply knockback resistance (0.0 = no resistance, 1.0 = full immunity)
+    let effective_strength = strength * (1.0 - victim_knockback_resistance);
+    if effective_strength <= 0.0 {
+        return;
+    }
+
     let yaw = attacker.yaw.load();
     victim.knockback(
-        strength * 0.5,
+        effective_strength * 0.5,
         f64::from((yaw.to_radians()).sin()),
         f64::from(-(yaw.to_radians()).cos()),
     );
 
     let velocity = attacker.velocity.load();
     attacker.velocity.store(velocity.multiply(0.6, 1.0, 0.6));
+}
+
+/// Calculate enchantment bonus damage for the given weapon enchantments against the victim.
+///
+/// Returns the extra damage from Sharpness, Smite, or Bane of Arthropods.
+pub fn get_enchantment_damage(
+    sharpness_level: i32,
+    smite_level: i32,
+    bane_level: i32,
+    victim: &dyn EntityBase,
+) -> f64 {
+    let victim_type = victim.get_entity().entity_type;
+
+    // Smite: +2.5 per level vs undead
+    if smite_level > 0 && victim_type.has_tag(&tag::EntityType::MINECRAFT_SENSITIVE_TO_SMITE) {
+        return 2.5 * f64::from(smite_level);
+    }
+
+    // Bane of Arthropods: +2.5 per level vs arthropods
+    if bane_level > 0
+        && victim_type.has_tag(&tag::EntityType::MINECRAFT_SENSITIVE_TO_BANE_OF_ARTHROPODS)
+    {
+        return 2.5 * f64::from(bane_level);
+    }
+
+    // Sharpness: +0.5 * level + 0.5 extra damage
+    if sharpness_level > 0 {
+        return f64::from(sharpness_level).mul_add(0.5, 0.5);
+    }
+
+    0.0
+}
+
+/// Calculate the sweep damage ratio based on Sweeping Edge enchantment level.
+///
+/// Formula: level / (level + 1)
+/// Level 0: 0% of attack damage (just 1 base)
+/// Level 1: 50%
+/// Level 2: 66.7%
+/// Level 3: 75%
+pub fn get_sweep_damage_ratio(sweeping_edge_level: i32) -> f32 {
+    if sweeping_edge_level > 0 {
+        sweeping_edge_level as f32 / (sweeping_edge_level as f32 + 1.0)
+    } else {
+        0.0
+    }
+}
+
+/// Apply sweep attack damage to all nearby entities around the victim.
+pub async fn apply_sweep_attack(
+    attacker: &Player,
+    victim_entity_id: i32,
+    victim_pos: &Vector3<f64>,
+    base_damage: f64,
+    sweeping_edge_level: i32,
+    knockback_enchant_level: i32,
+    world: &World,
+) {
+    let attacker_entity = &attacker.living_entity.entity;
+
+    // Sweep damage: 1 + sweeping_edge_ratio * base_damage
+    let sweep_ratio = get_sweep_damage_ratio(sweeping_edge_level);
+    let sweep_damage = 1.0 + sweep_ratio as f64 * base_damage;
+
+    // Find entities within range (vanilla uses 1.0 block horizontal + 0.25 vertical from victim)
+    let nearby = world.get_nearby_entities(*victim_pos, 2.0);
+
+    for entity in nearby.values() {
+        let ent = entity.get_entity();
+
+        // Skip the attacker and the original victim
+        if ent.entity_id == attacker_entity.entity_id || ent.entity_id == victim_entity_id {
+            continue;
+        }
+
+        // Only damage living entities
+        if entity.get_living_entity().is_none() {
+            continue;
+        }
+
+        // Check distance more precisely (1 block from victim)
+        let entity_pos = ent.pos.load();
+        let dx = entity_pos.x - victim_pos.x;
+        let dz = entity_pos.z - victim_pos.z;
+        let horizontal_dist_sq = dx * dx + dz * dz;
+        if horizontal_dist_sq > 9.0 {
+            // 3.0^2 - vanilla uses attack range + sweep range
+            continue;
+        }
+
+        // Vertical check
+        let dy = (entity_pos.y - victim_pos.y).abs();
+        if dy > 2.0 {
+            continue;
+        }
+
+        // Apply sweep damage
+        entity
+            .damage_with_context(
+                &**entity,
+                sweep_damage as f32,
+                DamageType::PLAYER_ATTACK,
+                None,
+                Some(attacker),
+                Some(attacker),
+            )
+            .await;
+
+        // Apply knockback to swept entities
+        let knockback_strength = 0.4 + f64::from(knockback_enchant_level) * 0.5;
+        let kb_resist = entity.get_living_entity().map_or(0.0, |le| {
+            le.get_attribute_value(&Attributes::KNOCKBACK_RESISTANCE)
+        });
+        handle_knockback(attacker_entity, ent, knockback_strength, kb_resist);
+        ent.send_velocity().await;
+    }
+
+    // Spawn sweep particle
+    spawn_sweep_particle(attacker_entity, world, victim_pos).await;
+}
+
+/// Spawn critical hit particles around the victim.
+pub async fn spawn_crit_particles(world: &World, victim_pos: &Vector3<f64>, enchanted: bool) {
+    let particle = if enchanted {
+        Particle::EnchantedHit
+    } else {
+        Particle::Crit
+    };
+
+    world
+        .spawn_particle(*victim_pos, Vector3::new(0.5, 0.5, 0.5), 0.2, 10, particle)
+        .await;
 }
 
 pub async fn spawn_sweep_particle(attacker_entity: &Entity, world: &World, pos: &Vector3<f64>) {
@@ -79,6 +223,115 @@ pub async fn spawn_sweep_particle(attacker_entity: &Entity, world: &World, pos: 
             Particle::SweepAttack,
         )
         .await;
+}
+
+/// Get enchantment levels from the player's held item.
+///
+/// Returns a `CombatEnchantments` struct with all combat-relevant enchantment levels.
+pub async fn get_combat_enchantments(player: &Player) -> CombatEnchantments {
+    let item = player.inventory().held_item();
+    let item_lock = item.lock().await;
+
+    CombatEnchantments {
+        sharpness: item_lock.get_enchantment_level(&Enchantment::SHARPNESS),
+        smite: item_lock.get_enchantment_level(&Enchantment::SMITE),
+        bane_of_arthropods: item_lock.get_enchantment_level(&Enchantment::BANE_OF_ARTHROPODS),
+        knockback: item_lock.get_enchantment_level(&Enchantment::KNOCKBACK),
+        fire_aspect: item_lock.get_enchantment_level(&Enchantment::FIRE_ASPECT),
+        sweeping_edge: item_lock.get_enchantment_level(&Enchantment::SWEEPING_EDGE),
+    }
+}
+
+/// Combat-related enchantment levels for the held weapon.
+pub struct CombatEnchantments {
+    pub sharpness: i32,
+    pub smite: i32,
+    pub bane_of_arthropods: i32,
+    pub knockback: i32,
+    pub fire_aspect: i32,
+    pub sweeping_edge: i32,
+}
+
+/// Context for post-damage combat effects.
+pub struct PostDamageContext<'a> {
+    pub attacker: &'a Player,
+    pub victim: &'a dyn EntityBase,
+    pub damage: f64,
+    pub enchant_damage: f64,
+    pub attack_type: AttackType,
+    pub enchants: &'a CombatEnchantments,
+    pub config_knockback: bool,
+}
+
+/// Handle post-damage combat effects: knockback, sweep attack, fire aspect, and particles.
+pub async fn handle_post_damage_effects(
+    ctx: &PostDamageContext<'_>,
+    world: &World,
+    pos: &Vector3<f64>,
+) {
+    let attacker_entity = &ctx.attacker.living_entity.entity;
+    let victim_entity = ctx.victim.get_entity();
+
+    // Spawn particles
+    if matches!(ctx.attack_type, AttackType::Critical) {
+        spawn_crit_particles(world, pos, ctx.enchant_damage > 0.0).await;
+    } else if ctx.enchant_damage > 0.0 {
+        spawn_crit_particles(world, pos, true).await;
+    }
+
+    if ctx.victim.get_living_entity().is_some() {
+        let mut knockback_strength = 1.0 + f64::from(ctx.enchants.knockback) * 0.5;
+
+        match ctx.attack_type {
+            AttackType::Knockback => knockback_strength += 1.0,
+            AttackType::Sweeping => {
+                apply_sweep_attack(
+                    ctx.attacker,
+                    victim_entity.entity_id,
+                    pos,
+                    ctx.damage,
+                    ctx.enchants.sweeping_edge,
+                    ctx.enchants.knockback,
+                    world,
+                )
+                .await;
+            }
+            _ => {}
+        }
+
+        if ctx.config_knockback {
+            // Armor stands only take knockback from sprint attacks or knockback enchantment
+            let is_armor_stand = *victim_entity.entity_type == EntityType::ARMOR_STAND;
+            let should_apply = !is_armor_stand
+                || matches!(ctx.attack_type, AttackType::Knockback)
+                || ctx.enchants.knockback > 0;
+
+            if should_apply {
+                let kb_resist = ctx.victim.get_living_entity().map_or(0.0, |le| {
+                    le.get_attribute_value(&Attributes::KNOCKBACK_RESISTANCE)
+                });
+                handle_knockback(
+                    attacker_entity,
+                    victim_entity,
+                    knockback_strength,
+                    kb_resist,
+                );
+                victim_entity.send_velocity().await;
+                attacker_entity.send_velocity().await;
+            }
+        }
+
+        // Sprint knockback attack should reset sprinting
+        if matches!(ctx.attack_type, AttackType::Knockback) {
+            attacker_entity.set_sprinting(false).await;
+        }
+
+        // Fire Aspect: set victim on fire (4 seconds per level)
+        if ctx.enchants.fire_aspect > 0 {
+            victim_entity.set_on_fire_for(4.0 * ctx.enchants.fire_aspect as f32);
+            victim_entity.set_on_fire(true).await;
+        }
+    }
 }
 
 pub async fn player_attack_sound(pos: &Vector3<f64>, world: &World, attack_type: AttackType) {

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -1852,7 +1852,7 @@ impl EntityBase for LivingEntity {
                 };
 
             // Finalize state
-            self.last_damage_taken.store(amount);
+            self.last_damage_taken.store(effective_amount);
             let damage_amount = damage_amount.max(0.0);
 
             let config = &world.server.upgrade().unwrap().advanced_config.pvp;

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -814,8 +814,6 @@ impl Entity {
     /// `LivingEntity.takeKnockback()`
     /// This function calculates the entity's new velocity based on the specified knockback strength and direction.
     pub fn apply_knockback(&self, strength: f64, mut x: f64, mut z: f64) {
-        // TODO: strength *= 1 - Entity attribute knockback resistance
-
         if strength <= 0.0 {
             return;
         }
@@ -1776,7 +1774,12 @@ impl Entity {
     ///
     /// This function calculates the entity's new velocity based on the specified knockback strength and direction.
     pub fn knockback(&self, strength: f64, x: f64, z: f64) {
-        // This has some vanilla magic
+        if strength <= 0.0 {
+            return;
+        }
+
+        self.velocity_dirty.store(true, Ordering::SeqCst);
+
         let mut x = x;
         let mut z = z;
         while x.mul_add(x, z * z) < 1.0E-5 {

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -662,58 +662,24 @@ impl Player {
         let world = self.world();
         let server = world.server.upgrade().unwrap();
         let victim_entity = victim.get_entity();
-        let attacker_entity = &self.living_entity.entity;
         let config = &server.advanced_config.pvp;
 
-        let inventory = self.inventory();
-        let item_stack = inventory.held_item();
+        let (mut damage, damage_multiplier) = self.calculate_attack_damage(&server, &*victim).await;
 
-        let base_damage = self
-            .living_entity
-            .get_attribute_value(&Attributes::ATTACK_DAMAGE);
-        let base_attack_speed = 4.0;
+        // Get combat enchantments from held weapon
+        let enchants = combat::get_combat_enchantments(self).await;
 
-        let mut damage_multiplier = 1.0;
-        let mut add_damage = 0.0;
-        let mut add_speed = 0.0;
-
-        // Get the attack damage from the held item
-        // TODO: this should be cached in memory, we shouldn't just use default here either
-        if let Some(modifiers) = item_stack
-            .lock()
-            .await
-            .get_data_component::<AttributeModifiersImpl>()
-        {
-            for item_mod in modifiers.attribute_modifiers.iter() {
-                if item_mod.operation == Operation::AddValue {
-                    if item_mod.id == "minecraft:base_attack_damage" {
-                        add_damage = item_mod.amount;
-                    } else if item_mod.id == "minecraft:base_attack_speed" {
-                        add_speed = item_mod.amount;
-                    }
-                }
-            }
-        }
-
-        let attack_speed = base_attack_speed + add_speed;
-
-        let attack_cooldown_progress = self.get_attack_cooldown_progress(
-            f64::from(server.basic_config.tps),
-            0.5,
-            attack_speed,
+        // Calculate enchantment bonus damage (Sharpness/Smite/Bane of Arthropods)
+        let enchant_damage = combat::get_enchantment_damage(
+            enchants.sharpness,
+            enchants.smite,
+            enchants.bane_of_arthropods,
+            &*victim,
         );
-        self.last_attacked_ticks.store(0, Ordering::Relaxed);
+        damage += enchant_damage * f64::from(damage_multiplier);
 
-        // Only reduce attack damage if in cooldown
-        // TODO: Enchantments are reduced in the same way, just without the square.
-        if attack_cooldown_progress < 1.0 {
-            damage_multiplier = attack_cooldown_progress.powi(2).mul_add(0.8, 0.2);
-        }
-
-        // Modify the added damage based on the multiplier.
-        let mut damage = base_damage + add_damage * damage_multiplier;
         let pos = victim_entity.pos.load();
-        let attack_type = AttackType::new(self, attack_cooldown_progress as f32).await;
+        let attack_type = AttackType::new(self, damage_multiplier).await;
 
         if matches!(attack_type, AttackType::Critical) {
             damage *= 1.5;
@@ -740,37 +706,86 @@ impl Player {
             return;
         }
 
+        // Reset attack cooldown only after confirmed hit
+        self.last_attacked_ticks.store(0, Ordering::Relaxed);
+
         player_attack_sound(&pos, &world, attack_type).await;
 
-        self.living_entity.last_attacking_id.store(
-            victim_entity.entity_id,
-            std::sync::atomic::Ordering::Relaxed,
-        );
+        self.living_entity
+            .last_attacking_id
+            .store(victim_entity.entity_id, Ordering::Relaxed);
         self.living_entity.last_attack_time.store(
-            self.living_entity
-                .entity
-                .age
-                .load(std::sync::atomic::Ordering::Relaxed),
-            std::sync::atomic::Ordering::Relaxed,
+            self.living_entity.entity.age.load(Ordering::Relaxed),
+            Ordering::Relaxed,
         );
 
-        if victim.get_living_entity().is_some() {
-            let mut knockback_strength = 1.0;
-            match attack_type {
-                AttackType::Knockback => knockback_strength += 1.0,
-                AttackType::Sweeping => {
-                    combat::spawn_sweep_particle(attacker_entity, &world, &pos).await;
+        let ctx = combat::PostDamageContext {
+            attacker: self,
+            victim: &*victim,
+            damage,
+            enchant_damage,
+            attack_type,
+            enchants: &enchants,
+            config_knockback: config.knockback,
+        };
+        combat::handle_post_damage_effects(&ctx, &world, &pos).await;
+
+        self.damage_held_item(1).await;
+    }
+
+    /// Calculate attack damage including item modifiers and cooldown scaling.
+    ///
+    /// Returns `(total_damage, cooldown_progress)` where `cooldown_progress` is in `[0.0, 1.0]`.
+    async fn calculate_attack_damage(
+        &self,
+        server: &crate::server::Server,
+        victim: &dyn EntityBase,
+    ) -> (f64, f32) {
+        let _ = victim; // used for future armor reduction
+
+        let base_damage = self
+            .living_entity
+            .get_attribute_value(&Attributes::ATTACK_DAMAGE);
+        let base_attack_speed = self
+            .living_entity
+            .get_attribute_value(&Attributes::ATTACK_SPEED);
+
+        let mut add_damage = 0.0;
+        let mut add_speed = 0.0;
+
+        if let Some(modifiers) = self
+            .inventory()
+            .held_item()
+            .lock()
+            .await
+            .get_data_component::<AttributeModifiersImpl>()
+        {
+            for item_mod in modifiers.attribute_modifiers.iter() {
+                if item_mod.operation == Operation::AddValue {
+                    if item_mod.id == "minecraft:base_attack_damage" {
+                        add_damage = item_mod.amount;
+                    } else if item_mod.id == "minecraft:base_attack_speed" {
+                        add_speed = item_mod.amount;
+                    }
                 }
-                _ => {}
-            }
-            if config.knockback {
-                combat::handle_knockback(attacker_entity, victim_entity, knockback_strength);
             }
         }
 
-        self.damage_held_item(1).await;
+        let attack_speed = base_attack_speed + add_speed;
+        let cooldown = self.get_attack_cooldown_progress(
+            f64::from(server.basic_config.tps),
+            0.5,
+            attack_speed,
+        );
 
-        if config.swing {}
+        let damage_multiplier = if cooldown < 1.0 {
+            cooldown.powi(2).mul_add(0.8, 0.2)
+        } else {
+            1.0
+        };
+
+        let damage = base_damage + add_damage * damage_multiplier;
+        (damage, cooldown as f32)
     }
 
     pub async fn sync_hand_slot(&self, slot_index: usize, stack: ItemStack) {


### PR DESCRIPTION
Implements combat mechanics from #1404 and fixes #1620:

- **Enchantment damage**: Sharpness, Smite (vs undead), Bane of Arthropods (vs arthropods) using entity type tags
- **Knockback enchantment**: +0.5 per level to knockback strength
- **Fire Aspect**: 4 seconds per level
- **Sweeping Edge**: Scales sweep damage ratio (level/(level+1))
- **Sweep attack**: Area damage hitting nearby living entities with scaled damage and knockback
- **Critical/enchanted hit particles**: Crit on critical hits, EnchantedHit on enchantment bonus
- **AttackType fixes**: Added missing `!sprinting` and `on_ground` conditions for vanilla parity
- **Armor stand knockback**: Only from sprint attacks or Knockback enchantment (fixes #1620)
- **Knockback sync, resistance, cooldown, sprint reset** fixes