### PR TITLE
fix(math): prevent NaN from zero-length normalization

### DIFF
--- a/pumpkin-util/src/math/vector2.rs
+++ b/pumpkin-util/src/math/vector2.rs
@@ -88,10 +88,17 @@ impl<T: Math + Copy + Float> Vector2<T> {
         self.length_squared().sqrt()
     }
 
-    /// Returns a normalized version of the vector with length 1.
+    /// Returns a normalized version of the vector, or the zero vector when its
+    /// length is negligible (prevents division by zero yielding NaN/infinity).
     #[must_use]
     pub fn normalize(&self) -> Self {
         let length = self.length();
+        if length < T::from(1.0e-4).unwrap() {
+            return Self {
+                x: T::zero(),
+                y: T::zero(),
+            };
+        }
         Self {
             x: self.x / length,
             y: self.y / length,

--- a/pumpkin-util/src/math/vector2.rs
+++ b/pumpkin-util/src/math/vector2.rs
@@ -88,20 +88,22 @@ impl<T: Math + Copy + Float> Vector2<T> {
         self.length_squared().sqrt()
     }
 
-    /// Returns a normalized version of the vector, or the zero vector when its
-    /// length is negligible (prevents division by zero yielding NaN/infinity).
+    /// Returns a normalized version of the vector, or the zero vector when
+    /// normalization is not possible.
     #[must_use]
     pub fn normalize(&self) -> Self {
-        let length = self.length();
-        if length < T::from(1.0e-4).unwrap() {
-            return Self {
+        let length_recip = self.length().recip();
+
+        if length_recip.is_finite() && length_recip > T::zero() {
+            Self {
+                x: self.x * length_recip,
+                y: self.y * length_recip,
+            }
+        } else {
+            Self {
                 x: T::zero(),
                 y: T::zero(),
-            };
-        }
-        Self {
-            x: self.x / length,
-            y: self.y / length,
+            }
         }
     }
 }

--- a/pumpkin-util/src/math/vector3.rs
+++ b/pumpkin-util/src/math/vector3.rs
@@ -424,6 +424,13 @@ impl<T: Math + Copy + Float> Vector3<T> {
     #[must_use]
     pub fn normalize(&self) -> Self {
         let length = self.length();
+        if length < T::from(1.0e-4).unwrap() {
+            return Self {
+                x: T::zero(),
+                y: T::zero(),
+                z: T::zero(),
+            };
+        }
         Self {
             x: self.x / length,
             y: self.y / length,

--- a/pumpkin-util/src/math/vector3.rs
+++ b/pumpkin-util/src/math/vector3.rs
@@ -415,7 +415,8 @@ impl<T: Math + Copy + Float> Vector3<T> {
         self.horizontal_length_squared().sqrt()
     }
 
-    /// Returns a normalized version of this vector (unit vector).
+    /// Returns a normalized version of this vector, or the zero vector when
+    /// normalization is not possible.
     ///
     /// The resulting vector will have the same direction but a length of 1.
     ///
@@ -423,18 +424,20 @@ impl<T: Math + Copy + Float> Vector3<T> {
     /// A new unit vector pointing in the same direction.
     #[must_use]
     pub fn normalize(&self) -> Self {
-        let length = self.length();
-        if length < T::from(1.0e-4).unwrap() {
-            return Self {
+        let length_recip = self.length().recip();
+
+        if length_recip.is_finite() && length_recip > T::zero() {
+            Self {
+                x: self.x * length_recip,
+                y: self.y * length_recip,
+                z: self.z * length_recip,
+            }
+        } else {
+            Self {
                 x: T::zero(),
                 y: T::zero(),
                 z: T::zero(),
-            };
-        }
-        Self {
-            x: self.x / length,
-            y: self.y / length,
-            z: self.z / length,
+            }
         }
     }
 


### PR DESCRIPTION
## Description

`Vector2::normalize()` and `Vector3::normalize()` could return non-finite values (`NaN`/`inf`) when called on zero-length vectors.


## Why

A non-finite vector can silently propagate into movement, knockback, rotation, and other calculations, making debugging difficult.

## Impact

- No behavior change for normal vectors
- Zero / near-zero vectors now return a zero vector instead of non-finite values