### PR TITLE
fix(networking): add login timeout for java and bedrock

### DIFF
--- a/pumpkin-config/src/networking/mod.rs
+++ b/pumpkin-config/src/networking/mod.rs
@@ -17,8 +17,12 @@ pub mod rcon;
 ///
 /// Covers authentication, query, RCON, proxying, packet compression,
 /// and LAN broadcast behaviour.
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize)]
+#[serde(default)]
 pub struct NetworkingConfig {
+    /// Maximum time, in milliseconds, that a client may remain in the login/configuration flow
+    /// before being disconnected. Set to `0` to disable this timeout.
+    pub login_timeout: u32,
     /// Authentication settings for client connections.
     pub authentication: AuthenticationConfig,
     /// Query protocol settings for server status requests.
@@ -31,4 +35,39 @@ pub struct NetworkingConfig {
     pub packet_compression: CompressionConfig,
     /// LAN broadcast settings.
     pub lan_broadcast: LANBroadcastConfig,
+}
+
+const fn default_login_timeout() -> u32 {
+    30_000
+}
+
+impl Default for NetworkingConfig {
+    fn default() -> Self {
+        Self {
+            login_timeout: default_login_timeout(),
+            authentication: AuthenticationConfig::default(),
+            query: QueryConfig::default(),
+            rcon: RCONConfig::default(),
+            proxy: ProxyConfig::default(),
+            packet_compression: CompressionConfig::default(),
+            lan_broadcast: LANBroadcastConfig::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NetworkingConfig;
+
+    #[test]
+    fn login_timeout_defaults_to_30_seconds() {
+        assert_eq!(NetworkingConfig::default().login_timeout, 30_000);
+    }
+
+    #[test]
+    fn login_timeout_is_filled_by_serde_default() {
+        let config: NetworkingConfig = toml::from_str("").expect("valid empty config");
+
+        assert_eq!(config.login_timeout, 30_000);
+    }
 }

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -28,7 +28,7 @@ use std::{net::SocketAddr, sync::LazyLock};
 use tokio::net::{TcpListener, UdpSocket};
 use tokio::select;
 use tokio::sync::Mutex;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info, warn};
@@ -442,40 +442,54 @@ impl PumpkinServer {
                         };
                         debug!("Accepted connection from Java Edition: {formatted_address} (id {client_id})");
                         let server_clone = self.server.clone();
+                        let login_timeout = server_clone.advanced_config.networking.login_timeout;
 
                         tasks.spawn(async move {
                             let mut java_client = JavaClient::new(connection, client_addr, client_id);
                             java_client.start_outgoing_packet_task();
-                            let login_result = java_client.handle_login_sequence(&server_clone).await;
+                            let login_result = if login_timeout == 0 {
+                                Ok(java_client.handle_login_sequence(&server_clone).await)
+                            } else {
+                                timeout(
+                                    Duration::from_millis(u64::from(login_timeout)),
+                                    java_client.handle_login_sequence(&server_clone),
+                                )
+                                .await
+                            };
 
                             match login_result {
-                                PacketHandlerResult::Stop => {
-                                     java_client.close();
-                                     java_client.await_tasks().await;
-                                },
-                                PacketHandlerResult::ReadyToPlay(profile,config) => {
-                                     if let Some((player, world)) = server_clone
-                                     .add_player(ClientPlatform::Java(java_client), profile, Some(config))
-                                          .await
-                                {
-                                    world
-                                        .spawn_java_player(&server_clone.basic_config, &player, &server_clone)
-                                        .await;
-                                    if let ClientPlatform::Java(client) = &player.client {
-                                        client.progress_player_packets(&player, &server_clone).await;
-                                        // Close when done
-                                        client.close();
-                                        client.await_tasks().await;
-                                    }
-                                    player.remove().await;
-                                    server_clone.remove_player(&player).await;
-                                    if let Err(e) = server_clone.player_data_storage
-                                        .handle_player_leave(&player)
-                                        .await {
+                                Ok(PacketHandlerResult::Stop) => {
+                                    java_client.close();
+                                    java_client.await_tasks().await;
+                                }
+                                Ok(PacketHandlerResult::ReadyToPlay(profile, config)) => {
+                                    if let Some((player, world)) = server_clone
+                                        .add_player(ClientPlatform::Java(java_client), profile, Some(config))
+                                        .await
+                                    {
+                                        world
+                                            .spawn_java_player(&server_clone.basic_config, &player, &server_clone)
+                                            .await;
+                                        if let ClientPlatform::Java(client) = &player.client {
+                                            client.progress_player_packets(&player, &server_clone).await;
+                                            // Close when done
+                                            client.close();
+                                            client.await_tasks().await;
+                                        }
+                                        player.remove().await;
+                                        server_clone.remove_player(&player).await;
+                                        if let Err(e) = server_clone.player_data_storage
+                                            .handle_player_leave(&player)
+                                            .await
+                                        {
                                             error!("Failed to save player data on disconnect: {e}");
                                         }
                                     }
-                                },
+                                }
+                                Err(_) => {
+                                    java_client.kick(TextComponent::text("Login timed out")).await;
+                                    java_client.await_tasks().await;
+                                }
                             }
                         });
                     }
@@ -510,15 +524,33 @@ impl PumpkinServer {
                                     });
                                 } else if let Ok(packet) = BedrockClient::is_connection_request(&mut Cursor::new(&udp_buf[4..len])) {
                                     *master_client_id_counter += 1;
+                                    let login_timeout = self.server.advanced_config.networking.login_timeout;
 
                                     let mut platform = BedrockClient::new(self.udp_socket.clone().unwrap(), client_addr, be_clients);
                                     platform.handle_connection_request(packet).await;
                                     platform.start_outgoing_packet_task();
 
-                                    clients_guard.insert(client_addr,
-                                    Arc::new(
-                                        platform
-                                    ));
+                                    let platform = Arc::new(platform);
+
+                                    if login_timeout > 0 {
+                                        let platform_clone = platform.clone();
+                                        platform.spawn_task(async move {
+                                            sleep(Duration::from_millis(u64::from(login_timeout))).await;
+
+                                            if !platform_clone.is_closed()
+                                                && platform_clone.player.lock().await.is_none()
+                                            {
+                                                platform_clone
+                                                    .kick(
+                                                        DisconnectReason::Timeout,
+                                                        "Login timed out".to_string(),
+                                                    )
+                                                    .await;
+                                            }
+                                        });
+                                    }
+
+                                    clients_guard.insert(client_addr, platform);
                                 }
                             } else {
                                 // Please keep the function as simple as possible!

--- a/pumpkin/src/net/authentication.rs
+++ b/pumpkin/src/net/authentication.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::IpAddr};
+use std::{collections::HashMap, net::IpAddr, time::Duration};
 
 use base64::{Engine, engine::general_purpose};
 use pumpkin_config::{AuthenticationConfig, networking::auth::TextureConfig};
