### PR TITLE
feat(command): add suggestion providers and their support in argument nodes and fix `list_suggestions` method

### DIFF
--- a/pumpkin/src/command/argument_builder.rs
+++ b/pumpkin/src/command/argument_builder.rs
@@ -6,6 +6,7 @@ use crate::command::node::detached::{
 use crate::command::node::{
     Command, CommandExecutor, RedirectModifier, Redirection, Requirement, Requirements,
 };
+use crate::command::suggestion::provider::SuggestionProvider;
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -119,6 +120,7 @@ pub struct RequiredArgumentBuilder {
     common: CommonArgumentBuilder,
     name: Cow<'static, str>,
     argument_type: Arc<dyn AnyArgumentType>,
+    suggestion_provider: Option<Arc<dyn SuggestionProvider>>,
 }
 
 mod private {
@@ -356,7 +358,21 @@ impl RequiredArgumentBuilder {
             common: CommonArgumentBuilder::new(),
             name: name.into(),
             argument_type: Arc::new(arg_type),
+            suggestion_provider: None,
         }
+    }
+
+    /// Sets the [`SuggestionProvider`] of this builder for the `ArgumentDetachedNode`.
+    #[must_use]
+    pub fn suggest(self, provider: impl SuggestionProvider + 'static) -> Self {
+        self.suggest_arc(Arc::new(provider))
+    }
+
+    /// Sets the [`SuggestionProvider`] of this builder for the `ArgumentDetachedNode`.
+    #[must_use]
+    pub fn suggest_arc(mut self, provider: Arc<dyn SuggestionProvider>) -> Self {
+        self.suggestion_provider = Some(provider);
+        self
     }
 }
 
@@ -410,6 +426,7 @@ impl ArgumentBuilder<ArgumentDetachedNode> for RequiredArgumentBuilder {
             self.common.target,
             self.common.modifier,
             self.common.forks,
+            self.suggestion_provider,
         );
         node.children = self.common.arguments;
         node

