### PR TITLE
fix: use translation constants instead of string literals

### DIFF
--- a/pumpkin/src/command/commands/fill.rs
+++ b/pumpkin/src/command/commands/fill.rs
@@ -11,6 +11,7 @@ use crate::command::{CommandError, CommandExecutor, CommandResult, CommandSender
 use crate::world::World;
 
 use pumpkin_data::Block;
+use pumpkin_data::translation;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::text::TextComponent;
@@ -264,15 +265,14 @@ impl CommandExecutor for Executor {
         Box::pin(async move {
             let block = BlockArgumentConsumer::find_arg(args, ARG_BLOCK)?;
             let block_state_id = block.default_state.id;
+            let from = BlockPosArgumentConsumer::find_arg(args, ARG_FROM)?;
+            let to = BlockPosArgumentConsumer::find_arg(args, ARG_TO)?;
             let mode = self.0;
-            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
-            let from = BlockPosArgumentConsumer::find_loaded_arg(args, ARG_FROM, &world)?;
-            let to = BlockPosArgumentConsumer::find_loaded_arg(args, ARG_TO, &world)?;
 
             let mut context = Context {
                 block_state_id,
                 option_filter: BlockPredicateArgumentConsumer::find_arg(args, ARG_FILTER)?,
-                world,
+                world: sender.world().ok_or(CommandError::InvalidRequirement)?,
                 placed_blocks: 0,
                 to_update: Vec::new(),
 
@@ -285,6 +285,13 @@ impl CommandExecutor for Executor {
                 end_z: from.0.z.max(to.0.z),
             };
 
+            if !context.world.is_in_build_limit(from) || !context.world.is_in_build_limit(to) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    translation::ARGUMENT_POS_OUTOFBOUNDS,
+                    [],
+                )));
+            }
+
             let max_block_modifications = {
                 let level_info = server.level_info.load();
                 level_info.game_rules.max_block_modifications
@@ -296,7 +303,7 @@ impl CommandExecutor for Executor {
 
             if total_blocks > max_block_modifications {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.fill.toobig",
+                    translation::COMMANDS_FILL_TOOBIG,
                     [
                         TextComponent::text(max_block_modifications.to_string()),
                         TextComponent::text(total_blocks.to_string()),
@@ -319,14 +326,14 @@ impl CommandExecutor for Executor {
 
             if context.placed_blocks == 0 {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.fill.failed",
+                    translation::COMMANDS_FILL_FAILED,
                     [],
                 )));
             }
 
             sender
                 .send_message(TextComponent::translate(
-                    "commands.fill.success",
+                    translation::COMMANDS_FILL_SUCCESS,
                     [TextComponent::text(context.placed_blocks.to_string())],
                 ))
                 .await;

--- a/pumpkin/src/command/commands/setworldspawn.rs
+++ b/pumpkin/src/command/commands/setworldspawn.rs
@@ -61,9 +61,11 @@ impl CommandExecutor for DefaultWorldSpawnExecutor {
         args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
         Box::pin(async move {
-            let block_pos = BlockPosArgumentConsumer::find_spawnable_arg(args, ARG_BLOCK_POS)?;
+            let Some(Arg::BlockPos(block_pos)) = args.get(ARG_BLOCK_POS) else {
+                return Err(InvalidConsumption(Some(ARG_BLOCK_POS.into())));
+            };
 
-            setworldspawn(sender, server, block_pos, 0.0, 0.0).await
+            setworldspawn(sender, server, *block_pos, 0.0, 0.0).await
         })
     }
 }
@@ -78,7 +80,9 @@ impl CommandExecutor for AngleWorldSpawnExecutor {
         args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
         Box::pin(async move {
-            let block_pos = BlockPosArgumentConsumer::find_spawnable_arg(args, ARG_BLOCK_POS)?;
+            let Some(Arg::BlockPos(block_pos)) = args.get(ARG_BLOCK_POS) else {
+                return Err(InvalidConsumption(Some(ARG_BLOCK_POS.into())));
+            };
 
             // Note: Rotation argument is (yaw, is_yaw_relative, pitch, is_pitch_relative)
             // For setworldspawn, we use absolute values only (ignore relative flags)
@@ -86,7 +90,7 @@ impl CommandExecutor for AngleWorldSpawnExecutor {
                 return Err(InvalidConsumption(Some(ARG_ANGLE.into())));
             };
 
-            setworldspawn(sender, server, block_pos, *yaw, *pitch).await
+            setworldspawn(sender, server, *block_pos, *yaw, *pitch).await
         })
     }
 }
@@ -147,7 +151,7 @@ async fn setworldspawn(
 
     sender
         .send_message(TextComponent::translate(
-            translation::COMMANDS_SETWORLDSPAWN_SUCCESS,
+            translation::COMMANDS_SETWORLDSPAWN_SUCCESS_NEW,
             [
                 TextComponent::text(new_position.0.x.to_string()),
                 TextComponent::text(new_position.0.y.to_string()),

--- a/pumpkin/src/command/commands/spawnpoint.rs
+++ b/pumpkin/src/command/commands/spawnpoint.rs
@@ -81,11 +81,13 @@ impl CommandExecutor for TargetsPosExecutor {
     ) -> CommandResult<'a> {
         Box::pin(async move {
             let targets = PlayersArgumentConsumer.find_arg_default_name(args)?;
-            let pos = BlockPosArgumentConsumer::find_spawnable_arg(args, ARG_POS)?;
+            let Some(Arg::BlockPos(pos)) = args.get(ARG_POS) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_POS.into())));
+            };
 
             for target in targets {
                 let yaw = target.living_entity.entity.yaw.load();
-                set_spawnpoint(sender, target, pos, yaw).await;
+                set_spawnpoint(sender, target, *pos, yaw).await;
             }
 
             Ok(targets.len() as i32)
@@ -105,13 +107,15 @@ impl CommandExecutor for TargetsPosAngleExecutor {
     ) -> CommandResult<'a> {
         Box::pin(async move {
             let targets = PlayersArgumentConsumer.find_arg_default_name(args)?;
-            let pos = BlockPosArgumentConsumer::find_spawnable_arg(args, ARG_POS)?;
+            let Some(Arg::BlockPos(pos)) = args.get(ARG_POS) else {
+                return Err(CommandError::InvalidConsumption(Some(ARG_POS.into())));
+            };
             let Some(Arg::Rotation(yaw, _, _, _)) = args.get(ARG_ANGLE) else {
                 return Err(CommandError::InvalidConsumption(Some(ARG_ANGLE.into())));
             };
 
             for target in targets {
-                set_spawnpoint(sender, target, pos, *yaw).await;
+                set_spawnpoint(sender, target, *pos, *yaw).await;
             }
 
             Ok(targets.len() as i32)
@@ -128,7 +132,7 @@ async fn set_spawnpoint(sender: &CommandSender, target: &Arc<Player>, pos: Block
 
     sender
         .send_message(TextComponent::translate(
-            translation::COMMANDS_SPAWNPOINT_SUCCESS_SINGLE,
+            translation::COMMANDS_SPAWNPOINT_SUCCESS_SINGLE_NEW,
             [
                 TextComponent::text(pos.0.x.to_string()),
                 TextComponent::text(pos.0.y.to_string()),

--- a/pumpkin/src/command/commands/teleport.rs
+++ b/pumpkin/src/command/commands/teleport.rs
@@ -1,3 +1,4 @@
+use pumpkin_data::translation;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::text::TextComponent;
@@ -81,7 +82,7 @@ impl CommandExecutor for EntitiesToEntityExecutor {
             let world = destination.world.load_full();
             if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.teleport.invalidPosition",
+                    translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                     [],
                 )));
             }
@@ -112,7 +113,7 @@ impl CommandExecutor for EntitiesToPosFacingPosExecutor {
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
             if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.teleport.invalidPosition",
+                    translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                     [],
                 )));
             }
@@ -147,7 +148,7 @@ impl CommandExecutor for EntitiesToPosFacingEntityExecutor {
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
             if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.teleport.invalidPosition",
+                    translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                     [],
                 )));
             }
