### PR TITLE
fix(net): correct wrong hand animation when mining (#2196)

### DIFF
--- a/pumpkin-util/src/lib.rs
+++ b/pumpkin-util/src/lib.rs
@@ -246,16 +246,19 @@ impl TryFrom<i32> for Hand {
 
     /// Converts an integer into a `Hand`.
     ///
+    /// In the Minecraft protocol, gameplay packets (`SwingArm`, `UseItemOn`, `UseItem`)
+    /// use `0` for the main hand and `1` for the off hand.
+    ///
     /// # Parameters
-    /// - `0`: `Left`
-    /// - `1`: `Right`
+    /// - `0`: `Right` (Main Hand)
+    /// - `1`: `Left` (Off Hand)
     ///
     /// # Errors
     /// Returns `InvalidHand` if the value is not 0 or 1.
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Self::Left),
-            1 => Ok(Self::Right),
+            0 => Ok(Self::Right),
+            1 => Ok(Self::Left),
             _ => Err(InvalidHand),
         }
     }

--- a/pumpkin/src/net/java/config.rs
+++ b/pumpkin/src/net/java/config.rs
@@ -42,25 +42,33 @@ impl JavaClient {
             return;
         }
 
-        if let (Ok(main_hand), Ok(chat_mode)) = (
-            Hand::try_from(client_information.main_hand.0),
-            ChatMode::try_from(client_information.chat_mode.0),
-        ) {
-            *self.config.lock().await = Some(PlayerConfig {
-                locale: client_information.locale,
-                // client_information.view_distance was checked above to be > 0 so compiler should optimize this out.
-                view_distance: NonZeroU8::new(client_information.view_distance as u8).unwrap(),
-                chat_mode,
-                chat_colors: client_information.chat_colors,
-                skin_parts: client_information.skin_parts,
-                main_hand,
-                text_filtering: client_information.text_filtering,
-                server_listing: client_information.server_listing,
-            });
-        } else {
+        // In ClientSettings, `main_hand` uses 0=Left, 1=Right — the inverse of
+        // gameplay packets — so we map it manually instead of using `Hand::try_from`.
+        let main_hand = match client_information.main_hand.0 {
+            0 => Hand::Left,
+            1 => Hand::Right,
+            _ => {
+                self.kick(TextComponent::text("Invalid hand or chat type"))
+                    .await;
+                return;
+            }
+        };
+        let Ok(chat_mode) = ChatMode::try_from(client_information.chat_mode.0) else {
             self.kick(TextComponent::text("Invalid hand or chat type"))
                 .await;
-        }
+            return;
+        };
+        *self.config.lock().await = Some(PlayerConfig {
+            locale: client_information.locale,
+            // client_information.view_distance was checked above to be > 0 so compiler should optimize this out.
+            view_distance: NonZeroU8::new(client_information.view_distance as u8).unwrap(),
+            chat_mode,
+            chat_colors: client_information.chat_colors,
+            skin_parts: client_information.skin_parts,
+            main_hand,
+            text_filtering: client_information.text_filtering,
+            server_listing: client_information.server_listing,
+        });
     }
 
     pub async fn handle_plugin_message(&self, plugin_message: SPluginMessage) {

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -1453,10 +1453,23 @@ impl JavaClient {
         player: &Arc<Player>,
         client_information: SClientInformationPlay,
     ) {
-        if let (Ok(main_hand), Ok(chat_mode)) = (
-            Hand::try_from(client_information.main_hand.0),
-            ChatMode::try_from(client_information.chat_mode.0),
-        ) {
+        // In ClientSettings, `main_hand` uses 0=Left, 1=Right — the inverse of
+        // gameplay packets — so we map it manually instead of using `Hand::try_from`.
+        let main_hand = match client_information.main_hand.0 {
+            0 => Hand::Left,
+            1 => Hand::Right,
+            _ => {
+                self.kick(TextComponent::text("Invalid hand or chat type"))
+                    .await;
+                return;
+            }
+        };
+        let Ok(chat_mode) = ChatMode::try_from(client_information.chat_mode.0) else {
+            self.kick(TextComponent::text("Invalid hand or chat type"))
+                .await;
+            return;
+        };
+        {
             if client_information.view_distance <= 0 {
                 self.kick(TextComponent::text(
                     "Cannot have zero or negative view distance!",
@@ -1526,9 +1539,6 @@ impl JavaClient {
                 );
                 player.send_client_information();
             }
-        } else {
-            self.kick(TextComponent::text("Invalid hand or chat type"))
-                .await;
         }
     }
 
@@ -2029,7 +2039,7 @@ impl JavaClient {
         let held_item_empty = held_item.lock().await.is_empty();
         let off_hand_item_empty = off_hand_item.lock().await.is_empty();
 
-        let item = if matches!(hand, Hand::Left) {
+        let item = if matches!(hand, Hand::Right) {
             held_item
         } else {
             off_hand_item
@@ -2085,7 +2095,7 @@ impl JavaClient {
             }
         }
 
-        let slot_index = if matches!(hand, Hand::Left) {
+        let slot_index = if matches!(hand, Hand::Right) {
             inventory.get_selected_slot() as usize
         } else {
             PlayerInventory::OFF_HAND_SLOT
@@ -2245,7 +2255,7 @@ impl JavaClient {
         };
         self.update_sequence(player, use_item.sequence.0);
 
-        let item_in_hand = if hand == Hand::Left {
+        let item_in_hand = if hand == Hand::Right {
             inventory.held_item()
         } else {
             inventory.off_hand_item().await


### PR DESCRIPTION
## Description

Fixes #2196 — when a player mines with their main hand, other players see the off-hand (left hand) swing instead of the main hand (right hand).

### Root cause

The Minecraft protocol uses two different semantics for hand fields:

| Packet type | Field | Meaning |
|---|---|---|
| Gameplay (SwingArm, UseItemOn, UseItem) | `hand` | `0 = Main Hand`, `1 = Off Hand` |
| ClientSettings | `main_hand` | `0 = Left`, `1 = Right` |

`Hand::try_from(i32)` was mapped as `0 → Left, 1 → Right`, which is correct for ClientSettings but inverted for gameplay packets. When a player mined with their main hand (protocol value `0`), the server resolved it to `Hand::Left` and sent `Animation::SwingOffhand` instead of `Animation::SwingMainArm`, causing other players to see the wrong hand swing.

### Impact

- Mining, item use, and block placement animations now correctly reflect the player's main hand for all other players
- `OFF_HAND_ACTIVE_FLAG` in `set_active_hand` is now set correctly
- ClientSettings main hand preference (left/right-handed) continues to work as before

### Known issues or limitations

None.