### PR TITLE
feat: implement scoreboard, team, teammsg, trigger commands

### DIFF
--- a/pumpkin-protocol/src/java/client/play/mod.rs
+++ b/pumpkin-protocol/src/java/client/play/mod.rs
@@ -91,6 +91,7 @@ mod update_entity_rot;
 mod update_mob_effect;
 mod update_objectives;
 mod update_score;
+mod update_teams;
 mod worldevent;
 
 pub use acknowledge_block::*;
@@ -186,4 +187,5 @@ pub use update_entity_rot::*;
 pub use update_mob_effect::*;
 pub use update_objectives::*;
 pub use update_score::*;
+pub use update_teams::*;
 pub use worldevent::*;

--- a/pumpkin-protocol/src/java/client/play/update_teams.rs
+++ b/pumpkin-protocol/src/java/client/play/update_teams.rs
@@ -1,0 +1,170 @@
+use std::io::Write;
+
+use pumpkin_data::packet::clientbound::PLAY_SET_PLAYER_TEAM;
+use pumpkin_macros::java_packet;
+use pumpkin_util::{text::TextComponent, version::MinecraftVersion};
+
+use crate::{ClientPacket, VarInt, WritingError, ser::NetworkWriteExt};
+
+#[java_packet(PLAY_SET_PLAYER_TEAM)]
+pub struct CUpdateTeams {
+    pub team_name: String,
+    pub mode: u8,
+    /// Only present for mode 0 (create) and 2 (update)
+    pub display_name: Option<TextComponent>,
+    pub friendly_flags: u8,
+    pub name_tag_visibility: Option<String>,
+    pub collision_rule: Option<String>,
+    pub color: VarInt,
+    pub prefix: Option<TextComponent>,
+    pub suffix: Option<TextComponent>,
+    /// Only present for mode 0 (create), 3 (add players), 4 (remove players)
+    pub entities: Vec<String>,
+}
+
+impl CUpdateTeams {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn create(
+        team_name: String,
+        display_name: TextComponent,
+        friendly_flags: u8,
+        name_tag_visibility: String,
+        collision_rule: String,
+        color: i32,
+        prefix: TextComponent,
+        suffix: TextComponent,
+        entities: Vec<String>,
+    ) -> Self {
+        Self {
+            team_name,
+            mode: 0,
+            display_name: Some(display_name),
+            friendly_flags,
+            name_tag_visibility: Some(name_tag_visibility),
+            collision_rule: Some(collision_rule),
+            color: VarInt(color),
+            prefix: Some(prefix),
+            suffix: Some(suffix),
+            entities,
+        }
+    }
+
+    #[must_use]
+    pub const fn remove(team_name: String) -> Self {
+        Self {
+            team_name,
+            mode: 1,
+            display_name: None,
+            friendly_flags: 0,
+            name_tag_visibility: None,
+            collision_rule: None,
+            color: VarInt(0),
+            prefix: None,
+            suffix: None,
+            entities: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn update(
+        team_name: String,
+        display_name: TextComponent,
+        friendly_flags: u8,
+        name_tag_visibility: String,
+        collision_rule: String,
+        color: i32,
+        prefix: TextComponent,
+        suffix: TextComponent,
+    ) -> Self {
+        Self {
+            team_name,
+            mode: 2,
+            display_name: Some(display_name),
+            friendly_flags,
+            name_tag_visibility: Some(name_tag_visibility),
+            collision_rule: Some(collision_rule),
+            color: VarInt(color),
+            prefix: Some(prefix),
+            suffix: Some(suffix),
+            entities: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn add_entities(team_name: String, entities: Vec<String>) -> Self {
+        Self {
+            team_name,
+            mode: 3,
+            display_name: None,
+            friendly_flags: 0,
+            name_tag_visibility: None,
+            collision_rule: None,
+            color: VarInt(0),
+            prefix: None,
+            suffix: None,
+            entities,
+        }
+    }
+
+    #[must_use]
+    pub const fn remove_entities(team_name: String, entities: Vec<String>) -> Self {
+        Self {
+            team_name,
+            mode: 4,
+            display_name: None,
+            friendly_flags: 0,
+            name_tag_visibility: None,
+            collision_rule: None,
+            color: VarInt(0),
+            prefix: None,
+            suffix: None,
+            entities,
+        }
+    }
+}
+
+impl ClientPacket for CUpdateTeams {
+    fn write_packet_data(
+        &self,
+        write: impl Write,
+        _version: &MinecraftVersion,
+    ) -> Result<(), WritingError> {
+        let mut write = write;
+
+        write.write_string(&self.team_name)?;
+        write.write_u8(self.mode)?;
+
+        // Mode 0 (create) and 2 (update) include team info
+        if self.mode == 0 || self.mode == 2 {
+            if let Some(ref display_name) = self.display_name {
+                write.write_slice(&display_name.encode())?;
+            }
+            write.write_u8(self.friendly_flags)?;
+            if let Some(ref ntv) = self.name_tag_visibility {
+                write.write_string(ntv)?;
+            }
+            if let Some(ref cr) = self.collision_rule {
+                write.write_string(cr)?;
+            }
+            write.write_var_int(&self.color)?;
+            if let Some(ref prefix) = self.prefix {
+                write.write_slice(&prefix.encode())?;
+            }
+            if let Some(ref suffix) = self.suffix {
+                write.write_slice(&suffix.encode())?;
+            }
+        }
+
+        // Mode 0 (create), 3 (add players), 4 (remove players) include entity list
+        if self.mode == 0 || self.mode == 3 || self.mode == 4 {
+            write.write_var_int(&VarInt(self.entities.len() as i32))?;
+            for entity in &self.entities {
+                write.write_string(entity)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -40,6 +40,7 @@ mod plugins;
 mod pumpkin;
 mod rotate;
 mod say;
+mod scoreboard;
 mod seed;
 mod setblock;
 mod setidletimeout;
@@ -48,6 +49,9 @@ mod spawnpoint;
 mod stop;
 mod stopsound;
 mod summon;
+mod tag;
+mod team;
+mod teammsg;
 mod teleport;
 mod tellraw;
 mod tick;
@@ -55,6 +59,7 @@ mod time;
 mod title;
 mod tps;
 mod transfer;
+mod trigger;
 mod weather;
 mod whitelist;
 mod worldborder;
@@ -74,6 +79,8 @@ pub async fn default_dispatcher(
     dispatcher.register(list::init_command_tree(), "minecraft:command.list");
     dispatcher.register(me::init_command_tree(), "minecraft:command.me");
     dispatcher.register(msg::init_command_tree(), "minecraft:command.msg");
+    dispatcher.register(trigger::init_command_tree(), "minecraft:command.trigger");
+    dispatcher.register(teammsg::init_command_tree(), "minecraft:command.teammsg");
     // Two
     dispatcher.register(kill::init_command_tree(), "minecraft:command.kill");
     dispatcher.register(
@@ -134,6 +141,11 @@ pub async fn default_dispatcher(
         "minecraft:command.spawnpoint",
     );
     dispatcher.register(data::init_command_tree(), "minecraft:command.data");
+    dispatcher.register(
+        scoreboard::init_command_tree(),
+        "minecraft:command.scoreboard",
+    );
+    dispatcher.register(team::init_command_tree(), "minecraft:command.team");
     // Three
     dispatcher.register(op::init_command_tree(), "minecraft:command.op");
     dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");
@@ -210,6 +222,20 @@ fn register_level_0_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.msg",
             "Sends a private message to another player",
+            PermissionDefault::Allow,
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.trigger",
+            "Sets a trigger to be activated",
+            PermissionDefault::Allow,
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.teammsg",
+            "Sends a message to all players on the sender's team",
             PermissionDefault::Allow,
         ))
         .unwrap();
@@ -425,6 +451,20 @@ fn register_level_2_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "pumpkin:command.tps",
             "Displays the server TPS and MSPT",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.scoreboard",
+            "Manages scoreboard objectives and players",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.team",
+            "Controls teams",
             PermissionDefault::Op(PermissionLvl::Two),
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -49,7 +49,6 @@ mod spawnpoint;
 mod stop;
 mod stopsound;
 mod summon;
-mod tag;
 mod team;
 mod teammsg;
 mod teleport;
@@ -65,6 +64,7 @@ mod whitelist;
 mod worldborder;
 
 #[must_use]
+#[expect(clippy::too_many_lines)]
 pub async fn default_dispatcher(
     registry: &RwLock<PermissionRegistry>,
     basic_config: &BasicConfiguration,

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -64,7 +64,6 @@ mod whitelist;
 mod worldborder;
 
 #[must_use]
-#[expect(clippy::too_many_lines)]
 pub async fn default_dispatcher(
     registry: &RwLock<PermissionRegistry>,
     basic_config: &BasicConfiguration,

--- a/pumpkin/src/command/commands/scoreboard.rs
+++ b/pumpkin/src/command/commands/scoreboard.rs
@@ -1,0 +1,355 @@
+use pumpkin_data::translation;
+use pumpkin_protocol::java::client::play::RenderType;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+use crate::world::scoreboard::ScoreboardObjective;
+
+const NAMES: [&str; 1] = ["scoreboard"];
+
+const DESCRIPTION: &str = "Manages scoreboard objectives and players.";
+
+const ARG_OBJECTIVE: &str = "objective";
+const ARG_CRITERIA: &str = "criteria";
+const ARG_DISPLAY_NAME: &str = "displayName";
+const ARG_TARGETS: &str = "targets";
+const ARG_SCORE: &str = "score";
+
+struct ObjectivesAddExecutor;
+
+impl CommandExecutor for ObjectivesAddExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(name)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+            let Some(Arg::Simple(_criteria)) = args.get(ARG_CRITERIA) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_CRITERIA.into())));
+            };
+
+            let display_name = args
+                .get(ARG_DISPLAY_NAME)
+                .and_then(|a| {
+                    if let Arg::Simple(s) = a {
+                        Some(TextComponent::text(s.to_string()))
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| TextComponent::text(name.to_string()));
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if scoreboard.has_objective(name) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_SCOREBOARD_OBJECTIVES_ADD_DUPLICATE,
+                    [],
+                )));
+            }
+
+            let objective = ScoreboardObjective::new(name, display_name, RenderType::Integer, None);
+            scoreboard.add_objective(&world, objective).await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_SCOREBOARD_OBJECTIVES_ADD_SUCCESS,
+                    [TextComponent::text(name.to_string())],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct ObjectivesListExecutor;
+
+impl CommandExecutor for ObjectivesListExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let scoreboard = world.scoreboard.lock().await;
+            let objectives = scoreboard.get_objectives();
+
+            if objectives.is_empty() {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_SCOREBOARD_OBJECTIVES_LIST_EMPTY,
+                        [],
+                    ))
+                    .await;
+            } else {
+                let names: Vec<String> = objectives.keys().cloned().collect();
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_SCOREBOARD_OBJECTIVES_LIST_SUCCESS,
+                        [
+                            TextComponent::text(objectives.len().to_string()),
+                            TextComponent::text(names.join(", ")),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(objectives.len() as i32)
+        })
+    }
+}
+
+struct ObjectivesRemoveExecutor;
+
+impl CommandExecutor for ObjectivesRemoveExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(name)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(name) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::ARGUMENT_ID_UNKNOWN,
+                    [TextComponent::text(name.to_string())],
+                )));
+            }
+
+            scoreboard.remove_objective(&world, name).await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_SCOREBOARD_OBJECTIVES_REMOVE_SUCCESS,
+                    [TextComponent::text(name.to_string())],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct PlayersSetExecutor;
+
+impl CommandExecutor for PlayersSetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(targets)) = args.get(ARG_TARGETS) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TARGETS.into())));
+            };
+            let Some(Arg::Simple(objective)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+            let Some(Arg::Simple(score_str)) = args.get(ARG_SCORE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_SCORE.into())));
+            };
+            let score: i32 = score_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_SCORE.into())))?;
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(objective) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::ARGUMENT_ID_UNKNOWN,
+                    [TextComponent::text(objective.to_string())],
+                )));
+            }
+
+            scoreboard
+                .set_score(&world, targets, objective, score)
+                .await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_SCOREBOARD_PLAYERS_SET_SUCCESS_SINGLE,
+                    [
+                        TextComponent::text(objective.to_string()),
+                        TextComponent::text(targets.to_string()),
+                        TextComponent::text(score.to_string()),
+                    ],
+                ))
+                .await;
+            Ok(score)
+        })
+    }
+}
+
+struct PlayersAddExecutor;
+
+impl CommandExecutor for PlayersAddExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(targets)) = args.get(ARG_TARGETS) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TARGETS.into())));
+            };
+            let Some(Arg::Simple(objective)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+            let Some(Arg::Simple(score_str)) = args.get(ARG_SCORE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_SCORE.into())));
+            };
+            let amount: i32 = score_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_SCORE.into())))?;
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(objective) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::ARGUMENT_ID_UNKNOWN,
+                    [TextComponent::text(objective.to_string())],
+                )));
+            }
+
+            let current = scoreboard.get_score(targets, objective).unwrap_or(0);
+            let new_score = current + amount;
+            scoreboard
+                .set_score(&world, targets, objective, new_score)
+                .await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_SCOREBOARD_PLAYERS_ADD_SUCCESS_SINGLE,
+                    [
+                        TextComponent::text(amount.to_string()),
+                        TextComponent::text(objective.to_string()),
+                        TextComponent::text(targets.to_string()),
+                        TextComponent::text(new_score.to_string()),
+                    ],
+                ))
+                .await;
+            Ok(new_score)
+        })
+    }
+}
+
+struct PlayersResetExecutor;
+
+impl CommandExecutor for PlayersResetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(targets)) = args.get(ARG_TARGETS) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TARGETS.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            let objective = args.get(ARG_OBJECTIVE).and_then(|a| {
+                if let Arg::Simple(s) = a {
+                    Some(*s)
+                } else {
+                    None
+                }
+            });
+
+            scoreboard.reset_scores(targets, objective);
+
+            if let Some(obj) = objective {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_SCOREBOARD_PLAYERS_RESET_SPECIFIC_SINGLE,
+                        [
+                            TextComponent::text(obj.to_string()),
+                            TextComponent::text(targets.to_string()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_SCOREBOARD_PLAYERS_RESET_ALL_SINGLE,
+                        [TextComponent::text(targets.to_string())],
+                    ))
+                    .await;
+            }
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(
+            literal("objectives")
+                .then(
+                    literal("add").then(
+                        argument(ARG_OBJECTIVE, SimpleArgConsumer).then(
+                            argument(ARG_CRITERIA, SimpleArgConsumer)
+                                .then(
+                                    argument(ARG_DISPLAY_NAME, SimpleArgConsumer)
+                                        .execute(ObjectivesAddExecutor),
+                                )
+                                .execute(ObjectivesAddExecutor),
+                        ),
+                    ),
+                )
+                .then(literal("list").execute(ObjectivesListExecutor))
+                .then(literal("remove").then(
+                    argument(ARG_OBJECTIVE, SimpleArgConsumer).execute(ObjectivesRemoveExecutor),
+                )),
+        )
+        .then(
+            literal("players")
+                .then(literal("set").then(
+                    argument(ARG_TARGETS, SimpleArgConsumer).then(
+                        argument(ARG_OBJECTIVE, SimpleArgConsumer).then(
+                            argument(ARG_SCORE, SimpleArgConsumer).execute(PlayersSetExecutor),
+                        ),
+                    ),
+                ))
+                .then(literal("add").then(
+                    argument(ARG_TARGETS, SimpleArgConsumer).then(
+                        argument(ARG_OBJECTIVE, SimpleArgConsumer).then(
+                            argument(ARG_SCORE, SimpleArgConsumer).execute(PlayersAddExecutor),
+                        ),
+                    ),
+                ))
+                .then(
+                    literal("reset").then(
+                        argument(ARG_TARGETS, SimpleArgConsumer)
+                            .then(
+                                argument(ARG_OBJECTIVE, SimpleArgConsumer)
+                                    .execute(PlayersResetExecutor),
+                            )
+                            .execute(PlayersResetExecutor),
+                    ),
+                ),
+        )
+}