--- a/pumpkin/src/command/argument_builder.rs
+++ b/pumpkin/src/command/argument_builder.rs
@@ -364,13 +364,13 @@ impl RequiredArgumentBuilder {
 
     /// Sets the [`SuggestionProvider`] of this builder for the `ArgumentDetachedNode`.
     #[must_use]
-    pub fn suggest(self, provider: impl SuggestionProvider + 'static) -> Self {
-        self.suggest_arc(Arc::new(provider))
+    pub fn suggests(self, provider: impl SuggestionProvider + 'static) -> Self {
+        self.suggests_arc(Arc::new(provider))
     }
 
     /// Sets the [`SuggestionProvider`] of this builder for the `ArgumentDetachedNode`.
     #[must_use]
-    pub fn suggest_arc(mut self, provider: Arc<dyn SuggestionProvider>) -> Self {
+    pub fn suggests_arc(mut self, provider: Arc<dyn SuggestionProvider>) -> Self {
         self.suggestion_provider = Some(provider);
         self
     }

--- a/pumpkin/src/command/argument_types/argument_type.rs
+++ b/pumpkin/src/command/argument_types/argument_type.rs
@@ -42,7 +42,7 @@ pub trait ArgumentType: Send + Sync {
     fn list_suggestions(
         &self,
         _context: &CommandContext,
-        _suggestions_builder: &mut SuggestionsBuilder,
+        _suggestions_builder: SuggestionsBuilder,
     ) -> Pin<Box<dyn Future<Output = Suggestions> + Send>> {
         Box::pin(async move { Suggestions::empty() })
     }
@@ -102,7 +102,7 @@ pub trait AnyArgumentType: Sealed + Send + Sync {
     fn list_suggestions(
         &self,
         context: &CommandContext,
-        suggestions_builder: &mut SuggestionsBuilder,
+        suggestions_builder: SuggestionsBuilder,
     ) -> Pin<Box<dyn Future<Output = Suggestions> + Send>>;
 
     /// Returns the Java client-side parser used for this argument type.
@@ -154,7 +154,7 @@ impl<U: ArgumentType<Item = T>, T: Send + Sync + 'static> AnyArgumentType for U 
     fn list_suggestions(
         &self,
         context: &CommandContext,
-        suggestions_builder: &mut SuggestionsBuilder,
+        suggestions_builder: SuggestionsBuilder,
     ) -> Pin<Box<dyn Future<Output = Suggestions> + Send>> {
         self.list_suggestions(context, suggestions_builder)
     }

--- a/pumpkin/src/command/client_suggestions.rs
+++ b/pumpkin/src/command/client_suggestions.rs
@@ -1,9 +1,3 @@
-use pumpkin_protocol::{
-    codec::var_int::VarInt,
-    java::client::play::{CCommands, ProtoNode, ProtoNodeType},
-};
-use std::sync::Arc;
-use pumpkin_protocol::java::client::play::SuggestionProviders;
 use super::tree::{Node, NodeType};
 use crate::server::Server;
 use crate::{
@@ -14,6 +8,12 @@ use crate::{
     },
     entity::player::Player,
 };
+use pumpkin_protocol::java::client::play::SuggestionProviders;
+use pumpkin_protocol::{
+    codec::var_int::VarInt,
+    java::client::play::{CCommands, ProtoNode, ProtoNodeType},
+};
+use std::sync::Arc;
 
 #[expect(clippy::too_many_lines)]
 pub async fn send_c_commands_packet(
@@ -151,7 +151,11 @@ pub async fn send_c_commands_packet(
                         name: &argument_attached_node.meta.name,
                         is_executable: argument_attached_node.owned.command.is_some(),
                         parser: arg_type.client_side_parser(),
-                        override_suggestion_type: if argument_attached_node.meta.suggestion_provider.is_some() {
+                        override_suggestion_type: if argument_attached_node
+                            .meta
+                            .suggestion_provider
+                            .is_some()
+                        {
                             Some(SuggestionProviders::AskServer)
                         } else {
                             arg_type.override_suggestion_providers()

--- a/pumpkin/src/command/client_suggestions.rs
+++ b/pumpkin/src/command/client_suggestions.rs
@@ -3,7 +3,7 @@ use pumpkin_protocol::{
     java::client::play::{CCommands, ProtoNode, ProtoNodeType},
 };
 use std::sync::Arc;
-
+use pumpkin_protocol::java::client::play::SuggestionProviders;
 use super::tree::{Node, NodeType};
 use crate::server::Server;
 use crate::{
@@ -151,7 +151,11 @@ pub async fn send_c_commands_packet(
                         name: &argument_attached_node.meta.name,
                         is_executable: argument_attached_node.owned.command.is_some(),
                         parser: arg_type.client_side_parser(),
-                        override_suggestion_type: arg_type.override_suggestion_providers(),
+                        override_suggestion_type: if argument_attached_node.meta.suggestion_provider.is_some() {
+                            Some(SuggestionProviders::AskServer)
+                        } else {
+                            arg_type.override_suggestion_providers()
+                        },
                         redirect_target,
                         restricted: !satisfies_requirements,
                     },

--- a/pumpkin/src/command/node/detached.rs
+++ b/pumpkin/src/command/node/detached.rs
@@ -3,6 +3,7 @@ use crate::command::node::{
     ArgumentNodeMetadata, Command, CommandNodeMetadata, LiteralNodeMetadata, NodeMetadata,
     OwnedNodeData, RedirectModifier, Redirection, Requirements,
 };
+use crate::command::suggestion::provider::SuggestionProvider;
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::num::NonZero;
@@ -150,6 +151,7 @@ impl ArgumentDetachedNode {
         redirect: Option<Redirection>,
         modifier: RedirectModifier,
         forks: bool,
+        suggestion_provider: Option<Arc<dyn SuggestionProvider>>,
     ) -> Self {
         Self {
             owned: OwnedNodeData {
@@ -161,7 +163,7 @@ impl ArgumentDetachedNode {
             },
             children: FxHashMap::default(),
             redirect,
-            meta: ArgumentNodeMetadata::new(name, argument_type),
+            meta: ArgumentNodeMetadata::new(name, argument_type, suggestion_provider),
         }
     }
 }

--- a/pumpkin/src/command/node/dispatcher.rs
+++ b/pumpkin/src/command/node/dispatcher.rs
@@ -490,6 +490,7 @@ impl CommandDispatcher {
         let mut futures = Vec::with_capacity(capacity);
 
         let context = context.build(truncated_input);
+        let mut provided_suggestions = Vec::new();
 
         for child in children {
             let mut builder = SuggestionsBuilder::new(truncated_input, start);
@@ -526,7 +527,7 @@ impl CommandDispatcher {
                         if let Some(provider) = &node.meta.suggestion_provider {
                             // For custom suggestions sent by the server, we simply
                             // wait instead of adding the future to join.
-                            provider.suggest(&context, builder).await;
+                            provided_suggestions.push(provider.suggest(&context, builder).await);
                             None
                         } else {
                             Some(
@@ -543,7 +544,8 @@ impl CommandDispatcher {
             }
         }
 
-        let suggestions = future::join_all(futures).await;
+        let mut suggestions = future::join_all(futures).await;
+        suggestions.append(&mut provided_suggestions);
         Suggestions::merge(full_input, suggestions)
     }
 

--- a/pumpkin/src/command/node/dispatcher.rs
+++ b/pumpkin/src/command/node/dispatcher.rs
@@ -493,7 +493,7 @@ impl CommandDispatcher {
         let mut provided_suggestions = Vec::new();
 
         for child in children {
-            let mut builder = SuggestionsBuilder::new(truncated_input, start);
+            let builder = SuggestionsBuilder::new(truncated_input, start);
 
             let future: Option<Pin<Box<dyn Future<Output = Suggestions> + Send>>> =
                 match self.tree.classify_id(child) {
@@ -530,11 +530,7 @@ impl CommandDispatcher {
                             provided_suggestions.push(provider.suggest(&context, builder).await);
                             None
                         } else {
-                            Some(
-                                node.meta
-                                    .argument_type
-                                    .list_suggestions(&context, &mut builder),
-                            )
+                            Some(node.meta.argument_type.list_suggestions(&context, builder))
                         }
                     }
                 };

--- a/pumpkin/src/command/node/dispatcher.rs
+++ b/pumpkin/src/command/node/dispatcher.rs
@@ -494,10 +494,10 @@ impl CommandDispatcher {
         for child in children {
             let mut builder = SuggestionsBuilder::new(truncated_input, start);
 
-            let future: Pin<Box<dyn Future<Output = Suggestions> + Send>> =
+            let future: Option<Pin<Box<dyn Future<Output = Suggestions> + Send>>> =
                 match self.tree.classify_id(child) {
-                    NodeIdClassification::Root => Box::pin(async { Suggestions::empty() }),
-                    NodeIdClassification::Literal(literal_node_id) => Box::pin(async move {
+                    NodeIdClassification::Root => Some(Box::pin(async { Suggestions::empty() })),
+                    NodeIdClassification::Literal(literal_node_id) => Some(Box::pin(async move {
                         let node = &self.tree[literal_node_id];
                         if node
                             .meta
@@ -508,8 +508,8 @@ impl CommandDispatcher {
                         } else {
                             Suggestions::empty()
                         }
-                    }),
-                    NodeIdClassification::Command(command_node_id) => Box::pin(async move {
+                    })),
+                    NodeIdClassification::Command(command_node_id) => Some(Box::pin(async move {
                         let node = &self.tree[command_node_id];
                         if node
                             .meta
@@ -520,20 +520,27 @@ impl CommandDispatcher {
                         } else {
                             Suggestions::empty()
                         }
-                    }),
+                    })),
                     NodeIdClassification::Argument(argument_node_id) => {
                         let node = &self.tree[argument_node_id];
                         if let Some(provider) = &node.meta.suggestion_provider {
-                            provider.suggest(&context, builder)
+                            // For custom suggestions sent by the server, we simply
+                            // wait instead of adding the future to join.
+                            provider.suggest(&context, builder).await;
+                            None
                         } else {
-                            node.meta
-                                .argument_type
-                                .list_suggestions(&context, &mut builder)
+                            Some(
+                                node.meta
+                                    .argument_type
+                                    .list_suggestions(&context, &mut builder),
+                            )
                         }
                     }
                 };
 
-            futures.push(future);
+            if let Some(future) = future {
+                futures.push(future);
+            }
         }
 
         let suggestions = future::join_all(futures).await;

--- a/pumpkin/src/command/node/dispatcher.rs
+++ b/pumpkin/src/command/node/dispatcher.rs
@@ -523,9 +523,13 @@ impl CommandDispatcher {
                     }),
                     NodeIdClassification::Argument(argument_node_id) => {
                         let node = &self.tree[argument_node_id];
-                        node.meta
-                            .argument_type
-                            .list_suggestions(&context, &mut builder)
+                        if let Some(provider) = &node.meta.suggestion_provider {
+                            provider.suggest(&context, builder)
+                        } else {
+                            node.meta
+                                .argument_type
+                                .list_suggestions(&context, &mut builder)
+                        }
                     }
                 };
 

--- a/pumpkin/src/command/node/mod.rs
+++ b/pumpkin/src/command/node/mod.rs
@@ -9,6 +9,7 @@ use crate::command::context::command_source::CommandSource;
 use crate::command::errors::command_syntax_error::CommandSyntaxError;
 use crate::command::node::attached::NodeId;
 use crate::command::node::detached::GlobalNodeId;
+use crate::command::suggestion::provider::SuggestionProvider;
 use std::borrow::Cow;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -218,16 +219,19 @@ impl CommandNodeMetadata {
 pub struct ArgumentNodeMetadata {
     pub name: Cow<'static, str>,
     pub argument_type: Arc<dyn AnyArgumentType>,
+    pub suggestion_provider: Option<Arc<dyn SuggestionProvider>>,
 }
 
 impl ArgumentNodeMetadata {
     pub fn new(
         name: impl Into<Cow<'static, str>>,
         argument_type: Arc<dyn AnyArgumentType>,
+        suggestion_provider: Option<Arc<dyn SuggestionProvider>>,
     ) -> Self {
         Self {
             name: name.into(),
             argument_type,
+            suggestion_provider,
         }
     }
 }

--- a/pumpkin/src/command/suggestion/mod.rs
+++ b/pumpkin/src/command/suggestion/mod.rs
@@ -1,3 +1,4 @@
+pub mod provider;
 pub mod suggestions;
 
 use pumpkin_util::text::TextComponent;

--- a/pumpkin/src/command/suggestion/provider.rs
+++ b/pumpkin/src/command/suggestion/provider.rs
@@ -2,6 +2,7 @@ use crate::command::context::command_context::CommandContext;
 use crate::command::suggestion::suggestions::{Suggestions, SuggestionsBuilder};
 use std::pin::Pin;
 
+/// The [`Suggestions`] future given by a [`SuggestionProvider`].
 pub type SuggestionProviderResult<'a> = Pin<Box<dyn Future<Output = Suggestions> + Send + 'a>>;
 
 /// A trait allowing an object to provide suggestions using a

--- a/pumpkin/src/command/suggestion/provider.rs
+++ b/pumpkin/src/command/suggestion/provider.rs
@@ -1,0 +1,21 @@
+use crate::command::context::command_context::CommandContext;
+use crate::command::suggestion::suggestions::{Suggestions, SuggestionsBuilder};
+use std::pin::Pin;
+
+/// A trait allowing an object to provide suggestions using a
+/// [`CommandContext`] and [`SuggestionsBuilder`].
+pub trait SuggestionProvider: Send + Sync {
+    /// Uses a [`CommandContext`] and [`SuggestionsBuilder`] to suggest.
+    ///
+    /// # Arguments
+    /// - `context`: The context to use for building the suggestions.
+    /// - `builder`: The builder to consume for the suggestions.
+    ///
+    /// # Returns
+    /// The [`Suggestions`] representing the suggested items.
+    fn suggest(
+        &self,
+        context: &CommandContext,
+        builder: SuggestionsBuilder,
+    ) -> Pin<Box<dyn Future<Output = Suggestions> + Send>>;
+}

--- a/pumpkin/src/command/suggestion/provider.rs
+++ b/pumpkin/src/command/suggestion/provider.rs
@@ -2,6 +2,8 @@ use crate::command::context::command_context::CommandContext;
 use crate::command::suggestion::suggestions::{Suggestions, SuggestionsBuilder};
 use std::pin::Pin;
 
+pub type SuggestionProviderResult<'a> = Pin<Box<dyn Future<Output = Suggestions> + Send + 'a>>;
+
 /// A trait allowing an object to provide suggestions using a
 /// [`CommandContext`] and [`SuggestionsBuilder`].
 pub trait SuggestionProvider: Send + Sync {
@@ -13,9 +15,9 @@ pub trait SuggestionProvider: Send + Sync {
     ///
     /// # Returns
     /// The [`Suggestions`] representing the suggested items.
-    fn suggest(
-        &self,
-        context: &CommandContext,
+    fn suggest<'a>(
+        &'a self,
+        context: &'a CommandContext,
         builder: SuggestionsBuilder,
-    ) -> Pin<Box<dyn Future<Output = Suggestions> + Send>>;
+    ) -> SuggestionProviderResult<'a>;
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This PR adds `SuggestionProvider`s for specific arguments that may require them.
- The `suggests` and `suggests_arc` methods can be used on an argument node to add a custom `SuggestionProvider` for it. This is used quite a lot: some commands that use this include `/op`, `/execute`, `/bossbar`, `/scoreboard` and `/tick`.
- Added support for it in the command dispatcher.
- Fixed the `list_suggestions` method to take a `SuggestionBuilder` rather than a *mutable reference* to one

## Testing

- Tested (locally) adding custom suggestions `1` to `5` for the integer argument of `/setidletimeout`, and it works for the server and the client!