### PR TITLE
perf: optimize chunk loading throughput and memory usage

### DIFF
--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -85,9 +85,10 @@ impl GenerationSchedule {
 
         // Use a bounded single-producer/single-consumer channel to prevent unbounded memory growth
         // when IO can't keep up. If the queue reaches capacity, producers will block until
-        // the disk catches up.
+        // the disk catches up. 2000 entries give enough headroom to keep generation threads
+        // from stalling on IO-heavy workloads while still bounding memory.
         let (send_write_io, recv_write_io) =
-            crossfire::compat::spsc::bounded_tx_blocking_rx_async(500);
+            crossfire::compat::spsc::bounded_tx_blocking_rx_async(2000);
 
         let (send_gen, recv_gen) = crossfire::compat::mpmc::bounded_blocking(gen_thread_count + 5);
 

--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -85,10 +85,9 @@ impl GenerationSchedule {
 
         // Use a bounded single-producer/single-consumer channel to prevent unbounded memory growth
         // when IO can't keep up. If the queue reaches capacity, producers will block until
-        // the disk catches up. 2000 entries give enough headroom to keep generation threads
-        // from stalling on IO-heavy workloads while still bounding memory.
+        // the disk catches up.
         let (send_write_io, recv_write_io) =
-            crossfire::compat::spsc::bounded_tx_blocking_rx_async(2000);
+            crossfire::compat::spsc::bounded_tx_blocking_rx_async(1000);
 
         let (send_gen, recv_gen) = crossfire::compat::mpmc::bounded_blocking(gen_thread_count + 5);
 

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -205,7 +205,7 @@ impl Level {
         });
 
         let total_cores = num_cpus::get().saturating_sub(2).max(1);
-        let io_read_threads = (total_cores / 4).clamp(2, 8);
+        let io_read_threads = (total_cores / 6).clamp(2, 4);
         let threads_per_dimension = (total_cores / 2).max(1);
         let entity_threads = (threads_per_dimension / 2).max(1);
 

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -204,13 +204,13 @@ impl Level {
             chunk_listener: listener.clone(),
         });
 
-        // TODO
         let total_cores = num_cpus::get().saturating_sub(2).max(1);
+        let io_read_threads = (total_cores / 4).clamp(2, 8);
         let threads_per_dimension = (total_cores / 2).max(1);
         let entity_threads = (threads_per_dimension / 2).max(1);
 
         GenerationSchedule::create(
-            2,
+            io_read_threads,
             threads_per_dimension,
             level_ref.clone(),
             level_channel,
@@ -519,11 +519,10 @@ impl Level {
             self.chunk_watchers.shrink_to_fit();
         }
 
-        // if the difference is too big, we can shrink the loaded chunks
-        // (1024 chunks is the equivalent to a 32x32 chunks area)
-        // if self.loaded_chunks.capacity() - self.loaded_chunks.len() >= 4096 {
-        //     self.loaded_chunks.shrink_to_fit();
-        // }
+        // Shrink loaded chunks map when significantly over-allocated
+        if self.loaded_chunks.capacity() - self.loaded_chunks.len() >= 4096 {
+            self.loaded_chunks.shrink_to_fit();
+        }
 
         if self.loaded_entity_chunks.capacity() - self.loaded_entity_chunks.len() >= 4096 {
             self.loaded_entity_chunks.shrink_to_fit();

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1437,15 +1437,21 @@ impl Player {
         };
 
         if let Some(chunk_of_chunks) = chunk_of_chunks {
-            let chunk_count = chunk_of_chunks.len();
             match &self.client {
                 ClientPlatform::Java(java_client) => {
+                    let watched = self.watched_section.load();
+                    // Skip chunks no longer in view (e.g. fast-moving player)
+                    let relevant_chunks: Vec<_> = chunk_of_chunks
+                        .into_iter()
+                        .filter(|c| watched.is_within_distance(c.x, c.z))
+                        .collect();
+                    if relevant_chunks.is_empty() {
+                        return;
+                    }
+                    let chunk_count = relevant_chunks.len();
                     java_client.send_packet_now(&CChunkBatchStart).await;
-                    for chunk in chunk_of_chunks {
-                        // log::debug!("send chunk {:?}", chunk.position);
-                        // TODO: Can we check if we still need to send the chunk? Like if it's a fast moving
-                        // player or something.
-                        java_client.send_packet_now(&CChunkData(&chunk)).await;
+                    for chunk in &relevant_chunks {
+                        java_client.send_packet_now(&CChunkData(chunk)).await;
                     }
                     java_client
                         .send_packet_now(&CChunkBatchEnd::new(chunk_count as u16))

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1439,19 +1439,10 @@ impl Player {
         if let Some(chunk_of_chunks) = chunk_of_chunks {
             match &self.client {
                 ClientPlatform::Java(java_client) => {
-                    let watched = self.watched_section.load();
-                    // Skip chunks no longer in view (e.g. fast-moving player)
-                    let relevant_chunks: Vec<_> = chunk_of_chunks
-                        .into_iter()
-                        .filter(|c| watched.is_within_distance(c.x, c.z))
-                        .collect();
-                    if relevant_chunks.is_empty() {
-                        return;
-                    }
-                    let chunk_count = relevant_chunks.len();
+                    let chunk_count = chunk_of_chunks.len();
                     java_client.send_packet_now(&CChunkBatchStart).await;
-                    for chunk in &relevant_chunks {
-                        java_client.send_packet_now(&CChunkData(chunk)).await;
+                    for chunk in chunk_of_chunks {
+                        java_client.send_packet_now(&CChunkData(&chunk)).await;
                     }
                     java_client
                         .send_packet_now(&CChunkBatchEnd::new(chunk_count as u16))


### PR DESCRIPTION
- Scale IO read thread count with CPU cores (`(cores/6).clamp(2,4)`) instead of hardcoded 2 — conservative scaling since chunk reading is disk-bound, not CPU-bound
- Increase IO write queue from 500 to 1000 entries — moderate headroom to reduce generation thread stalls without excessive memory usage
- Enable `loaded_chunks` DashMap `shrink_to_fit` when over-allocated by 4096+ entries (was commented out), reclaiming memory after mass chunk unloads