### PR TITLE
feat(command): implement UUID argument type

### DIFF
--- a/pumpkin-protocol/src/java/client/play/commands.rs
+++ b/pumpkin-protocol/src/java/client/play/commands.rs
@@ -227,6 +227,7 @@ pub enum ArgumentType<'a> {
     ResourceOrTagKey { identifier: &'a str },
     Resource { identifier: &'a str },
     ResourceKey { identifier: &'a str },
+    ResourceSelector,
     TemplateMirror,
     TemplateRotation,
     Heightmap,
@@ -247,20 +248,36 @@ impl ArgumentType<'_> {
     pub fn to_id(&self, version: &MinecraftVersion) -> i32 {
         // Safety: Since Self is repr(u32), it is guaranteed to hold the discriminant in the first 4 bytes
         // See https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
-        let mut id = unsafe { *std::ptr::from_ref::<Self>(self).cast::<i32>() };
+        let id = unsafe { *std::ptr::from_ref::<Self>(self).cast::<i32>() };
 
-        if version < &MinecraftVersion::V_1_21_6 {
+        // TODO: Should probably be extracting ViaVersion backward mapping data for this
+        if version < &MinecraftVersion::V_1_21_5 {
             match id {
-                ..=16 => {}
-                // 17 => HexColor
-                18..=53 => id -= 1,
-                // 54 => Dialog
-                55.. => id -= 2,
-                _ => panic!("{self:?} does not exist in this Minecraft version (< 1.21.6)."),
-            }
-        }
+                ..=16 => id,
+                18..=46 => id - 1,
+                48..=53 => id - 2,
+                55.. => id - 3,
 
-        id
+                // Fallbacks:
+                // 17 HexColor => String
+                // 47 ResourceSelector => String
+                // 54 Dialog => String
+                17 | 47 | 54 => 5,
+            }
+        } else if version < &MinecraftVersion::V_1_21_6 {
+            match id {
+                ..=16 => id,
+                18..=53 => id - 1,
+                55.. => id - 2,
+
+                // Fallbacks:
+                // 17 HexColor => String
+                // 54 Dialog => String
+                17 | 54 => 5,
+            }
+        } else {
+            id
+        }
     }
 
     #[expect(clippy::match_same_arms)]

--- a/pumpkin-util/src/lib.rs
+++ b/pumpkin-util/src/lib.rs
@@ -28,6 +28,7 @@ pub mod y_offset;
 
 pub mod identifier;
 pub mod jwt;
+pub mod uuid;
 
 /// Represents the different types of height maps used for terrain generation and collision checks.
 #[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]

--- a/pumpkin-util/src/uuid.rs
+++ b/pumpkin-util/src/uuid.rs
@@ -1,0 +1,115 @@
+use uuid::Uuid;
+
+/// Parses a UUID similar to the way that Java does, which makes it ideal for
+/// keeping the same behaviors sometimes.
+#[must_use]
+pub fn parse_uuid_array(uuid: &str) -> Option<[i32; 4]> {
+    // We can't directly use the uuid crate to parse UUIDs, as it parses them
+    // in a different way from Java.
+
+    if uuid.len() > 36 {
+        // UUID string is too large.
+        return None;
+    }
+
+    // Split by hyphen. (5 segments)
+    let mut parts = uuid.split('-');
+    let mut parsed_parts: [i64; 5] = [0; 5];
+
+    for part in &mut parsed_parts {
+        // If a part is empty, the parsing functions will error anyway - this is what we want.
+        *part = i64::from_str_radix(parts.next()?, 16).ok()?;
+    }
+
+    if parts.next().is_some() {
+        // UUIDs must have exactly 5 parts.
+        return None;
+    }
+
+    let bits = [
+        (parsed_parts[0] & 0xFFFFFFFF) << 32
+            | (parsed_parts[1] & 0xFFFF) << 16
+            | (parsed_parts[2] & 0xFFFF),
+        (parsed_parts[3] & 0xFFFF) << 48 | (parsed_parts[4] & 0xFFFFFFFFFFFF),
+    ];
+
+    Some([
+        (bits[0] >> 32) as i32,
+        bits[0] as i32,
+        (bits[1] >> 32) as i32,
+        bits[1] as i32,
+    ])
+}
+
+/// Parses a UUID similar to the way that Java does, which makes it ideal for
+/// keeping the same behaviors sometimes.
+#[must_use]
+pub fn parse_uuid_vec(uuid: &str) -> Option<Vec<i32>> {
+    parse_uuid_array(uuid).map(Vec::from)
+}
+
+/// Parses a UUID similar to the way that Java does, which makes it ideal for
+/// keeping the same behaviors sometimes.
+#[must_use]
+pub fn parse_uuid(uuid: &str) -> Option<Uuid> {
+    let [a, b, c, d] = parse_uuid_array(uuid)?;
+
+    let uuid_int = (a as u32 as u128) << 96
+        | (b as u32 as u128) << 64
+        | (c as u32 as u128) << 32
+        | (d as u32 as u128);
+
+    Some(Uuid::from_u128(uuid_int))
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use uuid::Uuid;
+
+    use crate::uuid::{parse_uuid, parse_uuid_array};
+
+    #[test]
+    fn parse_uuids() {
+        assert_eq!(
+            parse_uuid_array("3d569d3a-93ef-44a0-9f1c-f69db9d37a56"),
+            Some([1029086522, -1813035872, -1625491811, -1177322922])
+        );
+        assert_eq!(
+            parse_uuid_array("3d53a-f-40-c-f69db9d37a56"),
+            Some([251194, 983104, 849565, -1177322922])
+        );
+        assert_eq!(parse_uuid_array("3d53a-f40-c-f69db9d37a56"), None);
+        assert_eq!(
+            parse_uuid_array("fffffffffffffff-0-0-0-0"),
+            Some([-1, 0, 0, 0])
+        );
+        assert_eq!(parse_uuid_array("ffffffffffffffff-0-0-0-0"), None);
+        assert_eq!(
+            parse_uuid_array("+1-+2-+3-+4-+5"),
+            Some([1, 131075, 262144, 5])
+        );
+        assert_eq!(
+            parse_uuid_array("aaaaaaaaaaaaaaa-bbbbbbbbbbbbbb-c-d-e"),
+            Some([-1431655766, -1145372660, 851968, 14])
+        );
+        assert_eq!(
+            parse_uuid_array("aaaaaaaaaaaaaaa-bbbbbbbbbbbbbb-c--e"),
+            None
+        );
+
+        assert_eq!(
+            parse_uuid("3d569d3a-93ef-44a0-9f1c-f69db9d37a56"),
+            Some(Uuid::from_str("3d569d3a-93ef-44a0-9f1c-f69db9d37a56").unwrap())
+        );
+        assert_eq!(
+            parse_uuid("3d53a-f-40-c-f69db9d37a56"),
+            Some(Uuid::from_str("0003d53a-000f-0040-000c-f69db9d37a56").unwrap())
+        );
+        assert_eq!(
+            parse_uuid("+1-+2-+3-+4-+5"),
+            Some(Uuid::from_str("00000001-0002-0003-0004-000000000005").unwrap())
+        );
+    }
+}

--- a/pumpkin/src/command/argument_types/mod.rs
+++ b/pumpkin/src/command/argument_types/mod.rs
@@ -226,3 +226,4 @@ pub mod game_profile;
 pub mod identifier;
 pub mod range;
 pub mod time;
+pub mod uuid;

--- a/pumpkin/src/command/argument_types/uuid.rs
+++ b/pumpkin/src/command/argument_types/uuid.rs
@@ -1,0 +1,46 @@
+use pumpkin_data::translation::java::ARGUMENT_UUID_INVALID;
+use pumpkin_util::uuid::parse_uuid;
+use uuid::Uuid;
+
+use crate::command::{
+    argument_types::argument_type::{ArgumentType, JavaClientArgumentType},
+    errors::{command_syntax_error::CommandSyntaxError, error_types::CommandErrorType},
+    string_reader::StringReader,
+};
+
+pub const INVALID_UUID_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(ARGUMENT_UUID_INVALID, ARGUMENT_UUID_INVALID);
+
+/// Represents an argument type parsing a [`Uuid`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct UuidArgumentType;
+
+impl ArgumentType for UuidArgumentType {
+    type Item = Uuid;
+
+    fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
+        let start = reader.cursor();
+
+        while matches!(reader.peek(), Some('A'..='F' | 'a'..='f' | '0'..='9' | '-')) {
+            reader.skip();
+        }
+
+        parse_uuid(&reader.string()[start..reader.cursor()]).map_or_else(
+            || {
+                reader.set_cursor(start);
+                Err(INVALID_UUID_ERROR_TYPE.create(reader))
+            },
+            Ok,
+        )
+    }
+
+    fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
+        JavaClientArgumentType::Uuid
+    }
+
+    fn examples(&self) -> Vec<String> {
+        examples!("3d569d3a-93ef-44a0-9f1c-f69db9d37a56")
+    }
+}
+
+impl_copy_get!(UuidArgumentType, Uuid);

