### PR TITLE
Fix stale proto chunk generation tasks

### DIFF
--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -862,9 +862,11 @@ impl GenerationSchedule {
                             let mut holder = self.chunk_map.remove(&new_pos).unwrap();
 
                             let stage = chunk.stage_id();
-                            if stage < holder.tasks.len() as u8 {
-                                let task_idx = stage as usize;
+                            for task_idx in (holder.current_stage as usize + 1)
+                                ..=(stage as usize).min(holder.tasks.len() - 1)
+                            {
                                 if !holder.tasks[task_idx].is_null() {
+                                    self.waiting_for_chunks.remove(&holder.tasks[task_idx]);
                                     self.drop_node(holder.tasks[task_idx]);
                                     holder.tasks[task_idx] = NodeKey::null();
                                 }

--- a/pumpkin-world/src/chunk_system/tests.rs
+++ b/pumpkin-world/src/chunk_system/tests.rs
@@ -242,6 +242,56 @@ fn ensure_dependency_chain_early_return_skips_edge() {
 }
 
 #[test]
+fn completed_proto_stage_drops_all_satisfied_tasks() {
+    let mut graph = DAG::default();
+    let mut holder = ChunkHolder {
+        current_stage: StagedChunkEnum::None,
+        target_stage: StagedChunkEnum::StructureStart,
+        ..Default::default()
+    };
+
+    for stage in StagedChunkEnum::Empty as usize..=StagedChunkEnum::StructureStart as usize {
+        holder.tasks[stage] = graph.nodes.insert(Node::new(
+            ChunkPos::new(0, 0),
+            StagedChunkEnum::from(stage as u8),
+        ));
+    }
+
+    for stage in StagedChunkEnum::Empty as usize..StagedChunkEnum::StructureStart as usize {
+        graph.add_edge(holder.tasks[stage], holder.tasks[stage + 1]);
+    }
+
+    let returned_stage = StagedChunkEnum::Biomes as usize;
+    for task_idx in
+        (holder.current_stage as usize + 1)..=(returned_stage).min(holder.tasks.len() - 1)
+    {
+        if !holder.tasks[task_idx].is_null() {
+            if let Some(old) = graph.nodes.remove(holder.tasks[task_idx]) {
+                let mut edge = old.edge;
+                while !edge.is_null() {
+                    let cur = graph.edges.remove(edge).unwrap();
+                    if let Some(node) = graph.nodes.get_mut(cur.to) {
+                        node.in_degree -= 1;
+                    }
+                    edge = cur.next;
+                }
+            }
+            holder.tasks[task_idx] = NodeKey::null();
+        }
+    }
+
+    assert!(holder.tasks[StagedChunkEnum::Empty as usize].is_null());
+    assert!(holder.tasks[StagedChunkEnum::Biomes as usize].is_null());
+    assert!(!holder.tasks[StagedChunkEnum::StructureStart as usize].is_null());
+    assert!(
+        graph
+            .nodes
+            .get(holder.tasks[StagedChunkEnum::StructureStart as usize])
+            .is_some()
+    );
+}
+
+#[test]
 fn test_cancellation_path_decrements_in_degree() {
     let mut graph = DAG::default();
 


### PR DESCRIPTION
## Summary
- Drop all satisfied proto chunk generation task nodes when a returned proto chunk is already at an advanced stage
- Remove those completed task nodes from the waiting set to prevent stale queued generation work
- Add a regression test for stale lower-stage task cleanup

## Testing
- cargo fmt --check
- cargo test -p pumpkin-world chunk_system::tests
- cargo build -p pumpkin