### PR TITLE
feat: implement /random command

### DIFF
--- a/pumpkin-world/src/world_info/anvil.rs
+++ b/pumpkin-world/src/world_info/anvil.rs
@@ -136,6 +136,7 @@ pub struct LevelDat {
 mod test {
 
     use std::{
+        collections::HashMap,
         fs,
         io::{Cursor, Read},
         sync::LazyLock,
@@ -241,6 +242,7 @@ mod test {
                 snapshot: false,
                 series: "main".to_string(),
             },
+            random_sequences: HashMap::new(),
         },
     });
 

--- a/pumpkin-world/src/world_info/mod.rs
+++ b/pumpkin-world/src/world_info/mod.rs
@@ -80,6 +80,8 @@ pub struct LevelData {
     pub world_version: WorldVersion,
     #[serde(rename = "version", default = "default_level_version")]
     pub level_version: i32,
+    #[serde(default)]
+    pub random_sequences: HashMap<String, RandomSequence>,
 }
 
 const DEFAULT_BORDER_DAMAGE_PER_BLOCK: f64 = 0.2;
@@ -325,6 +327,7 @@ impl LevelData {
             spawn_pitch: 0.0,
             world_version: WorldVersion::default(),
             level_version: MAXIMUM_SUPPORTED_LEVEL_VERSION,
+            random_sequences: HashMap::new(),
         }
     }
 
@@ -355,4 +358,10 @@ impl From<std::io::Error> for WorldInfoError {
             value => Self::IoError(value),
         }
     }
+}
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Default)]
+pub struct RandomSequence {
+    pub seed: i64,
+    pub include_world_seed: bool,
+    pub include_sequence_id: bool,
 }

--- a/pumpkin/src/command/argument_types/core/mod.rs
+++ b/pumpkin/src/command/argument_types/core/mod.rs
@@ -10,6 +10,7 @@ pub mod double;
 pub mod float;
 pub mod integer;
 pub mod long;
+pub mod resource_location;
 pub mod string;
 
 /// Helper method for parsing with a reader and returning an [`Err`] if outside the range.

