### PR TITLE
fix: Place leaves around the trunk instead of 0,0

### DIFF
--- a/pumpkin-world/src/generation/feature/features/tree/foliage/random_spread.rs
+++ b/pumpkin-world/src/generation/feature/features/tree/foliage/random_spread.rs
@@ -1,6 +1,6 @@
 use pumpkin_data::BlockState;
 use pumpkin_util::{
-    math::{int_provider::IntProvider, position::BlockPos},
+    math::{int_provider::IntProvider, position::BlockPos, vector3::Vector3},
     random::{RandomGenerator, RandomImpl},
 };
 
@@ -19,7 +19,7 @@ impl RandomSpreadFoliagePlacer {
         &self,
         chunk: &mut T,
         random: &mut RandomGenerator,
-        _node: &TreeNode,
+        node: &TreeNode,
         foliage_height: i32,
         radius: i32,
         _offset: i32,
@@ -27,11 +27,11 @@ impl RandomSpreadFoliagePlacer {
     ) -> Vec<BlockPos> {
         let mut foliage_positions = Vec::new();
         for _ in 0..self.leaf_placement_attempts {
-            let pos = BlockPos::new(
+            let pos = BlockPos(node.center.0.add(&Vector3::new(
                 random.next_bounded_i32(radius) - random.next_bounded_i32(radius),
                 random.next_bounded_i32(foliage_height) - random.next_bounded_i32(foliage_height),
                 random.next_bounded_i32(radius) - random.next_bounded_i32(radius),
-            );
+            )));
             if FoliagePlacer::place_foliage_block(chunk, pos, foliage_provider) {
                 foliage_positions.push(pos);
             }


### PR DESCRIPTION
Fixes https://github.com/Pumpkin-MC/Pumpkin/issues/2126

## Description

Leaves generated by `random_spread.rs` was generated around 0,0 coordinates instead of being around of trunk coordinates.

## Testing

I have tested with the world provided in the bug report.

When we look at the world, we see more leaves than we usually see on a minecraft vanilla world and this is due to the mangrove being only trunks with no roots. I haven't made the root generation in this MR because it's just a bugfix, it would added hundreds of changes to the PR and I think it can be merged without fixing roots. (I will try to do it later on)