### PR TITLE
feat: implement clone, fillbiome, spreadplayers, random commands

### DIFF
--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -408,7 +408,7 @@ impl ChunkSections {
     }
 
     pub fn set_relative_biome(
-        &mut self,
+        &self,
         relative_x: usize,
         relative_y: usize,
         relative_z: usize,

--- a/pumpkin/src/command/commands/clone.rs
+++ b/pumpkin/src/command/commands/clone.rs
@@ -1,0 +1,323 @@
+use std::sync::Arc;
+
+use pumpkin_data::translation;
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::vector3::Vector3;
+use pumpkin_util::text::TextComponent;
+use pumpkin_world::world::BlockFlags;
+
+use crate::command::args::block::BlockPredicateArgumentConsumer;
+use crate::command::args::position_block::BlockPosArgumentConsumer;
+use crate::command::args::{ConsumedArgs, FindArg};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+use crate::world::World;
+
+const NAMES: [&str; 1] = ["clone"];
+
+const DESCRIPTION: &str = "Copies blocks from one region to another.";
+
+const ARG_BEGIN: &str = "begin";
+const ARG_END: &str = "end";
+const ARG_DESTINATION: &str = "destination";
+const ARG_FILTER: &str = "filter";
+
+#[derive(Clone, Copy, Default)]
+enum MaskMode {
+    #[default]
+    Replace,
+    Masked,
+    Filtered,
+}
+
+#[derive(Clone, Copy, Default)]
+enum CloneMode {
+    Force,
+    Move,
+    #[default]
+    Normal,
+}
+
+struct CloneExecutor {
+    mask_mode: MaskMode,
+    clone_mode: CloneMode,
+}
+
+struct StoredBlock {
+    pos: BlockPos,
+    state_id: u16,
+}
+
+const fn regions_overlap(src_min: Vector3<i32>, src_max: Vector3<i32>, dst: Vector3<i32>) -> bool {
+    let size = Vector3::new(
+        src_max.x - src_min.x,
+        src_max.y - src_min.y,
+        src_max.z - src_min.z,
+    );
+    let dst_max = Vector3::new(dst.x + size.x, dst.y + size.y, dst.z + size.z);
+
+    src_min.x <= dst_max.x
+        && src_max.x >= dst.x
+        && src_min.y <= dst_max.y
+        && src_max.y >= dst.y
+        && src_min.z <= dst_max.z
+        && src_max.z >= dst.z
+}
+
+async fn place_blocks(
+    world: &Arc<World>,
+    blocks: &[StoredBlock],
+    offset: Vector3<i32>,
+    clone_mode: CloneMode,
+) -> i32 {
+    let mut placed = 0i32;
+    for block in blocks {
+        let dst_pos = BlockPos(Vector3::new(
+            block.pos.0.x + offset.x,
+            block.pos.0.y + offset.y,
+            block.pos.0.z + offset.z,
+        ));
+        if world.is_in_build_limit(dst_pos) {
+            world
+                .set_block_state(&dst_pos, block.state_id, BlockFlags::NOTIFY_ALL)
+                .await;
+            placed += 1;
+        }
+    }
+
+    if matches!(clone_mode, CloneMode::Move) {
+        for block in blocks {
+            world
+                .set_block_state(&block.pos, 0, BlockFlags::NOTIFY_ALL)
+                .await;
+        }
+    }
+
+    placed
+}
+
+async fn collect_blocks(
+    world: &Arc<World>,
+    src_min: Vector3<i32>,
+    src_max: Vector3<i32>,
+    mask_mode: MaskMode,
+    filter: Option<&crate::command::args::block::BlockPredicate>,
+) -> Vec<StoredBlock> {
+    let mut blocks = Vec::new();
+    for x in src_min.x..=src_max.x {
+        for y in src_min.y..=src_max.y {
+            for z in src_min.z..=src_max.z {
+                let pos = BlockPos(Vector3::new(x, y, z));
+                let state_id = world.get_block_state_id(&pos).await;
+
+                let include = match mask_mode {
+                    MaskMode::Replace => true,
+                    MaskMode::Masked => !pumpkin_data::block_properties::is_air(state_id),
+                    MaskMode::Filtered => {
+                        if let Some(filter) = filter {
+                            let block = world.get_block(&pos).await;
+                            match filter {
+                                crate::command::args::block::BlockPredicate::Tag(tag) => {
+                                    tag.contains(&block.id)
+                                }
+                                crate::command::args::block::BlockPredicate::Block(id) => {
+                                    *id == block.id
+                                }
+                            }
+                        } else {
+                            true
+                        }
+                    }
+                };
+
+                if include {
+                    blocks.push(StoredBlock { pos, state_id });
+                }
+            }
+        }
+    }
+    blocks
+}
+
+impl CommandExecutor for CloneExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        let mask_mode = self.mask_mode;
+        let clone_mode = self.clone_mode;
+        Box::pin(async move {
+            let begin = BlockPosArgumentConsumer::find_arg(args, ARG_BEGIN)?;
+            let end = BlockPosArgumentConsumer::find_arg(args, ARG_END)?;
+            let destination = BlockPosArgumentConsumer::find_arg(args, ARG_DESTINATION)?;
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+
+            if !world.is_in_build_limit(begin)
+                || !world.is_in_build_limit(end)
+                || !world.is_in_build_limit(destination)
+            {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::ARGUMENT_POS_OUTOFBOUNDS,
+                    [],
+                )));
+            }
+
+            let src_min = Vector3::new(
+                begin.0.x.min(end.0.x),
+                begin.0.y.min(end.0.y),
+                begin.0.z.min(end.0.z),
+            );
+            let src_max = Vector3::new(
+                begin.0.x.max(end.0.x),
+                begin.0.y.max(end.0.y),
+                begin.0.z.max(end.0.z),
+            );
+
+            let total_blocks = (src_max.x - src_min.x + 1) as i64
+                * (src_max.y - src_min.y + 1) as i64
+                * (src_max.z - src_min.z + 1) as i64;
+
+            let max_block_modifications = {
+                let level_info = server.level_info.load();
+                level_info.game_rules.max_block_modifications
+            };
+
+            if total_blocks > max_block_modifications {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_CLONE_TOOBIG,
+                    [
+                        TextComponent::text(max_block_modifications.to_string()),
+                        TextComponent::text(total_blocks.to_string()),
+                    ],
+                )));
+            }
+
+            // Check overlap for normal mode
+            if matches!(clone_mode, CloneMode::Normal)
+                && regions_overlap(src_min, src_max, destination.0)
+            {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_CLONE_OVERLAP,
+                    [],
+                )));
+            }
+
+            let filter = if matches!(mask_mode, MaskMode::Filtered) {
+                BlockPredicateArgumentConsumer::find_arg(args, ARG_FILTER)?
+            } else {
+                None
+            };
+
+            // Collect source blocks
+            let blocks = collect_blocks(&world, src_min, src_max, mask_mode, filter.as_ref()).await;
+
+            if blocks.is_empty() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_CLONE_FAILED,
+                    [],
+                )));
+            }
+
+            let offset = Vector3::new(
+                destination.0.x - src_min.x,
+                destination.0.y - src_min.y,
+                destination.0.z - src_min.z,
+            );
+
+            let placed = place_blocks(&world, &blocks, offset, clone_mode).await;
+
+            if placed == 0 {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_CLONE_FAILED,
+                    [],
+                )));
+            }
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_CLONE_SUCCESS,
+                    [TextComponent::text(placed.to_string())],
+                ))
+                .await;
+            Ok(placed)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).then(
+        argument(ARG_BEGIN, BlockPosArgumentConsumer).then(
+            argument(ARG_END, BlockPosArgumentConsumer).then(
+                argument(ARG_DESTINATION, BlockPosArgumentConsumer)
+                    .then(
+                        literal("replace")
+                            .then(literal("force").execute(CloneExecutor {
+                                mask_mode: MaskMode::Replace,
+                                clone_mode: CloneMode::Force,
+                            }))
+                            .then(literal("move").execute(CloneExecutor {
+                                mask_mode: MaskMode::Replace,
+                                clone_mode: CloneMode::Move,
+                            }))
+                            .then(literal("normal").execute(CloneExecutor {
+                                mask_mode: MaskMode::Replace,
+                                clone_mode: CloneMode::Normal,
+                            }))
+                            .execute(CloneExecutor {
+                                mask_mode: MaskMode::Replace,
+                                clone_mode: CloneMode::Normal,
+                            }),
+                    )
+                    .then(
+                        literal("masked")
+                            .then(literal("force").execute(CloneExecutor {
+                                mask_mode: MaskMode::Masked,
+                                clone_mode: CloneMode::Force,
+                            }))
+                            .then(literal("move").execute(CloneExecutor {
+                                mask_mode: MaskMode::Masked,
+                                clone_mode: CloneMode::Move,
+                            }))
+                            .then(literal("normal").execute(CloneExecutor {
+                                mask_mode: MaskMode::Masked,
+                                clone_mode: CloneMode::Normal,
+                            }))
+                            .execute(CloneExecutor {
+                                mask_mode: MaskMode::Masked,
+                                clone_mode: CloneMode::Normal,
+                            }),
+                    )
+                    .then(
+                        literal("filtered").then(
+                            argument(ARG_FILTER, BlockPredicateArgumentConsumer)
+                                .then(literal("force").execute(CloneExecutor {
+                                    mask_mode: MaskMode::Filtered,
+                                    clone_mode: CloneMode::Force,
+                                }))
+                                .then(literal("move").execute(CloneExecutor {
+                                    mask_mode: MaskMode::Filtered,
+                                    clone_mode: CloneMode::Move,
+                                }))
+                                .then(literal("normal").execute(CloneExecutor {
+                                    mask_mode: MaskMode::Filtered,
+                                    clone_mode: CloneMode::Normal,
+                                }))
+                                .execute(CloneExecutor {
+                                    mask_mode: MaskMode::Filtered,
+                                    clone_mode: CloneMode::Normal,
+                                }),
+                        ),
+                    )
+                    .execute(CloneExecutor {
+                        mask_mode: MaskMode::Replace,
+                        clone_mode: CloneMode::Normal,
+                    }),
+            ),
+        ),
+    )
+}