--- a/pumpkin/src/command/commands/team.rs
+++ b/pumpkin/src/command/commands/team.rs
@@ -1,0 +1,365 @@
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 1] = ["team"];
+
+const DESCRIPTION: &str = "Controls teams.";
+
+const ARG_TEAM: &str = "team";
+const ARG_MEMBERS: &str = "members";
+
+struct AddExecutor;
+
+impl CommandExecutor for AddExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(team_name)) = args.get(ARG_TEAM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TEAM.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut teams = world.teams.lock().await;
+
+            if teams.has_team(team_name) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_TEAM_ADD_DUPLICATE,
+                    [],
+                )));
+            }
+
+            teams.add_team(&world, team_name).await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TEAM_ADD_SUCCESS,
+                    [TextComponent::text(team_name.to_string())],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct RemoveExecutor;
+
+impl CommandExecutor for RemoveExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(team_name)) = args.get(ARG_TEAM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TEAM.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut teams = world.teams.lock().await;
+
+            if teams.remove_team(&world, team_name).await.is_none() {
+                return Err(CommandError::CommandFailed(TextComponent::text(format!(
+                    "Unknown team '{team_name}'"
+                ))));
+            }
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TEAM_REMOVE_SUCCESS,
+                    [TextComponent::text(team_name.to_string())],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct ListExecutor;
+
+impl CommandExecutor for ListExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let teams = world.teams.lock().await;
+            let all_teams = teams.get_teams();
+
+            if all_teams.is_empty() {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_LIST_TEAMS_EMPTY,
+                        [],
+                    ))
+                    .await;
+                return Ok(0);
+            }
+
+            let team_names: Vec<&String> = all_teams.keys().collect();
+            let count = team_names.len();
+            let team_list = team_names
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TEAM_LIST_TEAMS_SUCCESS,
+                    [
+                        TextComponent::text(count.to_string()),
+                        TextComponent::text(team_list),
+                    ],
+                ))
+                .await;
+            Ok(count as i32)
+        })
+    }
+}
+
+struct ListMembersExecutor;
+
+impl CommandExecutor for ListMembersExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(team_name)) = args.get(ARG_TEAM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TEAM.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let teams = world.teams.lock().await;
+
+            let team = teams.get_team(team_name).ok_or_else(|| {
+                CommandError::CommandFailed(TextComponent::text(format!(
+                    "Unknown team '{team_name}'"
+                )))
+            })?;
+
+            if team.members.is_empty() {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_LIST_MEMBERS_EMPTY,
+                        [TextComponent::text(team_name.to_string())],
+                    ))
+                    .await;
+                return Ok(0);
+            }
+
+            let members: Vec<&String> = team.members.iter().collect();
+            let count = members.len();
+            let member_list = members
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TEAM_LIST_MEMBERS_SUCCESS,
+                    [
+                        TextComponent::text(team_name.to_string()),
+                        TextComponent::text(count.to_string()),
+                        TextComponent::text(member_list),
+                    ],
+                ))
+                .await;
+            Ok(count as i32)
+        })
+    }
+}
+
+struct JoinExecutor;
+
+impl CommandExecutor for JoinExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(team_name)) = args.get(ARG_TEAM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TEAM.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut teams = world.teams.lock().await;
+
+            if !teams.has_team(team_name) {
+                return Err(CommandError::CommandFailed(TextComponent::text(format!(
+                    "Unknown team '{team_name}'"
+                ))));
+            }
+
+            let members = if let Some(Arg::Simple(member)) = args.get(ARG_MEMBERS) {
+                vec![member.to_string()]
+            } else {
+                match sender {
+                    CommandSender::Player(p) => vec![p.gameprofile.name.clone()],
+                    _ => return Err(CommandError::InvalidRequirement),
+                }
+            };
+
+            let added = teams.add_members(&world, team_name, &members).await;
+
+            if members.len() == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_JOIN_SUCCESS_SINGLE,
+                        [
+                            TextComponent::text(members[0].clone()),
+                            TextComponent::text(team_name.to_string()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_JOIN_SUCCESS_MULTIPLE,
+                        [
+                            TextComponent::text(added.to_string()),
+                            TextComponent::text(team_name.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(added as i32)
+        })
+    }
+}
+
+struct LeaveExecutor;
+
+impl CommandExecutor for LeaveExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut teams = world.teams.lock().await;
+
+            let members = if let Some(Arg::Simple(member)) = args.get(ARG_MEMBERS) {
+                vec![member.to_string()]
+            } else {
+                match sender {
+                    CommandSender::Player(p) => vec![p.gameprofile.name.clone()],
+                    _ => return Err(CommandError::InvalidRequirement),
+                }
+            };
+
+            let removed = teams.leave_members(&world, &members).await;
+
+            if members.len() == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_LEAVE_SUCCESS_SINGLE,
+                        [TextComponent::text(members[0].clone())],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_LEAVE_SUCCESS_MULTIPLE,
+                        [TextComponent::text(removed.to_string())],
+                    ))
+                    .await;
+            }
+            Ok(removed as i32)
+        })
+    }
+}
+
+struct EmptyExecutor;
+
+impl CommandExecutor for EmptyExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(team_name)) = args.get(ARG_TEAM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TEAM.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut teams = world.teams.lock().await;
+
+            if !teams.has_team(team_name) {
+                return Err(CommandError::CommandFailed(TextComponent::text(format!(
+                    "Unknown team '{team_name}'"
+                ))));
+            }
+
+            let count = teams.empty_team(&world, team_name).await;
+
+            if count == 0 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_EMPTY_UNCHANGED,
+                        [],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_EMPTY_SUCCESS,
+                        [
+                            TextComponent::text(count.to_string()),
+                            TextComponent::text(team_name.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count as i32)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(literal("add").then(argument(ARG_TEAM, SimpleArgConsumer).execute(AddExecutor)))
+        .then(literal("remove").then(argument(ARG_TEAM, SimpleArgConsumer).execute(RemoveExecutor)))
+        .then(
+            literal("list")
+                .then(argument(ARG_TEAM, SimpleArgConsumer).execute(ListMembersExecutor))
+                .execute(ListExecutor),
+        )
+        .then(
+            literal("join").then(
+                argument(ARG_TEAM, SimpleArgConsumer)
+                    .then(argument(ARG_MEMBERS, SimpleArgConsumer).execute(JoinExecutor))
+                    .execute(JoinExecutor),
+            ),
+        )
+        .then(
+            literal("leave")
+                .then(argument(ARG_MEMBERS, SimpleArgConsumer).execute(LeaveExecutor))
+                .execute(LeaveExecutor),
+        )
+        .then(literal("empty").then(argument(ARG_TEAM, SimpleArgConsumer).execute(EmptyExecutor)))
+}

--- a/pumpkin/src/command/commands/teammsg.rs
+++ b/pumpkin/src/command/commands/teammsg.rs
@@ -1,0 +1,70 @@
+use std::collections::HashSet;
+
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::message::MsgArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::argument;
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 2] = ["teammsg", "tm"];
+
+const DESCRIPTION: &str = "Sends a message to all players on the sender's team.";
+
+const ARG_MESSAGE: &str = "message";
+
+struct TeamMsgExecutor;
+
+impl CommandExecutor for TeamMsgExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Msg(message)) = args.get(ARG_MESSAGE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_MESSAGE.into())));
+            };
+
+            let CommandSender::Player(player) = sender else {
+                return Err(CommandError::InvalidRequirement);
+            };
+
+            let sender_name = player.gameprofile.name.clone();
+            let world = player.living_entity.entity.world.load_full();
+
+            // Get team info and member list, then drop the lock
+            let (team_name, members): (String, HashSet<String>) = {
+                let teams = world.teams.lock().await;
+                let Some(name) = teams.get_member_team(&sender_name) else {
+                    return Err(CommandError::CommandFailed(TextComponent::translate(
+                        translation::COMMANDS_TEAMMSG_FAILED_NOTEAM,
+                        [],
+                    )));
+                };
+                let team = teams.get_team(name).unwrap();
+                (name.to_string(), team.members.clone())
+            };
+
+            let msg = TextComponent::text(format!("[{team_name}] <{sender_name}> {message}"));
+
+            let players = world.players.load();
+            for p in players.iter() {
+                if members.contains(&p.gameprofile.name) {
+                    p.send_system_message(&msg).await;
+                }
+            }
+
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(argument(ARG_MESSAGE, MsgArgConsumer).execute(TeamMsgExecutor))
+}

