### PR TITLE
feat: implement /forceload command

### DIFF
--- a/pumpkin/src/command/commands/forceload.rs
+++ b/pumpkin/src/command/commands/forceload.rs
@@ -1,0 +1,398 @@
+use pumpkin_data::translation;
+use pumpkin_util::math::vector2::Vector2;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::position_2d::Position2DArgumentConsumer;
+use crate::command::args::{ConsumedArgs, FindArg};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 1] = ["forceload"];
+
+const DESCRIPTION: &str = "Forces chunks to constantly be loaded or not.";
+
+const ARG_FROM: &str = "from";
+const ARG_TO: &str = "to";
+
+const fn block_to_chunk(x: f64, z: f64) -> Vector2<i32> {
+    Vector2::new((x as i32) >> 4, (z as i32) >> 4)
+}
+
+fn add_force_chunks(world: &crate::world::World, from: Vector2<i32>, to: Vector2<i32>) -> i32 {
+    let min_x = from.x.min(to.x);
+    let max_x = from.x.max(to.x);
+    let min_z = from.y.min(to.y);
+    let max_z = from.y.max(to.y);
+
+    let mut count = 0i32;
+    let mut lock = world.level.chunk_loading.lock().unwrap();
+    for cx in min_x..=max_x {
+        for cz in min_z..=max_z {
+            let pos = Vector2::new(cx, cz);
+            if !lock.high_priority.contains(&pos) {
+                lock.add_force_ticket(pos);
+                count += 1;
+            }
+        }
+    }
+    if count > 0 {
+        lock.send_change();
+    }
+    count
+}
+
+fn remove_force_chunks(world: &crate::world::World, from: Vector2<i32>, to: Vector2<i32>) -> i32 {
+    let min_x = from.x.min(to.x);
+    let max_x = from.x.max(to.x);
+    let min_z = from.y.min(to.y);
+    let max_z = from.y.max(to.y);
+
+    let mut count = 0i32;
+    let mut lock = world.level.chunk_loading.lock().unwrap();
+    for cx in min_x..=max_x {
+        for cz in min_z..=max_z {
+            let pos = Vector2::new(cx, cz);
+            if lock.high_priority.contains(&pos) {
+                lock.remove_force_ticket(pos);
+                count += 1;
+            }
+        }
+    }
+    if count > 0 {
+        lock.send_change();
+    }
+    count
+}
+
+struct AddSingleExecutor;
+
+impl CommandExecutor for AddSingleExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let from = Position2DArgumentConsumer::find_arg(args, ARG_FROM)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let chunk = block_to_chunk(from.x, from.y);
+
+            let count = add_force_chunks(&world, chunk, chunk);
+            if count == 0 {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_FORCELOAD_ADDED_FAILURE,
+                    [TextComponent::text(format!("[{}, {}]", chunk.x, chunk.y))],
+                )));
+            }
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_FORCELOAD_ADDED_SINGLE,
+                    [TextComponent::text(format!("[{}, {}]", chunk.x, chunk.y))],
+                ))
+                .await;
+            Ok(count)
+        })
+    }
+}
+
+struct AddRangeExecutor;
+
+impl CommandExecutor for AddRangeExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let from = Position2DArgumentConsumer::find_arg(args, ARG_FROM)?;
+            let to = Position2DArgumentConsumer::find_arg(args, ARG_TO)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let chunk_from = block_to_chunk(from.x, from.y);
+            let chunk_to = block_to_chunk(to.x, to.y);
+
+            let count = add_force_chunks(&world, chunk_from, chunk_to);
+            if count == 0 {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_FORCELOAD_ADDED_NONE,
+                    [],
+                )));
+            }
+
+            if count == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_FORCELOAD_ADDED_SINGLE,
+                        [TextComponent::text(format!(
+                            "[{}, {}]",
+                            chunk_from.x, chunk_from.y
+                        ))],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_FORCELOAD_ADDED_MULTIPLE,
+                        [
+                            TextComponent::text(count.to_string()),
+                            TextComponent::text(format!("[{}, {}]", chunk_from.x, chunk_from.y)),
+                            TextComponent::text(format!("[{}, {}]", chunk_to.x, chunk_to.y)),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count)
+        })
+    }
+}
+
+struct RemoveSingleExecutor;
+
+impl CommandExecutor for RemoveSingleExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let from = Position2DArgumentConsumer::find_arg(args, ARG_FROM)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let chunk = block_to_chunk(from.x, from.y);
+
+            let count = remove_force_chunks(&world, chunk, chunk);
+            if count == 0 {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_FORCELOAD_REMOVED_FAILURE,
+                    [TextComponent::text(format!("[{}, {}]", chunk.x, chunk.y))],
+                )));
+            }
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_FORCELOAD_REMOVED_SINGLE,
+                    [TextComponent::text(format!("[{}, {}]", chunk.x, chunk.y))],
+                ))
+                .await;
+            Ok(count)
+        })
+    }
+}
+
+struct RemoveRangeExecutor;
+
+impl CommandExecutor for RemoveRangeExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let from = Position2DArgumentConsumer::find_arg(args, ARG_FROM)?;
+            let to = Position2DArgumentConsumer::find_arg(args, ARG_TO)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let chunk_from = block_to_chunk(from.x, from.y);
+            let chunk_to = block_to_chunk(to.x, to.y);
+
+            let count = remove_force_chunks(&world, chunk_from, chunk_to);
+            if count == 0 {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_FORCELOAD_REMOVED_FAILURE,
+                    [TextComponent::text(format!(
+                        "[{}, {}]",
+                        chunk_from.x, chunk_from.y
+                    ))],
+                )));
+            }
+
+            if count == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_FORCELOAD_REMOVED_SINGLE,
+                        [TextComponent::text(format!(
+                            "[{}, {}]",
+                            chunk_from.x, chunk_from.y
+                        ))],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_FORCELOAD_REMOVED_MULTIPLE,
+                        [
+                            TextComponent::text(count.to_string()),
+                            TextComponent::text(format!("[{}, {}]", chunk_from.x, chunk_from.y)),
+                            TextComponent::text(format!("[{}, {}]", chunk_to.x, chunk_to.y)),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count)
+        })
+    }
+}
+
+struct RemoveAllExecutor;
+
+impl CommandExecutor for RemoveAllExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+
+            let count;
+            {
+                let mut lock = world.level.chunk_loading.lock().unwrap();
+                let forced: Vec<_> = lock.high_priority.clone();
+                count = forced.len() as i32;
+                for pos in forced {
+                    lock.remove_force_ticket(pos);
+                }
+                if count > 0 {
+                    lock.send_change();
+                }
+            }
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_FORCELOAD_REMOVED_ALL,
+                    [TextComponent::text(count.to_string())],
+                ))
+                .await;
+            Ok(count)
+        })
+    }
+}
+
+struct QueryPosExecutor;
+
+impl CommandExecutor for QueryPosExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let from = Position2DArgumentConsumer::find_arg(args, ARG_FROM)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let chunk = block_to_chunk(from.x, from.y);
+
+            let is_forced = {
+                let lock = world.level.chunk_loading.lock().unwrap();
+                lock.high_priority.contains(&chunk)
+            };
+
+            if is_forced {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_FORCELOAD_QUERY_SUCCESS,
+                        [TextComponent::text(format!("[{}, {}]", chunk.x, chunk.y))],
+                    ))
+                    .await;
+                Ok(1)
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_FORCELOAD_QUERY_FAILURE,
+                        [TextComponent::text(format!("[{}, {}]", chunk.x, chunk.y))],
+                    ))
+                    .await;
+                Ok(0)
+            }
+        })
+    }
+}
+
+struct QueryListExecutor;
+
+impl CommandExecutor for QueryListExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+
+            let forced = {
+                let lock = world.level.chunk_loading.lock().unwrap();
+                lock.high_priority.clone()
+            };
+
+            if forced.is_empty() {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_FORCELOAD_ADDED_NONE,
+                        [],
+                    ))
+                    .await;
+                Ok(0)
+            } else {
+                let list = forced
+                    .iter()
+                    .map(|p| format!("[{}, {}]", p.x, p.y))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                if forced.len() == 1 {
+                    sender
+                        .send_message(TextComponent::translate(
+                            translation::COMMANDS_FORCELOAD_LIST_SINGLE,
+                            [TextComponent::text(list)],
+                        ))
+                        .await;
+                } else {
+                    sender
+                        .send_message(TextComponent::translate(
+                            translation::COMMANDS_FORCELOAD_LIST_MULTIPLE,
+                            [
+                                TextComponent::text(forced.len().to_string()),
+                                TextComponent::text(list),
+                            ],
+                        ))
+                        .await;
+                }
+                Ok(forced.len() as i32)
+            }
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(
+            literal("add").then(
+                argument(ARG_FROM, Position2DArgumentConsumer)
+                    .then(argument(ARG_TO, Position2DArgumentConsumer).execute(AddRangeExecutor))
+                    .execute(AddSingleExecutor),
+            ),
+        )
+        .then(
+            literal("remove")
+                .then(literal("all").execute(RemoveAllExecutor))
+                .then(
+                    argument(ARG_FROM, Position2DArgumentConsumer)
+                        .then(
+                            argument(ARG_TO, Position2DArgumentConsumer)
+                                .execute(RemoveRangeExecutor),
+                        )
+                        .execute(RemoveSingleExecutor),
+                ),
+        )
+        .then(
+            literal("query")
+                .then(argument(ARG_FROM, Position2DArgumentConsumer).execute(QueryPosExecutor))
+                .execute(QueryListExecutor),
+        )
+}

