### PR TITLE
feat: implement /advancement command

### DIFF
--- a/pumpkin/src/block/blocks/redstone/rails/activator_rail.rs
+++ b/pumpkin/src/block/blocks/redstone/rails/activator_rail.rs
@@ -556,7 +556,6 @@ impl ActivatorRailBlock {
         pos: &BlockPos,
     ) -> Option<(&'static Block, RailProperties)> {
         let block = world.get_block(pos).await;
-        #[expect(clippy::if_then_some_else_none)]
         if *block == Block::ACTIVATOR_RAIL {
             let state_id = world.get_block_state_id(pos).await;
             let rail_props = RailProperties::new(state_id, block);

--- a/pumpkin/src/block/blocks/redstone/rails/powered_rail.rs
+++ b/pumpkin/src/block/blocks/redstone/rails/powered_rail.rs
@@ -557,7 +557,6 @@ impl PoweredRailBlock {
         pos: &BlockPos,
     ) -> Option<(&'static Block, RailProperties)> {
         let block = world.get_block(pos).await;
-        #[expect(clippy::if_then_some_else_none)]
         if *block == Block::POWERED_RAIL {
             let state_id = world.get_block_state_id(pos).await;
             let rail_props = RailProperties::new(state_id, block);

--- a/pumpkin/src/command/commands/advancement.rs
+++ b/pumpkin/src/command/commands/advancement.rs
@@ -1,10 +1,9 @@
 use pumpkin_data::translation;
 use pumpkin_util::text::TextComponent;
 
-use crate::command::args::entities::EntitiesArgumentConsumer;
+use crate::command::args::players::PlayersArgumentConsumer;
 use crate::command::args::simple::SimpleArgConsumer;
-use crate::command::args::{Arg, ConsumedArgs, FindArg};
-use crate::command::dispatcher::CommandError;
+use crate::command::args::{ConsumedArgs, FindArg};
 use crate::command::tree::CommandTree;
 use crate::command::tree::builder::{argument, literal};
 use crate::command::{CommandExecutor, CommandResult, CommandSender};
@@ -15,6 +14,7 @@ const DESCRIPTION: &str = "Gives, removes, or checks player advancements.";
 
 const ARG_TARGETS: &str = "targets";
 const ARG_ADVANCEMENT: &str = "advancement";
+const ARG_CRITERION: &str = "criterion";
 
 struct GrantEverythingExecutor;
 
@@ -26,25 +26,17 @@ impl CommandExecutor for GrantEverythingExecutor {
         args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
         Box::pin(async move {
-            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
-
-            if targets.is_empty() {
-                return Err(CommandError::CommandFailed(TextComponent::translate(
-                    translation::COMMANDS_ADVANCEMENT_GRANT_MANY_TO_ONE_FAILURE,
-                    [],
-                )));
-            }
+            let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
 
             // TODO: Implement advancement tracking system and grant all advancements
-
-            let count = targets.len() as i32;
+            let count = targets.len();
             if count == 1 {
                 sender
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_ADVANCEMENT_GRANT_MANY_TO_ONE_SUCCESS,
                         [
-                            TextComponent::text("all".to_string()),
-                            TextComponent::text(count.to_string()),
+                            TextComponent::text("0"),
+                            TextComponent::text(targets[0].gameprofile.name.clone()),
                         ],
                     ))
                     .await;
@@ -53,13 +45,13 @@ impl CommandExecutor for GrantEverythingExecutor {
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_ADVANCEMENT_GRANT_MANY_TO_MANY_SUCCESS,
                         [
-                            TextComponent::text("all".to_string()),
+                            TextComponent::text("0"),
                             TextComponent::text(count.to_string()),
                         ],
                     ))
                     .await;
             }
-            Ok(count)
+            Ok(count as i32)
         })
     }
 }
@@ -74,30 +66,18 @@ impl CommandExecutor for GrantOnlyExecutor {
         args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
         Box::pin(async move {
-            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
-            let Some(Arg::Simple(advancement)) = args.get(ARG_ADVANCEMENT) else {
-                return Err(CommandError::InvalidConsumption(Some(
-                    ARG_ADVANCEMENT.into(),
-                )));
-            };
-
-            if targets.is_empty() {
-                return Err(CommandError::CommandFailed(TextComponent::translate(
-                    translation::COMMANDS_ADVANCEMENT_GRANT_ONE_TO_ONE_FAILURE,
-                    [],
-                )));
-            }
+            let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+            let advancement = SimpleArgConsumer::find_arg(args, ARG_ADVANCEMENT)?;
 
             // TODO: Implement advancement tracking and grant specific advancement
-
-            let count = targets.len() as i32;
+            let count = targets.len();
             if count == 1 {
                 sender
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_ADVANCEMENT_GRANT_ONE_TO_ONE_SUCCESS,
                         [
                             TextComponent::text(advancement.to_string()),
-                            TextComponent::text(count.to_string()),
+                            TextComponent::text(targets[0].gameprofile.name.clone()),
                         ],
                     ))
                     .await;
@@ -112,7 +92,48 @@ impl CommandExecutor for GrantOnlyExecutor {
                     ))
                     .await;
             }
