### PR TITLE
fix: resolve memory leaks from Arc cycles, stale refs, and unbounded collections

### DIFF
--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -227,6 +227,16 @@ pub trait ScreenHandler: Send + Sync {
                 offer_or_drop_stack(player, cursor_stack_lock.clone()).await;
                 *cursor_stack_lock = ItemStack::EMPTY.clone();
             }
+
+            // Drop the lock before clearing listeners to avoid holding it unnecessarily
+            drop(cursor_stack_lock);
+
+            // Clear listeners and sync handler to prevent Arc reference leaks.
+            // Listeners hold Arc<Player> references that accumulate each time a
+            // container is opened, causing the Player to never be deallocated.
+            let behaviour = self.get_behaviour_mut();
+            behaviour.listeners.clear();
+            behaviour.sync_handler = None;
         })
     }
 

--- a/pumpkin/src/entity/ai/goal/chase_player.rs
+++ b/pumpkin/src/entity/ai/goal/chase_player.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use super::{Controls, Goal, GoalFuture};
 use crate::entity::EntityBase;
@@ -7,14 +7,14 @@ use crate::entity::mob::enderman::{EndermanEntity, PLAYER_EYE_HEIGHT};
 use crate::entity::player::Player;
 
 pub struct ChasePlayerGoal {
-    enderman: Arc<EndermanEntity>,
+    enderman: Weak<EndermanEntity>,
     target: Option<Arc<Player>>,
 }
 
 impl ChasePlayerGoal {
-    pub const fn new(enderman: Arc<EndermanEntity>) -> Self {
+    pub fn new(enderman: &Arc<EndermanEntity>) -> Self {
         Self {
-            enderman,
+            enderman: Arc::downgrade(enderman),
             target: None,
         }
     }
@@ -23,6 +23,10 @@ impl ChasePlayerGoal {
 impl Goal for ChasePlayerGoal {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async move {
+            let Some(enderman) = self.enderman.upgrade() else {
+                return false;
+            };
+
             let mob_entity = mob.get_mob_entity();
             let target = mob_entity.target.lock().await.clone();
 
@@ -44,7 +48,7 @@ impl Goal for ChasePlayerGoal {
                 return false;
             }
 
-            if !self.enderman.is_player_staring(player).await {
+            if !enderman.is_player_staring(player).await {
                 self.target = None;
                 return false;
             }
@@ -65,6 +69,10 @@ impl Goal for ChasePlayerGoal {
 
     fn should_continue<'a>(&'a self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async move {
+            let Some(enderman) = self.enderman.upgrade() else {
+                return false;
+            };
+
             let Some(player) = &self.target else {
                 return false;
             };
@@ -77,7 +85,7 @@ impl Goal for ChasePlayerGoal {
                 return false;
             }
 
-            self.enderman.is_player_staring(player).await
+            enderman.is_player_staring(player).await
         })
     }
 

--- a/pumpkin/src/entity/ai/goal/creeper_ignite.rs
+++ b/pumpkin/src/entity/ai/goal/creeper_ignite.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, Weak};
 
 use super::{Controls, Goal};
 use crate::entity::ai::goal::GoalFuture;
@@ -8,15 +8,15 @@ use crate::entity::mob::creeper::CreeperEntity;
 
 pub struct CreeperIgniteGoal {
     goal_control: Controls,
-    creeper: Arc<CreeperEntity>,
+    creeper: Weak<CreeperEntity>,
 }
 
 impl CreeperIgniteGoal {
     #[must_use]
-    pub const fn new(creeper: Arc<CreeperEntity>) -> Self {
+    pub fn new(creeper: &Arc<CreeperEntity>) -> Self {
         Self {
             goal_control: Controls::MOVE,
-            creeper,
+            creeper: Arc::downgrade(creeper),
         }
     }
 }
@@ -24,10 +24,14 @@ impl CreeperIgniteGoal {
 impl Goal for CreeperIgniteGoal {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async move {
-            let creeper = mob.get_mob_entity();
-            let target_lock = creeper.target.lock().await;
+            let Some(creeper) = self.creeper.upgrade() else {
+                return false;
+            };
 
-            if self.creeper.fuse_speed.load(Ordering::Relaxed) > 0 {
+            let mob_entity = mob.get_mob_entity();
+            let target_lock = mob_entity.target.lock().await;
+
+            if creeper.fuse_speed.load(Ordering::Relaxed) > 0 {
                 return true;
             }
 
@@ -53,16 +57,22 @@ impl Goal for CreeperIgniteGoal {
 
     fn stop<'a>(&'a mut self, _mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
         Box::pin(async move {
-            self.creeper.set_fuse_speed(-1).await;
+            if let Some(creeper) = self.creeper.upgrade() {
+                creeper.set_fuse_speed(-1).await;
+            }
         })
     }
 
     fn tick<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
         Box::pin(async move {
+            let Some(creeper) = self.creeper.upgrade() else {
+                return;
+            };
+
             let target_lock = mob.get_mob_entity().target.lock().await;
 
             let Some(target) = target_lock.as_ref() else {
-                self.creeper.set_fuse_speed(-1).await;
+                creeper.set_fuse_speed(-1).await;
                 return;
             };
 
@@ -73,11 +83,11 @@ impl Goal for CreeperIgniteGoal {
                 .squared_distance_to_vec(&target.get_entity().pos.load());
 
             if dist_sq > 49.0 {
-                self.creeper.set_fuse_speed(-1).await;
+                creeper.set_fuse_speed(-1).await;
             }
             // TODO: line of sight check (needs world raycast)
             else {
-                self.creeper.set_fuse_speed(1).await;
+                creeper.set_fuse_speed(1).await;
             }
         })
     }

--- a/pumpkin/src/entity/ai/goal/pick_up_block.rs
+++ b/pumpkin/src/entity/ai/goal/pick_up_block.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use super::{Goal, GoalFuture, to_goal_ticks};
 use crate::entity::mob::Mob;
@@ -9,19 +9,25 @@ use pumpkin_world::world::BlockFlags;
 use rand::RngExt;
 
 pub struct PickUpBlockGoal {
-    enderman: Arc<EndermanEntity>,
+    enderman: Weak<EndermanEntity>,
 }
 
 impl PickUpBlockGoal {
-    pub const fn new(enderman: Arc<EndermanEntity>) -> Self {
-        Self { enderman }
+    pub fn new(enderman: &Arc<EndermanEntity>) -> Self {
+        Self {
+            enderman: Arc::downgrade(enderman),
+        }
     }
 }
 
 impl Goal for PickUpBlockGoal {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async move {
-            if self.enderman.get_carried_block().is_some() {
+            let Some(enderman) = self.enderman.upgrade() else {
+                return false;
+            };
+
+            if enderman.get_carried_block().is_some() {
                 return false;
             }
 
@@ -41,6 +47,10 @@ impl Goal for PickUpBlockGoal {
 
     fn tick<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
         Box::pin(async move {
+            let Some(enderman) = self.enderman.upgrade() else {
+                return;
+            };
+
             let entity = &mob.get_mob_entity().living_entity.entity;
             let pos = entity.pos.load();
 
@@ -86,9 +96,7 @@ impl Goal for PickUpBlockGoal {
             world
                 .set_block_state(&target_pos, 0, BlockFlags::NOTIFY_ALL)
                 .await;
-            self.enderman
-                .set_carried_block(Some(default_state_id))
-                .await;
+            enderman.set_carried_block(Some(default_state_id)).await;
         })
     }
 

--- a/pumpkin/src/entity/ai/goal/place_block.rs
+++ b/pumpkin/src/entity/ai/goal/place_block.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use super::{Goal, GoalFuture, to_goal_ticks};
 use crate::entity::mob::Mob;
@@ -10,19 +10,25 @@ use pumpkin_world::world::BlockFlags;
 use rand::RngExt;
 
 pub struct PlaceBlockGoal {
-    enderman: Arc<EndermanEntity>,
+    enderman: Weak<EndermanEntity>,
 }
 
 impl PlaceBlockGoal {
-    pub const fn new(enderman: Arc<EndermanEntity>) -> Self {
-        Self { enderman }
+    pub fn new(enderman: &Arc<EndermanEntity>) -> Self {
+        Self {
+            enderman: Arc::downgrade(enderman),
+        }
     }
 }
 
 impl Goal for PlaceBlockGoal {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async move {
-            if self.enderman.get_carried_block().is_none() {
+            let Some(enderman) = self.enderman.upgrade() else {
+                return false;
+            };
+
+            if enderman.get_carried_block().is_none() {
                 return false;
             }
 
@@ -42,7 +48,11 @@ impl Goal for PlaceBlockGoal {
 
     fn tick<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
         Box::pin(async move {
-            let Some(block_state_id) = self.enderman.get_carried_block() else {
+            let Some(enderman) = self.enderman.upgrade() else {
+                return;
+            };
+
+            let Some(block_state_id) = enderman.get_carried_block() else {
                 return;
             };
 
@@ -80,7 +90,7 @@ impl Goal for PlaceBlockGoal {
             world
                 .set_block_state(&target_pos, block_state_id, BlockFlags::NOTIFY_ALL)
                 .await;
-            self.enderman.set_carried_block(None).await;
+            enderman.set_carried_block(None).await;
         })
     }
 

--- a/pumpkin/src/entity/ai/goal/teleport_towards_player.rs
+++ b/pumpkin/src/entity/ai/goal/teleport_towards_player.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use super::track_target::TrackTargetGoal;
 use super::{Controls, Goal, GoalFuture, to_goal_ticks};
@@ -13,7 +13,7 @@ const STARE_CLOSE_DISTANCE_SQ: f64 = 16.0;
 const TELEPORT_FAR_DISTANCE_SQ: f64 = 256.0;
 
 pub struct TeleportTowardsPlayerGoal {
-    enderman: Arc<EndermanEntity>,
+    enderman: Weak<EndermanEntity>,
     track_target_goal: TrackTargetGoal,
     target_player: Option<Arc<dyn EntityBase>>,
     committed_target: Option<Arc<dyn EntityBase>>,
@@ -23,7 +23,7 @@ pub struct TeleportTowardsPlayerGoal {
 }
 
 impl TeleportTowardsPlayerGoal {
-    pub fn new(enderman: Arc<EndermanEntity>) -> Self {
+    pub fn new(enderman: &Arc<EndermanEntity>) -> Self {
         let track_target_goal = TrackTargetGoal::with_default(false);
         let mut target_predicate = TargetPredicate::create_attackable();
         target_predicate.base_max_distance = enderman
@@ -31,7 +31,7 @@ impl TeleportTowardsPlayerGoal {
             .living_entity
             .get_attribute_value(&Attributes::FOLLOW_RANGE);
         Self {
-            enderman,
+            enderman: Arc::downgrade(enderman),
             track_target_goal,
             target_player: None,
             committed_target: None,
@@ -42,11 +42,11 @@ impl TeleportTowardsPlayerGoal {
     }
 
     async fn find_staring_player(&self) -> Option<Arc<Player>> {
-        let entity = &self.enderman.mob_entity.living_entity.entity;
+        let enderman = self.enderman.upgrade()?;
+        let entity = &enderman.mob_entity.living_entity.entity;
         let world = entity.world.load();
         let pos = entity.pos.load();
-        let follow_range = self
-            .enderman
+        let follow_range = enderman
             .mob_entity
             .living_entity
             .get_attribute_value(&Attributes::FOLLOW_RANGE);
@@ -58,15 +58,14 @@ impl TeleportTowardsPlayerGoal {
         }
 
         let living = player.get_living_entity()?;
-        if !self.target_predicate.test(
-            &world,
-            Some(&self.enderman.mob_entity.living_entity),
-            living,
-        ) {
+        if !self
+            .target_predicate
+            .test(&world, Some(&enderman.mob_entity.living_entity), living)
+        {
             return None;
         }
 
-        if self.enderman.is_player_staring(&player).await || self.enderman.is_angry() {
+        if enderman.is_player_staring(&player).await || enderman.is_angry() {
             return Some(player);
         }
 
@@ -87,10 +86,14 @@ impl Goal for TeleportTowardsPlayerGoal {
 
     fn should_continue<'a>(&'a self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async move {
+            let Some(enderman) = self.enderman.upgrade() else {
+                return false;
+            };
+
             if let Some(target) = &self.target_player
                 && let Some(player) = target.get_player()
             {
-                if !self.enderman.is_player_staring(player).await && !self.enderman.is_angry() {
+                if !enderman.is_player_staring(player).await && !enderman.is_angry() {
                     return false;
                 }
                 let player_pos = player.get_entity().pos.load();
@@ -137,12 +140,18 @@ impl Goal for TeleportTowardsPlayerGoal {
         Box::pin(async move {
             self.warmup = to_goal_ticks(5);
             self.unseen_ticks = 0;
-            self.enderman.set_provoked(true).await;
+            if let Some(enderman) = self.enderman.upgrade() {
+                enderman.set_provoked(true).await;
+            }
         })
     }
 
     fn tick<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
         Box::pin(async move {
+            let Some(enderman) = self.enderman.upgrade() else {
+                return;
+            };
+
             let external_target = mob.get_mob_entity().target.lock().await.clone();
             if external_target.is_none()
                 && self.target_player.is_none()
@@ -156,7 +165,7 @@ impl Goal for TeleportTowardsPlayerGoal {
                 if self.warmup <= 0 {
                     let target = self.target_player.take();
                     self.committed_target.clone_from(&target);
-                    self.enderman.set_target(target).await;
+                    enderman.set_target(target).await;
                     self.track_target_goal.start(mob).await;
                 }
                 return;
@@ -173,16 +182,16 @@ impl Goal for TeleportTowardsPlayerGoal {
             let dist_sq = pos.squared_distance_to_vec(&target_pos);
 
             if let Some(player) = target.get_player()
-                && self.enderman.is_player_staring(player).await
+                && enderman.is_player_staring(player).await
             {
                 if dist_sq < STARE_CLOSE_DISTANCE_SQ {
-                    self.enderman.teleport_randomly().await;
+                    enderman.teleport_randomly().await;
                 }
                 self.unseen_ticks = 0;
             } else if dist_sq > TELEPORT_FAR_DISTANCE_SQ {
                 self.unseen_ticks += 1;
                 if self.unseen_ticks >= to_goal_ticks(30) {
-                    self.enderman.teleport_towards(target.as_ref()).await;
+                    enderman.teleport_towards(target.as_ref()).await;
                     self.unseen_ticks = 0;
                 }
             }
@@ -193,7 +202,9 @@ impl Goal for TeleportTowardsPlayerGoal {
         Box::pin(async move {
             self.target_player = None;
             self.committed_target = None;
-            self.enderman.set_target(None).await;
+            if let Some(enderman) = self.enderman.upgrade() {
+                enderman.set_target(None).await;
+            }
         })
     }
 

--- a/pumpkin/src/entity/mob/creeper.rs
+++ b/pumpkin/src/entity/mob/creeper.rs
@@ -66,7 +66,7 @@ impl CreeperEntity {
             let mut target_selector = mob_arc.mob_entity.target_selector.lock().await;
 
             goal_selector.add_goal(1, Box::new(SwimGoal::default()));
-            goal_selector.add_goal(2, Box::new(CreeperIgniteGoal::new(mob_arc.clone())));
+            goal_selector.add_goal(2, Box::new(CreeperIgniteGoal::new(&mob_arc)));
             goal_selector.add_goal(4, Box::new(MeleeAttackGoal::new(1.0, false)));
             goal_selector.add_goal(5, Box::new(WanderAroundGoal::new(0.8)));
 

--- a/pumpkin/src/entity/mob/enderman.rs
+++ b/pumpkin/src/entity/mob/enderman.rs
@@ -94,7 +94,7 @@ impl EndermanEntity {
             let mut target_selector = mob_arc.mob_entity.target_selector.lock().await;
 
             goal_selector.add_goal(0, Box::new(SwimGoal::default()));
-            goal_selector.add_goal(1, Box::new(ChasePlayerGoal::new(mob_arc.clone())));
+            goal_selector.add_goal(1, Box::new(ChasePlayerGoal::new(&mob_arc)));
             goal_selector.add_goal(2, Box::new(MeleeAttackGoal::new(1.0, false)));
             goal_selector.add_goal(7, Box::new(WanderAroundGoal::new(1.0)));
             goal_selector.add_goal(
@@ -102,10 +102,10 @@ impl EndermanEntity {
                 LookAtEntityGoal::with_default(mob_weak, &EntityType::PLAYER, 8.0),
             );
             goal_selector.add_goal(8, Box::new(LookAroundGoal::default()));
-            goal_selector.add_goal(10, Box::new(PlaceBlockGoal::new(mob_arc.clone())));
-            goal_selector.add_goal(11, Box::new(PickUpBlockGoal::new(mob_arc.clone())));
+            goal_selector.add_goal(10, Box::new(PlaceBlockGoal::new(&mob_arc)));
+            goal_selector.add_goal(11, Box::new(PickUpBlockGoal::new(&mob_arc)));
 
-            target_selector.add_goal(1, Box::new(TeleportTowardsPlayerGoal::new(mob_arc.clone())));
+            target_selector.add_goal(1, Box::new(TeleportTowardsPlayerGoal::new(&mob_arc)));
             target_selector.add_goal(2, Box::new(RevengeGoal::new(true)));
             target_selector.add_goal(
                 3,

--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -314,6 +314,15 @@ impl<T: Mob + Send + 'static> EntityBase for T {
         Box::pin(async move {
             let mob_entity = self.get_mob_entity();
 
+            // Clear target Arc if the targeted entity was removed, preventing
+            // stale Arc references from keeping dead entities alive in memory
+            {
+                let mut target = mob_entity.target.lock().await;
+                if target.as_ref().is_some_and(|t| t.get_entity().is_removed()) {
+                    *target = None;
+                }
+            }
+
             if mob_entity.breeding_cooldown.load(Relaxed) > 0 {
                 mob_entity.breeding_cooldown.fetch_sub(1, Relaxed);
             }

--- a/pumpkin/src/net/query.rs
+++ b/pumpkin/src/net/query.rs
@@ -110,7 +110,13 @@ async fn handle_packet(
                         .send_to(response.encode().await.as_slice(), addr)
                         .await;
 
-                    clients.write().await.insert(challenge_token, addr);
+                    // Cap the number of pending challenge tokens to prevent OOM
+                    // from handshake flooding. Tokens are cleared every 30s, but
+                    // an attacker could insert thousands per second in between.
+                    let mut clients_guard = clients.write().await;
+                    if clients_guard.len() < 4096 {
+                        clients_guard.insert(challenge_token, addr);
+                    }
                 }
             }
             PacketType::Status => {

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -557,6 +557,20 @@ impl PluginManager {
         // Remove from plugin states
         self.plugin_states.write().await.remove(name);
 
+        // If no plugins remain active, clear all event handlers to prevent
+        // leaked Box<dyn DynEventHandler> references from accumulating.
+        // TODO: associate handlers with plugin names for selective removal
+        let active_count = self
+            .plugins
+            .read()
+            .await
+            .iter()
+            .filter(|p| p.is_active)
+            .count();
+        if active_count == 0 {
+            self.handlers.write().await.clear();
+        }
+
         Ok(())
     }
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -2739,6 +2739,25 @@ impl World {
     }
 
     pub async fn remove_entity(&self, entity: &Entity) {
+        // Break vehicle/passenger Arc cycles before removing from world
+        // This prevents circular references from keeping entities alive indefinitely
+        {
+            let mut passengers = entity.passengers.lock().await;
+            for passenger in passengers.drain(..) {
+                *passenger.get_entity().vehicle.lock().await = None;
+            }
+        }
+        {
+            let mut vehicle = entity.vehicle.lock().await;
+            if let Some(v) = vehicle.take() {
+                v.get_entity()
+                    .passengers
+                    .lock()
+                    .await
+                    .retain(|p| p.get_entity().entity_id != entity.entity_id);
+            }
+        }
+
         self.entities.rcu(|current_entities| {
             let mut new_entities = (**current_entities).clone();
             new_entities.retain(|e| e.get_entity().entity_uuid != entity.entity_uuid);


### PR DESCRIPTION
Fixes multiple memory leaks discovered through static analysis of Arc reference patterns, collection growth, and resource cleanup paths.

### Arc Reference Cycle Leaks (Critical)

- **AI Goal self-referential cycles**: `ChasePlayerGoal`, `CreeperIgniteGoal`, `PickUpBlockGoal`, `PlaceBlockGoal`, and `TeleportTowardsPlayerGoal` held `Arc<EndermanEntity/CreeperEntity>` while being stored inside the entity's own `GoalSelector`. This created a cycle (`Arc<Mob> → GoalSelector → Goal → Arc<Mob>`) that **permanently leaked every despawned enderman and creeper**. Replaced with `Weak<Mob>` references.

- **Vehicle/passenger cycles**: `Entity.passengers` and `Entity.vehicle` hold `Arc<dyn EntityBase>` to each other. When entity A is B's vehicle and B is A's passenger, neither can be freed. Added cleanup in `remove_entity()` to break these references before removal.

### Stale Reference Leaks (High)

- **Mob target**: `MobEntity.target: Option<Arc<dyn EntityBase>>` kept dead entities alive in memory indefinitely after they were removed from the world. Added `is_removed()` check at the start of each mob tick to clear stale targets.

- **Screen handler listeners**: `ScreenHandlerBehaviour.listeners` accumulated `Arc<Player>` references every time a player opened a container, but `default_on_closed()` never cleared them. Players would never be deallocated. Added `listeners.clear()` and `sync_handler = None` on close.

### Unbounded Collection Leaks (Medium)

- **Plugin event handlers**: `HandlerMap` entries were never removed when plugins were unloaded, causing `Box<dyn DynEventHandler>` to accumulate. Added cleanup when no active plugins remain.

- **Query challenge tokens**: The `valid_challenge_tokens` HashMap had no size limit—only a 30s periodic clear. A malicious client could flood handshake packets to exhaust memory between clears. Added a 4096-entry cap.