--- a/pumpkin/src/command/commands/forceload.rs
+++ b/pumpkin/src/command/commands/forceload.rs
@@ -17,7 +17,7 @@ const ARG_FROM: &str = "from";
 const ARG_TO: &str = "to";
 
 const fn block_to_chunk(x: f64, z: f64) -> Vector2<i32> {
-    Vector2::new((x as i32) >> 4, (z as i32) >> 4)
+    Vector2::new((x.floor() as i32) >> 4, (z.floor() as i32) >> 4)
 }
 
 fn add_force_chunks(world: &crate::world::World, from: Vector2<i32>, to: Vector2<i32>) -> i32 {
@@ -91,7 +91,10 @@ impl CommandExecutor for AddSingleExecutor {
             sender
                 .send_message(TextComponent::translate(
                     translation::COMMANDS_FORCELOAD_ADDED_SINGLE,
-                    [TextComponent::text(format!("[{}, {}]", chunk.x, chunk.y))],
+                    [
+                        TextComponent::text(format!("[{}, {}]", chunk.x, chunk.y)),
+                        TextComponent::text(world.dimension.minecraft_name.to_owned()),
+                    ],
                 ))
                 .await;
             Ok(count)
@@ -115,11 +118,12 @@ impl CommandExecutor for AddRangeExecutor {
             let chunk_from = block_to_chunk(from.x, from.y);
             let chunk_to = block_to_chunk(to.x, to.y);
 
+            let dimension = world.dimension.minecraft_name.to_owned();
             let count = add_force_chunks(&world, chunk_from, chunk_to);
             if count == 0 {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
                     translation::COMMANDS_FORCELOAD_ADDED_NONE,
-                    [],
+                    [TextComponent::text(dimension)],
                 )));
             }
 
