### PR TITLE
fix: melt snow layers near light sources

### DIFF
--- a/pumpkin/src/block/blocks/snow.rs
+++ b/pumpkin/src/block/blocks/snow.rs
@@ -119,7 +119,7 @@ fn can_place_at(block_accessor: &dyn BlockAccessor, position: &BlockPos) -> bool
 /// Snow melts away when exposed to a block light level greater than 11, e.g. from
 /// torches, campfires, lanterns, fire, lava, or glowstone.
 /// See <https://minecraft.wiki/w/Snow#Melting>.
-fn melts_at_light_level(block_light_level: u8) -> bool {
+const fn melts_at_light_level(block_light_level: u8) -> bool {
     block_light_level > 11
 }
 

--- a/pumpkin/src/block/blocks/snow.rs
+++ b/pumpkin/src/block/blocks/snow.rs
@@ -10,7 +10,7 @@ use pumpkin_world::{
 
 use crate::block::{
     BlockBehaviour, BlockFuture, GetStateForNeighborUpdateArgs, OnPlaceArgs, OnScheduledTickArgs,
-    UseWithItemArgs, registry::BlockActionResult,
+    RandomTickArgs, UseWithItemArgs, registry::BlockActionResult,
 };
 
 #[pumpkin_block("minecraft:snow")]
@@ -86,6 +86,17 @@ impl BlockBehaviour for LayeredSnowBlock {
         })
     }
 
+    fn random_tick<'a>(&'a self, args: RandomTickArgs<'a>) -> BlockFuture<'a, ()> {
+        Box::pin(async move {
+            let block_light_level = args.world.get_block_light_level(args.position).unwrap_or(0);
+            if melts_at_light_level(block_light_level) {
+                args.world
+                    .break_block(args.position, None, BlockFlags::empty())
+                    .await;
+            }
+        })
+    }
+
     fn get_state_for_neighbor_update<'a>(
         &'a self,
         args: GetStateForNeighborUpdateArgs<'a>,
@@ -103,4 +114,30 @@ impl BlockBehaviour for LayeredSnowBlock {
 fn can_place_at(block_accessor: &dyn BlockAccessor, position: &BlockPos) -> bool {
     let state = block_accessor.get_block_state(&position.down());
     state.is_side_solid(BlockDirection::Up)
+}
+
+/// Snow melts away when exposed to a block light level greater than 11, e.g. from
+/// torches, campfires, lanterns, fire, lava, or glowstone.
+/// See <https://minecraft.wiki/w/Snow#Melting>.
+fn melts_at_light_level(block_light_level: u8) -> bool {
+    block_light_level > 11
+}
+
+#[cfg(test)]
+mod tests {
+    use super::melts_at_light_level;
+
+    #[test]
+    fn does_not_melt_at_or_below_threshold() {
+        for light_level in 0..=11 {
+            assert!(!melts_at_light_level(light_level));
+        }
+    }
+
+    #[test]
+    fn melts_above_threshold() {
+        for light_level in 12..=15 {
+            assert!(melts_at_light_level(light_level));
+        }
+    }
 }


### PR DESCRIPTION
## Description

Snow layers (`minecraft:snow`) had no `random_tick` behavior, so they persisted indefinitely even when placed right next to bright light sources. In vanilla, `SnowLayerBlock#randomTick` removes the block once the surrounding **block light** level exceeds 11:

```java
if (level.getBrightness(LightLayer.BLOCK, pos) > 11) {
    dropResources(state, level, pos);
    level.removeBlock(pos, false);
}
```

This PR ports that behavior to `LayeredSnowBlock`:
- Added a `random_tick` implementation that checks `world.get_block_light_level` (block light only — sunlight/sky light does **not** melt snow in vanilla, which is why snow persists fine in sunny snowy biomes).
- Extracted the threshold check into a small pure helper `melts_at_light_level` for testability, with unit tests covering the boundary (11 = no melt, 12 = melt).
- Removal mirrors the existing "unsupported snow" cleanup already in `on_scheduled_tick` (`break_block` with no item context — matches vanilla, which doesn't drop snowballs from melting since the loot table requires a shovel).

Light sources that trigger melting include torches, campfires, lanterns, fire, lava, and glowstone — see https://minecraft.wiki/w/Snow#Melting.

Notes on related blocks:
- A layered snow stack melts away **all at once** regardless of its layer count (1–8) — vanilla removes the whole block, not layer by layer.
- The solid **Snow Block** (`minecraft:snow_block`) is a separate block class with no `randomTick` override, so it does not melt — this PR does not touch it.

Fixes #2179

## Testing

- `cargo check -p pumpkin`
- `cargo test -p pumpkin snow::` — new unit tests `does_not_melt_at_or_below_threshold` and `melts_above_threshold` pass
- Manually verified in-game: a stack of snow layers placed near a torch/lava disappears completely after a short time, while a solid Snow Block in the same spot remains unaffected.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)