### PR TITLE
feat(world): add superflat world generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,5 +151,6 @@ help.yml
 permissions.yml
 spigot.yml
 version_history.json
+world/
 world_nether/
 world_the_end/

--- a/pumpkin-config/src/world.rs
+++ b/pumpkin-config/src/world.rs
@@ -14,9 +14,25 @@ pub struct LevelConfig {
     /// Number of ticks between autosave checks. If 0, autosave is disabled.
     #[serde(default = "default_autosave_ticks")]
     pub autosave_ticks: u64,
+    /// The world generator to use, mirroring the vanilla `level-type` in
+    /// `server.properties`. Accepts the vanilla values (the `minecraft:`
+    /// prefix is optional), e.g. `minecraft:normal` or `minecraft:flat`.
+    /// Unknown values fall back to normal generation.
+    #[serde(default = "default_level_type")]
+    pub level_type: String,
+    /// Generator-specific settings, mirroring the vanilla `generator-settings`
+    /// in `server.properties`. For `minecraft:flat` this is the superflat
+    /// preset string (layers bottom-up as `count*block`, optionally followed by
+    /// `;biome`); an empty value selects the Classic Flat preset.
+    #[serde(default)]
+    pub generator_settings: String,
     // TODO: More options
 }
 
 const fn default_autosave_ticks() -> u64 {
     6000 // Default to 5 minutes at 20 TPS
+}
+
+fn default_level_type() -> String {
+    "minecraft:normal".to_string()
 }

