### PR TITLE
fix chunks not loading when riding a vehicle

### DIFF
--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -887,12 +887,16 @@ impl JavaClient {
 
     pub async fn handle_move_vehicle(&self, player: &Arc<Player>, packet: SMoveVehicle) {
         let entity = player.get_entity();
+        let pos = Vector3::new(packet.x, packet.y, packet.z);
         let vehicle = entity.vehicle.lock().await;
         if let Some(vehicle) = vehicle.as_ref() {
             let vehicle_entity = vehicle.get_entity();
-            vehicle_entity.set_pos(Vector3::new(packet.x, packet.y, packet.z));
+            vehicle_entity.set_pos(pos);
             vehicle_entity.set_rotation(packet.yaw, packet.pitch);
         }
+        drop(vehicle);
+        entity.set_pos(pos);
+        chunker::update_position(player).await;
     }
 
     pub async fn handle_paddle_boat(&self, player: &Arc<Player>, packet: SPaddleBoat) {


### PR DESCRIPTION
fix handle_move_vehicle not triggering chunk loading when player rides a boat/horse. the function was updating the vehicle position but never updating the player entity position or calling chunker::update_position so new chunks never loaded until the player dismounted