### PR TITLE
feat: implement execute, attribute, item commands + translation fixes

### DIFF
--- a/pumpkin/src/command/commands/attribute.rs
+++ b/pumpkin/src/command/commands/attribute.rs
@@ -1,0 +1,289 @@
+use std::sync::Arc;
+
+use pumpkin_data::attributes::Attributes;
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::entity::EntityArgumentConsumer;
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs, FindArg};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, argument_default_name, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+use crate::entity::EntityBase;
+
+const NAMES: [&str; 1] = ["attribute"];
+
+const DESCRIPTION: &str = "Queries, adds, removes, or sets an entity attribute.";
+
+const ARG_ATTRIBUTE: &str = "attribute";
+const ARG_SCALE: &str = "scale";
+const ARG_VALUE: &str = "value";
+
+fn lookup_attribute(name: &str) -> Option<Attributes> {
+    let name = name.strip_prefix("minecraft:").unwrap_or(name);
+    match name {
+        "armor" => Some(Attributes::ARMOR),
+        "armor_toughness" => Some(Attributes::ARMOR_TOUGHNESS),
+        "attack_damage" => Some(Attributes::ATTACK_DAMAGE),
+        "attack_knockback" => Some(Attributes::ATTACK_KNOCKBACK),
+        "attack_speed" => Some(Attributes::ATTACK_SPEED),
+        "block_break_speed" => Some(Attributes::BLOCK_BREAK_SPEED),
+        "block_interaction_range" => Some(Attributes::BLOCK_INTERACTION_RANGE),
+        "burning_time" => Some(Attributes::BURNING_TIME),
+        "camera_distance" => Some(Attributes::CAMERA_DISTANCE),
+        "explosion_knockback_resistance" => Some(Attributes::EXPLOSION_KNOCKBACK_RESISTANCE),
+        "entity_interaction_range" => Some(Attributes::ENTITY_INTERACTION_RANGE),
+        "fall_damage_multiplier" => Some(Attributes::FALL_DAMAGE_MULTIPLIER),
+        "flying_speed" => Some(Attributes::FLYING_SPEED),
+        "follow_range" => Some(Attributes::FOLLOW_RANGE),
+        "gravity" => Some(Attributes::GRAVITY),
+        "jump_strength" => Some(Attributes::JUMP_STRENGTH),
+        "knockback_resistance" => Some(Attributes::KNOCKBACK_RESISTANCE),
+        "luck" => Some(Attributes::LUCK),
+        "max_absorption" => Some(Attributes::MAX_ABSORPTION),
+        "max_health" => Some(Attributes::MAX_HEALTH),
+        "mining_efficiency" => Some(Attributes::MINING_EFFICIENCY),
+        "movement_efficiency" => Some(Attributes::MOVEMENT_EFFICIENCY),
+        "movement_speed" => Some(Attributes::MOVEMENT_SPEED),
+        "oxygen_bonus" => Some(Attributes::OXYGEN_BONUS),
+        "safe_fall_distance" => Some(Attributes::SAFE_FALL_DISTANCE),
+        "scale" => Some(Attributes::SCALE),
+        "sneaking_speed" => Some(Attributes::SNEAKING_SPEED),
+        "spawn_reinforcements" => Some(Attributes::SPAWN_REINFORCEMENTS),
+        "step_height" => Some(Attributes::STEP_HEIGHT),
+        "submerged_mining_speed" => Some(Attributes::SUBMERGED_MINING_SPEED),
+        "sweeping_damage_ratio" => Some(Attributes::SWEEPING_DAMAGE_RATIO),
+        "tempt_range" => Some(Attributes::TEMPT_RANGE),
+        "water_movement_efficiency" => Some(Attributes::WATER_MOVEMENT_EFFICIENCY),
+        _ => None,
+    }
+}
+
+fn get_attribute_arg<'a>(
+    args: &'a ConsumedArgs<'a>,
+    entity_name: &str,
+) -> Result<Attributes, CommandError> {
+    let Some(Arg::Simple(attr_name)) = args.get(ARG_ATTRIBUTE) else {
+        return Err(CommandError::InvalidConsumption(Some(ARG_ATTRIBUTE.into())));
+    };
+    lookup_attribute(attr_name).ok_or(CommandError::CommandFailed(TextComponent::translate(
+        translation::COMMANDS_ATTRIBUTE_FAILED_NO_ATTRIBUTE,
+        [
+            TextComponent::text(entity_name.to_string()),
+            TextComponent::text(attr_name.to_string()),
+        ],
+    )))
+}
+
+fn get_living_entity(
+    target: &Arc<dyn EntityBase>,
+) -> Result<&crate::entity::living::LivingEntity, CommandError> {
+    let entity_name = target.get_entity().entity_type.resource_name;
+    target
+        .get_living_entity()
+        .ok_or(CommandError::CommandFailed(TextComponent::translate(
+            translation::COMMANDS_ATTRIBUTE_FAILED_ENTITY,
+            [TextComponent::text(entity_name.to_string())],
+        )))
+}
+
+struct GetExecutor;
+
+impl CommandExecutor for GetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let target = EntityArgumentConsumer::find_arg(args, "target")?;
+            let entity_name = target.get_entity().entity_type.resource_name;
+            let attribute = get_attribute_arg(args, entity_name)?;
+            let living = get_living_entity(&target)?;
+
+            let Some(Arg::Simple(attr_name)) = args.get(ARG_ATTRIBUTE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_ATTRIBUTE.into())));
+            };
+
+            let scale: f64 = args
+                .get(ARG_SCALE)
+                .and_then(|a| {
+                    if let Arg::Simple(s) = a {
+                        s.parse::<f64>().ok()
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(1.0);
+
+            let value = living.get_attribute_value(&attribute) * scale;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_ATTRIBUTE_VALUE_GET_SUCCESS,
+                    [
+                        TextComponent::text(attr_name.to_string()),
+                        TextComponent::text(entity_name.to_string()),
+                        TextComponent::text(format!("{value}")),
+                    ],
+                ))
+                .await;
+            Ok(value as i32)
+        })
+    }
+}
+
+struct BaseGetExecutor;
+
+impl CommandExecutor for BaseGetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let target = EntityArgumentConsumer::find_arg(args, "target")?;
+            let entity_name = target.get_entity().entity_type.resource_name;
+            let attribute = get_attribute_arg(args, entity_name)?;
+            let living = get_living_entity(&target)?;
+
+            let Some(Arg::Simple(attr_name)) = args.get(ARG_ATTRIBUTE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_ATTRIBUTE.into())));
+            };
+
+            let scale: f64 = args
+                .get(ARG_SCALE)
+                .and_then(|a| {
+                    if let Arg::Simple(s) = a {
+                        s.parse::<f64>().ok()
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(1.0);
+
+            let value = living.get_attribute_base(&attribute) * scale;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_ATTRIBUTE_BASE_VALUE_GET_SUCCESS,
+                    [
+                        TextComponent::text(attr_name.to_string()),
+                        TextComponent::text(entity_name.to_string()),
+                        TextComponent::text(format!("{value}")),
+                    ],
+                ))
+                .await;
+            Ok(value as i32)
+        })
+    }
+}
+
+struct BaseSetExecutor;
+
+impl CommandExecutor for BaseSetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let target = EntityArgumentConsumer::find_arg(args, "target")?;
+            let entity_name = target.get_entity().entity_type.resource_name;
+            let attribute = get_attribute_arg(args, entity_name)?;
+            let living = get_living_entity(&target)?;
+
+            let Some(Arg::Simple(attr_name)) = args.get(ARG_ATTRIBUTE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_ATTRIBUTE.into())));
+            };
+            let Some(Arg::Simple(val_str)) = args.get(ARG_VALUE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_VALUE.into())));
+            };
+            let value: f64 = val_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_VALUE.into())))?;
+
+            living.set_attribute_base(&attribute, value);
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_ATTRIBUTE_BASE_VALUE_SET_SUCCESS,
+                    [
+                        TextComponent::text(attr_name.to_string()),
+                        TextComponent::text(entity_name.to_string()),
+                        TextComponent::text(format!("{value}")),
+                    ],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct BaseResetExecutor;
+
+impl CommandExecutor for BaseResetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let target = EntityArgumentConsumer::find_arg(args, "target")?;
+            let entity_name = target.get_entity().entity_type.resource_name;
+            let attribute = get_attribute_arg(args, entity_name)?;
+            let living = get_living_entity(&target)?;
+
+            let Some(Arg::Simple(attr_name)) = args.get(ARG_ATTRIBUTE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_ATTRIBUTE.into())));
+            };
+
+            living.set_attribute_base(&attribute, attribute.default_value);
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_ATTRIBUTE_BASE_VALUE_RESET_SUCCESS,
+                    [
+                        TextComponent::text(attr_name.to_string()),
+                        TextComponent::text(entity_name.to_string()),
+                        TextComponent::text(format!("{}", attribute.default_value)),
+                    ],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).then(
+        argument_default_name(EntityArgumentConsumer).then(
+            argument(ARG_ATTRIBUTE, SimpleArgConsumer)
+                .then(
+                    literal("get")
+                        .execute(GetExecutor)
+                        .then(argument(ARG_SCALE, SimpleArgConsumer).execute(GetExecutor)),
+                )
+                .then(
+                    literal("base")
+                        .then(
+                            literal("get").execute(BaseGetExecutor).then(
+                                argument(ARG_SCALE, SimpleArgConsumer).execute(BaseGetExecutor),
+                            ),
+                        )
+                        .then(
+                            literal("set").then(
+                                argument(ARG_VALUE, SimpleArgConsumer).execute(BaseSetExecutor),
+                            ),
+                        )
+                        .then(literal("reset").execute(BaseResetExecutor)),
+                ),
+        ),
+    )
+}