--- a/pumpkin-world/benches/chunk_gen.rs
+++ b/pumpkin-world/benches/chunk_gen.rs
@@ -12,8 +12,8 @@ fn bench_full_chunk_generation(c: &mut Criterion) {
     let dimension = Dimension::OVERWORLD;
     let seed = Seed(42);
     let block_registry = Arc::new(BlockRegistry);
-    let world_gen = get_world_gen(seed, dimension.clone());
-    let biome_mixer_seed = hash_seed(world_gen.random_config.seed);
+    let world_gen = get_world_gen(seed, dimension.clone(), "minecraft:normal", "");
+    let biome_mixer_seed = hash_seed(world_gen.random_config().seed);
 
     c.bench_function("full_chunk_generation", |b| {
         b.iter(|| {

--- a/pumpkin-world/src/biome/mod.rs
+++ b/pumpkin-world/src/biome/mod.rs
@@ -102,7 +102,10 @@ mod test {
             let chunk_x = data.x;
             let chunk_z = data.z;
 
-            let mut chunk = ProtoChunk::new(chunk_x, chunk_z, &generator);
+            let world_gen = crate::generation::generator::WorldGenerator::Vanilla(Box::new(
+                VanillaGenerator::new(Seed(seed as u64), Dimension::OVERWORLD),
+            ));
+            let mut chunk = ProtoChunk::new(chunk_x, chunk_z, &world_gen);
 
             // Create MultiNoiseSampler for populate_biomes
 

--- a/pumpkin-world/src/biome/multi_noise.rs
+++ b/pumpkin-world/src/biome/multi_noise.rs
@@ -59,9 +59,14 @@ mod test {
         let chunk_x = 0;
         let chunk_z = 0;
 
-        let generator = VanillaGenerator::new(Seed(seed as u64), Dimension::OVERWORLD);
+        let world_gen = crate::generation::generator::WorldGenerator::Vanilla(Box::new(
+            VanillaGenerator::new(Seed(seed as u64), Dimension::OVERWORLD),
+        ));
 
-        let _chunk = ProtoChunk::new(chunk_x, chunk_z, &generator);
+        let _chunk = ProtoChunk::new(chunk_x, chunk_z, &world_gen);
+        let crate::generation::generator::WorldGenerator::Vanilla(generator) = &world_gen else {
+            panic!("expected vanilla generator")
+        };
 
         let start_x = chunk_pos::start_block_x(chunk_x);
         let start_z = chunk_pos::start_block_z(chunk_z);

--- a/pumpkin-world/src/chunk/format/anvil.rs
+++ b/pumpkin-world/src/chunk/format/anvil.rs
@@ -920,7 +920,7 @@ mod tests {
 
         let _ = env_logger::try_init();
 
-        let generator = get_world_gen(Seed(0), Dimension::Overworld);
+        let generator = get_world_gen(Seed(0), Dimension::Overworld, "minecraft:normal", "");
 
         let temp_dir = TempDir::new().unwrap();
         let level_folder = LevelFolder {
@@ -1196,7 +1196,7 @@ mod tests {
 
         let _ = env_logger::try_init();
 
-        let generator = get_world_gen(Seed(0), Dimension::Overworld);
+        let generator = get_world_gen(Seed(0), Dimension::Overworld, "minecraft:normal", "");
 
         let temp_dir = TempDir::new().unwrap();
         let level_folder = LevelFolder {

--- a/pumpkin-world/src/chunk_system/generation.rs
+++ b/pumpkin-world/src/chunk_system/generation.rs
@@ -1,7 +1,7 @@
 use pumpkin_data::dimension::Dimension;
 
 use crate::ProtoChunk;
-use crate::generation::generator::VanillaGenerator;
+use crate::generation::generator::WorldGenerator;
 use crate::world::WorldPortalExt;
 use pumpkin_config::lighting::LightingEngineConfig;
 
@@ -10,7 +10,7 @@ use super::{Cache, Chunk, StagedChunkEnum};
 pub fn generate_single_chunk(
     _dimension: &Dimension,
     _biome_mixer_seed: i64,
-    generator: &VanillaGenerator,
+    generator: &WorldGenerator,
     block_registry: &dyn WorldPortalExt,
     chunk_x: i32,
     chunk_z: i32,
@@ -98,8 +98,8 @@ mod tests {
         let dimension = Dimension::OVERWORLD;
         let seed = Seed(42);
         let block_registry = Arc::new(BlockRegistry);
-        let world_gen = get_world_gen(seed, dimension.clone());
-        let biome_mixer_seed = hash_seed(world_gen.random_config.seed);
+        let world_gen = get_world_gen(seed, dimension.clone(), "minecraft:normal", "");
+        let biome_mixer_seed = hash_seed(world_gen.random_config().seed);
 
         let _ = generate_single_chunk(
             &dimension,

--- a/pumpkin-world/src/chunk_system/generation_cache.rs
+++ b/pumpkin-world/src/chunk_system/generation_cache.rs
@@ -343,42 +343,81 @@ impl Cache {
     pub fn advance(
         &mut self,
         stage: StagedChunkEnum,
-        generator: &generator::VanillaGenerator,
+        generator: &generator::WorldGenerator,
         block_registry: &dyn WorldPortalExt,
         lighting_config: &LightingEngineConfig,
     ) {
+        use generator::WorldGenerator;
         let mid = ((self.size * self.size) >> 1) as usize;
         match stage {
             StagedChunkEnum::Empty => panic!("empty stage"),
-            StagedChunkEnum::StructureStart => {
-                self.chunks[mid]
-                    .get_proto_chunk_mut()
-                    .set_structure_starts(generator);
-            }
-            StagedChunkEnum::StructureReferences => {
-                self.chunks[mid]
-                    .get_proto_chunk_mut()
-                    .set_structure_references(generator);
-            }
-            StagedChunkEnum::Biomes => self.chunks[mid]
-                .get_proto_chunk_mut()
-                .step_to_biomes(generator),
-            StagedChunkEnum::Noise => self.chunks[mid]
-                .get_proto_chunk_mut()
-                .step_to_noise(generator),
-            StagedChunkEnum::Surface => self.chunks[mid]
-                .get_proto_chunk_mut()
-                .step_to_surface(generator),
-            StagedChunkEnum::Carvers => self.chunks[mid]
-                .get_proto_chunk_mut()
-                .step_to_carvers(generator),
-            StagedChunkEnum::Features => {
-                ProtoChunk::generate_features_and_structure(
-                    self,
-                    block_registry,
-                    &generator.random_config,
-                );
-            }
+            StagedChunkEnum::StructureStart => match generator {
+                WorldGenerator::Vanilla(g) => {
+                    self.chunks[mid]
+                        .get_proto_chunk_mut()
+                        .set_structure_starts(g);
+                }
+                WorldGenerator::Flat(_) => {
+                    self.chunks[mid].get_proto_chunk_mut().stage = StagedChunkEnum::StructureStart;
+                }
+            },
+            StagedChunkEnum::StructureReferences => match generator {
+                WorldGenerator::Vanilla(g) => {
+                    self.chunks[mid]
+                        .get_proto_chunk_mut()
+                        .set_structure_references(g);
+                }
+                WorldGenerator::Flat(_) => {
+                    self.chunks[mid].get_proto_chunk_mut().stage =
+                        StagedChunkEnum::StructureReferences;
+                }
+            },
+            StagedChunkEnum::Biomes => match generator {
+                WorldGenerator::Vanilla(g) => {
+                    self.chunks[mid].get_proto_chunk_mut().step_to_biomes(g);
+                }
+                WorldGenerator::Flat(g) => {
+                    self.chunks[mid]
+                        .get_proto_chunk_mut()
+                        .step_to_flat_biomes(g);
+                }
+            },
+            StagedChunkEnum::Noise => match generator {
+                WorldGenerator::Vanilla(g) => {
+                    self.chunks[mid].get_proto_chunk_mut().step_to_noise(g);
+                }
+                WorldGenerator::Flat(g) => {
+                    self.chunks[mid].get_proto_chunk_mut().step_to_flat(g);
+                }
+            },
+            StagedChunkEnum::Surface => match generator {
+                WorldGenerator::Vanilla(g) => {
+                    self.chunks[mid].get_proto_chunk_mut().step_to_surface(g);
+                }
+                WorldGenerator::Flat(_) => {
+                    self.chunks[mid].get_proto_chunk_mut().stage = StagedChunkEnum::Surface;
+                }
+            },
+            StagedChunkEnum::Carvers => match generator {
+                WorldGenerator::Vanilla(g) => {
+                    self.chunks[mid].get_proto_chunk_mut().step_to_carvers(g);
+                }
+                WorldGenerator::Flat(_) => {
+                    self.chunks[mid].get_proto_chunk_mut().stage = StagedChunkEnum::Carvers;
+                }
+            },
+            StagedChunkEnum::Features => match generator {
+                WorldGenerator::Vanilla(g) => {
+                    ProtoChunk::generate_features_and_structure(
+                        self,
+                        block_registry,
+                        &g.random_config,
+                    );
+                }
+                WorldGenerator::Flat(_) => {
+                    self.chunks[mid].get_proto_chunk_mut().stage = StagedChunkEnum::Features;
+                }
+            },
             StagedChunkEnum::Lighting => {
                 let mut engine = crate::lighting::LightEngine::new();
                 engine.initialize_light(self, lighting_config);
@@ -398,7 +437,7 @@ impl Cache {
                 let chunk = self.chunks[mid].get_proto_chunk_mut();
                 debug_assert_eq!(chunk.stage, StagedChunkEnum::Spawn);
                 chunk.stage = StagedChunkEnum::Full;
-                self.chunks[mid].upgrade_to_level_chunk(&generator.dimension, lighting_config);
+                self.chunks[mid].upgrade_to_level_chunk(generator.dimension(), lighting_config);
             }
             StagedChunkEnum::None => {}
         }

--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -1195,7 +1195,7 @@ impl GenerationSchedule {
                             let send_chunk = self.send_chunk.clone();
                             let level = level.clone();
                             let settings =
-                                GenerationSettings::from_dimension(&level.world_gen.dimension);
+                                GenerationSettings::from_dimension(level.world_gen.dimension());
 
                             pool.spawn(move || {
                                 let result = crate::chunk_system::worker_logic::run_generation(

--- a/pumpkin-world/src/chunk_system/worker_logic.rs
+++ b/pumpkin-world/src/chunk_system/worker_logic.rs
@@ -183,7 +183,10 @@ pub async fn io_write_work(recv: AsyncRx<Vec<(ChunkPos, Chunk)>>, level: Arc<Lev
                 Chunk::Level(chunk) => vec.push((pos, chunk)),
                 Chunk::Proto(chunk) => {
                     let mut temp = Chunk::Proto(chunk);
-                    temp.upgrade_to_level_chunk(&level.world_gen.dimension, &level.lighting_config);
+                    temp.upgrade_to_level_chunk(
+                        level.world_gen.dimension(),
+                        &level.lighting_config,
+                    );
                     let Chunk::Level(chunk) = temp else { panic!() };
                     vec.push((pos, chunk));
                 }
@@ -266,7 +269,7 @@ pub fn generation_work(
     send: crossfire::compat::MTx<(ChunkPos, RecvChunk)>,
     level: Arc<Level>,
 ) {
-    let settings = GenerationSettings::from_dimension(&level.world_gen.dimension);
+    let settings = GenerationSettings::from_dimension(level.world_gen.dimension());
 
     loop {
         let (pos, cache, stage) = if let Ok(data) = recv.recv() {

--- a/pumpkin-world/src/generation/generator/flat.rs
+++ b/pumpkin-world/src/generation/generator/flat.rs
@@ -1,0 +1,223 @@
+use pumpkin_data::chunk::Biome;
+use pumpkin_data::chunk_gen_settings::GenerationSettings;
+use pumpkin_data::dimension::Dimension;
+use pumpkin_data::{Block, BlockState};
+
+use crate::generation::{GlobalRandomConfig, Seed};
+
+/// The Classic Flat preset: bedrock, two layers of dirt, a grass block, and the
+/// `plains` biome. Used when the preset string is empty.
+const CLASSIC_FLAT_PRESET: &str =
+    "minecraft:bedrock,2*minecraft:dirt,minecraft:grass_block;minecraft:plains";
+
+/// Resolved settings for the flat (superflat) world generator.
+///
+/// Block and biome names from the preset string are resolved to concrete game
+/// data here so chunk generation never has to perform name lookups.
+pub struct FlatGeneratorSettings {
+    /// The block layers, ordered bottom-to-top: `(block state, thickness)`.
+    pub layers: Vec<(&'static BlockState, u32)>,
+    /// The biome applied to every column of the world.
+    pub biome: &'static Biome,
+    /// The combined thickness of every layer, in blocks.
+    pub total_height: u32,
+}
+
+impl FlatGeneratorSettings {
+    /// Parses a vanilla superflat preset string into concrete layers and a
+    /// biome.
+    ///
+    /// The format mirrors vanilla's `generator-settings` legacy string:
+    /// `layers;biome`, where `layers` is a comma-separated list ordered
+    /// bottom-up and each entry is `block` or `count*block`. The `;biome`
+    /// suffix is optional. An empty string selects the Classic Flat preset.
+    ///
+    /// Unknown block names fall back to air and unknown or missing biome names
+    /// fall back to [`Biome::PLAINS`], each with a single warning rather than a
+    /// panic.
+    #[must_use]
+    pub fn from_preset(preset: &str) -> Self {
+        let preset = preset.trim();
+        let preset = if preset.is_empty() {
+            CLASSIC_FLAT_PRESET
+        } else {
+            preset
+        };
+
+        let (layers_part, biome_part) = match preset.split_once(';') {
+            Some((layers, biome)) => (layers, Some(biome.trim())),
+            None => (preset, None),
+        };
+
+        let biome = match biome_part.filter(|b| !b.is_empty()) {
+            Some(name) => Self::resolve_biome(name),
+            None => &Biome::PLAINS,
+        };
+
+        let mut layers = Vec::new();
+        let mut total_height = 0;
+        for entry in layers_part.split(',') {
+            let entry = entry.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            let (count, block_name) = match entry.split_once('*') {
+                Some((count, block)) => {
+                    let parsed = count.trim().parse::<u32>().unwrap_or_else(|_| {
+                        tracing::warn!(
+                            "Invalid flat world layer count `{count}` in `{entry}`, using 1"
+                        );
+                        1
+                    });
+                    (parsed, block.trim())
+                }
+                None => (1, entry),
+            };
+            if count == 0 {
+                continue;
+            }
+            let block = Self::resolve_block(block_name);
+            layers.push((block.default_state, count));
+            total_height += count;
+        }
+
+        Self {
+            layers,
+            biome,
+            total_height,
+        }
+    }
+
+    /// Resolves a block name, accepting an optional `minecraft:` prefix and
+    /// warning before falling back to air.
+    fn resolve_block(name: &str) -> &'static Block {
+        Block::from_name(name).unwrap_or_else(|| {
+            tracing::warn!("Unknown flat world block `{name}`, falling back to minecraft:air");
+            &Block::AIR
+        })
+    }
+
+    /// Resolves a biome name, accepting an optional `minecraft:` prefix and
+    /// warning before falling back to plains.
+    fn resolve_biome(name: &str) -> &'static Biome {
+        let stripped = name.strip_prefix("minecraft:").unwrap_or(name);
+        Biome::from_name(stripped).unwrap_or_else(|| {
+            tracing::warn!("Unknown flat world biome `{name}`, falling back to minecraft:plains");
+            &Biome::PLAINS
+        })
+    }
+}
+
+/// A superflat world generator producing fixed horizontal layers with a single
+/// biome, no terrain noise, carvers, or structures.
+pub struct FlatGenerator {
+    /// Shared random configuration, kept for parity with the vanilla pipeline
+    /// stages that still run (lighting, spawning, finalization).
+    pub random_config: GlobalRandomConfig,
+    /// The dimension this generator produces chunks for.
+    pub dimension: Dimension,
+    /// The resolved flat layers and biome.
+    pub settings: FlatGeneratorSettings,
+    /// The dimension's default block, required when constructing proto chunks.
+    pub default_block: &'static BlockState,
+    /// Seed used by the biome mixer, required when constructing proto chunks.
+    pub biome_mixer_seed: i64,
+}
+
+impl FlatGenerator {
+    /// Builds a flat generator for `dimension` from the given seed and preset.
+    ///
+    /// `preset` is the vanilla superflat `generator-settings` string; an empty
+    /// value selects the Classic Flat preset. See
+    /// [`FlatGeneratorSettings::from_preset`].
+    #[must_use]
+    pub fn new(seed: Seed, dimension: Dimension, preset: &str) -> Self {
+        let gen_settings = GenerationSettings::from_dimension(&dimension);
+        let random_config = GlobalRandomConfig::new(seed.0, gen_settings.legacy_random_source);
+        let biome_mixer_seed = crate::biome::hash_seed(seed.0);
+        let settings = FlatGeneratorSettings::from_preset(preset);
+
+        Self {
+            random_config,
+            dimension,
+            settings,
+            default_block: gen_settings.default_block,
+            biome_mixer_seed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FlatGeneratorSettings;
+    use pumpkin_data::Block;
+    use pumpkin_data::chunk::Biome;
+
+    #[test]
+    fn empty_preset_resolves_to_classic_flat() {
+        let settings = FlatGeneratorSettings::from_preset("");
+
+        assert_eq!(settings.biome.id, Biome::PLAINS.id);
+        assert_eq!(settings.total_height, 4);
+
+        let expected = [
+            (Block::BEDROCK.default_state.id, 1),
+            (Block::DIRT.default_state.id, 2),
+            (Block::GRASS_BLOCK.default_state.id, 1),
+        ];
+        let actual: Vec<_> = settings
+            .layers
+            .iter()
+            .map(|(state, height)| (state.id, *height))
+            .collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn preset_string_with_counts_and_biome_parses() {
+        let settings = FlatGeneratorSettings::from_preset(
+            "minecraft:bedrock,3*minecraft:stone;minecraft:desert",
+        );
+
+        let expected = [
+            (Block::BEDROCK.default_state.id, 1),
+            (Block::STONE.default_state.id, 3),
+        ];
+        let actual: Vec<_> = settings
+            .layers
+            .iter()
+            .map(|(state, height)| (state.id, *height))
+            .collect();
+        assert_eq!(actual, expected);
+        assert_eq!(settings.total_height, 4);
+        assert_eq!(settings.biome.id, Biome::DESERT.id);
+    }
+
+    #[test]
+    fn block_names_without_namespace_resolve() {
+        let settings = FlatGeneratorSettings::from_preset("2*dirt;plains");
+        assert_eq!(settings.layers[0].0.id, Block::DIRT.default_state.id);
+        assert_eq!(settings.layers[0].1, 2);
+        assert_eq!(settings.biome.id, Biome::PLAINS.id);
+    }
+
+    #[test]
+    fn unknown_block_falls_back_to_air() {
+        let settings = FlatGeneratorSettings::from_preset("3*minecraft:not_a_real_block");
+        assert_eq!(settings.layers[0].0.id, Block::AIR.default_state.id);
+        assert_eq!(settings.layers[0].1, 3);
+    }
+
+    #[test]
+    fn missing_biome_defaults_to_plains() {
+        let settings = FlatGeneratorSettings::from_preset("minecraft:stone");
+        assert_eq!(settings.biome.id, Biome::PLAINS.id);
+    }
+
+    #[test]
+    fn zero_count_layers_are_skipped() {
+        let settings = FlatGeneratorSettings::from_preset("0*minecraft:stone");
+        assert!(settings.layers.is_empty());
+        assert_eq!(settings.total_height, 0);
+    }
+}

--- a/pumpkin-world/src/generation/generator/mod.rs
+++ b/pumpkin-world/src/generation/generator/mod.rs
@@ -6,13 +6,66 @@ use pumpkin_data::noise_router::{
 };
 
 use super::noise::router::proto_noise_router::ProtoNoiseRouters;
+use crate::generation::generator::flat::FlatGenerator;
 use crate::generation::proto_chunk::TerrainCache;
 use crate::generation::{GlobalRandomConfig, Seed};
 
+pub mod flat;
 pub mod structure_finder;
 
 pub trait GeneratorInit {
     fn new(seed: Seed, dimension: Dimension) -> Self;
+}
+
+/// Dispatch over the available world generators.
+///
+/// An enum is used instead of a trait object so the performance-critical
+/// `step_to_*` methods on [`crate::generation::proto_chunk::ProtoChunk`] can
+/// keep their concrete generator parameters; the matching arm simply forwards
+/// the inner generator.
+pub enum WorldGenerator {
+    /// The default vanilla noise-based generator.
+    Vanilla(Box<VanillaGenerator>),
+    /// The superflat generator.
+    Flat(Box<FlatGenerator>),
+}
+
+impl WorldGenerator {
+    /// The dimension this generator produces chunks for.
+    #[must_use]
+    pub fn dimension(&self) -> &Dimension {
+        match self {
+            Self::Vanilla(g) => &g.dimension,
+            Self::Flat(g) => &g.dimension,
+        }
+    }
+
+    /// The shared random configuration used by the generation pipeline.
+    #[must_use]
+    pub fn random_config(&self) -> &GlobalRandomConfig {
+        match self {
+            Self::Vanilla(g) => &g.random_config,
+            Self::Flat(g) => &g.random_config,
+        }
+    }
+
+    /// The default block used when constructing proto chunks.
+    #[must_use]
+    pub fn default_block(&self) -> &'static BlockState {
+        match self {
+            Self::Vanilla(g) => g.default_block,
+            Self::Flat(g) => g.default_block,
+        }
+    }
+
+    /// The biome mixer seed used when constructing proto chunks.
+    #[must_use]
+    pub fn biome_mixer_seed(&self) -> i64 {
+        match self {
+            Self::Vanilla(g) => g.biome_mixer_seed,
+            Self::Flat(g) => g.biome_mixer_seed,
+        }
+    }
 }
 
 use pumpkin_data::structures::{StructurePlacementCalculator, StructureSet};

--- a/pumpkin-world/src/generation/mod.rs
+++ b/pumpkin-world/src/generation/mod.rs
@@ -17,17 +17,47 @@ pub mod rule;
 pub mod structure;
 mod surface;
 
-use generator::{GeneratorInit, VanillaGenerator};
+use generator::flat::FlatGenerator;
+use generator::{GeneratorInit, VanillaGenerator, WorldGenerator};
 use pumpkin_data::dimension::Dimension;
 use pumpkin_util::{
     random::xoroshiro128::{Xoroshiro, XoroshiroSplitter},
     world_seed::Seed,
 };
 
+/// Builds the configured world generator for `dimension`.
+///
+/// `level_type` mirrors the vanilla `level-type` from `server.properties`
+/// (the `minecraft:` prefix is optional); `minecraft:flat` selects the flat
+/// generator and any other value falls back to vanilla noise generation.
+/// `generator_settings` is the matching `generator-settings` value, consulted
+/// only by the flat generator.
 #[must_use]
-pub fn get_world_gen(seed: Seed, dimension: Dimension) -> Box<VanillaGenerator> {
-    // TODO decide which WorldGenerator to pick based on config.
-    Box::new(VanillaGenerator::new(seed, dimension))
+pub fn get_world_gen(
+    seed: Seed,
+    dimension: Dimension,
+    level_type: &str,
+    generator_settings: &str,
+) -> WorldGenerator {
+    let level_type = level_type
+        .trim()
+        .strip_prefix("minecraft:")
+        .unwrap_or_else(|| level_type.trim());
+
+    match level_type {
+        "flat" => WorldGenerator::Flat(Box::new(FlatGenerator::new(
+            seed,
+            dimension,
+            generator_settings,
+        ))),
+        "normal" | "large_biomes" | "amplified" => {
+            WorldGenerator::Vanilla(Box::new(VanillaGenerator::new(seed, dimension)))
+        }
+        other => {
+            tracing::warn!("Unknown level-type `{other}`, falling back to normal generation");
+            WorldGenerator::Vanilla(Box::new(VanillaGenerator::new(seed, dimension)))
+        }
+    }
 }
 
 pub struct GlobalRandomConfig {

--- a/pumpkin-world/src/generation/proto_chunk.rs
+++ b/pumpkin-world/src/generation/proto_chunk.rs
@@ -208,8 +208,8 @@ impl TerrainCache {
 
 impl ProtoChunk {
     #[must_use]
-    pub fn new(x: i32, z: i32, generator: &super::generator::VanillaGenerator) -> Self {
-        let dimension = &generator.dimension;
+    pub fn new(x: i32, z: i32, generator: &super::generator::WorldGenerator) -> Self {
+        let dimension = generator.dimension();
         let height = dimension.logical_height as u16;
         let section_count = (height as usize) / 16;
 
@@ -217,8 +217,8 @@ impl ProtoChunk {
         Self {
             x,
             z,
-            default_block: generator.default_block,
-            biome_mixer_seed: generator.biome_mixer_seed,
+            default_block: generator.default_block(),
+            biome_mixer_seed: generator.biome_mixer_seed(),
             flat_block_map: vec![0; CHUNK_AREA * height as usize].into_boxed_slice(),
             flat_biome_map: vec![
                 Biome::PLAINS.id;
@@ -263,7 +263,7 @@ impl ProtoChunk {
     #[must_use]
     pub fn from_chunk_data(
         chunk_data: &ChunkData,
-        generator: &super::generator::VanillaGenerator,
+        generator: &super::generator::WorldGenerator,
     ) -> Self {
         let mut proto_chunk = Self::new(chunk_data.x, chunk_data.z, generator);
 
@@ -564,6 +564,39 @@ impl ProtoChunk {
             MultiNoiseSampler::generate(&generator.base_router.multi_noise, &multi_noise_config);
         self.populate_biomes(generator, &mut multi_noise_sampler);
         self.stage = StagedChunkEnum::Biomes;
+    }
+
+    /// Biome stage for the flat generator: fills the whole chunk with the
+    /// single configured biome.
+    pub fn step_to_flat_biomes(&mut self, generator: &super::generator::flat::FlatGenerator) {
+        debug_assert_eq!(self.stage, StagedChunkEnum::Empty);
+        self.flat_biome_map.fill(generator.settings.biome.id);
+        self.stage = StagedChunkEnum::Biomes;
+    }
+
+    /// Terrain stage for the flat generator: stacks the configured layers
+    /// bottom-up from the dimension floor, leaving everything above as air.
+    pub fn step_to_flat(&mut self, generator: &super::generator::flat::FlatGenerator) {
+        debug_assert_eq!(self.stage, StagedChunkEnum::StructureReferences);
+        let start_x = start_block_x(self.x);
+        let start_z = start_block_z(self.z);
+        let bottom_y = self.bottom_y() as i32;
+
+        for local_x in 0..CHUNK_DIM as i32 {
+            for local_z in 0..CHUNK_DIM as i32 {
+                let world_x = start_x + local_x;
+                let world_z = start_z + local_z;
+                let mut y = bottom_y;
+                for (state, height) in &generator.settings.layers {
+                    for _ in 0..*height {
+                        self.set_block_state(world_x, y, world_z, state);
+                        y += 1;
+                    }
+                }
+            }
+        }
+
+        self.stage = StagedChunkEnum::Noise;
     }
 
     pub fn step_to_noise(&mut self, generator: &super::generator::VanillaGenerator) {

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -1,7 +1,7 @@
 use crate::chunk::format::linear::LinearV2File;
 use crate::chunk::format::pump::PumpFile;
 use crate::chunk_system::{ChunkListener, ChunkLoading, GenerationSchedule, LevelChannel};
-use crate::generation::generator::VanillaGenerator;
+use crate::generation::generator::WorldGenerator;
 use crate::lighting::DynamicLightEngine;
 use crate::{
     BlockStateId,
@@ -79,7 +79,7 @@ pub struct Level {
     pub chunk_saver: Arc<dyn FileIO<Data = SyncChunk>>,
     entity_saver: Arc<dyn FileIO<Data = SyncEntityChunk>>,
 
-    pub world_gen: Arc<VanillaGenerator>,
+    pub world_gen: Arc<WorldGenerator>,
 
     /// Handles runtime lighting updates
     pub light_engine: DynamicLightEngine,
@@ -145,7 +145,13 @@ impl Level {
         });
 
         let seed = Seed(seed as u64);
-        let world_gen = get_world_gen(seed, dimension).into();
+        let world_gen = get_world_gen(
+            seed,
+            dimension,
+            &level_config.level_type,
+            &level_config.generator_settings,
+        )
+        .into();
 
         let chunk_saver: Arc<dyn FileIO<Data = SyncChunk>> = match &level_config.chunk {
             ChunkConfig::Linear => Arc::new(ChunkFileManager::<LinearV2File<ChunkData>>::new(())),

--- a/pumpkin-world/src/lib.rs
+++ b/pumpkin-world/src/lib.rs
@@ -61,15 +61,21 @@ pub fn bench_create_and_populate_noise(
     _terrain_cache: &TerrainCache,
     _default_block: &'static BlockState,
 ) {
-    use crate::generation::generator::{GeneratorInit, VanillaGenerator};
+    use crate::generation::generator::{GeneratorInit, VanillaGenerator, WorldGenerator};
     use crate::generation::noise::router::surface_height_sampler::{
         SurfaceHeightEstimateSampler, SurfaceHeightSamplerBuilderOptions,
     };
     use crate::generation::proto_chunk::StandardChunkFluidLevelSampler;
     use pumpkin_util::world_seed::Seed;
 
-    let generator = VanillaGenerator::new(Seed(random_config.seed), Dimension::OVERWORLD);
-    let mut chunk = ProtoChunk::new(0, 0, &generator);
+    let world_gen = WorldGenerator::Vanilla(Box::new(VanillaGenerator::new(
+        Seed(random_config.seed),
+        Dimension::OVERWORLD,
+    )));
+    let mut chunk = ProtoChunk::new(0, 0, &world_gen);
+    let WorldGenerator::Vanilla(generator) = &world_gen else {
+        panic!("expected vanilla generator")
+    };
 
     // Create noise sampler and other required components
     let settings = generator.settings;
@@ -120,7 +126,7 @@ pub fn bench_create_and_populate_noise(
     );
 
     chunk.populate_noise(
-        &generator,
+        generator,
         &mut noise_sampler,
         &generator.random_config.ore_random_deriver,
         &mut surface_height_estimate_sampler,
@@ -134,15 +140,21 @@ pub fn bench_create_and_populate_biome(
     _terrain_cache: &TerrainCache,
     _default_block: &'static BlockState,
 ) {
-    use crate::generation::generator::{GeneratorInit, VanillaGenerator};
+    use crate::generation::generator::{GeneratorInit, VanillaGenerator, WorldGenerator};
     use crate::generation::noise::router::multi_noise_sampler::{
         MultiNoiseSampler, MultiNoiseSamplerBuilderOptions,
     };
     use crate::generation::{biome_coords, positions::chunk_pos};
     use pumpkin_util::world_seed::Seed;
 
-    let generator = VanillaGenerator::new(Seed(random_config.seed), Dimension::OVERWORLD);
-    let mut chunk = ProtoChunk::new(0, 0, &generator);
+    let world_gen = WorldGenerator::Vanilla(Box::new(VanillaGenerator::new(
+        Seed(random_config.seed),
+        Dimension::OVERWORLD,
+    )));
+    let mut chunk = ProtoChunk::new(0, 0, &world_gen);
+    let WorldGenerator::Vanilla(generator) = &world_gen else {
+        panic!("expected vanilla generator")
+    };
 
     // Create multi-noise sampler
     let start_x = chunk_pos::start_block_x(0);
@@ -160,7 +172,7 @@ pub fn bench_create_and_populate_biome(
     let mut multi_noise_sampler =
         MultiNoiseSampler::generate(&generator.base_router.multi_noise, &multi_noise_config);
 
-    chunk.populate_biomes(&generator, &mut multi_noise_sampler);
+    chunk.populate_biomes(generator, &mut multi_noise_sampler);
 }
 
 pub fn bench_create_and_populate_noise_with_surface(
@@ -170,7 +182,7 @@ pub fn bench_create_and_populate_noise_with_surface(
     _terrain_cache: &TerrainCache,
     _default_block: &'static BlockState,
 ) {
-    use crate::generation::generator::{GeneratorInit, VanillaGenerator};
+    use crate::generation::generator::{GeneratorInit, VanillaGenerator, WorldGenerator};
     use crate::generation::noise::router::{
         multi_noise_sampler::{MultiNoiseSampler, MultiNoiseSamplerBuilderOptions},
         surface_height_sampler::{
@@ -180,8 +192,14 @@ pub fn bench_create_and_populate_noise_with_surface(
     use crate::generation::proto_chunk::StandardChunkFluidLevelSampler;
     use pumpkin_util::world_seed::Seed;
 
-    let generator = VanillaGenerator::new(Seed(random_config.seed), Dimension::OVERWORLD);
-    let mut chunk = ProtoChunk::new(0, 0, &generator);
+    let world_gen = WorldGenerator::Vanilla(Box::new(VanillaGenerator::new(
+        Seed(random_config.seed),
+        Dimension::OVERWORLD,
+    )));
+    let mut chunk = ProtoChunk::new(0, 0, &world_gen);
+    let WorldGenerator::Vanilla(generator) = &world_gen else {
+        panic!("expected vanilla generator")
+    };
 
     // Create all required components
     let settings = generator.settings;
@@ -239,12 +257,12 @@ pub fn bench_create_and_populate_noise_with_surface(
         &surface_config,
     );
 
-    chunk.populate_biomes(&generator, &mut multi_noise_sampler);
+    chunk.populate_biomes(generator, &mut multi_noise_sampler);
     chunk.populate_noise(
-        &generator,
+        generator,
         &mut noise_sampler,
         &generator.random_config.ore_random_deriver,
         &mut surface_height_estimate_sampler,
     );
-    chunk.build_surface(&generator, &mut surface_height_estimate_sampler);
+    chunk.build_surface(generator, &mut surface_height_estimate_sampler);
 }

--- a/pumpkin-world/src/world_info/anvil.rs
+++ b/pumpkin-world/src/world_info/anvil.rs
@@ -158,7 +158,7 @@ mod test {
     fn preserve_level_dat_seed() {
         let seed = 1337;
 
-        let data = LevelData::default(Seed(1337));
+        let data = LevelData::default(Seed(1337), "minecraft:normal");
 
         let temp_dir = TempDir::new().unwrap();
 
@@ -226,7 +226,7 @@ mod test {
                 water_source_conversion: true,
                 ..Default::default()
             },
-            world_gen_settings: WorldGenSettings::new(Seed(1)),
+            world_gen_settings: WorldGenSettings::new(Seed(1), "minecraft:normal"),
             last_played: 1733847709327,
             level_name: "New World".to_string(),
             spawn_x: 160,

--- a/pumpkin-world/src/world_info/mod.rs
+++ b/pumpkin-world/src/world_info/mod.rs
@@ -220,8 +220,17 @@ pub struct DataPacks {
 
 impl WorldGenSettings {
     #[must_use]
-    pub fn new(seed: Seed) -> Self {
+    pub fn new(seed: Seed, level_type: &str) -> Self {
         // TODO: Adjust according to enabled worlds
+        let normalized = level_type
+            .trim()
+            .strip_prefix("minecraft:")
+            .unwrap_or_else(|| level_type.trim());
+        let overworld_generator_type = if normalized == "flat" {
+            "minecraft:flat"
+        } else {
+            "minecraft:noise"
+        };
         let mut dimensions = Dimensions::new();
         dimensions.insert(
             "minecraft:overworld".to_string(),
@@ -232,7 +241,7 @@ impl WorldGenSettings {
                         preset: "minecraft:overworld".to_string(),
                         biome_type: "minecraft:multi_noise".to_string(),
                     }),
-                    generator_type: "minecraft:noise".to_string(),
+                    generator_type: overworld_generator_type.to_string(),
                 },
                 dimension_type: "minecraft:overworld".to_string(),
             },
@@ -298,7 +307,7 @@ impl Default for WorldVersion {
 
 impl LevelData {
     #[must_use]
-    pub fn default(seed: Seed) -> Self {
+    pub fn default(seed: Seed, level_type: &str) -> Self {
         Self {
             allow_commands: true,
             border_center_x: 0.0,
@@ -317,7 +326,7 @@ impl LevelData {
             difficulty: DEFAULT_DIFFICULTY,
             difficulty_locked: false,
             game_rules: GameRuleRegistry::default(),
-            world_gen_settings: WorldGenSettings::new(seed),
+            world_gen_settings: WorldGenSettings::new(seed, level_type),
             last_played: -1,
             level_name: DEFAULT_LEVEL_NAME.to_string(),
             spawn_x: 0,

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -25,6 +25,7 @@ use pumpkin_protocol::bedrock::server::text::SText;
 use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_util::translation::Locale;
 use pumpkin_world::chunk::{ChunkData, ChunkEntityData};
+use pumpkin_world::generation::generator::WorldGenerator;
 use pumpkin_world::inventory::Inventory;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -2268,7 +2269,7 @@ impl Player {
                         self.gamemode.load() as u8,
                         self.gamemode.load() as i8,
                         false,
-                        false,
+                        matches!(*new_world.level.world_gen, WorldGenerator::Flat(_)),
                         Some((death_dimension, death_location)),
                         VarInt(self.get_entity().portal_cooldown.load(Ordering::Relaxed) as i32),
                         new_world.sea_level.into(),

--- a/pumpkin/src/item/items/ender_eye.rs
+++ b/pumpkin/src/item/items/ender_eye.rs
@@ -16,6 +16,7 @@ use pumpkin_data::world::WorldEvent;
 use pumpkin_data::{Block, BlockDirection};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
+use pumpkin_world::generation::generator::WorldGenerator;
 use pumpkin_world::generation::generator::structure_finder::find_nearest_structure;
 use pumpkin_world::world::BlockFlags;
 
@@ -137,7 +138,10 @@ impl ItemBehaviour for EnderEyeItem {
 
 fn find_stronghold(world: &Arc<World>, origin: BlockPos) -> Option<BlockPos> {
     let level = &world.level;
-    let generator = &level.world_gen;
+    // Strongholds only exist in the vanilla generator; flat worlds have none.
+    let WorldGenerator::Vanilla(generator) = level.world_gen.as_ref() else {
+        return None;
+    };
     let seed = level.seed.0;
 
     find_nearest_structure(

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -179,7 +179,8 @@ impl Server {
         }
         let level_info = level_info.unwrap_or_else(|err| {
             warn!("Failed to get level_info, using default instead: {err}");
-            let default_data = LevelData::default(basic_config.seed);
+            let default_data =
+                LevelData::default(basic_config.seed, &advanced_config.world.level_type);
             if let Err(err) = AnvilLevelInfo.write_world_info(&default_data, &world_path) {
                 error!("Failed to save level.dat: {err}");
             }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -125,6 +125,7 @@ use pumpkin_util::{
     math::{position::chunk_section_from_pos, vector2::Vector2},
     random::{RandomImpl, get_seed, xoroshiro128::Xoroshiro},
 };
+use pumpkin_world::generation::generator::WorldGenerator;
 use pumpkin_world::inventory::Clearable;
 use pumpkin_world::world::{GetBlockError, WorldPortalExt};
 use pumpkin_world::{
@@ -230,6 +231,14 @@ impl PartialEq for World {
 impl Eq for World {}
 
 impl World {
+    /// Returns true if this world uses a flat world generator.
+    /// Used to set the `is_flat` field on Join/Respawn packets, which fixes
+    /// black sky rendering below Y=61 (caves/underground).
+    #[must_use]
+    pub(crate) fn is_flat_world(&self) -> bool {
+        matches!(*self.level.world_gen, WorldGenerator::Flat(_))
+    }
+
     #[must_use]
     pub fn load(
         level: Arc<Level>,
@@ -2180,7 +2189,7 @@ impl World {
                     .load()
                     .map_or(-1, |gamemode| gamemode as i8),
                 false,
-                false,
+                self.is_flat_world(),
                 None,
                 VarInt(player.get_entity().portal_cooldown.load(Ordering::Relaxed) as i32),
                 self.sea_level.into(),
@@ -2964,7 +2973,7 @@ impl World {
                 player.gamemode.load() as u8,
                 player.gamemode.load() as i8,
                 false,
-                false,
+                target_world.is_flat_world(),
                 Some((death_dimension, death_location)),
                 VarInt(player.get_entity().portal_cooldown.load(Ordering::Relaxed) as i32),
                 target_world.sea_level.into(),


### PR DESCRIPTION
## Summary

Adds a superflat world generator, addressing one checkbox of the world
generation tracking issue Pumpkin-MC/Pumpkin#1403.

Setting `level_type = "flat"` in the world config produces a playable superflat
world with fixed, configurable horizontal layers, a single biome, and no terrain
noise or carvers. The generator is selected via config and persisted to
`level.dat` for client/tooling compatibility.

## What changed

- **Config** (`pumpkin-config/src/world.rs`): new `level_type` and
  `generator_settings` fields on `LevelConfig`, mirroring vanilla's
  `level-type` / `generator-settings` from `server.properties`. The
  `minecraft:` prefix is optional; unknown `level_type` values fall back to
  normal generation.
- **Flat generator** (`pumpkin-world/src/generation/generator/flat.rs`): new
  `FlatGenerator` plus a `FlatGeneratorSettings` preset parser. The preset
  string follows vanilla's legacy format `layers;biome`, where `layers` is a
  comma-separated, bottom-up list of `block` or `count*block` entries. An empty
  preset selects the Classic Flat preset (bedrock, 2×dirt, grass; plains).
  Unknown block names fall back to air and unknown/missing biomes to plains,
  each with a single warning rather than a panic.
- **Generator dispatch** (`generation/generator/mod.rs`): introduces a
  `WorldGenerator` enum (`Vanilla` | `Flat`) with `dimension()` /
  `random_config()` accessors, rather than a trait, to keep the blast radius off
  the performance-critical chunk pipeline.
- **Generation pipeline** (`proto_chunk.rs`, `chunk_system/generation_cache.rs`):
  adds `step_to_flat_biomes` and `step_to_flat`. `Cache::advance` matches on the
  generator: the flat path fills the single biome, stacks the configured layers
  bottom-up from the dimension floor, and no-ops the structure/surface/carver/
  feature stages. Lighting, spawning, and finalization run unchanged.
- **Generator selection** (`generation/mod.rs`): `get_world_gen` now takes
  `level_type` + `generator_settings` and returns a `WorldGenerator`.
- **`level.dat` persistence** (`world_info/mod.rs`): new flat worlds write
  `generator_type = "minecraft:flat"` for the overworld dimension.

## Test plan

- [x] Unit test: empty preset resolves to the Classic Flat layers and plains.
- [x] Unit test: preset string with `count*block` entries and a `;biome` suffix
      parses correctly.
- [x] Unit test: block names without a `minecraft:` namespace resolve; unknown
      blocks fall back to air; missing biome defaults to plains; zero-count
      layers are skipped.
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features` (zero warnings)
- [x] `cargo clippy --release --all-targets --all-features` (zero warnings)
- [x] `cargo test` (unit + doctests) — `cargo-machete` reports no unused deps
- [x] Manual in-client verification of lighting/sky rendering (see Known issues)

## Known issues

- ~~**Black sky below y=0.** In a superflat world the surface sits below y=0
  (Classic Flat spawns the player at y=-60), and the client renders a black void
  sky there even though the terrain is lit normally. Server-side sky light is
  correct — a generated flat chunk reports sky light 15 at the player's feet
  (y=-60) and above — so the bug is on the client-facing side, not in light
  generation. The one concrete protocol anomaly found is that the
  `dimension_type` registry encodes `min_y` / `height` / `logical_height` as
  `TAG_Long` rather than vanilla's `TAG_Int`; this is the leading suspect but is
  **not yet confirmed** as the root cause without a client-side packet capture.
  This affects rendering only and is likely pre-existing (it is simply not
  observable in normal worlds, where the surface is above y=0). Tracked as
  follow-up.~~

## Out of scope / follow-ups

- Structures (maybe villages) are not generated in flat worlds.
- Parsing/honoring a flat `generator-settings` compound from `level.dat` on
  load (config remains authoritative for now).
- Full vanilla preset string features beyond `layers;biome` (e.g. structure
  flags).