@@ -7,6 +7,7 @@ use rsa::RsaPublicKey;
 use rsa::pkcs8::DecodePublicKey;
 use serde::Deserialize;
 use thiserror::Error;
+use ureq::Agent;
 use ureq::http::{StatusCode, Uri};
 use uuid::Uuid;
 
@@ -50,6 +51,21 @@ const MOJANG_SERVICES_URL: &str = "https://api.minecraftservices.com/";
 const MOJANG_PROFILE_BY_NAME_URL: &str =
     "https://api.mojang.com/users/profiles/minecraft/{username}";
 
+fn build_auth_agent(auth_config: &AuthenticationConfig) -> Agent {
+    Agent::config_builder()
+        .timeout_connect(Some(Duration::from_millis(u64::from(
+            auth_config.connect_timeout,
+        ))))
+        .timeout_recv_response(Some(Duration::from_millis(u64::from(
+            auth_config.read_timeout,
+        ))))
+        .timeout_recv_body(Some(Duration::from_millis(u64::from(
+            auth_config.read_timeout,
+        ))))
+        .build()
+        .into()
+}
+
 /// Sends a GET request to Mojang's authentication servers to verify a client's Minecraft account.
 ///
 /// **Purpose:**
@@ -90,7 +106,10 @@ pub fn authenticate(
             .replace("{server_hash}", server_hash)
     };
 
-    let mut response = ureq::get(address)
+    let agent = build_auth_agent(auth_config);
+
+    let mut response = agent
+        .get(address)
         .call()
         .map_err(|_| AuthError::FailedResponse)?;
     match response.status() {
@@ -152,7 +171,10 @@ pub fn fetch_mojang_public_keys(
 
     let url = format!("{services_url}/publickeys");
 
-    let mut response = ureq::get(url)
+    let agent = build_auth_agent(auth_config);
+
+    let mut response = agent
+        .get(url)
         .call()
         .map_err(|_| AuthError::FailedResponse)?;
 
@@ -189,11 +211,14 @@ struct MojangProfileByNameResponse {
 
 pub fn lookup_profile_by_name(
     name: &str,
-    _auth_config: &AuthenticationConfig,
+    auth_config: &AuthenticationConfig,
 ) -> Result<Option<(Uuid, String)>, AuthError> {
     let url = MOJANG_PROFILE_BY_NAME_URL.replace("{username}", name);
 
-    let mut response = ureq::get(url)
+    let agent = build_auth_agent(auth_config);
+
+    let mut response = agent
+        .get(url)
         .call()
         .map_err(|_| AuthError::FailedResponse)?;
 


### PR DESCRIPTION
- add a shared `networking.login_timeout` setting for login/configuration flows
- disconnect Java and Bedrock clients that remain stuck before entering play
- apply existing auth connect/read timeouts to Mojang HTTP calls so login auth cannot hang indefinitely
