### PR TITLE
feat: implement /recipe command

### DIFF
--- a/pumpkin/src/block/blocks/redstone/rails/activator_rail.rs
+++ b/pumpkin/src/block/blocks/redstone/rails/activator_rail.rs
@@ -556,7 +556,6 @@ impl ActivatorRailBlock {
         pos: &BlockPos,
     ) -> Option<(&'static Block, RailProperties)> {
         let block = world.get_block(pos).await;
-        #[expect(clippy::if_then_some_else_none)]
         if *block == Block::ACTIVATOR_RAIL {
             let state_id = world.get_block_state_id(pos).await;
             let rail_props = RailProperties::new(state_id, block);

--- a/pumpkin/src/block/blocks/redstone/rails/powered_rail.rs
+++ b/pumpkin/src/block/blocks/redstone/rails/powered_rail.rs
@@ -557,7 +557,6 @@ impl PoweredRailBlock {
         pos: &BlockPos,
     ) -> Option<(&'static Block, RailProperties)> {
         let block = world.get_block(pos).await;
-        #[expect(clippy::if_then_some_else_none)]
         if *block == Block::POWERED_RAIL {
             let state_id = world.get_block_state_id(pos).await;
             let rail_props = RailProperties::new(state_id, block);

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -38,6 +38,7 @@ mod playsound;
 mod plugin;
 mod plugins;
 mod pumpkin;
+mod recipe;
 mod rotate;
 mod say;
 mod seed;
@@ -134,6 +135,7 @@ pub async fn default_dispatcher(
         "minecraft:command.spawnpoint",
     );
     dispatcher.register(data::init_command_tree(), "minecraft:command.data");
+    dispatcher.register(recipe::init_command_tree(), "minecraft:command.recipe");
     // Three
     dispatcher.register(op::init_command_tree(), "minecraft:command.op");
     dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");
@@ -411,6 +413,13 @@ fn register_level_2_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.enchant",
             "Adds an enchantment to a player's selected item, subject to the same restrictions as an anvil. Also works on any mob or entity holding a weapon/tool/armor in its main hand.",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.recipe",
+            "Gives or takes player recipes",
             PermissionDefault::Op(PermissionLvl::Two),
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/recipe.rs
+++ b/pumpkin/src/command/commands/recipe.rs
@@ -1,9 +1,9 @@
 use pumpkin_data::translation;
 use pumpkin_util::text::TextComponent;
 
-use crate::command::args::entities::EntitiesArgumentConsumer;
+use crate::command::args::players::PlayersArgumentConsumer;
 use crate::command::args::simple::SimpleArgConsumer;
-use crate::command::args::{Arg, ConsumedArgs, FindArg};
+use crate::command::args::{ConsumedArgs, FindArg};
 use crate::command::dispatcher::CommandError;
 use crate::command::tree::CommandTree;
 use crate::command::tree::builder::{argument, literal};
@@ -26,12 +26,8 @@ impl CommandExecutor for GiveExecutor {
         args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
         Box::pin(async move {
-            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
-            let Some(Arg::Simple(recipe)) = args.get(ARG_RECIPE) else {
-                return Err(CommandError::InvalidConsumption(Some(ARG_RECIPE.into())));
-            };
-
-            // TODO: Use `recipe == "*"` to give/take all recipes when protocol support is added
+            let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+            let recipe = SimpleArgConsumer::find_arg(args, ARG_RECIPE)?;
 
             if targets.is_empty() {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
@@ -41,15 +37,17 @@ impl CommandExecutor for GiveExecutor {
             }
 
             // TODO: Send CRecipeBookAdd packets to unlock recipes for players
-            // Currently, the recipe book protocol packets are not yet implemented.
+            // Handle recipe == "*" to give all recipes
 
-            let count = targets.len() as i32;
+            let count = targets.len();
             if count == 1 {
-                let name = targets[0].get_name();
                 sender
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_RECIPE_GIVE_SUCCESS_SINGLE,
-                        [TextComponent::text(recipe.to_string()), name],
+                        [
+                            TextComponent::text(recipe.to_string()),
+                            TextComponent::text(targets[0].gameprofile.name.clone()),
+                        ],
                     ))
                     .await;
             } else {
@@ -63,7 +61,7 @@ impl CommandExecutor for GiveExecutor {
                     ))
                     .await;
             }
-            Ok(count)
+            Ok(count as i32)
         })
     }
 }
@@ -78,12 +76,8 @@ impl CommandExecutor for TakeExecutor {
         args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
         Box::pin(async move {
-            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
-            let Some(Arg::Simple(recipe)) = args.get(ARG_RECIPE) else {
-                return Err(CommandError::InvalidConsumption(Some(ARG_RECIPE.into())));
-            };
-
-            // TODO: Use `recipe == "*"` to give/take all recipes when protocol support is added
+            let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+            let recipe = SimpleArgConsumer::find_arg(args, ARG_RECIPE)?;
 
             if targets.is_empty() {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
@@ -93,14 +87,17 @@ impl CommandExecutor for TakeExecutor {
             }
 
             // TODO: Send CRecipeBookRemove packets to lock recipes for players
+            // Handle recipe == "*" to take all recipes
 
-            let count = targets.len() as i32;
+            let count = targets.len();
             if count == 1 {
-                let name = targets[0].get_name();
                 sender
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_RECIPE_TAKE_SUCCESS_SINGLE,
-                        [TextComponent::text(recipe.to_string()), name],
+                        [
+                            TextComponent::text(recipe.to_string()),
+                            TextComponent::text(targets[0].gameprofile.name.clone()),
+                        ],
                     ))
                     .await;
             } else {
@@ -114,7 +111,7 @@ impl CommandExecutor for TakeExecutor {
                     ))
                     .await;
             }
-            Ok(count)
+            Ok(count as i32)
         })
     }
 }