--- a/pumpkin/src/command/commands/execute.rs
+++ b/pumpkin/src/command/commands/execute.rs
@@ -1,0 +1,191 @@
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::entities::EntitiesArgumentConsumer;
+use crate::command::args::message::MsgArgConsumer;
+use crate::command::args::position_block::BlockPosArgumentConsumer;
+use crate::command::args::{Arg, ConsumedArgs, FindArg};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 1] = ["execute"];
+
+const DESCRIPTION: &str = "Executes a command with context modifiers and conditions.";
+
+const ARG_COMMAND: &str = "command";
+const ARG_TARGETS: &str = "targets";
+
+struct RunExecutor;
+
+impl CommandExecutor for RunExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Msg(command)) = args.get(ARG_COMMAND) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_COMMAND.into())));
+            };
+
+            let cmd = if command.starts_with('/') {
+                command.clone()
+            } else {
+                format!("/{command}")
+            };
+
+            let dispatcher = server.command_dispatcher.read().await;
+            dispatcher.dispatch(sender, server, &cmd).await?;
+            Ok(1)
+        })
+    }
+}
+
+struct AsExecutor;
+
+impl CommandExecutor for AsExecutor {
+    fn execute<'a>(
+        &'a self,
+        _sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+
+            let Some(Arg::Msg(command)) = args.get(ARG_COMMAND) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_COMMAND.into())));
+            };
+
+            let cmd = if command.starts_with('/') {
+                command.clone()
+            } else {
+                format!("/{command}")
+            };
+
+            let dispatcher = server.command_dispatcher.read().await;
+            let mut success = 0i32;
+
+            // TODO: /execute as should work on any entity, not just players.
+            // Currently limited to players because CommandSender has no entity variant.
+            for target in targets {
+                let entity = target.get_entity();
+                if let Some(player) = entity.world.load().get_player_by_id(entity.entity_id) {
+                    let new_sender = CommandSender::Player(player);
+                    if dispatcher.dispatch(&new_sender, server, &cmd).await.is_ok() {
+                        success += 1;
+                    }
+                }
+            }
+
+            if success == 0 {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_EXECUTE_CONDITIONAL_FAIL,
+                    [],
+                )));
+            }
+            Ok(success)
+        })
+    }
+}
+
+// TODO: Use BlockPredicateArgumentConsumer instead of SimpleArgConsumer for block matching.
+// TODO: Support chaining multiple subcommands (e.g., `execute if ... if ... run`).
+struct IfBlockExecutor {
+    inverted: bool,
+}
+
+impl CommandExecutor for IfBlockExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        let inverted = self.inverted;
+        Box::pin(async move {
+            let pos = BlockPosArgumentConsumer::find_arg(args, "pos")?;
+            let Some(Arg::Simple(block_name)) = args.get("block") else {
+                return Err(CommandError::InvalidConsumption(Some("block".into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let block = world.get_block(&pos).await;
+
+            let block_name_clean = block_name.strip_prefix("minecraft:").unwrap_or(block_name);
+            let matches = block.name == block_name_clean;
+            let condition_met = if inverted { !matches } else { matches };
+
+            if !condition_met {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_EXECUTE_CONDITIONAL_FAIL,
+                    [],
+                )));
+            }
+
+            // If there's a run command, execute it; otherwise report pass
+            if let Some(Arg::Msg(command)) = args.get(ARG_COMMAND) {
+                let cmd = if command.starts_with('/') {
+                    command.clone()
+                } else {
+                    format!("/{command}")
+                };
+                let dispatcher = server.command_dispatcher.read().await;
+                dispatcher.dispatch(sender, server, &cmd).await?;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_EXECUTE_CONDITIONAL_PASS,
+                        [],
+                    ))
+                    .await;
+            }
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(literal("run").then(argument(ARG_COMMAND, MsgArgConsumer).execute(RunExecutor)))
+        .then(literal("as").then(
+            argument(ARG_TARGETS, EntitiesArgumentConsumer).then(
+                literal("run").then(argument(ARG_COMMAND, MsgArgConsumer).execute(AsExecutor)),
+            ),
+        ))
+        .then(
+            literal("if").then(
+                literal("block").then(
+                    argument("pos", BlockPosArgumentConsumer).then(
+                        argument("block", crate::command::args::simple::SimpleArgConsumer)
+                            .then(
+                                literal("run").then(
+                                    argument(ARG_COMMAND, MsgArgConsumer)
+                                        .execute(IfBlockExecutor { inverted: false }),
+                                ),
+                            )
+                            .execute(IfBlockExecutor { inverted: false }),
+                    ),
+                ),
+            ),
+        )
+        .then(
+            literal("unless").then(
+                literal("block").then(
+                    argument("pos", BlockPosArgumentConsumer).then(
+                        argument("block", crate::command::args::simple::SimpleArgConsumer)
+                            .then(
+                                literal("run").then(
+                                    argument(ARG_COMMAND, MsgArgConsumer)
+                                        .execute(IfBlockExecutor { inverted: true }),
+                                ),
+                            )
+                            .execute(IfBlockExecutor { inverted: true }),
+                    ),
+                ),
+            ),
+        )
+}

