### PR TITLE
feat: Add piston push_entites to match vanilla behaviour 

### DIFF
--- a/pumpkin/src/block/entities/piston.rs
+++ b/pumpkin/src/block/entities/piston.rs
@@ -1,9 +1,10 @@
+use std::sync::atomic::Ordering;
 use std::{pin::Pin, sync::Arc};
 
 use crossbeam::atomic::AtomicCell;
 use pumpkin_data::{Block, BlockDirection, BlockState};
 use pumpkin_nbt::compound::NbtCompound;
-use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::{boundingbox::BoundingBox, position::BlockPos, vector3::Vector3};
 
 use crate::world::{BlockFlags, World};
 
@@ -21,6 +22,174 @@ pub struct PistonBlockEntity {
 
 impl PistonBlockEntity {
     pub const ID: &'static str = "minecraft:piston";
+
+    const fn movement_direction(&self) -> BlockDirection {
+        if self.extending {
+            self.facing
+        } else {
+            self.facing.opposite()
+        }
+    }
+
+    /// Vanilla's `getAmountExtended`: how far back from the block's final position
+    /// the visual is at a given animation progress. Negative for extending.
+    fn amount_extended(&self, progress: f32) -> f32 {
+        if self.extending {
+            progress - 1.0
+        } else {
+            1.0 - progress
+        }
+    }
+
+    fn dir_vec(dir: BlockDirection, scale: f64) -> Vector3<f64> {
+        let off = dir.to_offset();
+        Vector3::new(
+            f64::from(off.x) * scale,
+            f64::from(off.y) * scale,
+            f64::from(off.z) * scale,
+        )
+    }
+
+    /// Ports vanilla `PistonBlockEntity.pushEntities`: pushes entities whose
+    /// bounding box intersects the moving block's swept volume during this tick.
+    fn push_entities(&self, world: &Arc<World>, new_progress: f32) {
+        let last = self.last_progress.load();
+        let delta = f64::from(new_progress - last);
+        if delta <= 0.0 {
+            return;
+        }
+
+        let motion_dir = self.movement_direction();
+        let amount = f64::from(self.amount_extended(last));
+
+        // Block AABB at the current visual position (start of this tick).
+        // For source=true (the piston head BE), vanilla uses the piston-head
+        // collision shape — a 4-pixel-thick slab at the front face — rather than
+        // the full cube. Without this, the head "sweeps" too much volume and
+        // drags entities (e.g. end crystals) back with it during retraction.
+        let raw_block_aabb = BoundingBox::from_block(&self.position);
+        let block_aabb = if self.source {
+            Self::head_shape_aabb(raw_block_aabb, self.facing)
+        } else {
+            raw_block_aabb
+        }
+        .shift(Self::dir_vec(self.facing, amount));
+
+        // Stretch by motion to get the swept volume (one tick of animation).
+        let motion = Self::dir_vec(motion_dir, delta);
+        let swept = block_aabb.stretch(motion);
+
+        for entity in world.get_entities_at_box(&swept) {
+            let e = entity.get_entity();
+            if e.no_clip.load(Ordering::Relaxed) {
+                continue;
+            }
+            // Player movement is client-authoritative; vanilla still nudges them
+            // via Entity.move(PISTON), but we skip them here to avoid teleport jank.
+            if entity.get_player().is_some() {
+                continue;
+            }
+
+            let entity_aabb = e.bounding_box.load();
+            let intersection = Self::intersection_size(swept, motion_dir, entity_aabb);
+            if intersection <= 0.0 {
+                continue;
+            }
+            let push_amount = intersection.min(delta) + 0.01;
+            Self::move_entity(e, motion_dir, push_amount);
+
+            // For a retracting head, vanilla also shoves the entity OUT of the
+            // piston body cube. Without this, entities get pulled into the
+            // piston and "stick" to it (looks like a sticky-piston drag).
+            // For a retract-head BE, `self.position` already IS the piston
+            // block position (it replaces the piston during animation).
+            if !self.extending && self.source {
+                Self::push_out_of_piston_body(e, &self.position, motion_dir, delta);
+            }
+        }
+    }
+
+    /// Vanilla `getIntersectionSize`: how much `entity` overlaps `swept` along
+    /// `motion_dir`. Positive means the entity is in the path of the moving block.
+    fn intersection_size(
+        swept: BoundingBox,
+        motion_dir: BlockDirection,
+        entity: BoundingBox,
+    ) -> f64 {
+        match motion_dir {
+            BlockDirection::East => swept.max.x - entity.min.x,
+            BlockDirection::West => entity.max.x - swept.min.x,
+            BlockDirection::Up => swept.max.y - entity.min.y,
+            BlockDirection::Down => entity.max.y - swept.min.y,
+            BlockDirection::South => swept.max.z - entity.min.z,
+            BlockDirection::North => entity.max.z - swept.min.z,
+        }
+    }
+
+    fn move_entity(entity: &crate::entity::Entity, dir: BlockDirection, distance: f64) {
+        let new_pos = entity.pos.load() + Self::dir_vec(dir, distance);
+        entity.set_pos(new_pos);
+        entity.send_pos();
+    }
+
+    /// Vanilla `push`: when a piston head retracts, shove entities that ended up
+    /// inside the piston-body cube back out the opposite direction (slightly past
+    /// the move they just got, so the net motion is essentially zero).
+    fn push_out_of_piston_body(
+        entity: &crate::entity::Entity,
+        piston_pos: &BlockPos,
+        motion_dir: BlockDirection,
+        amount: f64,
+    ) {
+        let body_aabb = BoundingBox::from_block(piston_pos);
+        let entity_aabb = entity.bounding_box.load();
+        if !body_aabb.intersects(&entity_aabb) {
+            return;
+        }
+        let back = motion_dir.opposite();
+        let e = Self::intersection_size(body_aabb, back, entity_aabb) + 0.01;
+        let f = Self::intersection_size(
+            body_aabb,
+            back,
+            Self::aabb_intersection(body_aabb, entity_aabb),
+        ) + 0.01;
+        if (e - f).abs() < 0.01 {
+            let distance = e.min(amount) + 0.01;
+            Self::move_entity(entity, back, distance);
+        }
+    }
+
+    /// Approximation of vanilla `PistonHeadBlock` collision shape: a 4-pixel
+    /// (0.25 block) slab at the front face of the block in the facing direction.
+    fn head_shape_aabb(block_aabb: BoundingBox, facing: BlockDirection) -> BoundingBox {
+        const HEAD_THICKNESS: f64 = 0.25;
+        let mut min = block_aabb.min;
+        let mut max = block_aabb.max;
+        match facing {
+            BlockDirection::East => min.x = max.x - HEAD_THICKNESS,
+            BlockDirection::West => max.x = min.x + HEAD_THICKNESS,
+            BlockDirection::Up => min.y = max.y - HEAD_THICKNESS,
+            BlockDirection::Down => max.y = min.y + HEAD_THICKNESS,
+            BlockDirection::South => min.z = max.z - HEAD_THICKNESS,
+            BlockDirection::North => max.z = min.z + HEAD_THICKNESS,
+        }
+        BoundingBox::new(min, max)
+    }
+
+    const fn aabb_intersection(a: BoundingBox, b: BoundingBox) -> BoundingBox {
+        BoundingBox::new(
+            Vector3::new(
+                a.min.x.max(b.min.x),
+                a.min.y.max(b.min.y),
+                a.min.z.max(b.min.z),
+            ),
+            Vector3::new(
+                a.max.x.min(b.max.x),
+                a.max.y.min(b.max.y),
+                a.max.z.min(b.max.z),
+            ),
+        )
+    }
 
     pub async fn finish(&self, world: Arc<World>) {
         if self.last_progress.load() < 1.0 {
@@ -97,11 +266,11 @@ impl BlockEntity for PistonBlockEntity {
                             .await;
                     }
                 }
+                return;
             }
-            self.current_progress.store(current_progress + 0.5);
-            if current_progress + 0.5 >= 1.0 {
-                self.current_progress.store(1.0);
-            }
+            let new_progress = (current_progress + 0.5).min(1.0);
+            self.push_entities(world, new_progress);
+            self.current_progress.store(new_progress);
         })
     }
 


### PR DESCRIPTION
Fix https://github.com/Pumpkin-MC/Pumpkin/issues/2114

## Description

Implements vanilla's piston entity-push behavior (`PistonBlockEntity.pushEntities`) so entities like end crystals get moved out of the way during piston animation instead of being left at their original server-side position (which caused ghost-block placement rejection).
Each tick of the moving-piston animation, `push_entities` builds the swept AABB of the block's current visual position, finds entities intersecting it via `get_entities_at_box`, and shifts each one by `min(intersection, delta) + 0.01` in the motion direction (calling `set_pos + send_pos` to update both server state and clients). For the piston head (`source=true`) the AABB is clipped to a 0.25-block slab on the facing side (`head_shape_aabb`) to match the real `PistonHeadBlock` collision shape — without this, a full-cube AABB drags entities backward during retraction and they stick to the piston. On retraction `push_out_of_piston_body` also shoves any entity that ended up inside the piston body cube back out, mirroring vanilla's `push` helper.

## Testing


https://github.com/user-attachments/assets/14039156-eb34-4041-9a8c-dd372d13a7b2