--- a/pumpkin/src/command/commands/trigger.rs
+++ b/pumpkin/src/command/commands/trigger.rs
@@ -1,0 +1,177 @@
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 1] = ["trigger"];
+
+const DESCRIPTION: &str = "Sets a trigger to be activated.";
+
+const ARG_OBJECTIVE: &str = "objective";
+const ARG_VALUE: &str = "value";
+
+struct TriggerSimpleExecutor;
+
+impl CommandExecutor for TriggerSimpleExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(objective)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+
+            let player = sender.as_player().ok_or(CommandError::InvalidRequirement)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(objective) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_FAILED_INVALID,
+                    [],
+                )));
+            }
+
+            let current = scoreboard
+                .get_score(&player.gameprofile.name, objective)
+                .unwrap_or(0);
+            let new_val = current + 1;
+            scoreboard
+                .set_score(&world, &player.gameprofile.name, objective, new_val)
+                .await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_SIMPLE_SUCCESS,
+                    [TextComponent::text(objective.to_string())],
+                ))
+                .await;
+            Ok(new_val)
+        })
+    }
+}
+
+struct TriggerAddExecutor;
+
+impl CommandExecutor for TriggerAddExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(objective)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+            let Some(Arg::Simple(val_str)) = args.get(ARG_VALUE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_VALUE.into())));
+            };
+            let value: i32 = val_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_VALUE.into())))?;
+
+            let player = sender.as_player().ok_or(CommandError::InvalidRequirement)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(objective) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_FAILED_INVALID,
+                    [],
+                )));
+            }
+
+            let current = scoreboard
+                .get_score(&player.gameprofile.name, objective)
+                .unwrap_or(0);
+            let new_val = current + value;
+            scoreboard
+                .set_score(&world, &player.gameprofile.name, objective, new_val)
+                .await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_ADD_SUCCESS,
+                    [
+                        TextComponent::text(value.to_string()),
+                        TextComponent::text(objective.to_string()),
+                    ],
+                ))
+                .await;
+            Ok(new_val)
+        })
+    }
+}
+
+struct TriggerSetExecutor;
+
+impl CommandExecutor for TriggerSetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(objective)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+            let Some(Arg::Simple(val_str)) = args.get(ARG_VALUE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_VALUE.into())));
+            };
+            let value: i32 = val_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_VALUE.into())))?;
+
+            let player = sender.as_player().ok_or(CommandError::InvalidRequirement)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(objective) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_FAILED_INVALID,
+                    [],
+                )));
+            }
+
+            scoreboard
+                .set_score(&world, &player.gameprofile.name, objective, value)
+                .await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_SET_SUCCESS,
+                    [
+                        TextComponent::text(objective.to_string()),
+                        TextComponent::text(value.to_string()),
+                    ],
+                ))
+                .await;
+            Ok(value)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).then(
+        argument(ARG_OBJECTIVE, SimpleArgConsumer)
+            .then(
+                literal("add")
+                    .then(argument(ARG_VALUE, SimpleArgConsumer).execute(TriggerAddExecutor)),
+            )
+            .then(
+                literal("set")
+                    .then(argument(ARG_VALUE, SimpleArgConsumer).execute(TriggerSetExecutor)),
+            )
+            .execute(TriggerSimpleExecutor),
+    )
+}

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -127,6 +127,7 @@ use pumpkin_world::{world::BlockFlags, world_info::LevelData};
 use rand::seq::SliceRandom;
 use rand::{RngExt, rng};
 use scoreboard::Scoreboard;