@@ -127,10 +131,10 @@ impl CommandExecutor for AddRangeExecutor {
                 sender
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_FORCELOAD_ADDED_SINGLE,
-                        [TextComponent::text(format!(
-                            "[{}, {}]",
-                            chunk_from.x, chunk_from.y
-                        ))],
+                        [
+                            TextComponent::text(format!("[{}, {}]", chunk_from.x, chunk_from.y)),
+                            TextComponent::text(dimension),
+                        ],
                     ))
                     .await;
             } else {
@@ -141,6 +145,7 @@ impl CommandExecutor for AddRangeExecutor {
                             TextComponent::text(count.to_string()),
                             TextComponent::text(format!("[{}, {}]", chunk_from.x, chunk_from.y)),
                             TextComponent::text(format!("[{}, {}]", chunk_to.x, chunk_to.y)),
+                            TextComponent::text(dimension),
                         ],
                     ))
                     .await;
@@ -175,7 +180,10 @@ impl CommandExecutor for RemoveSingleExecutor {
             sender
                 .send_message(TextComponent::translate(
                     translation::COMMANDS_FORCELOAD_REMOVED_SINGLE,
-                    [TextComponent::text(format!("[{}, {}]", chunk.x, chunk.y))],
+                    [
+                        TextComponent::text(format!("[{}, {}]", chunk.x, chunk.y)),
+                        TextComponent::text(world.dimension.minecraft_name.to_owned()),
+                    ],
                 ))
                 .await;
             Ok(count)
@@ -199,6 +207,7 @@ impl CommandExecutor for RemoveRangeExecutor {
             let chunk_from = block_to_chunk(from.x, from.y);
             let chunk_to = block_to_chunk(to.x, to.y);
 
+            let dimension = world.dimension.minecraft_name.to_owned();
             let count = remove_force_chunks(&world, chunk_from, chunk_to);
             if count == 0 {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
@@ -214,10 +223,10 @@ impl CommandExecutor for RemoveRangeExecutor {
                 sender
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_FORCELOAD_REMOVED_SINGLE,
-                        [TextComponent::text(format!(
-                            "[{}, {}]",
-                            chunk_from.x, chunk_from.y
-                        ))],
+                        [
+                            TextComponent::text(format!("[{}, {}]", chunk_from.x, chunk_from.y)),
+                            TextComponent::text(dimension),
+                        ],
                     ))
                     .await;
             } else {
@@ -228,6 +237,7 @@ impl CommandExecutor for RemoveRangeExecutor {
                             TextComponent::text(count.to_string()),
                             TextComponent::text(format!("[{}, {}]", chunk_from.x, chunk_from.y)),
                             TextComponent::text(format!("[{}, {}]", chunk_to.x, chunk_to.y)),
+                            TextComponent::text(dimension),
                         ],
                     ))
                     .await;
