### PR TITLE
fix(bedrock): allow larger login payloads

### DIFF
--- a/pumpkin-protocol/src/bedrock/packet_decoder.rs
+++ b/pumpkin-protocol/src/bedrock/packet_decoder.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::Cursor,
+    io::{Cursor, Read},
     pin::Pin,
     task::{Context, Poll},
 };
@@ -8,9 +8,8 @@ use async_compression::tokio::bufread::DeflateDecoder;
 use tokio::io::{AsyncRead, BufReader, ReadBuf};
 
 use crate::{
-    Aes128Cfb8Dec, CompressionThreshold, PacketDecodeError, RawPacket, StreamDecryptor,
-    codec::var_uint::VarUInt,
-    ser::{NetworkReadExt, ReadingError},
+    Aes128Cfb8Dec, CompressionThreshold, MAX_PACKET_DATA_SIZE, PacketDecodeError, RawPacket,
+    StreamDecryptor, codec::var_uint::VarUInt, ser::ReadingError,
 };
 
 pub enum DecryptionReader<R: AsyncRead + Unpin> {
@@ -104,28 +103,42 @@ impl UDPNetworkDecoder {
 
         // If compression is NOT enabled yet, the payload starts at index 1.
         if self.compression.is_none() {
-            return Ok(full_packet[1..].to_vec());
+            let payload = &full_packet[1..];
+            if payload.len() > MAX_PACKET_DATA_SIZE {
+                return Err(PacketDecodeError::TooLong);
+            }
+            return Ok(payload.to_vec());
         }
 
         // If compression IS enabled, Bedrock expects a compression method byte at index 1.
-        let compression_method = full_packet[1];
+        let compression_method = *full_packet.get(1).ok_or_else(|| {
+            PacketDecodeError::MalformedLength("Missing Bedrock compression method".into())
+        })?;
         let data_start = 2;
 
         match compression_method {
             0x00 => {
                 use tokio::io::AsyncReadExt;
                 let compressed_payload = &full_packet[data_start..];
-                let mut decoder = DeflateDecoder::new(BufReader::new(compressed_payload));
+                let mut decoder = DeflateDecoder::new(BufReader::new(compressed_payload))
+                    .take(MAX_PACKET_DATA_SIZE as u64 + 1);
                 let mut decompressed = Vec::new();
                 decoder
                     .read_to_end(&mut decompressed)
                     .await
                     .map_err(|e| PacketDecodeError::FailedDecompression(e.to_string()))?;
+                if decompressed.len() > MAX_PACKET_DATA_SIZE {
+                    return Err(PacketDecodeError::TooLong);
+                }
                 Ok(decompressed)
             }
             0xff => {
                 // None (Compression enabled but this specific packet is raw)
-                Ok(full_packet[data_start..].to_vec())
+                let payload = &full_packet[data_start..];
+                if payload.len() > MAX_PACKET_DATA_SIZE {
+                    return Err(PacketDecodeError::TooLong);
+                }
+                Ok(payload.to_vec())
             }
             _ => Err(PacketDecodeError::FailedDecompression(format!(
                 "Unsupported compression method: 0x{compression_method:02x}"
@@ -141,21 +154,83 @@ impl UDPNetworkDecoder {
             ReadingError::CleanEOF(_) => PacketDecodeError::ConnectionClosed,
             err => PacketDecodeError::MalformedLength(err.to_string()),
         })?;
+        let packet_len = packet_len.0 as usize;
+        if packet_len == 0 {
+            return Err(PacketDecodeError::MalformedLength(
+                "Bedrock game packet length is zero".into(),
+            ));
+        }
+        if packet_len > MAX_PACKET_DATA_SIZE {
+            return Err(PacketDecodeError::TooLong);
+        }
 
         let var_header = VarUInt::decode(decompressed_reader)?;
         let header = var_header.0 & 0x3FFF;
         let gamepacket_id = (header & 0x3FF) as u16;
 
         let header_size = var_header.written_size();
-        let payload_len = packet_len.0 as usize - header_size;
+        if packet_len < header_size {
+            return Err(PacketDecodeError::MalformedLength(format!(
+                "Bedrock game packet length {packet_len} is smaller than header size {header_size}"
+            )));
+        }
 
-        let payload = decompressed_reader
-            .read_boxed_slice(payload_len)
+        let payload_len = packet_len - header_size;
+        let remaining = decompressed_reader
+            .get_ref()
+            .len()
+            .saturating_sub(decompressed_reader.position() as usize);
+        if payload_len > remaining {
+            return Err(PacketDecodeError::MalformedLength(format!(
+                "Bedrock game packet payload length {payload_len} exceeds remaining batch bytes {remaining}"
+            )));
+        }
+
+        let mut payload = vec![0; payload_len].into_boxed_slice();
+        decompressed_reader
+            .read_exact(&mut payload)
             .map_err(|err| PacketDecodeError::FailedDecompression(err.to_string()))?;
 
         Ok(RawPacket {
             id: i32::from(gamepacket_id),
             payload: payload.into(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use crate::bedrock::{SubClient, packet_encoder::UDPNetworkEncoder};
+
+    use super::*;
+
+    #[test]
+    fn decodes_payload_larger_than_two_mib() {
+        const PAYLOAD_LEN: usize = 2 * 1024 * 1024 + 1;
+        let payload = vec![0x2a; PAYLOAD_LEN];
+        let mut wire_buf = Vec::new();
+        let mut network_encoder = UDPNetworkEncoder::new();
+        network_encoder
+            .write_game_packet(
+                0x01,
+                SubClient::Main,
+                SubClient::Main,
+                &payload,
+                &mut wire_buf,
+            )
+            .expect("encode Bedrock game packet");
+
+        let mut cursor = Cursor::new(wire_buf[1..].to_vec());
+        let mut decoder = UDPNetworkDecoder::new();
+
+        let packet = decoder
+            .get_game_packet(&mut cursor)
+            .expect("decode Bedrock game packet");
+
+        assert_eq!(packet.id, 0x01);
+        assert_eq!(packet.payload.len(), PAYLOAD_LEN);
+        assert_eq!(packet.payload.as_ref(), payload.as_slice());
     }
 }

--- a/pumpkin-protocol/src/bedrock/server/login.rs
+++ b/pumpkin-protocol/src/bedrock/server/login.rs
@@ -2,7 +2,7 @@ use pumpkin_macros::packet;
 use serde::Deserialize;
 use std::io::{Error, ErrorKind, Read};
 
-use crate::{codec::var_uint::VarUInt, serial::PacketRead};
+use crate::{MAX_PACKET_DATA_SIZE, codec::var_uint::VarUInt, serial::PacketRead};
 
 #[packet(1)]
 pub struct SLogin {
@@ -16,28 +16,35 @@ pub struct SLogin {
 
 impl PacketRead for SLogin {
     fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
-        const MAX_TOKEN_SIZE: usize = 2000 * 1024; // 2MB limit
         let protocol_version = i32::read_be(reader)?;
-        let _len = VarUInt::read(reader)?;
-
-        let jwt_len = u32::read(reader)?;
-        if jwt_len as usize > MAX_TOKEN_SIZE {
+        let connection_request_len = VarUInt::read(reader)?.0 as usize;
+        if connection_request_len > MAX_PACKET_DATA_SIZE {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                "JWT length exceeds limit",
+                format!(
+                    "Connection request length {connection_request_len} exceeds limit {MAX_PACKET_DATA_SIZE}"
+                ),
             ));
         }
-        let mut jwt = vec![0; jwt_len as _];
+
+        let jwt_len = u32::read(reader)? as usize;
+        if jwt_len > MAX_PACKET_DATA_SIZE {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("JWT length {jwt_len} exceeds limit {MAX_PACKET_DATA_SIZE}"),
+            ));
+        }
+        let mut jwt = vec![0; jwt_len];
         reader.read_exact(&mut jwt)?;
 
-        let raw_token_len = u32::read(reader)?;
-        if raw_token_len as usize > MAX_TOKEN_SIZE {
+        let raw_token_len = u32::read(reader)? as usize;
+        if raw_token_len > MAX_PACKET_DATA_SIZE {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                "Raw token length exceeds limit",
+                format!("Raw token length {raw_token_len} exceeds limit {MAX_PACKET_DATA_SIZE}"),
             ));
         }
-        let mut raw_token = vec![0; raw_token_len as _];
+        let mut raw_token = vec![0; raw_token_len];
         reader.read_exact(&mut raw_token)?;
 
         Ok(Self {
@@ -48,6 +55,43 @@ impl PacketRead for SLogin {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use crate::serial::{PacketRead, PacketWrite};
+
+    use super::*;
+
+    #[test]
+    fn reads_raw_token_larger_than_two_mib() {
+        const RAW_TOKEN_LEN: usize = 2 * 1024 * 1024 + 1;
+        let jwt = b"{}";
+        let client_token = vec![0x41; RAW_TOKEN_LEN];
+        let connection_request_len = 4 + jwt.len() + 4 + client_token.len();
+        let mut input = Vec::new();
+
+        975i32.write_be(&mut input).expect("write protocol version");
+        VarUInt(connection_request_len as u32)
+            .write(&mut input)
+            .expect("write connection request length");
+        (jwt.len() as u32)
+            .write(&mut input)
+            .expect("write JWT length");
+        input.extend_from_slice(jwt);
+        (client_token.len() as u32)
+            .write(&mut input)
+            .expect("write raw token length");
+        input.extend_from_slice(&client_token);
+
+        let packet = SLogin::read(&mut Cursor::new(input)).expect("read login packet");
+
+        assert_eq!(packet.protocol_version, 975);
+        assert_eq!(packet.jwt, jwt);
+        assert_eq!(packet.raw_token.len(), RAW_TOKEN_LEN);
+        assert_eq!(packet.raw_token, client_token);
+    }
+}
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct SkinAnimation {

--- a/pumpkin/src/net/bedrock/mod.rs
+++ b/pumpkin/src/net/bedrock/mod.rs
@@ -849,7 +849,9 @@ impl BedrockClient {
                         Ok(p) => p,
                         Err(err) => {
                             error!("Failed to read SLogin: {err}");
-                            continue;
+                            self.kick(DisconnectReason::BadPacket, err.to_string())
+                                .await;
+                            return PacketHandlerResult::Stop;
                         }
                     };
                     match self.handle_login(packet, server).await {


### PR DESCRIPTION
## Summary
- let Bedrock game packet decoding use the protocol packet-data limit instead of the generic 2 MiB slice limit
- bound decompression/raw payload reads to `MAX_PACKET_DATA_SIZE`
- raise Bedrock login JWT/raw-token bounds to the same packet-data limit and stop login after malformed SLogin packets
- add regression tests for >2 MiB Bedrock payloads/login tokens

Closes #2204

## Testing
- `cargo test -p pumpkin-protocol larger_than_two_mib`
- `cargo clippy -p pumpkin-protocol --tests -- -D warnings`
- `cargo check -p pumpkin`