-            Ok(count)
+            Ok(count as i32)
+        })
+    }
+}
+
+struct GrantTreeExecutor;
+
+impl CommandExecutor for GrantTreeExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+            let _advancement = SimpleArgConsumer::find_arg(args, ARG_ADVANCEMENT)?;
+
+            // TODO: Implement from/through/until advancement tree traversal
+            let count = targets.len();
+            if count == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_GRANT_MANY_TO_ONE_SUCCESS,
+                        [
+                            TextComponent::text("0"),
+                            TextComponent::text(targets[0].gameprofile.name.clone()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_GRANT_MANY_TO_MANY_SUCCESS,
+                        [
+                            TextComponent::text("0"),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count as i32)
         })
     }
 }
@@ -127,25 +148,17 @@ impl CommandExecutor for RevokeEverythingExecutor {
         args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
         Box::pin(async move {
-            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
-
-            if targets.is_empty() {
-                return Err(CommandError::CommandFailed(TextComponent::translate(
-                    translation::COMMANDS_ADVANCEMENT_REVOKE_MANY_TO_ONE_FAILURE,
-                    [],
-                )));
-            }
+            let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
 
             // TODO: Implement advancement tracking and revoke all advancements
-
-            let count = targets.len() as i32;
+            let count = targets.len();
             if count == 1 {
                 sender
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_ADVANCEMENT_REVOKE_MANY_TO_ONE_SUCCESS,
                         [
-                            TextComponent::text("all".to_string()),
-                            TextComponent::text(count.to_string()),
+                            TextComponent::text("0"),
+                            TextComponent::text(targets[0].gameprofile.name.clone()),
                         ],
                     ))
                     .await;
@@ -154,13 +167,13 @@ impl CommandExecutor for RevokeEverythingExecutor {
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_ADVANCEMENT_REVOKE_MANY_TO_MANY_SUCCESS,
                         [
-                            TextComponent::text("all".to_string()),
+                            TextComponent::text("0"),
                             TextComponent::text(count.to_string()),
                         ],
                     ))
                     .await;
             }
-            Ok(count)
+            Ok(count as i32)
         })
     }
 }