--- a/pumpkin/src/command/commands/fillbiome.rs
+++ b/pumpkin/src/command/commands/fillbiome.rs
@@ -1,0 +1,197 @@
+use pumpkin_data::biome::Biome;
+use pumpkin_data::translation;
+use pumpkin_util::math::vector2::Vector2;
+use pumpkin_util::math::vector3::Vector3;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::position_block::BlockPosArgumentConsumer;
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs, FindArg};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+use crate::world::World;
+
+const NAMES: [&str; 1] = ["fillbiome"];
+
+const DESCRIPTION: &str = "Fills a region with a specific biome.";
+
+const ARG_FROM: &str = "from";
+const ARG_TO: &str = "to";
+const ARG_BIOME: &str = "biome";
+const ARG_REPLACE: &str = "replace_biome";
+
+fn parse_biome(name: &str) -> Result<&'static Biome, CommandError> {
+    let name = name.strip_prefix("minecraft:").unwrap_or(name);
+    Biome::from_name(name).ok_or(CommandError::CommandFailed(TextComponent::translate(
+        translation::ARGUMENT_RESOURCE_INVALID_TYPE,
+        [
+            TextComponent::text(format!("minecraft:{name}")),
+            TextComponent::text("worldgen/biome".to_string()),
+        ],
+    )))
+}
+
+async fn fill_biome_region(
+    world: &World,
+    min: Vector3<i32>,
+    max: Vector3<i32>,
+    biome: &'static Biome,
+    replace_biome: Option<&'static Biome>,
+) -> i32 {
+    let biome_min_x = min.x >> 2;
+    let biome_min_y = min.y >> 2;
+    let biome_min_z = min.z >> 2;
+    let biome_max_x = max.x >> 2;
+    let biome_max_y = max.y >> 2;
+    let biome_max_z = max.z >> 2;
+
+    let mut changed = 0i32;
+
+    for bx in biome_min_x..=biome_max_x {
+        for bz in biome_min_z..=biome_max_z {
+            let chunk_x = bx >> 2;
+            let chunk_z = bz >> 2;
+            let chunk_pos = Vector2::new(chunk_x, chunk_z);
+            let chunk = world.level.get_chunk(chunk_pos).await;
+
+            let rel_x = (bx & 3) as usize;
+            let rel_z = (bz & 3) as usize;
+
+            for by in biome_min_y..=biome_max_y {
+                if let Some(replace) = replace_biome {
+                    let section_idx = ((by - (chunk.section.min_y >> 2)) / 4).max(0) as usize;
+                    let rel_y_in_section = ((by - (chunk.section.min_y >> 2)) & 3) as usize;
+                    if let Some(current_biome_id) =
+                        chunk
+                            .section
+                            .get_noise_biome(section_idx, rel_x, rel_y_in_section, rel_z)
+                        && current_biome_id != replace.id
+                    {
+                        continue;
+                    }
+                }
+
+                let rel_y = (by - (chunk.section.min_y >> 2)) as usize;
+                chunk
+                    .section
+                    .set_relative_biome(rel_x, rel_y, rel_z, biome.id);
+                changed += 1;
+            }
+
+            chunk
+                .dirty
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    changed
+}
+
+struct FillBiomeExecutor {
+    has_replace: bool,
+}
+
+impl CommandExecutor for FillBiomeExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        let has_replace = self.has_replace;
+        Box::pin(async move {
+            let from = BlockPosArgumentConsumer::find_arg(args, ARG_FROM)?;
+            let to = BlockPosArgumentConsumer::find_arg(args, ARG_TO)?;
+
+            let Some(Arg::Simple(biome_name)) = args.get(ARG_BIOME) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_BIOME.into())));
+            };
+            let biome = parse_biome(biome_name)?;
+
+            let replace_biome = if has_replace {
+                let Some(Arg::Simple(replace_name)) = args.get(ARG_REPLACE) else {
+                    return Err(CommandError::InvalidConsumption(Some(ARG_REPLACE.into())));
+                };
+                Some(parse_biome(replace_name)?)
+            } else {
+                None
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+
+            if !world.is_in_build_limit(from) || !world.is_in_build_limit(to) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::ARGUMENT_POS_OUTOFBOUNDS,
+                    [],
+                )));
+            }
+
+            let min = Vector3::new(
+                from.0.x.min(to.0.x),
+                from.0.y.min(to.0.y),
+                from.0.z.min(to.0.z),
+            );
+            let max = Vector3::new(
+                from.0.x.max(to.0.x),
+                from.0.y.max(to.0.y),
+                from.0.z.max(to.0.z),
+            );
+
+            let total_biomes = (((max.x >> 2) - (min.x >> 2) + 1) as i64)
+                * (((max.y >> 2) - (min.y >> 2) + 1) as i64)
+                * (((max.z >> 2) - (min.z >> 2) + 1) as i64);
+
+            let max_block_modifications = {
+                let level_info = server.level_info.load();
+                level_info.game_rules.max_block_modifications
+            };
+
+            if total_biomes > max_block_modifications {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_FILLBIOME_TOOBIG,
+                    [
+                        TextComponent::text(max_block_modifications.to_string()),
+                        TextComponent::text(total_biomes.to_string()),
+                    ],
+                )));
+            }
+
+            let changed = fill_biome_region(&world, min, max, biome, replace_biome).await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_FILLBIOME_SUCCESS,
+                    [
+                        TextComponent::text(min.x.to_string()),
+                        TextComponent::text(min.y.to_string()),
+                        TextComponent::text(min.z.to_string()),
+                        TextComponent::text(max.x.to_string()),
+                        TextComponent::text(max.y.to_string()),
+                        TextComponent::text(max.z.to_string()),
+                    ],
+                ))
+                .await;
+
+            Ok(changed)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).then(
+        argument(ARG_FROM, BlockPosArgumentConsumer).then(
+            argument(ARG_TO, BlockPosArgumentConsumer).then(
+                argument(ARG_BIOME, SimpleArgConsumer)
+                    .then(
+                        literal("replace").then(
+                            argument(ARG_REPLACE, SimpleArgConsumer)
+                                .execute(FillBiomeExecutor { has_replace: true }),
+                        ),
+                    )
+                    .execute(FillBiomeExecutor { has_replace: false }),
+            ),
+        ),
+    )
+}

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -64,6 +64,7 @@ mod whitelist;
 mod worldborder;
 
 #[must_use]