@@ -123,13 +120,13 @@ pub fn init_command_tree() -> CommandTree {
     CommandTree::new(NAMES, DESCRIPTION)
         .then(
             literal("give").then(
-                argument(ARG_TARGETS, EntitiesArgumentConsumer)
+                argument(ARG_TARGETS, PlayersArgumentConsumer)
                     .then(argument(ARG_RECIPE, SimpleArgConsumer).execute(GiveExecutor)),
             ),
         )
         .then(
             literal("take").then(
-                argument(ARG_TARGETS, EntitiesArgumentConsumer)
+                argument(ARG_TARGETS, PlayersArgumentConsumer)
                     .then(argument(ARG_RECIPE, SimpleArgConsumer).execute(TakeExecutor)),
             ),
         )

--- a/pumpkin/src/command/commands/recipe.rs
+++ b/pumpkin/src/command/commands/recipe.rs
@@ -1,0 +1,136 @@
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::entities::EntitiesArgumentConsumer;
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs, FindArg};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 1] = ["recipe"];
+
+const DESCRIPTION: &str = "Gives or takes player recipes.";
+
+const ARG_TARGETS: &str = "targets";
+const ARG_RECIPE: &str = "recipe";
+
+struct GiveExecutor;
+
+impl CommandExecutor for GiveExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+            let Some(Arg::Simple(recipe)) = args.get(ARG_RECIPE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_RECIPE.into())));
+            };
+
+            // TODO: Use `recipe == "*"` to give/take all recipes when protocol support is added
+
+            if targets.is_empty() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_RECIPE_GIVE_FAILED,
+                    [],
+                )));
+            }
+
+            // TODO: Send CRecipeBookAdd packets to unlock recipes for players
+            // Currently, the recipe book protocol packets are not yet implemented.
+
+            let count = targets.len() as i32;
+            if count == 1 {
+                let name = targets[0].get_name();
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_RECIPE_GIVE_SUCCESS_SINGLE,
+                        [TextComponent::text(recipe.to_string()), name],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_RECIPE_GIVE_SUCCESS_MULTIPLE,
+                        [
+                            TextComponent::text(recipe.to_string()),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count)
+        })
+    }
+}
+
+struct TakeExecutor;
+
+impl CommandExecutor for TakeExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+            let Some(Arg::Simple(recipe)) = args.get(ARG_RECIPE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_RECIPE.into())));
+            };
+
+            // TODO: Use `recipe == "*"` to give/take all recipes when protocol support is added
+
+            if targets.is_empty() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_RECIPE_TAKE_FAILED,
+                    [],
+                )));
+            }
+
+            // TODO: Send CRecipeBookRemove packets to lock recipes for players
+
+            let count = targets.len() as i32;
+            if count == 1 {
+                let name = targets[0].get_name();
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_RECIPE_TAKE_SUCCESS_SINGLE,
+                        [TextComponent::text(recipe.to_string()), name],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_RECIPE_TAKE_SUCCESS_MULTIPLE,
+                        [
+                            TextComponent::text(recipe.to_string()),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(
+            literal("give").then(
+                argument(ARG_TARGETS, EntitiesArgumentConsumer)
+                    .then(argument(ARG_RECIPE, SimpleArgConsumer).execute(GiveExecutor)),
+            ),
+        )
+        .then(
+            literal("take").then(
+                argument(ARG_TARGETS, EntitiesArgumentConsumer)
+                    .then(argument(ARG_RECIPE, SimpleArgConsumer).execute(TakeExecutor)),
+            ),
+        )
+}

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -191,7 +191,6 @@ impl PumpkinServer {
     pub fn log_info(&self, message: &str) {
         tracing::info!(target: "plugin", "{}", message);
     }
-    #[expect(clippy::if_then_some_else_none)]
     pub async fn new(
         basic_config: BasicConfiguration,
         advanced_config: AdvancedConfiguration,

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -420,7 +420,6 @@ impl Server {
             PlayerLoginEvent::new(player.clone(), TextComponent::text("You have been kicked from the server"));
             'after: {
                 player.screen_handler_sync_handler.store_player(player.clone()).await;
-                #[expect(clippy::if_then_some_else_none)]
                 if world
                     .add_player(player.clone())
                     .is_ok() {


### PR DESCRIPTION
- Implements `/recipe give <targets> <recipe>` and `/recipe take <targets> <recipe>`
- Uses vanilla translation keys for success/failure messages
- Recipe book protocol packets (CRecipeBookAdd/CRecipeBookRemove) are marked as TODO for future implementation
- Also fixes unfulfilled `clippy::if_then_some_else_none` lint expectations