### PR TITLE
fix(command): prevent SuggestionsBuilder panic on out-of-bounds start

### DIFF
--- a/pumpkin/src/command/argument_types/entity_selector/parser.rs
+++ b/pumpkin/src/command/argument_types/entity_selector/parser.rs
@@ -475,7 +475,7 @@ impl EntitySelectorParserSuggestions {
         match self {
             Self::Nothing => {}
             Self::Selector => {
-                let mut sub = builder.create_offset(builder.start - 1);
+                let mut sub = builder.create_offset(builder.start.saturating_sub(1));
                 sub = Self::fill_selector_suggestions(sub);
                 builder = builder.append(sub);
             }

--- a/pumpkin/src/command/suggestion/mod.rs
+++ b/pumpkin/src/command/suggestion/mod.rs
@@ -451,6 +451,13 @@ mod test {
     }
 
     #[test]
+    fn remaining_past_end() {
+        let builder = SuggestionsBuilder::new("ab", 10);
+        assert_eq!(builder.remaining(), "");
+        assert_eq!(builder.remaining_lowercase(), "");
+    }
+
+    #[test]
     fn sort() {
         let suggestions = SuggestionsBuilder::new("A random thing to say is foobar", 25)
             .suggest("1")

--- a/pumpkin/src/command/suggestion/suggestions.rs
+++ b/pumpkin/src/command/suggestion/suggestions.rs
@@ -36,13 +36,13 @@ impl SuggestionsBuilder {
     /// Gets the remaining substring of the underlying input string.
     #[must_use]
     pub fn remaining(&self) -> &str {
-        &self.input[self.start..]
+        &self.input[self.start.min(self.input.len())..]
     }
 
     /// Gets the remaining substring of the underlying lowercased input string.
     #[must_use]
     pub fn remaining_lowercase(&self) -> &str {
-        &self.input_lowercase[self.start..]
+        &self.input_lowercase[self.start.min(self.input_lowercase.len())..]
     }
 
     /// Builds the [`Suggestions`] object, consuming itself in the process.


### PR DESCRIPTION
### Summary

During my first run of pumpkin on MacOS i ran into a panic when trying to figure out the right command to op myself, when entering a sequences of text and pressing tab it caused the server to panic.

### Description/Changes 

Clamp the start position to the input length in `remaining()` and 
`remaining_lowercase()` at suggestions.rs to prevent an unbounded slice 
panic (`&self.input[self.start..]`) when `start` exceeds `input.len()`.

Also, use `saturating_sub(1)` in the entity_selector parser to 
prevent a panic in debug mode when `start` is 0.

Fixes panic from:
- Console completer passing cursor positions without adjusting for a stripped '/'
- `create_offset()` constructing a builder with `start > input.len()`
- `entity_selector` parser underflowing on `builder.start - 1`