### PR TITLE
feat: implement /teammsg command

### DIFF
--- a/pumpkin-protocol/src/java/client/play/mod.rs
+++ b/pumpkin-protocol/src/java/client/play/mod.rs
@@ -91,6 +91,7 @@ mod update_entity_rot;
 mod update_mob_effect;
 mod update_objectives;
 mod update_score;
+mod update_teams;
 mod worldevent;
 
 pub use acknowledge_block::*;
@@ -186,4 +187,5 @@ pub use update_entity_rot::*;
 pub use update_mob_effect::*;
 pub use update_objectives::*;
 pub use update_score::*;
+pub use update_teams::*;
 pub use worldevent::*;

--- a/pumpkin-protocol/src/java/client/play/update_teams.rs
+++ b/pumpkin-protocol/src/java/client/play/update_teams.rs
@@ -1,0 +1,170 @@
+use std::io::Write;
+
+use pumpkin_data::packet::clientbound::PLAY_SET_PLAYER_TEAM;
+use pumpkin_macros::java_packet;
+use pumpkin_util::{text::TextComponent, version::MinecraftVersion};
+
+use crate::{ClientPacket, VarInt, WritingError, ser::NetworkWriteExt};
+
+#[java_packet(PLAY_SET_PLAYER_TEAM)]
+pub struct CUpdateTeams {
+    pub team_name: String,
+    pub mode: u8,
+    /// Only present for mode 0 (create) and 2 (update)
+    pub display_name: Option<TextComponent>,
+    pub friendly_flags: u8,
+    pub name_tag_visibility: Option<String>,
+    pub collision_rule: Option<String>,
+    pub color: VarInt,
+    pub prefix: Option<TextComponent>,
+    pub suffix: Option<TextComponent>,
+    /// Only present for mode 0 (create), 3 (add players), 4 (remove players)
+    pub entities: Vec<String>,
+}
+
+impl CUpdateTeams {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn create(
+        team_name: String,
+        display_name: TextComponent,
+        friendly_flags: u8,
+        name_tag_visibility: String,
+        collision_rule: String,
+        color: i32,
+        prefix: TextComponent,
+        suffix: TextComponent,
+        entities: Vec<String>,
+    ) -> Self {
+        Self {
+            team_name,
+            mode: 0,
+            display_name: Some(display_name),
+            friendly_flags,
+            name_tag_visibility: Some(name_tag_visibility),
+            collision_rule: Some(collision_rule),
+            color: VarInt(color),
+            prefix: Some(prefix),
+            suffix: Some(suffix),
+            entities,
+        }
+    }
+
+    #[must_use]
+    pub const fn remove(team_name: String) -> Self {
+        Self {
+            team_name,
+            mode: 1,
+            display_name: None,
+            friendly_flags: 0,
+            name_tag_visibility: None,
+            collision_rule: None,
+            color: VarInt(0),
+            prefix: None,
+            suffix: None,
+            entities: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn update(
+        team_name: String,
+        display_name: TextComponent,
+        friendly_flags: u8,
+        name_tag_visibility: String,
+        collision_rule: String,
+        color: i32,
+        prefix: TextComponent,
+        suffix: TextComponent,
+    ) -> Self {
+        Self {
+            team_name,
+            mode: 2,
+            display_name: Some(display_name),
+            friendly_flags,
+            name_tag_visibility: Some(name_tag_visibility),
+            collision_rule: Some(collision_rule),
+            color: VarInt(color),
+            prefix: Some(prefix),
+            suffix: Some(suffix),
+            entities: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn add_entities(team_name: String, entities: Vec<String>) -> Self {
+        Self {
+            team_name,
+            mode: 3,
+            display_name: None,
+            friendly_flags: 0,
+            name_tag_visibility: None,
+            collision_rule: None,
+            color: VarInt(0),
+            prefix: None,
+            suffix: None,
+            entities,
+        }
+    }
+
+    #[must_use]
+    pub const fn remove_entities(team_name: String, entities: Vec<String>) -> Self {
+        Self {
+            team_name,
+            mode: 4,
+            display_name: None,
+            friendly_flags: 0,
+            name_tag_visibility: None,
+            collision_rule: None,
+            color: VarInt(0),
+            prefix: None,
+            suffix: None,
+            entities,
+        }
+    }
+}
+
+impl ClientPacket for CUpdateTeams {
+    fn write_packet_data(
+        &self,
+        write: impl Write,
+        _version: &MinecraftVersion,
+    ) -> Result<(), WritingError> {
+        let mut write = write;
+
+        write.write_string(&self.team_name)?;
+        write.write_u8(self.mode)?;
+
+        // Mode 0 (create) and 2 (update) include team info
+        if self.mode == 0 || self.mode == 2 {
+            if let Some(ref display_name) = self.display_name {
+                write.write_slice(&display_name.encode())?;
+            }
+            write.write_u8(self.friendly_flags)?;
+            if let Some(ref ntv) = self.name_tag_visibility {
+                write.write_string(ntv)?;
+            }
+            if let Some(ref cr) = self.collision_rule {
+                write.write_string(cr)?;
+            }
+            write.write_var_int(&self.color)?;
+            if let Some(ref prefix) = self.prefix {
+                write.write_slice(&prefix.encode())?;
+            }
+            if let Some(ref suffix) = self.suffix {
+                write.write_slice(&suffix.encode())?;
+            }
+        }
+
+        // Mode 0 (create), 3 (add players), 4 (remove players) include entity list
+        if self.mode == 0 || self.mode == 3 || self.mode == 4 {
+            write.write_var_int(&VarInt(self.entities.len() as i32))?;
+            for entity in &self.entities {
+                write.write_string(entity)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -47,6 +47,7 @@ mod spawnpoint;
 mod stop;
 mod stopsound;
 mod summon;
+mod team;
 mod teleport;
 mod tellraw;
 mod tick;
@@ -135,6 +136,10 @@ pub async fn default_dispatcher(
         "minecraft:command.spawnpoint",
     );
     dispatcher.register(data::init_command_tree(), "minecraft:command.data");
+    dispatcher.register(
+        team::init_command_tree(),
+        "minecraft:command.team",
+    );
     // Three
     dispatcher.register(op::init_command_tree(), "minecraft:command.op");
     dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");
@@ -425,6 +430,13 @@ fn register_level_2_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "pumpkin:command.tps",
             "Displays the server TPS and MSPT",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.team",
+            "Controls teams",
             PermissionDefault::Op(PermissionLvl::Two),
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -136,10 +136,7 @@ pub async fn default_dispatcher(
         "minecraft:command.spawnpoint",
     );
     dispatcher.register(data::init_command_tree(), "minecraft:command.data");
-    dispatcher.register(
-        team::init_command_tree(),
-        "minecraft:command.team",
-    );
+    dispatcher.register(team::init_command_tree(), "minecraft:command.team");
     // Three
     dispatcher.register(op::init_command_tree(), "minecraft:command.op");
     dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -48,6 +48,7 @@ mod stop;
 mod stopsound;
 mod summon;
 mod team;
+mod teammsg;
 mod teleport;
 mod tellraw;
 mod tick;
@@ -76,6 +77,7 @@ pub async fn default_dispatcher(
     dispatcher.register(list::init_command_tree(), "minecraft:command.list");
     dispatcher.register(me::init_command_tree(), "minecraft:command.me");
     dispatcher.register(msg::init_command_tree(), "minecraft:command.msg");
+    dispatcher.register(teammsg::init_command_tree(), "minecraft:command.teammsg");
     // Two
     dispatcher.register(kill::init_command_tree(), "minecraft:command.kill");
     dispatcher.register(
@@ -435,6 +437,13 @@ fn register_level_2_permissions(registry: &mut PermissionRegistry) {
             "minecraft:command.team",
             "Controls teams",
             PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.teammsg",
+            "Sends a message to all players on the sender's team",
+            PermissionDefault::Allow,
         ))
         .unwrap();
 }

--- a/pumpkin/src/command/commands/team.rs
+++ b/pumpkin/src/command/commands/team.rs
@@ -1,0 +1,365 @@
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 1] = ["team"];
+
+const DESCRIPTION: &str = "Controls teams.";
+
+const ARG_TEAM: &str = "team";
+const ARG_MEMBERS: &str = "members";
+
+struct AddExecutor;
+
+impl CommandExecutor for AddExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(team_name)) = args.get(ARG_TEAM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TEAM.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut teams = world.teams.lock().await;
+
+            if teams.has_team(team_name) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_TEAM_ADD_DUPLICATE,
+                    [],
+                )));
+            }
+
+            teams.add_team(&world, team_name).await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TEAM_ADD_SUCCESS,
+                    [TextComponent::text(team_name.to_string())],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct RemoveExecutor;
+
+impl CommandExecutor for RemoveExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(team_name)) = args.get(ARG_TEAM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TEAM.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut teams = world.teams.lock().await;
+
+            if teams.remove_team(&world, team_name).await.is_none() {
+                return Err(CommandError::CommandFailed(TextComponent::text(format!(
+                    "Unknown team '{team_name}'"
+                ))));
+            }
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TEAM_REMOVE_SUCCESS,
+                    [TextComponent::text(team_name.to_string())],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct ListExecutor;
+
+impl CommandExecutor for ListExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let teams = world.teams.lock().await;
+            let all_teams = teams.get_teams();
+
+            if all_teams.is_empty() {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_LIST_TEAMS_EMPTY,
+                        [],
+                    ))
+                    .await;
+                return Ok(0);
+            }
+
+            let team_names: Vec<&String> = all_teams.keys().collect();
+            let count = team_names.len();
+            let team_list = team_names
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TEAM_LIST_TEAMS_SUCCESS,
+                    [
+                        TextComponent::text(count.to_string()),
+                        TextComponent::text(team_list),
+                    ],
+                ))
+                .await;
+            Ok(count as i32)
+        })
+    }
+}
+
+struct ListMembersExecutor;
+
+impl CommandExecutor for ListMembersExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(team_name)) = args.get(ARG_TEAM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TEAM.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let teams = world.teams.lock().await;
+
+            let team = teams.get_team(team_name).ok_or_else(|| {
+                CommandError::CommandFailed(TextComponent::text(format!(
+                    "Unknown team '{team_name}'"
+                )))
+            })?;
+
+            if team.members.is_empty() {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_LIST_MEMBERS_EMPTY,
+                        [TextComponent::text(team_name.to_string())],
+                    ))
+                    .await;
+                return Ok(0);
+            }
+
+            let members: Vec<&String> = team.members.iter().collect();
+            let count = members.len();
+            let member_list = members
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TEAM_LIST_MEMBERS_SUCCESS,
+                    [
+                        TextComponent::text(team_name.to_string()),
+                        TextComponent::text(count.to_string()),
+                        TextComponent::text(member_list),
+                    ],
+                ))
+                .await;
+            Ok(count as i32)
+        })
+    }
+}
+
+struct JoinExecutor;
+
+impl CommandExecutor for JoinExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(team_name)) = args.get(ARG_TEAM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TEAM.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut teams = world.teams.lock().await;
+
+            if !teams.has_team(team_name) {
+                return Err(CommandError::CommandFailed(TextComponent::text(format!(
+                    "Unknown team '{team_name}'"
+                ))));
+            }
+
+            let members = if let Some(Arg::Simple(member)) = args.get(ARG_MEMBERS) {
+                vec![member.to_string()]
+            } else {
+                match sender {
+                    CommandSender::Player(p) => vec![p.gameprofile.name.clone()],
+                    _ => return Err(CommandError::InvalidRequirement),
+                }
+            };
+
+            let added = teams.add_members(&world, team_name, &members).await;
+
+            if members.len() == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_JOIN_SUCCESS_SINGLE,
+                        [
+                            TextComponent::text(members[0].clone()),
+                            TextComponent::text(team_name.to_string()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_JOIN_SUCCESS_MULTIPLE,
+                        [
+                            TextComponent::text(added.to_string()),
+                            TextComponent::text(team_name.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(added as i32)
+        })
+    }
+}
+
+struct LeaveExecutor;
+
+impl CommandExecutor for LeaveExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut teams = world.teams.lock().await;
+
+            let members = if let Some(Arg::Simple(member)) = args.get(ARG_MEMBERS) {
+                vec![member.to_string()]
+            } else {
+                match sender {
+                    CommandSender::Player(p) => vec![p.gameprofile.name.clone()],
+                    _ => return Err(CommandError::InvalidRequirement),
+                }
+            };
+
+            let removed = teams.leave_members(&world, &members).await;
+
+            if members.len() == 1 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_LEAVE_SUCCESS_SINGLE,
+                        [TextComponent::text(members[0].clone())],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_LEAVE_SUCCESS_MULTIPLE,
+                        [TextComponent::text(removed.to_string())],
+                    ))
+                    .await;
+            }
+            Ok(removed as i32)
+        })
+    }
+}
+
+struct EmptyExecutor;
+
+impl CommandExecutor for EmptyExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(team_name)) = args.get(ARG_TEAM) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TEAM.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut teams = world.teams.lock().await;
+
+            if !teams.has_team(team_name) {
+                return Err(CommandError::CommandFailed(TextComponent::text(format!(
+                    "Unknown team '{team_name}'"
+                ))));
+            }
+
+            let count = teams.empty_team(&world, team_name).await;
+
+            if count == 0 {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_EMPTY_UNCHANGED,
+                        [],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_TEAM_EMPTY_SUCCESS,
+                        [
+                            TextComponent::text(count.to_string()),
+                            TextComponent::text(team_name.to_string()),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(count as i32)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(literal("add").then(argument(ARG_TEAM, SimpleArgConsumer).execute(AddExecutor)))
+        .then(literal("remove").then(argument(ARG_TEAM, SimpleArgConsumer).execute(RemoveExecutor)))
+        .then(
+            literal("list")
+                .then(argument(ARG_TEAM, SimpleArgConsumer).execute(ListMembersExecutor))
+                .execute(ListExecutor),
+        )
+        .then(
+            literal("join").then(
+                argument(ARG_TEAM, SimpleArgConsumer)
+                    .then(argument(ARG_MEMBERS, SimpleArgConsumer).execute(JoinExecutor))
+                    .execute(JoinExecutor),
+            ),
+        )
+        .then(
+            literal("leave")
+                .then(argument(ARG_MEMBERS, SimpleArgConsumer).execute(LeaveExecutor))
+                .execute(LeaveExecutor),
+        )
+        .then(literal("empty").then(argument(ARG_TEAM, SimpleArgConsumer).execute(EmptyExecutor)))
+}

--- a/pumpkin/src/command/commands/teammsg.rs
+++ b/pumpkin/src/command/commands/teammsg.rs
@@ -1,0 +1,70 @@
+use std::collections::HashSet;
+
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::message::MsgArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::argument;
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 2] = ["teammsg", "tm"];
+
+const DESCRIPTION: &str = "Sends a message to all players on the sender's team.";
+
+const ARG_MESSAGE: &str = "message";
+
+struct TeamMsgExecutor;
+
+impl CommandExecutor for TeamMsgExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Msg(message)) = args.get(ARG_MESSAGE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_MESSAGE.into())));
+            };
+
+            let CommandSender::Player(player) = sender else {
+                return Err(CommandError::InvalidRequirement);
+            };
+
+            let sender_name = player.gameprofile.name.clone();
+            let world = player.living_entity.entity.world.load_full();
+
+            // Get team info and member list, then drop the lock
+            let (team_name, members): (String, HashSet<String>) = {
+                let teams = world.teams.lock().await;
+                let Some(name) = teams.get_member_team(&sender_name) else {
+                    return Err(CommandError::CommandFailed(TextComponent::translate(
+                        translation::COMMANDS_TEAMMSG_FAILED_NOTEAM,
+                        [],
+                    )));
+                };
+                let team = teams.get_team(name).unwrap();
+                (name.to_string(), team.members.clone())
+            };
+
+            let msg = TextComponent::text(format!("[{team_name}] <{sender_name}> {message}"));
+
+            let players = world.players.load();
+            for p in players.iter() {
+                if members.contains(&p.gameprofile.name) {
+                    p.send_system_message(&msg).await;
+                }
+            }
+
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(argument(ARG_MESSAGE, MsgArgConsumer).execute(TeamMsgExecutor))
+}

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -129,6 +129,7 @@ use pumpkin_world::{world::BlockFlags, world_info::LevelData};
 use rand::seq::SliceRandom;
 use rand::{RngExt, rng};
 use scoreboard::Scoreboard;