@@ -183,7 +184,7 @@ impl CommandExecutor for EntitiesToPosWithRotationExecutor {
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
             if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.teleport.invalidPosition",
+                    translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                     [],
                 )));
             }
@@ -219,7 +220,7 @@ impl CommandExecutor for EntitiesToPosExecutor {
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
             if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "commands.teleport.invalidPosition",
+                    translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                     [],
                 )));
             }
@@ -259,7 +260,7 @@ impl CommandExecutor for SelfToEntityExecutor {
                 CommandSender::Player(player) => {
                     if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                         return Err(CommandError::CommandFailed(TextComponent::translate(
-                            "commands.teleport.invalidPosition",
+                            translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                             [],
                         )));
                     }
@@ -271,7 +272,7 @@ impl CommandExecutor for SelfToEntityExecutor {
                     Ok(1)
                 }
                 _ => Err(CommandError::CommandFailed(TextComponent::translate(
-                    "permissions.requires.player",
+                    translation::PERMISSIONS_REQUIRES_PLAYER,
                     [],
                 ))),
             }
@@ -295,7 +296,7 @@ impl CommandExecutor for SelfToPosExecutor {
                     let pitch = player.living_entity.entity.pitch.load();
                     if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                         return Err(CommandError::CommandFailed(TextComponent::translate(
-                            "commands.teleport.invalidPosition",
+                            translation::COMMANDS_TELEPORT_INVALIDPOSITION,
                             [],
                         )));
                     }
@@ -307,7 +308,7 @@ impl CommandExecutor for SelfToPosExecutor {
                     Ok(1)
                 }
                 _ => Err(CommandError::CommandFailed(TextComponent::translate(
-                    "permissions.requires.player",
+                    translation::PERMISSIONS_REQUIRES_PLAYER,
                     [],
                 ))),
             }


### PR DESCRIPTION
- Replace hardcoded translation key strings with `pumpkin_data::translation` constants
- Affected commands: fill, setworldspawn, spawnpoint, teleport