### PR TITLE
fix: add panic location to crash reports

### DIFF
--- a/pumpkin/src/crash.rs
+++ b/pumpkin/src/crash.rs
@@ -178,6 +178,11 @@ impl CrashReport {
             "Message: {}",
             self.payload.as_deref().unwrap_or("<unknown>")
         );
+
+        if let Some(panic_location) = &self.panic_location {
+            writeln_output!(&mut output, "Panic Location: {}", panic_location);
+        }
+
         writeln_output!(&mut output);
         writeln_output!(&mut output, "--- Panicking Thread ---");
         writeln_output!(&mut output, "ID: {:?}", self.thread.id());


### PR DESCRIPTION
## Description

While making the crash reports PR (#1790), it looks like I forgot to put the panic location in the generated crash report file itself, even though it is printed on the console.
As this is a very key detail to diagnosing a crash, I have created this PR to add it near the top of the file:

## Testing
<img width="466" height="85" alt="Screenshot_20260415_130305" src="https://github.com/user-attachments/assets/f23e3d12-972a-43f3-894b-47481d5998c6" />

As observed in the above screenshot, it has now been added.
(Don't mind the `stop.rs` panic location, I just added a `panic!()` macro call in it for testing. That's not included in the PR.)