### PR TITLE
feat(command): add entity anchor and rotation argument types

### DIFF
--- a/pumpkin/src/command/argument_types/coordinates/mod.rs
+++ b/pumpkin/src/command/argument_types/coordinates/mod.rs
@@ -9,6 +9,7 @@ use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::math::vector3::{Axis, Vector3};
 
 pub mod block_pos;
+pub mod rotation;
 pub mod vec3;
 
 pub const MIXED_TYPE_ERROR_TYPE: CommandErrorType<0> =
@@ -188,6 +189,24 @@ impl Coordinates {
                 let start = source.entity_anchor.position_at_source(source);
                 convert_local_coordinates(*left, *up, *forward, source.rotation).add(&start)
             }
+        }
+    }
+
+    /// Returns the rotation, as a [`Vector2`], that these [`Coordinates`] represent.
+    ///
+    /// - The returned *x*-component of the vector is the **pitch**.
+    /// - The returned *y*-component of the vector is the **yaw**.
+    #[must_use]
+    pub const fn rotation(&self, source: &CommandSource) -> Vector2<f32> {
+        match self {
+            Self::World(coords) => {
+                let rotation = source.rotation;
+                Vector2::new(
+                    coords.x.resolve(rotation.x as f64) as f32,
+                    coords.y.resolve(rotation.y as f64) as f32,
+                )
+            }
+            Self::Local { .. } => Vector2::new(0.0, 0.0),
         }
     }
 

