### PR TITLE
fix(world): handle unsupported custom anvil compression 🤖🤖🤖

### DIFF
--- a/pumpkin-world/src/chunk/format/anvil.rs
+++ b/pumpkin-world/src/chunk/format/anvil.rs
@@ -191,7 +191,7 @@ impl Compression {
                 drop(encoder);
                 Ok(compressed_data)
             }
-            Self::Custom => todo!(),
+            Self::Custom => Err(CompressionError::UnknownCompression),
         }
     }
 
@@ -1321,3 +1321,23 @@ mod tests {
     */
 }
  */
+#[cfg(test)]
+mod tests {
+    use super::{Compression, CompressionError};
+
+    #[test]
+    fn custom_compression_returns_unknown_compression_error() {
+        assert!(matches!(
+            Compression::Custom.compress_data(b"chunk data", 6),
+            Err(CompressionError::UnknownCompression)
+        ));
+    }
+
+    #[test]
+    fn custom_decompression_returns_unknown_compression_error() {
+        assert!(matches!(
+            Compression::Custom.decompress_data(b"chunk data"),
+            Err(CompressionError::UnknownCompression)
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- Return `UnknownCompression` instead of panicking when Anvil custom compression is selected for writes
- Add focused tests for unsupported custom compression/decompression behavior

## Testing
- `cargo test --manifest-path C:/Users/mstaf/Documents/Projects/Pumpkin/Cargo.toml -p pumpkin-world custom_`
- `cargo fmt --manifest-path C:/Users/mstaf/AppData/Local/Temp/pumpkin-anvil-custom-compression-pr/Cargo.toml --all --check`
- `git diff --check`