### PR TITLE
feat: Add workflow to publish WIT files to other repo.

### DIFF
--- a/.github/workflows/sync-wit.yml
+++ b/.github/workflows/sync-wit.yml
@@ -1,0 +1,40 @@
+name: Sync WIT API to `pumpkin-plugin-wit`
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "pumpkin-plugin-wit/**"
+
+jobs:
+  sync-wit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          path: main-repo
+          sparse-checkout: pumpkin-plugin-wit
+
+      - name: Checkout WIT repo
+        uses: actions/checkout@v4
+        with:
+          repository: "PumpkinMC/pumpkin-plugin-wit"
+          token: ${{ secrets.WIT_SYNC_TOKEN }}
+          path: wit-repo
+
+      - name: Sync and commit changes
+        run: |
+          cd wit-repo
+          rsync -av --delete --exclude='.git' --exclude='.github' ../main-repo/pumpkin-plugin-wit/ .
+
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "sync: update WIT to PumpkinMC/Pumpkin@${{ github.sha }}"
+            git push origin master
+          else
+            echo "No changes detected in WIT files. Skipping push."
+          fi


### PR DESCRIPTION
## Description

Right now plugin languages bindings need to submodule the entirety of Pumpkin, in it's source breadth and commit depth, when all they need is a handful of files in a single directory.

To help alleviate this issue without causing headache for developers, this adds a simple workflow/action that to sync any commits to the `master` branch modifying `pumpkin-plugin-wit` to an external repo of the same name.

This PR won't function as is without more setup from someone with org access (i.e. @Snowiiii).

- `pumpkin-plugin-wit` needs to be created and initially populated.
- The way the action is set up, a PAT with write access to the `pumpkin-plugin-wit` repo is required. This PAT will then need to be added as a repository secret (or perhaps an organization secret): `WIT_SYNC_TOKEN`.

## Testing

I did some private testing of the workflow in some dummy repos to make sure the core logic is solid. Beyond that, I can't be 100% sure it works flawlessly without actually trying it out for real.