### PR TITLE
re-export EntityType and Dialog related stuff

### DIFF
--- a/pumpkin-plugin-api/src/lib.rs
+++ b/pumpkin-plugin-api/src/lib.rs
@@ -51,9 +51,15 @@ pub mod command {
 pub use wit::pumpkin::plugin::{
     bedrock_packets, block_entity, boss_bar, command as command_wit, common,
     context::{Context, Server},
-    entity, entity_types, gui, i18n, java_packets, particles, permission, player, scoreboard,
-    server, text, world,
+    entity,
+    entity_types::EntityType,
+    gui, i18n, java_dialogs, java_packets, particles, permission, player, scoreboard, server, text,
+    world,
 };
+
+pub mod java_dialog {
+    pub use crate::wit::pumpkin::plugin::java_dialogs::{ActionButton, DialogBody, DialogType};
+}
 
 pub mod logging;
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

As the title says, made EntityType and Dialog related stuff pub, for use on the plugin devving.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