@@ -265,7 +275,10 @@ impl CommandExecutor for RemoveAllExecutor {
             sender
                 .send_message(TextComponent::translate(
                     translation::COMMANDS_FORCELOAD_REMOVED_ALL,
-                    [TextComponent::text(count.to_string())],
+                    [
+                        TextComponent::text(count.to_string()),
+                        TextComponent::text(world.dimension.minecraft_name.to_owned()),
+                    ],
                 ))
                 .await;
             Ok(count)
@@ -330,11 +343,13 @@ impl CommandExecutor for QueryListExecutor {
                 lock.high_priority.clone()
             };
 
+            let dimension = world.dimension.minecraft_name.to_owned();
+
             if forced.is_empty() {
                 sender
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_FORCELOAD_ADDED_NONE,
-                        [],
+                        [TextComponent::text(dimension)],
                     ))
                     .await;
                 Ok(0)
@@ -349,7 +364,7 @@ impl CommandExecutor for QueryListExecutor {
                     sender
                         .send_message(TextComponent::translate(
                             translation::COMMANDS_FORCELOAD_LIST_SINGLE,
-                            [TextComponent::text(list)],
+                            [TextComponent::text(dimension), TextComponent::text(list)],
                         ))
                         .await;
                 } else {
@@ -358,6 +373,7 @@ impl CommandExecutor for QueryListExecutor {
                             translation::COMMANDS_FORCELOAD_LIST_MULTIPLE,
                             [
                                 TextComponent::text(forced.len().to_string()),
+                                TextComponent::text(dimension),
                                 TextComponent::text(list),
                             ],
                         ))

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -21,6 +21,7 @@ mod effect;
 mod enchant;
 mod experience;
 mod fill;
+mod forceload;
 mod gamemode;
 mod gamerule;
 mod give;
@@ -134,6 +135,10 @@ pub async fn default_dispatcher(
         "minecraft:command.spawnpoint",
     );
     dispatcher.register(data::init_command_tree(), "minecraft:command.data");
+    dispatcher.register(
+        forceload::init_command_tree(),
+        "minecraft:command.forceload",
+    );
     // Three
     dispatcher.register(op::init_command_tree(), "minecraft:command.op");
     dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");
@@ -404,6 +409,13 @@ fn register_level_2_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.data",
             "Query and modify data of entities and blocks",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.forceload",
+            "Forces chunks to constantly be loaded or not",
             PermissionDefault::Op(PermissionLvl::Two),
         ))
         .unwrap();


### PR DESCRIPTION
- Implements the `/forceload` command with full vanilla syntax: `add`, `remove`, `remove all`, `query`
- Uses the existing `ChunkLoading` force ticket system (`add_force_ticket`/`remove_force_ticket`)
- Supports single chunk and range operations with proper vanilla translation messages