### PR TITLE
fix: harden protocol safety & add movement validation

### DIFF
--- a/pumpkin-inventory/src/container_click.rs
+++ b/pumpkin-inventory/src/container_click.rs
@@ -40,7 +40,7 @@ impl Click {
         let slot = if slot == SLOT_INDEX_OUTSIDE {
             Slot::OutsideInventory
         } else {
-            let slot = slot.try_into().unwrap_or(0);
+            let slot = slot.try_into().or(Err(InventoryError::InvalidSlot))?;
             Slot::Normal(slot)
         };
         let button = match button {
@@ -81,7 +81,7 @@ impl Click {
         let slot = if slot == SLOT_INDEX_OUTSIDE {
             Slot::OutsideInventory
         } else {
-            let slot = slot.try_into().unwrap_or(0);
+            let slot = slot.try_into().or(Err(InventoryError::InvalidSlot))?;
             Slot::Normal(slot)
         };
         Ok(Self {

--- a/pumpkin-nbt/src/deserializer.rs
+++ b/pumpkin-nbt/src/deserializer.rs
@@ -80,10 +80,14 @@ impl<R: Read + Seek> NbtReadHelper<R> {
 pub struct Deserializer<R: Read + Seek> {
     input: NbtReadHelper<R>,
     tag_to_deserialize_stack: Option<u8>,
-    // Yes, this breaks with recursion. Just an attempt at a sanity check
     in_list: bool,
     is_named: bool,
+    depth: usize,
 }
+
+/// Maximum allowed nesting depth for NBT compounds/lists.
+/// A deeply nested structure (~10K+ levels) causes stack overflow.
+const MAX_NBT_DEPTH: usize = 512;
 
 impl<R: Read + Seek> Deserializer<R> {
     pub const fn new(input: R, is_named: bool) -> Self {
@@ -92,6 +96,7 @@ impl<R: Read + Seek> Deserializer<R> {
             tag_to_deserialize_stack: None,
             in_list: false,
             is_named,
+            depth: 0,
         }
     }
 }
@@ -137,6 +142,13 @@ impl<'de, R: Read + Seek> de::Deserializer<'de> for &mut Deserializer<R> {
                 "Trying to deserialize an END tag!".to_string(),
             )),
             LIST_ID | INT_ARRAY_ID | LONG_ARRAY_ID | BYTE_ARRAY_ID => {
+                self.depth += 1;
+                if self.depth > MAX_NBT_DEPTH {
+                    return Err(Error::SerdeError(format!(
+                        "NBT nesting depth exceeds maximum ({MAX_NBT_DEPTH})"
+                    )));
+                }
+
                 let list_type = match tag_to_deserialize {
                     LIST_ID => self.input.get_u8_be()?,
                     INT_ARRAY_ID => INT_ID,
@@ -158,9 +170,20 @@ impl<'de, R: Read + Seek> de::Deserializer<'de> for &mut Deserializer<R> {
                     list_type,
                     remaining_values: remaining_values as usize,
                 })?;
+                self.depth -= 1;
                 Ok(result)
             }
-            COMPOUND_ID => visitor.visit_map(CompoundAccess { de: self }),
+            COMPOUND_ID => {
+                self.depth += 1;
+                if self.depth > MAX_NBT_DEPTH {
+                    return Err(Error::SerdeError(format!(
+                        "NBT nesting depth exceeds maximum ({MAX_NBT_DEPTH})"
+                    )));
+                }
+                let result = visitor.visit_map(CompoundAccess { de: self })?;
+                self.depth -= 1;
+                Ok(result)
+            }
             _ => {
                 let result = match NbtTag::deserialize_data(&mut self.input, tag_to_deserialize)? {
                     NbtTag::Byte(value) => visitor.visit_i8::<Error>(value)?,
@@ -248,7 +271,14 @@ impl<'de, R: Read + Seek> de::Deserializer<'de> for &mut Deserializer<R> {
             }
         }
 
+        self.depth += 1;
+        if self.depth > MAX_NBT_DEPTH {
+            return Err(Error::SerdeError(format!(
+                "NBT nesting depth exceeds maximum ({MAX_NBT_DEPTH})"
+            )));
+        }
         let value = visitor.visit_map(CompoundAccess { de: self })?;
+        self.depth -= 1;
         Ok(value)
     }
 

--- a/pumpkin-protocol/src/codec/bit_set.rs
+++ b/pumpkin-protocol/src/codec/bit_set.rs
@@ -24,8 +24,17 @@ impl BitSet {
     }
 
     pub fn decode(read: &mut impl Read) -> Result<Self, ReadingError> {
-        // Read length
+        // A BitSet with more than 8192 longs (512 KiB) would exceed any reasonable
+        // use in the Minecraft protocol. Reject to prevent OOM from crafted packets.
+        const MAX_BITSET_LENGTH: i32 = 8192;
+
         let length = read.get_var_int()?;
+        if length.0 < 0 || length.0 > MAX_BITSET_LENGTH {
+            return Err(ReadingError::Message(format!(
+                "BitSet length {} out of bounds (max {MAX_BITSET_LENGTH})",
+                length.0
+            )));
+        }
         let mut array: Vec<i64> = Vec::with_capacity(length.0 as usize);
         for _ in 0..length.0 {
             let long = read.get_i64_be()?;

--- a/pumpkin-protocol/src/java/server/play/click_container.rs
+++ b/pumpkin-protocol/src/java/server/play/click_container.rs
@@ -29,6 +29,8 @@ impl<'de> Deserialize<'de> for SClickSlot {
             }
 
             fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                const MAX_CHANGED_SLOTS: i32 = 128;
+
                 let sync_id = seq
                     .next_element::<VarInt>()?
                     .ok_or(de::Error::custom("Failed to decode u8"))?;
@@ -48,6 +50,12 @@ impl<'de> Deserialize<'de> for SClickSlot {
                 let length_of_array = seq
                     .next_element::<VarInt>()?
                     .ok_or(de::Error::custom("Failed to decode VarInt"))?;
+                if length_of_array.0 < 0 || length_of_array.0 > MAX_CHANGED_SLOTS {
+                    return Err(de::Error::custom(format!(
+                        "Changed slots array length {} out of bounds (max {MAX_CHANGED_SLOTS})",
+                        length_of_array.0
+                    )));
+                }
                 let mut array_of_changed_slots = vec![];
                 for _ in 0..length_of_array.0 {
                     let slot_number = seq

--- a/pumpkin-protocol/src/serial/deserializer.rs
+++ b/pumpkin-protocol/src/serial/deserializer.rs
@@ -134,23 +134,24 @@ impl<T: PacketRead, const N: usize> PacketRead for [T; N] {
 impl PacketRead for String {
     fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
         let vec = Vec::read(reader)?;
-        Ok(unsafe { Self::from_utf8_unchecked(vec) })
+        Self::from_utf8(vec).map_err(|e| Error::other(format!("Invalid UTF-8: {e}")))
     }
 }
 
 impl PacketRead for Vec<u8> {
-    #[expect(clippy::read_zero_byte_vec)]
     fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
-        #[expect(clippy::uninit_vec)]
-        {
-            let len = VarUInt::read(reader)?.0 as _;
-            let mut buf = Self::with_capacity(len);
-            unsafe {
-                buf.set_len(len);
-            };
-            reader.read_exact(&mut buf)?;
-            Ok(buf)
+        // Cap at 1 MB to prevent OOM from a malicious length prefix.
+        const MAX_VEC_LENGTH: u32 = 1024 * 1024;
+        let len = VarUInt::read(reader)?.0;
+        if len > MAX_VEC_LENGTH {
+            return Err(Error::other(format!(
+                "Vec<u8> length {len} exceeds maximum ({MAX_VEC_LENGTH})"
+            )));
         }
+        let len = len as usize;
+        let mut buf = vec![0u8; len];
+        reader.read_exact(&mut buf)?;
+        Ok(buf)
     }
 }
 

--- a/pumpkin/src/net/authentication.rs
+++ b/pumpkin/src/net/authentication.rs
@@ -45,7 +45,7 @@ pub struct MojangPublicKeys {
 
 pub const MOJANG_BEDROCK_PUBLIC_KEY_BASE64: &str = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECRXueJeTDqNRRgJi/vlRufByu/2G0i2Ebt6YMar5QX/R0DIIyrJMcUpruK4QveTfJSTp3Shlq4Gk34cD/4GUWwkv0DVuzeuB+tXija7HBxii03NHDbPAD0AKnLr2wdAp";
 const MOJANG_AUTHENTICATION_URL: &str = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}";
-const MOJANG_PREVENT_PROXY_AUTHENTICATION_URL: &str = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}";
+const MOJANG_PREVENT_PROXY_AUTHENTICATION_URL: &str = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}&ip={ip}";
 const MOJANG_SERVICES_URL: &str = "https://api.minecraftservices.com/";
 
 /// Sends a GET request to Mojang's authentication servers to verify a client's Minecraft account.
@@ -121,7 +121,7 @@ pub fn validate_textures(property: &Property, config: &TextureConfig) -> Result<
 }
 
 pub fn is_texture_url_valid(url: &Uri, config: &TextureConfig) -> Result<(), TextureError> {
-    let scheme = url.scheme().unwrap();
+    let scheme = url.scheme().ok_or(TextureError::InvalidURL)?;
     if !config
         .allowed_url_schemes
         .iter()
@@ -129,7 +129,7 @@ pub fn is_texture_url_valid(url: &Uri, config: &TextureConfig) -> Result<(), Tex
     {
         return Err(TextureError::DisallowedUrlScheme(scheme.to_string()));
     }
-    let domain = url.authority().unwrap();
+    let domain = url.authority().ok_or(TextureError::InvalidURL)?;
     if !config
         .allowed_url_domains
         .iter()

--- a/pumpkin/src/net/bedrock/mod.rs
+++ b/pumpkin/src/net/bedrock/mod.rs
@@ -423,9 +423,17 @@ impl BedrockClient {
         self.send_ack(&Ack::new(vec![frame_set.sequence.0])).await;
         // TODO
         for frame in frame_set.frames {
-            self.handle_frame(server, frame).await.unwrap();
+            if let Err(e) = self.handle_frame(server, frame).await {
+                tracing::error!("Error handling Bedrock frame: {e}");
+                return;
+            }
         }
     }
+
+    /// Maximum allowed split size for fragmented packets.
+    const MAX_SPLIT_SIZE: u32 = 512;
+    /// Maximum number of pending compound reassembly entries.
+    const MAX_PENDING_COMPOUNDS: usize = 64;
 
     async fn handle_frame(
         self: &Arc<Self>,
@@ -433,9 +441,30 @@ impl BedrockClient {
         mut frame: Frame,
     ) -> Result<(), Error> {
         if frame.split_size > 0 {
+            if frame.split_size > Self::MAX_SPLIT_SIZE {
+                return Err(Error::other(format!(
+                    "Split size {} exceeds maximum {}",
+                    frame.split_size,
+                    Self::MAX_SPLIT_SIZE
+                )));
+            }
+
             let fragment_index = frame.split_index as usize;
+            if fragment_index >= frame.split_size as usize {
+                return Err(Error::other(format!(
+                    "Fragment index {fragment_index} out of bounds for split size {}",
+                    frame.split_size
+                )));
+            }
+
             let compound_id = frame.split_id;
             let mut compounds = self.compounds.lock().await;
+
+            if !compounds.contains_key(&compound_id)
+                && compounds.len() >= Self::MAX_PENDING_COMPOUNDS
+            {
+                return Err(Error::other("Too many pending fragment reassembly entries"));
+            }
 
             let entry = compounds.entry(compound_id).or_insert_with(|| {
                 let mut vec = Vec::with_capacity(frame.split_size as usize);
@@ -452,19 +481,22 @@ impl BedrockClient {
 
             let mut frames = compounds.remove(&compound_id).unwrap();
 
-            // Safety: We already checked that all frames are Some at this point
-            let len = frames
+            let len: usize = frames
                 .iter()
-                .map(|frame| unsafe { frame.as_ref().unwrap_unchecked().payload.len() })
+                .map(|frame| frame.as_ref().map_or(0, |f| f.payload.len()))
                 .sum();
 
             let mut merged = Vec::with_capacity(len);
 
             for frame in &frames {
-                merged.extend_from_slice(unsafe { &frame.as_ref().unwrap_unchecked().payload });
+                if let Some(f) = frame.as_ref() {
+                    merged.extend_from_slice(&f.payload);
+                }
             }
 
-            frame = unsafe { frames[0].take().unwrap_unchecked() };
+            frame = frames[0]
+                .take()
+                .ok_or_else(|| Error::other("Missing first frame in reassembly"))?;
 
             frame.payload = merged;
             frame.split_size = 0;

--- a/pumpkin/src/net/java/login.rs
+++ b/pumpkin/src/net/java/login.rs
@@ -111,10 +111,14 @@ impl JavaClient {
         encryption_response: SEncryptionResponse,
     ) {
         debug!("Handling encryption");
-        let shared_secret = server
-            .decrypt(&encryption_response.shared_secret)
-            .await
-            .unwrap();
+        let shared_secret = match server.decrypt(&encryption_response.shared_secret).await {
+            Ok(secret) => secret,
+            Err(e) => {
+                self.kick(TextComponent::text(format!("Decryption failed: {e}")))
+                    .await;
+                return;
+            }
+        };
 
         if let Err(error) = self.set_encryption(&shared_secret).await {
             self.kick(TextComponent::text(error.to_string())).await;

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -32,6 +32,7 @@ use crate::plugin::player::player_interact_unknown_entity_event::PlayerInteractU
 use crate::plugin::player::player_move::PlayerMoveEvent;
 use crate::server::{Server, seasonal_events};
 use crate::world::{World, chunker};
+use pumpkin_data::attributes::Attributes;
 use pumpkin_data::block_properties::{
     BlockProperties, CommandBlockLikeProperties, WaterLikeProperties,
 };
@@ -252,6 +253,59 @@ impl JavaClient {
         player.set_client_loaded(true);
     }
 
+    /// Calculates the maximum allowed squared distance for a single movement packet,
+    /// accounting for the player's current state (flying, sprinting, elytra, speed effects)
+    /// and any pending velocity (knockback, explosions, slime blocks, wind charges, etc.).
+    async fn max_movement_distance_sq(player: &Player) -> f64 {
+        // Hard cap: no legitimate single-packet movement should ever exceed this.
+        // Even massive TNT arrays in water launching a player cannot exceed ~200 blocks
+        // in a single packet. This catches teleport hacks while allowing all legit play.
+        const HARD_CAP: f64 = 300.0;
+
+        // Base: effective movement speed attribute (includes Speed potion effects)
+        let movement_speed = player
+            .living_entity
+            .get_attribute_value(&Attributes::MOVEMENT_SPEED);
+
+        let entity = &player.living_entity.entity;
+        let is_elytra = entity.fall_flying.load(Ordering::Relaxed);
+        let is_sprinting = entity.sprinting.load(Ordering::Relaxed);
+        let abilities = player.abilities.lock().await;
+        let is_flying = abilities.flying;
+
+        // Convert attribute speed to approximate blocks/tick then to blocks/packet.
+        // Packets can span multiple ticks, so we use a per-second rate with tolerance.
+        let max_blocks_per_second = if is_elytra {
+            // Elytra + firework can reach ~67 blocks/sec
+            80.0
+        } else if is_flying {
+            // Creative fly speed: fly_speed * 20 ticks * (2x if sprinting)
+            let fly = f64::from(abilities.fly_speed) * 20.0;
+            (if is_sprinting { fly * 2.0 } else { fly }) + 5.0
+        } else {
+            // Ground movement: movement_speed * ~43 (empirical blocks/sec per attribute unit)
+            // Speed II (attr ~0.16) → ~6.9 b/s, Sprint adds ~30%
+            let base = movement_speed * 43.0;
+            let base = if is_sprinting { base * 1.3 } else { base };
+            base + 5.0 // jump-sprint boost margin
+        };
+
+        // Account for pending velocity from knockback, explosions, slime blocks,
+        // wind charges, etc. Velocity is in blocks/tick; give extra ticks for decay.
+        let velocity = entity.velocity.load();
+        let velocity_magnitude =
+            (velocity.x * velocity.x + velocity.y * velocity.y + velocity.z * velocity.z).sqrt();
+        // Velocity can persist across several ticks as it decays; allow ~15 ticks worth
+        // to handle stacked explosions (multiple TNT in one tick compound velocity).
+        let velocity_allowance = velocity_magnitude * 15.0;
+
+        // Allow up to 3x the theoretical max + velocity allowance.
+        // Minimum 10 blocks to avoid false positives from lag spikes.
+        // Hard cap at 300 blocks to catch teleport hacks even in edge cases.
+        let max_dist = (max_blocks_per_second * 3.0 + velocity_allowance).clamp(10.0, HARD_CAP);
+        max_dist * max_dist
+    }
+
     /// Returns whether syncing the position was needed
     #[expect(clippy::too_many_arguments)]
     async fn sync_position(
@@ -288,6 +342,7 @@ impl JavaClient {
         true
     }
 
+    #[expect(clippy::too_many_lines)]
     pub async fn handle_position(
         &self,
         player: &Arc<Player>,
@@ -317,6 +372,25 @@ impl JavaClient {
             Self::clamp_horizontal(position.z),
         );
 
+        // Movement speed validation: reject impossibly fast movement
+        {
+            let last_pos = player.living_entity.entity.pos.load();
+            let dx = position.x - last_pos.x;
+            let dy = position.y - last_pos.y;
+            let dz = position.z - last_pos.z;
+            let dist_sq = dx * dx + dy * dy + dz * dz;
+            let max_dist_sq = Self::max_movement_distance_sq(player).await;
+            if dist_sq > max_dist_sq {
+                warn!(
+                    "Player '{}' moved too fast ({:.1} blocks), rubber-banding",
+                    player.gameprofile.name,
+                    dist_sq.sqrt()
+                );
+                self.force_tp(player, last_pos).await;
+                return;
+            }
+        }
+
         send_cancellable! {{
             server;
             PlayerMoveEvent {
@@ -339,8 +413,6 @@ impl JavaClient {
 
                 entity.on_ground.store(packet.collision & FLAG_ON_GROUND != 0, Ordering::Relaxed);
                 let world = &player.world();
-
-                // TODO: Warn when player moves to quickly
                 if !self.sync_position(player, world, pos, last_pos, entity.yaw.load(), entity.pitch.load(), packet.collision & FLAG_ON_GROUND != 0).await {
                     // Send the new position to all other players.
                     world
@@ -435,6 +507,25 @@ impl JavaClient {
             Self::clamp_horizontal(position.z),
         );
 
+        // Movement speed validation: reject impossibly fast movement
+        {
+            let last_pos = player.living_entity.entity.pos.load();
+            let dx = position.x - last_pos.x;
+            let dy = position.y - last_pos.y;
+            let dz = position.z - last_pos.z;
+            let dist_sq = dx * dx + dy * dy + dz * dz;
+            let max_dist_sq = Self::max_movement_distance_sq(player).await;
+            if dist_sq > max_dist_sq {
+                warn!(
+                    "Player '{}' moved too fast ({:.1} blocks), rubber-banding",
+                    player.gameprofile.name,
+                    dist_sq.sqrt()
+                );
+                self.force_tp(player, last_pos).await;
+                return;
+            }
+        }
+
         send_cancellable! {{
             server;
             PlayerMoveEvent::new(
@@ -469,7 +560,7 @@ impl JavaClient {
                 // let head_yaw = (entity.head_yaw * 256.0 / 360.0).floor();
                 let world = entity.world.load_full();
 
-                // TODO: Warn when player moves to quickly
+
                 if !self
                     .sync_position(player, &world, pos, last_pos, yaw, pitch, (packet.collision & FLAG_ON_GROUND) != 0)
                     .await
@@ -842,11 +933,27 @@ impl JavaClient {
     }
 
     pub async fn handle_move_vehicle(&self, player: &Arc<Player>, packet: SMoveVehicle) {
+        if !packet.x.is_finite()
+            || !packet.y.is_finite()
+            || !packet.z.is_finite()
+            || !packet.yaw.is_finite()
+            || !packet.pitch.is_finite()
+        {
+            self.kick(TextComponent::text("Invalid vehicle move position"))
+                .await;
+            return;
+        }
+
         let entity = player.get_entity();
         let vehicle = entity.vehicle.lock().await;
         if let Some(vehicle) = vehicle.as_ref() {
             let vehicle_entity = vehicle.get_entity();
-            vehicle_entity.set_pos(Vector3::new(packet.x, packet.y, packet.z));
+            let pos = Vector3::new(
+                Self::clamp_horizontal(packet.x),
+                Self::clamp_vertical(packet.y),
+                Self::clamp_horizontal(packet.z),
+            );
+            vehicle_entity.set_pos(pos);
             vehicle_entity.set_rotation(packet.yaw, packet.pitch);
         }
     }
@@ -1247,6 +1354,7 @@ impl JavaClient {
         }
     }
 
+    #[expect(clippy::too_many_lines)]
     pub async fn handle_interact(
         &self,
         player: &Arc<Player>,
@@ -1278,6 +1386,22 @@ impl JavaClient {
             .or_else(|| world.get_entity_by_id(entity_id.0));
 
         if let Some(target) = target {
+            // Verify the player is close enough to interact with the target entity.
+            // Vanilla uses 3.0 for survival and 6.0 for creative; add 1.0 margin.
+            let max_range = if player.gamemode.load() == GameMode::Creative {
+                7.0
+            } else {
+                4.0
+            };
+            let player_pos = player.living_entity.entity.pos.load();
+            let target_pos = target.get_entity().pos.load();
+            let dx = player_pos.x - target_pos.x;
+            let dy = player_pos.y - target_pos.y;
+            let dz = player_pos.z - target_pos.z;
+            if dx * dx + dy * dy + dz * dz > max_range * max_range {
+                return;
+            }
+
             send_cancellable! {{
                 server;
                 PlayerInteractEntityEvent::new(
@@ -1775,6 +1899,10 @@ impl JavaClient {
     }
 
     pub async fn handle_sign_update(&self, player: &Player, sign_data: SUpdateSign) {
+        if !player.can_interact_with_block_at(&sign_data.location, 4.0) {
+            return;
+        }
+
         let world = player.living_entity.entity.world.load_full();
         let Some(block_entity) = world.get_block_entity(&sign_data.location).await else {
             return;

--- a/pumpkin/src/net/proxy/velocity.rs
+++ b/pumpkin/src/net/proxy/velocity.rs
@@ -111,6 +111,9 @@ pub fn receive_velocity_plugin_response(
 ) -> Result<(GameProfile, SocketAddr), VelocityError> {
     debug!("Received velocity response");
     if let Some(data) = response.data {
+        if data.len() < 32 {
+            return Err(VelocityError::FailedVerifyIntegrity);
+        }
         let (signature, mut data_without_signature) = data.split_at(32);
 
         if !check_integrity((signature, data_without_signature), &config.secret) {


### PR DESCRIPTION
Hardens protocol handling and adds server-side movement validation.

### Protocol & Memory Safety
- **NBT recursion depth limit** (max 512): prevents stack overflow from deeply nested compounds
- **Click container array cap** (max 128): prevents DoS from malicious VarInt length
- **BitSet length validation** (max 8192): prevents OOM from oversized allocations
- **Bedrock deserializer**: safe UTF-8 parsing, bounded Vec allocation (1MB cap), fragment bounds checks
- **Container click**: reject negative slot indices

### Movement & Interaction Validation
- **Vehicle position**: reject NaN/Infinity values (previously unvalidated)
- **Entity interaction range**: 4 blocks survival, 7 blocks creative
- **Sign edit range**: prevent remote sign editing
- **Movement speed**: server-side validation based on player state (walk/sprint/fly/elytra + speed effects), rubber-band on violation. Accounts for velocity and stacked explosions.

### Auth & Proxy
- **`prevent_proxy_connections`**: fix missing `&ip={ip}` parameter in URL
- **Login/auth**: replace `.unwrap()` with proper error handling
- **Velocity proxy**: add length check before `split_at(32)` to prevent panic