### PR TITLE
Init submodules from build.rs

### DIFF
--- a/pumpkin-plugin-api/build.rs
+++ b/pumpkin-plugin-api/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+fn main() {
+    // Sync submodules
+    Command::new("git")
+        .args(["submodule", "update", "--init"])
+        .current_dir("..")
+        .output()
+        .expect("Failed to update submodules");
+
+    println!("cargo::rerun-if-changed=../.git/HEAD");
+    println!("cargo::rerun-if-changed=../.git/refs/heads/");
+}

--- a/pumpkin/build.rs
+++ b/pumpkin/build.rs
@@ -1,6 +1,13 @@
 use std::process::Command;
 
 fn main() {
+    // Sync submodules
+    Command::new("git")
+        .args(["submodule", "update", "--init"])
+        .current_dir("..")
+        .output()
+        .expect("Failed to update submodules");
+
     // Get short hash (7 chars) for display
     let short_output = Command::new("git")
         .args(["rev-parse", "--short=7", "HEAD"])


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Since the `pumpkin-plugin-wit` was moved to a git sub-module, people keep running into the same issue of their local copy not building since the wit folder is missing. The fix is easy, but cannot be easily determined from the error message unless the person already knows a bit about submodules and rust errors.

This PR calls the `git submodule update --init` command from the build.rs file of the main pumpkin crate, as well as adds a new build.rs file to the `pumpkin-plugin-api` crate, as it is outside the main dependency tree (doesn't depend on the `pumpkin` crate) and can therefore be built before the build.rs of the `pumpkin` crate runs.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