--- a/pumpkin/src/command/argument_types/core/resource_location.rs
+++ b/pumpkin/src/command/argument_types/core/resource_location.rs
@@ -1,0 +1,27 @@
+use crate::command::{
+    argument_types::argument_type::{ArgumentType, JavaClientArgumentType},
+    errors::command_syntax_error::CommandSyntaxError,
+    string_reader::StringReader,
+};
+
+pub struct ResourceLocationArgumentType;
+
+impl ArgumentType for ResourceLocationArgumentType {
+    type Item = String;
+
+    fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
+        reader.read_unquoted_string()
+    }
+
+    fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
+        JavaClientArgumentType::ResourceLocation
+    }
+
+    fn examples(&self) -> Vec<String> {
+        examples!(
+            "minecraft:stone",
+            "pumpkin:test/path",
+            "namespace:identifier"
+        )
+    }
+}

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -75,7 +75,6 @@ pub async fn default_dispatcher(
     dispatcher.register(pumpkin::init_command_tree(), "pumpkin:command.pumpkin");
     dispatcher.register(me::init_command_tree(), "minecraft:command.me");
     dispatcher.register(msg::init_command_tree(), "minecraft:command.msg");
-    dispatcher.register(random::init_command_tree(), "minecraft:command.random");
     // Two
     dispatcher.register(kill::init_command_tree(), "minecraft:command.kill");
     dispatcher.register(
@@ -157,6 +156,7 @@ pub async fn default_dispatcher(
     difficulty::register(&mut dispatcher, registry);
     help::register(&mut dispatcher, registry);
     list::register(&mut dispatcher, registry);
+    random::register(&mut dispatcher, registry);
     seed::register(&mut dispatcher, registry);
     setidletimeout::register(&mut dispatcher, registry);
     stop::register(&mut dispatcher, registry);
@@ -204,13 +204,6 @@ fn register_level_0_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.msg",
             "Sends a private message to another player",
-            PermissionDefault::Allow,
-        ))
-        .unwrap();
-    registry
-        .register_permission(Permission::new(
-            "minecraft:command.random",
-            "Generates a random value or rolls it publicly",
             PermissionDefault::Allow,
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -37,6 +37,7 @@ mod playsound;
 mod plugin;
 mod plugins;
 mod pumpkin;
+mod random;
 mod rotate;
 mod say;
 mod seed;
@@ -74,6 +75,7 @@ pub async fn default_dispatcher(
     dispatcher.register(pumpkin::init_command_tree(), "pumpkin:command.pumpkin");
     dispatcher.register(me::init_command_tree(), "minecraft:command.me");
     dispatcher.register(msg::init_command_tree(), "minecraft:command.msg");
+    dispatcher.register(random::init_command_tree(), "minecraft:command.random");
     // Two
     dispatcher.register(kill::init_command_tree(), "minecraft:command.kill");
     dispatcher.register(
@@ -202,6 +204,13 @@ fn register_level_0_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.msg",
             "Sends a private message to another player",
+            PermissionDefault::Allow,
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.random",
+            "Generates a random value or rolls it publicly",
             PermissionDefault::Allow,
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/random.rs
+++ b/pumpkin/src/command/commands/random.rs
@@ -6,6 +6,7 @@ use std::{
 use pumpkin_data::{translation, world::SAY_COMMAND};
 use pumpkin_util::{
     PermissionLvl,
+    math::bounds::IntBounds,
     permission::{Permission, PermissionDefault, PermissionRegistry},
     random::{RandomImpl, xoroshiro128::Xoroshiro},
     text::TextComponent,
@@ -14,27 +15,28 @@ use pumpkin_world::world_info::RandomSequence;
 use rand::RngExt;
 use tokio::sync::Mutex;
 
-#[cfg(test)]
-use crate::command::dispatcher::CommandError;
 use crate::command::{
     argument_builder::{ArgumentBuilder, argument, command, literal},
     argument_types::{
-        argument_type::{ArgumentType, JavaClientArgumentType},
-        core::{bool::BoolArgumentType, long::LongArgumentType, string::StringArgumentType},
+        core::{
+            bool::BoolArgumentType, long::LongArgumentType,
+            resource_location::ResourceLocationArgumentType,
+        },
+        range::IntRangeArgumentType,
     },
-    context::{command_context::CommandContext, command_source::CommandSource},
+    context::command_context::CommandContext,
     errors::{
         command_syntax_error::{CommandSyntaxError, CommandSyntaxErrorContext},
         error_types,
     },
     node::{CommandExecutor, CommandExecutorResult, dispatcher::CommandDispatcher},
-    string_reader::StringReader,
     tree::RawArg,
 };
-use pumpkin_protocol::java::client::play::StringProtoArgBehavior;
 
 const DESCRIPTION: &str = "Generates a random integer, or controls random sequences.";
 const PERMISSION: &str = "minecraft:command.random";
+const PERMISSION_SEQUENCE: &str = "minecraft:command.random.sequence";
+const PERMISSION_RESET: &str = "minecraft:command.random.reset";
 
 const ARG_RANGE: &str = "range";
 const ARG_SEQUENCE: &str = "sequence";
@@ -112,127 +114,21 @@ enum ResetTarget {
 #[derive(Clone, Copy)]
 struct ResetExecutor {
     target: ResetTarget,
+    mode: ResetMode,
+}
+
+#[derive(Clone, Copy)]
+enum ResetMode {
+    Defaults,
+    SeedOnly,
+    SeedAndWorldSeed,
+    Full,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
 struct InclusiveRange {
     min: i32,
     max: i32,
-}
-
-struct RangeArgumentType;
-
-impl ArgumentType for RangeArgumentType {
-    type Item = (i32, i32);
-
-    fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
-        let start = reader.cursor();
-
-        let min = if reader.peek() == Some('.') {
-            None
-        } else {
-            Some(reader.read_int()?)
-        };
-
-        let has_separator = reader.peek() == Some('.') && reader.peek_with_offset(1) == Some('.');
-
-        let (min, max) = if has_separator {
-            reader.expect('.')?;
-            reader.expect('.')?;
-
-            let max = match reader.peek() {
-                None => None,
-                Some(c) if c.is_whitespace() => None,
-                _ => Some(reader.read_int()?),
-            };
-
-            (min.unwrap_or(i32::MIN), max.unwrap_or(i32::MAX))
-        } else {
-            let Some(value) = min else {
-                reader.set_cursor(start);
-                return Err(error_types::READER_EXPECTED_INT.create(reader));
-            };
-
-            (value, value)
-        };
-
-        let range_size = i64::from(max) - i64::from(min) + 1;
-        if range_size < 2 {
-            return Err(
-                error_types::DISPATCHER_PARSE_EXCEPTION.create_without_context(
-                    TextComponent::translate(
-                        translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_SMALL,
-                        [],
-                    ),
-                ),
-            );
-        }
-        if range_size > 2_147_483_646 {
-            return Err(
-                error_types::DISPATCHER_PARSE_EXCEPTION.create_without_context(
-                    TextComponent::translate(
-                        translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_LARGE,
-                        [],
-                    ),
-                ),
-            );
-        }
-
-        Ok((min, max))
-    }
-
-    fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
-        JavaClientArgumentType::String(StringProtoArgBehavior::SingleWord)
-    }
-}
-
-impl InclusiveRange {
-    #[cfg(test)]
-    fn parse(range: &str) -> Result<Self, CommandError> {
-        let (min, max) = if let Some((min_raw, max_raw)) = range.split_once("..") {
-            let min = if min_raw.is_empty() {
-                i32::MIN
-            } else {
-                parse_i32_range_bound(min_raw)?
-            };
-            let max = if max_raw.is_empty() {
-                i32::MAX
-            } else {
-                parse_i32_range_bound(max_raw)?
-            };
-
-            (min, max)
-        } else {
-            let value = parse_i32_range_bound(range)?;
-            (value, value)
-        };
-
-        let range_size = i64::from(max) - i64::from(min) + 1;
-        if range_size < 2 {
-            return Err(CommandError::CommandFailed(TextComponent::translate(
-                translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_SMALL,
-                [],
-            )));
-        }
-        if range_size > 2_147_483_646 {
-            return Err(CommandError::CommandFailed(TextComponent::translate(
-                translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_LARGE,
-                [],
-            )));
-        }
-
-        Ok(Self { min, max })
-    }
-}
-
-#[cfg(test)]
-fn parse_i32_range_bound(raw: &str) -> Result<i32, CommandError> {
-    raw.parse::<i32>().map_err(|_| {
-        CommandError::CommandFailed(TextComponent::translate(
-            translation::PARSING_INT_INVALID,
-            [TextComponent::text(raw.to_string())],
-        ))
-    })
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -456,19 +352,32 @@ fn usize_to_i32_saturating(value: usize) -> i32 {
     i32::try_from(value).unwrap_or(i32::MAX)
 }
 
-fn get_optional_argument<'a, T: 'static>(
-    context: &'a CommandContext,
-    name: &str,
-) -> Result<Option<&'a T>, CommandSyntaxError> {
-    if context.arguments.contains_key(name) {
-        context.get_argument(name).map(Some)
-    } else {
-        Ok(None)
+fn validate_random_range(min: i32, max: i32) -> Result<(), CommandSyntaxError> {
+    let range_size = i64::from(max) - i64::from(min) + 1;
+    if range_size < 2 {
+        return Err(
+            error_types::DISPATCHER_PARSE_EXCEPTION.create_without_context(
+                TextComponent::translate(translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_SMALL, []),
+            ),
+        );
     }
+    if range_size > 2_147_483_646 {
+        return Err(
+            error_types::DISPATCHER_PARSE_EXCEPTION.create_without_context(
+                TextComponent::translate(translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_LARGE, []),
+            ),
+        );
+    }
+
+    Ok(())
 }
 
 fn parse_range_arg(context: &CommandContext) -> Result<InclusiveRange, CommandSyntaxError> {
-    let &(min, max) = context.get_argument::<(i32, i32)>(ARG_RANGE)?;
+    let bounds = context.get_argument::<IntBounds>(ARG_RANGE)?;
+    let min = bounds.min().unwrap_or(i32::MIN);
+    let max = bounds.max().unwrap_or(i32::MAX);
+    validate_random_range(min, max)?;
+
     Ok(InclusiveRange { min, max })
 }
 
@@ -486,31 +395,42 @@ fn parse_sequence_arg<'a>(context: &'a CommandContext) -> Result<&'a str, Comman
 
 fn parse_reset_parameters(
     context: &CommandContext,
+    mode: ResetMode,
 ) -> Result<Option<SequenceParameters>, CommandSyntaxError> {
-    let Some(seed) = get_optional_argument::<i64>(context, ARG_SEED)? else {
-        return Ok(None);
-    };
-
-    let include_world_seed =
-        *get_optional_argument::<bool>(context, ARG_INCLUDE_WORLD_SEED)?.unwrap_or(&true);
-    let include_sequence_id =
-        *get_optional_argument::<bool>(context, ARG_INCLUDE_SEQUENCE_ID)?.unwrap_or(&true);
-
-    Ok(Some(SequenceParameters {
-        seed: *seed,
-        include_world_seed,
-        include_sequence_id,
-    }))
+    match mode {
+        ResetMode::Defaults => Ok(None),
+        ResetMode::SeedOnly => {
+            let seed = *context.get_argument::<i64>(ARG_SEED)?;
+            Ok(Some(SequenceParameters {
+                seed,
+                include_world_seed: true,
+                include_sequence_id: true,
+            }))
+        }
+        ResetMode::SeedAndWorldSeed => {
+            let seed = *context.get_argument::<i64>(ARG_SEED)?;
+            let include_world_seed = *context.get_argument::<bool>(ARG_INCLUDE_WORLD_SEED)?;
+            Ok(Some(SequenceParameters {
+                seed,
+                include_world_seed,
+                include_sequence_id: true,
+            }))
+        }
+        ResetMode::Full => {
+            let seed = *context.get_argument::<i64>(ARG_SEED)?;
+            let include_world_seed = *context.get_argument::<bool>(ARG_INCLUDE_WORLD_SEED)?;
+            let include_sequence_id = *context.get_argument::<bool>(ARG_INCLUDE_SEQUENCE_ID)?;
+            Ok(Some(SequenceParameters {
+                seed,
+                include_world_seed,
+                include_sequence_id,
+            }))
+        }
+    }
 }
 
 const fn seed_argument_type() -> LongArgumentType {
     LongArgumentType::any()
-}
-
-fn level_two_requirement(
-    source: &CommandSource,
-) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
-    Box::pin(async move { source.output.has_permission_lvl(PermissionLvl::Two) })
 }
 
 impl CommandExecutor for DrawExecutor {
@@ -571,7 +491,7 @@ impl CommandExecutor for DrawExecutor {
 impl CommandExecutor for ResetExecutor {
     fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
         Box::pin(async move {
-            let parameter_override = parse_reset_parameters(context)?;
+            let parameter_override = parse_reset_parameters(context, self.mode)?;
 
             match self.target {
                 ResetTarget::All => {
@@ -605,11 +525,22 @@ impl CommandExecutor for ResetExecutor {
     }
 }
 
+#[expect(clippy::too_many_lines)]
 pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
     registry.register_permission_or_panic(Permission::new(
         PERMISSION,
         DESCRIPTION,
         PermissionDefault::Allow,
+    ));
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION_SEQUENCE,
+        "Uses named random sequences in the /random command.",
+        PermissionDefault::Op(PermissionLvl::Two),
+    ));
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION_RESET,
+        "Resets and updates random sequence state.",
+        PermissionDefault::Op(PermissionLvl::Two),
     ));
 
     dispatcher.register(
@@ -617,14 +548,14 @@ pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionReg
             .requires(PERMISSION)
             .then(
                 literal("value").then(
-                    argument(ARG_RANGE, RangeArgumentType)
+                    argument(ARG_RANGE, IntRangeArgumentType)
                         .executes(DrawExecutor {
                             mode: DrawMode::Value,
                             uses_sequence: false,
                         })
                         .then(
-                            argument(ARG_SEQUENCE, StringArgumentType::SingleWord)
-                                .requires(level_two_requirement)
+                            argument(ARG_SEQUENCE, ResourceLocationArgumentType)
+                                .requires(PERMISSION_SEQUENCE)
                                 .executes(DrawExecutor {
                                     mode: DrawMode::Value,
                                     uses_sequence: true,
@@ -634,14 +565,14 @@ pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionReg
             )
             .then(
                 literal("roll").then(
-                    argument(ARG_RANGE, RangeArgumentType)
+                    argument(ARG_RANGE, IntRangeArgumentType)
                         .executes(DrawExecutor {
                             mode: DrawMode::Roll,
                             uses_sequence: false,
                         })
                         .then(
-                            argument(ARG_SEQUENCE, StringArgumentType::SingleWord)
-                                .requires(level_two_requirement)
+                            argument(ARG_SEQUENCE, ResourceLocationArgumentType)
+                                .requires(PERMISSION_SEQUENCE)
                                 .executes(DrawExecutor {
                                     mode: DrawMode::Roll,
                                     uses_sequence: true,
@@ -651,50 +582,58 @@ pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionReg
             )
             .then(
                 literal("reset")
-                    .requires(level_two_requirement)
+                    .requires(PERMISSION_RESET)
                     .then(
                         literal("*")
                             .executes(ResetExecutor {
                                 target: ResetTarget::All,
+                                mode: ResetMode::Defaults,
                             })
                             .then(
                                 argument(ARG_SEED, seed_argument_type())
                                     .executes(ResetExecutor {
                                         target: ResetTarget::All,
+                                        mode: ResetMode::SeedOnly,
                                     })
                                     .then(
                                         argument(ARG_INCLUDE_WORLD_SEED, BoolArgumentType)
                                             .executes(ResetExecutor {
                                                 target: ResetTarget::All,
+                                                mode: ResetMode::SeedAndWorldSeed,
                                             })
                                             .then(
                                                 argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgumentType)
                                                     .executes(ResetExecutor {
                                                         target: ResetTarget::All,
+                                                        mode: ResetMode::Full,
                                                     }),
                                             ),
                                     ),
                             ),
                     )
                     .then(
-                        argument(ARG_SEQUENCE, StringArgumentType::SingleWord)
+                        argument(ARG_SEQUENCE, ResourceLocationArgumentType)
                             .executes(ResetExecutor {
                                 target: ResetTarget::Sequence,
+                                mode: ResetMode::Defaults,
                             })
                             .then(
                                 argument(ARG_SEED, seed_argument_type())
                                     .executes(ResetExecutor {
                                         target: ResetTarget::Sequence,
+                                        mode: ResetMode::SeedOnly,
                                     })
                                     .then(
                                         argument(ARG_INCLUDE_WORLD_SEED, BoolArgumentType)
                                             .executes(ResetExecutor {
                                                 target: ResetTarget::Sequence,
+                                                mode: ResetMode::SeedAndWorldSeed,
                                             })
                                             .then(
                                                 argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgumentType)
                                                     .executes(ResetExecutor {
                                                         target: ResetTarget::Sequence,
+                                                        mode: ResetMode::Full,
                                                     }),
                                             ),
                                     ),
@@ -706,56 +645,8 @@ pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionReg
 
 #[cfg(test)]
 mod test {
-    use super::{
-        CommandError, InclusiveRange, SequenceParameters, derive_sequence_seed,
-        validate_sequence_name,
-    };
+    use super::{SequenceParameters, derive_sequence_seed, validate_sequence_name};
     use crate::command::{errors::error_types, tree::RawArg};
-
-    #[test]
-    fn parse_valid_closed_range() {
-        let range = InclusiveRange::parse("1..10").expect("range should parse");
-        assert_eq!(range.min, 1);
-        assert_eq!(range.max, 10);
-    }
-
-    #[test]
-    fn parse_valid_open_lower_bound_range() {
-        let range = InclusiveRange::parse("..-2147483647").expect("range should parse");
-        assert_eq!(range.min, i32::MIN);
-        assert_eq!(range.max, -2_147_483_647);
-    }
-
-    #[test]
-    fn parse_valid_open_upper_bound_range() {
-        let range = InclusiveRange::parse("2147483646..").expect("range should parse");
-        assert_eq!(range.min, 2_147_483_646);
-        assert_eq!(range.max, i32::MAX);
-    }
-
-    #[test]
-    fn reject_single_value_range() {
-        assert!(matches!(
-            InclusiveRange::parse("5"),
-            Err(CommandError::CommandFailed(_))
-        ));
-    }
-
-    #[test]
-    fn reject_reversed_range() {
-        assert!(matches!(
-            InclusiveRange::parse("10..1"),
-            Err(CommandError::CommandFailed(_))
-        ));
-    }
-
-    #[test]
-    fn reject_too_large_range_size() {
-        assert!(matches!(
-            InclusiveRange::parse("-2147483648..2147483647"),
-            Err(CommandError::CommandFailed(_))
-        ));
-    }
 
     #[test]
     fn derived_seed_depends_on_sequence_id_when_enabled() {

--- a/pumpkin/src/command/commands/random.rs
+++ b/pumpkin/src/command/commands/random.rs
@@ -1,12 +1,14 @@
 use std::{
     collections::HashMap,
+    pin::Pin,
     sync::{Arc, LazyLock},
 };
 
 use pumpkin_data::world::SAY_COMMAND;
-use pumpkin_protocol::java::client::play::{ArgumentType, CommandSuggestion, SuggestionProviders};
+use pumpkin_protocol::java::client::play::SuggestionProviders;
 use pumpkin_util::{
     PermissionLvl,
+    permission::{Permission, PermissionDefault, PermissionRegistry},
     random::{RandomImpl, xoroshiro128::Xoroshiro},
     text::TextComponent,
 };
@@ -15,27 +17,24 @@ use rand::RngExt;
 use tokio::sync::Mutex;
 
 use crate::command::{
-    CommandError, CommandExecutor, CommandResult, CommandSender,
-    args::{
-        Arg, ArgumentConsumer, ConsumeResult, ConsumeResultWithSyntax, ConsumedArgs,
-        GetClientSideArgParser, SplitSingleWhitespaceIncludingEmptyParts, SuggestResult,
-        bool::BoolArgConsumer,
-        bounded_num::{BoundedNumArgumentConsumer, Number},
-        simple::SimpleArgConsumer,
+    argument_builder::{ArgumentBuilder, argument, command, literal},
+    argument_types::{
+        argument_type::{ArgumentType, JavaClientArgumentType},
+        core::{bool::BoolArgumentType, long::LongArgumentType, string::StringArgumentType},
     },
+    context::command_context::CommandContext,
+    dispatcher::CommandError,
     errors::{
         command_syntax_error::{CommandSyntaxError, CommandSyntaxErrorContext},
-        error_types,
+        error_types::{self, LiteralCommandErrorType},
     },
-    tree::{
-        CommandTree, RawArg, RawArgs,
-        builder::{argument, literal},
-    },
+    node::{CommandExecutor, CommandExecutorResult, dispatcher::CommandDispatcher},
+    suggestion::suggestions::{Suggestions, SuggestionsBuilder},
+    tree::RawArg,
 };
-use CommandError::{CommandFailed, InvalidConsumption, PermissionDenied};
 
-const NAMES: [&str; 1] = ["random"];
 const DESCRIPTION: &str = "Generates a random integer, or controls random sequences.";
+const PERMISSION: &str = "minecraft:command.random";
 
 const ARG_RANGE: &str = "range";
 const ARG_SEQUENCE: &str = "sequence";
@@ -43,15 +42,68 @@ const ARG_SEED: &str = "seed";
 const ARG_INCLUDE_WORLD_SEED: &str = "includeWorldSeed";
 const ARG_INCLUDE_SEQUENCE_ID: &str = "includeSequenceId";
 
-#[derive(Clone, Copy)]
-struct SequenceArgumentConsumer;
+const RANDOM_COMMAND_FAILED: LiteralCommandErrorType =
+    LiteralCommandErrorType::new("random command failed");
+const PERMISSION_DENIED: LiteralCommandErrorType = LiteralCommandErrorType::new(
+    "I'm sorry, but you do not have permission to perform this command. Please contact the server administrator if you believe this is an error.",
+);
 
-impl GetClientSideArgParser for SequenceArgumentConsumer {
-    fn get_client_side_parser(&self) -> ArgumentType<'_> {
-        ArgumentType::ResourceLocation
+#[derive(Clone, Copy)]
+struct SequenceArgumentType;
+
+impl ArgumentType for SequenceArgumentType {
+    type Item = String;
+
+    fn parse(
+        &self,
+        reader: &mut crate::command::string_reader::StringReader,
+    ) -> Result<String, CommandSyntaxError> {
+        let start = reader.cursor();
+
+        while let Some(c) = reader.peek() {
+            if c.is_whitespace() {
+                break;
+            }
+            reader.skip();
+        }
+
+        let end = reader.cursor();
+        let input = reader.string();
+        let raw_arg = RawArg {
+            value: &input[start..end],
+            start,
+            end,
+            input,
+        };
+
+        validate_sequence_name(raw_arg).map(ToOwned::to_owned)
     }
 
-    fn get_client_side_suggestion_type_override(&self) -> Option<SuggestionProviders> {
+    fn list_suggestions(
+        &self,
+        context: &CommandContext,
+        suggestions_builder: &mut SuggestionsBuilder,
+    ) -> Pin<Box<dyn std::future::Future<Output = Suggestions> + Send>> {
+        let prefix = suggestions_builder.remaining().to_string();
+        let mut builder = suggestions_builder.create_offset(suggestions_builder.start);
+
+        let level_info = context.server().level_info.load();
+        for sequence in level_info
+            .random_sequences
+            .keys()
+            .filter(|sequence| sequence.starts_with(&prefix))
+        {
+            builder = builder.suggest(sequence.as_str());
+        }
+
+        Box::pin(async move { builder.build() })
+    }
+
+    fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
+        JavaClientArgumentType::ResourceLocation
+    }
+
+    fn override_suggestion_providers(&self) -> Option<SuggestionProviders> {
         Some(SuggestionProviders::AskServer)
     }
 }
@@ -105,63 +157,6 @@ fn validate_sequence_name(raw_arg: RawArg<'_>) -> Result<&str, CommandSyntaxErro
     Ok(value)
 }
 
-impl ArgumentConsumer for SequenceArgumentConsumer {
-    fn consume<'a>(
-        &'a self,
-        _sender: &'a CommandSender,
-        _server: &'a crate::server::Server,
-        args: &mut RawArgs<'a>,
-    ) -> ConsumeResult<'a> {
-        let Some(raw_arg) = args.pop() else {
-            return Box::pin(async { None });
-        };
-
-        let parsed = validate_sequence_name(raw_arg)
-            .ok()
-            .map(Arg::ResourceLocation);
-        Box::pin(async move { parsed })
-    }
-
-    fn consume_with_syntax<'a>(
-        &'a self,
-        _sender: &'a CommandSender,
-        _server: &'a crate::server::Server,
-        args: &mut RawArgs<'a>,
-    ) -> ConsumeResultWithSyntax<'a> {
-        let Some(raw_arg) = args.pop() else {
-            return Box::pin(async { Ok(None) });
-        };
-
-        Box::pin(async move {
-            let sequence = validate_sequence_name(raw_arg)?;
-            Ok(Some(Arg::ResourceLocation(sequence)))
-        })
-    }
-
-    fn suggest<'a>(
-        &'a self,
-        _sender: &CommandSender,
-        server: &'a crate::server::Server,
-        input: &'a str,
-    ) -> SuggestResult<'a> {
-        Box::pin(async move {
-            let Some(prefix) = input.split_single_whitespace_including_empty_parts().last() else {
-                return Ok(None);
-            };
-
-            let level_info = server.level_info.load();
-            let suggestions: Vec<CommandSuggestion> = level_info
-                .random_sequences
-                .keys()
-                .filter(|sequence| sequence.starts_with(prefix))
-                .map(|sequence| CommandSuggestion::new(sequence.clone(), None))
-                .collect();
-
-            Ok(Some(suggestions))
-        })
-    }
-}
-
 #[derive(Clone, Copy)]
 enum DrawMode {
     Value,
@@ -213,7 +208,7 @@ impl InclusiveRange {
 
         let range_size = i64::from(max) - i64::from(min) + 1;
         if !(2..=2_147_483_646).contains(&range_size) {
-            return Err(CommandFailed(TextComponent::text(format!(
+            return Err(CommandError::CommandFailed(TextComponent::text(format!(
                 "The range '{range}' is invalid. Its size must be between 2 and 2147483646."
             ))));
         }
@@ -224,7 +219,7 @@ impl InclusiveRange {
 
 fn parse_i32_range_bound(raw: &str, bound_name: &str) -> Result<i32, CommandError> {
     raw.parse::<i32>().map_err(|_| {
-        CommandFailed(TextComponent::text(format!(
+        CommandError::CommandFailed(TextComponent::text(format!(
             "Invalid {bound_name} bound '{raw}'. Expected a 32-bit integer."
         )))
     })
@@ -451,86 +446,91 @@ fn usize_to_i32_saturating(value: usize) -> i32 {
     i32::try_from(value).unwrap_or(i32::MAX)
 }
 
-fn require_level_two(sender: &CommandSender) -> Result<(), CommandError> {
-    if sender.has_permission_lvl(PermissionLvl::Two) {
+fn command_failed(message: TextComponent) -> CommandSyntaxError {
+    CommandSyntaxError::create_without_context(&RANDOM_COMMAND_FAILED, message)
+}
+
+fn command_error_to_syntax(error: CommandError) -> CommandSyntaxError {
+    match error {
+        CommandError::CommandFailed(message) => command_failed(message),
+        CommandError::SyntaxError(error) => error,
+        CommandError::PermissionDenied => PERMISSION_DENIED.create_without_context(),
+        CommandError::InvalidConsumption(argument) => error_types::DISPATCHER_PARSE_EXCEPTION
+            .create_without_context(TextComponent::text(format!(
+                "Could not parse argument: {argument:?}"
+            ))),
+        CommandError::InvalidRequirement => error_types::DISPATCHER_PARSE_EXCEPTION
+            .create_without_context(TextComponent::text("Command requirement failed")),
+    }
+}
+
+fn require_level_two(context: &CommandContext) -> Result<(), CommandSyntaxError> {
+    if context.source.output.has_permission_lvl(PermissionLvl::Two) {
         Ok(())
     } else {
-        Err(PermissionDenied)
+        Err(PERMISSION_DENIED.create_without_context())
     }
 }
 
-fn parse_range_arg(args: &ConsumedArgs<'_>) -> Result<InclusiveRange, CommandError> {
-    let Some(Arg::Simple(range)) = args.get(ARG_RANGE) else {
-        return Err(InvalidConsumption(Some(ARG_RANGE.into())));
-    };
-
-    InclusiveRange::parse(range)
-}
-
-fn parse_sequence_arg<'a>(args: &'a ConsumedArgs<'a>) -> Result<&'a str, CommandError> {
-    let Some(Arg::ResourceLocation(sequence)) = args.get(ARG_SEQUENCE) else {
-        return Err(InvalidConsumption(Some(ARG_SEQUENCE.into())));
-    };
-
-    Ok(sequence)
-}
-
-fn parse_optional_seed(args: &ConsumedArgs<'_>) -> Result<Option<i64>, CommandError> {
-    match args.get(ARG_SEED) {
-        None => Ok(None),
-        Some(Arg::Num(Ok(Number::I64(seed)))) => Ok(Some(*seed)),
-        _ => Err(InvalidConsumption(Some(ARG_SEED.into()))),
+fn get_optional_argument<'a, T: 'static>(
+    context: &'a CommandContext,
+    name: &str,
+) -> Result<Option<&'a T>, CommandSyntaxError> {
+    if context.arguments.contains_key(name) {
+        context.get_argument(name).map(Some)
+    } else {
+        Ok(None)
     }
 }
 
-fn parse_optional_bool(args: &ConsumedArgs<'_>, name: &str) -> Result<Option<bool>, CommandError> {
-    match args.get(name) {
-        None => Ok(None),
-        Some(Arg::Bool(value)) => Ok(Some(*value)),
-        _ => Err(InvalidConsumption(Some(name.into()))),
-    }
+fn parse_range_arg(context: &CommandContext) -> Result<InclusiveRange, CommandSyntaxError> {
+    let range = context.get_argument::<String>(ARG_RANGE)?;
+    InclusiveRange::parse(range).map_err(command_error_to_syntax)
+}
+
+fn parse_sequence_arg<'a>(context: &'a CommandContext) -> Result<&'a str, CommandSyntaxError> {
+    context
+        .get_argument::<String>(ARG_SEQUENCE)
+        .map(String::as_str)
 }
 
 fn parse_reset_parameters(
-    args: &ConsumedArgs<'_>,
-) -> Result<Option<SequenceParameters>, CommandError> {
-    let Some(seed) = parse_optional_seed(args)? else {
+    context: &CommandContext,
+) -> Result<Option<SequenceParameters>, CommandSyntaxError> {
+    let Some(seed) = get_optional_argument::<i64>(context, ARG_SEED)? else {
         return Ok(None);
     };
 
-    let include_world_seed = parse_optional_bool(args, ARG_INCLUDE_WORLD_SEED)?.unwrap_or(true);
-    let include_sequence_id = parse_optional_bool(args, ARG_INCLUDE_SEQUENCE_ID)?.unwrap_or(true);
+    let include_world_seed =
+        *get_optional_argument::<bool>(context, ARG_INCLUDE_WORLD_SEED)?.unwrap_or(&true);
+    let include_sequence_id =
+        *get_optional_argument::<bool>(context, ARG_INCLUDE_SEQUENCE_ID)?.unwrap_or(&true);
 
     Ok(Some(SequenceParameters {
-        seed,
+        seed: *seed,
         include_world_seed,
         include_sequence_id,
     }))
 }
 
-const fn seed_consumer() -> BoundedNumArgumentConsumer<i64> {
-    BoundedNumArgumentConsumer::new().name(ARG_SEED)
+const fn seed_argument_type() -> LongArgumentType {
+    LongArgumentType::any()
 }
 
 impl CommandExecutor for DrawExecutor {
-    fn execute<'a>(
-        &'a self,
-        sender: &'a CommandSender,
-        server: &'a crate::server::Server,
-        args: &'a ConsumedArgs<'a>,
-    ) -> CommandResult<'a> {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
         Box::pin(async move {
-            let range = parse_range_arg(args)?;
+            let range = parse_range_arg(context)?;
 
             let sequence = if self.uses_sequence {
-                require_level_two(sender)?;
-                Some(parse_sequence_arg(args)?)
+                require_level_two(context)?;
+                Some(parse_sequence_arg(context)?)
             } else {
                 None
             };
 
             let result = if let Some(sequence_id) = sequence {
-                sample_sequence_value(server, sequence_id, range).await
+                sample_sequence_value(context.server(), sequence_id, range).await
             } else {
                 rand::rng().random_range(range.min..=range.max)
             };
@@ -552,7 +552,7 @@ impl CommandExecutor for DrawExecutor {
                         },
                     );
 
-                    sender.send_message(message).await;
+                    context.source.send_message(message).await;
                 }
                 DrawMode::Roll => {
                     let message = sequence.map_or_else(
@@ -570,13 +570,10 @@ impl CommandExecutor for DrawExecutor {
                         },
                     );
 
-                    server
-                        .broadcast_message(
-                            &message,
-                            &TextComponent::text(sender.to_string()),
-                            SAY_COMMAND,
-                            None,
-                        )
+                    let sender_name = TextComponent::text(context.source.output.to_string());
+                    context
+                        .server()
+                        .broadcast_message(&message, &sender_name, SAY_COMMAND, None)
                         .await;
                 }
             }
@@ -587,22 +584,18 @@ impl CommandExecutor for DrawExecutor {
 }
 
 impl CommandExecutor for ResetExecutor {
-    fn execute<'a>(
-        &'a self,
-        sender: &'a CommandSender,
-        server: &'a crate::server::Server,
-        args: &'a ConsumedArgs<'a>,
-    ) -> CommandResult<'a> {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
         Box::pin(async move {
-            require_level_two(sender)?;
+            require_level_two(context)?;
 
-            let parameter_override = parse_reset_parameters(args)?;
+            let parameter_override = parse_reset_parameters(context)?;
 
             match self.target {
                 ResetTarget::All => {
                     let (reset_count, defaults) =
-                        reset_all_sequences(server, parameter_override).await;
-                    sender
+                        reset_all_sequences(context.server(), parameter_override).await;
+                    context
+                        .source
                         .send_message(TextComponent::text(format!(
                             "Reset {reset_count} random sequence(s). Defaults are now seed={}, includeWorldSeed={}, includeSequenceId={}.",
                             defaults.seed, defaults.include_world_seed, defaults.include_sequence_id
@@ -611,15 +604,17 @@ impl CommandExecutor for ResetExecutor {
                     Ok(reset_count)
                 }
                 ResetTarget::Sequence => {
-                    let sequence_id = parse_sequence_arg(args)?;
+                    let sequence_id = parse_sequence_arg(context)?;
                     if sequence_id == "*" {
-                        return Err(CommandFailed(TextComponent::text(
+                        return Err(command_failed(TextComponent::text(
                             "Sequence name '*' is reserved for resetting all sequences.",
                         )));
                     }
 
-                    let parameters = reset_sequence(server, sequence_id, parameter_override).await;
-                    sender
+                    let parameters =
+                        reset_sequence(context.server(), sequence_id, parameter_override).await;
+                    context
+                        .source
                         .send_message(TextComponent::text(format!(
                             "Reset random sequence '{sequence_id}' with seed={}, includeWorldSeed={}, includeSequenceId={}.",
                             parameters.seed, parameters.include_world_seed, parameters.include_sequence_id
@@ -633,89 +628,98 @@ impl CommandExecutor for ResetExecutor {
     }
 }
 
-pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION)
-        .then(
-            literal("value").then(
-                argument(ARG_RANGE, SimpleArgConsumer)
-                    .execute(DrawExecutor {
-                        mode: DrawMode::Value,
-                        uses_sequence: false,
-                    })
-                    .then(
-                        argument(ARG_SEQUENCE, SequenceArgumentConsumer).execute(DrawExecutor {
+pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION,
+        DESCRIPTION,
+        PermissionDefault::Allow,
+    ));
+
+    dispatcher.register(
+        command("random", DESCRIPTION)
+            .requires(PERMISSION)
+            .then(
+                literal("value").then(
+                    argument(ARG_RANGE, StringArgumentType::SingleWord)
+                        .executes(DrawExecutor {
                             mode: DrawMode::Value,
-                            uses_sequence: true,
-                        }),
-                    ),
-            ),
-        )
-        .then(
-            literal("roll").then(
-                argument(ARG_RANGE, SimpleArgConsumer)
-                    .execute(DrawExecutor {
-                        mode: DrawMode::Roll,
-                        uses_sequence: false,
-                    })
-                    .then(
-                        argument(ARG_SEQUENCE, SequenceArgumentConsumer).execute(DrawExecutor {
-                            mode: DrawMode::Roll,
-                            uses_sequence: true,
-                        }),
-                    ),
-            ),
-        )
-        .then(
-            literal("reset")
-                .then(
-                    literal("*")
-                        .execute(ResetExecutor {
-                            target: ResetTarget::All,
+                            uses_sequence: false,
                         })
-                        .then(
-                            argument(ARG_SEED, seed_consumer())
-                                .execute(ResetExecutor {
-                                    target: ResetTarget::All,
-                                })
-                                .then(
-                                    argument(ARG_INCLUDE_WORLD_SEED, BoolArgConsumer)
-                                        .execute(ResetExecutor {
-                                            target: ResetTarget::All,
-                                        })
-                                        .then(
-                                            argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgConsumer)
-                                                .execute(ResetExecutor {
-                                                    target: ResetTarget::All,
-                                                }),
-                                        ),
-                                ),
-                        ),
-                )
-                .then(
-                    argument(ARG_SEQUENCE, SequenceArgumentConsumer)
-                        .execute(ResetExecutor {
-                            target: ResetTarget::Sequence,
-                        })
-                        .then(
-                            argument(ARG_SEED, seed_consumer())
-                                .execute(ResetExecutor {
-                                    target: ResetTarget::Sequence,
-                                })
-                                .then(
-                                    argument(ARG_INCLUDE_WORLD_SEED, BoolArgConsumer)
-                                        .execute(ResetExecutor {
-                                            target: ResetTarget::Sequence,
-                                        })
-                                        .then(
-                                            argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgConsumer)
-                                                .execute(ResetExecutor {
-                                                    target: ResetTarget::Sequence,
-                                                }),
-                                        ),
-                                ),
-                        ),
+                        .then(argument(ARG_SEQUENCE, SequenceArgumentType).executes(
+                            DrawExecutor {
+                                mode: DrawMode::Value,
+                                uses_sequence: true,
+                            },
+                        )),
                 ),
-        )
+            )
+            .then(
+                literal("roll").then(
+                    argument(ARG_RANGE, StringArgumentType::SingleWord)
+                        .executes(DrawExecutor {
+                            mode: DrawMode::Roll,
+                            uses_sequence: false,
+                        })
+                        .then(argument(ARG_SEQUENCE, SequenceArgumentType).executes(
+                            DrawExecutor {
+                                mode: DrawMode::Roll,
+                                uses_sequence: true,
+                            },
+                        )),
+                ),
+            )
+            .then(
+                literal("reset")
+                    .then(
+                        literal("*")
+                            .executes(ResetExecutor {
+                                target: ResetTarget::All,
+                            })
+                            .then(
+                                argument(ARG_SEED, seed_argument_type())
+                                    .executes(ResetExecutor {
+                                        target: ResetTarget::All,
+                                    })
+                                    .then(
+                                        argument(ARG_INCLUDE_WORLD_SEED, BoolArgumentType)
+                                            .executes(ResetExecutor {
+                                                target: ResetTarget::All,
+                                            })
+                                            .then(
+                                                argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgumentType)
+                                                    .executes(ResetExecutor {
+                                                        target: ResetTarget::All,
+                                                    }),
+                                            ),
+                                    ),
+                            ),
+                    )
+                    .then(
+                        argument(ARG_SEQUENCE, SequenceArgumentType)
+                            .executes(ResetExecutor {
+                                target: ResetTarget::Sequence,
+                            })
+                            .then(
+                                argument(ARG_SEED, seed_argument_type())
+                                    .executes(ResetExecutor {
+                                        target: ResetTarget::Sequence,
+                                    })
+                                    .then(
+                                        argument(ARG_INCLUDE_WORLD_SEED, BoolArgumentType)
+                                            .executes(ResetExecutor {
+                                                target: ResetTarget::Sequence,
+                                            })
+                                            .then(
+                                                argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgumentType)
+                                                    .executes(ResetExecutor {
+                                                        target: ResetTarget::Sequence,
+                                                    }),
+                                            ),
+                                    ),
+                            ),
+                    ),
+            ),
+    );
 }
 
 #[cfg(test)]

--- a/pumpkin/src/command/commands/random.rs
+++ b/pumpkin/src/command/commands/random.rs
@@ -14,26 +14,25 @@ use pumpkin_world::world_info::RandomSequence;
 use rand::RngExt;
 use tokio::sync::Mutex;
 
-use crate::command::dispatcher::CommandError::{
-    CommandFailed, InvalidConsumption, PermissionDenied,
-};
-use crate::command::node::dispatcher::CommandDispatcher;
+#[cfg(test)]
+use crate::command::dispatcher::CommandError;
 use crate::command::{
-    CommandError, CommandExecutor, CommandResult, CommandSender,
-    args::{
-        Arg, ConsumedArgs,
-        bool::BoolArgConsumer,
-        bounded_num::{BoundedNumArgumentConsumer, Number},
-        resource_location::ResourceLocationArgumentConsumer,
-        simple::SimpleArgConsumer,
+    argument_builder::{ArgumentBuilder, argument, command, literal},
+    argument_types::{
+        argument_type::{ArgumentType, JavaClientArgumentType},
+        core::{bool::BoolArgumentType, long::LongArgumentType, string::StringArgumentType},
     },
-    tree::{
-        CommandTree, RawArg,
-        builder::{argument, literal},
+    context::{command_context::CommandContext, command_source::CommandSource},
+    errors::{
+        command_syntax_error::{CommandSyntaxError, CommandSyntaxErrorContext},
+        error_types,
     },
+    node::{CommandExecutor, CommandExecutorResult, dispatcher::CommandDispatcher},
+    string_reader::StringReader,
+    tree::RawArg,
 };
+use pumpkin_protocol::java::client::play::StringProtoArgBehavior;
 
-const NAMES: [&str; 1] = ["random"];
 const DESCRIPTION: &str = "Generates a random integer, or controls random sequences.";
 const PERMISSION: &str = "minecraft:command.random";
 
@@ -47,26 +46,21 @@ const fn is_valid_namespaced_id_char(c: char) -> bool {
     matches!(c, 'a'..='z' | '0'..='9' | '_' | '-' | '.' | '/' | ':')
 }
 
-fn syntax_expected_separator(
-    raw_arg: RawArg<'_>,
-    local_cursor: usize,
-) -> crate::command::errors::command_syntax_error::CommandSyntaxError {
+fn syntax_expected_separator(raw_arg: RawArg<'_>, local_cursor: usize) -> CommandSyntaxError {
     let mut clamped_local_cursor = local_cursor.min(raw_arg.value.len());
     while clamped_local_cursor > 0 && !raw_arg.value.is_char_boundary(clamped_local_cursor) {
         clamped_local_cursor -= 1;
     }
 
-    let context = crate::command::errors::command_syntax_error::CommandSyntaxErrorContext {
+    let context = CommandSyntaxErrorContext {
         input: raw_arg.input.to_string(),
         cursor: raw_arg.start + clamped_local_cursor,
     };
 
-    crate::command::errors::error_types::DISPATCHER_EXPECTED_ARGUMENT_SEPARATOR.create(&context)
+    error_types::DISPATCHER_EXPECTED_ARGUMENT_SEPARATOR.create(&context)
 }
 
-fn validate_sequence_name(
-    raw_arg: RawArg<'_>,
-) -> Result<&str, crate::command::errors::command_syntax_error::CommandSyntaxError> {
+fn validate_sequence_name(raw_arg: RawArg<'_>) -> Result<&str, CommandSyntaxError> {
     let value = raw_arg.value;
     if value.is_empty() {
         return Err(syntax_expected_separator(raw_arg, 0));
@@ -126,7 +120,74 @@ struct InclusiveRange {
     max: i32,
 }
 
+struct RangeArgumentType;
+
+impl ArgumentType for RangeArgumentType {
+    type Item = (i32, i32);
+
+    fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
+        let start = reader.cursor();
+
+        let min = if reader.peek() == Some('.') {
+            None
+        } else {
+            Some(reader.read_int()?)
+        };
+
+        let has_separator = reader.peek() == Some('.') && reader.peek_with_offset(1) == Some('.');
+
+        let (min, max) = if has_separator {
+            reader.expect('.')?;
+            reader.expect('.')?;
+
+            let max = match reader.peek() {
+                None => None,
+                Some(c) if c.is_whitespace() => None,
+                _ => Some(reader.read_int()?),
+            };
+
+            (min.unwrap_or(i32::MIN), max.unwrap_or(i32::MAX))
+        } else {
+            let Some(value) = min else {
+                reader.set_cursor(start);
+                return Err(error_types::READER_EXPECTED_INT.create(reader));
+            };
+
+            (value, value)
+        };
+
+        let range_size = i64::from(max) - i64::from(min) + 1;
+        if range_size < 2 {
+            return Err(
+                error_types::DISPATCHER_PARSE_EXCEPTION.create_without_context(
+                    TextComponent::translate(
+                        translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_SMALL,
+                        [],
+                    ),
+                ),
+            );
+        }
+        if range_size > 2_147_483_646 {
+            return Err(
+                error_types::DISPATCHER_PARSE_EXCEPTION.create_without_context(
+                    TextComponent::translate(
+                        translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_LARGE,
+                        [],
+                    ),
+                ),
+            );
+        }
+
+        Ok((min, max))
+    }
+
+    fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
+        JavaClientArgumentType::String(StringProtoArgBehavior::SingleWord)
+    }
+}
+
 impl InclusiveRange {
+    #[cfg(test)]
     fn parse(range: &str) -> Result<Self, CommandError> {
         let (min, max) = if let Some((min_raw, max_raw)) = range.split_once("..") {
             let min = if min_raw.is_empty() {
@@ -148,13 +209,13 @@ impl InclusiveRange {
 
         let range_size = i64::from(max) - i64::from(min) + 1;
         if range_size < 2 {
-            return Err(CommandFailed(TextComponent::translate(
+            return Err(CommandError::CommandFailed(TextComponent::translate(
                 translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_SMALL,
                 [],
             )));
         }
         if range_size > 2_147_483_646 {
-            return Err(CommandFailed(TextComponent::translate(
+            return Err(CommandError::CommandFailed(TextComponent::translate(
                 translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_LARGE,
                 [],
             )));
@@ -164,9 +225,10 @@ impl InclusiveRange {
     }
 }
 
+#[cfg(test)]
 fn parse_i32_range_bound(raw: &str) -> Result<i32, CommandError> {
     raw.parse::<i32>().map_err(|_| {
-        CommandFailed(TextComponent::translate(
+        CommandError::CommandFailed(TextComponent::translate(
             translation::PARSING_INT_INVALID,
             [TextComponent::text(raw.to_string())],
         ))
@@ -394,99 +456,84 @@ fn usize_to_i32_saturating(value: usize) -> i32 {
     i32::try_from(value).unwrap_or(i32::MAX)
 }
 
-fn require_level_two(sender: &CommandSender) -> Result<(), CommandError> {
-    if sender.has_permission_lvl(PermissionLvl::Two) {
-        Ok(())
+fn get_optional_argument<'a, T: 'static>(
+    context: &'a CommandContext,
+    name: &str,
+) -> Result<Option<&'a T>, CommandSyntaxError> {
+    if context.arguments.contains_key(name) {
+        context.get_argument(name).map(Some)
     } else {
-        Err(PermissionDenied)
+        Ok(None)
     }
 }
 
-fn parse_range_arg(args: &ConsumedArgs<'_>) -> Result<InclusiveRange, CommandError> {
-    let Some(Arg::Simple(range)) = args.get(ARG_RANGE) else {
-        return Err(InvalidConsumption(Some(ARG_RANGE.into())));
-    };
-
-    InclusiveRange::parse(range)
+fn parse_range_arg(context: &CommandContext) -> Result<InclusiveRange, CommandSyntaxError> {
+    let &(min, max) = context.get_argument::<(i32, i32)>(ARG_RANGE)?;
+    Ok(InclusiveRange { min, max })
 }
 
-fn parse_sequence_arg<'a>(args: &'a ConsumedArgs<'a>) -> Result<&'a str, CommandError> {
-    let Some(Arg::ResourceLocation(sequence)) = args.get(ARG_SEQUENCE) else {
-        return Err(InvalidConsumption(Some(ARG_SEQUENCE.into())));
-    };
-
+fn parse_sequence_arg<'a>(context: &'a CommandContext) -> Result<&'a str, CommandSyntaxError> {
+    let sequence = context.get_argument::<String>(ARG_SEQUENCE)?;
     let raw_arg = RawArg {
         value: sequence,
         start: 0,
         end: sequence.len(),
         input: sequence,
     };
-    validate_sequence_name(raw_arg).map_err(CommandError::SyntaxError)
-}
 
-fn parse_optional_seed(args: &ConsumedArgs<'_>) -> Result<Option<i64>, CommandError> {
-    match args.get(ARG_SEED) {
-        None => Ok(None),
-        Some(Arg::Num(Ok(Number::I64(seed)))) => Ok(Some(*seed)),
-        _ => Err(InvalidConsumption(Some(ARG_SEED.into()))),
-    }
-}
-
-fn parse_optional_bool(args: &ConsumedArgs<'_>, name: &str) -> Result<Option<bool>, CommandError> {
-    match args.get(name) {
-        None => Ok(None),
-        Some(Arg::Bool(value)) => Ok(Some(*value)),
-        _ => Err(InvalidConsumption(Some(name.into()))),
-    }
+    validate_sequence_name(raw_arg)
 }
 
 fn parse_reset_parameters(
-    args: &ConsumedArgs<'_>,
-) -> Result<Option<SequenceParameters>, CommandError> {
-    let Some(seed) = parse_optional_seed(args)? else {
+    context: &CommandContext,
+) -> Result<Option<SequenceParameters>, CommandSyntaxError> {
+    let Some(seed) = get_optional_argument::<i64>(context, ARG_SEED)? else {
         return Ok(None);
     };
 
-    let include_world_seed = parse_optional_bool(args, ARG_INCLUDE_WORLD_SEED)?.unwrap_or(true);
-    let include_sequence_id = parse_optional_bool(args, ARG_INCLUDE_SEQUENCE_ID)?.unwrap_or(true);
+    let include_world_seed =
+        *get_optional_argument::<bool>(context, ARG_INCLUDE_WORLD_SEED)?.unwrap_or(&true);
+    let include_sequence_id =
+        *get_optional_argument::<bool>(context, ARG_INCLUDE_SEQUENCE_ID)?.unwrap_or(&true);
 
     Ok(Some(SequenceParameters {
-        seed,
+        seed: *seed,
         include_world_seed,
         include_sequence_id,
     }))
 }
 
-const fn seed_consumer() -> BoundedNumArgumentConsumer<i64> {
-    BoundedNumArgumentConsumer::new().name(ARG_SEED)
+const fn seed_argument_type() -> LongArgumentType {
+    LongArgumentType::any()
+}
+
+fn level_two_requirement(
+    source: &CommandSource,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
+    Box::pin(async move { source.output.has_permission_lvl(PermissionLvl::Two) })
 }
 
 impl CommandExecutor for DrawExecutor {
-    fn execute<'a>(
-        &'a self,
-        sender: &'a CommandSender,
-        server: &'a crate::server::Server,
-        args: &'a ConsumedArgs<'a>,
-    ) -> CommandResult<'a> {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
         Box::pin(async move {
-            let range = parse_range_arg(args)?;
+            let range = parse_range_arg(context)?;
 
             let sequence = if self.uses_sequence {
-                require_level_two(sender)?;
-                Some(parse_sequence_arg(args)?)
+                Some(parse_sequence_arg(context)?)
             } else {
                 None
             };
 
             let result = if let Some(sequence_id) = sequence {
-                sample_sequence_value(server, sequence_id, range).await
+                sample_sequence_value(context.server(), sequence_id, range).await
             } else {
                 rand::rng().random_range(range.min..=range.max)
             };
 
             match self.mode {
                 DrawMode::Value => {
-                    sender
+                    context
+                        .source
                         .send_message(TextComponent::translate(
                             translation::COMMANDS_RANDOM_SAMPLE_SUCCESS,
                             [TextComponent::text(result.to_string())],
@@ -497,17 +544,18 @@ impl CommandExecutor for DrawExecutor {
                     let message = TextComponent::translate(
                         translation::COMMANDS_RANDOM_ROLL,
                         [
-                            TextComponent::text(sender.to_string()),
+                            TextComponent::text(context.source.output.to_string()),
                             TextComponent::text(result.to_string()),
                             TextComponent::text(range.min.to_string()),
                             TextComponent::text(range.max.to_string()),
                         ],
                     );
 
-                    server
+                    context
+                        .server()
                         .broadcast_message(
                             &message,
-                            &TextComponent::text(sender.to_string()),
+                            &TextComponent::text(context.source.output.to_string()),
                             SAY_COMMAND,
                             None,
                         )
@@ -521,21 +569,16 @@ impl CommandExecutor for DrawExecutor {
 }
 
 impl CommandExecutor for ResetExecutor {
-    fn execute<'a>(
-        &'a self,
-        sender: &'a CommandSender,
-        server: &'a crate::server::Server,
-        args: &'a ConsumedArgs<'a>,
-    ) -> CommandResult<'a> {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
         Box::pin(async move {
-            require_level_two(sender)?;
-
-            let parameter_override = parse_reset_parameters(args)?;
+            let parameter_override = parse_reset_parameters(context)?;
 
             match self.target {
                 ResetTarget::All => {
-                    let (reset_count, _) = reset_all_sequences(server, parameter_override).await;
-                    sender
+                    let (reset_count, _) =
+                        reset_all_sequences(context.server(), parameter_override).await;
+                    context
+                        .source
                         .send_message(TextComponent::translate(
                             translation::COMMANDS_RANDOM_RESET_ALL_SUCCESS,
                             [TextComponent::text(reset_count.to_string())],
@@ -544,10 +587,11 @@ impl CommandExecutor for ResetExecutor {
                     Ok(reset_count)
                 }
                 ResetTarget::Sequence => {
-                    let sequence_id = parse_sequence_arg(args)?;
+                    let sequence_id = parse_sequence_arg(context)?;
 
-                    let _ = reset_sequence(server, sequence_id, parameter_override).await;
-                    sender
+                    let _ = reset_sequence(context.server(), sequence_id, parameter_override).await;
+                    context
+                        .source
                         .send_message(TextComponent::translate(
                             translation::COMMANDS_RANDOM_RESET_SUCCESS,
                             [TextComponent::text(sequence_id.to_string())],
@@ -561,95 +605,6 @@ impl CommandExecutor for ResetExecutor {
     }
 }
 
-pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION)
-        .then(
-            literal("value").then(
-                argument(ARG_RANGE, SimpleArgConsumer)
-                    .execute(DrawExecutor {
-                        mode: DrawMode::Value,
-                        uses_sequence: false,
-                    })
-                    .then(
-                        argument(ARG_SEQUENCE, ResourceLocationArgumentConsumer).execute(
-                            DrawExecutor {
-                                mode: DrawMode::Value,
-                                uses_sequence: true,
-                            },
-                        ),
-                    ),
-            ),
-        )
-        .then(
-            literal("roll").then(
-                argument(ARG_RANGE, SimpleArgConsumer)
-                    .execute(DrawExecutor {
-                        mode: DrawMode::Roll,
-                        uses_sequence: false,
-                    })
-                    .then(
-                        argument(ARG_SEQUENCE, ResourceLocationArgumentConsumer).execute(
-                            DrawExecutor {
-                                mode: DrawMode::Roll,
-                                uses_sequence: true,
-                            },
-                        ),
-                    ),
-            ),
-        )
-        .then(
-            literal("reset")
-                .then(
-                    literal("*")
-                        .execute(ResetExecutor {
-                            target: ResetTarget::All,
-                        })
-                        .then(
-                            argument(ARG_SEED, seed_consumer())
-                                .execute(ResetExecutor {
-                                    target: ResetTarget::All,
-                                })
-                                .then(
-                                    argument(ARG_INCLUDE_WORLD_SEED, BoolArgConsumer)
-                                        .execute(ResetExecutor {
-                                            target: ResetTarget::All,
-                                        })
-                                        .then(
-                                            argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgConsumer)
-                                                .execute(ResetExecutor {
-                                                    target: ResetTarget::All,
-                                                }),
-                                        ),
-                                ),
-                        ),
-                )
-                .then(
-                    argument(ARG_SEQUENCE, ResourceLocationArgumentConsumer)
-                        .execute(ResetExecutor {
-                            target: ResetTarget::Sequence,
-                        })
-                        .then(
-                            argument(ARG_SEED, seed_consumer())
-                                .execute(ResetExecutor {
-                                    target: ResetTarget::Sequence,
-                                })
-                                .then(
-                                    argument(ARG_INCLUDE_WORLD_SEED, BoolArgConsumer)
-                                        .execute(ResetExecutor {
-                                            target: ResetTarget::Sequence,
-                                        })
-                                        .then(
-                                            argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgConsumer)
-                                                .execute(ResetExecutor {
-                                                    target: ResetTarget::Sequence,
-                                                }),
-                                        ),
-                                ),
-                        ),
-                ),
-        )
-}
-
 pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
     registry.register_permission_or_panic(Permission::new(
         PERMISSION,
@@ -657,9 +612,96 @@ pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionReg
         PermissionDefault::Allow,
     ));
 
-    dispatcher
-        .fallback_dispatcher
-        .register(init_command_tree(), PERMISSION);
+    dispatcher.register(
+        command("random", DESCRIPTION)
+            .requires(PERMISSION)
+            .then(
+                literal("value").then(
+                    argument(ARG_RANGE, RangeArgumentType)
+                        .executes(DrawExecutor {
+                            mode: DrawMode::Value,
+                            uses_sequence: false,
+                        })
+                        .then(
+                            argument(ARG_SEQUENCE, StringArgumentType::SingleWord)
+                                .requires(level_two_requirement)
+                                .executes(DrawExecutor {
+                                    mode: DrawMode::Value,
+                                    uses_sequence: true,
+                                }),
+                        ),
+                ),
+            )
+            .then(
+                literal("roll").then(
+                    argument(ARG_RANGE, RangeArgumentType)
+                        .executes(DrawExecutor {
+                            mode: DrawMode::Roll,
+                            uses_sequence: false,
+                        })
+                        .then(
+                            argument(ARG_SEQUENCE, StringArgumentType::SingleWord)
+                                .requires(level_two_requirement)
+                                .executes(DrawExecutor {
+                                    mode: DrawMode::Roll,
+                                    uses_sequence: true,
+                                }),
+                        ),
+                ),
+            )
+            .then(
+                literal("reset")
+                    .requires(level_two_requirement)
+                    .then(
+                        literal("*")
+                            .executes(ResetExecutor {
+                                target: ResetTarget::All,
+                            })
+                            .then(
+                                argument(ARG_SEED, seed_argument_type())
+                                    .executes(ResetExecutor {
+                                        target: ResetTarget::All,
+                                    })
+                                    .then(
+                                        argument(ARG_INCLUDE_WORLD_SEED, BoolArgumentType)
+                                            .executes(ResetExecutor {
+                                                target: ResetTarget::All,
+                                            })
+                                            .then(
+                                                argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgumentType)
+                                                    .executes(ResetExecutor {
+                                                        target: ResetTarget::All,
+                                                    }),
+                                            ),
+                                    ),
+                            ),
+                    )
+                    .then(
+                        argument(ARG_SEQUENCE, StringArgumentType::SingleWord)
+                            .executes(ResetExecutor {
+                                target: ResetTarget::Sequence,
+                            })
+                            .then(
+                                argument(ARG_SEED, seed_argument_type())
+                                    .executes(ResetExecutor {
+                                        target: ResetTarget::Sequence,
+                                    })
+                                    .then(
+                                        argument(ARG_INCLUDE_WORLD_SEED, BoolArgumentType)
+                                            .executes(ResetExecutor {
+                                                target: ResetTarget::Sequence,
+                                            })
+                                            .then(
+                                                argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgumentType)
+                                                    .executes(ResetExecutor {
+                                                        target: ResetTarget::Sequence,
+                                                    }),
+                                            ),
+                                    ),
+                            ),
+                    ),
+            ),
+    );
 }
 
 #[cfg(test)]

--- a/pumpkin/src/command/commands/random.rs
+++ b/pumpkin/src/command/commands/random.rs
@@ -1,11 +1,9 @@
 use std::{
     collections::HashMap,
-    pin::Pin,
     sync::{Arc, LazyLock},
 };
 
-use pumpkin_data::world::SAY_COMMAND;
-use pumpkin_protocol::java::client::play::SuggestionProviders;
+use pumpkin_data::{translation, world::SAY_COMMAND};
 use pumpkin_util::{
     PermissionLvl,
     permission::{Permission, PermissionDefault, PermissionRegistry},
@@ -16,23 +14,26 @@ use pumpkin_world::world_info::RandomSequence;
 use rand::RngExt;
 use tokio::sync::Mutex;
 
+use crate::command::dispatcher::CommandError::{
+    CommandFailed, InvalidConsumption, PermissionDenied,
+};
+use crate::command::node::dispatcher::CommandDispatcher;
 use crate::command::{
-    argument_builder::{ArgumentBuilder, argument, command, literal},
-    argument_types::{
-        argument_type::{ArgumentType, JavaClientArgumentType},
-        core::{bool::BoolArgumentType, long::LongArgumentType, string::StringArgumentType},
+    CommandError, CommandExecutor, CommandResult, CommandSender,
+    args::{
+        Arg, ConsumedArgs,
+        bool::BoolArgConsumer,
+        bounded_num::{BoundedNumArgumentConsumer, Number},
+        resource_location::ResourceLocationArgumentConsumer,
+        simple::SimpleArgConsumer,
     },
-    context::command_context::CommandContext,
-    dispatcher::CommandError,
-    errors::{
-        command_syntax_error::{CommandSyntaxError, CommandSyntaxErrorContext},
-        error_types::{self, LiteralCommandErrorType},
+    tree::{
+        CommandTree, RawArg,
+        builder::{argument, literal},
     },
-    node::{CommandExecutor, CommandExecutorResult, dispatcher::CommandDispatcher},
-    suggestion::suggestions::{Suggestions, SuggestionsBuilder},
-    tree::RawArg,
 };
 
+const NAMES: [&str; 1] = ["random"];
 const DESCRIPTION: &str = "Generates a random integer, or controls random sequences.";
 const PERMISSION: &str = "minecraft:command.random";
 
@@ -42,91 +43,30 @@ const ARG_SEED: &str = "seed";
 const ARG_INCLUDE_WORLD_SEED: &str = "includeWorldSeed";
 const ARG_INCLUDE_SEQUENCE_ID: &str = "includeSequenceId";
 
-const RANDOM_COMMAND_FAILED: LiteralCommandErrorType =
-    LiteralCommandErrorType::new("random command failed");
-const PERMISSION_DENIED: LiteralCommandErrorType = LiteralCommandErrorType::new(
-    "I'm sorry, but you do not have permission to perform this command. Please contact the server administrator if you believe this is an error.",
-);
-
-#[derive(Clone, Copy)]
-struct SequenceArgumentType;
-
-impl ArgumentType for SequenceArgumentType {
-    type Item = String;
-
-    fn parse(
-        &self,
-        reader: &mut crate::command::string_reader::StringReader,
-    ) -> Result<String, CommandSyntaxError> {
-        let start = reader.cursor();
-
-        while let Some(c) = reader.peek() {
-            if c.is_whitespace() {
-                break;
-            }
-            reader.skip();
-        }
-
-        let end = reader.cursor();
-        let input = reader.string();
-        let raw_arg = RawArg {
-            value: &input[start..end],
-            start,
-            end,
-            input,
-        };
-
-        validate_sequence_name(raw_arg).map(ToOwned::to_owned)
-    }
-
-    fn list_suggestions(
-        &self,
-        context: &CommandContext,
-        suggestions_builder: &mut SuggestionsBuilder,
-    ) -> Pin<Box<dyn std::future::Future<Output = Suggestions> + Send>> {
-        let prefix = suggestions_builder.remaining().to_string();
-        let mut builder = suggestions_builder.create_offset(suggestions_builder.start);
-
-        let level_info = context.server().level_info.load();
-        for sequence in level_info
-            .random_sequences
-            .keys()
-            .filter(|sequence| sequence.starts_with(&prefix))
-        {
-            builder = builder.suggest(sequence.as_str());
-        }
-
-        Box::pin(async move { builder.build() })
-    }
-
-    fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
-        JavaClientArgumentType::ResourceLocation
-    }
-
-    fn override_suggestion_providers(&self) -> Option<SuggestionProviders> {
-        Some(SuggestionProviders::AskServer)
-    }
-}
-
 const fn is_valid_namespaced_id_char(c: char) -> bool {
     matches!(c, 'a'..='z' | '0'..='9' | '_' | '-' | '.' | '/' | ':')
 }
 
-fn syntax_expected_separator(raw_arg: RawArg<'_>, local_cursor: usize) -> CommandSyntaxError {
+fn syntax_expected_separator(
+    raw_arg: RawArg<'_>,
+    local_cursor: usize,
+) -> crate::command::errors::command_syntax_error::CommandSyntaxError {
     let mut clamped_local_cursor = local_cursor.min(raw_arg.value.len());
     while clamped_local_cursor > 0 && !raw_arg.value.is_char_boundary(clamped_local_cursor) {
         clamped_local_cursor -= 1;
     }
 
-    let context = CommandSyntaxErrorContext {
+    let context = crate::command::errors::command_syntax_error::CommandSyntaxErrorContext {
         input: raw_arg.input.to_string(),
         cursor: raw_arg.start + clamped_local_cursor,
     };
 
-    error_types::DISPATCHER_EXPECTED_ARGUMENT_SEPARATOR.create(&context)
+    crate::command::errors::error_types::DISPATCHER_EXPECTED_ARGUMENT_SEPARATOR.create(&context)
 }
 
-fn validate_sequence_name(raw_arg: RawArg<'_>) -> Result<&str, CommandSyntaxError> {
+fn validate_sequence_name(
+    raw_arg: RawArg<'_>,
+) -> Result<&str, crate::command::errors::command_syntax_error::CommandSyntaxError> {
     let value = raw_arg.value;
     if value.is_empty() {
         return Err(syntax_expected_separator(raw_arg, 0));
@@ -192,36 +132,44 @@ impl InclusiveRange {
             let min = if min_raw.is_empty() {
                 i32::MIN
             } else {
-                parse_i32_range_bound(min_raw, "minimum")?
+                parse_i32_range_bound(min_raw)?
             };
             let max = if max_raw.is_empty() {
                 i32::MAX
             } else {
-                parse_i32_range_bound(max_raw, "maximum")?
+                parse_i32_range_bound(max_raw)?
             };
 
             (min, max)
         } else {
-            let value = parse_i32_range_bound(range, "value")?;
+            let value = parse_i32_range_bound(range)?;
             (value, value)
         };
 
         let range_size = i64::from(max) - i64::from(min) + 1;
-        if !(2..=2_147_483_646).contains(&range_size) {
-            return Err(CommandError::CommandFailed(TextComponent::text(format!(
-                "The range '{range}' is invalid. Its size must be between 2 and 2147483646."
-            ))));
+        if range_size < 2 {
+            return Err(CommandFailed(TextComponent::translate(
+                translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_SMALL,
+                [],
+            )));
+        }
+        if range_size > 2_147_483_646 {
+            return Err(CommandFailed(TextComponent::translate(
+                translation::COMMANDS_RANDOM_ERROR_RANGE_TOO_LARGE,
+                [],
+            )));
         }
 
         Ok(Self { min, max })
     }
 }
 
-fn parse_i32_range_bound(raw: &str, bound_name: &str) -> Result<i32, CommandError> {
+fn parse_i32_range_bound(raw: &str) -> Result<i32, CommandError> {
     raw.parse::<i32>().map_err(|_| {
-        CommandError::CommandFailed(TextComponent::text(format!(
-            "Invalid {bound_name} bound '{raw}'. Expected a 32-bit integer."
-        )))
+        CommandFailed(TextComponent::translate(
+            translation::PARSING_INT_INVALID,
+            [TextComponent::text(raw.to_string())],
+        ))
     })
 }
 
@@ -446,134 +394,123 @@ fn usize_to_i32_saturating(value: usize) -> i32 {
     i32::try_from(value).unwrap_or(i32::MAX)
 }
 
-fn command_failed(message: TextComponent) -> CommandSyntaxError {
-    CommandSyntaxError::create_without_context(&RANDOM_COMMAND_FAILED, message)
-}
-
-fn command_error_to_syntax(error: CommandError) -> CommandSyntaxError {
-    match error {
-        CommandError::CommandFailed(message) => command_failed(message),
-        CommandError::SyntaxError(error) => error,
-        CommandError::PermissionDenied => PERMISSION_DENIED.create_without_context(),
-        CommandError::InvalidConsumption(argument) => error_types::DISPATCHER_PARSE_EXCEPTION
-            .create_without_context(TextComponent::text(format!(
-                "Could not parse argument: {argument:?}"
-            ))),
-        CommandError::InvalidRequirement => error_types::DISPATCHER_PARSE_EXCEPTION
-            .create_without_context(TextComponent::text("Command requirement failed")),
-    }
-}
-
-fn require_level_two(context: &CommandContext) -> Result<(), CommandSyntaxError> {
-    if context.source.output.has_permission_lvl(PermissionLvl::Two) {
+fn require_level_two(sender: &CommandSender) -> Result<(), CommandError> {
+    if sender.has_permission_lvl(PermissionLvl::Two) {
         Ok(())
     } else {
-        Err(PERMISSION_DENIED.create_without_context())
+        Err(PermissionDenied)
     }
 }
 
-fn get_optional_argument<'a, T: 'static>(
-    context: &'a CommandContext,
-    name: &str,
-) -> Result<Option<&'a T>, CommandSyntaxError> {
-    if context.arguments.contains_key(name) {
-        context.get_argument(name).map(Some)
-    } else {
-        Ok(None)
+fn parse_range_arg(args: &ConsumedArgs<'_>) -> Result<InclusiveRange, CommandError> {
+    let Some(Arg::Simple(range)) = args.get(ARG_RANGE) else {
+        return Err(InvalidConsumption(Some(ARG_RANGE.into())));
+    };
+
+    InclusiveRange::parse(range)
+}
+
+fn parse_sequence_arg<'a>(args: &'a ConsumedArgs<'a>) -> Result<&'a str, CommandError> {
+    let Some(Arg::ResourceLocation(sequence)) = args.get(ARG_SEQUENCE) else {
+        return Err(InvalidConsumption(Some(ARG_SEQUENCE.into())));
+    };
+
+    let raw_arg = RawArg {
+        value: sequence,
+        start: 0,
+        end: sequence.len(),
+        input: sequence,
+    };
+    validate_sequence_name(raw_arg).map_err(CommandError::SyntaxError)
+}
+
+fn parse_optional_seed(args: &ConsumedArgs<'_>) -> Result<Option<i64>, CommandError> {
+    match args.get(ARG_SEED) {
+        None => Ok(None),
+        Some(Arg::Num(Ok(Number::I64(seed)))) => Ok(Some(*seed)),
+        _ => Err(InvalidConsumption(Some(ARG_SEED.into()))),
     }
 }
 
-fn parse_range_arg(context: &CommandContext) -> Result<InclusiveRange, CommandSyntaxError> {
-    let range = context.get_argument::<String>(ARG_RANGE)?;
-    InclusiveRange::parse(range).map_err(command_error_to_syntax)
-}
-
-fn parse_sequence_arg<'a>(context: &'a CommandContext) -> Result<&'a str, CommandSyntaxError> {
-    context
-        .get_argument::<String>(ARG_SEQUENCE)
-        .map(String::as_str)
+fn parse_optional_bool(args: &ConsumedArgs<'_>, name: &str) -> Result<Option<bool>, CommandError> {
+    match args.get(name) {
+        None => Ok(None),
+        Some(Arg::Bool(value)) => Ok(Some(*value)),
+        _ => Err(InvalidConsumption(Some(name.into()))),
+    }
 }
 
 fn parse_reset_parameters(
-    context: &CommandContext,
-) -> Result<Option<SequenceParameters>, CommandSyntaxError> {
-    let Some(seed) = get_optional_argument::<i64>(context, ARG_SEED)? else {
+    args: &ConsumedArgs<'_>,
+) -> Result<Option<SequenceParameters>, CommandError> {
+    let Some(seed) = parse_optional_seed(args)? else {
         return Ok(None);
     };
 
-    let include_world_seed =
-        *get_optional_argument::<bool>(context, ARG_INCLUDE_WORLD_SEED)?.unwrap_or(&true);
-    let include_sequence_id =
-        *get_optional_argument::<bool>(context, ARG_INCLUDE_SEQUENCE_ID)?.unwrap_or(&true);
+    let include_world_seed = parse_optional_bool(args, ARG_INCLUDE_WORLD_SEED)?.unwrap_or(true);
+    let include_sequence_id = parse_optional_bool(args, ARG_INCLUDE_SEQUENCE_ID)?.unwrap_or(true);
 
     Ok(Some(SequenceParameters {
-        seed: *seed,
+        seed,
         include_world_seed,
         include_sequence_id,
     }))
 }
 
-const fn seed_argument_type() -> LongArgumentType {
-    LongArgumentType::any()
+const fn seed_consumer() -> BoundedNumArgumentConsumer<i64> {
+    BoundedNumArgumentConsumer::new().name(ARG_SEED)
 }
 
 impl CommandExecutor for DrawExecutor {
-    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
         Box::pin(async move {
-            let range = parse_range_arg(context)?;
+            let range = parse_range_arg(args)?;
 
             let sequence = if self.uses_sequence {
-                require_level_two(context)?;
-                Some(parse_sequence_arg(context)?)
+                require_level_two(sender)?;
+                Some(parse_sequence_arg(args)?)
             } else {
                 None
             };
 
             let result = if let Some(sequence_id) = sequence {
-                sample_sequence_value(context.server(), sequence_id, range).await
+                sample_sequence_value(server, sequence_id, range).await
             } else {
                 rand::rng().random_range(range.min..=range.max)
             };
 
             match self.mode {
                 DrawMode::Value => {
-                    let message = sequence.map_or_else(
-                        || {
-                            TextComponent::text(format!(
-                                "Random value ({0}..{1}): {result}",
-                                range.min, range.max
-                            ))
-                        },
-                        |sequence_id| {
-                            TextComponent::text(format!(
-                                "Random value ({0}..{1}, sequence {sequence_id}): {result}",
-                                range.min, range.max
-                            ))
-                        },
-                    );
-
-                    context.source.send_message(message).await;
+                    sender
+                        .send_message(TextComponent::translate(
+                            translation::COMMANDS_RANDOM_SAMPLE_SUCCESS,
+                            [TextComponent::text(result.to_string())],
+                        ))
+                        .await;
                 }
                 DrawMode::Roll => {
-                    let message = sequence.map_or_else(
-                        || {
-                            TextComponent::text(format!(
-                                "rolled {result} (from {} to {})",
-                                range.min, range.max
-                            ))
-                        },
-                        |sequence_id| {
-                            TextComponent::text(format!(
-                                "rolled {result} (from {} to {}, sequence {sequence_id})",
-                                range.min, range.max
-                            ))
-                        },
+                    let message = TextComponent::translate(
+                        translation::COMMANDS_RANDOM_ROLL,
+                        [
+                            TextComponent::text(sender.to_string()),
+                            TextComponent::text(result.to_string()),
+                            TextComponent::text(range.min.to_string()),
+                            TextComponent::text(range.max.to_string()),
+                        ],
                     );
 
-                    let sender_name = TextComponent::text(context.source.output.to_string());
-                    context
-                        .server()
-                        .broadcast_message(&message, &sender_name, SAY_COMMAND, None)
+                    server
+                        .broadcast_message(
+                            &message,
+                            &TextComponent::text(sender.to_string()),
+                            SAY_COMMAND,
+                            None,
+                        )
                         .await;
                 }
             }
@@ -584,41 +521,37 @@ impl CommandExecutor for DrawExecutor {
 }
 
 impl CommandExecutor for ResetExecutor {
-    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
         Box::pin(async move {
-            require_level_two(context)?;
+            require_level_two(sender)?;
 
-            let parameter_override = parse_reset_parameters(context)?;
+            let parameter_override = parse_reset_parameters(args)?;
 
             match self.target {
                 ResetTarget::All => {
-                    let (reset_count, defaults) =
-                        reset_all_sequences(context.server(), parameter_override).await;
-                    context
-                        .source
-                        .send_message(TextComponent::text(format!(
-                            "Reset {reset_count} random sequence(s). Defaults are now seed={}, includeWorldSeed={}, includeSequenceId={}.",
-                            defaults.seed, defaults.include_world_seed, defaults.include_sequence_id
-                        )))
+                    let (reset_count, _) = reset_all_sequences(server, parameter_override).await;
+                    sender
+                        .send_message(TextComponent::translate(
+                            translation::COMMANDS_RANDOM_RESET_ALL_SUCCESS,
+                            [TextComponent::text(reset_count.to_string())],
+                        ))
                         .await;
                     Ok(reset_count)
                 }
                 ResetTarget::Sequence => {
-                    let sequence_id = parse_sequence_arg(context)?;
-                    if sequence_id == "*" {
-                        return Err(command_failed(TextComponent::text(
-                            "Sequence name '*' is reserved for resetting all sequences.",
-                        )));
-                    }
+                    let sequence_id = parse_sequence_arg(args)?;
 
-                    let parameters =
-                        reset_sequence(context.server(), sequence_id, parameter_override).await;
-                    context
-                        .source
-                        .send_message(TextComponent::text(format!(
-                            "Reset random sequence '{sequence_id}' with seed={}, includeWorldSeed={}, includeSequenceId={}.",
-                            parameters.seed, parameters.include_world_seed, parameters.include_sequence_id
-                        )))
+                    let _ = reset_sequence(server, sequence_id, parameter_override).await;
+                    sender
+                        .send_message(TextComponent::translate(
+                            translation::COMMANDS_RANDOM_RESET_SUCCESS,
+                            [TextComponent::text(sequence_id.to_string())],
+                        ))
                         .await;
 
                     Ok(1)
@@ -628,6 +561,95 @@ impl CommandExecutor for ResetExecutor {
     }
 }
 
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(
+            literal("value").then(
+                argument(ARG_RANGE, SimpleArgConsumer)
+                    .execute(DrawExecutor {
+                        mode: DrawMode::Value,
+                        uses_sequence: false,
+                    })
+                    .then(
+                        argument(ARG_SEQUENCE, ResourceLocationArgumentConsumer).execute(
+                            DrawExecutor {
+                                mode: DrawMode::Value,
+                                uses_sequence: true,
+                            },
+                        ),
+                    ),
+            ),
+        )
+        .then(
+            literal("roll").then(
+                argument(ARG_RANGE, SimpleArgConsumer)
+                    .execute(DrawExecutor {
+                        mode: DrawMode::Roll,
+                        uses_sequence: false,
+                    })
+                    .then(
+                        argument(ARG_SEQUENCE, ResourceLocationArgumentConsumer).execute(
+                            DrawExecutor {
+                                mode: DrawMode::Roll,
+                                uses_sequence: true,
+                            },
+                        ),
+                    ),
+            ),
+        )
+        .then(
+            literal("reset")
+                .then(
+                    literal("*")
+                        .execute(ResetExecutor {
+                            target: ResetTarget::All,
+                        })
+                        .then(
+                            argument(ARG_SEED, seed_consumer())
+                                .execute(ResetExecutor {
+                                    target: ResetTarget::All,
+                                })
+                                .then(
+                                    argument(ARG_INCLUDE_WORLD_SEED, BoolArgConsumer)
+                                        .execute(ResetExecutor {
+                                            target: ResetTarget::All,
+                                        })
+                                        .then(
+                                            argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgConsumer)
+                                                .execute(ResetExecutor {
+                                                    target: ResetTarget::All,
+                                                }),
+                                        ),
+                                ),
+                        ),
+                )
+                .then(
+                    argument(ARG_SEQUENCE, ResourceLocationArgumentConsumer)
+                        .execute(ResetExecutor {
+                            target: ResetTarget::Sequence,
+                        })
+                        .then(
+                            argument(ARG_SEED, seed_consumer())
+                                .execute(ResetExecutor {
+                                    target: ResetTarget::Sequence,
+                                })
+                                .then(
+                                    argument(ARG_INCLUDE_WORLD_SEED, BoolArgConsumer)
+                                        .execute(ResetExecutor {
+                                            target: ResetTarget::Sequence,
+                                        })
+                                        .then(
+                                            argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgConsumer)
+                                                .execute(ResetExecutor {
+                                                    target: ResetTarget::Sequence,
+                                                }),
+                                        ),
+                                ),
+                        ),
+                ),
+        )
+}
+
 pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
     registry.register_permission_or_panic(Permission::new(
         PERMISSION,
@@ -635,91 +657,9 @@ pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionReg
         PermissionDefault::Allow,
     ));
 
-    dispatcher.register(
-        command("random", DESCRIPTION)
-            .requires(PERMISSION)
-            .then(
-                literal("value").then(
-                    argument(ARG_RANGE, StringArgumentType::SingleWord)
-                        .executes(DrawExecutor {
-                            mode: DrawMode::Value,
-                            uses_sequence: false,
-                        })
-                        .then(argument(ARG_SEQUENCE, SequenceArgumentType).executes(
-                            DrawExecutor {
-                                mode: DrawMode::Value,
-                                uses_sequence: true,
-                            },
-                        )),
-                ),
-            )
-            .then(
-                literal("roll").then(
-                    argument(ARG_RANGE, StringArgumentType::SingleWord)
-                        .executes(DrawExecutor {
-                            mode: DrawMode::Roll,
-                            uses_sequence: false,
-                        })
-                        .then(argument(ARG_SEQUENCE, SequenceArgumentType).executes(
-                            DrawExecutor {
-                                mode: DrawMode::Roll,
-                                uses_sequence: true,
-                            },
-                        )),
-                ),
-            )
-            .then(
-                literal("reset")
-                    .then(
-                        literal("*")
-                            .executes(ResetExecutor {
-                                target: ResetTarget::All,
-                            })
-                            .then(
-                                argument(ARG_SEED, seed_argument_type())
-                                    .executes(ResetExecutor {
-                                        target: ResetTarget::All,
-                                    })
-                                    .then(
-                                        argument(ARG_INCLUDE_WORLD_SEED, BoolArgumentType)
-                                            .executes(ResetExecutor {
-                                                target: ResetTarget::All,
-                                            })
-                                            .then(
-                                                argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgumentType)
-                                                    .executes(ResetExecutor {
-                                                        target: ResetTarget::All,
-                                                    }),
-                                            ),
-                                    ),
-                            ),
-                    )
-                    .then(
-                        argument(ARG_SEQUENCE, SequenceArgumentType)
-                            .executes(ResetExecutor {
-                                target: ResetTarget::Sequence,
-                            })
-                            .then(
-                                argument(ARG_SEED, seed_argument_type())
-                                    .executes(ResetExecutor {
-                                        target: ResetTarget::Sequence,
-                                    })
-                                    .then(
-                                        argument(ARG_INCLUDE_WORLD_SEED, BoolArgumentType)
-                                            .executes(ResetExecutor {
-                                                target: ResetTarget::Sequence,
-                                            })
-                                            .then(
-                                                argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgumentType)
-                                                    .executes(ResetExecutor {
-                                                        target: ResetTarget::Sequence,
-                                                    }),
-                                            ),
-                                    ),
-                            ),
-                    ),
-            ),
-    );
+    dispatcher
+        .fallback_dispatcher
+        .register(init_command_tree(), PERMISSION);
 }
 
 #[cfg(test)]

--- a/pumpkin/src/command/commands/random.rs
+++ b/pumpkin/src/command/commands/random.rs
@@ -1,0 +1,836 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+};
+
+use pumpkin_data::world::SAY_COMMAND;
+use pumpkin_protocol::java::client::play::{ArgumentType, CommandSuggestion, SuggestionProviders};
+use pumpkin_util::{
+    PermissionLvl,
+    random::{RandomImpl, xoroshiro128::Xoroshiro},
+    text::TextComponent,
+};
+use pumpkin_world::world_info::RandomSequence;
+use rand::RngExt;
+use tokio::sync::Mutex;
+
+use crate::command::{
+    CommandError, CommandExecutor, CommandResult, CommandSender,
+    args::{
+        Arg, ArgumentConsumer, ConsumeResult, ConsumeResultWithSyntax, ConsumedArgs,
+        GetClientSideArgParser, SplitSingleWhitespaceIncludingEmptyParts, SuggestResult,
+        bool::BoolArgConsumer,
+        bounded_num::{BoundedNumArgumentConsumer, Number},
+        simple::SimpleArgConsumer,
+    },
+    errors::{
+        command_syntax_error::{CommandSyntaxError, CommandSyntaxErrorContext},
+        error_types,
+    },
+    tree::{
+        CommandTree, RawArg, RawArgs,
+        builder::{argument, literal},
+    },
+};
+use CommandError::{CommandFailed, InvalidConsumption, PermissionDenied};
+
+const NAMES: [&str; 1] = ["random"];
+const DESCRIPTION: &str = "Generates a random integer, or controls random sequences.";
+
+const ARG_RANGE: &str = "range";
+const ARG_SEQUENCE: &str = "sequence";
+const ARG_SEED: &str = "seed";
+const ARG_INCLUDE_WORLD_SEED: &str = "includeWorldSeed";
+const ARG_INCLUDE_SEQUENCE_ID: &str = "includeSequenceId";
+
+#[derive(Clone, Copy)]
+struct SequenceArgumentConsumer;
+
+impl GetClientSideArgParser for SequenceArgumentConsumer {
+    fn get_client_side_parser(&self) -> ArgumentType<'_> {
+        ArgumentType::ResourceLocation
+    }
+
+    fn get_client_side_suggestion_type_override(&self) -> Option<SuggestionProviders> {
+        Some(SuggestionProviders::AskServer)
+    }
+}
+
+fn is_valid_namespaced_id_char(c: char) -> bool {
+    matches!(c, 'a'..='z' | '0'..='9' | '_' | '-' | '.' | '/' | ':')
+}
+
+fn syntax_expected_separator(raw_arg: RawArg<'_>, local_cursor: usize) -> CommandSyntaxError {
+    let mut clamped_local_cursor = local_cursor.min(raw_arg.value.len());
+    while clamped_local_cursor > 0 && !raw_arg.value.is_char_boundary(clamped_local_cursor) {
+        clamped_local_cursor -= 1;
+    }
+
+    let context = CommandSyntaxErrorContext {
+        input: raw_arg.input.to_string(),
+        cursor: raw_arg.start + clamped_local_cursor,
+    };
+
+    error_types::DISPATCHER_EXPECTED_ARGUMENT_SEPARATOR.create(&context)
+}
+
+fn validate_sequence_name(raw_arg: RawArg<'_>) -> Result<&str, CommandSyntaxError> {
+    let value = raw_arg.value;
+    if value.is_empty() {
+        return Err(syntax_expected_separator(raw_arg, 0));
+    }
+
+    let mut namespace_separator_at = None;
+    for (index, c) in value.char_indices() {
+        if !is_valid_namespaced_id_char(c) {
+            return Err(syntax_expected_separator(raw_arg, index));
+        }
+        if c == ':' {
+            if namespace_separator_at.is_some() {
+                return Err(syntax_expected_separator(raw_arg, index));
+            }
+            namespace_separator_at = Some(index);
+        }
+    }
+
+    if let Some(separator_index) = namespace_separator_at {
+        if separator_index == 0 {
+            return Err(syntax_expected_separator(raw_arg, 0));
+        }
+        if separator_index + 1 == value.len() {
+            return Err(syntax_expected_separator(raw_arg, value.len()));
+        }
+    }
+
+    Ok(value)
+}
+
+impl ArgumentConsumer for SequenceArgumentConsumer {
+    fn consume<'a>(
+        &'a self,
+        _sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &mut RawArgs<'a>,
+    ) -> ConsumeResult<'a> {
+        let Some(raw_arg) = args.pop() else {
+            return Box::pin(async { None });
+        };
+
+        let parsed = validate_sequence_name(raw_arg)
+            .ok()
+            .map(Arg::ResourceLocation);
+        Box::pin(async move { parsed })
+    }
+
+    fn consume_with_syntax<'a>(
+        &'a self,
+        _sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        args: &mut RawArgs<'a>,
+    ) -> ConsumeResultWithSyntax<'a> {
+        let Some(raw_arg) = args.pop() else {
+            return Box::pin(async { Ok(None) });
+        };
+
+        Box::pin(async move {
+            let sequence = validate_sequence_name(raw_arg)?;
+            Ok(Some(Arg::ResourceLocation(sequence)))
+        })
+    }
+
+    fn suggest<'a>(
+        &'a self,
+        _sender: &CommandSender,
+        server: &'a crate::server::Server,
+        input: &'a str,
+    ) -> SuggestResult<'a> {
+        Box::pin(async move {
+            let Some(prefix) = input.split_single_whitespace_including_empty_parts().last() else {
+                return Ok(None);
+            };
+
+            let level_info = server.level_info.load();
+            let suggestions: Vec<CommandSuggestion> = level_info
+                .random_sequences
+                .keys()
+                .filter(|sequence| sequence.starts_with(prefix))
+                .map(|sequence| CommandSuggestion::new(sequence.clone(), None))
+                .collect();
+
+            Ok(Some(suggestions))
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DrawMode {
+    Value,
+    Roll,
+}
+
+#[derive(Clone, Copy)]
+struct DrawExecutor {
+    mode: DrawMode,
+    uses_sequence: bool,
+}
+
+#[derive(Clone, Copy)]
+enum ResetTarget {
+    All,
+    Sequence,
+}
+
+#[derive(Clone, Copy)]
+struct ResetExecutor {
+    target: ResetTarget,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct InclusiveRange {
+    min: i32,
+    max: i32,
+}
+
+impl InclusiveRange {
+    fn parse(range: &str) -> Result<Self, CommandError> {
+        let (min, max) = if let Some((min_raw, max_raw)) = range.split_once("..") {
+            let min = if min_raw.is_empty() {
+                i32::MIN
+            } else {
+                parse_i32_range_bound(min_raw, "minimum")?
+            };
+            let max = if max_raw.is_empty() {
+                i32::MAX
+            } else {
+                parse_i32_range_bound(max_raw, "maximum")?
+            };
+
+            (min, max)
+        } else {
+            let value = parse_i32_range_bound(range, "value")?;
+            (value, value)
+        };
+
+        let range_size = i64::from(max) - i64::from(min) + 1;
+        if !(2..=2_147_483_646).contains(&range_size) {
+            return Err(CommandFailed(TextComponent::text(format!(
+                "The range '{range}' is invalid. Its size must be between 2 and 2147483646."
+            ))));
+        }
+
+        Ok(Self { min, max })
+    }
+}
+
+fn parse_i32_range_bound(raw: &str, bound_name: &str) -> Result<i32, CommandError> {
+    raw.parse::<i32>().map_err(|_| {
+        CommandFailed(TextComponent::text(format!(
+            "Invalid {bound_name} bound '{raw}'. Expected a 32-bit integer."
+        )))
+    })
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SequenceParameters {
+    seed: i64,
+    include_world_seed: bool,
+    include_sequence_id: bool,
+}
+
+impl Default for SequenceParameters {
+    fn default() -> Self {
+        // Snapshot 23w31a default parameters for random sequences.
+        Self {
+            seed: 0,
+            include_world_seed: true,
+            include_sequence_id: true,
+        }
+    }
+}
+
+impl From<RandomSequence> for SequenceParameters {
+    fn from(value: RandomSequence) -> Self {
+        Self {
+            seed: value.seed,
+            include_world_seed: value.include_world_seed,
+            include_sequence_id: value.include_sequence_id,
+        }
+    }
+}
+
+impl From<SequenceParameters> for RandomSequence {
+    fn from(value: SequenceParameters) -> Self {
+        Self {
+            seed: value.seed,
+            include_world_seed: value.include_world_seed,
+            include_sequence_id: value.include_sequence_id,
+        }
+    }
+}
+
+struct SequenceState {
+    rng: Xoroshiro,
+}
+
+impl SequenceState {
+    fn new(parameters: SequenceParameters, world_seed: i64, sequence_id: &str) -> Self {
+        let effective_seed = derive_sequence_seed(parameters, world_seed, sequence_id);
+        Self {
+            rng: Xoroshiro::from_seed(effective_seed),
+        }
+    }
+
+    fn sample(&mut self, range: InclusiveRange) -> i32 {
+        self.rng.next_inbetween_i32(range.min, range.max)
+    }
+}
+
+#[derive(Default)]
+struct WorldSequenceState {
+    defaults: SequenceParameters,
+    sequences: HashMap<String, SequenceState>,
+}
+
+#[derive(Default)]
+struct SequenceStore {
+    worlds: HashMap<String, WorldSequenceState>,
+}
+
+static RANDOM_SEQUENCES: LazyLock<Mutex<SequenceStore>> =
+    LazyLock::new(|| Mutex::new(SequenceStore::default()));
+
+fn world_key(server: &crate::server::Server) -> String {
+    server
+        .basic_config
+        .get_world_path()
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn world_seed(server: &crate::server::Server) -> i64 {
+    server.level_info.load().world_gen_settings.seed
+}
+
+const fn stafford_mix_13(value: u64) -> u64 {
+    let value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    let value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    value ^ (value >> 31)
+}
+
+fn sequence_id_hash(sequence_id: &str) -> u64 {
+    const OFFSET_BASIS: u64 = 14_695_981_039_346_656_037;
+    const PRIME: u64 = 1_099_511_628_211;
+
+    let mut hash = OFFSET_BASIS;
+    for byte in sequence_id.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+fn derive_sequence_seed(parameters: SequenceParameters, world_seed: i64, sequence_id: &str) -> u64 {
+    let mut seed = parameters.seed as u64;
+    if parameters.include_world_seed {
+        seed ^= world_seed as u64;
+    }
+    if parameters.include_sequence_id {
+        seed ^= sequence_id_hash(sequence_id);
+    }
+    stafford_mix_13(seed)
+}
+
+fn load_sequence_parameters(
+    server: &crate::server::Server,
+    sequence_id: &str,
+) -> Option<SequenceParameters> {
+    let info = server.level_info.load();
+    info.random_sequences
+        .get(sequence_id)
+        .cloned()
+        .map(SequenceParameters::from)
+}
+
+fn persist_sequence_parameters(
+    server: &crate::server::Server,
+    sequence_id: &str,
+    parameters: SequenceParameters,
+) {
+    let current_info = server.level_info.load();
+    let mut new_info = (**current_info).clone();
+    new_info
+        .random_sequences
+        .insert(sequence_id.to_string(), parameters.into());
+    server.level_info.store(Arc::new(new_info));
+}
+
+fn remove_sequence_parameters(server: &crate::server::Server, sequence_id: &str) {
+    let current_info = server.level_info.load();
+    let mut new_info = (**current_info).clone();
+    new_info.random_sequences.remove(sequence_id);
+    server.level_info.store(Arc::new(new_info));
+}
+
+async fn sample_sequence_value(
+    server: &crate::server::Server,
+    sequence_id: &str,
+    range: InclusiveRange,
+) -> i32 {
+    let world_seed = world_seed(server);
+    let key = world_key(server);
+    let persisted_parameters = load_sequence_parameters(server, sequence_id);
+
+    let mut store = RANDOM_SEQUENCES.lock().await;
+    let world_state = store.worlds.entry(key).or_default();
+    let parameters = persisted_parameters.unwrap_or(world_state.defaults);
+
+    let sequence = world_state
+        .sequences
+        .entry(sequence_id.to_string())
+        .or_insert_with(|| SequenceState::new(parameters, world_seed, sequence_id));
+
+    let result = sequence.sample(range);
+    drop(store);
+
+    if persisted_parameters.is_none() {
+        persist_sequence_parameters(server, sequence_id, parameters);
+    }
+
+    result
+}
+
+async fn reset_all_sequences(
+    server: &crate::server::Server,
+    parameter_override: Option<SequenceParameters>,
+) -> (i32, SequenceParameters) {
+    let key = world_key(server);
+    let mut store = RANDOM_SEQUENCES.lock().await;
+    let world_state = store.worlds.entry(key).or_default();
+
+    let new_defaults = parameter_override.unwrap_or_default();
+    world_state.defaults = new_defaults;
+    world_state.sequences.clear();
+    drop(store);
+
+    let current_info = server.level_info.load();
+    let reset_count = usize_to_i32_saturating(current_info.random_sequences.len());
+    let mut new_info = (**current_info).clone();
+    new_info.random_sequences.clear();
+    server.level_info.store(Arc::new(new_info));
+
+    (reset_count, new_defaults)
+}
+
+async fn reset_sequence(
+    server: &crate::server::Server,
+    sequence_id: &str,
+    parameter_override: Option<SequenceParameters>,
+) -> SequenceParameters {
+    let world_seed = world_seed(server);
+    let key = world_key(server);
+
+    let mut store = RANDOM_SEQUENCES.lock().await;
+    let world_state = store.worlds.entry(key).or_default();
+
+    let parameters = parameter_override.unwrap_or_default();
+    world_state.sequences.insert(
+        sequence_id.to_string(),
+        SequenceState::new(parameters, world_seed, sequence_id),
+    );
+    drop(store);
+
+    if parameter_override.is_some() {
+        persist_sequence_parameters(server, sequence_id, parameters);
+    } else {
+        remove_sequence_parameters(server, sequence_id);
+    }
+    parameters
+}
+
+fn usize_to_i32_saturating(value: usize) -> i32 {
+    i32::try_from(value).unwrap_or(i32::MAX)
+}
+
+fn require_level_two(sender: &CommandSender) -> Result<(), CommandError> {
+    if sender.has_permission_lvl(PermissionLvl::Two) {
+        Ok(())
+    } else {
+        Err(PermissionDenied)
+    }
+}
+
+fn parse_range_arg(args: &ConsumedArgs<'_>) -> Result<InclusiveRange, CommandError> {
+    let Some(Arg::Simple(range)) = args.get(ARG_RANGE) else {
+        return Err(InvalidConsumption(Some(ARG_RANGE.into())));
+    };
+
+    InclusiveRange::parse(range)
+}
+
+fn parse_sequence_arg<'a>(args: &'a ConsumedArgs<'a>) -> Result<&'a str, CommandError> {
+    let Some(Arg::ResourceLocation(sequence)) = args.get(ARG_SEQUENCE) else {
+        return Err(InvalidConsumption(Some(ARG_SEQUENCE.into())));
+    };
+
+    Ok(sequence)
+}
+
+fn parse_optional_seed(args: &ConsumedArgs<'_>) -> Result<Option<i64>, CommandError> {
+    match args.get(ARG_SEED) {
+        None => Ok(None),
+        Some(Arg::Num(Ok(Number::I64(seed)))) => Ok(Some(*seed)),
+        _ => Err(InvalidConsumption(Some(ARG_SEED.into()))),
+    }
+}
+
+fn parse_optional_bool(args: &ConsumedArgs<'_>, name: &str) -> Result<Option<bool>, CommandError> {
+    match args.get(name) {
+        None => Ok(None),
+        Some(Arg::Bool(value)) => Ok(Some(*value)),
+        _ => Err(InvalidConsumption(Some(name.into()))),
+    }
+}
+
+fn parse_reset_parameters(
+    args: &ConsumedArgs<'_>,
+) -> Result<Option<SequenceParameters>, CommandError> {
+    let Some(seed) = parse_optional_seed(args)? else {
+        return Ok(None);
+    };
+
+    let include_world_seed = parse_optional_bool(args, ARG_INCLUDE_WORLD_SEED)?.unwrap_or(true);
+    let include_sequence_id = parse_optional_bool(args, ARG_INCLUDE_SEQUENCE_ID)?.unwrap_or(true);
+
+    Ok(Some(SequenceParameters {
+        seed,
+        include_world_seed,
+        include_sequence_id,
+    }))
+}
+
+const fn seed_consumer() -> BoundedNumArgumentConsumer<i64> {
+    BoundedNumArgumentConsumer::new().name(ARG_SEED)
+}
+
+impl CommandExecutor for DrawExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            let range = parse_range_arg(args)?;
+
+            let sequence = if self.uses_sequence {
+                require_level_two(sender)?;
+                Some(parse_sequence_arg(args)?)
+            } else {
+                None
+            };
+
+            let result = if let Some(sequence_id) = sequence {
+                sample_sequence_value(server, sequence_id, range).await
+            } else {
+                rand::rng().random_range(range.min..=range.max)
+            };
+
+            match self.mode {
+                DrawMode::Value => {
+                    let message = sequence.map_or_else(
+                        || {
+                            TextComponent::text(format!(
+                                "Random value ({0}..{1}): {result}",
+                                range.min, range.max
+                            ))
+                        },
+                        |sequence_id| {
+                            TextComponent::text(format!(
+                                "Random value ({0}..{1}, sequence {sequence_id}): {result}",
+                                range.min, range.max
+                            ))
+                        },
+                    );
+
+                    sender.send_message(message).await;
+                }
+                DrawMode::Roll => {
+                    let message = sequence.map_or_else(
+                        || {
+                            TextComponent::text(format!(
+                                "rolled {result} (from {} to {})",
+                                range.min, range.max
+                            ))
+                        },
+                        |sequence_id| {
+                            TextComponent::text(format!(
+                                "rolled {result} (from {} to {}, sequence {sequence_id})",
+                                range.min, range.max
+                            ))
+                        },
+                    );
+
+                    server
+                        .broadcast_message(
+                            &message,
+                            &TextComponent::text(sender.to_string()),
+                            SAY_COMMAND,
+                            None,
+                        )
+                        .await;
+                }
+            }
+
+            Ok(result)
+        })
+    }
+}
+
+impl CommandExecutor for ResetExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            require_level_two(sender)?;
+
+            let parameter_override = parse_reset_parameters(args)?;
+
+            match self.target {
+                ResetTarget::All => {
+                    let (reset_count, defaults) =
+                        reset_all_sequences(server, parameter_override).await;
+                    sender
+                        .send_message(TextComponent::text(format!(
+                            "Reset {reset_count} random sequence(s). Defaults are now seed={}, includeWorldSeed={}, includeSequenceId={}.",
+                            defaults.seed, defaults.include_world_seed, defaults.include_sequence_id
+                        )))
+                        .await;
+                    Ok(reset_count)
+                }
+                ResetTarget::Sequence => {
+                    let sequence_id = parse_sequence_arg(args)?;
+                    if sequence_id == "*" {
+                        return Err(CommandFailed(TextComponent::text(
+                            "Sequence name '*' is reserved for resetting all sequences.",
+                        )));
+                    }
+
+                    let parameters = reset_sequence(server, sequence_id, parameter_override).await;
+                    sender
+                        .send_message(TextComponent::text(format!(
+                            "Reset random sequence '{sequence_id}' with seed={}, includeWorldSeed={}, includeSequenceId={}.",
+                            parameters.seed, parameters.include_world_seed, parameters.include_sequence_id
+                        )))
+                        .await;
+
+                    Ok(1)
+                }
+            }
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(
+            literal("value").then(
+                argument(ARG_RANGE, SimpleArgConsumer)
+                    .execute(DrawExecutor {
+                        mode: DrawMode::Value,
+                        uses_sequence: false,
+                    })
+                    .then(
+                        argument(ARG_SEQUENCE, SequenceArgumentConsumer).execute(DrawExecutor {
+                            mode: DrawMode::Value,
+                            uses_sequence: true,
+                        }),
+                    ),
+            ),
+        )
+        .then(
+            literal("roll").then(
+                argument(ARG_RANGE, SimpleArgConsumer)
+                    .execute(DrawExecutor {
+                        mode: DrawMode::Roll,
+                        uses_sequence: false,
+                    })
+                    .then(
+                        argument(ARG_SEQUENCE, SequenceArgumentConsumer).execute(DrawExecutor {
+                            mode: DrawMode::Roll,
+                            uses_sequence: true,
+                        }),
+                    ),
+            ),
+        )
+        .then(
+            literal("reset")
+                .then(
+                    literal("*")
+                        .execute(ResetExecutor {
+                            target: ResetTarget::All,
+                        })
+                        .then(
+                            argument(ARG_SEED, seed_consumer())
+                                .execute(ResetExecutor {
+                                    target: ResetTarget::All,
+                                })
+                                .then(
+                                    argument(ARG_INCLUDE_WORLD_SEED, BoolArgConsumer)
+                                        .execute(ResetExecutor {
+                                            target: ResetTarget::All,
+                                        })
+                                        .then(
+                                            argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgConsumer)
+                                                .execute(ResetExecutor {
+                                                    target: ResetTarget::All,
+                                                }),
+                                        ),
+                                ),
+                        ),
+                )
+                .then(
+                    argument(ARG_SEQUENCE, SequenceArgumentConsumer)
+                        .execute(ResetExecutor {
+                            target: ResetTarget::Sequence,
+                        })
+                        .then(
+                            argument(ARG_SEED, seed_consumer())
+                                .execute(ResetExecutor {
+                                    target: ResetTarget::Sequence,
+                                })
+                                .then(
+                                    argument(ARG_INCLUDE_WORLD_SEED, BoolArgConsumer)
+                                        .execute(ResetExecutor {
+                                            target: ResetTarget::Sequence,
+                                        })
+                                        .then(
+                                            argument(ARG_INCLUDE_SEQUENCE_ID, BoolArgConsumer)
+                                                .execute(ResetExecutor {
+                                                    target: ResetTarget::Sequence,
+                                                }),
+                                        ),
+                                ),
+                        ),
+                ),
+        )
+}
+
+#[cfg(test)]
+mod test {
+    use super::{
+        CommandError, InclusiveRange, SequenceParameters, derive_sequence_seed,
+        validate_sequence_name,
+    };
+    use crate::command::{errors::error_types, tree::RawArg};
+
+    #[test]
+    fn parse_valid_closed_range() {
+        let range = InclusiveRange::parse("1..10").expect("range should parse");
+        assert_eq!(range.min, 1);
+        assert_eq!(range.max, 10);
+    }
+
+    #[test]
+    fn parse_valid_open_lower_bound_range() {
+        let range = InclusiveRange::parse("..-2147483647").expect("range should parse");
+        assert_eq!(range.min, i32::MIN);
+        assert_eq!(range.max, -2_147_483_647);
+    }
+
+    #[test]
+    fn parse_valid_open_upper_bound_range() {
+        let range = InclusiveRange::parse("2147483646..").expect("range should parse");
+        assert_eq!(range.min, 2_147_483_646);
+        assert_eq!(range.max, i32::MAX);
+    }
+
+    #[test]
+    fn reject_single_value_range() {
+        assert!(matches!(
+            InclusiveRange::parse("5"),
+            Err(CommandError::CommandFailed(_))
+        ));
+    }
+
+    #[test]
+    fn reject_reversed_range() {
+        assert!(matches!(
+            InclusiveRange::parse("10..1"),
+            Err(CommandError::CommandFailed(_))
+        ));
+    }
+
+    #[test]
+    fn reject_too_large_range_size() {
+        assert!(matches!(
+            InclusiveRange::parse("-2147483648..2147483647"),
+            Err(CommandError::CommandFailed(_))
+        ));
+    }
+
+    #[test]
+    fn derived_seed_depends_on_sequence_id_when_enabled() {
+        let params = SequenceParameters {
+            seed: 123,
+            include_world_seed: false,
+            include_sequence_id: true,
+        };
+        assert_ne!(
+            derive_sequence_seed(params, 0, "pumpkin:first"),
+            derive_sequence_seed(params, 0, "pumpkin:second")
+        );
+    }
+
+    #[test]
+    fn derived_seed_ignores_sequence_id_when_disabled() {
+        let params = SequenceParameters {
+            seed: 123,
+            include_world_seed: false,
+            include_sequence_id: false,
+        };
+        assert_eq!(
+            derive_sequence_seed(params, 0, "pumpkin:first"),
+            derive_sequence_seed(params, 0, "pumpkin:second")
+        );
+    }
+
+    #[test]
+    fn sequence_name_allows_lowercase_namespaced_ids() {
+        let input = "random reset pumpkin:test/path_1";
+        let raw_arg = RawArg {
+            value: "pumpkin:test/path_1",
+            start: 13,
+            end: input.len(),
+            input,
+        };
+
+        assert_eq!(
+            validate_sequence_name(raw_arg).expect("name should be valid"),
+            "pumpkin:test/path_1"
+        );
+    }
+
+    #[test]
+    fn sequence_name_rejects_uppercase_with_precise_cursor() {
+        let input = "random reset seqA 111 true true";
+        let raw_arg = RawArg {
+            value: "seqA",
+            start: 13,
+            end: 17,
+            input,
+        };
+
+        let error = validate_sequence_name(raw_arg).expect_err("name should be rejected");
+        assert!(error.is(&error_types::DISPATCHER_EXPECTED_ARGUMENT_SEPARATOR));
+        assert_eq!(
+            error
+                .context
+                .expect("syntax error should have context")
+                .cursor,
+            16
+        );
+    }
+}

--- a/pumpkin/src/command/commands/random.rs
+++ b/pumpkin/src/command/commands/random.rs
@@ -56,7 +56,7 @@ impl GetClientSideArgParser for SequenceArgumentConsumer {
     }
 }
 
-fn is_valid_namespaced_id_char(c: char) -> bool {
+const fn is_valid_namespaced_id_char(c: char) -> bool {
     matches!(c, 'a'..='z' | '0'..='9' | '_' | '-' | '.' | '/' | ':')
 }
 

--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -269,7 +269,7 @@ impl CommandDispatcher {
         let Some(key) = parts.next() else {
             return Vec::new();
         };
-        let mut raw_args: RawArgs<'a> = parts
+        let raw_args: RawArgs<'a> = parts
             .rev()
             .map(|value| RawArg {
                 value,
@@ -288,8 +288,16 @@ impl CommandDispatcher {
         // try paths and collect the nodes that fail
         // todo: make this more fine-grained
         for path in tree.iter_paths() {
-            match Self::try_find_suggestions_on_path(src, server, &path, tree, &mut raw_args, cmd)
-                .await
+            let mut path_raw_args = raw_args.clone();
+            match Self::try_find_suggestions_on_path(
+                src,
+                server,
+                &path,
+                tree,
+                &mut path_raw_args,
+                cmd,
+            )
+            .await
             {
                 Err(InvalidConsumption(s)) => {
                     debug!(

--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -269,7 +269,7 @@ impl CommandDispatcher {
         let Some(key) = parts.next() else {
             return Vec::new();
         };
-        let raw_args: RawArgs<'a> = parts
+        let mut raw_args: RawArgs<'a> = parts
             .rev()
             .map(|value| RawArg {
                 value,
@@ -288,16 +288,8 @@ impl CommandDispatcher {
         // try paths and collect the nodes that fail
         // todo: make this more fine-grained
         for path in tree.iter_paths() {
-            let mut path_raw_args = raw_args.clone();
-            match Self::try_find_suggestions_on_path(
-                src,
-                server,
-                &path,
-                tree,
-                &mut path_raw_args,
-                cmd,
-            )
-            .await
+            match Self::try_find_suggestions_on_path(src, server, &path, tree, &mut raw_args, cmd)
+                .await
             {
                 Err(InvalidConsumption(s)) => {
                     debug!(


### PR DESCRIPTION
## Description
Implements the vanilla `/random` command.

**Supported syntax:**
- `/random value <range>` - result visible only to sender
- `/random roll <range>` - result broadcast to all players
- `/random value <range> <sequence>` - sample from named sequence
- `/random roll <range> <sequence>` - same with broadcast
- `/random reset <sequence> [seed] [includeWorldSeed] [includeSequenceId]`
- `/random reset *` - reset all sequences

**Implementation notes:**
- Sequence names validated as namespaced IDs (lowercase only), 
  error position matches vanilla behavior.
- Tab completion suggests existing sequence names
- Sequences persisted in level.dat via RandomSequence in LevelData
  (same pattern as GameRules - vanilla uses separate random_sequences.dat,
  can be migrated in follow-up PR once world/data/ infrastructure exists)
- xoroshiro128 RNG for deterministic sequence generation.

## Testing
- Valid/invalid range inputs tested manually in-game
- Sequence reset + deterministic replay verified.
- `cargo fmt`, `cargo clippy`, `cargo test` - all pass.