### PR TITLE
fix(wasm-api): re-exported InterAction

### DIFF
--- a/pumpkin-plugin-api/src/events/mod.rs
+++ b/pumpkin-plugin-api/src/events/mod.rs
@@ -8,7 +8,7 @@ use std::{
     },
 };
 
-pub use crate::wit::pumpkin::plugin::event::{Event, EventPriority};
+pub use crate::wit::pumpkin::plugin::event::{Event, EventPriority, InteractAction};
 use crate::{Context, Result, Server, wit::pumpkin::plugin::event::EventType};
 
 pub mod block;


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

re-exported InterAction so that we can use it to compare event.action to the enum.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
