### PR TITLE
feat(codec): implement `Encode` and `Decode` for some `pumpkin-util` items and convenience codec macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,6 +3011,7 @@ dependencies = [
  "num-traits",
  "p384",
  "proc-macro2",
+ "pumpkin-codecs",
  "pumpkin-nbt",
  "quote",
  "rsa",

--- a/pumpkin-codecs/src/codec/list.rs
+++ b/pumpkin-codecs/src/codec/list.rs
@@ -133,6 +133,75 @@ where
     }
 }
 
+/// A wrapper around a `Vec` that cannot have it be empty, similar to Minecraft's `ExtraCodecs.nonEmptyList`.
+pub struct NonEmptyVec<T>(Vec<T>);
+
+impl<T> From<NonEmptyVec<T>> for Vec<T> {
+    /// Returns the wrapped `Vec` of this `NonEmptyVec`.
+    fn from(value: NonEmptyVec<T>) -> Self {
+        value.0
+    }
+}
+
+impl<T> Encode for NonEmptyVec<T>
+where
+    T: Encode,
+{
+    fn encode<O: DynamicOps>(&self, ops: &'static O, prefix: O::Value) -> DataResult<O::Value> {
+        if self.0.is_empty() {
+            DataResult::new_error("List must have contents")
+        } else {
+            self.0.encode(ops, prefix)
+        }
+    }
+}
+
+impl<T> Decode for NonEmptyVec<T>
+where
+    T: Decode,
+{
+    fn decode<O: DynamicOps>(input: O::Value, ops: &'static O) -> DataResult<(Self, O::Value)> {
+        Vec::<T>::decode(input, ops).flat_map(|(v, c)| Self::flat_try_from(v).map(|v| (v, c)))
+    }
+}
+
+impl<T> FlatTryFrom<Vec<T>> for NonEmptyVec<T> {
+    fn flat_try_from(value: Vec<T>) -> DataResult<Self> {
+        if value.is_empty() {
+            DataResult::new_error("List must have contents")
+        } else {
+            DataResult::new_success(Self(value))
+        }
+    }
+}
+
+// Utility functions
+
+/// Tries to check a list to have a fixed size `size`, returning the appropriate
+/// [`DataResult`].
+///
+/// # Arguments
+/// - `list`: The list to validate.
+/// - `size`: The required size.
+///
+/// # Returns
+/// A successful result if `list.len() == size`; otherwise, it returns a partial/non-result.
+/// If this result is partial, it will also be `size` elements long.
+pub fn validate_fixed_size<T>(list: Vec<T>, size: usize) -> DataResult<Vec<T>> {
+    if list.len() == size {
+        DataResult::new_success(list)
+    } else {
+        let message = format!("Input is not a list of {size} elements");
+        if list.len() > size {
+            DataResult::new_partial_error(message, list.into_iter().take(size).collect())
+        } else {
+            DataResult::new_error(message)
+        }
+    }
+}
+
+//
+
 #[cfg(test)]
 mod test {
     use crate::assert_decode;

--- a/pumpkin-codecs/src/codec/map.rs
+++ b/pumpkin-codecs/src/codec/map.rs
@@ -99,7 +99,10 @@ where
 mod test {
     use crate::codec::*;
     use crate::json_ops::JsonOps;
-    use crate::{assert_decode, assert_encode_success, comap_flat_map_codec_impl, flat_xmap_codec_impl, FlatTryFrom};
+    use crate::{
+        FlatTryFrom, assert_decode, assert_encode_success, comap_flat_map_codec_impl,
+        flat_xmap_codec_impl,
+    };
     use serde_json::json;
     use std::collections::HashMap;
     use std::fmt::{Display, Formatter};

--- a/pumpkin-codecs/src/codec/map.rs
+++ b/pumpkin-codecs/src/codec/map.rs
@@ -99,7 +99,7 @@ where
 mod test {
     use crate::codec::*;
     use crate::json_ops::JsonOps;
-    use crate::{assert_decode, assert_encode_success};
+    use crate::{assert_decode, assert_encode_success, comap_flat_map_codec_impl, flat_xmap_codec_impl, FlatTryFrom};
     use serde_json::json;
     use std::collections::HashMap;
     use std::fmt::{Display, Formatter};
@@ -140,31 +140,24 @@ mod test {
             }
         }
 
-        impl Encode for StringInteger {
-            fn encode<O: DynamicOps>(
-                &self,
-                ops: &'static O,
-                prefix: O::Value,
-            ) -> DataResult<O::Value> {
+        impl From<&StringInteger> for String {
+            fn from(value: &StringInteger) -> Self {
                 // This will always succeed.
-                self.0.to_string().encode(ops, prefix)
+                value.0.to_string()
             }
         }
 
-        impl Decode for StringInteger {
-            fn decode<O: DynamicOps>(
-                input: O::Value,
-                ops: &'static O,
-            ) -> DataResult<(Self, O::Value)> {
-                String::decode(input, ops).flat_map(|s| {
-                    // Try to parse an integer.
-                    s.0.parse().map_or_else(
-                        |_| DataResult::new_error("Could not parse String"),
-                        |i| DataResult::new_success((Self(i), s.1)),
-                    )
-                })
+        impl FlatTryFrom<String> for StringInteger {
+            fn flat_try_from(value: String) -> DataResult<Self> {
+                // Try to parse an integer.
+                value.parse().map_or_else(
+                    |_| DataResult::new_error("Could not parse String"),
+                    |i| DataResult::new_success(Self(i)),
+                )
             }
         }
+
+        comap_flat_map_codec_impl!(String => StringInteger, StringInteger::flat_try_from, String::from);
 
         let mut map = HashMap::<StringInteger, bool>::new();
 
@@ -198,40 +191,30 @@ mod test {
         #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Hash)]
         struct Letter(String);
 
-        fn check_letter(string: String) -> DataResult<Letter> {
-            // Try to parse a single letter.
-            if string.len() == 1 {
-                DataResult::new_success(Letter(string))
-            } else {
-                DataResult::new_error(format!("Not a letter: {string}"))
-            }
-        }
-
         impl Display for Letter {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
                 write!(f, "{}", self.0)
             }
         }
 
-        impl Encode for Letter {
-            fn encode<O: DynamicOps>(
-                &self,
-                ops: &'static O,
-                prefix: O::Value,
-            ) -> DataResult<O::Value> {
-                // This will always succeed.
-                check_letter(self.0.clone()).flat_map(|l| l.0.encode(ops, prefix))
+        impl FlatTryFrom<String> for Letter {
+            fn flat_try_from(value: String) -> DataResult<Self> {
+                // Try to parse a single letter.
+                if value.len() == 1 {
+                    DataResult::new_success(Self(value))
+                } else {
+                    DataResult::new_error(format!("Not a letter: {value}"))
+                }
             }
         }
 
-        impl Decode for Letter {
-            fn decode<O: DynamicOps>(
-                input: O::Value,
-                ops: &'static O,
-            ) -> DataResult<(Self, O::Value)> {
-                String::decode(input, ops).flat_map(|(s, v)| check_letter(s).map(|l| (l, v)))
+        impl FlatTryFrom<&Letter> for String {
+            fn flat_try_from(value: &Letter) -> DataResult<Self> {
+                Letter::flat_try_from(value.0.clone()).map(|l| l.0)
             }
         }
+
+        flat_xmap_codec_impl!(String => Letter, Letter::flat_try_from, String::flat_try_from);
 
         type LetterData = HashMap<Letter, u64>;
 

--- a/pumpkin-codecs/src/codec/mod.rs
+++ b/pumpkin-codecs/src/codec/mod.rs
@@ -182,8 +182,7 @@ macro_rules! decode_impl {
                 input: O::Value,
                 ops: &'static O,
             ) -> $crate::DataResult<(Self, O::Value)> {
-                <$first_type>::decode(input, ops)
-                    .map(|(s, p)| ($forward(s), p))
+                <$first_type>::decode(input, ops).map(|(s, p)| ($forward(s), p))
             }
         }
     };

--- a/pumpkin-codecs/src/codec/mod.rs
+++ b/pumpkin-codecs/src/codec/mod.rs
@@ -158,7 +158,7 @@ macro_rules! encode_impl {
         }
     };
 
-    (fallible $backward:path) => {
+    (fallible $second_type:ty, $backward:path) => {
         impl $crate::Encode for $second_type {
             fn encode<O: $crate::DynamicOps>(
                 &self,

--- a/pumpkin-codecs/src/codec/mod.rs
+++ b/pumpkin-codecs/src/codec/mod.rs
@@ -140,3 +140,122 @@ impl<T: Decode> FieldDecode for T {
         decoded_option.map(|o| o.unwrap_or(default))
     }
 }
+
+/// Provides a fallible/infallible encode conversion from a first type to a second type via `backward`.
+///
+/// You probably do not need to use this directly.
+#[macro_export]
+macro_rules! encode_impl {
+    (infallible $second_type:ty, $backward:path) => {
+        impl $crate::Encode for $second_type {
+            fn encode<O: $crate::DynamicOps>(
+                &self,
+                ops: &'static O,
+                prefix: O::Value,
+            ) -> $crate::DataResult<O::Value> {
+                $backward(self).encode(ops, prefix)
+            }
+        }
+    };
+
+    (fallible $backward:path) => {
+        impl $crate::Encode for $second_type {
+            fn encode<O: $crate::DynamicOps>(
+                &self,
+                ops: &'static O,
+                prefix: O::Value,
+            ) -> $crate::DataResult<O::Value> {
+                $backward(self).flat_map(|m| m.encode(ops, prefix))
+            }
+        }
+    };
+}
+
+/// Provides a fallible/infallible decode conversion from a first type to a second type via `forward`.
+///
+/// You probably do not need to use this directly.
+#[macro_export]
+macro_rules! decode_impl {
+    (infallible $first_type:ty, $second_type:ty, $forward:path) => {
+        impl $crate::Decode for $second_type {
+            fn decode<O: $crate::DynamicOps>(
+                input: O::Value,
+                ops: &'static O,
+            ) -> $crate::DataResult<(Self, O::Value)> {
+                <$first_type>::decode(input, ops).flat_map(|(s, p)| ($forward(s), p))
+            }
+        }
+    };
+
+    (fallible $first_type:ty, $second_type:ty, $forward:path) => {
+        impl $crate::Decode for $second_type {
+            fn decode<O: $crate::DynamicOps>(
+                input: O::Value,
+                ops: &'static O,
+            ) -> $crate::DataResult<(Self, O::Value)> {
+                <$first_type>::decode(input, ops)
+                    .flat_map(|(s, p)| $forward(s).map(|ident| (ident, p)))
+            }
+        }
+    };
+}
+
+/// Provides an easy `xmap`-like implementation of a *second type*
+/// by using the already-existing implementation of a *first type*.
+///
+/// The macro is written as `xmap_codec_impl!(first => second, forward, backward)`,
+/// where:
+/// - `forward` is the infallible conversion `fn(first_type) -> second_type` (for decoding).
+/// - `backward` is the infallible conversion `fn(&second_type) -> first_type` (for encoding).
+#[macro_export]
+macro_rules! xmap_codec_impl {
+    ($first_type:ty => $second_type:ty, $forward:path, $backward:path) => {
+        $crate::encode_impl!(infallible $second_type, $backward);
+        $crate::decode_impl!(infallible $first_type, $second_type, $forward);
+    };
+}
+
+/// Provides an easy `comapFlatMap`-like implementation of a *second type*
+/// by using the already-existing implementation of a *first type*.
+///
+/// The macro is written as `comap_flat_map_codec_impl!(first => second, forward, backward)`,
+/// where:
+/// - `forward` is the fallible conversion `fn(first_type) -> DataResult<second_type>` (for decoding).
+/// - `backward` is the infallible conversion `fn(&second_type) -> first_type` (for encoding).
+#[macro_export]
+macro_rules! comap_flat_map_codec_impl {
+    ($first_type:ty => $second_type:ty, $forward:path, $backward:path) => {
+        $crate::encode_impl!(infallible $second_type, $backward);
+        $crate::decode_impl!(fallible $first_type, $second_type, $forward);
+    };
+}
+
+/// Provides an easy `flatComapMap`-like implementation of a *second type*
+/// by using the already-existing implementation of a *first type*.
+///
+/// The macro is written as `flat_comap_map_codec_impl!(first => second, forward, backward)`,
+/// where:
+/// - `forward` is the infallible conversion `fn(first_type) -> second_type` (for decoding).
+/// - `backward` is the fallible conversion `fn(&second_type) -> DataResult<first_type>` (for encoding).
+#[macro_export]
+macro_rules! flat_comap_map_codec_impl {
+    ($first_type:ty => $second_type:ty, $forward:path, $backward:path) => {
+        $crate::encode_impl!(fallible $second_type, $backward);
+        $crate::decode_impl!(infallible $first_type, $second_type, $forward);
+    };
+}
+
+/// Provides an easy `flatXmap`-like implementation of a *second type*
+/// by using the already-existing implementation of a *first type*.
+///
+/// The macro is written as `flat_xmap_codec_impl!(first => second, forward, backward)`,
+/// where:
+/// - `forward` is the fallible conversion `fn(first_type) -> DataResult<second_type>` (for decoding).
+/// - `backward` is the fallible conversion `fn(&second_type) -> DataResult<first_type>` (for encoding).
+#[macro_export]
+macro_rules! flat_xmap_codec_impl {
+    ($first_type:ty => $second_type:ty, $forward:path, $backward:path) => {
+        $crate::encode_impl!(fallible $second_type, $backward);
+        $crate::decode_impl!(fallible $first_type, $second_type, $forward);
+    };
+}

--- a/pumpkin-codecs/src/codec/mod.rs
+++ b/pumpkin-codecs/src/codec/mod.rs
@@ -200,13 +200,13 @@ macro_rules! decode_impl {
     };
 }
 
-/// Provides an easy `xmap`-like implementation of a *second type*
-/// by using the already-existing implementation of a *first type*.
+/// Provides easy `xmap`-like `Encode` and `Decode` implementations of a *second type*
+/// by using the already-existing implementations of a *first type*.
 ///
 /// The macro is written as `xmap_codec_impl!(first => second, forward, backward)`,
 /// where:
-/// - `forward` is the infallible conversion `fn(first_type) -> second_type` (for decoding).
-/// - `backward` is the infallible conversion `fn(&second_type) -> first_type` (for encoding).
+/// - `forward` is the infallible conversion `fn(first) -> second` (for decoding).
+/// - `backward` is the infallible conversion `fn(&second) -> first` (for encoding).
 #[macro_export]
 macro_rules! xmap_codec_impl {
     ($first_type:ty => $second_type:ty, $forward:path, $backward:path) => {
@@ -215,13 +215,13 @@ macro_rules! xmap_codec_impl {
     };
 }
 
-/// Provides an easy `comapFlatMap`-like implementation of a *second type*
-/// by using the already-existing implementation of a *first type*.
+/// Provides easy `comapFlatMap`-like `Encode` and `Decode` implementations of a *second type*
+/// by using the already-existing implementations of a *first type*.
 ///
 /// The macro is written as `comap_flat_map_codec_impl!(first => second, forward, backward)`,
 /// where:
-/// - `forward` is the fallible conversion `fn(first_type) -> DataResult<second_type>` (for decoding).
-/// - `backward` is the infallible conversion `fn(&second_type) -> first_type` (for encoding).
+/// - `forward` is the fallible conversion `fn(first) -> DataResult<second>` (for decoding).
+/// - `backward` is the infallible conversion `fn(&second) -> first` (for encoding).
 #[macro_export]
 macro_rules! comap_flat_map_codec_impl {
     ($first_type:ty => $second_type:ty, $forward:path, $backward:path) => {
@@ -230,13 +230,13 @@ macro_rules! comap_flat_map_codec_impl {
     };
 }
 
-/// Provides an easy `flatComapMap`-like implementation of a *second type*
-/// by using the already-existing implementation of a *first type*.
+/// Provides easy `flatComapMap`-like `Encode` and `Decode` implementations of a *second type*
+/// by using the already-existing implementations of a *first type*.
 ///
 /// The macro is written as `flat_comap_map_codec_impl!(first => second, forward, backward)`,
 /// where:
-/// - `forward` is the infallible conversion `fn(first_type) -> second_type` (for decoding).
-/// - `backward` is the fallible conversion `fn(&second_type) -> DataResult<first_type>` (for encoding).
+/// - `forward` is the infallible conversion `fn(first) -> second` (for decoding).
+/// - `backward` is the fallible conversion `fn(&second) -> DataResult<first>` (for encoding).
 #[macro_export]
 macro_rules! flat_comap_map_codec_impl {
     ($first_type:ty => $second_type:ty, $forward:path, $backward:path) => {
@@ -245,13 +245,13 @@ macro_rules! flat_comap_map_codec_impl {
     };
 }
 
-/// Provides an easy `flatXmap`-like implementation of a *second type*
-/// by using the already-existing implementation of a *first type*.
+/// Provides easy `flatXmap`-like `Encode` and `Decode` implementations of a *second type*
+/// by using the already-existing implementations of a *first type*.
 ///
 /// The macro is written as `flat_xmap_codec_impl!(first => second, forward, backward)`,
 /// where:
-/// - `forward` is the fallible conversion `fn(first_type) -> DataResult<second_type>` (for decoding).
-/// - `backward` is the fallible conversion `fn(&second_type) -> DataResult<first_type>` (for encoding).
+/// - `forward` is the fallible conversion `fn(first) -> DataResult<second>` (for decoding).
+/// - `backward` is the fallible conversion `fn(&second) -> DataResult<first>` (for encoding).
 #[macro_export]
 macro_rules! flat_xmap_codec_impl {
     ($first_type:ty => $second_type:ty, $forward:path, $backward:path) => {

--- a/pumpkin-codecs/src/codec/mod.rs
+++ b/pumpkin-codecs/src/codec/mod.rs
@@ -182,7 +182,8 @@ macro_rules! decode_impl {
                 input: O::Value,
                 ops: &'static O,
             ) -> $crate::DataResult<(Self, O::Value)> {
-                <$first_type>::decode(input, ops).flat_map(|(s, p)| ($forward(s), p))
+                <$first_type>::decode(input, ops)
+                    .map(|(s, p)| ($forward(s), p))
             }
         }
     };
@@ -193,8 +194,7 @@ macro_rules! decode_impl {
                 input: O::Value,
                 ops: &'static O,
             ) -> $crate::DataResult<(Self, O::Value)> {
-                <$first_type>::decode(input, ops)
-                    .flat_map(|(s, p)| $forward(s).map(|ident| (ident, p)))
+                <$first_type>::decode(input, ops).flat_map(|(s, p)| $forward(s).map(|m| (m, p)))
             }
         }
     };

--- a/pumpkin-codegen/Cargo.lock
+++ b/pumpkin-codegen/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "num-traits",
  "p384",
  "proc-macro2",
+ "pumpkin-codecs",
  "pumpkin-nbt",
  "quote",
  "rsa",

--- a/pumpkin-util/Cargo.toml
+++ b/pumpkin-util/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 pumpkin-nbt.workspace = true
+pumpkin-codecs.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 bytes.workspace = true

--- a/pumpkin-util/src/identifier.rs
+++ b/pumpkin-util/src/identifier.rs
@@ -1,8 +1,6 @@
 use std::{borrow::Cow, fmt::Display};
 
-use pumpkin_codecs::{
-    DataResult, FlatTryFrom, comap_flat_map_codec_impl,
-};
+use pumpkin_codecs::{DataResult, FlatTryFrom, comap_flat_map_codec_impl};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/pumpkin-util/src/identifier.rs
+++ b/pumpkin-util/src/identifier.rs
@@ -1,8 +1,10 @@
 use std::{borrow::Cow, fmt::Display};
 
+use pumpkin_codecs::{
+    DataResult, FlatTryFrom, comap_flat_map_codec_impl,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use pumpkin_codecs::{DataResult, Decode, DynamicOps, Encode, FlatTryFrom};
 
 pub const VANILLA_NAMESPACE: &str = "minecraft";
 pub const PUMPKIN_NAMESPACE: &str = "pumpkin";
@@ -383,35 +385,23 @@ impl<'de> Deserialize<'de> for Identifier {
     }
 }
 
+comap_flat_map_codec_impl!(String => Identifier, Identifier::flat_try_from, ToString::to_string);
+
 impl FlatTryFrom<String> for Identifier {
     fn flat_try_from(value: String) -> DataResult<Self> {
         Self::parse(&value).map_or_else(
             |_| DataResult::new_error(format!("Not a valid resource location: {value}")),
-            DataResult::new_success
+            DataResult::new_success,
         )
-    }
-}
-
-impl Encode for Identifier {
-    fn encode<O: DynamicOps>(&self, ops: &'static O, prefix: O::Value) -> DataResult<O::Value> {
-        self.to_string().encode(ops, prefix)
-    }
-}
-
-impl Decode for Identifier {
-    fn decode<O: DynamicOps>(input: O::Value, ops: &'static O) -> DataResult<(Self, O::Value)> {
-        String::decode(input, ops).flat_map(|(s, p)| {
-            Identifier::flat_try_from(s).map(|ident| (ident, p))
-        })
     }
 }
 
 #[cfg(test)]
 mod test {
-    use serde_json::json;
-    use pumpkin_codecs::{assert_decode, assert_encode_success};
-    use pumpkin_codecs::json_ops::JsonOps;
     use crate::identifier::{Identifier, IdentifierError};
+    use pumpkin_codecs::json_ops::JsonOps;
+    use pumpkin_codecs::{assert_decode, assert_encode_success};
+    use serde_json::json;
 
     #[test]
     fn new() -> Result<(), IdentifierError> {
@@ -446,9 +436,21 @@ mod test {
 
     #[test]
     fn codec() {
-        assert_encode_success!(Identifier::from_static("abc", "def"), JsonOps, json!("abc:def"));
-        assert_encode_success!(Identifier::from_static("", "no_namespace"), JsonOps, json!(":no_namespace"));
-        assert_encode_success!(Identifier::vanilla_static("example"), JsonOps, json!("minecraft:example"));
+        assert_encode_success!(
+            Identifier::from_static("abc", "def"),
+            JsonOps,
+            json!("abc:def")
+        );
+        assert_encode_success!(
+            Identifier::from_static("", "no_namespace"),
+            JsonOps,
+            json!(":no_namespace")
+        );
+        assert_encode_success!(
+            Identifier::vanilla_static("example"),
+            JsonOps,
+            json!("minecraft:example")
+        );
 
         assert_decode!(Identifier, json!("abc:def"), JsonOps, is_success);
         assert_decode!(Identifier, json!("vanilla"), JsonOps, is_success);

--- a/pumpkin-util/src/identifier.rs
+++ b/pumpkin-util/src/identifier.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, fmt::Display};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use pumpkin_codecs::{DataResult, Decode, DynamicOps, Encode, FlatTryFrom};
 
 pub const VANILLA_NAMESPACE: &str = "minecraft";
 pub const PUMPKIN_NAMESPACE: &str = "pumpkin";
@@ -382,8 +383,34 @@ impl<'de> Deserialize<'de> for Identifier {
     }
 }
 
+impl FlatTryFrom<String> for Identifier {
+    fn flat_try_from(value: String) -> DataResult<Self> {
+        Self::parse(&value).map_or_else(
+            |_| DataResult::new_error(format!("Not a valid resource location: {value}")),
+            DataResult::new_success
+        )
+    }
+}
+
+impl Encode for Identifier {
+    fn encode<O: DynamicOps>(&self, ops: &'static O, prefix: O::Value) -> DataResult<O::Value> {
+        self.to_string().encode(ops, prefix)
+    }
+}
+
+impl Decode for Identifier {
+    fn decode<O: DynamicOps>(input: O::Value, ops: &'static O) -> DataResult<(Self, O::Value)> {
+        String::decode(input, ops).flat_map(|(s, p)| {
+            Identifier::flat_try_from(s).map(|ident| (ident, p))
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use serde_json::json;
+    use pumpkin_codecs::{assert_decode, assert_encode_success};
+    use pumpkin_codecs::json_ops::JsonOps;
     use crate::identifier::{Identifier, IdentifierError};
 
     #[test]
@@ -415,5 +442,17 @@ mod test {
         assert!(Identifier::parse("1234+567:89").is_err());
 
         Ok(())
+    }
+
+    #[test]
+    fn codec() {
+        assert_encode_success!(Identifier::from_static("abc", "def"), JsonOps, json!("abc:def"));
+        assert_encode_success!(Identifier::from_static("", "no_namespace"), JsonOps, json!(":no_namespace"));
+        assert_encode_success!(Identifier::vanilla_static("example"), JsonOps, json!("minecraft:example"));
+
+        assert_decode!(Identifier, json!("abc:def"), JsonOps, is_success);
+        assert_decode!(Identifier, json!("vanilla"), JsonOps, is_success);
+        assert_decode!(Identifier, json!("2 + 3"), JsonOps, is_error);
+        assert_decode!(Identifier, json!("a._b-c:/4_-/5.9"), JsonOps, is_success);
     }
 }

--- a/pumpkin-util/src/math/block_box.rs
+++ b/pumpkin-util/src/math/block_box.rs
@@ -1,3 +1,5 @@
+use pumpkin_codecs::{comap_flat_map_codec_impl, DataResult, FlatTryFrom, IntStream};
+use pumpkin_codecs::codec::list::validate_fixed_size;
 use crate::{
     BlockDirection,
     math::{
@@ -262,3 +264,26 @@ impl BlockBox {
         Some(result)
     }
 }
+
+impl From<&BlockBox> for IntStream {
+    fn from(value: &BlockBox) -> Self {
+        let Vector3 { x: min_x, y: min_y, z: min_z } = value.min;
+        let Vector3 { x: max_x, y: max_y, z: max_z } = value.max;
+        Self(vec![min_x, min_y, min_z, max_x, max_y, max_z])
+    }
+}
+
+impl FlatTryFrom<IntStream> for BlockBox {
+    fn flat_try_from(value: IntStream) -> DataResult<Self> {
+        validate_fixed_size(value.0, 6)
+            .map(|v| {
+                let [ min_x, min_y, min_z, max_x, max_y, max_z ]: [i32; 6] = v.try_into().unwrap_or_else(|_| unreachable!());
+                Self {
+                    min: Vector3::new(min_x, min_y, min_z),
+                    max: Vector3::new(max_x, max_y, max_z)
+                }
+            })
+    }
+}
+
+comap_flat_map_codec_impl!(IntStream => BlockBox, BlockBox::flat_try_from, IntStream::from);

--- a/pumpkin-util/src/math/block_box.rs
+++ b/pumpkin-util/src/math/block_box.rs
@@ -1,5 +1,3 @@
-use pumpkin_codecs::{comap_flat_map_codec_impl, DataResult, FlatTryFrom, IntStream};
-use pumpkin_codecs::codec::list::validate_fixed_size;
 use crate::{
     BlockDirection,
     math::{
@@ -7,6 +5,8 @@ use crate::{
         vector3::{Axis, Vector3},
     },
 };
+use pumpkin_codecs::codec::list::validate_fixed_size;
+use pumpkin_codecs::{DataResult, FlatTryFrom, IntStream, comap_flat_map_codec_impl};
 
 /// Represents an axis-aligned 3D block bounding box in integer coordinates.
 #[derive(Clone, Copy, Debug)]
@@ -267,22 +267,30 @@ impl BlockBox {
 
 impl From<&BlockBox> for IntStream {
     fn from(value: &BlockBox) -> Self {
-        let Vector3 { x: min_x, y: min_y, z: min_z } = value.min;
-        let Vector3 { x: max_x, y: max_y, z: max_z } = value.max;
+        let Vector3 {
+            x: min_x,
+            y: min_y,
+            z: min_z,
+        } = value.min;
+        let Vector3 {
+            x: max_x,
+            y: max_y,
+            z: max_z,
+        } = value.max;
         Self(vec![min_x, min_y, min_z, max_x, max_y, max_z])
     }
 }
 
 impl FlatTryFrom<IntStream> for BlockBox {
     fn flat_try_from(value: IntStream) -> DataResult<Self> {
-        validate_fixed_size(value.0, 6)
-            .map(|v| {
-                let [ min_x, min_y, min_z, max_x, max_y, max_z ]: [i32; 6] = v.try_into().unwrap_or_else(|_| unreachable!());
-                Self {
-                    min: Vector3::new(min_x, min_y, min_z),
-                    max: Vector3::new(max_x, max_y, max_z)
-                }
-            })
+        validate_fixed_size(value.0, 6).map(|v| {
+            let [min_x, min_y, min_z, max_x, max_y, max_z]: [i32; 6] =
+                v.try_into().unwrap_or_else(|_| unreachable!());
+            Self {
+                min: Vector3::new(min_x, min_y, min_z),
+                max: Vector3::new(max_x, max_y, max_z),
+            }
+        })
     }
 }
 

--- a/pumpkin-util/src/math/euler_angle.rs
+++ b/pumpkin-util/src/math/euler_angle.rs
@@ -1,5 +1,7 @@
 use pumpkin_nbt::tag::NbtTag;
 use serde::{Deserialize, Serialize};
+use pumpkin_codecs::{comap_flat_map_codec_impl, DataResult, FlatTryFrom};
+use pumpkin_codecs::codec::list::validate_fixed_size;
 
 /// Represents a 3D rotation using Euler angles in degrees.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -81,3 +83,22 @@ impl From<NbtTag> for EulerAngle {
         Self::ZERO
     }
 }
+
+impl From<&EulerAngle> for Vec<f32> {
+    fn from(value: &EulerAngle) -> Self {
+        let EulerAngle { pitch, yaw, roll } = value;
+        vec![*pitch, *yaw, *roll]
+    }
+}
+
+impl FlatTryFrom<Vec<f32>> for EulerAngle {
+    fn flat_try_from(value: Vec<f32>) -> DataResult<Self> {
+        validate_fixed_size(value, 6)
+            .map(|v| {
+                let [ x, y, z ]: [f32; 3] = v.try_into().unwrap_or_else(|_| unreachable!());
+                Self { pitch: x, yaw: y, roll: z }
+            })
+    }
+}
+
+comap_flat_map_codec_impl!(Vec<f32> => EulerAngle, EulerAngle::flat_try_from, Vec::<f32>::from);

--- a/pumpkin-util/src/math/euler_angle.rs
+++ b/pumpkin-util/src/math/euler_angle.rs
@@ -1,7 +1,7 @@
+use pumpkin_codecs::codec::list::validate_fixed_size;
+use pumpkin_codecs::{DataResult, FlatTryFrom, comap_flat_map_codec_impl};
 use pumpkin_nbt::tag::NbtTag;
 use serde::{Deserialize, Serialize};
-use pumpkin_codecs::{comap_flat_map_codec_impl, DataResult, FlatTryFrom};
-use pumpkin_codecs::codec::list::validate_fixed_size;
 
 /// Represents a 3D rotation using Euler angles in degrees.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -93,11 +93,14 @@ impl From<&EulerAngle> for Vec<f32> {
 
 impl FlatTryFrom<Vec<f32>> for EulerAngle {
     fn flat_try_from(value: Vec<f32>) -> DataResult<Self> {
-        validate_fixed_size(value, 6)
-            .map(|v| {
-                let [ x, y, z ]: [f32; 3] = v.try_into().unwrap_or_else(|_| unreachable!());
-                Self { pitch: x, yaw: y, roll: z }
-            })
+        validate_fixed_size(value, 6).map(|v| {
+            let [x, y, z]: [f32; 3] = v.try_into().unwrap_or_else(|_| unreachable!());
+            Self {
+                pitch: x,
+                yaw: y,
+                roll: z,
+            }
+        })
     }
 }
 

--- a/pumpkin-util/src/math/mod.rs
+++ b/pumpkin-util/src/math/mod.rs
@@ -404,6 +404,41 @@ pub fn java_string_hash(string: &str) -> i32 {
     result
 }
 
+macro_rules! vector_codec_impl {
+    ($vector:ty, $number:literal, $($components:ident),+ ) => {
+        impl<T> From<&$vector> for Vec<T> where T: Clone {
+            fn from(value: &$vector) -> Self {
+                vec![
+                    $( value.$components.clone(), )+
+                ]
+            }
+        }
+
+        impl<T> FlatTryFrom<Vec<T>> for $vector {
+            fn flat_try_from(value: Vec<T>) -> DataResult<Self> {
+                validate_fixed_size(value, 2)
+                    .map(|v| {
+                        let [ $( $components, )+ ]: [T; $number] = v.try_into().unwrap_or_else(|_| unreachable!());
+                        Self { $( $components, )+ }
+                    })
+            }
+        }
+
+        impl<T> Encode for $vector where T: Encode + Clone {
+            fn encode<O: DynamicOps>(&self, ops: &'static O, prefix: O::Value) -> DataResult<O::Value> {
+                Vec::<T>::from(self).encode(ops, prefix)
+            }
+        }
+
+        impl<T> Decode for $vector where T: Decode {
+            fn decode<O: DynamicOps>(input: O::Value, ops: &'static O) -> DataResult<(Self, O::Value)> {
+                <Vec<T>>::decode(input, ops).flat_map(|(s, p)| Self::flat_try_from(s).map(|v| (v, p)))
+            }
+        }
+    };
+}
+pub(crate) use vector_codec_impl;
+
 /// Tests the Java-style string and array hash implementations.
 ///
 /// This verifies that `java_string_hash` and `java_array_hash` produce the expected

--- a/pumpkin-util/src/math/position.rs
+++ b/pumpkin-util/src/math/position.rs
@@ -7,9 +7,9 @@ use std::hash::Hash;
 
 use crate::math::vector2::Vector2;
 use num_traits::Euclid;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use pumpkin_codecs::{comap_flat_map_codec_impl, xmap_codec_impl, DataResult, FlatTryFrom, IntStream};
 use pumpkin_codecs::codec::list::validate_fixed_size;
+use pumpkin_codecs::{DataResult, FlatTryFrom, IntStream, comap_flat_map_codec_impl};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// An iterator that yields all `BlockPos` positions within a cuboid region.
 pub struct BlockPosIterator {
@@ -635,18 +635,17 @@ impl<'de> Deserialize<'de> for BlockPos {
 
 impl From<&BlockPos> for IntStream {
     fn from(value: &BlockPos) -> Self {
-        let Vector3 {x, y, z } = value.0;
+        let Vector3 { x, y, z } = value.0;
         Self(vec![x, y, z])
     }
 }
 
 impl FlatTryFrom<IntStream> for BlockPos {
     fn flat_try_from(value: IntStream) -> DataResult<Self> {
-        validate_fixed_size(value.0, 3)
-            .map(|v| {
-                let [ x, y, z ]: [i32; 3] = v.try_into().unwrap_or_else(|_| unreachable!());
-                Self(Vector3::new(x, y, z))
-            })
+        validate_fixed_size(value.0, 3).map(|v| {
+            let [x, y, z]: [i32; 3] = v.try_into().unwrap_or_else(|_| unreachable!());
+            Self(Vector3::new(x, y, z))
+        })
     }
 }
 

--- a/pumpkin-util/src/math/position.rs
+++ b/pumpkin-util/src/math/position.rs
@@ -8,6 +8,8 @@ use std::hash::Hash;
 use crate::math::vector2::Vector2;
 use num_traits::Euclid;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use pumpkin_codecs::{comap_flat_map_codec_impl, xmap_codec_impl, DataResult, FlatTryFrom, IntStream};
+use pumpkin_codecs::codec::list::validate_fixed_size;
 
 /// An iterator that yields all `BlockPos` positions within a cuboid region.
 pub struct BlockPosIterator {
@@ -630,6 +632,25 @@ impl<'de> Deserialize<'de> for BlockPos {
         deserializer.deserialize_i64(Visitor)
     }
 }
+
+impl From<&BlockPos> for IntStream {
+    fn from(value: &BlockPos) -> Self {
+        let Vector3 {x, y, z } = value.0;
+        Self(vec![x, y, z])
+    }
+}
+
+impl FlatTryFrom<IntStream> for BlockPos {
+    fn flat_try_from(value: IntStream) -> DataResult<Self> {
+        validate_fixed_size(value.0, 3)
+            .map(|v| {
+                let [ x, y, z ]: [i32; 3] = v.try_into().unwrap_or_else(|_| unreachable!());
+                Self(Vector3::new(x, y, z))
+            })
+    }
+}
+
+comap_flat_map_codec_impl!(IntStream => BlockPos, BlockPos::flat_try_from, IntStream::from);
 
 impl fmt::Display for BlockPos {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/pumpkin-util/src/math/position.rs
+++ b/pumpkin-util/src/math/position.rs
@@ -708,21 +708,58 @@ pub const fn pack_local_chunk_section(block_pos: &BlockPos) -> i16 {
 
 #[cfg(test)]
 mod test {
+    use crate::math::position::BlockPos;
     use pumpkin_codecs::{assert_decode, assert_encode_success};
     use pumpkin_nbt::nbt_ops::NbtOps;
     use pumpkin_nbt::tag::NbtTag;
-    use crate::math::position::BlockPos;
 
     #[test]
     fn codec() {
-        assert_encode_success!(BlockPos::new(1, 2, 3), NbtOps, NbtTag::IntArray(vec![1, 2, 3]));
-        assert_encode_success!(BlockPos::new(-1000, 200, 4521), NbtOps, NbtTag::IntArray(vec![-1000, 200, 4521]));
+        assert_encode_success!(
+            BlockPos::new(1, 2, 3),
+            NbtOps,
+            NbtTag::IntArray(vec![1, 2, 3])
+        );
+        assert_encode_success!(
+            BlockPos::new(-1000, 200, 4521),
+            NbtOps,
+            NbtTag::IntArray(vec![-1000, 200, 4521])
+        );
 
-        assert_decode!(BlockPos, NbtTag::IntArray(vec![1, 2, 3]), NbtOps, is_success);
+        assert_decode!(
+            BlockPos,
+            NbtTag::IntArray(vec![1, 2, 3]),
+            NbtOps,
+            is_success
+        );
 
         assert_decode!(BlockPos, NbtTag::List(vec![]), NbtOps, is_error);
-        assert_decode!(BlockPos, NbtTag::List(vec![NbtTag::Int(1), NbtTag::Float(2.0), NbtTag::Int(3)]), NbtOps, is_success);
-        assert_decode!(BlockPos, NbtTag::List(vec![NbtTag::Int(1), NbtTag::Float(2.0), NbtTag::String("69".to_string())]), NbtOps, is_error);
-        assert_decode!(BlockPos, NbtTag::List(vec![NbtTag::Int(1), NbtTag::Float(2.0), NbtTag::Int(3), NbtTag::Byte(3)]), NbtOps, is_error);
+        assert_decode!(
+            BlockPos,
+            NbtTag::List(vec![NbtTag::Int(1), NbtTag::Float(2.0), NbtTag::Int(3)]),
+            NbtOps,
+            is_success
+        );
+        assert_decode!(
+            BlockPos,
+            NbtTag::List(vec![
+                NbtTag::Int(1),
+                NbtTag::Float(2.0),
+                NbtTag::String("69".to_string())
+            ]),
+            NbtOps,
+            is_error
+        );
+        assert_decode!(
+            BlockPos,
+            NbtTag::List(vec![
+                NbtTag::Int(1),
+                NbtTag::Float(2.0),
+                NbtTag::Int(3),
+                NbtTag::Byte(3)
+            ]),
+            NbtOps,
+            is_error
+        );
     }
 }

--- a/pumpkin-util/src/math/position.rs
+++ b/pumpkin-util/src/math/position.rs
@@ -705,3 +705,24 @@ pub const fn pack_local_chunk_section(block_pos: &BlockPos) -> i16 {
     let y = get_local_cord(block_pos.0.y);
     vector3::packed_local(&Vector3::new(x, y, z))
 }
+
+#[cfg(test)]
+mod test {
+    use pumpkin_codecs::{assert_decode, assert_encode_success};
+    use pumpkin_nbt::nbt_ops::NbtOps;
+    use pumpkin_nbt::tag::NbtTag;
+    use crate::math::position::BlockPos;
+
+    #[test]
+    fn codec() {
+        assert_encode_success!(BlockPos::new(1, 2, 3), NbtOps, NbtTag::IntArray(vec![1, 2, 3]));
+        assert_encode_success!(BlockPos::new(-1000, 200, 4521), NbtOps, NbtTag::IntArray(vec![-1000, 200, 4521]));
+
+        assert_decode!(BlockPos, NbtTag::IntArray(vec![1, 2, 3]), NbtOps, is_success);
+
+        assert_decode!(BlockPos, NbtTag::List(vec![]), NbtOps, is_error);
+        assert_decode!(BlockPos, NbtTag::List(vec![NbtTag::Int(1), NbtTag::Float(2.0), NbtTag::Int(3)]), NbtOps, is_success);
+        assert_decode!(BlockPos, NbtTag::List(vec![NbtTag::Int(1), NbtTag::Float(2.0), NbtTag::String("69".to_string())]), NbtOps, is_error);
+        assert_decode!(BlockPos, NbtTag::List(vec![NbtTag::Int(1), NbtTag::Float(2.0), NbtTag::Int(3), NbtTag::Byte(3)]), NbtOps, is_error);
+    }
+}

--- a/pumpkin-util/src/math/vector2.rs
+++ b/pumpkin-util/src/math/vector2.rs
@@ -1,9 +1,11 @@
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
+use super::vector3::Vector3;
+use crate::math::vector_codec_impl;
 use bytes::BufMut;
 use num_traits::Float;
-
-use super::vector3::Vector3;
+use pumpkin_codecs::codec::list::validate_fixed_size;
+use pumpkin_codecs::{DataResult, Decode, DynamicOps, Encode, FlatTryFrom};
 
 /// A 2-dimensional vector with generic numeric components.
 #[derive(Clone, Copy, Debug, PartialEq, Hash, Eq, Default)]
@@ -182,3 +184,5 @@ impl serde::Serialize for Vector2<f32> {
         serializer.serialize_bytes(&buf)
     }
 }
+
+vector_codec_impl!(Vector2<T>, 2, x, y);

--- a/pumpkin-util/src/math/vector3.rs
+++ b/pumpkin-util/src/math/vector3.rs
@@ -1,10 +1,12 @@
 use bytes::BufMut;
 use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
-use num_traits::{Float, Num};
-
 use super::position::BlockPos;
 use super::vector2::Vector2;
+use crate::math::vector_codec_impl;
+use num_traits::{Float, Num};
+use pumpkin_codecs::codec::list::validate_fixed_size;
+use pumpkin_codecs::{DataResult, Decode, DynamicOps, Encode, FlatTryFrom};
 
 /// A 3-dimensional vector with components of type `T`.
 #[derive(Clone, Copy, Debug, PartialEq, Hash, Eq, Default)]
@@ -763,6 +765,8 @@ impl serde::Serialize for Vector3<i32> {
         serializer.serialize_bytes(&buf)
     }
 }
+
+vector_codec_impl!(Vector3<T>, 3, x, y, z);
 
 /// Packs a chunk position vector into a single 64-bit integer.
 ///


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This PR adds `Encode` and `Decode` for the following `pumpkin-util` items (similar to their respective *Minecraft* `Codec`s):
- `Identifier`
- `Vector2<T>` and `Vector3<T>` (similar to `Vec2` and `Vec3`)
- `BlockPos`
- `BlockBox`
- `EulerAngle`

It also adds macros to create simple `Encode` and `Decode` implementations for *mutually convertible types* (see https://docs.fabricmc.net/develop/codecs#mutually-convertible-types): `xmap_codec_impl`, `comap_flat_map_codec_impl`, `flat_comap_map_codec_impl` and `flat_xmap_impl`.

## Testing
Added codec tests for `Identifier`s and `BlockPos`es, which both pass (the other `Codec` implementations are very similar to `BlockPos`).