--- a/pumpkin/src/command/argument_types/coordinates/rotation.rs
+++ b/pumpkin/src/command/argument_types/coordinates/rotation.rs
@@ -19,7 +19,7 @@ impl ArgumentType for RotationArgumentType {
         let i = reader.cursor();
         if reader.can_read_char() {
             let y = Coordinates::parse_world_single(i, reader, false)?;
-            if reader.peek() == Some('_') {
+            if reader.peek() == Some(' ') {
                 reader.skip();
                 let x = Coordinates::parse_world_single(i, reader, false)?;
                 Ok(Coordinates::World(Vector3::new(

--- a/pumpkin/src/command/argument_types/coordinates/rotation.rs
+++ b/pumpkin/src/command/argument_types/coordinates/rotation.rs
@@ -50,17 +50,19 @@ impl RotationArgumentType {
         NOT_COMPLETE_ERROR_TYPE.create(reader)
     }
 
-    /// Returns the rotation of a parsed rotation argument.
+    /// Returns the [`Coordinates`] representing the rotation of a parsed rotation argument.
+    ///
+    /// Use [`Coordinates::rotation`] to resolve the coordinates to a rotation [`Vector2`].
     ///
     /// If the rotation is successfully provided in an `Ok`:
-    /// - The returned *x*-component of the vector is the **pitch**.
-    /// - The returned *y*-component of the vector is the **yaw**.
+    /// - The returned *x*-coordinate of the coordinates is the absolute/relative **pitch**.
+    /// - The returned *y*-coordinate of the coordinates is the absolute/relative **yaw**.
+    /// - The returned *z*-coordinate of the coordinates is always 0.
     pub fn get_rotation(
         context: &CommandContext,
         name: &str,
-    ) -> Result<Vector2<f32>, CommandSyntaxError> {
+    ) -> Result<Coordinates, CommandSyntaxError> {
         context
-            .get_argument::<Coordinates>(name)
-            .map(|c| c.rotation(context.source.as_ref()))
+            .get_argument::<Coordinates>(name).copied()
     }
 }

--- a/pumpkin/src/command/argument_types/coordinates/rotation.rs
+++ b/pumpkin/src/command/argument_types/coordinates/rotation.rs
@@ -18,16 +18,17 @@ impl ArgumentType for RotationArgumentType {
     fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
         let i = reader.cursor();
         if reader.can_read_char() {
-            let y = Coordinates::parse_world_single(i, reader, false)?;
+            let y = WorldCoordinate::parse(reader, false)?;
             if reader.peek() == Some(' ') {
                 reader.skip();
-                let x = Coordinates::parse_world_single(i, reader, false)?;
+                let x = WorldCoordinate::parse(reader, false)?;
                 Ok(Coordinates::World(Vector3::new(
                     x,
                     y,
                     WorldCoordinate::Relative(0.0),
                 )))
             } else {
+                reader.set_cursor(i);
                 Err(Self::syntax_error(reader))
             }
         } else {

--- a/pumpkin/src/command/argument_types/coordinates/rotation.rs
+++ b/pumpkin/src/command/argument_types/coordinates/rotation.rs
@@ -57,11 +57,7 @@ impl RotationArgumentType {
     /// - The returned *x*-coordinate of the coordinates is the absolute/relative **pitch**.
     /// - The returned *y*-coordinate of the coordinates is the absolute/relative **yaw**.
     /// - The returned *z*-coordinate of the coordinates is always 0.
-    pub fn get(
-        context: &CommandContext,
-        name: &str,
-    ) -> Result<Coordinates, CommandSyntaxError> {
-        context
-            .get_argument::<Coordinates>(name).copied()
+    pub fn get(context: &CommandContext, name: &str) -> Result<Coordinates, CommandSyntaxError> {
+        context.get_argument::<Coordinates>(name).copied()
     }
 }

--- a/pumpkin/src/command/argument_types/coordinates/rotation.rs
+++ b/pumpkin/src/command/argument_types/coordinates/rotation.rs
@@ -5,7 +5,6 @@ use crate::command::errors::command_syntax_error::CommandSyntaxError;
 use crate::command::errors::error_types::CommandErrorType;
 use crate::command::string_reader::StringReader;
 use pumpkin_data::translation;
-use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::math::vector3::Vector3;
 
 pub const NOT_COMPLETE_ERROR_TYPE: CommandErrorType<0> =

--- a/pumpkin/src/command/argument_types/coordinates/rotation.rs
+++ b/pumpkin/src/command/argument_types/coordinates/rotation.rs
@@ -1,0 +1,66 @@
+use crate::command::argument_types::argument_type::{ArgumentType, JavaClientArgumentType};
+use crate::command::argument_types::coordinates::{Coordinates, WorldCoordinate};
+use crate::command::context::command_context::CommandContext;
+use crate::command::errors::command_syntax_error::CommandSyntaxError;
+use crate::command::errors::error_types::CommandErrorType;
+use crate::command::string_reader::StringReader;
+use pumpkin_data::translation;
+use pumpkin_util::math::vector2::Vector2;
+use pumpkin_util::math::vector3::Vector3;
+
+pub const NOT_COMPLETE_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::ARGUMENT_ROTATION_INCOMPLETE);
+
+pub struct RotationArgumentType;
+
+impl ArgumentType for RotationArgumentType {
+    type Item = Coordinates;
+
+    fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
+        let i = reader.cursor();
+        if reader.can_read_char() {
+            let y = Coordinates::parse_world_single(i, reader, false)?;
+            if reader.peek() == Some('_') {
+                reader.skip();
+                let x = Coordinates::parse_world_single(i, reader, false)?;
+                Ok(Coordinates::World(Vector3::new(
+                    x,
+                    y,
+                    WorldCoordinate::Relative(0.0),
+                )))
+            } else {
+                Err(Self::syntax_error(reader))
+            }
+        } else {
+            Err(Self::syntax_error(reader))
+        }
+    }
+
+    fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
+        JavaClientArgumentType::Rotation
+    }
+
+    fn examples(&self) -> Vec<String> {
+        examples!("1 1", "~5 4", "~-6 ~-6")
+    }
+}
+
+impl RotationArgumentType {
+    fn syntax_error(reader: &StringReader) -> CommandSyntaxError {
+        NOT_COMPLETE_ERROR_TYPE.create(reader)
+    }
+
+    /// Returns the rotation of a parsed rotation argument.
+    ///
+    /// If the rotation is successfully provided in an `Ok`:
+    /// - The returned *x*-component of the vector is the **pitch**.
+    /// - The returned *y*-component of the vector is the **yaw**.
+    pub fn get_rotation(
+        context: &CommandContext,
+        name: &str,
+    ) -> Result<Vector2<f32>, CommandSyntaxError> {
+        context
+            .get_argument::<Coordinates>(name)
+            .map(|c| c.rotation(context.source.as_ref()))
+    }
+}

--- a/pumpkin/src/command/argument_types/coordinates/rotation.rs
+++ b/pumpkin/src/command/argument_types/coordinates/rotation.rs
@@ -58,7 +58,7 @@ impl RotationArgumentType {
     /// - The returned *x*-coordinate of the coordinates is the absolute/relative **pitch**.
     /// - The returned *y*-coordinate of the coordinates is the absolute/relative **yaw**.
     /// - The returned *z*-coordinate of the coordinates is always 0.
-    pub fn get_rotation(
+    pub fn get(
         context: &CommandContext,
         name: &str,
     ) -> Result<Coordinates, CommandSyntaxError> {

--- a/pumpkin/src/command/argument_types/entity_anchor.rs
+++ b/pumpkin/src/command/argument_types/entity_anchor.rs
@@ -1,0 +1,92 @@
+use crate::command::argument_types::argument_type::{ArgumentType, JavaClientArgumentType};
+use crate::command::context::command_source::CommandSource;
+use crate::command::errors::command_syntax_error::CommandSyntaxError;
+use crate::command::errors::error_types::CommandErrorType;
+use crate::command::string_reader::StringReader;
+use crate::entity::EntityBase;
+use pumpkin_data::translation;
+use pumpkin_util::math::vector3::Vector3;
+use pumpkin_util::text::TextComponent;
+use std::sync::Arc;
+
+pub const INVALID_ERROR_TYPE: CommandErrorType<1> =
+    CommandErrorType::new(translation::ARGUMENT_ANCHOR_INVALID);
+
+pub struct EntityAnchorArgumentType;
+
+impl ArgumentType for EntityAnchorArgumentType {
+    type Item = EntityAnchor;
+
+    fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
+        let i = reader.cursor();
+        let anchor = reader.read_unquoted_string()?;
+        EntityAnchor::from_id(anchor.as_str()).map_or_else(
+            || {
+                reader.set_cursor(i);
+                Err(INVALID_ERROR_TYPE.create(reader, TextComponent::text(anchor)))
+            },
+            Ok,
+        )
+    }
+
+    fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
+        JavaClientArgumentType::EntityAnchor
+    }
+
+    fn examples(&self) -> Vec<String> {
+        examples!("eyes", "feet")
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum EntityAnchor {
+    Feet,
+    Eyes,
+}
+
+impl EntityAnchor {
+    /// Gets the [`EntityAnchor`] whose identity is the ID provided.
+    #[must_use]
+    pub fn from_id(id: &str) -> Option<Self> {
+        match id {
+            "feet" => Some(Self::Feet),
+            "eyes" => Some(Self::Eyes),
+            _ => None,
+        }
+    }
+
+    /// Gets the ID of this [`EntityAnchor`]
+    #[must_use]
+    pub const fn id(self) -> &'static str {
+        match self {
+            Self::Feet => "feet",
+            Self::Eyes => "eyes",
+        }
+    }
+
+    fn transform_position(self, position: Vector3<f64>, entity: &dyn EntityBase) -> Vector3<f64> {
+        match self {
+            Self::Feet => position,
+            Self::Eyes => position.add(&Vector3::new(
+                0.0,
+                entity.get_entity().get_eye_height(),
+                0.0,
+            )),
+        }
+    }
+
+    /// Gets the position of an entity with respect to this anchor.
+    pub fn position_at_entity(self, entity: &Arc<dyn EntityBase>) -> Vector3<f64> {
+        self.transform_position(entity.get_entity().pos.load(), entity.as_ref())
+    }
+
+    /// Gets the position of a source with respect to this anchor.
+    #[must_use]
+    pub fn position_at_source(self, command_source: &CommandSource) -> Vector3<f64> {
+        let pos = command_source.position;
+        command_source
+            .entity
+            .as_ref()
+            .map_or_else(|| pos, |e| self.position_at_entity(e))
+    }
+}

--- a/pumpkin/src/command/argument_types/entity_anchor.rs
+++ b/pumpkin/src/command/argument_types/entity_anchor.rs
@@ -38,6 +38,8 @@ impl ArgumentType for EntityAnchorArgumentType {
     }
 }
 
+impl_copy_get!(EntityAnchorArgumentType, EntityAnchor);
+
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum EntityAnchor {
     Feet,

--- a/pumpkin/src/command/argument_types/entity_anchor.rs
+++ b/pumpkin/src/command/argument_types/entity_anchor.rs
@@ -3,11 +3,10 @@ use crate::command::context::command_source::CommandSource;
 use crate::command::errors::command_syntax_error::CommandSyntaxError;
 use crate::command::errors::error_types::CommandErrorType;
 use crate::command::string_reader::StringReader;
-use crate::entity::EntityBase;
+use crate::entity::Entity;
 use pumpkin_data::translation;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::text::TextComponent;
-use std::sync::Arc;
 
 pub const INVALID_ERROR_TYPE: CommandErrorType<1> =
     CommandErrorType::new(translation::ARGUMENT_ANCHOR_INVALID);
@@ -66,20 +65,16 @@ impl EntityAnchor {
         }
     }
 
-    fn transform_position(self, position: Vector3<f64>, entity: &dyn EntityBase) -> Vector3<f64> {
+    fn transform_position(self, position: Vector3<f64>, entity: &Entity) -> Vector3<f64> {
         match self {
             Self::Feet => position,
-            Self::Eyes => position.add(&Vector3::new(
-                0.0,
-                entity.get_entity().get_eye_height(),
-                0.0,
-            )),
+            Self::Eyes => position.add(&Vector3::new(0.0, entity.get_eye_height(), 0.0)),
         }
     }
 
     /// Gets the position of an entity with respect to this anchor.
-    pub fn position_at_entity(self, entity: &Arc<dyn EntityBase>) -> Vector3<f64> {
-        self.transform_position(entity.get_entity().pos.load(), entity.as_ref())
+    pub fn position_at_entity(self, entity: &Entity) -> Vector3<f64> {
+        self.transform_position(entity.pos.load(), entity)
     }
 
     /// Gets the position of a source with respect to this anchor.
@@ -89,6 +84,6 @@ impl EntityAnchor {
         command_source
             .entity
             .as_ref()
-            .map_or_else(|| pos, |e| self.position_at_entity(e))
+            .map_or_else(|| pos, |e| self.position_at_entity(e.get_entity()))
     }
 }

--- a/pumpkin/src/command/argument_types/mod.rs
+++ b/pumpkin/src/command/argument_types/mod.rs
@@ -189,6 +189,7 @@ pub mod argument_type;
 pub mod coordinates;
 pub mod core;
 pub mod entity;
+pub mod entity_anchor;
 pub mod entity_selector;
 pub mod game_profile;
 pub mod range;

--- a/pumpkin/src/command/context/command_source.rs
+++ b/pumpkin/src/command/context/command_source.rs
@@ -327,7 +327,7 @@ impl CommandSource {
         entity: &Arc<dyn EntityBase>,
         anchor: EntityAnchor,
     ) -> Self {
-        self.with_looking_at_pos(anchor.position_at_entity(entity))
+        self.with_looking_at_pos(anchor.position_at_entity(entity.get_entity()))
     }
 
     /// Returns a new [`CommandSource`] with the rotation changed in such

--- a/pumpkin/src/command/context/command_source.rs
+++ b/pumpkin/src/command/context/command_source.rs
@@ -1,4 +1,5 @@
 use crate::command::CommandSender;
+use crate::command::argument_types::entity_anchor::EntityAnchor;
 use crate::command::errors::command_syntax_error::CommandSyntaxError;
 use crate::command::errors::error_types::CommandErrorType;
 use crate::entity::EntityBase;
@@ -489,60 +490,6 @@ impl CommandSource {
             None => true,
             Some(permission) => self.has_permission(permission).await,
         }
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum EntityAnchor {
-    Feet,
-    Eyes,
-}
-
-// TODO: Move this to the /execute command when implemented.
-impl EntityAnchor {
-    /// Gets the [`EntityAnchor`] whose identity is the ID provided.
-    #[must_use]
-    pub fn from_id(id: &str) -> Option<Self> {
-        match id {
-            "feet" => Some(Self::Feet),
-            "eyes" => Some(Self::Eyes),
-            _ => None,
-        }
-    }
-
-    /// Gets the ID of this [`EntityAnchor`]
-    #[must_use]
-    pub const fn id(self) -> &'static str {
-        match self {
-            Self::Feet => "feet",
-            Self::Eyes => "eyes",
-        }
-    }
-
-    fn transform_position(self, position: Vector3<f64>, entity: &dyn EntityBase) -> Vector3<f64> {
-        match self {
-            Self::Feet => position,
-            Self::Eyes => position.add(&Vector3::new(
-                0.0,
-                entity.get_entity().get_eye_height(),
-                0.0,
-            )),
-        }
-    }
-
-    /// Gets the position of an entity with respect to this anchor.
-    pub fn position_at_entity(self, entity: &Arc<dyn EntityBase>) -> Vector3<f64> {
-        self.transform_position(entity.get_entity().pos.load(), entity.as_ref())
-    }
-
-    /// Gets the position of a source with respect to this anchor.
-    #[must_use]
-    pub fn position_at_source(self, command_source: &CommandSource) -> Vector3<f64> {
-        let pos = command_source.position;
-        command_source
-            .entity
-            .as_ref()
-            .map_or_else(|| pos, |e| self.position_at_entity(e))
     }
 }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Adds the `EntityAnchorArgumentType` (eyes/feet) and `RotationArgumentType` (for a yaw and pitch) for the new command dispatcher.

## Testing

Reimplemented the `/rotate` command (in another PR, which relies on this one), and it works properly! 
