### PR TITLE
fix: prevent server crashes from malicious/malformed packets

### DIFF
--- a/pumpkin/src/net/authentication.rs
+++ b/pumpkin/src/net/authentication.rs
@@ -121,7 +121,7 @@ pub fn validate_textures(property: &Property, config: &TextureConfig) -> Result<
 }
 
 pub fn is_texture_url_valid(url: &Uri, config: &TextureConfig) -> Result<(), TextureError> {
-    let scheme = url.scheme().unwrap();
+    let scheme = url.scheme().ok_or(TextureError::InvalidURL)?;
     if !config
         .allowed_url_schemes
         .iter()
@@ -129,7 +129,7 @@ pub fn is_texture_url_valid(url: &Uri, config: &TextureConfig) -> Result<(), Tex
     {
         return Err(TextureError::DisallowedUrlScheme(scheme.to_string()));
     }
-    let domain = url.authority().unwrap();
+    let domain = url.authority().ok_or(TextureError::InvalidURL)?;
     if !config
         .allowed_url_domains
         .iter()

--- a/pumpkin/src/net/bedrock/mod.rs
+++ b/pumpkin/src/net/bedrock/mod.rs
@@ -423,9 +423,17 @@ impl BedrockClient {
         self.send_ack(&Ack::new(vec![frame_set.sequence.0])).await;
         // TODO
         for frame in frame_set.frames {
-            self.handle_frame(server, frame).await.unwrap();
+            if let Err(e) = self.handle_frame(server, frame).await {
+                tracing::error!("Error handling Bedrock frame: {e}");
+                return;
+            }
         }
     }
+
+    /// Maximum allowed split size for fragmented packets.
+    const MAX_SPLIT_SIZE: u32 = 512;
+    /// Maximum number of pending compound reassembly entries.
+    const MAX_PENDING_COMPOUNDS: usize = 64;
 
     async fn handle_frame(
         self: &Arc<Self>,
@@ -433,9 +441,30 @@ impl BedrockClient {
         mut frame: Frame,
     ) -> Result<(), Error> {
         if frame.split_size > 0 {
+            if frame.split_size > Self::MAX_SPLIT_SIZE {
+                return Err(Error::other(format!(
+                    "Split size {} exceeds maximum {}",
+                    frame.split_size,
+                    Self::MAX_SPLIT_SIZE
+                )));
+            }
+
             let fragment_index = frame.split_index as usize;
+            if fragment_index >= frame.split_size as usize {
+                return Err(Error::other(format!(
+                    "Fragment index {fragment_index} out of bounds for split size {}",
+                    frame.split_size
+                )));
+            }
+
             let compound_id = frame.split_id;
             let mut compounds = self.compounds.lock().await;
+
+            if !compounds.contains_key(&compound_id)
+                && compounds.len() >= Self::MAX_PENDING_COMPOUNDS
+            {
+                return Err(Error::other("Too many pending fragment reassembly entries"));
+            }
 
             let entry = compounds.entry(compound_id).or_insert_with(|| {
                 let mut vec = Vec::with_capacity(frame.split_size as usize);
@@ -452,19 +481,26 @@ impl BedrockClient {
 
             let mut frames = compounds.remove(&compound_id).unwrap();
 
-            // Safety: We already checked that all frames are Some at this point
             let len = frames
                 .iter()
-                .map(|frame| unsafe { frame.as_ref().unwrap_unchecked().payload.len() })
+                .map(|frame| {
+                    frame
+                        .as_ref()
+                        .map_or(0, |f| f.payload.len())
+                })
                 .sum();
 
             let mut merged = Vec::with_capacity(len);
 
             for frame in &frames {
-                merged.extend_from_slice(unsafe { &frame.as_ref().unwrap_unchecked().payload });
+                if let Some(f) = frame.as_ref() {
+                    merged.extend_from_slice(&f.payload);
+                }
             }
 
-            frame = unsafe { frames[0].take().unwrap_unchecked() };
+            frame = frames[0]
+                .take()
+                .ok_or_else(|| Error::other("Missing first frame in reassembly"))?;
 
             frame.payload = merged;
             frame.split_size = 0;

--- a/pumpkin/src/net/java/login.rs
+++ b/pumpkin/src/net/java/login.rs
@@ -111,10 +111,17 @@ impl JavaClient {
         encryption_response: SEncryptionResponse,
     ) {
         debug!("Handling encryption");
-        let shared_secret = server
+        let shared_secret = match server
             .decrypt(&encryption_response.shared_secret)
             .await
-            .unwrap();
+        {
+            Ok(secret) => secret,
+            Err(e) => {
+                self.kick(TextComponent::text(format!("Decryption failed: {e}")))
+                    .await;
+                return;
+            }
+        };
 
         if let Err(error) = self.set_encryption(&shared_secret).await {
             self.kick(TextComponent::text(error.to_string())).await;

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -510,11 +510,13 @@ impl World {
             );
             recipient.client.enqueue_packet(packet).await;
 
-            recipient
-                .signature_cache
-                .lock()
-                .await
-                .add_seen_signature(&chat_message.signature.clone().unwrap()); // Unwrap is safe because we check for None in validate_chat_message
+            if let Some(signature) = &chat_message.signature {
+                recipient
+                    .signature_cache
+                    .lock()
+                    .await
+                    .add_seen_signature(signature);
+            }
 
             if recipient.gameprofile.id != sender.gameprofile.id {
                 // Sender may update recipient on signatures recipient hasn't seen


### PR DESCRIPTION
Fixes multiple critical issues that allow malicious or malformed packets to crash or exhaust the server:

- **Bedrock OOB panic**: A crafted fragmented packet with `split_index >= split_size` causes an unchecked array index panic, instantly crashing the server
- **Bedrock memory exhaustion DoS**: No limits on `split_size` (up to u32::MAX) or pending compound entries allows unbounded memory allocation via a few packets
- **Bedrock unsafe code**: `unwrap_unchecked` in frame reassembly replaced with safe alternatives
- **Authentication panic**: `unwrap()` on URL scheme/authority parsing crashes the server when a player has a malformed texture URL in their profile
- **Login decryption panic**: `unwrap()` on RSA decryption result crashes the server instead of kicking the client
- **Chat signature panic**: `unwrap()` on `chat_message.signature` panics when `allow_chat_reports` is disabled (signature is `None` in that path)

## Details

### Bedrock Fragment Handling (`net/bedrock/mod.rs`)
- Added bounds check: `fragment_index >= split_size` now returns an error
- Added `MAX_SPLIT_SIZE = 512` limit to prevent huge vector allocations
- Added `MAX_PENDING_COMPOUNDS = 64` limit to prevent unbounded HashMap growth
- Replaced `unsafe { unwrap_unchecked() }` with safe `map_or` / `ok_or_else`
- `handle_frame_set` now logs errors instead of panicking via `unwrap()`

### Authentication (`net/authentication.rs`)
- `url.scheme().unwrap()` → `url.scheme().ok_or(TextureError::InvalidURL)?`
- `url.authority().unwrap()` → `url.authority().ok_or(TextureError::InvalidURL)?`

### Login (`net/java/login.rs`)
- `server.decrypt(...).await.unwrap()` → `match` with kick on error

### Chat (`world/mod.rs`)
- `.signature.clone().unwrap()` → `if let Some(signature)` guard