### PR TITLE
feat: implement /trigger command

### DIFF
--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -55,6 +55,7 @@ mod time;
 mod title;
 mod tps;
 mod transfer;
+mod trigger;
 mod weather;
 mod whitelist;
 mod worldborder;
@@ -76,6 +77,7 @@ pub async fn default_dispatcher(
     dispatcher.register(list::init_command_tree(), "minecraft:command.list");
     dispatcher.register(me::init_command_tree(), "minecraft:command.me");
     dispatcher.register(msg::init_command_tree(), "minecraft:command.msg");
+    dispatcher.register(trigger::init_command_tree(), "minecraft:command.trigger");
     // Two
     dispatcher.register(kill::init_command_tree(), "minecraft:command.kill");
     dispatcher.register(
@@ -438,6 +440,13 @@ fn register_level_2_permissions(registry: &mut PermissionRegistry) {
             "minecraft:command.scoreboard",
             "Manages scoreboard objectives and players",
             PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.trigger",
+            "Sets a trigger to be activated",
+            PermissionDefault::Allow,
         ))
         .unwrap();
 }

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -39,6 +39,7 @@ mod plugins;
 mod pumpkin;
 mod rotate;
 mod say;
+mod scoreboard;
 mod seed;
 mod setblock;
 mod setidletimeout;
@@ -135,6 +136,10 @@ pub async fn default_dispatcher(
         "minecraft:command.spawnpoint",
     );
     dispatcher.register(data::init_command_tree(), "minecraft:command.data");
+    dispatcher.register(
+        scoreboard::init_command_tree(),
+        "minecraft:command.scoreboard",
+    );
     // Three
     dispatcher.register(op::init_command_tree(), "minecraft:command.op");
     dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");
@@ -425,6 +430,13 @@ fn register_level_2_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "pumpkin:command.tps",
             "Displays the server TPS and MSPT",
+            PermissionDefault::Op(PermissionLvl::Two),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.scoreboard",
+            "Manages scoreboard objectives and players",
             PermissionDefault::Op(PermissionLvl::Two),
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/scoreboard.rs
+++ b/pumpkin/src/command/commands/scoreboard.rs
@@ -1,0 +1,355 @@
+use pumpkin_data::translation;
+use pumpkin_protocol::java::client::play::RenderType;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+use crate::world::scoreboard::ScoreboardObjective;
+
+const NAMES: [&str; 1] = ["scoreboard"];
+
+const DESCRIPTION: &str = "Manages scoreboard objectives and players.";
+
+const ARG_OBJECTIVE: &str = "objective";
+const ARG_CRITERIA: &str = "criteria";
+const ARG_DISPLAY_NAME: &str = "displayName";
+const ARG_TARGETS: &str = "targets";
+const ARG_SCORE: &str = "score";
+
+struct ObjectivesAddExecutor;
+
+impl CommandExecutor for ObjectivesAddExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(name)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+            let Some(Arg::Simple(_criteria)) = args.get(ARG_CRITERIA) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_CRITERIA.into())));
+            };
+
+            let display_name = args
+                .get(ARG_DISPLAY_NAME)
+                .and_then(|a| {
+                    if let Arg::Simple(s) = a {
+                        Some(TextComponent::text(s.to_string()))
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| TextComponent::text(name.to_string()));
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if scoreboard.has_objective(name) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_SCOREBOARD_OBJECTIVES_ADD_DUPLICATE,
+                    [],
+                )));
+            }
+
+            let objective = ScoreboardObjective::new(name, display_name, RenderType::Integer, None);
+            scoreboard.add_objective(&world, objective).await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_SCOREBOARD_OBJECTIVES_ADD_SUCCESS,
+                    [TextComponent::text(name.to_string())],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct ObjectivesListExecutor;
+
+impl CommandExecutor for ObjectivesListExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let scoreboard = world.scoreboard.lock().await;
+            let objectives = scoreboard.get_objectives();
+
+            if objectives.is_empty() {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_SCOREBOARD_OBJECTIVES_LIST_EMPTY,
+                        [],
+                    ))
+                    .await;
+            } else {
+                let names: Vec<String> = objectives.keys().cloned().collect();
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_SCOREBOARD_OBJECTIVES_LIST_SUCCESS,
+                        [
+                            TextComponent::text(objectives.len().to_string()),
+                            TextComponent::text(names.join(", ")),
+                        ],
+                    ))
+                    .await;
+            }
+            Ok(objectives.len() as i32)
+        })
+    }
+}
+
+struct ObjectivesRemoveExecutor;
+
+impl CommandExecutor for ObjectivesRemoveExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(name)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(name) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::ARGUMENT_ID_UNKNOWN,
+                    [TextComponent::text(name.to_string())],
+                )));
+            }
+
+            scoreboard.remove_objective(&world, name).await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_SCOREBOARD_OBJECTIVES_REMOVE_SUCCESS,
+                    [TextComponent::text(name.to_string())],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct PlayersSetExecutor;
+
+impl CommandExecutor for PlayersSetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(targets)) = args.get(ARG_TARGETS) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TARGETS.into())));
+            };
+            let Some(Arg::Simple(objective)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+            let Some(Arg::Simple(score_str)) = args.get(ARG_SCORE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_SCORE.into())));
+            };
+            let score: i32 = score_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_SCORE.into())))?;
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(objective) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::ARGUMENT_ID_UNKNOWN,
+                    [TextComponent::text(objective.to_string())],
+                )));
+            }
+
+            scoreboard
+                .set_score(&world, targets, objective, score)
+                .await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_SCOREBOARD_PLAYERS_SET_SUCCESS_SINGLE,
+                    [
+                        TextComponent::text(objective.to_string()),
+                        TextComponent::text(targets.to_string()),
+                        TextComponent::text(score.to_string()),
+                    ],
+                ))
+                .await;
+            Ok(score)
+        })
+    }
+}
+
+struct PlayersAddExecutor;
+
+impl CommandExecutor for PlayersAddExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(targets)) = args.get(ARG_TARGETS) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TARGETS.into())));
+            };
+            let Some(Arg::Simple(objective)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+            let Some(Arg::Simple(score_str)) = args.get(ARG_SCORE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_SCORE.into())));
+            };
+            let amount: i32 = score_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_SCORE.into())))?;
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(objective) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::ARGUMENT_ID_UNKNOWN,
+                    [TextComponent::text(objective.to_string())],
+                )));
+            }
+
+            let current = scoreboard.get_score(targets, objective).unwrap_or(0);
+            let new_score = current + amount;
+            scoreboard
+                .set_score(&world, targets, objective, new_score)
+                .await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_SCOREBOARD_PLAYERS_ADD_SUCCESS_SINGLE,
+                    [
+                        TextComponent::text(amount.to_string()),
+                        TextComponent::text(objective.to_string()),
+                        TextComponent::text(targets.to_string()),
+                        TextComponent::text(new_score.to_string()),
+                    ],
+                ))
+                .await;
+            Ok(new_score)
+        })
+    }
+}
+
+struct PlayersResetExecutor;
+
+impl CommandExecutor for PlayersResetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(targets)) = args.get(ARG_TARGETS) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_TARGETS.into())));
+            };
+
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            let objective = args.get(ARG_OBJECTIVE).and_then(|a| {
+                if let Arg::Simple(s) = a {
+                    Some(*s)
+                } else {
+                    None
+                }
+            });
+
+            scoreboard.reset_scores(targets, objective);
+
+            if let Some(obj) = objective {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_SCOREBOARD_PLAYERS_RESET_SPECIFIC_SINGLE,
+                        [
+                            TextComponent::text(obj.to_string()),
+                            TextComponent::text(targets.to_string()),
+                        ],
+                    ))
+                    .await;
+            } else {
+                sender
+                    .send_message(TextComponent::translate(
+                        translation::COMMANDS_SCOREBOARD_PLAYERS_RESET_ALL_SINGLE,
+                        [TextComponent::text(targets.to_string())],
+                    ))
+                    .await;
+            }
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(
+            literal("objectives")
+                .then(
+                    literal("add").then(
+                        argument(ARG_OBJECTIVE, SimpleArgConsumer).then(
+                            argument(ARG_CRITERIA, SimpleArgConsumer)
+                                .then(
+                                    argument(ARG_DISPLAY_NAME, SimpleArgConsumer)
+                                        .execute(ObjectivesAddExecutor),
+                                )
+                                .execute(ObjectivesAddExecutor),
+                        ),
+                    ),
+                )
+                .then(literal("list").execute(ObjectivesListExecutor))
+                .then(literal("remove").then(
+                    argument(ARG_OBJECTIVE, SimpleArgConsumer).execute(ObjectivesRemoveExecutor),
+                )),
+        )
+        .then(
+            literal("players")
+                .then(literal("set").then(
+                    argument(ARG_TARGETS, SimpleArgConsumer).then(
+                        argument(ARG_OBJECTIVE, SimpleArgConsumer).then(
+                            argument(ARG_SCORE, SimpleArgConsumer).execute(PlayersSetExecutor),
+                        ),
+                    ),
+                ))
+                .then(literal("add").then(
+                    argument(ARG_TARGETS, SimpleArgConsumer).then(
+                        argument(ARG_OBJECTIVE, SimpleArgConsumer).then(
+                            argument(ARG_SCORE, SimpleArgConsumer).execute(PlayersAddExecutor),
+                        ),
+                    ),
+                ))
+                .then(
+                    literal("reset").then(
+                        argument(ARG_TARGETS, SimpleArgConsumer)
+                            .then(
+                                argument(ARG_OBJECTIVE, SimpleArgConsumer)
+                                    .execute(PlayersResetExecutor),
+                            )
+                            .execute(PlayersResetExecutor),
+                    ),
+                ),
+        )
+}