@@ -175,30 +188,18 @@ impl CommandExecutor for RevokeOnlyExecutor {
         args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
         Box::pin(async move {
-            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
-            let Some(Arg::Simple(advancement)) = args.get(ARG_ADVANCEMENT) else {
-                return Err(CommandError::InvalidConsumption(Some(
-                    ARG_ADVANCEMENT.into(),
-                )));
-            };
-
-            if targets.is_empty() {
-                return Err(CommandError::CommandFailed(TextComponent::translate(
-                    translation::COMMANDS_ADVANCEMENT_REVOKE_ONE_TO_ONE_FAILURE,
-                    [],
-                )));
-            }
+            let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+            let advancement = SimpleArgConsumer::find_arg(args, ARG_ADVANCEMENT)?;
 
             // TODO: Implement advancement tracking and revoke specific advancement
-
-            let count = targets.len() as i32;
+            let count = targets.len();
             if count == 1 {
                 sender
                     .send_message(TextComponent::translate(
                         translation::COMMANDS_ADVANCEMENT_REVOKE_ONE_TO_ONE_SUCCESS,
                         [
                             TextComponent::text(advancement.to_string()),
-                            TextComponent::text(count.to_string()),
+                            TextComponent::text(targets[0].gameprofile.name.clone()),
                         ],
                     ))
                     .await;
@@ -213,53 +214,102 @@ impl CommandExecutor for RevokeOnlyExecutor {
                     ))
                     .await;
             }
-            Ok(count)
+            Ok(count as i32)
+        })
+    }
+}
+
+struct RevokeTreeExecutor;
+
+impl CommandExecutor for RevokeTreeExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+            let _advancement = SimpleArgConsumer::find_arg(args, ARG_ADVANCEMENT)?;
+
+            // TODO: Implement from/through/until advancement tree traversal
+            let count = targets.len();
+            if count == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_REVOKE_MANY_TO_ONE_SUCCESS,
+                        [
+                            TextComponent::text("0"),
+                            TextComponent::text(targets[0].gameprofile.name.clone()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_REVOKE_MANY_TO_MANY_SUCCESS,
+                        [
+                            TextComponent::text("0"),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count as i32)
         })
     }
 }
 
 fn grant_tree() -> crate::command::tree::builder::NonLeafNodeBuilder {
     literal("grant").then(
-        argument(ARG_TARGETS, EntitiesArgumentConsumer)
+        argument(ARG_TARGETS, PlayersArgumentConsumer)
             .then(literal("everything").execute(GrantEverythingExecutor))
             .then(
-                literal("only")
-                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantOnlyExecutor)),
+                literal("only").then(
+                    argument(ARG_ADVANCEMENT, SimpleArgConsumer)
+                        .then(argument(ARG_CRITERION, SimpleArgConsumer).execute(GrantOnlyExecutor))
+                        .execute(GrantOnlyExecutor),
+                ),
             )
             .then(
                 literal("from")
-                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantOnlyExecutor)),
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantTreeExecutor)),
             )
             .then(
                 literal("through")
-                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantOnlyExecutor)),
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantTreeExecutor)),
             )
             .then(
                 literal("until")
-                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantOnlyExecutor)),
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantTreeExecutor)),
             ),
     )
 }
 
 fn revoke_tree() -> crate::command::tree::builder::NonLeafNodeBuilder {
     literal("revoke").then(
-        argument(ARG_TARGETS, EntitiesArgumentConsumer)
+        argument(ARG_TARGETS, PlayersArgumentConsumer)
             .then(literal("everything").execute(RevokeEverythingExecutor))
             .then(
-                literal("only")
-                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeOnlyExecutor)),
+                literal("only").then(
+                    argument(ARG_ADVANCEMENT, SimpleArgConsumer)
+                        .then(
+                            argument(ARG_CRITERION, SimpleArgConsumer).execute(RevokeOnlyExecutor),
+                        )
+                        .execute(RevokeOnlyExecutor),
+                ),
             )
             .then(
                 literal("from")
-                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeOnlyExecutor)),
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeTreeExecutor)),
             )
             .then(
                 literal("through")
-                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeOnlyExecutor)),
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeTreeExecutor)),
             )
             .then(
                 literal("until")
-                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeOnlyExecutor)),
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeTreeExecutor)),
             ),
     )
 }

