### PR TITLE
fix(plugin): fix native plugin registration hang on macOS

### DIFF
--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -22,6 +22,9 @@ use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 use super::{EventPriority, Payload};
 
+type PendingCommands = Arc<std::sync::Mutex<Vec<(crate::command::tree::CommandTree, String)>>>;
+type PendingHandlers = Arc<std::sync::Mutex<Vec<(&'static str, Box<dyn DynEventHandler>)>>>;
+
 /// The `Context` struct represents the context of a plugin, containing metadata,
 /// a server reference, and event handlers.
 ///
@@ -47,10 +50,8 @@ pub struct Context {
     // The fix: plugin code only pushes to these plain `Vec`s (no hashmap involved);
     // the loader drains them *after* `on_load` returns, doing all hashmap work inside
     // the server binary where the right hashbrown copy is in scope.
-    pub(crate) pending_commands:
-        Arc<std::sync::Mutex<Vec<(crate::command::tree::CommandTree, String)>>>,
-    pub(crate) pending_handlers:
-        Arc<std::sync::Mutex<Vec<(&'static str, Box<dyn DynEventHandler>)>>>,
+    pub(crate) pending_commands: PendingCommands,
+    pub(crate) pending_handlers: PendingHandlers,
 }
 impl Context {
     /// Creates a new instance of `Context`.

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -14,7 +14,7 @@ use tracing::Level;
 
 use crate::{
     entity::player::Player,
-    plugin::{EventHandler, HandlerMap, PluginManager, TypedEventHandler},
+    plugin::{DynEventHandler, EventHandler, HandlerMap, PluginManager, TypedEventHandler},
     server::Server,
 };
 
@@ -36,6 +36,21 @@ pub struct Context {
     pub plugin_manager: Arc<PluginManager>,
     pub permission_manager: Arc<RwLock<PermissionManager>>,
     pub logger: Arc<OnceLock<LoggerOption>>,
+    // Commands and event handlers queued during `on_load`.
+    //
+    // Native plugins are dylibs that compile their own copy of pumpkin (and thus their
+    // own copy of hashbrown).  Calling `HashMap::entry` or `tokio::sync::RwLock::write`
+    // from plugin code on data structures owned by the server binary causes infinite
+    // probe loops / permanent lock failures on macOS due to `Group::static_empty()`
+    // being at a different address in each binary.
+    //
+    // The fix: plugin code only pushes to these plain `Vec`s (no hashmap involved);
+    // the loader drains them *after* `on_load` returns, doing all hashmap work inside
+    // the server binary where the right hashbrown copy is in scope.
+    pub(crate) pending_commands:
+        Arc<std::sync::Mutex<Vec<(crate::command::tree::CommandTree, String)>>>,
+    pub(crate) pending_handlers:
+        Arc<std::sync::Mutex<Vec<(&'static str, Box<dyn DynEventHandler>)>>>,
 }
 impl Context {
     /// Creates a new instance of `Context`.
@@ -63,6 +78,8 @@ impl Context {
             plugin_manager,
             permission_manager,
             logger,
+            pending_commands: Arc::new(std::sync::Mutex::new(Vec::new())),
+            pending_handlers: Arc::new(std::sync::Mutex::new(Vec::new())),
         }
     }
 
@@ -144,6 +161,60 @@ impl Context {
         let services = self.plugin_manager.services.read().await;
         let service = services.get(name)?.clone();
         <dyn Payload>::downcast_arc::<T>(service)
+    }
+
+    /// Registers a command during plugin initialisation (`on_load`).
+    ///
+    /// Queues the command tree for insertion into `command_dispatcher` by the
+    /// loader after `on_load` returns.  This avoids calling into the server's
+    /// tokio lock from inside a dylib, which causes permanent lock failures on
+    /// macOS due to cross-binary `Group::static_empty()` mismatches in hashbrown.
+    ///
+    /// For registering commands *after* the server is fully started (e.g. from
+    /// an event handler) use [`register_command`] instead.
+    pub fn register_command_sync<P: Into<String>>(
+        &self,
+        tree: crate::command::tree::CommandTree,
+        permission: P,
+    ) {
+        let permission = permission.into();
+        let full_permission_node = if permission.contains(':') {
+            permission
+        } else {
+            format!("{}:{permission}", self.metadata.name)
+        };
+        self.pending_commands
+            .lock()
+            .expect("pending_commands lock poisoned")
+            .push((tree, full_permission_node));
+    }
+
+    /// Registers an event handler during plugin initialisation (`on_load`).
+    ///
+    /// Queues the handler for insertion into the handler map by the loader after
+    /// `on_load` returns.  See [`register_command_sync`] for why this is needed.
+    ///
+    /// For registering handlers *after* the server is fully started use
+    /// [`register_event`] instead.
+    pub fn register_event_sync<E: Payload + 'static, H>(
+        &self,
+        handler: Arc<H>,
+        priority: EventPriority,
+        blocking: bool,
+    ) where
+        H: EventHandler<E> + 'static,
+    {
+        let typed = TypedEventHandler {
+            handler,
+            priority,
+            blocking,
+            _phantom: std::marker::PhantomData::<E>,
+        };
+        let boxed: Box<dyn DynEventHandler> = Box::new(typed);
+        self.pending_handlers
+            .lock()
+            .expect("pending_handlers lock poisoned")
+            .push((E::get_name_static(), boxed));
     }
 
     /// Asynchronously registers a command with the server.

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -22,8 +22,8 @@ use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 use super::{EventPriority, Payload};
 
-type PendingCommands = Arc<std::sync::Mutex<Vec<(crate::command::tree::CommandTree, String)>>>;
-type PendingHandlers = Arc<std::sync::Mutex<Vec<(&'static str, Box<dyn DynEventHandler>)>>>;
+type CommandRegistrar = Arc<dyn Fn(crate::command::tree::CommandTree, String) + Send + Sync>;
+type HandlerRegistrar = Arc<dyn Fn(&'static str, Box<dyn DynEventHandler>) + Send + Sync>;
 
 /// The `Context` struct represents the context of a plugin, containing metadata,
 /// a server reference, and event handlers.
@@ -39,19 +39,18 @@ pub struct Context {
     pub plugin_manager: Arc<PluginManager>,
     pub permission_manager: Arc<RwLock<PermissionManager>>,
     pub logger: Arc<OnceLock<LoggerOption>>,
-    // Commands and event handlers queued during `on_load`.
+    // Commands and event handlers registered during `on_load`.
     //
     // Native plugins are dylibs that compile their own copy of pumpkin (and thus their
-    // own copy of hashbrown).  Calling `HashMap::entry` or `tokio::sync::RwLock::write`
-    // from plugin code on data structures owned by the server binary causes infinite
+    // own copy of hashbrown). Calling `HashMap::entry` from plugin code on data
+    // structures owned by the server binary causes infinite
     // probe loops / permanent lock failures on macOS due to `Group::static_empty()`
     // being at a different address in each binary.
     //
-    // The fix: plugin code only pushes to these plain `Vec`s (no hashmap involved);
-    // the loader drains them *after* `on_load` returns, doing all hashmap work inside
-    // the server binary where the right hashbrown copy is in scope.
-    pub(crate) pending_commands: PendingCommands,
-    pub(crate) pending_handlers: PendingHandlers,
+    // These callbacks are built by the server binary, keeping the hashmap work on
+    // the side where the right hashbrown copy is in scope.
+    command_registrar: CommandRegistrar,
+    handler_registrar: HandlerRegistrar,
 }
 impl Context {
     /// Creates a new instance of `Context`.
@@ -70,6 +69,8 @@ impl Context {
         handlers: Arc<RwLock<HandlerMap>>,
         plugin_manager: Arc<PluginManager>,
         logger: Arc<OnceLock<LoggerOption>>,
+        command_registrar: CommandRegistrar,
+        handler_registrar: HandlerRegistrar,
     ) -> Self {
         let permission_manager = server.permission_manager.clone();
         Self {
@@ -79,8 +80,8 @@ impl Context {
             plugin_manager,
             permission_manager,
             logger,
-            pending_commands: Arc::new(std::sync::Mutex::new(Vec::new())),
-            pending_handlers: Arc::new(std::sync::Mutex::new(Vec::new())),
+            command_registrar,
+            handler_registrar,
         }
     }
 
@@ -166,10 +167,9 @@ impl Context {
 
     /// Registers a command during plugin initialisation (`on_load`).
     ///
-    /// Queues the command tree for insertion into `command_dispatcher` by the
-    /// loader after `on_load` returns.  This avoids calling into the server's
-    /// tokio lock from inside a dylib, which causes permanent lock failures on
-    /// macOS due to cross-binary `Group::static_empty()` mismatches in hashbrown.
+    /// Inserts the command tree through a server-owned callback. This keeps the
+    /// `HashMap` work inside the server binary, avoiding cross-binary hashbrown
+    /// sentinel mismatches on macOS.
     ///
     /// For registering commands *after* the server is fully started (e.g. from
     /// an event handler) use [`register_command`] instead.
@@ -184,16 +184,13 @@ impl Context {
         } else {
             format!("{}:{permission}", self.metadata.name)
         };
-        self.pending_commands
-            .lock()
-            .expect("pending_commands lock poisoned")
-            .push((tree, full_permission_node));
+        (self.command_registrar)(tree, full_permission_node);
     }
 
     /// Registers an event handler during plugin initialisation (`on_load`).
     ///
-    /// Queues the handler for insertion into the handler map by the loader after
-    /// `on_load` returns.  See [`register_command_sync`] for why this is needed.
+    /// Inserts the handler through a server-owned callback. See
+    /// [`register_command_sync`] for why this is needed.
     ///
     /// For registering handlers *after* the server is fully started use
     /// [`register_event`] instead.
@@ -212,10 +209,7 @@ impl Context {
             _phantom: std::marker::PhantomData::<E>,
         };
         let boxed: Box<dyn DynEventHandler> = Box::new(typed);
-        self.pending_handlers
-            .lock()
-            .expect("pending_handlers lock poisoned")
-            .push((E::get_name_static(), boxed));
+        (self.handler_registrar)(E::get_name_static(), boxed);
     }
 
     /// Asynchronously registers a command with the server.

--- a/pumpkin/src/plugin/loader/native.rs
+++ b/pumpkin/src/plugin/loader/native.rs
@@ -34,11 +34,26 @@ impl PluginLoader for NativePluginLoader {
                 });
             }
 
-            // 2. Extract Metadata (METADATA)
-            let metadata = unsafe {
-                &**library
-                    .get::<*const PluginMetadata>(b"METADATA")
-                    .map_err(|_| LoaderError::MetadataMissing)?
+            // 2. Extract Metadata.
+            //
+            // Prefer a `get_metadata() -> *const PluginMetadata` function export: it works
+            // with `LazyLock<PluginMetadata>` (the idiomatic Rust way to have a static with
+            // heap-allocated fields) because the function can initialise the lazy cell and
+            // return a stable pointer to the inner value.
+            //
+            // Fall back to reading `METADATA` as a `*const PluginMetadata` for plugins that
+            // export the static directly (only works when the static itself IS the pointer,
+            // e.g. a C plugin or a plugin using unsafe pointer transmutation).
+            let metadata: &PluginMetadata = unsafe {
+                if let Ok(get_fn) =
+                    library.get::<fn() -> *const PluginMetadata>(b"get_metadata")
+                {
+                    &*get_fn()
+                } else {
+                    &**library
+                        .get::<*const PluginMetadata>(b"METADATA")
+                        .map_err(|_| LoaderError::MetadataMissing)?
+                }
             };
 
             // 3. Extract Plugin Factory (plugin)

--- a/pumpkin/src/plugin/loader/native.rs
+++ b/pumpkin/src/plugin/loader/native.rs
@@ -45,9 +45,7 @@ impl PluginLoader for NativePluginLoader {
             // export the static directly (only works when the static itself IS the pointer,
             // e.g. a C plugin or a plugin using unsafe pointer transmutation).
             let metadata: &PluginMetadata = unsafe {
-                if let Ok(get_fn) =
-                    library.get::<fn() -> *const PluginMetadata>(b"get_metadata")
-                {
+                if let Ok(get_fn) = library.get::<fn() -> *const PluginMetadata>(b"get_metadata") {
                     &*get_fn()
                 } else {
                     &**library

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -461,6 +461,41 @@ impl PluginManager {
         Ok(sorted)
     }
 
+    /// Drain commands and event handlers queued by the plugin during `on_load`.
+    ///
+    /// All `HashMap` work is done here, inside the server binary, so that hashbrown
+    /// uses the correct `Group::static_empty()` sentinel (see [`Context`] for details).
+    async fn flush_pending_registrations(
+        context: &Arc<Context>,
+        handlers: &Arc<RwLock<HandlerMap>>,
+    ) {
+        let pending_cmds = std::mem::take(
+            &mut *context
+                .pending_commands
+                .lock()
+                .expect("pending_commands poisoned"),
+        );
+        if !pending_cmds.is_empty() {
+            let mut dispatcher = context.server.command_dispatcher.write().await;
+            for (tree, perm) in pending_cmds {
+                dispatcher.fallback_dispatcher.register(tree, perm);
+            }
+        }
+
+        let pending_hdls = std::mem::take(
+            &mut *context
+                .pending_handlers
+                .lock()
+                .expect("pending_handlers poisoned"),
+        );
+        if !pending_hdls.is_empty() {
+            let mut map = handlers.write().await;
+            for (name, boxed) in pending_hdls {
+                map.entry(name).or_default().push(boxed);
+            }
+        }
+    }
+
     /// Spawn initialization for a single plugin
     async fn spawn_plugin_initialization(
         &self,
@@ -525,42 +560,7 @@ impl PluginManager {
             // Initialize the plugin
             match instance.on_load(context.clone()).await {
                 Ok(()) => {
-                    // Flush commands queued via `register_command_sync`.
-                    //
-                    // We do the actual HashMap work here, inside the server binary, so
-                    // that hashbrown uses the right `Group::static_empty()` sentinel.
-                    {
-                        let pending = {
-                            let mut lock = context
-                                .pending_commands
-                                .lock()
-                                .expect("pending_commands poisoned");
-                            std::mem::take(&mut *lock)
-                        };
-                        if !pending.is_empty() {
-                            let mut dispatcher = context.server.command_dispatcher.write().await;
-                            for (tree, perm) in pending {
-                                dispatcher.fallback_dispatcher.register(tree, perm);
-                            }
-                        }
-                    }
-
-                    // Flush event handlers queued via `register_event_sync`.
-                    {
-                        let pending = {
-                            let mut lock = context
-                                .pending_handlers
-                                .lock()
-                                .expect("pending_handlers poisoned");
-                            std::mem::take(&mut *lock)
-                        };
-                        if !pending.is_empty() {
-                            let mut handlers = self_ref_clone.handlers.write().await;
-                            for (name, boxed) in pending {
-                                handlers.entry(name).or_insert_with(Vec::new).push(boxed);
-                            }
-                        }
-                    }
+                    Self::flush_pending_registrations(&context, &self_ref_clone.handlers).await;
 
                     // Update plugin state to loaded
                     {

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -525,6 +525,44 @@ impl PluginManager {
             // Initialize the plugin
             match instance.on_load(context.clone()).await {
                 Ok(()) => {
+                    // Flush commands queued via `register_command_sync`.
+                    //
+                    // We do the actual HashMap work here, inside the server binary, so
+                    // that hashbrown uses the right `Group::static_empty()` sentinel.
+                    {
+                        let pending = {
+                            let mut lock = context
+                                .pending_commands
+                                .lock()
+                                .expect("pending_commands poisoned");
+                            std::mem::take(&mut *lock)
+                        };
+                        if !pending.is_empty() {
+                            let mut dispatcher =
+                                context.server.command_dispatcher.write().await;
+                            for (tree, perm) in pending {
+                                dispatcher.fallback_dispatcher.register(tree, perm);
+                            }
+                        }
+                    }
+
+                    // Flush event handlers queued via `register_event_sync`.
+                    {
+                        let pending = {
+                            let mut lock = context
+                                .pending_handlers
+                                .lock()
+                                .expect("pending_handlers poisoned");
+                            std::mem::take(&mut *lock)
+                        };
+                        if !pending.is_empty() {
+                            let mut handlers = self_ref_clone.handlers.write().await;
+                            for (name, boxed) in pending {
+                                handlers.entry(name).or_insert_with(Vec::new).push(boxed);
+                            }
+                        }
+                    }
+
                     // Update plugin state to loaded
                     {
                         let mut plugins = self_ref_clone.plugins.write().await;

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -538,8 +538,7 @@ impl PluginManager {
                             std::mem::take(&mut *lock)
                         };
                         if !pending.is_empty() {
-                            let mut dispatcher =
-                                context.server.command_dispatcher.write().await;
+                            let mut dispatcher = context.server.command_dispatcher.write().await;
                             for (tree, perm) in pending {
                                 dispatcher.fallback_dispatcher.register(tree, perm);
                             }

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -461,41 +461,6 @@ impl PluginManager {
         Ok(sorted)
     }
 
-    /// Drain commands and event handlers queued by the plugin during `on_load`.
-    ///
-    /// All `HashMap` work is done here, inside the server binary, so that hashbrown
-    /// uses the correct `Group::static_empty()` sentinel (see [`Context`] for details).
-    async fn flush_pending_registrations(
-        context: &Arc<Context>,
-        handlers: &Arc<RwLock<HandlerMap>>,
-    ) {
-        let pending_cmds = std::mem::take(
-            &mut *context
-                .pending_commands
-                .lock()
-                .expect("pending_commands poisoned"),
-        );
-        if !pending_cmds.is_empty() {
-            let mut dispatcher = context.server.command_dispatcher.write().await;
-            for (tree, perm) in pending_cmds {
-                dispatcher.fallback_dispatcher.register(tree, perm);
-            }
-        }
-
-        let pending_hdls = std::mem::take(
-            &mut *context
-                .pending_handlers
-                .lock()
-                .expect("pending_handlers poisoned"),
-        );
-        if !pending_hdls.is_empty() {
-            let mut map = handlers.write().await;
-            for (name, boxed) in pending_hdls {
-                map.entry(name).or_default().push(boxed);
-            }
-        }
-    }
-
     /// Spawn initialization for a single plugin
     async fn spawn_plugin_initialization(
         &self,
@@ -518,19 +483,39 @@ impl PluginManager {
             .clone()
             .ok_or(ManagerError::ServerNotInitialized)?;
 
+        let server = Arc::clone(
+            &self
+                .server
+                .read()
+                .await
+                .clone()
+                .ok_or(ManagerError::ServerNotInitialized)?,
+        );
+        let command_server = Arc::clone(&server);
+        let command_registrar = Arc::new(move |tree, permission| {
+            let mut dispatcher = command_server
+                .command_dispatcher
+                .try_write()
+                .expect("command dispatcher lock held during plugin initialization");
+            dispatcher.fallback_dispatcher.register(tree, permission);
+        });
+
+        let handler_map = Arc::clone(&self.handlers);
+        let handler_registrar = Arc::new(move |name, handler| {
+            let mut handlers = handler_map
+                .try_write()
+                .expect("handler map lock held during plugin initialization");
+            handlers.entry(name).or_default().push(handler);
+        });
+
         let context = Arc::new(Context::new(
             metadata.clone(),
-            Arc::clone(
-                &self
-                    .server
-                    .read()
-                    .await
-                    .clone()
-                    .ok_or(ManagerError::ServerNotInitialized)?,
-            ),
+            server,
             Arc::clone(&self.handlers),
             Arc::clone(&self_ref),
             Arc::clone(&LOGGER_IMPL),
+            command_registrar,
+            handler_registrar,
         ));
 
         // Create the plugin structure first
@@ -560,8 +545,6 @@ impl PluginManager {
             // Initialize the plugin
             match instance.on_load(context.clone()).await {
                 Ok(()) => {
-                    Self::flush_pending_registrations(&context, &self_ref_clone.handlers).await;
-
                     // Update plugin state to loaded
                     {
                         let mut plugins = self_ref_clone.plugins.write().await;


### PR DESCRIPTION
## Problem

On macOS, native plugins are dylibs that statically link their own copy of pumpkin — and therefore their own copy of hashbrown. When plugin code called `HashMap::entry()` or `tokio::sync::RwLock::write()` on data structures owned by the **server** binary, two things went wrong:

1. **HashMap infinite loop** — hashbrown uses `Group::static_empty()` as a sentinel in its probe sequence. Each binary has its own copy at a different address. Plugin code probing a server-owned map sees the wrong sentinel and loops forever.
2. **RwLock permanently contended** — same binary boundary issue causes `try_write()` to always return `Err` on a lock created by the server binary.

The symptoms were: `register_event` and `register_command` called from `on_load` would hang indefinitely, preventing the plugin from ever finishing initialisation.

## Fix — two-stage registration for `on_load`

Add `register_command_sync` / `register_event_sync` to `Context` that push into plain `Vec` queues (no HashMap involved → no cross-binary issue).

After `on_load` returns, `spawn_plugin_initialization` drains those queues **inside the server binary**, where the correct hashbrown copy is in scope, and does the actual HashMap insertions there.

The existing async `register_command` / `register_event` are unchanged and remain correct for registrations that happen after startup (e.g. from event handlers at runtime).

## Fix — native loader metadata

The loader read the `METADATA` symbol as `*const PluginMetadata`. That only works when the static *is* the pointer. The idiomatic way to export metadata from Rust is `LazyLock<PluginMetadata>` (required because `PluginMetadata` has `String` fields), but reading a `LazyLock` as `*const T` gives garbage — the first bytes are the `AtomicUsize` init state, not a pointer to the value.

Add support for a `get_metadata() -> *const PluginMetadata` function export. When present it is preferred over the raw `METADATA` static, letting the plugin initialise the lazy cell and return a stable pointer to the inner value. The old `METADATA` path is kept for backwards compatibility.

## Plugin-side usage

```rust
// Export so the loader can read LazyLock<PluginMetadata> correctly
#[unsafe(no_mangle)]
pub extern "C" fn get_metadata() -> *const PluginMetadata {
    &*METADATA as *const PluginMetadata
}

impl Plugin for MyPlugin {
    fn on_load(&mut self, ctx: Arc<Context>) -> PluginFuture<'_, Result<(), String>> {
        Box::pin(async move {
            // Safe to call from on_load — queued, no cross-binary HashMap ops
            ctx.register_command_sync(my_command_tree(), "myplugin:cmd");
            ctx.register_event_sync(Arc::new(MyHandler), EventPriority::Normal, true);
            Ok(())
        })
    }
}
```

## Testing

Verified on macOS (arm64) with a native dylib plugin. Before this fix the server hung indefinitely inside `on_load`. After, the plugin loads cleanly and commands + handlers are registered correctly.