+#[expect(clippy::too_many_lines)]
 pub async fn default_dispatcher(
     registry: &RwLock<PermissionRegistry>,
     basic_config: &BasicConfiguration,

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -12,6 +12,7 @@ mod banip;
 mod banlist;
 mod bossbar;
 mod clear;
+mod clone;
 mod damage;
 mod data;
 pub mod defaultgamemode;
@@ -21,6 +22,7 @@ mod effect;
 mod enchant;
 mod experience;
 mod fill;
+mod fillbiome;
 mod gamemode;
 mod gamerule;
 mod give;
@@ -38,6 +40,7 @@ mod playsound;
 mod plugin;
 mod plugins;
 mod pumpkin;
+mod random;
 mod rotate;
 mod say;
 mod seed;
@@ -45,6 +48,7 @@ mod setblock;
 mod setidletimeout;
 mod setworldspawn;
 mod spawnpoint;
+mod spreadplayers;
 mod stop;
 mod stopsound;
 mod summon;
@@ -74,6 +78,7 @@ pub async fn default_dispatcher(
     dispatcher.register(list::init_command_tree(), "minecraft:command.list");
     dispatcher.register(me::init_command_tree(), "minecraft:command.me");
     dispatcher.register(msg::init_command_tree(), "minecraft:command.msg");
+    dispatcher.register(random::init_command_tree(), "minecraft:command.random");
     // Two
     dispatcher.register(kill::init_command_tree(), "minecraft:command.kill");
     dispatcher.register(
@@ -134,6 +139,15 @@ pub async fn default_dispatcher(
         "minecraft:command.spawnpoint",
     );
     dispatcher.register(data::init_command_tree(), "minecraft:command.data");
+    dispatcher.register(clone::init_command_tree(), "minecraft:command.clone");
+    dispatcher.register(
+        fillbiome::init_command_tree(),
+        "minecraft:command.fillbiome",
+    );
+    dispatcher.register(
+        spreadplayers::init_command_tree(),
+        "minecraft:command.spreadplayers",
+    );
     // Three
     dispatcher.register(op::init_command_tree(), "minecraft:command.op");
     dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");
@@ -210,6 +224,13 @@ fn register_level_0_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.msg",
             "Sends a private message to another player",
+            PermissionDefault::Allow,
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.random",
+            "Draw a random value or control random sequences",
             PermissionDefault::Allow,
         ))
         .unwrap();
@@ -425,6 +446,27 @@ fn register_level_2_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "pumpkin:command.tps",
             "Displays the server TPS and MSPT",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.clone",
+            "Copies blocks from one region to another",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.fillbiome",
+            "Fills a region with a specific biome",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.spreadplayers",
+            "Teleports entities to random surface locations in an area",
             PermissionDefault::Op(PermissionLvl::Two),
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -64,7 +64,6 @@ mod whitelist;
 mod worldborder;
 
 #[must_use]
-#[expect(clippy::too_many_lines)]
 pub async fn default_dispatcher(
     registry: &RwLock<PermissionRegistry>,
     basic_config: &BasicConfiguration,

--- a/pumpkin/src/command/commands/random.rs
+++ b/pumpkin/src/command/commands/random.rs
@@ -1,0 +1,152 @@
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 1] = ["random"];
+
+const DESCRIPTION: &str = "Draw a random value or control random sequences.";
+
+const ARG_RANGE: &str = "range";
+
+fn parse_range(s: &str) -> Result<(i32, i32), CommandError> {
+    if let Some(rest) = s.strip_prefix("..") {
+        let max: i32 = rest
+            .parse()
+            .map_err(|_| CommandError::InvalidConsumption(Some(ARG_RANGE.into())))?;
+        Ok((i32::MIN, max))
+    } else if let Some(rest) = s.strip_suffix("..") {
+        let min: i32 = rest
+            .parse()
+            .map_err(|_| CommandError::InvalidConsumption(Some(ARG_RANGE.into())))?;
+        Ok((min, i32::MAX))
+    } else if let Some((min_s, max_s)) = s.split_once("..") {
+        let min: i32 = min_s
+            .parse()
+            .map_err(|_| CommandError::InvalidConsumption(Some(ARG_RANGE.into())))?;
+        let max: i32 = max_s
+            .parse()
+            .map_err(|_| CommandError::InvalidConsumption(Some(ARG_RANGE.into())))?;
+        Ok((min, max))
+    } else {
+        let val: i32 = s
+            .parse()
+            .map_err(|_| CommandError::InvalidConsumption(Some(ARG_RANGE.into())))?;
+        Ok((val, val))
+    }
+}
+
+struct ValueExecutor;
+
+impl CommandExecutor for ValueExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(range_str)) = args.get(ARG_RANGE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_RANGE.into())));
+            };
+
+            let (min, max) = parse_range(range_str)?;
+
+            if min == max {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_SMALL,
+                    [],
+                )));
+            }
+
+            let range_size = (max as i64) - (min as i64) + 1;
+            if !(2..=2_147_483_646).contains(&range_size) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_LARGE,
+                    [],
+                )));
+            }
+
+            let result = rand::random_range(min..=max);
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_RANDOM_SAMPLE_SUCCESS,
+                    [TextComponent::text(result.to_string())],
+                ))
+                .await;
+            Ok(result)
+        })
+    }
+}
+
+struct RollExecutor;
+
+impl CommandExecutor for RollExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(range_str)) = args.get(ARG_RANGE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_RANGE.into())));
+            };
+
+            let (min, max) = parse_range(range_str)?;
+
+            if min == max {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_SMALL,
+                    [],
+                )));
+            }
+
+            let range_size = (max as i64) - (min as i64) + 1;
+            if !(2..=2_147_483_646).contains(&range_size) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_LARGE,
+                    [],
+                )));
+            }
+
+            let result = rand::random_range(min..=max);
+
+            let sender_name = match sender {
+                CommandSender::Player(p) => p.gameprofile.name.clone(),
+                _ => "Server".to_string(),
+            };
+
+            // Broadcast to all players
+            let msg = TextComponent::translate(
+                translation::COMMANDS_RANDOM_ROLL,
+                [
+                    TextComponent::text(sender_name),
+                    TextComponent::text(result.to_string()),
+                    TextComponent::text(min.to_string()),
+                    TextComponent::text(max.to_string()),
+                ],
+            );
+
+            for world in server.worlds.load().iter() {
+                for player in world.players.load().iter() {
+                    player.send_system_message(&msg).await;
+                }
+            }
+
+            Ok(result)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(literal("value").then(argument(ARG_RANGE, SimpleArgConsumer).execute(ValueExecutor)))
+        .then(literal("roll").then(argument(ARG_RANGE, SimpleArgConsumer).execute(RollExecutor)))
+}