--- a/pumpkin/src/command/commands/trigger.rs
+++ b/pumpkin/src/command/commands/trigger.rs
@@ -1,0 +1,177 @@
+use pumpkin_data::translation;
+use pumpkin_util::text::TextComponent;
+
+use crate::command::args::simple::SimpleArgConsumer;
+use crate::command::args::{Arg, ConsumedArgs};
+use crate::command::dispatcher::CommandError;
+use crate::command::tree::CommandTree;
+use crate::command::tree::builder::{argument, literal};
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+
+const NAMES: [&str; 1] = ["trigger"];
+
+const DESCRIPTION: &str = "Sets a trigger to be activated.";
+
+const ARG_OBJECTIVE: &str = "objective";
+const ARG_VALUE: &str = "value";
+
+struct TriggerSimpleExecutor;
+
+impl CommandExecutor for TriggerSimpleExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(objective)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+
+            let player = sender.as_player().ok_or(CommandError::InvalidRequirement)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(objective) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_FAILED_INVALID,
+                    [],
+                )));
+            }
+
+            let current = scoreboard
+                .get_score(&player.gameprofile.name, objective)
+                .unwrap_or(0);
+            let new_val = current + 1;
+            scoreboard
+                .set_score(&world, &player.gameprofile.name, objective, new_val)
+                .await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_SIMPLE_SUCCESS,
+                    [TextComponent::text(objective.to_string())],
+                ))
+                .await;
+            Ok(new_val)
+        })
+    }
+}
+
+struct TriggerAddExecutor;
+
+impl CommandExecutor for TriggerAddExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(objective)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+            let Some(Arg::Simple(val_str)) = args.get(ARG_VALUE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_VALUE.into())));
+            };
+            let value: i32 = val_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_VALUE.into())))?;
+
+            let player = sender.as_player().ok_or(CommandError::InvalidRequirement)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(objective) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_FAILED_INVALID,
+                    [],
+                )));
+            }
+
+            let current = scoreboard
+                .get_score(&player.gameprofile.name, objective)
+                .unwrap_or(0);
+            let new_val = current + value;
+            scoreboard
+                .set_score(&world, &player.gameprofile.name, objective, new_val)
+                .await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_ADD_SUCCESS,
+                    [
+                        TextComponent::text(value.to_string()),
+                        TextComponent::text(objective.to_string()),
+                    ],
+                ))
+                .await;
+            Ok(new_val)
+        })
+    }
+}
+
+struct TriggerSetExecutor;
+
+impl CommandExecutor for TriggerSetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let Some(Arg::Simple(objective)) = args.get(ARG_OBJECTIVE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_OBJECTIVE.into())));
+            };
+            let Some(Arg::Simple(val_str)) = args.get(ARG_VALUE) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_VALUE.into())));
+            };
+            let value: i32 = val_str
+                .parse()
+                .map_err(|_| CommandError::InvalidConsumption(Some(ARG_VALUE.into())))?;
+
+            let player = sender.as_player().ok_or(CommandError::InvalidRequirement)?;
+            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.has_objective(objective) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_FAILED_INVALID,
+                    [],
+                )));
+            }
+
+            scoreboard
+                .set_score(&world, &player.gameprofile.name, objective, value)
+                .await;
+
+            sender
+                .send_message(TextComponent::translate(
+                    translation::COMMANDS_TRIGGER_SET_SUCCESS,
+                    [
+                        TextComponent::text(objective.to_string()),
+                        TextComponent::text(value.to_string()),
+                    ],
+                ))
+                .await;
+            Ok(value)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).then(
+        argument(ARG_OBJECTIVE, SimpleArgConsumer)
+            .then(
+                literal("add")
+                    .then(argument(ARG_VALUE, SimpleArgConsumer).execute(TriggerAddExecutor)),
+            )
+            .then(
+                literal("set")
+                    .then(argument(ARG_VALUE, SimpleArgConsumer).execute(TriggerSetExecutor)),
+            )
+            .execute(TriggerSimpleExecutor),
+    )
+}

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1,3 +1,4 @@
+use pumpkin_protocol::codec::data_component::data_to_proto_sound;
 use std::pin::Pin;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::{Arc, Weak};
@@ -14,7 +15,8 @@ pub mod portal;
 pub mod time;
 
 use crate::block::RandomTickArgs;
-use crate::world::loot::LootContextParameters;
+use crate::world::chunker::is_within_view_distance;
+use crate::world::{chunker::get_view_distance, loot::LootContextParameters};
 use crate::{
     block::BlockEvent, entity::experience_orb::ExperienceOrbEntity, entity::item::ItemEntity,
 };