+use teams::Teams;
 use time::LevelTime;
 use tokio::sync::Mutex;
 
@@ -137,6 +138,7 @@ pub mod bossbar;
 pub mod custom_bossbar;
 pub mod natural_spawner;
 pub mod scoreboard;
+pub mod teams;
 pub mod weather;
 
 use crate::world::natural_spawner::{SpawnState, spawn_for_chunk};
@@ -184,6 +186,8 @@ pub struct World {
     pub entities: ArcSwap<Vec<Arc<dyn EntityBase>>>,
     /// The world's scoreboard, used for tracking scores, objectives, and display information.
     pub scoreboard: Mutex<Scoreboard>,
+    /// The world's teams
+    pub teams: Mutex<Teams>,
     /// The world's worldborder, defining the playable area and controlling its expansion or contraction.
     pub worldborder: Mutex<Worldborder>,
     /// The world's time, including counting ticks for weather, time cycles, and statistics.
@@ -234,6 +238,7 @@ impl World {
             players: ArcSwap::new(Arc::new(Vec::new())),
             entities: ArcSwap::new(Arc::new(Vec::new())),
             scoreboard: Mutex::new(Scoreboard::default()),
+            teams: Mutex::new(Teams::default()),
             worldborder: Mutex::new(Worldborder::new(0.0, 0.0, 5.999_996_8E7, 0, 5, 300)),
             level_time: Mutex::new(LevelTime::new()),
             dimension,

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1,3 +1,4 @@
+use pumpkin_protocol::codec::data_component::data_to_proto_sound;
 use std::pin::Pin;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::{Arc, Weak};
@@ -14,7 +15,8 @@ pub mod portal;
 pub mod time;
 
 use crate::block::RandomTickArgs;
-use crate::world::loot::LootContextParameters;
+use crate::world::chunker::is_within_view_distance;
+use crate::world::{chunker::get_view_distance, loot::LootContextParameters};
 use crate::{
     block::BlockEvent, entity::experience_orb::ExperienceOrbEntity, entity::item::ItemEntity,
 };
@@ -95,7 +97,7 @@ use pumpkin_protocol::{
 };
 use pumpkin_protocol::{
     codec::item_stack_seralizer::ItemStackSerializer,
-    java::client::play::{CBlockEvent, CRemoveMobEffect, CSetEquipment},
+    java::client::play::{CBlockEvent, CRemoveMobEffect, CSetEquipment, CUpdateMobEffect},
 };
 use pumpkin_protocol::{
     codec::var_int::VarInt,
@@ -127,7 +129,6 @@ use pumpkin_world::{world::BlockFlags, world_info::LevelData};
 use rand::seq::SliceRandom;
 use rand::{RngExt, rng};
 use scoreboard::Scoreboard;
-use teams::Teams;
 use time::LevelTime;
 use tokio::sync::Mutex;
 
@@ -136,7 +137,6 @@ pub mod bossbar;
 pub mod custom_bossbar;
 pub mod natural_spawner;
 pub mod scoreboard;
-pub mod teams;
 pub mod weather;
 
 use crate::world::natural_spawner::{SpawnState, spawn_for_chunk};
@@ -184,8 +184,6 @@ pub struct World {
     pub entities: ArcSwap<Vec<Arc<dyn EntityBase>>>,
     /// The world's scoreboard, used for tracking scores, objectives, and display information.
     pub scoreboard: Mutex<Scoreboard>,
-    /// The world's teams, used for grouping players and entities.
-    pub teams: Mutex<Teams>,
     /// The world's worldborder, defining the playable area and controlling its expansion or contraction.
     pub worldborder: Mutex<Worldborder>,
     /// The world's time, including counting ticks for weather, time cycles, and statistics.
@@ -236,7 +234,6 @@ impl World {
             players: ArcSwap::new(Arc::new(Vec::new())),
             entities: ArcSwap::new(Arc::new(Vec::new())),
             scoreboard: Mutex::new(Scoreboard::default()),
-            teams: Mutex::new(Teams::default()),
             worldborder: Mutex::new(Worldborder::new(0.0, 0.0, 5.999_996_8E7, 0, 5, 300)),
             level_time: Mutex::new(LevelTime::new()),
             dimension,
@@ -328,10 +325,14 @@ impl World {
         }
     }
 
+    /// Sends an entity status update to all players tracking the specified entity.
     pub async fn send_entity_status(&self, entity: &Entity, status: EntityStatus) {
-        // TODO: only nearby
-        self.broadcast_packet_all(&CEntityStatus::new(entity.entity_id, status as i8))
-            .await;
+        let chunk_pos = entity.chunk_pos.load();
+        self.broadcast_to_chunk(
+            chunk_pos,
+            &CEntityStatus::new(entity.entity_id, status as i8),
+        )
+        .await;
     }
 
     pub async fn send_remove_mob_effect(
@@ -339,10 +340,37 @@ impl World {
         entity: &Entity,
         effect_type: &'static StatusEffect,
     ) {
+        let chunk_pos = entity.chunk_pos.load();
+        self.broadcast_to_chunk(
+            chunk_pos,
+            &CRemoveMobEffect::new(entity.entity_id.into(), VarInt(i32::from(effect_type.id))),
+        )
+        .await;
+    }
+
+    pub async fn send_add_mob_effect(
+        &self,
+        entity: &Entity,
+        effect: &pumpkin_data::potion::Effect,
+    ) {
         // TODO: only nearby
-        self.broadcast_packet_all(&CRemoveMobEffect::new(
-            entity.entity_id.into(),
-            VarInt(i32::from(effect_type.id)),
+        let mut flags: i8 = 0;
+        if effect.ambient {
+            flags |= 0x01;
+        }
+        if effect.show_particles {
+            flags |= 0x02;
+        }
+        if effect.show_icon {
+            flags |= 0x04;
+        }
+
+        self.broadcast_packet_all(&CUpdateMobEffect::new(
+            VarInt(entity.entity_id),
+            VarInt(i32::from(effect.effect_type.id)),
+            VarInt(i32::from(effect.amplifier)),
+            VarInt(effect.duration),
+            flags,
         ))
         .await;
     }
@@ -385,12 +413,16 @@ impl World {
             {
                 continue;
             }
-            self.broadcast_packet_all(&CBlockEvent::new(
-                event.pos,
-                event.r#type,
-                event.data,
-                VarInt(i32::from(block.id)),
-            ))
+            let chunk_pos = event.pos.chunk_position();
+            self.broadcast_to_chunk(
+                chunk_pos,
+                &CBlockEvent::new(
+                    event.pos,
+                    event.r#type,
+                    event.data,
+                    VarInt(i32::from(block.id)),
+                ),
+            )
             .await;
         }
     }
@@ -510,7 +542,7 @@ impl World {
                 Some(decorated_message.clone()),
                 FilterType::PassThrough,
                 (RAW + 1).into(), // Custom registry chat_type with no sender name
-                TextComponent::text(""), // Not needed since we're injecting the name in the message for custom formatting
+                TextComponent::empty(), // Not needed since we're injecting the name in the message for custom formatting
                 None,
             );
             recipient.client.enqueue_packet(packet).await;
@@ -574,6 +606,26 @@ impl World {
             .await;
     }
 
+    pub async fn play_sound_event(
+        &self,
+        sound: pumpkin_data::data_component_impl::IdOr<
+            pumpkin_data::data_component_impl::SoundEvent,
+        >,
+        category: SoundCategory,
+        position: &Vector3<f64>,
+    ) {
+        let seed = rng().random::<f64>();
+        let packet = CSoundEffect::new(
+            data_to_proto_sound(&sound),
+            category,
+            position,
+            1.0,
+            1.0,
+            seed,
+        );
+        self.broadcast_packet_all(&packet).await;
+    }
+
     pub async fn play_sound_fine(
         &self,
         sound: Sound,
@@ -605,9 +657,22 @@ impl World {
         volume: f32,
         pitch: f32,
     ) {
-        let seed = rng().random::<f64>();
+        let seed = rand::rng().random::<f64>();
         let packet = CSoundEffect::new(IdOr::Id(sound_id), category, position, volume, pitch, seed);
-        self.broadcast_packet_all(&packet).await;
+
+        // Calculate the number of chunks the sound can be heard from based on its volume.
+        let audible_chunks = f64::from(volume.max(1.0)).ceil() as i32;
+        let chunk_pos = BlockPos::floored_v(*position).chunk_position();
+
+        let players = self.players.load();
+        let recipients = players.iter().filter(|p| {
+            let center = p.living_entity.entity.chunk_pos.load();
+            // If the sound reaches their chunk, send it!
+            is_within_view_distance(chunk_pos, center, audible_chunks)
+        });
+
+        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
+        Self::broadcast_java_grouped(&packet, recipients_by_version).await;
     }
 
     pub async fn play_sound_raw_expect(
@@ -619,10 +684,25 @@ impl World {
         volume: f32,
         pitch: f32,
     ) {
-        let seed = rng().random::<f64>();
+        let seed = rand::rng().random::<f64>();
         let packet = CSoundEffect::new(IdOr::Id(sound_id), category, position, volume, pitch, seed);
-        self.broadcast_packet_except(&[player.gameprofile.id], &packet)
-            .await;
+
+        let audible_chunks = f64::from(volume.max(1.0)).ceil() as i32;
+        let chunk_pos = BlockPos::floored_v(*position).chunk_position();
+
+        let players = self.players.load();
+        let recipients = players.iter().filter(|p| {
+            // Skip the expected player
+            if p.gameprofile.id == player.gameprofile.id {
+                return false;
+            }
+
+            let center = p.living_entity.entity.chunk_pos.load();
+            is_within_view_distance(chunk_pos, center, audible_chunks)
+        });
+
+        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
+        Self::broadcast_java_grouped(&packet, recipients_by_version).await;
     }
 
     pub async fn play_block_sound(
@@ -730,19 +810,20 @@ impl World {
 
         // TODO: only send packet to players who have the chunks loaded
         // TODO: Send light updates to update the wire directly next to a broken block
-        for chunk_section in block_state_updates_by_chunk_section.values() {
-            if chunk_section.is_empty() {
+        for (chunk_section, updates) in block_state_updates_by_chunk_section {
+            if updates.is_empty() {
                 continue;
             }
-            if chunk_section.len() == 1 {
-                let (block_pos, block_state_id) = chunk_section[0];
-                self.broadcast_packet_all(&CBlockUpdate::new(
-                    block_pos,
-                    i32::from(block_state_id).into(),
-                ))
+            let chunk_pos = Vector2::new(chunk_section.x, chunk_section.z);
+            if updates.len() == 1 {
+                let (block_pos, block_state_id) = updates[0];
+                self.broadcast_to_chunk(
+                    chunk_pos,
+                    &CBlockUpdate::new(block_pos, i32::from(block_state_id).into()),
+                )
                 .await;
             } else {
-                self.broadcast_packet_all(&CMultiBlockUpdate::new(chunk_section))
+                self.broadcast_to_chunk(chunk_pos, &CMultiBlockUpdate::new(&updates))
                     .await;
             }
         }
@@ -824,14 +905,33 @@ impl World {
         }
 
         for scheduled_tick in tick_data.random_ticks {
-            let block = self.get_block(&scheduled_tick.position).await;
-            if let Some(pumpkin_block) = self.block_registry.get_pumpkin_block(block.id) {
+            let (block, fluid) = match (scheduled_tick.tick_block, scheduled_tick.tick_fluid) {
+                (true, true) => {
+                    let (block, fluid) = self.get_block_and_fluid(&scheduled_tick.position).await;
+                    (Some(block), Some(fluid))
+                }
+                (true, false) => (Some(self.get_block(&scheduled_tick.position).await), None),
+                (false, true) => (None, Some(self.get_fluid(&scheduled_tick.position).await)),
+                (false, false) => (None, None),
+            };
+
+            if let Some(block) = block
+                && let Some(pumpkin_block) = self.block_registry.get_pumpkin_block(block.id)
+            {
                 pumpkin_block
                     .random_tick(RandomTickArgs {
                         world: self,
                         block,
                         position: &scheduled_tick.position,
                     })
+                    .await;
+            }
+
+            if let Some(fluid) = fluid
+                && let Some(pumpkin_fluid) = self.block_registry.get_pumpkin_fluid(fluid.id)
+            {
+                pumpkin_fluid
+                    .random_tick(fluid, self, &scheduled_tick.position)
                     .await;
             }
         }
@@ -860,13 +960,21 @@ impl World {
             SpawnState::new(spawning_chunks_map.len() as i32, &self.entities, self).await; // TODO store it
 
         // TODO gamerule this.spawnEnemies || this.spawnFriendlies
+        let (spawn_mobs, spawn_monsters, peaceful) = {
+            let lock = self.level_info.load();
+            (
+                lock.game_rules.spawn_mobs,
+                lock.game_rules.spawn_monsters,
+                lock.difficulty == Difficulty::Peaceful,
+            )
+        };
         let spawn_passives = self.level_time.lock().await.time_of_day % 400 == 0;
         let spawn_list: Vec<&'static MobCategory> =
             natural_spawner::get_filtered_spawning_categories(
                 &spawn_state,
-                true,
-                true,
-                spawn_passives,
+                spawn_mobs,
+                peaceful && spawn_mobs && spawn_monsters,
+                peaceful && spawn_mobs && spawn_passives && spawn_monsters,
             );
 
         // log::debug!("spawning list size {}", spawn_list.len());
@@ -1564,7 +1672,7 @@ impl World {
         &self,
         base_config: &BasicConfiguration,
         player: &Arc<Player>,
-        server: &Server,
+        server: &Arc<Server>,
     ) {
         let dimensions: Vec<ResourceLocation> = server
             .dimensions
@@ -1908,9 +2016,6 @@ impl World {
 
         player.send_active_effects().await;
         self.send_player_equipment(player).await;
-
-        // Send existing teams to the joining player
-        self.teams.lock().await.send_to_player(client).await;
     }
 
     async fn send_player_equipment(&self, from: &Player) {
@@ -1930,7 +2035,9 @@ impl World {
             .iter()
             .map(|(slot, stack)| (*slot, ItemStackSerializer::from(stack.clone())))
             .collect();
-        self.broadcast_packet_except(
+        let chunk_pos = from.get_entity().chunk_pos.load();
+        self.broadcast_to_chunk_except(
+            chunk_pos,
             &[from.get_entity().entity_uuid],
             &CSetEquipment::new(from.entity_id().into(), equipment),
         )
@@ -2726,7 +2833,8 @@ impl World {
 
     pub async fn spawn_entity(&self, entity: Arc<dyn EntityBase>) {
         let base_entity = entity.get_entity();
-        self.broadcast_packet_all(&base_entity.create_spawn_packet())
+        let chunk_pos = base_entity.chunk_pos.load();
+        self.broadcast_to_chunk(chunk_pos, &base_entity.create_spawn_packet())
             .await;
         entity.init_data_tracker().await;
 
@@ -2753,14 +2861,17 @@ impl World {
             new_entities
         });
 
-        self.broadcast_packet_all(&CRemoveEntities::new(&[entity.entity_id.into()]))
+        let chunk_pos = entity.chunk_pos.load();
+        self.broadcast_to_chunk(chunk_pos, &CRemoveEntities::new(&[entity.entity_id.into()]))
             .await;
 
         self.remove_entity_data(entity).await;
     }
 
     pub async fn set_block_breaking(&self, from: &Entity, location: BlockPos, progress: i32) {
-        self.broadcast_packet_except(
+        let chunk_pos = location.chunk_position(); // pumpkin's BlockPos already has this method
+        self.broadcast_to_chunk_except(
+            chunk_pos,
             &[from.entity_uuid],
             &CSetBlockDestroyStage::new(from.entity_id.into(), location, progress as i8),
         )
@@ -3005,12 +3116,17 @@ impl World {
                     broken_state_id.into(),
                     false,
                 );
+                let chunk_pos = position.chunk_position();
                 match cause {
                     Some(player) => {
-                        self.broadcast_packet_except(&[player.gameprofile.id], &particles_packet)
-                            .await;
+                        self.broadcast_to_chunk_except(
+                            chunk_pos,
+                            &[player.living_entity.entity.entity_uuid],
+                            &particles_packet,
+                        )
+                        .await;
                     }
-                    None => self.broadcast_packet_all(&particles_packet).await,
+                    None => self.broadcast_to_chunk(chunk_pos, &particles_packet).await,
                 }
             }
 
@@ -3101,8 +3217,12 @@ impl World {
     /* End ItemScatterer.java */
 
     pub async fn sync_world_event(&self, world_event: WorldEvent, position: BlockPos, data: i32) {
-        self.broadcast_packet_all(&CWorldEvent::new(world_event as i32, position, data, false))
-            .await;
+        let chunk_pos = position.chunk_position();
+        self.broadcast_to_chunk(
+            chunk_pos,
+            &CWorldEvent::new(world_event as i32, position, data, false),
+        )
+        .await;
     }
     #[must_use]
     pub fn is_valid(dest: BlockPos) -> bool {
@@ -3137,6 +3257,30 @@ impl World {
     pub async fn get_block(&self, position: &BlockPos) -> &'static Block {
         let id = self.get_block_state_id(position).await;
         Block::from_state_id(id)
+    }
+
+    #[must_use]
+    pub fn get_block_state_id_if_loaded(&self, position: &BlockPos) -> Option<BlockStateId> {
+        if !self.is_in_build_limit(*position) {
+            return None;
+        }
+
+        let (chunk_coordinate, relative) = position.chunk_and_chunk_relative_position();
+        let chunk = self.level.try_get_chunk(&chunk_coordinate)?;
+        chunk
+            .section
+            .get_block_absolute_y(relative.x as usize, relative.y, relative.z as usize)
+    }
+
+    #[must_use]
+    pub fn get_block_state_if_loaded(&self, position: &BlockPos) -> Option<&'static BlockState> {
+        self.get_block_state_id_if_loaded(position)
+            .map(BlockState::from_id)
+    }
+
+    #[must_use]
+    pub fn is_loaded(&self, position: &BlockPos) -> bool {
+        self.get_block_state_id_if_loaded(position).is_some()
     }
 
     pub async fn get_fluid(&self, position: &BlockPos) -> &'static pumpkin_data::fluid::Fluid {
@@ -3367,11 +3511,15 @@ impl World {
         if let Some(nbt) = &block_entity_nbt {
             let mut bytes = Vec::new();
             to_bytes_unnamed(nbt, &mut bytes).unwrap();
-            self.broadcast_packet_all(&CBlockEntityData::new(
-                block_entity.get_position(),
-                VarInt(block_entity.get_id() as i32),
-                bytes.into_boxed_slice(),
-            ))
+            let chunk_pos = block_pos.chunk_position();
+            self.broadcast_to_chunk(
+                chunk_pos,
+                &CBlockEntityData::new(
+                    block_entity.get_position(),
+                    VarInt(block_entity.get_id() as i32),
+                    bytes.into_boxed_slice(),
+                ),
+            )
             .await;
         }
 
@@ -3404,11 +3552,15 @@ impl World {
         if let Some(nbt) = &block_entity_nbt {
             let mut bytes = Vec::new();
             to_bytes_unnamed(nbt, &mut bytes).unwrap();
-            self.broadcast_packet_all(&CBlockEntityData::new(
-                block_entity.get_position(),
-                VarInt(block_entity.get_id() as i32),
-                bytes.into_boxed_slice(),
-            ))
+            let chunk_pos = block_pos.chunk_position();
+            self.broadcast_to_chunk(
+                chunk_pos,
+                &CBlockEntityData::new(
+                    block_entity.get_position(),
+                    VarInt(block_entity.get_id() as i32),
+                    bytes.into_boxed_slice(),
+                ),
+            )
             .await;
         }
         chunk.mark_dirty(true);
@@ -3609,6 +3761,46 @@ impl World {
         }
 
         None
+    }
+
+    /// Broadcasts a packet to all players who currently have the target chunk loaded.
+    /// This uses highly optimized Chebyshev distance math (Chunk Grid) instead of floating point distance checks.
+    pub async fn broadcast_to_chunk<P: ClientPacket>(&self, chunk_pos: Vector2<i32>, packet: &P) {
+        let players = self.players.load();
+
+        let recipients = players.iter().filter(|p| {
+            let center = p.living_entity.entity.chunk_pos.load();
+            let view_distance = get_view_distance(p).get() as i32;
+
+            // Chebyshev distance (Minecraft's chunk loading shape)
+            is_within_view_distance(chunk_pos, center, view_distance)
+        });
+
+        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
+        Self::broadcast_java_grouped(packet, recipients_by_version).await;
+    }
+
+    /// Broadcasts a packet to chunk watchers, excluding specific players.
+    pub async fn broadcast_to_chunk_except<P: ClientPacket>(
+        &self,
+        chunk_pos: Vector2<i32>,
+        except: &[uuid::Uuid],
+        packet: &P,
+    ) {
+        let players = self.players.load();
+
+        let recipients = players.iter().filter(|p| {
+            if except.contains(&p.living_entity.entity.entity_uuid) {
+                return false;
+            }
+            let center = p.living_entity.entity.chunk_pos.load();
+            let view_distance = get_view_distance(p).get() as i32;
+
+            is_within_view_distance(chunk_pos, center, view_distance)
+        });
+
+        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
+        Self::broadcast_java_grouped(packet, recipients_by_version).await;
     }
 }
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1,4 +1,3 @@
-use pumpkin_protocol::codec::data_component::data_to_proto_sound;
 use std::pin::Pin;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::{Arc, Weak};
@@ -15,8 +14,7 @@ pub mod portal;
 pub mod time;
 
 use crate::block::RandomTickArgs;
-use crate::world::chunker::is_within_view_distance;
-use crate::world::{chunker::get_view_distance, loot::LootContextParameters};
+use crate::world::loot::LootContextParameters;
 use crate::{
     block::BlockEvent, entity::experience_orb::ExperienceOrbEntity, entity::item::ItemEntity,
 };
@@ -97,7 +95,7 @@ use pumpkin_protocol::{
 };
 use pumpkin_protocol::{
     codec::item_stack_seralizer::ItemStackSerializer,
-    java::client::play::{CBlockEvent, CRemoveMobEffect, CSetEquipment, CUpdateMobEffect},
+    java::client::play::{CBlockEvent, CRemoveMobEffect, CSetEquipment},
 };
 use pumpkin_protocol::{
     codec::var_int::VarInt,
@@ -129,6 +127,7 @@ use pumpkin_world::{world::BlockFlags, world_info::LevelData};
 use rand::seq::SliceRandom;
 use rand::{RngExt, rng};
 use scoreboard::Scoreboard;
+use teams::Teams;
 use time::LevelTime;
 use tokio::sync::Mutex;
 
@@ -137,6 +136,7 @@ pub mod bossbar;
 pub mod custom_bossbar;
 pub mod natural_spawner;
 pub mod scoreboard;
+pub mod teams;
 pub mod weather;
 
 use crate::world::natural_spawner::{SpawnState, spawn_for_chunk};
@@ -184,6 +184,8 @@ pub struct World {
     pub entities: ArcSwap<Vec<Arc<dyn EntityBase>>>,
     /// The world's scoreboard, used for tracking scores, objectives, and display information.
     pub scoreboard: Mutex<Scoreboard>,
+    /// The world's teams, used for grouping players and entities.
+    pub teams: Mutex<Teams>,
     /// The world's worldborder, defining the playable area and controlling its expansion or contraction.
     pub worldborder: Mutex<Worldborder>,
     /// The world's time, including counting ticks for weather, time cycles, and statistics.
@@ -234,6 +236,7 @@ impl World {
             players: ArcSwap::new(Arc::new(Vec::new())),
             entities: ArcSwap::new(Arc::new(Vec::new())),
             scoreboard: Mutex::new(Scoreboard::default()),
+            teams: Mutex::new(Teams::default()),
             worldborder: Mutex::new(Worldborder::new(0.0, 0.0, 5.999_996_8E7, 0, 5, 300)),
             level_time: Mutex::new(LevelTime::new()),
             dimension,
@@ -325,14 +328,10 @@ impl World {
         }
     }
 
-    /// Sends an entity status update to all players tracking the specified entity.
     pub async fn send_entity_status(&self, entity: &Entity, status: EntityStatus) {
-        let chunk_pos = entity.chunk_pos.load();
-        self.broadcast_to_chunk(
-            chunk_pos,
-            &CEntityStatus::new(entity.entity_id, status as i8),
-        )
-        .await;
+        // TODO: only nearby
+        self.broadcast_packet_all(&CEntityStatus::new(entity.entity_id, status as i8))
+            .await;
     }
 
     pub async fn send_remove_mob_effect(
@@ -340,37 +339,10 @@ impl World {
         entity: &Entity,
         effect_type: &'static StatusEffect,
     ) {
-        let chunk_pos = entity.chunk_pos.load();
-        self.broadcast_to_chunk(
-            chunk_pos,
-            &CRemoveMobEffect::new(entity.entity_id.into(), VarInt(i32::from(effect_type.id))),
-        )
-        .await;
-    }
-
-    pub async fn send_add_mob_effect(
-        &self,
-        entity: &Entity,
-        effect: &pumpkin_data::potion::Effect,
-    ) {
         // TODO: only nearby
-        let mut flags: i8 = 0;
-        if effect.ambient {
-            flags |= 0x01;
-        }
-        if effect.show_particles {
-            flags |= 0x02;
-        }
-        if effect.show_icon {
-            flags |= 0x04;
-        }
-
-        self.broadcast_packet_all(&CUpdateMobEffect::new(
-            VarInt(entity.entity_id),
-            VarInt(i32::from(effect.effect_type.id)),
-            VarInt(i32::from(effect.amplifier)),
-            VarInt(effect.duration),
-            flags,
+        self.broadcast_packet_all(&CRemoveMobEffect::new(
+            entity.entity_id.into(),
+            VarInt(i32::from(effect_type.id)),
         ))
         .await;
     }
@@ -413,16 +385,12 @@ impl World {
             {
                 continue;
             }
-            let chunk_pos = event.pos.chunk_position();
-            self.broadcast_to_chunk(
-                chunk_pos,
-                &CBlockEvent::new(
-                    event.pos,
-                    event.r#type,
-                    event.data,
-                    VarInt(i32::from(block.id)),
-                ),
-            )
+            self.broadcast_packet_all(&CBlockEvent::new(
+                event.pos,
+                event.r#type,
+                event.data,
+                VarInt(i32::from(block.id)),
+            ))
             .await;
         }
     }
@@ -542,7 +510,7 @@ impl World {
                 Some(decorated_message.clone()),
                 FilterType::PassThrough,
                 (RAW + 1).into(), // Custom registry chat_type with no sender name
-                TextComponent::empty(), // Not needed since we're injecting the name in the message for custom formatting
+                TextComponent::text(""), // Not needed since we're injecting the name in the message for custom formatting
                 None,
             );
             recipient.client.enqueue_packet(packet).await;
@@ -606,26 +574,6 @@ impl World {
             .await;
     }
 
-    pub async fn play_sound_event(
-        &self,
-        sound: pumpkin_data::data_component_impl::IdOr<
-            pumpkin_data::data_component_impl::SoundEvent,
-        >,
-        category: SoundCategory,
-        position: &Vector3<f64>,
-    ) {
-        let seed = rng().random::<f64>();
-        let packet = CSoundEffect::new(
-            data_to_proto_sound(&sound),
-            category,
-            position,
-            1.0,
-            1.0,
-            seed,
-        );
-        self.broadcast_packet_all(&packet).await;
-    }
-
     pub async fn play_sound_fine(
         &self,
         sound: Sound,
@@ -657,22 +605,9 @@ impl World {
         volume: f32,
         pitch: f32,
     ) {
-        let seed = rand::rng().random::<f64>();
+        let seed = rng().random::<f64>();
         let packet = CSoundEffect::new(IdOr::Id(sound_id), category, position, volume, pitch, seed);
-
-        // Calculate the number of chunks the sound can be heard from based on its volume.
-        let audible_chunks = f64::from(volume.max(1.0)).ceil() as i32;
-        let chunk_pos = BlockPos::floored_v(*position).chunk_position();
-
-        let players = self.players.load();
-        let recipients = players.iter().filter(|p| {
-            let center = p.living_entity.entity.chunk_pos.load();
-            // If the sound reaches their chunk, send it!
-            is_within_view_distance(chunk_pos, center, audible_chunks)
-        });
-
-        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
-        Self::broadcast_java_grouped(&packet, recipients_by_version).await;
+        self.broadcast_packet_all(&packet).await;
     }
 
     pub async fn play_sound_raw_expect(
@@ -684,25 +619,10 @@ impl World {
         volume: f32,
         pitch: f32,
     ) {
-        let seed = rand::rng().random::<f64>();
+        let seed = rng().random::<f64>();
         let packet = CSoundEffect::new(IdOr::Id(sound_id), category, position, volume, pitch, seed);
-
-        let audible_chunks = f64::from(volume.max(1.0)).ceil() as i32;
-        let chunk_pos = BlockPos::floored_v(*position).chunk_position();
-
-        let players = self.players.load();
-        let recipients = players.iter().filter(|p| {
-            // Skip the expected player
-            if p.gameprofile.id == player.gameprofile.id {
-                return false;
-            }
-
-            let center = p.living_entity.entity.chunk_pos.load();
-            is_within_view_distance(chunk_pos, center, audible_chunks)
-        });
-
-        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
-        Self::broadcast_java_grouped(&packet, recipients_by_version).await;
+        self.broadcast_packet_except(&[player.gameprofile.id], &packet)
+            .await;
     }
 
     pub async fn play_block_sound(
@@ -810,20 +730,19 @@ impl World {
 
         // TODO: only send packet to players who have the chunks loaded
         // TODO: Send light updates to update the wire directly next to a broken block
-        for (chunk_section, updates) in block_state_updates_by_chunk_section {
-            if updates.is_empty() {
+        for chunk_section in block_state_updates_by_chunk_section.values() {
+            if chunk_section.is_empty() {
                 continue;
             }
-            let chunk_pos = Vector2::new(chunk_section.x, chunk_section.z);
-            if updates.len() == 1 {
-                let (block_pos, block_state_id) = updates[0];
-                self.broadcast_to_chunk(
-                    chunk_pos,
-                    &CBlockUpdate::new(block_pos, i32::from(block_state_id).into()),
-                )
+            if chunk_section.len() == 1 {
+                let (block_pos, block_state_id) = chunk_section[0];
+                self.broadcast_packet_all(&CBlockUpdate::new(
+                    block_pos,
+                    i32::from(block_state_id).into(),
+                ))
                 .await;
             } else {
-                self.broadcast_to_chunk(chunk_pos, &CMultiBlockUpdate::new(&updates))
+                self.broadcast_packet_all(&CMultiBlockUpdate::new(chunk_section))
                     .await;
             }
         }
@@ -905,33 +824,14 @@ impl World {
         }
 
         for scheduled_tick in tick_data.random_ticks {
-            let (block, fluid) = match (scheduled_tick.tick_block, scheduled_tick.tick_fluid) {
-                (true, true) => {
-                    let (block, fluid) = self.get_block_and_fluid(&scheduled_tick.position).await;
-                    (Some(block), Some(fluid))
-                }
-                (true, false) => (Some(self.get_block(&scheduled_tick.position).await), None),
-                (false, true) => (None, Some(self.get_fluid(&scheduled_tick.position).await)),
-                (false, false) => (None, None),
-            };
-
-            if let Some(block) = block
-                && let Some(pumpkin_block) = self.block_registry.get_pumpkin_block(block.id)
-            {
+            let block = self.get_block(&scheduled_tick.position).await;
+            if let Some(pumpkin_block) = self.block_registry.get_pumpkin_block(block.id) {
                 pumpkin_block
                     .random_tick(RandomTickArgs {
                         world: self,
                         block,
                         position: &scheduled_tick.position,
                     })
-                    .await;
-            }
-
-            if let Some(fluid) = fluid
-                && let Some(pumpkin_fluid) = self.block_registry.get_pumpkin_fluid(fluid.id)
-            {
-                pumpkin_fluid
-                    .random_tick(fluid, self, &scheduled_tick.position)
                     .await;
             }
         }
@@ -960,21 +860,13 @@ impl World {
             SpawnState::new(spawning_chunks_map.len() as i32, &self.entities, self).await; // TODO store it
 
         // TODO gamerule this.spawnEnemies || this.spawnFriendlies
-        let (spawn_mobs, spawn_monsters, peaceful) = {
-            let lock = self.level_info.load();
-            (
-                lock.game_rules.spawn_mobs,
-                lock.game_rules.spawn_monsters,
-                lock.difficulty == Difficulty::Peaceful,
-            )
-        };
         let spawn_passives = self.level_time.lock().await.time_of_day % 400 == 0;
         let spawn_list: Vec<&'static MobCategory> =
             natural_spawner::get_filtered_spawning_categories(
                 &spawn_state,
-                spawn_mobs,
-                peaceful && spawn_mobs && spawn_monsters,
-                peaceful && spawn_mobs && spawn_passives && spawn_monsters,
+                true,
+                true,
+                spawn_passives,
             );
 
         // log::debug!("spawning list size {}", spawn_list.len());
@@ -1672,7 +1564,7 @@ impl World {
         &self,
         base_config: &BasicConfiguration,
         player: &Arc<Player>,
-        server: &Arc<Server>,
+        server: &Server,
     ) {
         let dimensions: Vec<ResourceLocation> = server
             .dimensions
@@ -2016,6 +1908,9 @@ impl World {
 
         player.send_active_effects().await;
         self.send_player_equipment(player).await;
+
+        // Send existing teams to the joining player
+        self.teams.lock().await.send_to_player(client).await;
     }
 
     async fn send_player_equipment(&self, from: &Player) {
@@ -2035,9 +1930,7 @@ impl World {
             .iter()
             .map(|(slot, stack)| (*slot, ItemStackSerializer::from(stack.clone())))
             .collect();
-        let chunk_pos = from.get_entity().chunk_pos.load();
-        self.broadcast_to_chunk_except(
-            chunk_pos,
+        self.broadcast_packet_except(
             &[from.get_entity().entity_uuid],
             &CSetEquipment::new(from.entity_id().into(), equipment),
         )
@@ -2833,8 +2726,7 @@ impl World {
 
     pub async fn spawn_entity(&self, entity: Arc<dyn EntityBase>) {
         let base_entity = entity.get_entity();
-        let chunk_pos = base_entity.chunk_pos.load();
-        self.broadcast_to_chunk(chunk_pos, &base_entity.create_spawn_packet())
+        self.broadcast_packet_all(&base_entity.create_spawn_packet())
             .await;
         entity.init_data_tracker().await;
 
@@ -2861,17 +2753,14 @@ impl World {
             new_entities
         });
 
-        let chunk_pos = entity.chunk_pos.load();
-        self.broadcast_to_chunk(chunk_pos, &CRemoveEntities::new(&[entity.entity_id.into()]))
+        self.broadcast_packet_all(&CRemoveEntities::new(&[entity.entity_id.into()]))
             .await;
 
         self.remove_entity_data(entity).await;
     }
 
     pub async fn set_block_breaking(&self, from: &Entity, location: BlockPos, progress: i32) {
-        let chunk_pos = location.chunk_position(); // pumpkin's BlockPos already has this method
-        self.broadcast_to_chunk_except(
-            chunk_pos,
+        self.broadcast_packet_except(
             &[from.entity_uuid],
             &CSetBlockDestroyStage::new(from.entity_id.into(), location, progress as i8),
         )
@@ -3116,17 +3005,12 @@ impl World {
                     broken_state_id.into(),
                     false,
                 );
-                let chunk_pos = position.chunk_position();
                 match cause {
                     Some(player) => {
-                        self.broadcast_to_chunk_except(
-                            chunk_pos,
-                            &[player.living_entity.entity.entity_uuid],
-                            &particles_packet,
-                        )
-                        .await;
+                        self.broadcast_packet_except(&[player.gameprofile.id], &particles_packet)
+                            .await;
                     }
-                    None => self.broadcast_to_chunk(chunk_pos, &particles_packet).await,
+                    None => self.broadcast_packet_all(&particles_packet).await,
                 }
             }
 
@@ -3217,12 +3101,8 @@ impl World {
     /* End ItemScatterer.java */
 
     pub async fn sync_world_event(&self, world_event: WorldEvent, position: BlockPos, data: i32) {
-        let chunk_pos = position.chunk_position();
-        self.broadcast_to_chunk(
-            chunk_pos,
-            &CWorldEvent::new(world_event as i32, position, data, false),
-        )
-        .await;
+        self.broadcast_packet_all(&CWorldEvent::new(world_event as i32, position, data, false))
+            .await;
     }
     #[must_use]
     pub fn is_valid(dest: BlockPos) -> bool {
@@ -3257,30 +3137,6 @@ impl World {
     pub async fn get_block(&self, position: &BlockPos) -> &'static Block {
         let id = self.get_block_state_id(position).await;
         Block::from_state_id(id)
-    }
-
-    #[must_use]
-    pub fn get_block_state_id_if_loaded(&self, position: &BlockPos) -> Option<BlockStateId> {
-        if !self.is_in_build_limit(*position) {
-            return None;
-        }
-
-        let (chunk_coordinate, relative) = position.chunk_and_chunk_relative_position();
-        let chunk = self.level.try_get_chunk(&chunk_coordinate)?;
-        chunk
-            .section
-            .get_block_absolute_y(relative.x as usize, relative.y, relative.z as usize)
-    }
-
-    #[must_use]
-    pub fn get_block_state_if_loaded(&self, position: &BlockPos) -> Option<&'static BlockState> {
-        self.get_block_state_id_if_loaded(position)
-            .map(BlockState::from_id)
-    }
-
-    #[must_use]
-    pub fn is_loaded(&self, position: &BlockPos) -> bool {
-        self.get_block_state_id_if_loaded(position).is_some()
     }
 
     pub async fn get_fluid(&self, position: &BlockPos) -> &'static pumpkin_data::fluid::Fluid {
@@ -3511,15 +3367,11 @@ impl World {
         if let Some(nbt) = &block_entity_nbt {
             let mut bytes = Vec::new();
             to_bytes_unnamed(nbt, &mut bytes).unwrap();
-            let chunk_pos = block_pos.chunk_position();
-            self.broadcast_to_chunk(
-                chunk_pos,
-                &CBlockEntityData::new(
-                    block_entity.get_position(),
-                    VarInt(block_entity.get_id() as i32),
-                    bytes.into_boxed_slice(),
-                ),
-            )
+            self.broadcast_packet_all(&CBlockEntityData::new(
+                block_entity.get_position(),
+                VarInt(block_entity.get_id() as i32),
+                bytes.into_boxed_slice(),
+            ))
             .await;
         }
 
@@ -3552,15 +3404,11 @@ impl World {
         if let Some(nbt) = &block_entity_nbt {
             let mut bytes = Vec::new();
             to_bytes_unnamed(nbt, &mut bytes).unwrap();
-            let chunk_pos = block_pos.chunk_position();
-            self.broadcast_to_chunk(
-                chunk_pos,
-                &CBlockEntityData::new(
-                    block_entity.get_position(),
-                    VarInt(block_entity.get_id() as i32),
-                    bytes.into_boxed_slice(),
-                ),
-            )
+            self.broadcast_packet_all(&CBlockEntityData::new(
+                block_entity.get_position(),
+                VarInt(block_entity.get_id() as i32),
+                bytes.into_boxed_slice(),
+            ))
             .await;
         }
         chunk.mark_dirty(true);
@@ -3761,46 +3609,6 @@ impl World {
         }
 
         None
-    }
-
-    /// Broadcasts a packet to all players who currently have the target chunk loaded.
-    /// This uses highly optimized Chebyshev distance math (Chunk Grid) instead of floating point distance checks.
-    pub async fn broadcast_to_chunk<P: ClientPacket>(&self, chunk_pos: Vector2<i32>, packet: &P) {
-        let players = self.players.load();
-
-        let recipients = players.iter().filter(|p| {
-            let center = p.living_entity.entity.chunk_pos.load();
-            let view_distance = get_view_distance(p).get() as i32;
-
-            // Chebyshev distance (Minecraft's chunk loading shape)
-            is_within_view_distance(chunk_pos, center, view_distance)
-        });
-
-        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
-        Self::broadcast_java_grouped(packet, recipients_by_version).await;
-    }
-
-    /// Broadcasts a packet to chunk watchers, excluding specific players.
-    pub async fn broadcast_to_chunk_except<P: ClientPacket>(
-        &self,
-        chunk_pos: Vector2<i32>,
-        except: &[uuid::Uuid],
-        packet: &P,
-    ) {
-        let players = self.players.load();
-
-        let recipients = players.iter().filter(|p| {
-            if except.contains(&p.living_entity.entity.entity_uuid) {
-                return false;
-            }
-            let center = p.living_entity.entity.chunk_pos.load();
-            let view_distance = get_view_distance(p).get() as i32;
-
-            is_within_view_distance(chunk_pos, center, view_distance)
-        });
-
-        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
-        Self::broadcast_java_grouped(packet, recipients_by_version).await;
     }
 }
 

--- a/pumpkin/src/world/teams.rs
+++ b/pumpkin/src/world/teams.rs
@@ -1,0 +1,256 @@
+use std::collections::{HashMap, HashSet};
+
+use pumpkin_protocol::java::client::play::CUpdateTeams;
+use pumpkin_util::text::TextComponent;
+
+use crate::net::java::JavaClient;
+
+use super::World;
+
+#[derive(Default)]
+pub struct Teams {
+    teams: HashMap<String, Team>,
+}
+
+pub struct Team {
+    pub display_name: TextComponent,
+    pub prefix: TextComponent,
+    pub suffix: TextComponent,
+    pub friendly_fire: bool,
+    pub see_friendly_invisibles: bool,
+    pub name_tag_visibility: String,
+    pub collision_rule: String,
+    /// Vanilla color index (0-15 for colors, 21 for reset/white)
+    pub color: i32,
+    pub members: HashSet<String>,
+}
+
+impl Team {
+    #[must_use]
+    pub fn new(name: &str) -> Self {
+        Self {
+            display_name: TextComponent::text(name.to_string()),
+            prefix: TextComponent::text(String::new()),
+            suffix: TextComponent::text(String::new()),
+            friendly_fire: true,
+            see_friendly_invisibles: true,
+            name_tag_visibility: "always".to_string(),
+            collision_rule: "always".to_string(),
+            color: 21, // Reset (white)
+            members: HashSet::new(),
+        }
+    }
+
+    const fn friendly_flags(&self) -> u8 {
+        let mut flags = 0u8;
+        if self.friendly_fire {
+            flags |= 0x01;
+        }
+        if self.see_friendly_invisibles {
+            flags |= 0x02;
+        }
+        flags
+    }
+}
+
+impl Teams {
+    /// Send all existing teams to a joining player
+    pub async fn send_to_player(&self, client: &JavaClient) {
+        for (name, team) in &self.teams {
+            let members: Vec<String> = team.members.iter().cloned().collect();
+            client
+                .enqueue_packet(&CUpdateTeams::create(
+                    name.clone(),
+                    team.display_name.clone(),
+                    team.friendly_flags(),
+                    team.name_tag_visibility.clone(),
+                    team.collision_rule.clone(),
+                    team.color,
+                    team.prefix.clone(),
+                    team.suffix.clone(),
+                    members,
+                ))
+                .await;
+        }
+    }
+
+    #[must_use]
+    pub fn has_team(&self, name: &str) -> bool {
+        self.teams.contains_key(name)
+    }
+
+    #[must_use]
+    pub const fn get_teams(&self) -> &HashMap<String, Team> {
+        &self.teams
+    }
+
+    #[must_use]
+    pub fn get_team(&self, name: &str) -> Option<&Team> {
+        self.teams.get(name)
+    }
+
+    #[must_use]
+    pub fn get_team_mut(&mut self, name: &str) -> Option<&mut Team> {
+        self.teams.get_mut(name)
+    }
+
+    /// Find which team a member belongs to
+    #[must_use]
+    pub fn get_member_team(&self, member: &str) -> Option<&str> {
+        for (name, team) in &self.teams {
+            if team.members.contains(member) {
+                return Some(name);
+            }
+        }
+        None
+    }
+
+    pub async fn add_team(&mut self, world: &World, name: &str) {
+        let team = Team::new(name);
+        let packet = CUpdateTeams::create(
+            name.to_string(),
+            team.display_name.clone(),
+            team.friendly_flags(),
+            team.name_tag_visibility.clone(),
+            team.collision_rule.clone(),
+            team.color,
+            team.prefix.clone(),
+            team.suffix.clone(),
+            Vec::new(),
+        );
+        self.teams.insert(name.to_string(), team);
+        world.broadcast_packet_all(&packet).await;
+    }
+
+    pub async fn remove_team(&mut self, world: &World, name: &str) -> Option<Team> {
+        let team = self.teams.remove(name)?;
+        world
+            .broadcast_packet_all(&CUpdateTeams::remove(name.to_string()))
+            .await;
+        Some(team)
+    }
+
+    pub async fn add_members(
+        &mut self,
+        world: &World,
+        team_name: &str,
+        members: &[String],
+    ) -> usize {
+        let mut added = 0;
+
+        // Remove members from any existing teams first
+        for member in members {
+            for (name, team) in &mut self.teams {
+                if *name != team_name && team.members.remove(member) {
+                    world
+                        .broadcast_packet_all(&CUpdateTeams::remove_entities(
+                            name.clone(),
+                            vec![member.clone()],
+                        ))
+                        .await;
+                }
+            }
+        }
+
+        if let Some(team) = self.teams.get_mut(team_name) {
+            let mut new_members = Vec::new();
+            for member in members {
+                if team.members.insert(member.clone()) {
+                    new_members.push(member.clone());
+                    added += 1;
+                }
+            }
+            if !new_members.is_empty() {
+                world
+                    .broadcast_packet_all(&CUpdateTeams::add_entities(
+                        team_name.to_string(),
+                        new_members,
+                    ))
+                    .await;
+            }
+        }
+        added
+    }
+
+    pub async fn remove_members(
+        &mut self,
+        world: &World,
+        team_name: &str,
+        members: &[String],
+    ) -> usize {
+        let mut removed = 0;
+        if let Some(team) = self.teams.get_mut(team_name) {
+            let mut removed_members = Vec::new();
+            for member in members {
+                if team.members.remove(member) {
+                    removed_members.push(member.clone());
+                    removed += 1;
+                }
+            }
+            if !removed_members.is_empty() {
+                world
+                    .broadcast_packet_all(&CUpdateTeams::remove_entities(
+                        team_name.to_string(),
+                        removed_members,
+                    ))
+                    .await;
+            }
+        }
+        removed
+    }
+
+    /// Remove members from whatever team they're on (for `/team leave`)
+    pub async fn leave_members(&mut self, world: &World, members: &[String]) -> usize {
+        let mut removed = 0;
+        for (team_name, team) in &mut self.teams {
+            let mut left = Vec::new();
+            for member in members {
+                if team.members.remove(member) {
+                    left.push(member.clone());
+                    removed += 1;
+                }
+            }
+            if !left.is_empty() {
+                world
+                    .broadcast_packet_all(&CUpdateTeams::remove_entities(team_name.clone(), left))
+                    .await;
+            }
+        }
+        removed
+    }
+
+    /// Broadcast a team update packet (mode 2) for the given team
+    pub async fn broadcast_team_update(&self, world: &World, team_name: &str) {
+        if let Some(team) = self.teams.get(team_name) {
+            let packet = CUpdateTeams::update(
+                team_name.to_string(),
+                team.display_name.clone(),
+                team.friendly_flags(),
+                team.name_tag_visibility.clone(),
+                team.collision_rule.clone(),
+                team.color,
+                team.prefix.clone(),
+                team.suffix.clone(),
+            );
+            world.broadcast_packet_all(&packet).await;
+        }
+    }
+
+    pub async fn empty_team(&mut self, world: &World, team_name: &str) -> usize {
+        if let Some(team) = self.teams.get_mut(team_name) {
+            let members: Vec<String> = team.members.drain().collect();
+            let count = members.len();
+            if !members.is_empty() {
+                world
+                    .broadcast_packet_all(&CUpdateTeams::remove_entities(
+                        team_name.to_string(),
+                        members,
+                    ))
+                    .await;
+            }
+            count
+        } else {
+            0
+        }
+    }
+}


### PR DESCRIPTION
- Implements `/teammsg` command for sending messages to team members
- OP level 0 (all players can use)

> **Depends on:** #1906 (`/team` command) must be merged first — this command references `World.teams`.