### PR TITLE
fix: allow snow layers to be placed on top of leaves

### DIFF
--- a/pumpkin/src/block/blocks/snow.rs
+++ b/pumpkin/src/block/blocks/snow.rs
@@ -1,5 +1,6 @@
 use pumpkin_data::block_properties::BlockProperties;
-use pumpkin_data::{Block, BlockDirection, block_properties::SnowLikeProperties, item::Item};
+use pumpkin_data::tag::Taggable;
+use pumpkin_data::{Block, block_properties::SnowLikeProperties, item::Item, tag};
 use pumpkin_macros::pumpkin_block;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::{
@@ -101,6 +102,24 @@ impl BlockBehaviour for LayeredSnowBlock {
 }
 
 fn can_place_at(block_accessor: &dyn BlockAccessor, position: &BlockPos) -> bool {
-    let state = block_accessor.get_block_state(&position.down());
-    state.is_side_solid(BlockDirection::Up)
+    let below_pos = position.down();
+    let (below_block, state) = block_accessor.get_block_and_state(&below_pos);
+
+    if below_block.has_tag(&tag::Block::MINECRAFT_CANNOT_SUPPORT_SNOW_LAYER) {
+        return false;
+    }
+    if below_block.has_tag(&tag::Block::MINECRAFT_SUPPORT_OVERRIDE_SNOW_LAYER) {
+        return true;
+    }
+
+    // Block.isFaceFullSquare(collisionShape, Direction.UP): the collision shape must fully cover
+    // the top face, e.g. leaves are not "side solid" but do support snow layers.
+    state.get_block_collision_shapes().any(|shape| {
+        shape.max.y >= 1.0
+            && shape.min.x <= 0.0
+            && shape.max.x >= 1.0
+            && shape.min.z <= 0.0
+            && shape.max.z >= 1.0
+    }) || (below_block == &Block::SNOW
+        && SnowLikeProperties::from_state_id(state.id, below_block).layers == 8)
 }


### PR DESCRIPTION
## Description

Snow layer placement checked `is_side_solid` (`isSideSolidFullSquare` / support shape), which leaves override to be empty — so snow could never be placed on top of leaves.

Vanilla's `SnowBlock#canPlaceAt` instead:
1. Rejects blocks tagged `minecraft:cannot_support_snow_layer` (ice, packed ice, barrier).
2. Allows blocks tagged `minecraft:support_override_snow_layer` (honey block, soul sand, mud) regardless of their collision shape.
3. Otherwise checks whether the block's collision shape fully covers the top face (`Block.isFaceFullSquare`). Leaves have a full-cube collision shape (only their support/side-solid shape is empty), so they pass this check and can support snow layers.
4. Also allows stacking on top of a fully-layered (8-layer) snow block.

This PR ports that logic to `LayeredSnowBlock::can_place_at`.

Fixes #2218

## Testing

Manually verified in-game against a local server:
- Snow layers can now be placed on oak/spruce/azalea leaves and stack up to 8 layers.
- Snow still cannot be placed on ice, packed ice, or barrier (full collision shape, but tagged `cannot_support_snow_layer`).
- Snow can be placed on honey block, soul sand, and mud (tagged `support_override_snow_layer`, despite not having a full top-face collision shape).
- Snow still cannot be placed on glass, fences, slabs, stairs, carpets, torches, etc. (no full top-face collision, not in the override tag).
- Snow can be placed on top of a fully-layered (8-layer) snow block.

Also ran the full local CI suite:
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features` (debug & release, `-Dwarnings`)
- `cargo test --workspace`

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)