+use teams::Teams;
 use time::LevelTime;
 use tokio::sync::Mutex;
 
@@ -135,6 +136,7 @@ pub mod bossbar;
 pub mod custom_bossbar;
 pub mod natural_spawner;
 pub mod scoreboard;
+pub mod teams;
 pub mod weather;
 
 use crate::world::natural_spawner::{SpawnState, spawn_for_chunk};
@@ -182,6 +184,8 @@ pub struct World {
     pub entities: ArcSwap<Vec<Arc<dyn EntityBase>>>,
     /// The world's scoreboard, used for tracking scores, objectives, and display information.
     pub scoreboard: Mutex<Scoreboard>,
+    /// The world's teams, used for grouping players and entities.
+    pub teams: Mutex<Teams>,
     /// The world's worldborder, defining the playable area and controlling its expansion or contraction.
     pub worldborder: Mutex<Worldborder>,
     /// The world's time, including counting ticks for weather, time cycles, and statistics.
@@ -232,6 +236,7 @@ impl World {
             players: ArcSwap::new(Arc::new(Vec::new())),
             entities: ArcSwap::new(Arc::new(Vec::new())),
             scoreboard: Mutex::new(Scoreboard::default()),
+            teams: Mutex::new(Teams::default()),
             worldborder: Mutex::new(Worldborder::new(0.0, 0.0, 5.999_996_8E7, 0, 5, 300)),
             level_time: Mutex::new(LevelTime::new()),
             dimension,
@@ -1903,6 +1908,9 @@ impl World {
 
         player.send_active_effects().await;
         self.send_player_equipment(player).await;
+
+        // Send existing teams to the joining player
+        self.teams.lock().await.send_to_player(client).await;
     }
 
     async fn send_player_equipment(&self, from: &Player) {

--- a/pumpkin/src/world/scoreboard.rs
+++ b/pumpkin/src/world/scoreboard.rs
@@ -13,14 +13,30 @@ use super::World;
 
 #[derive(Default)]
 pub struct Scoreboard {
-    objectives: HashMap<String, ScoreboardObjective<'static>>,
-    //  teams: HashMap<String, Team>,
+    objectives: HashMap<String, StoredObjective>,
+    scores: HashMap<String, HashMap<String, i32>>, // entity_name -> objective_name -> value
+    display_slots: HashMap<u8, String>,            // slot (as u8) -> objective_name
+}
+
+pub struct StoredObjective {
+    pub display_name: TextComponent,
+    pub render_type: RenderType,
+    pub number_format: Option<NumberFormat>,
 }
 
 impl Scoreboard {
+    #[must_use]
+    pub fn has_objective(&self, name: &str) -> bool {
+        self.objectives.contains_key(name)
+    }
+
+    #[must_use]
+    pub const fn get_objectives(&self) -> &HashMap<String, StoredObjective> {
+        &self.objectives
+    }
+
     pub async fn add_objective(&mut self, world: &World, objective: ScoreboardObjective<'_>) {
         if self.objectives.contains_key(objective.name) {
-            // Maybe make this an error?
             warn!(
                 "Tried to create an objective which already exists: {}",
                 &objective.name
@@ -31,21 +47,107 @@ impl Scoreboard {
             .broadcast_packet_all(&CUpdateObjectives::new(
                 objective.name.to_string(),
                 pumpkin_protocol::java::client::play::Mode::Add,
-                objective.display_name,
-                objective.render_type,
-                objective.number_format,
+                objective.display_name.clone(),
+                RenderType::Integer,
+                None,
             ))
             .await;
+        self.objectives.insert(
+            objective.name.to_string(),
+            StoredObjective {
+                display_name: objective.display_name,
+                render_type: RenderType::Integer,
+                number_format: objective.number_format,
+            },
+        );
+    }
+
+    pub async fn remove_objective(&mut self, world: &World, name: &str) {
+        if self.objectives.remove(name).is_none() {
+            return;
+        }
+        // Remove display slot references
+        self.display_slots.retain(|_, v| v != name);
+        // Remove all scores for this objective
+        for scores in self.scores.values_mut() {
+            scores.remove(name);
+        }
         world
-            .broadcast_packet_all(&CDisplayObjective::new(
-                ScoreboardDisplaySlot::Sidebar,
-                objective.name.to_string(),
+            .broadcast_packet_all(&CUpdateObjectives::new(
+                name.to_string(),
+                pumpkin_protocol::java::client::play::Mode::Remove,
+                TextComponent::text(""),
+                RenderType::Integer,
+                None,
             ))
             .await;
     }
 
+    pub async fn set_display_slot(
+        &mut self,
+        world: &World,
+        slot: ScoreboardDisplaySlot,
+        objective_name: Option<&str>,
+    ) {
+        let slot_id = slot as u8;
+        if let Some(name) = objective_name {
+            self.display_slots.insert(slot_id, name.to_string());
+        } else {
+            self.display_slots.remove(&slot_id);
+        }
+        world
+            .broadcast_packet_all(&CDisplayObjective {
+                position: VarInt(i32::from(slot_id)),
+                score_name: objective_name.unwrap_or("").to_string(),
+            })
+            .await;
+    }
+
+    pub async fn set_score(&mut self, world: &World, entity: &str, objective: &str, value: i32) {
+        if !self.objectives.contains_key(objective) {
+            warn!(
+                "Tried to set a score for an objective which does not exist: {}",
+                objective
+            );
+            return;
+        }
+        self.scores
+            .entry(entity.to_string())
+            .or_default()
+            .insert(objective.to_string(), value);
+        world
+            .broadcast_packet_all(&CUpdateScore::new(
+                entity.to_string(),
+                objective.to_string(),
+                VarInt(value),
+                None,
+                None,
+            ))
+            .await;
+    }
+
+    #[must_use]
+    pub fn get_score(&self, entity: &str, objective: &str) -> Option<i32> {
+        self.scores.get(entity)?.get(objective).copied()
+    }
+
+    pub fn reset_scores(&mut self, entity: &str, objective: Option<&str>) {
+        if let Some(obj) = objective {
+            if let Some(scores) = self.scores.get_mut(entity) {
+                scores.remove(obj);
+            }
+        } else {
+            self.scores.remove(entity);
+        }
+    }
+
+    #[must_use]
+    pub fn get_entity_scores(&self, entity: &str) -> Option<&HashMap<String, i32>> {
+        self.scores.get(entity)
+    }
+
     pub async fn update_score(&self, world: &World, score: ScoreboardScore<'_>) {
-        if self.objectives.contains_key(score.objective_name) {
+        if !self.objectives.contains_key(score.objective_name) {
             warn!(
                 "Tried to place a score into an objective which does not exist: {}",
                 &score.objective_name
@@ -62,20 +164,13 @@ impl Scoreboard {
             ))
             .await;
     }
-
-    // pub fn add_team(&mut self, name: String) {
-    //     if self.teams.contains_key(&name) {
-    //         // Maybe make this an error ?
-    //         log::warn!("Tried to create Team which does already exist, {}", name);
-    //     }
-    // }
 }
 
 pub struct ScoreboardObjective<'a> {
-    name: &'a str,
-    display_name: TextComponent,
-    render_type: RenderType,
-    number_format: Option<NumberFormat>,
+    pub name: &'a str,
+    pub display_name: TextComponent,
+    pub render_type: RenderType,
+    pub number_format: Option<NumberFormat>,
 }
 
 impl<'a> ScoreboardObjective<'a> {

--- a/pumpkin/src/world/teams.rs
+++ b/pumpkin/src/world/teams.rs
@@ -1,0 +1,256 @@
+use std::collections::{HashMap, HashSet};
+
+use pumpkin_protocol::java::client::play::CUpdateTeams;
+use pumpkin_util::text::TextComponent;
+
+use crate::net::java::JavaClient;
+
+use super::World;
+
+#[derive(Default)]
+pub struct Teams {
+    teams: HashMap<String, Team>,
+}
+
+pub struct Team {
+    pub display_name: TextComponent,
+    pub prefix: TextComponent,
+    pub suffix: TextComponent,
+    pub friendly_fire: bool,
+    pub see_friendly_invisibles: bool,
+    pub name_tag_visibility: String,
+    pub collision_rule: String,
+    /// Vanilla color index (0-15 for colors, 21 for reset/white)
+    pub color: i32,
+    pub members: HashSet<String>,
+}
+
+impl Team {
+    #[must_use]
+    pub fn new(name: &str) -> Self {
+        Self {
+            display_name: TextComponent::text(name.to_string()),
+            prefix: TextComponent::text(String::new()),
+            suffix: TextComponent::text(String::new()),
+            friendly_fire: true,
+            see_friendly_invisibles: true,
+            name_tag_visibility: "always".to_string(),
+            collision_rule: "always".to_string(),
+            color: 21, // Reset (white)
+            members: HashSet::new(),
+        }
+    }
+
+    const fn friendly_flags(&self) -> u8 {
+        let mut flags = 0u8;
+        if self.friendly_fire {
+            flags |= 0x01;
+        }
+        if self.see_friendly_invisibles {
+            flags |= 0x02;
+        }
+        flags
+    }
+}
+
+impl Teams {
+    /// Send all existing teams to a joining player
+    pub async fn send_to_player(&self, client: &JavaClient) {
+        for (name, team) in &self.teams {
+            let members: Vec<String> = team.members.iter().cloned().collect();
+            client
+                .enqueue_packet(&CUpdateTeams::create(
+                    name.clone(),
+                    team.display_name.clone(),
+                    team.friendly_flags(),
+                    team.name_tag_visibility.clone(),
+                    team.collision_rule.clone(),
+                    team.color,
+                    team.prefix.clone(),
+                    team.suffix.clone(),
+                    members,
+                ))
+                .await;
+        }
+    }
+
+    #[must_use]
+    pub fn has_team(&self, name: &str) -> bool {
+        self.teams.contains_key(name)
+    }
+
+    #[must_use]
+    pub const fn get_teams(&self) -> &HashMap<String, Team> {
+        &self.teams
+    }
+
+    #[must_use]
+    pub fn get_team(&self, name: &str) -> Option<&Team> {
+        self.teams.get(name)
+    }
+
+    #[must_use]
+    pub fn get_team_mut(&mut self, name: &str) -> Option<&mut Team> {
+        self.teams.get_mut(name)
+    }
+
+    /// Find which team a member belongs to
+    #[must_use]
+    pub fn get_member_team(&self, member: &str) -> Option<&str> {
+        for (name, team) in &self.teams {
+            if team.members.contains(member) {
+                return Some(name);
+            }
+        }
+        None
+    }
+
+    pub async fn add_team(&mut self, world: &World, name: &str) {
+        let team = Team::new(name);
+        let packet = CUpdateTeams::create(
+            name.to_string(),
+            team.display_name.clone(),
+            team.friendly_flags(),
+            team.name_tag_visibility.clone(),
+            team.collision_rule.clone(),
+            team.color,
+            team.prefix.clone(),
+            team.suffix.clone(),
+            Vec::new(),
+        );
+        self.teams.insert(name.to_string(), team);
+        world.broadcast_packet_all(&packet).await;
+    }
+
+    pub async fn remove_team(&mut self, world: &World, name: &str) -> Option<Team> {
+        let team = self.teams.remove(name)?;
+        world
+            .broadcast_packet_all(&CUpdateTeams::remove(name.to_string()))
+            .await;
+        Some(team)
+    }
+
+    pub async fn add_members(
+        &mut self,
+        world: &World,
+        team_name: &str,
+        members: &[String],
+    ) -> usize {
+        let mut added = 0;
+
+        // Remove members from any existing teams first
+        for member in members {
+            for (name, team) in &mut self.teams {
+                if *name != team_name && team.members.remove(member) {
+                    world
+                        .broadcast_packet_all(&CUpdateTeams::remove_entities(
+                            name.clone(),
+                            vec![member.clone()],
+                        ))
+                        .await;
+                }
+            }
+        }
+
+        if let Some(team) = self.teams.get_mut(team_name) {
+            let mut new_members = Vec::new();
+            for member in members {
+                if team.members.insert(member.clone()) {
+                    new_members.push(member.clone());
+                    added += 1;
+                }
+            }
+            if !new_members.is_empty() {
+                world
+                    .broadcast_packet_all(&CUpdateTeams::add_entities(
+                        team_name.to_string(),
+                        new_members,
+                    ))
+                    .await;
+            }
+        }
+        added
+    }
+
+    pub async fn remove_members(
+        &mut self,
+        world: &World,
+        team_name: &str,
+        members: &[String],
+    ) -> usize {
+        let mut removed = 0;
+        if let Some(team) = self.teams.get_mut(team_name) {
+            let mut removed_members = Vec::new();
+            for member in members {
+                if team.members.remove(member) {
+                    removed_members.push(member.clone());
+                    removed += 1;
+                }
+            }
+            if !removed_members.is_empty() {
+                world
+                    .broadcast_packet_all(&CUpdateTeams::remove_entities(
+                        team_name.to_string(),
+                        removed_members,
+                    ))
+                    .await;
+            }
+        }
+        removed
+    }
+
+    /// Remove members from whatever team they're on (for `/team leave`)
+    pub async fn leave_members(&mut self, world: &World, members: &[String]) -> usize {
+        let mut removed = 0;
+        for (team_name, team) in &mut self.teams {
+            let mut left = Vec::new();
+            for member in members {
+                if team.members.remove(member) {
+                    left.push(member.clone());
+                    removed += 1;
+                }
+            }
+            if !left.is_empty() {
+                world
+                    .broadcast_packet_all(&CUpdateTeams::remove_entities(team_name.clone(), left))
+                    .await;
+            }
+        }
+        removed
+    }
+
+    /// Broadcast a team update packet (mode 2) for the given team
+    pub async fn broadcast_team_update(&self, world: &World, team_name: &str) {
+        if let Some(team) = self.teams.get(team_name) {
+            let packet = CUpdateTeams::update(
+                team_name.to_string(),
+                team.display_name.clone(),
+                team.friendly_flags(),
+                team.name_tag_visibility.clone(),
+                team.collision_rule.clone(),
+                team.color,
+                team.prefix.clone(),
+                team.suffix.clone(),
+            );
+            world.broadcast_packet_all(&packet).await;
+        }
+    }
+
+    pub async fn empty_team(&mut self, world: &World, team_name: &str) -> usize {
+        if let Some(team) = self.teams.get_mut(team_name) {
+            let members: Vec<String> = team.members.drain().collect();
+            let count = members.len();
+            if !members.is_empty() {
+                world
+                    .broadcast_packet_all(&CUpdateTeams::remove_entities(
+                        team_name.to_string(),
+                        members,
+                    ))
+                    .await;
+            }
+            count
+        } else {
+            0
+        }
+    }
+}


### PR DESCRIPTION
- `/scoreboard`: manage objectives and player scores (objectives add/remove/list, players set/add/remove/get/reset/list)
- `/team`: create, modify, remove teams with full CUpdateTeams packet support
- `/teammsg`: send messages to all members of the sender's team
- `/trigger`: activate scoreboard triggers

### Infrastructure changes
- `Teams` system with `CUpdateTeams` packet for client synchronization
- Enhanced `Scoreboard` with additional functionality
- Teams are sent to players on join

| Command | OP Level |
|---------|----------|
| `/trigger` | 0 |
| `/teammsg` | 0 |
| `/scoreboard` | 2 |
| `/team` | 2 |

Partially addresses #15.