### PR TITLE
fix(plugins): permission prompt displays incorrect default

### DIFF
--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -497,7 +497,7 @@ impl PluginManager {
         }
 
         let prompt = format!(
-            "\n{} [Y/n]: ",
+            "\n{} [y/N]: ",
             "Do you want to allow these permissions and load the plugin?".bold()
         );
 


### PR DESCRIPTION
## Description

default answer is no so i changed the prompt to reflect that
(screenshot is from before fix)
<img width="955" height="109" alt="image" src="https://github.com/user-attachments/assets/5bd9811e-5bab-40b0-b8fd-171b9bb33fc9" />

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