--- a/pumpkin/src/command/commands/fill.rs
+++ b/pumpkin/src/command/commands/fill.rs
@@ -11,6 +11,7 @@ use crate::command::{CommandError, CommandExecutor, CommandResult, CommandSender
 use crate::world::World;
 
 use pumpkin_data::Block;
+use pumpkin_data::translation;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::text::TextComponent;
@@ -286,7 +287,7 @@ impl CommandExecutor for Executor {
 
             if !context.world.is_in_build_limit(from) || !context.world.is_in_build_limit(to) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "argument.pos.outofbounds",
+                    translation::ARGUMENT_POS_OUTOFBOUNDS,
                     [],
                 )));
             }
@@ -302,7 +303,7 @@ impl CommandExecutor for Executor {
 
             if total_blocks > max_block_modifications {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.fill.toobig",
+                    translation::COMMANDS_FILL_TOOBIG,
                     [
                         TextComponent::text(max_block_modifications.to_string()),
                         TextComponent::text(total_blocks.to_string()),
@@ -325,14 +326,14 @@ impl CommandExecutor for Executor {
 
             if context.placed_blocks == 0 {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.fill.failed",
+                    translation::COMMANDS_FILL_FAILED,
                     [],
                 )));
             }
 
             sender
                 .send_message(TextComponent::translate(
-                    "commands.fill.success",
+                    translation::COMMANDS_FILL_SUCCESS,
                     [TextComponent::text(context.placed_blocks.to_string())],
                 ))
                 .await;

--- a/pumpkin/src/command/commands/item.rs
+++ b/pumpkin/src/command/commands/item.rs
@@ -1,0 +1,157 @@
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+use pumpkin_world::inventory::Inventory;
+use pumpkin_world::item::ItemStack;
+
+use crate::command::args::players::PlayersArgumentConsumer;
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs, FindArg};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 1] = ["item"];
+
+const DESCRIPTION: &str = "Manipulates items in inventories.";
+
+const ARG_TARGETS: &str = "targets";
+const ARG_SLOT: &str = "slot";
+const ARG_ITEM: &str = "item";
+const ARG_COUNT: &str = "count";
+
+/// Returns the slot index. `weapon.mainhand` returns `None` to indicate
+/// that the player's currently selected hotbar slot should be used.
+fn parse_slot(slot_str: &str) -> Result<Option<usize>, CommandError> {
+    let no_such_slot = || {
+        CommandError::CommandFailed(TextComponent::translate(
+            translation::COMMANDS_ITEM_SOURCE_NO_SUCH_SLOT,
+            [TextComponent::text(slot_str.to_string())],
+        ))
+    };
+    // Parse slot identifiers like "container.0", "hotbar.0", "armor.head", etc.
+    if let Some(rest) = slot_str.strip_prefix("container.") {
+        rest.parse::<usize>().map(Some).map_err(|_| no_such_slot())
+    } else if let Some(rest) = slot_str.strip_prefix("hotbar.") {
+        let idx: usize = rest.parse().map_err(|_| no_such_slot())?;
+        if idx > 8 {
+            return Err(no_such_slot());
+        }
+        Ok(Some(idx))
+    } else if let Some(rest) = slot_str.strip_prefix("inventory.") {
+        let idx: usize = rest.parse().map_err(|_| no_such_slot())?;
+        Ok(Some(idx + 9)) // inventory slots start at 9
+    } else {
+        match slot_str {
+            "armor.head" => Ok(Some(36)),
+            "armor.chest" => Ok(Some(37)),
+            "armor.legs" => Ok(Some(38)),
+            "armor.feet" => Ok(Some(39)),
+            "weapon.offhand" => Ok(Some(40)),
+            "weapon.mainhand" => Ok(None), // Resolved to selected slot at runtime
+            _ => Err(CommandError::CommandFailed(TextComponent::translate(
+                translation::COMMANDS_ITEM_TARGET_NO_SUCH_SLOT,
+                [TextComponent::text(slot_str.to_string())],
+            ))),
+        }
+    }
+}
+
+// TODO: Use EntitiesArgumentConsumer instead of PlayersArgumentConsumer to support all entities.
+// TODO: Use ItemArgumentConsumer instead of SimpleArgConsumer for the item argument.
+// TODO: Use BoundedNumArgumentConsumer<i32> (1..=99) instead of SimpleArgConsumer for count.
+struct ReplaceEntityExecutor;
+
+impl CommandExecutor for ReplaceEntityExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+
+            let Some(Arg::Simple(slot_str)) = args.get(ARG_SLOT) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_SLOT.into())));
+            };
+            let slot_opt = parse_slot(slot_str)?;
+
+            let Some(Arg::Simple(item_name)) = args.get(ARG_ITEM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_ITEM.into())));
+            };
+
+            let item = pumpkin_data::item::Item::from_registry_key(item_name).ok_or(
+                CommandError::CommandFailed(TextComponent::translate(
+                    translation::ARGUMENT_ITEM_ID_INVALID,
+                    [TextComponent::text(item_name.to_string())],
+                )),
+            )?;
+
+            let count: u8 = args
+                .get(ARG_COUNT)
+                .and_then(|a| {
+                    if let Arg::Simple(s) = a {
+                        s.parse::<u8>().ok()
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(1);
+
+            let stack = ItemStack::new(count, item);
+            let mut changed = 0i32;
+
+            for target in targets {
+                let slot =
+                    slot_opt.unwrap_or_else(|| target.inventory().get_selected_slot() as usize);
+                target.inventory().set_stack(slot, stack.clone()).await;
+                changed += 1;
+            }
+
+            if targets.len() == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ITEM_ENTITY_SET_SUCCESS_SINGLE,
+                        [
+                            TextComponent::text(targets[0].gameprofile.name.clone()),
+                            TextComponent::text(item_name.to_string()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_ITEM_ENTITY_SET_SUCCESS_MULTIPLE,
+                        [
+                            TextComponent::text(changed.to_string()),
+                            TextComponent::text(item_name.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(changed)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).then(
+        literal("replace").then(
+            literal("entity").then(
+                argument(ARG_TARGETS, PlayersArgumentConsumer).then(
+                    argument(ARG_SLOT, SimpleArgConsumer).then(
+                        literal("with").then(
+                            argument(ARG_ITEM, SimpleArgConsumer)
+                                .then(
+                                    argument(ARG_COUNT, SimpleArgConsumer)
+                                        .execute(ReplaceEntityExecutor),
+                                )
+                                .execute(ReplaceEntityExecutor),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+}

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -7,6 +7,7 @@ use tokio::sync::RwLock;
 
 use super::dispatcher::CommandDispatcher;
 
+mod attribute;
 mod ban;
 mod banip;
 mod banlist;
@@ -19,12 +20,14 @@ mod deop;
 mod difficulty;
 mod effect;
 mod enchant;
+mod execute;
 mod experience;
 mod fill;
 mod gamemode;
 mod gamerule;
 mod give;
 mod help;
+mod item;
 mod kick;
 mod kill;
 mod list;
@@ -134,6 +137,12 @@ pub async fn default_dispatcher(
         "minecraft:command.spawnpoint",
     );
     dispatcher.register(data::init_command_tree(), "minecraft:command.data");
+    dispatcher.register(
+        attribute::init_command_tree(),
+        "minecraft:command.attribute",
+    );
+    dispatcher.register(item::init_command_tree(), "minecraft:command.item");
+    dispatcher.register(execute::init_command_tree(), "minecraft:command.execute");
     // Three
     dispatcher.register(op::init_command_tree(), "minecraft:command.op");
     dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");
@@ -425,6 +434,27 @@ fn register_level_2_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "pumpkin:command.tps",
             "Displays the server TPS and MSPT",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.attribute",
+            "Queries, adds, removes, or sets an entity attribute",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.item",
+            "Manipulates items in inventories",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.execute",
+            "Executes a command",
             PermissionDefault::Op(PermissionLvl::Two),
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/setworldspawn.rs
+++ b/pumpkin/src/command/commands/setworldspawn.rs
@@ -151,7 +151,7 @@ async fn setworldspawn(
 
     sender
         .send_message(TextComponent::translate(
-            translation::COMMANDS_SETWORLDSPAWN_SUCCESS,
+            translation::COMMANDS_SETWORLDSPAWN_SUCCESS_NEW,
             [
                 TextComponent::text(new_position.0.x.to_string()),
                 TextComponent::text(new_position.0.y.to_string()),

--- a/pumpkin/src/command/commands/spawnpoint.rs
+++ b/pumpkin/src/command/commands/spawnpoint.rs
@@ -132,7 +132,7 @@ async fn set_spawnpoint(sender: &CommandSender, target: &Arc<Player>, pos: Block
 
     sender
         .send_message(TextComponent::translate(
-            translation::COMMANDS_SPAWNPOINT_SUCCESS_SINGLE,
+            translation::COMMANDS_SPAWNPOINT_SUCCESS_SINGLE_NEW,
             [
                 TextComponent::text(pos.0.x.to_string()),
                 TextComponent::text(pos.0.y.to_string()),

--- a/pumpkin/src/command/commands/teleport.rs
+++ b/pumpkin/src/command/commands/teleport.rs
@@ -1,3 +1,4 @@
+use pumpkin_data::translation;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::text::TextComponent;
@@ -81,7 +82,7 @@ impl CommandExecutor for EntitiesToEntityExecutor {
             let world = destination.world.load_full();
             if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.teleport.invalidPosition",
+                    translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                     [],
                 )));
             }
@@ -112,7 +113,7 @@ impl CommandExecutor for EntitiesToPosFacingPosExecutor {
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
             if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.teleport.invalidPosition",
+                    translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                     [],
                 )));
             }
@@ -147,7 +148,7 @@ impl CommandExecutor for EntitiesToPosFacingEntityExecutor {
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
             if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.teleport.invalidPosition",
+                    translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                     [],
                 )));
             }
@@ -183,7 +184,7 @@ impl CommandExecutor for EntitiesToPosWithRotationExecutor {
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
             if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.teleport.invalidPosition",
+                    translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                     [],
                 )));
             }
@@ -219,7 +220,7 @@ impl CommandExecutor for EntitiesToPosExecutor {
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
             if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.teleport.invalidPosition",
+                    translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                     [],
                 )));
             }
@@ -259,7 +260,7 @@ impl CommandExecutor for SelfToEntityExecutor {
                 CommandSender::Player(player) => {
                     if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                         return Err(CommandError::CommandFailed(TextComponent::translate(
-                            "commands.teleport.invalidPosition",
+                            translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                             [],
                         )));
                     }
@@ -271,7 +272,7 @@ impl CommandExecutor for SelfToEntityExecutor {
                     Ok(1)
                 }
                 _ => Err(CommandError::CommandFailed(TextComponent::translate(
-                    "permissions.requires.player",
+                    translation::PERMISSIONS_REQUIRES_PLAYER,
                     [],
                 ))),
             }
@@ -295,7 +296,7 @@ impl CommandExecutor for SelfToPosExecutor {
                     let pitch = player.living_entity.entity.pitch.load();
                     if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                         return Err(CommandError::CommandFailed(TextComponent::translate(
-                            "commands.teleport.invalidPosition",
+                            translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                             [],
                         )));
                     }
@@ -307,7 +308,7 @@ impl CommandExecutor for SelfToPosExecutor {
                     Ok(1)
                 }
                 _ => Err(CommandError::CommandFailed(TextComponent::translate(
-                    "permissions.requires.player",
+                    translation::PERMISSIONS_REQUIRES_PLAYER,
                     [],
                 ))),
             }


### PR DESCRIPTION
- `/execute`: run commands with conditions (`if`/`unless`) and context modifiers
- `/attribute`: query, add, remove, or set entity attributes
- `/item`: manipulate items in entity/block inventories

### Translation fixes
- Replace hardcoded English error messages with proper translation key constants in:
  - `fill.rs` (pos out of bounds, too big, failed, success)
  - `setworldspawn.rs` (success message key)
  - `spawnpoint.rs` (success message key)
  - `teleport.rs` (invalid position, requires player)

| Command | OP Level |
|---------|----------|
| `/execute` | 2 |
| `/attribute` | 2 |
| `/item` | 2 |

Partially addresses #15.