### PR TITLE
fix: taking damage on magma block with frost walker

### DIFF
--- a/pumpkin/src/block/blocks/magma.rs
+++ b/pumpkin/src/block/blocks/magma.rs
@@ -1,6 +1,8 @@
 use std::sync::atomic::Ordering;
 
-use pumpkin_data::damage::DamageType;
+use pumpkin_data::{
+    Enchantment, damage::DamageType, data_component_impl::EquipmentSlot, effect::StatusEffect,
+};
 use pumpkin_macros::pumpkin_block;
 
 use crate::block::{BlockBehaviour, BlockFuture, OnEntityStepArgs};
@@ -12,9 +14,9 @@ impl BlockBehaviour for MagmaBlock {
     fn on_entity_step<'a>(&'a self, args: OnEntityStepArgs<'a>) -> BlockFuture<'a, ()> {
         Box::pin(async move {
             // Only living entities take damage
-            if args.entity.get_living_entity().is_none() {
+            let Some(living_entity) = args.entity.get_living_entity() else {
                 return;
-            }
+            };
 
             let ent = args.entity.get_entity();
 
@@ -25,6 +27,24 @@ impl BlockBehaviour for MagmaBlock {
 
             // Fire immune entities don't take damage
             if ent.entity_type.fire_immune || ent.fire_immune.load(Ordering::Relaxed) {
+                return;
+            }
+
+            let has_frost_walker = {
+                let equipment = living_entity.entity_equipment.lock().await;
+                let boots = equipment.get(&EquipmentSlot::FEET);
+                let boots_stack = boots.lock().await;
+                boots_stack.get_enchantment_level(&Enchantment::FROST_WALKER) != 0
+            };
+            if has_frost_walker {
+                return;
+            }
+
+            if living_entity
+                .get_effect(&StatusEffect::FIRE_RESISTANCE)
+                .await
+                .is_some()
+            {
                 return;
             }
 


### PR DESCRIPTION
Fix #2115 

## Description
Fix Frost Walker boots and Fire Resistance not negating magma block damage. Mirrors the existing campfire handling: before applying `HOT_FLOOR` damage in `MagmaBlock::on_entity_step`, check for the Frost Walker enchantment on the feet slot and the FIRE_RESISTANCE status effect, returning early in either case.

## Testing


https://github.com/user-attachments/assets/41b33f8f-efff-4fb7-af43-b01edfdddcb1