--- a/pumpkin/src/command/commands/spreadplayers.rs
+++ b/pumpkin/src/command/commands/spreadplayers.rs
@@ -1,0 +1,248 @@
+use std::sync::Arc;
+
+use pumpkin_data::translation;
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::vector2::Vector2;
+use pumpkin_util::math::vector3::Vector3;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::bool::BoolArgConsumer;
+use crate::command::args::entities::EntitiesArgumentConsumer;
+use crate::command::args::position_2d::Position2DArgumentConsumer;
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs, FindArg};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::argument;
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+use crate::entity::EntityBase;
+
+const NAMES: [&str; 1] = ["spreadplayers"];
+
+const DESCRIPTION: &str = "Teleports entities to random surface locations in an area.";
+
+const ARG_CENTER: &str = "center";
+const ARG_SPREAD_DISTANCE: &str = "spreadDistance";
+const ARG_MAX_RANGE: &str = "maxRange";
+const ARG_RESPECT_TEAMS: &str = "respectTeams";
+const ARG_TARGETS: &str = "targets";
+
+struct SpreadExecutor;
+
+async fn find_surface_y(world: &crate::world::World, x: i32, z: i32) -> Option<i32> {
+    let top_y = world.get_top_y();
+    let bottom_y = world.get_bottom_y();
+    let mut y = top_y;
+    while y >= bottom_y {
+        let pos = BlockPos(Vector3::new(x, y, z));
+        let state = world.get_block_state(&pos).await;
+        if state.is_solid() {
+            return Some(y + 1);
+        }
+        y -= 1;
+    }
+    None
+}
+
+/// Vector2 uses x=worldX, y=worldZ
+fn spread_positions(
+    center: Vector2<f64>,
+    spread_distance: f64,
+    max_range: f64,
+    count: usize,
+) -> Vec<Vector2<f64>> {
+    let mut positions = Vec::with_capacity(count);
+    let min_x = center.x - max_range;
+    let min_z = center.y - max_range;
+    let range = max_range * 2.0;
+
+    for _ in 0..count {
+        let x = min_x + rand::random::<f64>() * range;
+        let z = min_z + rand::random::<f64>() * range;
+        positions.push(Vector2::new(x, z));
+    }
+
+    // Iterative relaxation to ensure minimum distance
+    for _ in 0..10000 {
+        let mut any_moved = false;
+        for i in 0..count {
+            let mut dx = 0.0;
+            let mut dz = 0.0;
+            let mut too_close = false;
+
+            for j in 0..count {
+                if i == j {
+                    continue;
+                }
+                let diff_x = positions[i].x - positions[j].x;
+                let diff_z = positions[i].y - positions[j].y;
+                let dist_sq = diff_x * diff_x + diff_z * diff_z;
+                let min_dist_sq = spread_distance * spread_distance;
+
+                if dist_sq < min_dist_sq {
+                    too_close = true;
+                    if diff_x.abs() < 1e-10 && diff_z.abs() < 1e-10 {
+                        dx += rand::random::<f64>() - 0.5;
+                        dz += rand::random::<f64>() - 0.5;
+                    } else {
+                        let dist = dist_sq.sqrt();
+                        dx += diff_x / dist;
+                        dz += diff_z / dist;
+                    }
+                }
+            }
+
+            if too_close {
+                let len = dx.hypot(dz);
+                if len > 0.0 {
+                    dx /= len;
+                    dz /= len;
+                }
+                let new_x = (positions[i].x + dx).clamp(min_x, min_x + range);
+                let new_z = (positions[i].y + dz).clamp(min_z, min_z + range);
+                positions[i] = Vector2::new(new_x, new_z);
+                any_moved = true;
+            }
+        }
+        if !any_moved {
+            break;
+        }
+    }
+
+    positions
+}
+
+impl CommandExecutor for SpreadExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let center = Position2DArgumentConsumer::find_arg(args, ARG_CENTER)?;
+
+            let Some(Arg::Simple(spread_str)) = args.get(ARG_SPREAD_DISTANCE) else {
+                return Err(CommandError::InvalidConsumption(Some(
+                    ARG_SPREAD_DISTANCE.into(),
+                )));
+            };
+            let spread_distance: f64 = spread_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_SPREAD_DISTANCE.into())))?;
+
+            let Some(Arg::Simple(range_str)) = args.get(ARG_MAX_RANGE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_MAX_RANGE.into())));
+            };
+            let max_range: f64 = range_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_MAX_RANGE.into())))?;
+
+            let _respect_teams = BoolArgConsumer::find_arg(args, ARG_RESPECT_TEAMS)?;
+            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+
+            if targets.is_empty() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_SPREADPLAYERS_FAILED_ENTITIES,
+                    [
+                        TextComponent::text("0".to_string()),
+                        TextComponent::text(format!("{:.1}", center.x)),
+                        TextComponent::text(format!("{:.1}", center.y)),
+                        TextComponent::text(format!("{spread_distance:.1}")),
+                    ],
+                )));
+            }
+
+            if spread_distance < 0.0 {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_SPREADPLAYERS_FAILED_INVALID_HEIGHT,
+                    [
+                        TextComponent::text(format!("{spread_distance:.1}")),
+                        TextComponent::text("0".to_string()),
+                    ],
+                )));
+            }
+
+            if max_range < spread_distance + 1.0 {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_SPREADPLAYERS_FAILED_ENTITIES,
+                    [
+                        TextComponent::text(targets.len().to_string()),
+                        TextComponent::text(format!("{:.1}", center.x)),
+                        TextComponent::text(format!("{:.1}", center.y)),
+                        TextComponent::text(format!("{spread_distance:.1}")),
+                    ],
+                )));
+            }
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+
+            let positions = spread_positions(center, spread_distance, max_range, targets.len());
+
+            let mut spread_count = 0i32;
+            for (i, target) in targets.iter().enumerate() {
+                let pos = positions[i];
+                let x = pos.x.floor() as i32;
+                let z = pos.y.floor() as i32; // Vector2.y = world Z
+
+                let y = match find_surface_y(&world, x, z).await {
+                    Some(y) => y as f64,
+                    None => continue,
+                };
+
+                let dest = Vector3::new(pos.x, y, pos.y); // Vector2.y = world Z
+
+                // Check if entity is a player for request_teleport
+                let entity = target.get_entity();
+                if let Some(player) = entity.world.load().get_player_by_id(entity.entity_id) {
+                    player.request_teleport(dest, 0.0, 0.0).await;
+                } else {
+                    let target_clone: Arc<dyn EntityBase> = target.clone();
+                    target_clone
+                        .teleport(dest, Some(0.0), Some(0.0), world.clone())
+                        .await;
+                }
+                spread_count += 1;
+            }
+
+            if spread_count == 0 {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_SPREADPLAYERS_FAILED_ENTITIES,
+                    [
+                        TextComponent::text(targets.len().to_string()),
+                        TextComponent::text(format!("{:.1}", center.x)),
+                        TextComponent::text(format!("{:.1}", center.y)),
+                        TextComponent::text(format!("{spread_distance:.1}")),
+                    ],
+                )));
+            }
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_SPREADPLAYERS_SUCCESS_ENTITIES,
+                    [
+                        TextComponent::text(spread_count.to_string()),
+                        TextComponent::text(format!("{:.1}", center.x)),
+                        TextComponent::text(format!("{:.1}", center.y)),
+                        TextComponent::text(format!("{:.1}", max_range * 2.0)),
+                    ],
+                ))
+                .await;
+            Ok(spread_count)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).then(
+        argument(ARG_CENTER, Position2DArgumentConsumer).then(
+            argument(ARG_SPREAD_DISTANCE, SimpleArgConsumer).then(
+                argument(ARG_MAX_RANGE, SimpleArgConsumer).then(
+                    argument(ARG_RESPECT_TEAMS, BoolArgConsumer).then(
+                        argument(ARG_TARGETS, EntitiesArgumentConsumer).execute(SpreadExecutor),
+                    ),
+                ),
+            ),
+        ),
+    )
+}


### PR DESCRIPTION
- `/clone`: copy blocks from one region to another with filtered/masked/replace modes
- `/fillbiome`: fill a region with a specific biome
- `/spreadplayers`: teleport entities to random surface locations in an area
- `/random`: value and roll subcommands with range parsing and broadcast

| Command | OP Level |
|---------|----------|
| `/random` | 0 |
| `/clone` | 2 |
| `/fillbiome` | 2 |
| `/spreadplayers` | 2 |

Partially addresses #15.