### PR TITLE
fix(plugin-api): fix packet codegen and export more wit

### DIFF
--- a/pumpkin-codegen/src/wit/bedrock_packet.rs
+++ b/pumpkin-codegen/src/wit/bedrock_packet.rs
@@ -88,14 +88,18 @@ fn parse_packet_file(path: &Path, interface: &mut Interface, variant: &mut Varia
             }
 
             let wit_name = struct_name.to_kebab_case();
-            interface.type_def(TypeDef::new(
-                wit_name.clone(),
-                TypeDefKind::Record(Record::new(fields_list)),
-            ));
-            variant.case(VariantCase::value(
-                wit_name.clone(),
-                WitType::named(wit_name),
-            ));
+            if !fields_list.is_empty() {
+                interface.type_def(TypeDef::new(
+                    wit_name.clone(),
+                    TypeDefKind::Record(Record::new(fields_list)),
+                ));
+                variant.case(VariantCase::value(
+                    wit_name.clone(),
+                    WitType::named(wit_name),
+                ));
+            } else {
+                variant.case(VariantCase::empty(wit_name));
+            }
         }
     }
 }

--- a/pumpkin-codegen/src/wit/java_packet.rs
+++ b/pumpkin-codegen/src/wit/java_packet.rs
@@ -86,16 +86,19 @@ fn parse_packet_file(path: &Path, interface: &mut Interface, variant: &mut Varia
                     fields_list.push(Field::new(field_name, field_type));
                 }
             }
-
             let wit_name = struct_name.to_kebab_case();
-            interface.type_def(TypeDef::new(
-                wit_name.clone(),
-                TypeDefKind::Record(Record::new(fields_list)),
-            ));
-            variant.case(VariantCase::value(
-                wit_name.clone(),
-                WitType::named(wit_name),
-            ));
+            if !fields_list.is_empty() {
+                interface.type_def(TypeDef::new(
+                    wit_name.clone(),
+                    TypeDefKind::Record(Record::new(fields_list)),
+                ));
+                variant.case(VariantCase::value(
+                    wit_name.clone(),
+                    WitType::named(wit_name),
+                ));
+            } else {
+                variant.case(VariantCase::empty(wit_name));
+            }
         }
     }
 }

--- a/pumpkin-plugin-api/src/lib.rs
+++ b/pumpkin-plugin-api/src/lib.rs
@@ -48,9 +48,10 @@ pub mod command {
 }
 
 pub use wit::pumpkin::plugin::{
-    block_entity, command as command_wit, common,
+    bedrock_packets, block_entity, boss_bar, command as command_wit, common,
     context::{Context, Server},
-    entity, gui, permission, player, scoreboard, server, text, world,
+    entity, entity_types, gui, i18n, java_packets, particles, permission, player, scoreboard,
+    server, text, world,
 };
 
 pub mod logging;

--- a/pumpkin-plugin-wit/v0.1/bedrock-packets.wit
+++ b/pumpkin-plugin-wit/v0.1/bedrock-packets.wit
@@ -79,7 +79,6 @@ interface bedrock-packets {
     ping-time: s64,
     pong-time: s64,
   }
-  record s-disconnect {  }
   record s-open-connection-request1 {
     magic: string,
     protocol-version: u8,
@@ -343,7 +342,7 @@ interface bedrock-packets {
     s-connected-ping(s-connected-ping),
     s-connection-request(s-connection-request),
     s-new-incoming-connection(s-new-incoming-connection),
-    s-disconnect(s-disconnect),
+    s-disconnect,
     s-open-connection-request1(s-open-connection-request1),
     s-open-connection-request2(s-open-connection-request2),
     s-unconnected-ping(s-unconnected-ping),

--- a/pumpkin-plugin-wit/v0.1/java-packets.wit
+++ b/pumpkin-plugin-wit/v0.1/java-packets.wit
@@ -45,7 +45,6 @@ interface java-packets {
     text-filtering: bool,
     server-listing: bool,
   }
-  record s-client-tick-end {  }
   record s-close-container {
     window-id: s32,
   }
@@ -125,7 +124,6 @@ interface java-packets {
   record s-player-input {
     input: u8,
   }
-  record s-player-loaded {  }
   record s-player-position {
     position: tuple<f64, f64, f64>,
     collision: u8,
@@ -245,8 +243,6 @@ interface java-packets {
   record c-chunk-batch-end {
     batch-size: s32,
   }
-  record c-chunk-batch-start {  }
-  record c-chunk-data {  }
   record c-clear-title {
     reset: bool,
   }
@@ -370,7 +366,6 @@ interface java-packets {
     data: s32,
     disable-relative-volume: bool,
   }
-  record c-light-update {  }
   record c-login {
     entity-id: s32,
     is-hardcore: bool,
@@ -717,7 +712,7 @@ interface java-packets {
     s-click-slot(s-click-slot),
     s-client-command(s-client-command),
     s-client-information-play(s-client-information-play),
-    s-client-tick-end(s-client-tick-end),
+    s-client-tick-end,
     s-close-container(s-close-container),
     s-command-suggestion(s-command-suggestion),
     s-confirm-teleport(s-confirm-teleport),
@@ -737,7 +732,7 @@ interface java-packets {
     s-player-command(s-player-command),
     s-set-player-ground(s-set-player-ground),
     s-player-input(s-player-input),
-    s-player-loaded(s-player-loaded),
+    s-player-loaded,
     s-player-position(s-player-position),
     s-player-position-rotation(s-player-position-rotation),
     s-player-rotation(s-player-rotation),
@@ -766,8 +761,8 @@ interface java-packets {
     c-center-chunk(c-center-chunk),
     c-change-difficulty(c-change-difficulty),
     c-chunk-batch-end(c-chunk-batch-end),
-    c-chunk-batch-start(c-chunk-batch-start),
-    c-chunk-data(c-chunk-data),
+    c-chunk-batch-start,
+    c-chunk-data,
     c-clear-title(c-clear-title),
     c-close-container(c-close-container),
     c-combat-death(c-combat-death),
@@ -793,7 +788,7 @@ interface java-packets {
     c-item-cooldown(c-item-cooldown),
     c-keep-alive(c-keep-alive),
     c-level-event(c-level-event),
-    c-light-update(c-light-update),
+    c-light-update,
     c-login(c-login),
     c-map-item-data(c-map-item-data),
     c-merchant-offers(c-merchant-offers),


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
- Fix `pumpkin-codegen` to generate valid wit for packets.
- Export generated wit modules previously kept private.

## Testing
Everything compiles

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
