### PR TITLE
Fix: messed up terminal after "stop" command

### DIFF
--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -621,6 +621,7 @@ fn setup_stdin_console(server: Arc<Server>) {
 
 fn setup_console(mut rl: Editor<PumpkinCommandCompleter, FileHistory>, server: Arc<Server>) {
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    let (tx_reply, mut rx_reply) = tokio::sync::mpsc::channel(1);
 
     if let Some(helper) = rl.helper_mut() {
         if let Ok(mut server_lock) = helper.server.write() {
@@ -638,6 +639,9 @@ fn setup_console(mut rl: Editor<PumpkinCommandCompleter, FileHistory>, server: A
                     if tx.blocking_send(line).is_err() {
                         break;
                     }
+
+                    // Wait for the command to be fully processed before continuing
+                    let _ = rx_reply.blocking_recv();
                 }
                 Err(ReadlineError::Interrupted) => {
                     info!("CTRL-C");
@@ -679,6 +683,8 @@ fn setup_console(mut rl: Editor<PumpkinCommandCompleter, FileHistory>, server: A
                         server.command_dispatcher.read().await
                             .handle_command(&command::CommandSender::Console.into_source(&server).await, &line)
                             .await;
+
+                        let _ = tx_reply.send(1).await;
                     }
                 }}
             } else {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Because the commands loop handle commands asynchronously, when you press enter for a command, before it is fully executed the loop will send a new "$ " and wait for input.
This cause issues with terminals as seen in this issue : #2133

This PR waits for the command to be fully executed before waiting the next one.

## Testing
Before :
<img width="1253" height="600" alt="before" src="https://github.com/user-attachments/assets/06bac935-3509-47d4-803c-9a18e4a17812" />

After :
<img width="1274" height="565" alt="after" src="https://github.com/user-attachments/assets/9b50a803-a5d5-430d-b1e2-85aa2dbc8191" />

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
