### PR TITLE
feat(command): make `GameProfileArgumentType` search and reimplement `/op` command

### DIFF
--- a/pumpkin/src/command/argument_types/game_profile.rs
+++ b/pumpkin/src/command/argument_types/game_profile.rs
@@ -33,7 +33,9 @@ impl GameProfileResult {
 
     /// Resolves this result with the help of a [`CommandSource`].
     ///
-    /// **Warning**: Do not lock write/read access to one of these data locks
+    /// # Warning
+    ///
+    /// Do not lock write/read access to one of these data locks
     /// before calling this method, as that may cause a *deadlock*:
     /// - `server.data.user_cache`
     /// - `server.data.operator_config`
@@ -229,7 +231,9 @@ impl GameProfileArgumentType {
 
     /// Tries to get any number of [`GameProfile`]s from a parsed argument of the provided [`CommandContext`].
     ///
-    /// **Warning**: Do not lock write/read access to one of these data locks
+    /// # Warning
+    ///
+    /// Do not lock write/read access to one of these data locks
     /// before calling this method, as that may cause a *deadlock*:
     /// - `server.data.user_cache`
     /// - `server.data.operator_config`

--- a/pumpkin/src/command/argument_types/game_profile.rs
+++ b/pumpkin/src/command/argument_types/game_profile.rs
@@ -7,7 +7,9 @@ use crate::command::context::command_source::CommandSource;
 use crate::command::errors::command_syntax_error::CommandSyntaxError;
 use crate::command::errors::error_types::CommandErrorType;
 use crate::command::string_reader::StringReader;
-use crate::net::GameProfile;
+use crate::net::authentication::lookup_profile_by_name;
+use crate::net::{GameProfile, offline_uuid};
+use crate::server::Server;
 use pumpkin_data::translation;
 use uuid::Uuid;
 
@@ -25,27 +27,151 @@ pub enum GameProfileResult {
 }
 
 impl GameProfileResult {
+    fn unknown_player_syntax_error() -> CommandSyntaxError {
+        UNKNOWN_PLAYER_ERROR_TYPE.create_without_context()
+    }
+
     /// Resolves this result with the help of a [`CommandSource`].
+    ///
+    /// **Warning**: Do not lock write/read access to one of these data locks
+    /// before calling this method, as that may cause a *deadlock*:
+    /// - `server.data.user_cache`
+    /// - `server.data.operator_config`
+    /// - `server.data.banned_player_list`
+    /// - `server.data.whitelist_config`
+    ///
+    /// Instead, call this method *before* using `write()`/`read()` on a lock.
     pub async fn resolve(
         &self,
         source: &CommandSource,
     ) -> Result<Vec<GameProfile>, CommandSyntaxError> {
         let players = match self {
             Self::Selector(selector) => selector.find_players(source).await,
-            Self::Name(name) => source
-                .server()
-                .get_player_by_name(name.as_str())
-                .map_or_else(
-                    || Err(UNKNOWN_PLAYER_ERROR_TYPE.create_without_context()),
-                    |p| Ok(vec![p]),
-                ),
-            Self::Uuid(uuid) => source.server().get_player_by_uuid(*uuid).map_or_else(
-                || Err(UNKNOWN_PLAYER_ERROR_TYPE.create_without_context()),
-                |p| Ok(vec![p]),
-            ),
+            Self::Name(name) => {
+                let server = source.server();
+                if let Some(player) = server.get_player_by_name(name) {
+                    return Ok(vec![player.gameprofile.clone()]);
+                }
+
+                let cached_entry = server.data.user_cache.write().await.get_by_name(name);
+                if let Some(entry) = cached_entry {
+                    return Ok(vec![Self::profile_from_uuid_name(entry.uuid, entry.name)]);
+                }
+
+                if let Some(profile) = Self::resolve_known_profile_by_name(server, name).await {
+                    return Ok(vec![profile]);
+                }
+
+                if server.basic_config.online_mode {
+                    return match lookup_profile_by_name(
+                        name,
+                        &server.advanced_config.networking.authentication,
+                    ) {
+                        Ok(Some((uuid, resolved_name))) => {
+                            server
+                                .data
+                                .user_cache
+                                .write()
+                                .await
+                                .upsert(uuid, resolved_name.clone());
+                            Ok(vec![Self::profile_from_uuid_name(uuid, resolved_name)])
+                        }
+                        _ => Err(Self::unknown_player_syntax_error()),
+                    };
+                } else if let Ok(uuid) = offline_uuid(name) {
+                    let profile = Self::profile_from_uuid_name(uuid, name.to_string());
+                    server
+                        .data
+                        .user_cache
+                        .write()
+                        .await
+                        .upsert(profile.id, profile.name.clone());
+                    return Ok(vec![profile]);
+                }
+
+                return Err(Self::unknown_player_syntax_error());
+            }
+            Self::Uuid(uuid) => {
+                let server = source.server();
+
+                if let Some(player) = server.get_player_by_uuid(*uuid) {
+                    return Ok(vec![player.gameprofile.clone()]);
+                }
+
+                let cached_entry = server.data.user_cache.write().await.get_by_uuid(*uuid);
+                if let Some(entry) = cached_entry {
+                    return Ok(vec![Self::profile_from_uuid_name(entry.uuid, entry.name)]);
+                }
+
+                if let Some(profile) = Self::resolve_known_profile_by_uuid(server, *uuid).await {
+                    return Ok(vec![profile]);
+                }
+
+                return Err(Self::unknown_player_syntax_error());
+            }
         }?;
 
         Ok(players.iter().map(|p| &p.gameprofile).cloned().collect())
+    }
+
+    async fn resolve_known_profile_by_name(server: &Server, name: &str) -> Option<GameProfile> {
+        let ops = server.data.operator_config.read().await;
+        if let Some(op) = ops.ops.iter().find(|op| op.name.eq_ignore_ascii_case(name)) {
+            return Some(Self::profile_from_uuid_name(op.uuid, op.name.clone()));
+        }
+
+        let banned_players = server.data.banned_player_list.read().await;
+        if let Some(entry) = banned_players
+            .banned_players
+            .iter()
+            .find(|entry| entry.name.eq_ignore_ascii_case(name))
+        {
+            return Some(Self::profile_from_uuid_name(entry.uuid, entry.name.clone()));
+        }
+
+        let whitelist = server.data.whitelist_config.read().await;
+        if let Some(entry) = whitelist
+            .whitelist
+            .iter()
+            .find(|entry| entry.name.eq_ignore_ascii_case(name))
+        {
+            return Some(Self::profile_from_uuid_name(entry.uuid, entry.name.clone()));
+        }
+
+        None
+    }
+
+    async fn resolve_known_profile_by_uuid(server: &Server, uuid: Uuid) -> Option<GameProfile> {
+        let ops = server.data.operator_config.read().await;
+        if let Some(op) = ops.ops.iter().find(|op| op.uuid == uuid) {
+            return Some(Self::profile_from_uuid_name(op.uuid, op.name.clone()));
+        }
+
+        let banned_players = server.data.banned_player_list.read().await;
+        if let Some(entry) = banned_players
+            .banned_players
+            .iter()
+            .find(|entry| entry.uuid == uuid)
+        {
+            return Some(Self::profile_from_uuid_name(entry.uuid, entry.name.clone()));
+        }
+
+        let whitelist = server.data.whitelist_config.read().await;
+        if let Some(entry) = whitelist.whitelist.iter().find(|entry| entry.uuid == uuid) {
+            return Some(Self::profile_from_uuid_name(entry.uuid, entry.name.clone()));
+        }
+
+        None
+    }
+
+    #[allow(clippy::missing_const_for_fn)]
+    fn profile_from_uuid_name(uuid: Uuid, name: String) -> GameProfile {
+        GameProfile {
+            id: uuid,
+            name,
+            properties: vec![],
+            profile_actions: None,
+        }
     }
 }
 
@@ -102,6 +228,15 @@ impl GameProfileArgumentType {
     }
 
     /// Tries to get any number of [`GameProfile`]s from a parsed argument of the provided [`CommandContext`].
+    ///
+    /// **Warning**: Do not lock write/read access to one of these data locks
+    /// before calling this method, as that may cause a *deadlock*:
+    /// - `server.data.user_cache`
+    /// - `server.data.operator_config`
+    /// - `server.data.banned_player_list`
+    /// - `server.data.whitelist_config`
+    ///
+    /// Instead, call this function *before* using `write()`/`read()` on a lock.
     pub async fn get(
         context: &CommandContext<'_>,
         name: &str,

--- a/pumpkin/src/command/argument_types/game_profile.rs
+++ b/pumpkin/src/command/argument_types/game_profile.rs
@@ -81,7 +81,7 @@ impl GameProfileResult {
                         _ => Err(Self::unknown_player_syntax_error()),
                     };
                 } else if let Ok(uuid) = offline_uuid(name) {
-                    let profile = Self::profile_from_uuid_name(uuid, name.to_string());
+                    let profile = Self::profile_from_uuid_name(uuid, name.clone());
                     server
                         .data
                         .user_cache

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -129,7 +129,6 @@ pub async fn default_dispatcher(
     );
     dispatcher.register(data::init_command_tree(), "minecraft:command.data");
     // Three
-    dispatcher.register(op::init_command_tree(), "minecraft:command.op");
     dispatcher.register(deop::init_command_tree(), "minecraft:command.deop");
     dispatcher.register(kick::init_command_tree(), "minecraft:command.kick");
     dispatcher.register(plugin::init_command_tree(), "pumpkin:command.plugin");
@@ -154,6 +153,7 @@ pub async fn default_dispatcher(
     difficulty::register(&mut dispatcher, registry);
     help::register(&mut dispatcher, registry);
     kill::register(&mut dispatcher, registry);
+    op::register(&mut dispatcher, registry);
     list::register(&mut dispatcher, registry);
     seed::register(&mut dispatcher, registry);
     setidletimeout::register(&mut dispatcher, registry);
@@ -407,13 +407,6 @@ fn register_level_3_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.setworldspawn",
             "Sets the world spawn point",
-            PermissionDefault::Op(PermissionLvl::Three),
-        ))
-        .unwrap();
-    registry
-        .register_permission(Permission::new(
-            "minecraft:command.op",
-            "Grants operator status to a player",
             PermissionDefault::Op(PermissionLvl::Three),
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/op.rs
+++ b/pumpkin/src/command/commands/op.rs
@@ -58,8 +58,8 @@ impl CommandExecutor for OpCommandExecutor {
                     .source
                     .send_feedback(
                         TextComponent::translate_cross(
-                            "commands.op.success",
-                            "commands.op.success",
+                            translation::java::COMMANDS_OP_SUCCESS,
+                            translation::bedrock::COMMANDS_OP_SUCCESS,
                             [TextComponent::text(profile.name.clone())],
                         ),
                         true,

--- a/pumpkin/src/command/commands/op.rs
+++ b/pumpkin/src/command/commands/op.rs
@@ -13,8 +13,10 @@ use pumpkin_util::PermissionLvl;
 use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
 use pumpkin_util::text::TextComponent;
 
-pub const ALREADY_OP_ERROR_TYPE: CommandErrorType<0> =
-    CommandErrorType::new(translation::java::COMMANDS_OP_FAILED, translation::bedrock::COMMANDS_OP_FAILED);
+pub const ALREADY_OP_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMANDS_OP_FAILED,
+    translation::bedrock::COMMANDS_OP_FAILED,
+);
 
 const DESCRIPTION: &str = "Grants operator status to a player.";
 const PERMISSION: &str = "minecraft:command.op";

--- a/pumpkin/src/command/commands/op.rs
+++ b/pumpkin/src/command/commands/op.rs
@@ -1,47 +1,38 @@
-use crate::command::CommandResult;
-use crate::{
-    command::{
-        CommandError, CommandExecutor, CommandSender,
-        args::{
-            Arg, ConsumedArgs,
-            gameprofile::{GameProfileSuggestionMode, GameProfilesArgumentConsumer},
-        },
-        tree::CommandTree,
-        tree::builder::argument,
-    },
-    data::SaveJSONConfiguration,
-};
-use CommandError::InvalidConsumption;
+use crate::command::argument_builder::{ArgumentBuilder, argument, command};
+use crate::command::argument_types::game_profile::GameProfileArgumentType;
+use crate::command::context::command_context::CommandContext;
+use crate::command::errors::error_types::CommandErrorType;
+use crate::command::node::dispatcher::CommandDispatcher;
+use crate::command::node::{CommandExecutor, CommandExecutorResult};
+use crate::command::suggestion::provider::{SuggestionProvider, SuggestionProviderResult};
+use crate::command::suggestion::suggestions::SuggestionsBuilder;
+use crate::data::SaveJSONConfiguration;
 use pumpkin_config::op::Op;
+use pumpkin_data::translation;
+use pumpkin_util::PermissionLvl;
+use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
 use pumpkin_util::text::TextComponent;
 
-const NAMES: [&str; 1] = ["op"];
+pub const ALREADY_OP_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::java::COMMANDS_OP_FAILED, translation::bedrock::COMMANDS_OP_FAILED);
+
 const DESCRIPTION: &str = "Grants operator status to a player.";
+const PERMISSION: &str = "minecraft:command.op";
 const ARG_TARGETS: &str = "targets";
 
-struct Executor;
+struct OpCommandExecutor;
 
-impl CommandExecutor for Executor {
-    fn execute<'a>(
-        &'a self,
-        sender: &'a CommandSender,
-        server: &'a crate::server::Server,
-        args: &'a ConsumedArgs<'a>,
-    ) -> CommandResult<'a> {
+impl CommandExecutor for OpCommandExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
         Box::pin(async move {
+            let server = context.server();
+            let profiles = GameProfileArgumentType::get(context, ARG_TARGETS).await?;
+
             let mut config = server.data.operator_config.write().await;
-
-            let Some(Arg::GameProfiles(targets)) = args.get(&ARG_TARGETS) else {
-                return Err(InvalidConsumption(Some(ARG_TARGETS.into())));
-            };
-
             let mut successes: i32 = 0;
-            let new_level = server
-                .basic_config
-                .op_permission_level
-                .min(sender.permission_lvl());
+            let new_level = server.basic_config.op_permission_level;
 
-            for profile in targets {
+            for profile in profiles {
                 let maybe_existing_entry = config.ops.iter_mut().find(|o| o.uuid == profile.id);
 
                 if let Some(op) = maybe_existing_entry {
@@ -63,12 +54,16 @@ impl CommandExecutor for Executor {
                         .await;
                 }
 
-                sender
-                    .send_message(TextComponent::translate_cross(
-                        "commands.op.success",
-                        "commands.op.success",
-                        [TextComponent::text(profile.name.clone())],
-                    ))
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            "commands.op.success",
+                            "commands.op.success",
+                            [TextComponent::text(profile.name.clone())],
+                        ),
+                        true,
+                    )
                     .await;
 
                 successes += 1;
@@ -79,11 +74,7 @@ impl CommandExecutor for Executor {
             }
 
             if successes == 0 {
-                Err(CommandError::CommandFailed(TextComponent::translate_cross(
-                    "commands.op.failed",
-                    "commands.op.failed",
-                    [],
-                )))
+                Err(ALREADY_OP_ERROR_TYPE.create_without_context())
             } else {
                 Ok(successes)
             }
@@ -91,12 +82,39 @@ impl CommandExecutor for Executor {
     }
 }
 
-pub fn init_command_tree() -> CommandTree {
-    CommandTree::new(NAMES, DESCRIPTION).then(
-        argument(
-            ARG_TARGETS,
-            GameProfilesArgumentConsumer::new(GameProfileSuggestionMode::NonOpOnlinePlayers, false),
-        )
-        .execute(Executor),
-    )
+struct OpSuggestionProvider;
+
+impl SuggestionProvider for OpSuggestionProvider {
+    fn suggest<'a>(
+        &'a self,
+        context: &'a CommandContext,
+        mut builder: SuggestionsBuilder,
+    ) -> SuggestionProviderResult<'a> {
+        Box::pin(async move {
+            // Suggest every non-opped player.
+            let ops = context.server().data.operator_config.read().await;
+            for player in context.source.server().get_all_players() {
+                if ops.ops.iter().all(|op| op.uuid != player.gameprofile.id) {
+                    builder = builder.suggest(player.gameprofile.name.clone());
+                }
+            }
+            builder.build()
+        })
+    }
+}
+
+pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION,
+        DESCRIPTION,
+        PermissionDefault::Op(PermissionLvl::Three),
+    ));
+
+    dispatcher.register(
+        command("op", DESCRIPTION).requires(PERMISSION).then(
+            argument(ARG_TARGETS, GameProfileArgumentType)
+                .suggests(OpSuggestionProvider)
+                .executes(OpCommandExecutor),
+        ),
+    );
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This PR makes the `GameProfileArgumentType` able to search for online players (by copying the existing code from the equivalent `args` argument).

Along with that, it also reimplements the `/op` command with the new argument type.

## Testing

Tested the command, and it seems to work properly with online, offline and non-existent players.