### PR TITLE
fix: orientation placing block in-place of existing one 

### DIFF
--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -2667,7 +2667,7 @@ impl JavaClient {
 
         let (final_block_pos, final_face, replacing) =
             if let Some(replacing) = replace_clicked_block {
-                (clicked_block_pos, face, replacing)
+                (clicked_block_pos, face.opposite(), replacing)
             } else {
                 let block_pos = BlockPos(location.0 + face.to_offset());
                 let (previous_block, previous_block_state) = world.get_block_and_state(&block_pos);


### PR DESCRIPTION
Fix https://github.com/Pumpkin-MC/Pumpkin/issues/2112

## Description

When a block is placed on a replaceable block (snow, grass, etc.), the clicked face was passed as-is to the placement logic, unlike the non-replaceable path which uses `face.opposite()`. This caused directional blocks (stairs, slabs, trapdoors, buttons) to compute incorrect orientation. Fixed by inverting the face in the replaceable case to match the existing convention.

## Testing

Tested manually :
- Stairs on snow ✅ 
- Lever on snow ✅ 
- Stairs on water ✅ 