### PR TITLE
fix(entity): filter creative/spectator players from hostile mob targeting

### DIFF
--- a/pumpkin/src/entity/ai/target_predicate.rs
+++ b/pumpkin/src/entity/ai/target_predicate.rs
@@ -1,4 +1,5 @@
-use pumpkin_util::Difficulty;
+use pumpkin_data::entity::EntityType;
+use pumpkin_util::{Difficulty, GameMode};
 
 use crate::entity::living::LivingEntity;
 use crate::world::World;
@@ -7,6 +8,11 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 const MIN_DISTANCE: f64 = 2.0;
+
+/// Returns true if players in this gamemode must be excluded from hostile targeting.
+const fn is_excluded_gamemode(gamemode: GameMode) -> bool {
+    matches!(gamemode, GameMode::Creative | GameMode::Spectator)
+}
 
 pub type PredicateFn = dyn Fn(Arc<LivingEntity>, Arc<World>) -> Pin<Box<dyn Future<Output = bool> + Send>>
     + Send
@@ -105,6 +111,16 @@ impl TargetPredicate {
             return false;
         }
 
+        // Vanilla parity: EntityPredicate::EXCEPT_CREATIVE_OR_SPECTATOR — filter
+        // creative/spectator players at acquisition so hostile mobs never briefly
+        // target them (issue #1760).
+        if target.entity.entity_type == &EntityType::PLAYER
+            && let Some(player) = world.get_player_by_uuid(target.entity.entity_uuid)
+            && is_excluded_gamemode(player.gamemode.load())
+        {
+            return false;
+        }
+
         if self.attackable
             && (!target.can_take_damage()
                 || world.level_info.load().difficulty == Difficulty::Peaceful)
@@ -130,5 +146,30 @@ impl TargetPredicate {
         }
 
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn survival_player_not_excluded() {
+        assert!(!is_excluded_gamemode(GameMode::Survival));
+    }
+
+    #[test]
+    fn adventure_player_not_excluded() {
+        assert!(!is_excluded_gamemode(GameMode::Adventure));
+    }
+
+    #[test]
+    fn creative_player_excluded() {
+        assert!(is_excluded_gamemode(GameMode::Creative));
+    }
+
+    #[test]
+    fn spectator_player_excluded() {
+        assert!(is_excluded_gamemode(GameMode::Spectator));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1760. `TargetPredicate::test` currently acquires creative/spectator players as targets, which `MeleeAttackGoal::should_continue` then immediately drops — producing brief aggro flashes and one-tick pathing on players in Creative. This patch filters them at the acquisition step, matching vanilla Yarn's `EntityPredicate.EXCEPT_CREATIVE_OR_SPECTATOR` semantics.

## Implementation

One file changed: `pumpkin/src/entity/ai/target_predicate.rs` (+42/-1).

- New private `const fn is_excluded_gamemode(GameMode) -> bool` — returns `true` for `Creative` / `Spectator`.
- In `TargetPredicate::test`, after the `is_part_of_game()` check and before the peaceful/distance checks, resolve the target to a `Player` via `world.get_player_by_uuid(target.entity.entity_uuid)` (consistent with the lookup at `command/argument_types/entity_selector/mod.rs:203`) and filter on gamemode.
- Guarded by `entity_type == &EntityType::PLAYER`, so mounts/vehicles ridden by creative players are unaffected (vanilla parity).

The UUID round-trip is valid because `Player::new` constructs its `Entity` via `Entity::from_uuid(gameprofile.id, …)` (`player.rs:499-506`), so `entity.entity_uuid == gameprofile.id` for every Player.

## Why not reuse `EntityPredicate::ExceptCreativeOrSpectator`?

`TargetPredicate::test` is sync; `EntityPredicate::test` is async. Making `test` async would ripple through `ActiveTargetGoal::find_closest_target`, `TrackTargetGoal::can_track`, and `TeleportTowardsPlayer` — out of scope for a one-line bug.

Noted for a follow-up: `ExceptCreativeOrSpectator` in `entity/predicate/mod.rs:36-38` has a latent bug (calls `get_player()` on bare `&Entity`, which returns `None` via the default trait impl — virtual dispatch is lost) plus inverted semantics. Only consumer is `melee_attack.rs:128`, negated. Deliberately out of scope here.

Also noted: `LookAtEntityGoal::can_start` bypasses `TargetPredicate` entirely, so mobs still *look at* creative players even after this fix. Worth a separate PR.

## Tests

Added `#[cfg(test)] mod tests` in `target_predicate.rs` covering the four `GameMode` variants:

```
test entity::ai::target_predicate::tests::survival_player_not_excluded ... ok
test entity::ai::target_predicate::tests::adventure_player_not_excluded ... ok
test entity::ai::target_predicate::tests::creative_player_excluded ... ok
test entity::ai::target_predicate::tests::spectator_player_excluded ... ok

test result: ok. 4 passed; 0 failed
```

The wiring (UUID lookup + `entity_type` guard) is 3 lines and mirrors existing patterns; full integration testing would require a `MockWorld` fixture that doesn't exist in the repo today.

## Gates

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p pumpkin --lib entity::ai` passes
- [x] `cargo build --release` clean