### PR TITLE
fix(living): prevent panic when applying effects with attribute modifiers

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -356,7 +356,18 @@ impl LivingEntity {
                 .attributes
                 .iter()
                 .find(|a| a.0.id == attribute.id)
-                .map_or(attribute.default_value, |a| a.1);
+                .map_or_else(
+                    || {
+                        tracing::warn!(
+                            "Entity type {:?} has no base value for attribute {:?}; falling back to default {}",
+                            self.entity.entity_type,
+                            attribute.id,
+                            attribute.default_value,
+                        );
+                        attribute.default_value
+                    },
+                    |a| a.1,
+                );
             AttributeInstance::new(base)
         });
 

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -356,8 +356,8 @@ impl LivingEntity {
                 .attributes
                 .iter()
                 .find(|a| a.0.id == attribute.id)
-                .unwrap()
-                .1;
+                .map(|a| a.1)
+                .unwrap_or(attribute.default_value);
             AttributeInstance::new(base)
         });
 

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -356,8 +356,7 @@ impl LivingEntity {
                 .attributes
                 .iter()
                 .find(|a| a.0.id == attribute.id)
-                .map(|a| a.1)
-                .unwrap_or(attribute.default_value);
+                .map_or(attribute.default_value, |a| a.1);
             AttributeInstance::new(base)
         });
 


### PR DESCRIPTION
### Description
Eating a golden apple panicked the server because MAX_ABSORPTION wasn't registered as a player attribute. Falling back on default_value fixes it.

### Testing
- Eating a golden apple no longer panics
- Absorption hearts appear correctly