### PR TITLE
fix(entity): mobs no longer burn at night

### DIFF
--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -76,6 +76,16 @@ pub struct MobEntity {
     last_sent_head_yaw: AtomicU8,
 }
 
+/// Tick boundaries (both inclusive) when monsters do not burn in sunlight (26.1).
+///
+/// Sourced from `data/minecraft/timeline/day.json` — `monsters_burn` keyframes:
+/// `value=false` at tick 12542 (dusk), `value=true` at tick 23460 (dawn).
+///
+/// TODO: Replace with `EnvironmentAttributes::MONSTERS_BURN` lookup once the
+/// `EnvironmentAttributeSystem` is implemented in `pumpkin-data`.
+const NIGHT_START: i64 = 12542;
+const NIGHT_END: i64 = 23459;
+
 impl MobEntity {
     #[expect(dead_code)]
     const AI_DISABLED_FLAG: u8 = 1;
@@ -262,7 +272,14 @@ impl MobEntity {
         let world_arc = entity.world.load();
         let world = world_arc.as_ref();
 
-        // TODO: gate behind EnvironmentAttributes::MONSTERS_BURN once implemented.
+        // Night boundary from data/minecraft/timeline/day.json — monsters_burn keyframes:
+        // value=false at tick 12542 (dusk), value=true at tick 23460 (dawn).
+        // TODO: read directly from EnvironmentAttributes::MONSTERS_BURN once implemented.
+
+        let day_time = world.get_time_of_day().await % 24000;
+        if (NIGHT_START..=NIGHT_END).contains(&day_time) {
+            return false;
+        }
 
         // Vanilla: getLightLevelDependentMagicValue() — sky light at eye pos, scaled 0–1.
         let eye_block_pos = entity.get_eye_pos();


### PR DESCRIPTION
## Description

Fixed sun-sensitive mobs burning to death during the night by adding day/night gate from vanilla. For now hardcoded values from official .json and left TODO.

## Testing

Manually verified in-game by setting time at boundary ticks using '/time' command. Rain still blocks burning via the existing check.