@@ -95,7 +97,7 @@ use pumpkin_protocol::{
 };
 use pumpkin_protocol::{
     codec::item_stack_seralizer::ItemStackSerializer,
-    java::client::play::{CBlockEvent, CRemoveMobEffect, CSetEquipment},
+    java::client::play::{CBlockEvent, CRemoveMobEffect, CSetEquipment, CUpdateMobEffect},
 };
 use pumpkin_protocol::{
     codec::var_int::VarInt,
@@ -127,7 +129,6 @@ use pumpkin_world::{world::BlockFlags, world_info::LevelData};
 use rand::seq::SliceRandom;
 use rand::{RngExt, rng};
 use scoreboard::Scoreboard;
-use teams::Teams;
 use time::LevelTime;
 use tokio::sync::Mutex;
 
@@ -136,7 +137,6 @@ pub mod bossbar;
 pub mod custom_bossbar;
 pub mod natural_spawner;
 pub mod scoreboard;
-pub mod teams;
 pub mod weather;
 
 use crate::world::natural_spawner::{SpawnState, spawn_for_chunk};
@@ -184,8 +184,6 @@ pub struct World {
     pub entities: ArcSwap<Vec<Arc<dyn EntityBase>>>,
     /// The world's scoreboard, used for tracking scores, objectives, and display information.
     pub scoreboard: Mutex<Scoreboard>,
-    /// The world's teams, used for grouping players and entities.
-    pub teams: Mutex<Teams>,
     /// The world's worldborder, defining the playable area and controlling its expansion or contraction.
     pub worldborder: Mutex<Worldborder>,
     /// The world's time, including counting ticks for weather, time cycles, and statistics.
@@ -236,7 +234,6 @@ impl World {
             players: ArcSwap::new(Arc::new(Vec::new())),
             entities: ArcSwap::new(Arc::new(Vec::new())),
             scoreboard: Mutex::new(Scoreboard::default()),
-            teams: Mutex::new(Teams::default()),
             worldborder: Mutex::new(Worldborder::new(0.0, 0.0, 5.999_996_8E7, 0, 5, 300)),
             level_time: Mutex::new(LevelTime::new()),
             dimension,
@@ -328,10 +325,14 @@ impl World {
         }
     }
 
+    /// Sends an entity status update to all players tracking the specified entity.
     pub async fn send_entity_status(&self, entity: &Entity, status: EntityStatus) {
-        // TODO: only nearby
-        self.broadcast_packet_all(&CEntityStatus::new(entity.entity_id, status as i8))
-            .await;
+        let chunk_pos = entity.chunk_pos.load();
+        self.broadcast_to_chunk(
+            chunk_pos,
+            &CEntityStatus::new(entity.entity_id, status as i8),
+        )
+        .await;
     }
 
     pub async fn send_remove_mob_effect(
@@ -339,10 +340,37 @@ impl World {
         entity: &Entity,
         effect_type: &'static StatusEffect,
     ) {
+        let chunk_pos = entity.chunk_pos.load();
+        self.broadcast_to_chunk(
+            chunk_pos,
+            &CRemoveMobEffect::new(entity.entity_id.into(), VarInt(i32::from(effect_type.id))),
+        )
+        .await;
+    }
+
+    pub async fn send_add_mob_effect(
+        &self,
+        entity: &Entity,
+        effect: &pumpkin_data::potion::Effect,
+    ) {
         // TODO: only nearby
-        self.broadcast_packet_all(&CRemoveMobEffect::new(
-            entity.entity_id.into(),
-            VarInt(i32::from(effect_type.id)),
+        let mut flags: i8 = 0;
+        if effect.ambient {
+            flags |= 0x01;
+        }
+        if effect.show_particles {
+            flags |= 0x02;
+        }
+        if effect.show_icon {
+            flags |= 0x04;
+        }
+
+        self.broadcast_packet_all(&CUpdateMobEffect::new(
+            VarInt(entity.entity_id),
+            VarInt(i32::from(effect.effect_type.id)),
+            VarInt(i32::from(effect.amplifier)),
+            VarInt(effect.duration),
+            flags,
         ))
         .await;
     }
@@ -385,12 +413,16 @@ impl World {
             {
                 continue;
             }
-            self.broadcast_packet_all(&CBlockEvent::new(
-                event.pos,
-                event.r#type,
-                event.data,
-                VarInt(i32::from(block.id)),
-            ))
+            let chunk_pos = event.pos.chunk_position();
+            self.broadcast_to_chunk(
+                chunk_pos,
+                &CBlockEvent::new(
+                    event.pos,
+                    event.r#type,
+                    event.data,
+                    VarInt(i32::from(block.id)),
+                ),
+            )
             .await;
         }
     }
@@ -510,7 +542,7 @@ impl World {
                 Some(decorated_message.clone()),
                 FilterType::PassThrough,
                 (RAW + 1).into(), // Custom registry chat_type with no sender name
-                TextComponent::text(""), // Not needed since we're injecting the name in the message for custom formatting
+                TextComponent::empty(), // Not needed since we're injecting the name in the message for custom formatting
                 None,
             );
             recipient.client.enqueue_packet(packet).await;
@@ -574,6 +606,26 @@ impl World {
             .await;
     }
 
+    pub async fn play_sound_event(
+        &self,
+        sound: pumpkin_data::data_component_impl::IdOr<
+            pumpkin_data::data_component_impl::SoundEvent,
+        >,
+        category: SoundCategory,
+        position: &Vector3<f64>,
+    ) {
+        let seed = rng().random::<f64>();
+        let packet = CSoundEffect::new(
+            data_to_proto_sound(&sound),
+            category,
+            position,
+            1.0,
+            1.0,
+            seed,
+        );
+        self.broadcast_packet_all(&packet).await;
+    }
+
     pub async fn play_sound_fine(
         &self,
         sound: Sound,
@@ -605,9 +657,22 @@ impl World {
         volume: f32,
         pitch: f32,
     ) {
-        let seed = rng().random::<f64>();
+        let seed = rand::rng().random::<f64>();
         let packet = CSoundEffect::new(IdOr::Id(sound_id), category, position, volume, pitch, seed);
-        self.broadcast_packet_all(&packet).await;
+
+        // Calculate the number of chunks the sound can be heard from based on its volume.
+        let audible_chunks = f64::from(volume.max(1.0)).ceil() as i32;
+        let chunk_pos = BlockPos::floored_v(*position).chunk_position();
+
+        let players = self.players.load();
+        let recipients = players.iter().filter(|p| {
+            let center = p.living_entity.entity.chunk_pos.load();
+            // If the sound reaches their chunk, send it!
+            is_within_view_distance(chunk_pos, center, audible_chunks)
+        });
+
+        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
+        Self::broadcast_java_grouped(&packet, recipients_by_version).await;
     }
 
     pub async fn play_sound_raw_expect(
@@ -619,10 +684,25 @@ impl World {
         volume: f32,
         pitch: f32,
     ) {
-        let seed = rng().random::<f64>();
+        let seed = rand::rng().random::<f64>();
         let packet = CSoundEffect::new(IdOr::Id(sound_id), category, position, volume, pitch, seed);
-        self.broadcast_packet_except(&[player.gameprofile.id], &packet)
-            .await;
+
+        let audible_chunks = f64::from(volume.max(1.0)).ceil() as i32;
+        let chunk_pos = BlockPos::floored_v(*position).chunk_position();
+
+        let players = self.players.load();
+        let recipients = players.iter().filter(|p| {
+            // Skip the expected player
+            if p.gameprofile.id == player.gameprofile.id {
+                return false;
+            }
+
+            let center = p.living_entity.entity.chunk_pos.load();
+            is_within_view_distance(chunk_pos, center, audible_chunks)
+        });
+
+        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
+        Self::broadcast_java_grouped(&packet, recipients_by_version).await;
     }
 
     pub async fn play_block_sound(
@@ -730,19 +810,20 @@ impl World {
 
         // TODO: only send packet to players who have the chunks loaded
         // TODO: Send light updates to update the wire directly next to a broken block
-        for chunk_section in block_state_updates_by_chunk_section.values() {
-            if chunk_section.is_empty() {
+        for (chunk_section, updates) in block_state_updates_by_chunk_section {
+            if updates.is_empty() {
                 continue;
             }
-            if chunk_section.len() == 1 {
-                let (block_pos, block_state_id) = chunk_section[0];
-                self.broadcast_packet_all(&CBlockUpdate::new(
-                    block_pos,
-                    i32::from(block_state_id).into(),
-                ))
+            let chunk_pos = Vector2::new(chunk_section.x, chunk_section.z);
+            if updates.len() == 1 {
+                let (block_pos, block_state_id) = updates[0];
+                self.broadcast_to_chunk(
+                    chunk_pos,
+                    &CBlockUpdate::new(block_pos, i32::from(block_state_id).into()),
+                )
                 .await;
             } else {
-                self.broadcast_packet_all(&CMultiBlockUpdate::new(chunk_section))
+                self.broadcast_to_chunk(chunk_pos, &CMultiBlockUpdate::new(&updates))
                     .await;
             }
         }
@@ -824,14 +905,33 @@ impl World {
         }
 
         for scheduled_tick in tick_data.random_ticks {
-            let block = self.get_block(&scheduled_tick.position).await;
-            if let Some(pumpkin_block) = self.block_registry.get_pumpkin_block(block.id) {
+            let (block, fluid) = match (scheduled_tick.tick_block, scheduled_tick.tick_fluid) {
+                (true, true) => {
+                    let (block, fluid) = self.get_block_and_fluid(&scheduled_tick.position).await;
+                    (Some(block), Some(fluid))
+                }
+                (true, false) => (Some(self.get_block(&scheduled_tick.position).await), None),
+                (false, true) => (None, Some(self.get_fluid(&scheduled_tick.position).await)),
+                (false, false) => (None, None),
+            };
+
+            if let Some(block) = block
+                && let Some(pumpkin_block) = self.block_registry.get_pumpkin_block(block.id)
+            {
                 pumpkin_block
                     .random_tick(RandomTickArgs {
                         world: self,
                         block,
                         position: &scheduled_tick.position,
                     })
+                    .await;
+            }
+
+            if let Some(fluid) = fluid
+                && let Some(pumpkin_fluid) = self.block_registry.get_pumpkin_fluid(fluid.id)
+            {
+                pumpkin_fluid
+                    .random_tick(fluid, self, &scheduled_tick.position)
                     .await;
             }
         }
@@ -860,13 +960,21 @@ impl World {
             SpawnState::new(spawning_chunks_map.len() as i32, &self.entities, self).await; // TODO store it
 
         // TODO gamerule this.spawnEnemies || this.spawnFriendlies
+        let (spawn_mobs, spawn_monsters, peaceful) = {
+            let lock = self.level_info.load();
+            (
+                lock.game_rules.spawn_mobs,
+                lock.game_rules.spawn_monsters,
+                lock.difficulty == Difficulty::Peaceful,
+            )
+        };
         let spawn_passives = self.level_time.lock().await.time_of_day % 400 == 0;
         let spawn_list: Vec<&'static MobCategory> =
             natural_spawner::get_filtered_spawning_categories(
                 &spawn_state,
-                true,
-                true,
-                spawn_passives,
+                spawn_mobs,
+                peaceful && spawn_mobs && spawn_monsters,
+                peaceful && spawn_mobs && spawn_passives && spawn_monsters,
             );
 
         // log::debug!("spawning list size {}", spawn_list.len());
@@ -1564,7 +1672,7 @@ impl World {
         &self,
         base_config: &BasicConfiguration,
         player: &Arc<Player>,
-        server: &Server,
+        server: &Arc<Server>,
     ) {
         let dimensions: Vec<ResourceLocation> = server
             .dimensions
@@ -1908,9 +2016,6 @@ impl World {
 
         player.send_active_effects().await;
         self.send_player_equipment(player).await;
-
-        // Send existing teams to the joining player
-        self.teams.lock().await.send_to_player(client).await;
     }
 
     async fn send_player_equipment(&self, from: &Player) {
@@ -1930,7 +2035,9 @@ impl World {
             .iter()
             .map(|(slot, stack)| (*slot, ItemStackSerializer::from(stack.clone())))
             .collect();
-        self.broadcast_packet_except(
+        let chunk_pos = from.get_entity().chunk_pos.load();
+        self.broadcast_to_chunk_except(
+            chunk_pos,
             &[from.get_entity().entity_uuid],
             &CSetEquipment::new(from.entity_id().into(), equipment),
         )
@@ -2726,7 +2833,8 @@ impl World {
 
     pub async fn spawn_entity(&self, entity: Arc<dyn EntityBase>) {
         let base_entity = entity.get_entity();
-        self.broadcast_packet_all(&base_entity.create_spawn_packet())
+        let chunk_pos = base_entity.chunk_pos.load();
+        self.broadcast_to_chunk(chunk_pos, &base_entity.create_spawn_packet())
             .await;
         entity.init_data_tracker().await;
 
@@ -2753,14 +2861,17 @@ impl World {
             new_entities
         });
 
-        self.broadcast_packet_all(&CRemoveEntities::new(&[entity.entity_id.into()]))
+        let chunk_pos = entity.chunk_pos.load();
+        self.broadcast_to_chunk(chunk_pos, &CRemoveEntities::new(&[entity.entity_id.into()]))
             .await;
 
         self.remove_entity_data(entity).await;
     }
 
     pub async fn set_block_breaking(&self, from: &Entity, location: BlockPos, progress: i32) {
-        self.broadcast_packet_except(
+        let chunk_pos = location.chunk_position(); // pumpkin's BlockPos already has this method
+        self.broadcast_to_chunk_except(
+            chunk_pos,
             &[from.entity_uuid],
             &CSetBlockDestroyStage::new(from.entity_id.into(), location, progress as i8),
         )
@@ -3005,12 +3116,17 @@ impl World {
                     broken_state_id.into(),
                     false,
                 );
+                let chunk_pos = position.chunk_position();
                 match cause {
                     Some(player) => {
-                        self.broadcast_packet_except(&[player.gameprofile.id], &particles_packet)
-                            .await;
+                        self.broadcast_to_chunk_except(
+                            chunk_pos,
+                            &[player.living_entity.entity.entity_uuid],
+                            &particles_packet,
+                        )
+                        .await;
                     }
-                    None => self.broadcast_packet_all(&particles_packet).await,
+                    None => self.broadcast_to_chunk(chunk_pos, &particles_packet).await,
                 }
             }
 
@@ -3101,8 +3217,12 @@ impl World {
     /* End ItemScatterer.java */
 
     pub async fn sync_world_event(&self, world_event: WorldEvent, position: BlockPos, data: i32) {
-        self.broadcast_packet_all(&CWorldEvent::new(world_event as i32, position, data, false))
-            .await;
+        let chunk_pos = position.chunk_position();
+        self.broadcast_to_chunk(
+            chunk_pos,
+            &CWorldEvent::new(world_event as i32, position, data, false),
+        )
+        .await;
     }
     #[must_use]
     pub fn is_valid(dest: BlockPos) -> bool {
@@ -3137,6 +3257,30 @@ impl World {
     pub async fn get_block(&self, position: &BlockPos) -> &'static Block {
         let id = self.get_block_state_id(position).await;
         Block::from_state_id(id)
+    }
+
+    #[must_use]
+    pub fn get_block_state_id_if_loaded(&self, position: &BlockPos) -> Option<BlockStateId> {
+        if !self.is_in_build_limit(*position) {
+            return None;
+        }
+
+        let (chunk_coordinate, relative) = position.chunk_and_chunk_relative_position();
+        let chunk = self.level.try_get_chunk(&chunk_coordinate)?;
+        chunk
+            .section
+            .get_block_absolute_y(relative.x as usize, relative.y, relative.z as usize)
+    }
+
+    #[must_use]
+    pub fn get_block_state_if_loaded(&self, position: &BlockPos) -> Option<&'static BlockState> {
+        self.get_block_state_id_if_loaded(position)
+            .map(BlockState::from_id)
+    }
+
+    #[must_use]
+    pub fn is_loaded(&self, position: &BlockPos) -> bool {
+        self.get_block_state_id_if_loaded(position).is_some()
     }
 
     pub async fn get_fluid(&self, position: &BlockPos) -> &'static pumpkin_data::fluid::Fluid {
@@ -3367,11 +3511,15 @@ impl World {
         if let Some(nbt) = &block_entity_nbt {
             let mut bytes = Vec::new();
             to_bytes_unnamed(nbt, &mut bytes).unwrap();
-            self.broadcast_packet_all(&CBlockEntityData::new(
-                block_entity.get_position(),
-                VarInt(block_entity.get_id() as i32),
-                bytes.into_boxed_slice(),
-            ))
+            let chunk_pos = block_pos.chunk_position();
+            self.broadcast_to_chunk(
+                chunk_pos,
+                &CBlockEntityData::new(
+                    block_entity.get_position(),
+                    VarInt(block_entity.get_id() as i32),
+                    bytes.into_boxed_slice(),
+                ),
+            )
             .await;
         }
 
@@ -3404,11 +3552,15 @@ impl World {
         if let Some(nbt) = &block_entity_nbt {
             let mut bytes = Vec::new();
             to_bytes_unnamed(nbt, &mut bytes).unwrap();
-            self.broadcast_packet_all(&CBlockEntityData::new(
-                block_entity.get_position(),
-                VarInt(block_entity.get_id() as i32),
-                bytes.into_boxed_slice(),
-            ))
+            let chunk_pos = block_pos.chunk_position();
+            self.broadcast_to_chunk(
+                chunk_pos,
+                &CBlockEntityData::new(
+                    block_entity.get_position(),
+                    VarInt(block_entity.get_id() as i32),
+                    bytes.into_boxed_slice(),
+                ),
+            )
             .await;
         }
         chunk.mark_dirty(true);
@@ -3609,6 +3761,46 @@ impl World {
         }
 
         None
+    }
+
+    /// Broadcasts a packet to all players who currently have the target chunk loaded.
+    /// This uses highly optimized Chebyshev distance math (Chunk Grid) instead of floating point distance checks.
+    pub async fn broadcast_to_chunk<P: ClientPacket>(&self, chunk_pos: Vector2<i32>, packet: &P) {
+        let players = self.players.load();
+
+        let recipients = players.iter().filter(|p| {
+            let center = p.living_entity.entity.chunk_pos.load();
+            let view_distance = get_view_distance(p).get() as i32;
+
+            // Chebyshev distance (Minecraft's chunk loading shape)
+            is_within_view_distance(chunk_pos, center, view_distance)
+        });
+
+        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
+        Self::broadcast_java_grouped(packet, recipients_by_version).await;
+    }
+
+    /// Broadcasts a packet to chunk watchers, excluding specific players.
+    pub async fn broadcast_to_chunk_except<P: ClientPacket>(
+        &self,
+        chunk_pos: Vector2<i32>,
+        except: &[uuid::Uuid],
+        packet: &P,
+    ) {
+        let players = self.players.load();
+
+        let recipients = players.iter().filter(|p| {
+            if except.contains(&p.living_entity.entity.entity_uuid) {
+                return false;
+            }
+            let center = p.living_entity.entity.chunk_pos.load();
+            let view_distance = get_view_distance(p).get() as i32;
+
+            is_within_view_distance(chunk_pos, center, view_distance)
+        });
+
+        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
+        Self::broadcast_java_grouped(packet, recipients_by_version).await;
     }
 }
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1,4 +1,3 @@
-use pumpkin_protocol::codec::data_component::data_to_proto_sound;
 use std::pin::Pin;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::{Arc, Weak};
@@ -15,8 +14,7 @@ pub mod portal;
 pub mod time;
 
 use crate::block::RandomTickArgs;
-use crate::world::chunker::is_within_view_distance;
-use crate::world::{chunker::get_view_distance, loot::LootContextParameters};
+use crate::world::loot::LootContextParameters;
 use crate::{
     block::BlockEvent, entity::experience_orb::ExperienceOrbEntity, entity::item::ItemEntity,
 };
@@ -97,7 +95,7 @@ use pumpkin_protocol::{
 };
 use pumpkin_protocol::{
     codec::item_stack_seralizer::ItemStackSerializer,
-    java::client::play::{CBlockEvent, CRemoveMobEffect, CSetEquipment, CUpdateMobEffect},
+    java::client::play::{CBlockEvent, CRemoveMobEffect, CSetEquipment},
 };
 use pumpkin_protocol::{
     codec::var_int::VarInt,
@@ -129,6 +127,7 @@ use pumpkin_world::{world::BlockFlags, world_info::LevelData};
 use rand::seq::SliceRandom;
 use rand::{RngExt, rng};
 use scoreboard::Scoreboard;
+use teams::Teams;
 use time::LevelTime;
 use tokio::sync::Mutex;
 
@@ -137,6 +136,7 @@ pub mod bossbar;
 pub mod custom_bossbar;
 pub mod natural_spawner;
 pub mod scoreboard;
+pub mod teams;
 pub mod weather;
 
 use crate::world::natural_spawner::{SpawnState, spawn_for_chunk};
@@ -184,6 +184,8 @@ pub struct World {
     pub entities: ArcSwap<Vec<Arc<dyn EntityBase>>>,
     /// The world's scoreboard, used for tracking scores, objectives, and display information.
     pub scoreboard: Mutex<Scoreboard>,
+    /// The world's teams, used for grouping players and entities.
+    pub teams: Mutex<Teams>,
     /// The world's worldborder, defining the playable area and controlling its expansion or contraction.
     pub worldborder: Mutex<Worldborder>,
     /// The world's time, including counting ticks for weather, time cycles, and statistics.
@@ -234,6 +236,7 @@ impl World {
             players: ArcSwap::new(Arc::new(Vec::new())),
             entities: ArcSwap::new(Arc::new(Vec::new())),
             scoreboard: Mutex::new(Scoreboard::default()),
+            teams: Mutex::new(Teams::default()),
             worldborder: Mutex::new(Worldborder::new(0.0, 0.0, 5.999_996_8E7, 0, 5, 300)),
             level_time: Mutex::new(LevelTime::new()),
             dimension,
@@ -325,14 +328,10 @@ impl World {
         }
     }
 
-    /// Sends an entity status update to all players tracking the specified entity.
     pub async fn send_entity_status(&self, entity: &Entity, status: EntityStatus) {
-        let chunk_pos = entity.chunk_pos.load();
-        self.broadcast_to_chunk(
-            chunk_pos,
-            &CEntityStatus::new(entity.entity_id, status as i8),
-        )
-        .await;
+        // TODO: only nearby
+        self.broadcast_packet_all(&CEntityStatus::new(entity.entity_id, status as i8))
+            .await;
     }
 
     pub async fn send_remove_mob_effect(
@@ -340,37 +339,10 @@ impl World {
         entity: &Entity,
         effect_type: &'static StatusEffect,
     ) {
-        let chunk_pos = entity.chunk_pos.load();
-        self.broadcast_to_chunk(
-            chunk_pos,
-            &CRemoveMobEffect::new(entity.entity_id.into(), VarInt(i32::from(effect_type.id))),
-        )
-        .await;
-    }
-
-    pub async fn send_add_mob_effect(
-        &self,
-        entity: &Entity,
-        effect: &pumpkin_data::potion::Effect,
-    ) {
         // TODO: only nearby
-        let mut flags: i8 = 0;
-        if effect.ambient {
-            flags |= 0x01;
-        }
-        if effect.show_particles {
-            flags |= 0x02;
-        }
-        if effect.show_icon {
-            flags |= 0x04;
-        }
-
-        self.broadcast_packet_all(&CUpdateMobEffect::new(
-            VarInt(entity.entity_id),
-            VarInt(i32::from(effect.effect_type.id)),
-            VarInt(i32::from(effect.amplifier)),
-            VarInt(effect.duration),
-            flags,
+        self.broadcast_packet_all(&CRemoveMobEffect::new(
+            entity.entity_id.into(),
+            VarInt(i32::from(effect_type.id)),
         ))
         .await;
     }
@@ -413,16 +385,12 @@ impl World {
             {
                 continue;
             }
-            let chunk_pos = event.pos.chunk_position();
-            self.broadcast_to_chunk(
-                chunk_pos,
-                &CBlockEvent::new(
-                    event.pos,
-                    event.r#type,
-                    event.data,
-                    VarInt(i32::from(block.id)),
-                ),
-            )
+            self.broadcast_packet_all(&CBlockEvent::new(
+                event.pos,
+                event.r#type,
+                event.data,
+                VarInt(i32::from(block.id)),
+            ))
             .await;
         }
     }
@@ -542,7 +510,7 @@ impl World {
                 Some(decorated_message.clone()),
                 FilterType::PassThrough,
                 (RAW + 1).into(), // Custom registry chat_type with no sender name
-                TextComponent::empty(), // Not needed since we're injecting the name in the message for custom formatting
+                TextComponent::text(""), // Not needed since we're injecting the name in the message for custom formatting
                 None,
             );
             recipient.client.enqueue_packet(packet).await;
@@ -606,26 +574,6 @@ impl World {
             .await;
     }
 
-    pub async fn play_sound_event(
-        &self,
-        sound: pumpkin_data::data_component_impl::IdOr<
-            pumpkin_data::data_component_impl::SoundEvent,
-        >,
-        category: SoundCategory,
-        position: &Vector3<f64>,
-    ) {
-        let seed = rng().random::<f64>();
-        let packet = CSoundEffect::new(
-            data_to_proto_sound(&sound),
-            category,
-            position,
-            1.0,
-            1.0,
-            seed,
-        );
-        self.broadcast_packet_all(&packet).await;
-    }
-
     pub async fn play_sound_fine(
         &self,
         sound: Sound,
@@ -657,22 +605,9 @@ impl World {
         volume: f32,
         pitch: f32,
     ) {
-        let seed = rand::rng().random::<f64>();
+        let seed = rng().random::<f64>();
         let packet = CSoundEffect::new(IdOr::Id(sound_id), category, position, volume, pitch, seed);
-
-        // Calculate the number of chunks the sound can be heard from based on its volume.
-        let audible_chunks = f64::from(volume.max(1.0)).ceil() as i32;
-        let chunk_pos = BlockPos::floored_v(*position).chunk_position();
-
-        let players = self.players.load();
-        let recipients = players.iter().filter(|p| {
-            let center = p.living_entity.entity.chunk_pos.load();
-            // If the sound reaches their chunk, send it!
-            is_within_view_distance(chunk_pos, center, audible_chunks)
-        });
-
-        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
-        Self::broadcast_java_grouped(&packet, recipients_by_version).await;
+        self.broadcast_packet_all(&packet).await;
     }
 
     pub async fn play_sound_raw_expect(
@@ -684,25 +619,10 @@ impl World {
         volume: f32,
         pitch: f32,
     ) {
-        let seed = rand::rng().random::<f64>();
+        let seed = rng().random::<f64>();
         let packet = CSoundEffect::new(IdOr::Id(sound_id), category, position, volume, pitch, seed);
-
-        let audible_chunks = f64::from(volume.max(1.0)).ceil() as i32;
-        let chunk_pos = BlockPos::floored_v(*position).chunk_position();
-
-        let players = self.players.load();
-        let recipients = players.iter().filter(|p| {
-            // Skip the expected player
-            if p.gameprofile.id == player.gameprofile.id {
-                return false;
-            }
-
-            let center = p.living_entity.entity.chunk_pos.load();
-            is_within_view_distance(chunk_pos, center, audible_chunks)
-        });
-
-        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
-        Self::broadcast_java_grouped(&packet, recipients_by_version).await;
+        self.broadcast_packet_except(&[player.gameprofile.id], &packet)
+            .await;
     }
 
     pub async fn play_block_sound(
@@ -810,20 +730,19 @@ impl World {
 
         // TODO: only send packet to players who have the chunks loaded
         // TODO: Send light updates to update the wire directly next to a broken block
-        for (chunk_section, updates) in block_state_updates_by_chunk_section {
-            if updates.is_empty() {
+        for chunk_section in block_state_updates_by_chunk_section.values() {
+            if chunk_section.is_empty() {
                 continue;
             }
-            let chunk_pos = Vector2::new(chunk_section.x, chunk_section.z);
-            if updates.len() == 1 {
-                let (block_pos, block_state_id) = updates[0];
-                self.broadcast_to_chunk(
-                    chunk_pos,
-                    &CBlockUpdate::new(block_pos, i32::from(block_state_id).into()),
-                )
+            if chunk_section.len() == 1 {
+                let (block_pos, block_state_id) = chunk_section[0];
+                self.broadcast_packet_all(&CBlockUpdate::new(
+                    block_pos,
+                    i32::from(block_state_id).into(),
+                ))
                 .await;
             } else {
-                self.broadcast_to_chunk(chunk_pos, &CMultiBlockUpdate::new(&updates))
+                self.broadcast_packet_all(&CMultiBlockUpdate::new(chunk_section))
                     .await;
             }
         }
@@ -905,33 +824,14 @@ impl World {
         }
 
         for scheduled_tick in tick_data.random_ticks {
-            let (block, fluid) = match (scheduled_tick.tick_block, scheduled_tick.tick_fluid) {
-                (true, true) => {
-                    let (block, fluid) = self.get_block_and_fluid(&scheduled_tick.position).await;
-                    (Some(block), Some(fluid))
-                }
-                (true, false) => (Some(self.get_block(&scheduled_tick.position).await), None),
-                (false, true) => (None, Some(self.get_fluid(&scheduled_tick.position).await)),
-                (false, false) => (None, None),
-            };
-
-            if let Some(block) = block
-                && let Some(pumpkin_block) = self.block_registry.get_pumpkin_block(block.id)
-            {
+            let block = self.get_block(&scheduled_tick.position).await;
+            if let Some(pumpkin_block) = self.block_registry.get_pumpkin_block(block.id) {
                 pumpkin_block
                     .random_tick(RandomTickArgs {
                         world: self,
                         block,
                         position: &scheduled_tick.position,
                     })
-                    .await;
-            }
-
-            if let Some(fluid) = fluid
-                && let Some(pumpkin_fluid) = self.block_registry.get_pumpkin_fluid(fluid.id)
-            {
-                pumpkin_fluid
-                    .random_tick(fluid, self, &scheduled_tick.position)
                     .await;
             }
         }
@@ -960,21 +860,13 @@ impl World {
             SpawnState::new(spawning_chunks_map.len() as i32, &self.entities, self).await; // TODO store it
 
         // TODO gamerule this.spawnEnemies || this.spawnFriendlies
-        let (spawn_mobs, spawn_monsters, peaceful) = {
-            let lock = self.level_info.load();
-            (
-                lock.game_rules.spawn_mobs,
-                lock.game_rules.spawn_monsters,
-                lock.difficulty == Difficulty::Peaceful,
-            )
-        };
         let spawn_passives = self.level_time.lock().await.time_of_day % 400 == 0;
         let spawn_list: Vec<&'static MobCategory> =
             natural_spawner::get_filtered_spawning_categories(
                 &spawn_state,
-                spawn_mobs,
-                peaceful && spawn_mobs && spawn_monsters,
-                peaceful && spawn_mobs && spawn_passives && spawn_monsters,
+                true,
+                true,
+                spawn_passives,
             );
 
         // log::debug!("spawning list size {}", spawn_list.len());
@@ -1672,7 +1564,7 @@ impl World {
         &self,
         base_config: &BasicConfiguration,
         player: &Arc<Player>,
-        server: &Arc<Server>,
+        server: &Server,
     ) {
         let dimensions: Vec<ResourceLocation> = server
             .dimensions
@@ -2016,6 +1908,9 @@ impl World {
 
         player.send_active_effects().await;
         self.send_player_equipment(player).await;
+
+        // Send existing teams to the joining player
+        self.teams.lock().await.send_to_player(client).await;
     }
 
     async fn send_player_equipment(&self, from: &Player) {
@@ -2035,9 +1930,7 @@ impl World {
             .iter()
             .map(|(slot, stack)| (*slot, ItemStackSerializer::from(stack.clone())))
             .collect();
-        let chunk_pos = from.get_entity().chunk_pos.load();
-        self.broadcast_to_chunk_except(
-            chunk_pos,
+        self.broadcast_packet_except(
             &[from.get_entity().entity_uuid],
             &CSetEquipment::new(from.entity_id().into(), equipment),
         )
@@ -2833,8 +2726,7 @@ impl World {
 
     pub async fn spawn_entity(&self, entity: Arc<dyn EntityBase>) {
         let base_entity = entity.get_entity();
-        let chunk_pos = base_entity.chunk_pos.load();
-        self.broadcast_to_chunk(chunk_pos, &base_entity.create_spawn_packet())
+        self.broadcast_packet_all(&base_entity.create_spawn_packet())
             .await;
         entity.init_data_tracker().await;
 
@@ -2861,17 +2753,14 @@ impl World {
             new_entities
         });
 
-        let chunk_pos = entity.chunk_pos.load();
-        self.broadcast_to_chunk(chunk_pos, &CRemoveEntities::new(&[entity.entity_id.into()]))
+        self.broadcast_packet_all(&CRemoveEntities::new(&[entity.entity_id.into()]))
             .await;
 
         self.remove_entity_data(entity).await;
     }
 
     pub async fn set_block_breaking(&self, from: &Entity, location: BlockPos, progress: i32) {
-        let chunk_pos = location.chunk_position(); // pumpkin's BlockPos already has this method
-        self.broadcast_to_chunk_except(
-            chunk_pos,
+        self.broadcast_packet_except(
             &[from.entity_uuid],
             &CSetBlockDestroyStage::new(from.entity_id.into(), location, progress as i8),
         )
@@ -3116,17 +3005,12 @@ impl World {
                     broken_state_id.into(),
                     false,
                 );
-                let chunk_pos = position.chunk_position();
                 match cause {
                     Some(player) => {
-                        self.broadcast_to_chunk_except(
-                            chunk_pos,
-                            &[player.living_entity.entity.entity_uuid],
-                            &particles_packet,
-                        )
-                        .await;
+                        self.broadcast_packet_except(&[player.gameprofile.id], &particles_packet)
+                            .await;
                     }
-                    None => self.broadcast_to_chunk(chunk_pos, &particles_packet).await,
+                    None => self.broadcast_packet_all(&particles_packet).await,
                 }
             }
 
@@ -3217,12 +3101,8 @@ impl World {
     /* End ItemScatterer.java */
 
     pub async fn sync_world_event(&self, world_event: WorldEvent, position: BlockPos, data: i32) {
-        let chunk_pos = position.chunk_position();
-        self.broadcast_to_chunk(
-            chunk_pos,
-            &CWorldEvent::new(world_event as i32, position, data, false),
-        )
-        .await;
+        self.broadcast_packet_all(&CWorldEvent::new(world_event as i32, position, data, false))
+            .await;
     }
     #[must_use]
     pub fn is_valid(dest: BlockPos) -> bool {
@@ -3257,30 +3137,6 @@ impl World {
     pub async fn get_block(&self, position: &BlockPos) -> &'static Block {
         let id = self.get_block_state_id(position).await;
         Block::from_state_id(id)
-    }
-
-    #[must_use]
-    pub fn get_block_state_id_if_loaded(&self, position: &BlockPos) -> Option<BlockStateId> {
-        if !self.is_in_build_limit(*position) {
-            return None;
-        }
-
-        let (chunk_coordinate, relative) = position.chunk_and_chunk_relative_position();
-        let chunk = self.level.try_get_chunk(&chunk_coordinate)?;
-        chunk
-            .section
-            .get_block_absolute_y(relative.x as usize, relative.y, relative.z as usize)
-    }
-
-    #[must_use]
-    pub fn get_block_state_if_loaded(&self, position: &BlockPos) -> Option<&'static BlockState> {
-        self.get_block_state_id_if_loaded(position)
-            .map(BlockState::from_id)
-    }
-
-    #[must_use]
-    pub fn is_loaded(&self, position: &BlockPos) -> bool {
-        self.get_block_state_id_if_loaded(position).is_some()
     }
 
     pub async fn get_fluid(&self, position: &BlockPos) -> &'static pumpkin_data::fluid::Fluid {
@@ -3511,15 +3367,11 @@ impl World {
         if let Some(nbt) = &block_entity_nbt {
             let mut bytes = Vec::new();
             to_bytes_unnamed(nbt, &mut bytes).unwrap();
-            let chunk_pos = block_pos.chunk_position();
-            self.broadcast_to_chunk(
-                chunk_pos,
-                &CBlockEntityData::new(
-                    block_entity.get_position(),
-                    VarInt(block_entity.get_id() as i32),
-                    bytes.into_boxed_slice(),
-                ),
-            )
+            self.broadcast_packet_all(&CBlockEntityData::new(
+                block_entity.get_position(),
+                VarInt(block_entity.get_id() as i32),
+                bytes.into_boxed_slice(),
+            ))
             .await;
         }
 
@@ -3552,15 +3404,11 @@ impl World {
         if let Some(nbt) = &block_entity_nbt {
             let mut bytes = Vec::new();
             to_bytes_unnamed(nbt, &mut bytes).unwrap();
-            let chunk_pos = block_pos.chunk_position();
-            self.broadcast_to_chunk(
-                chunk_pos,
-                &CBlockEntityData::new(
-                    block_entity.get_position(),
-                    VarInt(block_entity.get_id() as i32),
-                    bytes.into_boxed_slice(),
-                ),
-            )
+            self.broadcast_packet_all(&CBlockEntityData::new(
+                block_entity.get_position(),
+                VarInt(block_entity.get_id() as i32),
+                bytes.into_boxed_slice(),
+            ))
             .await;
         }
         chunk.mark_dirty(true);
@@ -3761,46 +3609,6 @@ impl World {
         }
 
         None
-    }
-
-    /// Broadcasts a packet to all players who currently have the target chunk loaded.
-    /// This uses highly optimized Chebyshev distance math (Chunk Grid) instead of floating point distance checks.
-    pub async fn broadcast_to_chunk<P: ClientPacket>(&self, chunk_pos: Vector2<i32>, packet: &P) {
-        let players = self.players.load();
-
-        let recipients = players.iter().filter(|p| {
-            let center = p.living_entity.entity.chunk_pos.load();
-            let view_distance = get_view_distance(p).get() as i32;
-
-            // Chebyshev distance (Minecraft's chunk loading shape)
-            is_within_view_distance(chunk_pos, center, view_distance)
-        });
-
-        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
-        Self::broadcast_java_grouped(packet, recipients_by_version).await;
-    }
-
-    /// Broadcasts a packet to chunk watchers, excluding specific players.
-    pub async fn broadcast_to_chunk_except<P: ClientPacket>(
-        &self,
-        chunk_pos: Vector2<i32>,
-        except: &[uuid::Uuid],
-        packet: &P,
-    ) {
-        let players = self.players.load();
-
-        let recipients = players.iter().filter(|p| {
-            if except.contains(&p.living_entity.entity.entity_uuid) {
-                return false;
-            }
-            let center = p.living_entity.entity.chunk_pos.load();
-            let view_distance = get_view_distance(p).get() as i32;
-
-            is_within_view_distance(chunk_pos, center, view_distance)
-        });
-
-        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
-        Self::broadcast_java_grouped(packet, recipients_by_version).await;
     }
 }
 

--- a/pumpkin/src/world/scoreboard.rs
+++ b/pumpkin/src/world/scoreboard.rs
@@ -13,14 +13,30 @@ use super::World;
 
 #[derive(Default)]
 pub struct Scoreboard {
-    objectives: HashMap<String, ScoreboardObjective<'static>>,
-    //  teams: HashMap<String, Team>,
+    objectives: HashMap<String, StoredObjective>,
+    scores: HashMap<String, HashMap<String, i32>>, // entity_name -> objective_name -> value
+    display_slots: HashMap<u8, String>,            // slot (as u8) -> objective_name
+}
+
+pub struct StoredObjective {
+    pub display_name: TextComponent,
+    pub render_type: RenderType,
+    pub number_format: Option<NumberFormat>,
 }
 
 impl Scoreboard {
+    #[must_use]
+    pub fn has_objective(&self, name: &str) -> bool {
+        self.objectives.contains_key(name)
+    }
+
+    #[must_use]
+    pub const fn get_objectives(&self) -> &HashMap<String, StoredObjective> {
+        &self.objectives
+    }
+
     pub async fn add_objective(&mut self, world: &World, objective: ScoreboardObjective<'_>) {
         if self.objectives.contains_key(objective.name) {
-            // Maybe make this an error?
             warn!(
                 "Tried to create an objective which already exists: {}",
                 &objective.name
@@ -31,21 +47,107 @@ impl Scoreboard {
             .broadcast_packet_all(&CUpdateObjectives::new(
                 objective.name.to_string(),
                 pumpkin_protocol::java::client::play::Mode::Add,
-                objective.display_name,
-                objective.render_type,
-                objective.number_format,
+                objective.display_name.clone(),
+                RenderType::Integer,
+                None,
             ))
             .await;
+        self.objectives.insert(
+            objective.name.to_string(),
+            StoredObjective {
+                display_name: objective.display_name,
+                render_type: RenderType::Integer,
+                number_format: objective.number_format,
+            },
+        );
+    }
+
+    pub async fn remove_objective(&mut self, world: &World, name: &str) {
+        if self.objectives.remove(name).is_none() {
+            return;
+        }
+        // Remove display slot references
+        self.display_slots.retain(|_, v| v != name);
+        // Remove all scores for this objective
+        for scores in self.scores.values_mut() {
+            scores.remove(name);
+        }
         world
-            .broadcast_packet_all(&CDisplayObjective::new(
-                ScoreboardDisplaySlot::Sidebar,
-                objective.name.to_string(),
+            .broadcast_packet_all(&CUpdateObjectives::new(
+                name.to_string(),
+                pumpkin_protocol::java::client::play::Mode::Remove,
+                TextComponent::text(""),
+                RenderType::Integer,
+                None,
             ))
             .await;
     }
 
+    pub async fn set_display_slot(
+        &mut self,
+        world: &World,
+        slot: ScoreboardDisplaySlot,
+        objective_name: Option<&str>,
+    ) {
+        let slot_id = slot as u8;
+        if let Some(name) = objective_name {
+            self.display_slots.insert(slot_id, name.to_string());
+        } else {
+            self.display_slots.remove(&slot_id);
+        }
+        world
+            .broadcast_packet_all(&CDisplayObjective {
+                position: VarInt(i32::from(slot_id)),
+                score_name: objective_name.unwrap_or("").to_string(),
+            })
+            .await;
+    }
+
+    pub async fn set_score(&mut self, world: &World, entity: &str, objective: &str, value: i32) {
+        if !self.objectives.contains_key(objective) {
+            warn!(
+                "Tried to set a score for an objective which does not exist: {}",
+                objective
+            );
+            return;
+        }
+        self.scores
+            .entry(entity.to_string())
+            .or_default()
+            .insert(objective.to_string(), value);
+        world
+            .broadcast_packet_all(&CUpdateScore::new(
+                entity.to_string(),
+                objective.to_string(),
+                VarInt(value),
+                None,
+                None,
+            ))
+            .await;
+    }
+
+    #[must_use]
+    pub fn get_score(&self, entity: &str, objective: &str) -> Option<i32> {
+        self.scores.get(entity)?.get(objective).copied()
+    }
+
+    pub fn reset_scores(&mut self, entity: &str, objective: Option<&str>) {
+        if let Some(obj) = objective {
+            if let Some(scores) = self.scores.get_mut(entity) {
+                scores.remove(obj);
+            }
+        } else {
+            self.scores.remove(entity);
+        }
+    }
+
+    #[must_use]
+    pub fn get_entity_scores(&self, entity: &str) -> Option<&HashMap<String, i32>> {
+        self.scores.get(entity)
+    }
+
     pub async fn update_score(&self, world: &World, score: ScoreboardScore<'_>) {
-        if self.objectives.contains_key(score.objective_name) {
+        if !self.objectives.contains_key(score.objective_name) {
             warn!(
                 "Tried to place a score into an objective which does not exist: {}",
                 &score.objective_name
@@ -62,20 +164,13 @@ impl Scoreboard {
             ))
             .await;
     }
-
-    // pub fn add_team(&mut self, name: String) {
-    //     if self.teams.contains_key(&name) {
-    //         // Maybe make this an error ?
-    //         log::warn!("Tried to create Team which does already exist, {}", name);
-    //     }
-    // }
 }
 
 pub struct ScoreboardObjective<'a> {
-    name: &'a str,
-    display_name: TextComponent,
-    render_type: RenderType,
-    number_format: Option<NumberFormat>,
+    pub name: &'a str,
+    pub display_name: TextComponent,
+    pub render_type: RenderType,
+    pub number_format: Option<NumberFormat>,
 }
 
 impl<'a> ScoreboardObjective<'a> {


### PR DESCRIPTION
- Implements `/trigger` command for activating scoreboard triggers
- OP level 0 (all players can use)

> **Depends on:** #1905 (`/scoreboard` command) must be merged first — this command references enhanced `Scoreboard` methods.