### PR TITLE
feat(plugins): Enable WasmGC

### DIFF
--- a/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
@@ -56,6 +56,12 @@ impl PluginRuntime {
         config.cache(Some(
             Cache::new(cache_config).expect("Failed to create cache"),
         ));
+
+        config.gc_support(true);
+        config.wasm_gc(true);
+        config.wasm_exceptions(true);
+        config.wasm_function_references(true);
+
         let engine = Engine::new(&config).map_err(PluginInitError::EngineCreationFailed)?;
 
         let linker = setup_linker(&engine).map_err(PluginInitError::LinkerSetupFailed)?;


### PR DESCRIPTION
## Description

Flips some switches in the `Engine` config for the Wasm plugin loader to allow the use of newer GC and exception handling features in plugins.

This is required to be able to build Pumpkin Wasm plugins with some languages, e.g. Kotlin.

## Testing

`cargo clippy` and `cargo fmt` both pass

I don't have a publicly available reproducer right now, but I tested this building and running a dummy plugin in Kotlin (just logs on load and unload). Kotlin uses WasmGC and exception handling features when targetting Wasm with Kotlin/Wasm.