--- a/pumpkin/src/command/commands/advancement.rs
+++ b/pumpkin/src/command/commands/advancement.rs
@@ -1,0 +1,271 @@
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::entities::EntitiesArgumentConsumer;
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs, FindArg};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 1] = ["advancement"];
+
+const DESCRIPTION: &str = "Gives, removes, or checks player advancements.";
+
+const ARG_TARGETS: &str = "targets";
+const ARG_ADVANCEMENT: &str = "advancement";
+
+struct GrantEverythingExecutor;
+
+impl CommandExecutor for GrantEverythingExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+
+            if targets.is_empty() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_ADVANCEMENT_GRANT_MANY_TO_ONE_FAILURE,
+                    [],
+                )));
+            }
+
+            // TODO: Implement advancement tracking system and grant all advancements
+
+            let count = targets.len() as i32;
+            if count == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_GRANT_MANY_TO_ONE_SUCCESS,
+                        [
+                            TextComponent::text("all".to_string()),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_GRANT_MANY_TO_MANY_SUCCESS,
+                        [
+                            TextComponent::text("all".to_string()),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count)
+        })
+    }
+}
+
+struct GrantOnlyExecutor;
+
+impl CommandExecutor for GrantOnlyExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+            let Some(Arg::Simple(advancement)) = args.get(ARG_ADVANCEMENT) else {
+                return Err(CommandError::InvalidConsumption(Some(
+                    ARG_ADVANCEMENT.into(),
+                )));
+            };
+
+            if targets.is_empty() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_ADVANCEMENT_GRANT_ONE_TO_ONE_FAILURE,
+                    [],
+                )));
+            }
+
+            // TODO: Implement advancement tracking and grant specific advancement
+
+            let count = targets.len() as i32;
+            if count == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_GRANT_ONE_TO_ONE_SUCCESS,
+                        [
+                            TextComponent::text(advancement.to_string()),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_GRANT_ONE_TO_MANY_SUCCESS,
+                        [
+                            TextComponent::text(advancement.to_string()),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count)
+        })
+    }
+}
+
+struct RevokeEverythingExecutor;
+
+impl CommandExecutor for RevokeEverythingExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+
+            if targets.is_empty() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_ADVANCEMENT_REVOKE_MANY_TO_ONE_FAILURE,
+                    [],
+                )));
+            }
+
+            // TODO: Implement advancement tracking and revoke all advancements
+
+            let count = targets.len() as i32;
+            if count == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_REVOKE_MANY_TO_ONE_SUCCESS,
+                        [
+                            TextComponent::text("all".to_string()),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_REVOKE_MANY_TO_MANY_SUCCESS,
+                        [
+                            TextComponent::text("all".to_string()),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count)
+        })
+    }
+}
+
+struct RevokeOnlyExecutor;
+
+impl CommandExecutor for RevokeOnlyExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+            let Some(Arg::Simple(advancement)) = args.get(ARG_ADVANCEMENT) else {
+                return Err(CommandError::InvalidConsumption(Some(
+                    ARG_ADVANCEMENT.into(),
+                )));
+            };
+
+            if targets.is_empty() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_ADVANCEMENT_REVOKE_ONE_TO_ONE_FAILURE,
+                    [],
+                )));
+            }
+
+            // TODO: Implement advancement tracking and revoke specific advancement
+
+            let count = targets.len() as i32;
+            if count == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_REVOKE_ONE_TO_ONE_SUCCESS,
+                        [
+                            TextComponent::text(advancement.to_string()),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ADVANCEMENT_REVOKE_ONE_TO_MANY_SUCCESS,
+                        [
+                            TextComponent::text(advancement.to_string()),
+                            TextComponent::text(count.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count)
+        })
+    }
+}
+
+fn grant_tree() -> crate::command::tree::builder::NonLeafNodeBuilder {
+    literal("grant").then(
+        argument(ARG_TARGETS, EntitiesArgumentConsumer)
+            .then(literal("everything").execute(GrantEverythingExecutor))
+            .then(
+                literal("only")
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantOnlyExecutor)),
+            )
+            .then(
+                literal("from")
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantOnlyExecutor)),
+            )
+            .then(
+                literal("through")
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantOnlyExecutor)),
+            )
+            .then(
+                literal("until")
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(GrantOnlyExecutor)),
+            ),
+    )
+}
+
+fn revoke_tree() -> crate::command::tree::builder::NonLeafNodeBuilder {
+    literal("revoke").then(
+        argument(ARG_TARGETS, EntitiesArgumentConsumer)
+            .then(literal("everything").execute(RevokeEverythingExecutor))
+            .then(
+                literal("only")
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeOnlyExecutor)),
+            )
+            .then(
+                literal("from")
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeOnlyExecutor)),
+            )
+            .then(
+                literal("through")
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeOnlyExecutor)),
+            )
+            .then(
+                literal("until")
+                    .then(argument(ARG_ADVANCEMENT, SimpleArgConsumer).execute(RevokeOnlyExecutor)),
+            ),
+    )
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(grant_tree())
+        .then(revoke_tree())
+}

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -7,6 +7,7 @@ use tokio::sync::RwLock;
 
 use super::dispatcher::CommandDispatcher;
 
+mod advancement;
 mod ban;
 mod banip;
 mod banlist;
@@ -134,6 +135,10 @@ pub async fn default_dispatcher(
         "minecraft:command.spawnpoint",
     );
     dispatcher.register(data::init_command_tree(), "minecraft:command.data");
+    dispatcher.register(
+        advancement::init_command_tree(),
+        "minecraft:command.advancement",
+    );
     // Three
     dispatcher.register(op::init_command_tree(), "minecraft:command.op");
     dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");
@@ -411,6 +416,13 @@ fn register_level_2_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.enchant",
             "Adds an enchantment to a player's selected item, subject to the same restrictions as an anvil. Also works on any mob or entity holding a weapon/tool/armor in its main hand.",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.advancement",
+            "Gives, removes, or checks player advancements",
             PermissionDefault::Op(PermissionLvl::Two),
         ))
         .unwrap();

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -191,7 +191,6 @@ impl PumpkinServer {
     pub fn log_info(&self, message: &str) {
         tracing::info!(target: "plugin", "{}", message);
     }
-    #[expect(clippy::if_then_some_else_none)]
     pub async fn new(
         basic_config: BasicConfiguration,
         advanced_config: AdvancedConfiguration,

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -420,7 +420,6 @@ impl Server {
             PlayerLoginEvent::new(player.clone(), TextComponent::text("You have been kicked from the server"));
             'after: {
                 player.screen_handler_sync_handler.store_player(player.clone()).await;
-                #[expect(clippy::if_then_some_else_none)]
                 if world
                     .add_player(player.clone())
                     .is_ok() {


### PR DESCRIPTION
- Implements `/advancement grant` and `/advancement revoke` with all vanilla subcommands
- Supports `everything`, `only`, `from`, `through`, `until` modes
- Uses vanilla translation keys for success/failure messages
- Advancement tracking system is TODO - command tree and message handling are complete