--- a/pumpkin/src/command/snbt/operations.rs
+++ b/pumpkin/src/command/snbt/operations.rs
@@ -1,5 +1,6 @@
 use pumpkin_data::translation;
 use pumpkin_nbt::{nbt_ops::NbtOps, tag::NbtTag};
+use pumpkin_util::uuid::parse_uuid_vec;
 
 use crate::command::{errors::error_types::CommandErrorType, parser::Parser, snbt::SnbtParser};
 use pumpkin_codecs::DynamicOps;
@@ -52,86 +53,12 @@ impl SnbtOperations {
     /// Parses a UUID in a string to an array of 4 integers.
     fn uuid(parser: &mut SnbtParser, args: &[NbtTag]) -> Option<NbtTag> {
         if let NbtTag::String(string) = &args[0]
-            && let Some(ints) = Self::parse_uuid(string)
+            && let Some(ints) = parse_uuid_vec(string)
         {
             Some(NbtTag::IntArray(ints))
         } else {
             parser.store_simple_error(&EXPECTED_STRING_UUID);
             None
         }
-    }
-}
-
-impl SnbtOperations {
-    /// Parses UUIDs the 'Java' way.
-    #[inline]
-    #[must_use]
-    fn parse_uuid(uuid: &str) -> Option<Vec<i32>> {
-        // We can't directly use the uuid crate to parse UUIDs, as it parses them
-        // in a different way from Java.
-
-        if uuid.len() > 36 {
-            // UUID string is too large.
-            return None;
-        }
-
-        // Split by hyphen. (5 segments)
-        let mut parts = uuid.split('-');
-        let mut parsed_parts: [i64; 5] = [0; 5];
-
-        for part in &mut parsed_parts {
-            // If a part is empty, the parsing functions will error anyway - this is what we want.
-            *part = i64::from_str_radix(parts.next()?, 16).ok()?;
-        }
-
-        if parts.next().is_some() {
-            // UUIDs must have exactly 5 parts.
-            return None;
-        }
-
-        let bits = [
-            (parsed_parts[0] & 0xFFFFFFFF) << 32
-                | (parsed_parts[1] & 0xFFFF) << 16
-                | (parsed_parts[2] & 0xFFFF),
-            (parsed_parts[3] & 0xFFFF) << 48 | (parsed_parts[4] & 0xFFFFFFFFFFFF),
-        ];
-
-        Some(vec![
-            (bits[0] >> 32) as i32,
-            bits[0] as i32,
-            (bits[1] >> 32) as i32,
-            bits[1] as i32,
-        ])
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::command::snbt::operations::SnbtOperations;
-
-    #[test]
-    fn parse_uuids() {
-        assert_eq!(
-            SnbtOperations::parse_uuid("3d569d3a-93ef-44a0-9f1c-f69db9d37a56"),
-            Some(vec![1029086522, -1813035872, -1625491811, -1177322922])
-        );
-        assert_eq!(
-            SnbtOperations::parse_uuid("3d53a-f-40-c-f69db9d37a56"),
-            Some(vec![251194, 983104, 849565, -1177322922])
-        );
-        assert_eq!(SnbtOperations::parse_uuid("3d53a-f40-c-f69db9d37a56"), None);
-        assert_eq!(
-            SnbtOperations::parse_uuid("fffffffffffffff-0-0-0-0"),
-            Some(vec![-1, 0, 0, 0])
-        );
-        assert_eq!(SnbtOperations::parse_uuid("ffffffffffffffff-0-0-0-0"), None);
-        assert_eq!(
-            SnbtOperations::parse_uuid("+1-+2-+3-+4-+5"),
-            Some(vec![1, 131075, 262144, 5])
-        );
-        assert_eq!(
-            SnbtOperations::parse_uuid("aaaaaaaaaaaaaaa-bbbbbbbbbbbbbb-c-d-e"),
-            Some(vec![-1431655766, -1145372660, 851968, 14])
-        );
     }
 }


### PR DESCRIPTION
## Description

Implements the argument type `UuidArgumentType`, which parses UUIDs like Java.
To do this, I decided to move the methods and tests responsible for parsing UUIDs from the `pumpkin` crate to the `pumpkin-util` crate, so that it can be used by some other Pumpkin crates as well, in addition to using it in the argument type.

Also fixes the argument type numeric IDs so that UUIDs display correctly client-side.

## Testing
Tested the UUID argument type in a local-only test command, and it works as intended.