### PR TITLE
Batch blocks update implementation

### DIFF
--- a/pumpkin-plugin-api/src/lib.rs
+++ b/pumpkin-plugin-api/src/lib.rs
@@ -51,10 +51,10 @@ pub mod command {
 pub use wit::pumpkin::plugin::{
     bedrock_packets, block_entity, boss_bar, command as command_wit, common,
     context::{Context, Server},
-    entity,
+    data_components, entity,
     entity_types::EntityType,
-    gui, i18n, java_dialogs, java_packets, particles, permission, player, scoreboard, server, text,
-    world,
+    gui, i18n, item_stack, java_dialogs, java_packets, particles, permission, player, scoreboard,
+    server, text, world,
 };
 
 pub mod java_dialog {

--- a/pumpkin-protocol/src/java/client/play/chunk_data.rs
+++ b/pumpkin-protocol/src/java/client/play/chunk_data.rs
@@ -11,13 +11,104 @@ use pumpkin_world::chunk::format::LightContainer;
 use pumpkin_world::chunk::{ChunkData, palette::NetworkPalette};
 use std::io::Write;
 
+pub struct ChunkBlockEntityData {
+    pub position: pumpkin_util::math::position::BlockPos,
+    pub type_id: i32,
+    pub nbt: pumpkin_nbt::compound::NbtCompound,
+}
+
 /// Sent by the server to provide the client with the full data for a chunk.
 ///
 /// This includes heightmaps, the actual block and biome data (organized into sections),
 /// block entities (like signs or chests), and the light level information for both
 /// sky and block light.
 #[java_packet(PLAY_LEVEL_CHUNK_WITH_LIGHT)]
-pub struct CChunkData<'a>(pub &'a ChunkData);
+pub struct CChunkData<'a> {
+    chunk: &'a ChunkData,
+    live_block_entities: &'a [ChunkBlockEntityData],
+}
+
+pub(crate) fn write_chunk_light_data(
+    chunk: &ChunkData,
+    mut write: impl Write,
+) -> Result<(), WritingError> {
+    // Light masks include sections from -1 (below world) to num_sections (above world).
+    let light_engine = chunk
+        .light_engine
+        .lock()
+        .map_err(|_| WritingError::Message("light_engine lock poisoned".into()))?;
+    let num_sections = light_engine.sky_light.len();
+
+    let mut sky_light_empty_mask = 1u64;
+    let mut block_light_empty_mask = 1u64;
+    let mut sky_light_mask = 0u64;
+    let mut block_light_mask = 0u64;
+
+    for section_index in 0..num_sections {
+        let bit_index = section_index + 1;
+
+        if let LightContainer::Full(_) = &light_engine.sky_light[section_index] {
+            sky_light_mask |= 1 << bit_index;
+        } else {
+            sky_light_empty_mask |= 1 << bit_index;
+        }
+
+        if let LightContainer::Full(_) = &light_engine.block_light[section_index] {
+            block_light_mask |= 1 << bit_index;
+        } else {
+            block_light_empty_mask |= 1 << bit_index;
+        }
+    }
+
+    sky_light_empty_mask |= 1 << (num_sections + 1);
+    block_light_empty_mask |= 1 << (num_sections + 1);
+
+    write.write_bitset(&BitSet(Box::new([sky_light_mask as i64])))?;
+    write.write_bitset(&BitSet(Box::new([block_light_mask as i64])))?;
+    write.write_bitset(&BitSet(Box::new([sky_light_empty_mask as i64])))?;
+    write.write_bitset(&BitSet(Box::new([block_light_empty_mask as i64])))?;
+
+    let light_data_size = VarInt(LightContainer::ARRAY_SIZE as i32);
+
+    write.write_var_int(&VarInt(sky_light_mask.count_ones() as i32))?;
+    for section in &light_engine.sky_light {
+        if let LightContainer::Full(data) = section {
+            write.write_var_int(&light_data_size)?;
+            write.write_slice(data)?;
+        }
+    }
+
+    write.write_var_int(&VarInt(block_light_mask.count_ones() as i32))?;
+    for section in &light_engine.block_light {
+        if let LightContainer::Full(data) = section {
+            write.write_var_int(&light_data_size)?;
+            write.write_slice(data)?;
+        }
+    }
+
+    Ok(())
+}
+
+impl<'a> CChunkData<'a> {
+    #[must_use]
+    pub const fn new(chunk: &'a ChunkData) -> Self {
+        Self {
+            chunk,
+            live_block_entities: &[],
+        }
+    }
+
+    #[must_use]
+    pub const fn with_block_entities(
+        chunk: &'a ChunkData,
+        live_block_entities: &'a [ChunkBlockEntityData],
+    ) -> Self {
+        Self {
+            chunk,
+            live_block_entities,
+        }
+    }
+}
 
 impl ClientPacket for CChunkData<'_> {
     #[expect(clippy::too_many_lines)]
@@ -27,12 +118,12 @@ impl ClientPacket for CChunkData<'_> {
         version: &JavaMinecraftVersion,
     ) -> Result<(), WritingError> {
         // Chunk X
-        write.write_i32_be(self.0.x)?;
+        write.write_i32_be(self.chunk.x)?;
         // Chunk Z
-        write.write_i32_be(self.0.z)?;
+        write.write_i32_be(self.chunk.z)?;
 
         let heightmaps = self
-            .0
+            .chunk
             .heightmap
             .lock()
             .map_err(|_| WritingError::Message("heightmap lock poisoned".into()))?;
@@ -66,11 +157,11 @@ impl ClientPacket for CChunkData<'_> {
         {
             let mut blocks_and_biomes_buf = Vec::new();
             let block_sections =
-                self.0.section.block_sections.read().map_err(|_| {
+                self.chunk.section.block_sections.read().map_err(|_| {
                     WritingError::Message("block_sections read lock poisoned".into())
                 })?;
             let biome_sections =
-                self.0.section.biome_sections.read().map_err(|_| {
+                self.chunk.section.biome_sections.read().map_err(|_| {
                     WritingError::Message("biome_sections read lock poisoned".into())
                 })?;
 
@@ -193,12 +284,30 @@ impl ClientPacket for CChunkData<'_> {
         };
 
         let block_entities = self
-            .0
+            .chunk
             .pending_block_entities
             .lock()
             .map_err(|_| WritingError::Message("block_entities lock poisoned".into()))?;
-        write.write_var_int(&VarInt(block_entities.len() as i32))?;
+        let persisted_count = block_entities
+            .keys()
+            .filter(|pos| {
+                !self
+                    .live_block_entities
+                    .iter()
+                    .any(|entity| entity.position == **pos)
+            })
+            .count();
+        write.write_var_int(&VarInt(
+            (persisted_count + self.live_block_entities.len()) as i32,
+        ))?;
         for (pos, nbt) in block_entities.iter() {
+            if self
+                .live_block_entities
+                .iter()
+                .any(|entity| entity.position == *pos)
+            {
+                continue;
+            }
             let local_xz = ((get_local_cord(pos.0.x) & 0xF) << 4) | (get_local_cord(pos.0.z) & 0xF);
 
             write.write_u8(local_xz as u8)?;
@@ -215,76 +324,19 @@ impl ClientPacket for CChunkData<'_> {
             write.write_var_int(&VarInt(id as i32))?;
             write.write_nbt(nbt.clone().into())?;
         }
+        drop(block_entities);
 
-        {
-            // Light masks include sections from -1 (below world) to num_sections (above world)
-            // This means we need to account for 2 extra sections in the bitset
-            let light_engine = self
-                .0
-                .light_engine
-                .lock()
-                .map_err(|_| WritingError::Message("light_engine lock poisoned".into()))?;
-            let num_sections = light_engine.sky_light.len();
+        for entity in self.live_block_entities {
+            let pos = entity.position;
+            let local_xz = ((get_local_cord(pos.0.x) & 0xF) << 4) | (get_local_cord(pos.0.z) & 0xF);
 
-            let mut sky_light_empty_mask = 0u64;
-            let mut block_light_empty_mask = 0u64;
-            let mut sky_light_mask = 0u64;
-            let mut block_light_mask = 0u64;
-
-            // Bit 0 represents the section below the world (always empty)
-            sky_light_empty_mask |= 1 << 0;
-            block_light_empty_mask |= 1 << 0;
-
-            // Bits 1..=num_sections represent the actual world sections
-            for section_index in 0..num_sections {
-                let bit_index = section_index + 1; // Offset by 1 for the below-world section
-
-                if let LightContainer::Full(_) = &light_engine.sky_light[section_index] {
-                    sky_light_mask |= 1 << bit_index;
-                } else {
-                    sky_light_empty_mask |= 1 << bit_index;
-                }
-
-                if let LightContainer::Full(_) = &light_engine.block_light[section_index] {
-                    block_light_mask |= 1 << bit_index;
-                } else {
-                    block_light_empty_mask |= 1 << bit_index;
-                }
-            }
-
-            // Bit num_sections+1 represents the section above the world (always empty)
-            sky_light_empty_mask |= 1 << (num_sections + 1);
-            block_light_empty_mask |= 1 << (num_sections + 1);
-
-            // Write Sky Light Mask
-            write.write_bitset(&BitSet(Box::new([sky_light_mask as i64])))?;
-            // Write Block Light Mask
-            write.write_bitset(&BitSet(Box::new([block_light_mask as i64])))?;
-            // Write Empty Sky Light Mask
-            write.write_bitset(&BitSet(Box::new([sky_light_empty_mask as i64])))?;
-            // Write Empty Block Light Mask
-            write.write_bitset(&BitSet(Box::new([block_light_empty_mask as i64])))?;
-
-            let light_data_size: VarInt = VarInt(LightContainer::ARRAY_SIZE as i32);
-
-            // Write Sky Light arrays
-            write.write_var_int(&VarInt(sky_light_mask.count_ones() as i32))?;
-            for section_index in 0..num_sections {
-                if let LightContainer::Full(data) = &light_engine.sky_light[section_index] {
-                    write.write_var_int(&light_data_size)?;
-                    write.write_slice(data.as_ref())?;
-                }
-            }
-
-            // Write Block Light arrays
-            write.write_var_int(&VarInt(block_light_mask.count_ones() as i32))?;
-            for section_index in 0..num_sections {
-                if let LightContainer::Full(data) = &light_engine.block_light[section_index] {
-                    write.write_var_int(&light_data_size)?;
-                    write.write_slice(data.as_ref())?;
-                }
-            }
+            write.write_u8(local_xz as u8)?;
+            write.write_i16_be(pos.0.y as i16)?;
+            write.write_var_int(&VarInt(entity.type_id))?;
+            write.write_nbt(entity.nbt.clone().into())?;
         }
+
+        write_chunk_light_data(self.chunk, &mut write)?;
         Ok(())
     }
 }

--- a/pumpkin-protocol/src/java/client/play/chunk_data.rs
+++ b/pumpkin-protocol/src/java/client/play/chunk_data.rs
@@ -28,7 +28,7 @@ pub struct CChunkData<'a> {
     live_block_entities: &'a [ChunkBlockEntityData],
 }
 
-pub(crate) fn write_chunk_light_data(
+pub(super) fn write_chunk_light_data(
     chunk: &ChunkData,
     mut write: impl Write,
 ) -> Result<(), WritingError> {

--- a/pumpkin-protocol/src/java/client/play/light_update.rs
+++ b/pumpkin-protocol/src/java/client/play/light_update.rs
@@ -1,12 +1,12 @@
 use crate::WritingError;
-use crate::codec::bit_set::BitSet;
 use crate::{ClientPacket, VarInt, ser::NetworkWriteExt};
 use pumpkin_data::packet::clientbound::PLAY_LIGHT_UPDATE;
 use pumpkin_macros::java_packet;
 use pumpkin_util::version::JavaMinecraftVersion;
 use pumpkin_world::chunk::ChunkData;
-use pumpkin_world::chunk::format::LightContainer;
 use std::io::Write;
+
+use super::chunk_data::write_chunk_light_data;
 
 /// Sent by the server to update light levels (block light and sky light) for a chunk.
 ///
@@ -28,76 +28,6 @@ impl ClientPacket for CLightUpdate<'_> {
         // Chunk Z
         write.write_var_int(&VarInt(self.0.z))?;
 
-        // Light masks include sections from -1 (below world) to num_sections (above world)
-        // This means we need to account for 2 extra sections in the bitset
-        let light_engine = self
-            .0
-            .light_engine
-            .lock()
-            .map_err(|_| WritingError::Message("light_engine lock poisoned".into()))?;
-        let num_sections = light_engine.sky_light.len();
-
-        let mut sky_light_empty_mask = 0u64;
-        let mut block_light_empty_mask = 0u64;
-        let mut sky_light_mask = 0u64;
-        let mut block_light_mask = 0u64;
-
-        // Bits 0..num_sections represent the sections including padding
-        for section_index in 0..num_sections {
-            let bit_index = section_index;
-
-            if let LightContainer::Full(_) = &light_engine.sky_light[section_index] {
-                sky_light_mask |= 1 << bit_index;
-            } else {
-                sky_light_empty_mask |= 1 << bit_index;
-            }
-
-            if let LightContainer::Full(_) = &light_engine.block_light[section_index] {
-                block_light_mask |= 1 << bit_index;
-            } else {
-                block_light_empty_mask |= 1 << bit_index;
-            }
-        }
-
-        // Write Sky Light Mask
-        write.write_bitset(&BitSet(Box::new([sky_light_mask as i64])))?;
-        // Write Block Light Mask
-        write.write_bitset(&BitSet(Box::new([block_light_mask as i64])))?;
-        // Write Empty Sky Light Mask
-        write.write_bitset(&BitSet(Box::new([sky_light_empty_mask as i64])))?;
-        // Write Empty Block Light Mask
-        write.write_bitset(&BitSet(Box::new([block_light_empty_mask as i64])))?;
-
-        let light_data_size: VarInt = VarInt(LightContainer::ARRAY_SIZE as i32);
-
-        // Write Sky Light arrays
-        write.write_var_int(&VarInt(sky_light_mask.count_ones() as i32))?;
-        for section_index in 0..num_sections {
-            if let LightContainer::Full(data) = &light_engine.sky_light[section_index] {
-                // Ensure network nibble ordering matches client expectations
-                // by swapping high/low nibbles per byte.
-                write.write_var_int(&light_data_size)?;
-                let mut swapped = Vec::with_capacity(data.len());
-                for &b in data {
-                    swapped.push(b.rotate_right(4));
-                }
-                write.write_slice(&swapped)?;
-            }
-        }
-
-        // Write Block Light arrays
-        write.write_var_int(&VarInt(block_light_mask.count_ones() as i32))?;
-        for section_index in 0..num_sections {
-            if let LightContainer::Full(data) = &light_engine.block_light[section_index] {
-                write.write_var_int(&light_data_size)?;
-                let mut swapped = Vec::with_capacity(data.len());
-                for &b in data {
-                    swapped.push(b.rotate_right(4));
-                }
-                write.write_slice(&swapped)?;
-            }
-        }
-
-        Ok(())
+        write_chunk_light_data(self.0, write)
     }
 }

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -603,6 +603,125 @@ impl ChunkData {
         old
     }
 
+    /// Sets many blocks in this chunk and returns the changed entries with their old state IDs.
+    ///
+    /// This keeps the block-section, random-tick, and heightmap locks held once for the batch
+    /// instead of re-taking them for every block.
+    pub fn set_blocks_absolute_y(
+        &self,
+        changes: &[(usize, usize, i32, usize, BlockStateId)],
+    ) -> Vec<(usize, BlockStateId)> {
+        let min_y = self.section.min_y;
+        let mut changed = Vec::new();
+        let mut sections = self.section.block_sections.write().unwrap();
+        let mut random_tick_sections_guard = self.section.random_tick_sections.write().unwrap();
+        let mut heightmap = self.heightmap.lock().unwrap();
+        let mut ticking_mask = self
+            .section
+            .randomly_ticking_mask
+            .load(std::sync::atomic::Ordering::Relaxed);
+
+        for &(index, relative_x, y, relative_z, block_state_id) in changes {
+            let y_rel = y - min_y;
+            if y_rel < 0 {
+                if block_state_id != Block::AIR.default_state.id {
+                    changed.push((index, Block::AIR.default_state.id));
+                }
+                continue;
+            }
+
+            let relative_y = y_rel as usize;
+            let section_index = relative_y / BlockPalette::SIZE;
+            let section_y = relative_y % BlockPalette::SIZE;
+
+            let replaced_block_state_id = {
+                let Some(section) = sections.get_mut(section_index) else {
+                    if block_state_id != Block::AIR.default_state.id {
+                        changed.push((index, Block::AIR.default_state.id));
+                    }
+                    continue;
+                };
+                section.set(relative_x, section_y, relative_z, block_state_id)
+            };
+
+            if replaced_block_state_id == block_state_id {
+                continue;
+            }
+
+            if (has_random_ticks(block_state_id) || has_random_ticking_fluid(block_state_id))
+                && random_tick_sections_guard.is_none()
+            {
+                let new_cache =
+                    vec![RandomTickSectionCache::default(); self.section.count].into_boxed_slice();
+                *random_tick_sections_guard = Some(new_cache);
+            }
+
+            if let Some(random_tick_sections) = random_tick_sections_guard.as_mut() {
+                let random_tick_cache = &mut random_tick_sections[section_index];
+                if has_random_ticks(replaced_block_state_id) {
+                    random_tick_cache.random_ticking_block_count = random_tick_cache
+                        .random_ticking_block_count
+                        .saturating_sub(1);
+                }
+                if has_random_ticking_fluid(replaced_block_state_id) {
+                    random_tick_cache.random_ticking_fluid_count = random_tick_cache
+                        .random_ticking_fluid_count
+                        .saturating_sub(1);
+                }
+
+                if has_random_ticks(block_state_id) {
+                    random_tick_cache.random_ticking_block_count = random_tick_cache
+                        .random_ticking_block_count
+                        .saturating_add(1);
+                }
+                if has_random_ticking_fluid(block_state_id) {
+                    random_tick_cache.random_ticking_fluid_count = random_tick_cache
+                        .random_ticking_fluid_count
+                        .saturating_add(1);
+                }
+
+                if random_tick_cache.is_randomly_ticking() {
+                    ticking_mask |= 1 << section_index;
+                } else {
+                    ticking_mask &= !(1 << section_index);
+                }
+            }
+
+            let state = BlockState::from_id(block_state_id);
+            let x = relative_x as i32;
+            let z = relative_z as i32;
+            for &hm_type in &[
+                ChunkHeightmapType::WorldSurface,
+                ChunkHeightmapType::MotionBlocking,
+                ChunkHeightmapType::MotionBlockingNoLeaves,
+            ] {
+                heightmap.update(hm_type, x, z, y, state, min_y, |y_at| {
+                    let y_rel = y_at - min_y;
+                    if y_rel < 0 {
+                        return BlockState::from_id(Block::AIR.default_state.id);
+                    }
+
+                    let relative_y = y_rel as usize;
+                    let section_index = relative_y / BlockPalette::SIZE;
+                    let section_y = relative_y % BlockPalette::SIZE;
+                    let id = sections
+                        .get(section_index)
+                        .map(|section| section.get(relative_x, section_y, relative_z))
+                        .unwrap_or(Block::AIR.default_state.id);
+                    BlockState::from_id(id)
+                });
+            }
+
+            changed.push((index, replaced_block_state_id));
+        }
+
+        self.section
+            .randomly_ticking_mask
+            .store(ticking_mask, std::sync::atomic::Ordering::Relaxed);
+
+        changed
+    }
+
     fn update_heightmap(
         &self,
         relative_x: usize,

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -124,6 +124,75 @@ pub struct LevelFolder {
 }
 
 impl Level {
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn new_for_lighting_bench(root_folder: PathBuf) -> Arc<Self> {
+        let level_config = LevelConfig::default();
+        let region_folder = root_folder.join("region");
+        let entities_folder = root_folder.join("entities");
+
+        std::fs::create_dir_all(&region_folder).expect("Failed to create Region folder");
+        std::fs::create_dir_all(&entities_folder).expect("Failed to create Entities folder");
+
+        let level_folder = Arc::new(LevelFolder {
+            root_folder,
+            region_folder,
+            entities_folder,
+        });
+
+        let seed = Seed(0);
+        let world_gen = get_world_gen(seed, Dimension::OVERWORLD).into();
+
+        let chunk_saver: Arc<dyn FileIO<Data = SyncChunk>> = match &level_config.chunk {
+            ChunkConfig::Linear => Arc::new(ChunkFileManager::<LinearV2File<ChunkData>>::new(())),
+            ChunkConfig::Anvil(config) => Arc::new(
+                ChunkFileManager::<AnvilChunkFile<ChunkData>>::new(config.clone()),
+            ),
+            ChunkConfig::Pump => Arc::new(ChunkFileManager::<PumpFile<ChunkData>>::new(())),
+        };
+        let entity_saver: Arc<dyn FileIO<Data = SyncEntityChunk>> = match &level_config.chunk {
+            ChunkConfig::Linear => {
+                Arc::new(ChunkFileManager::<LinearV2File<ChunkEntityData>>::new(()))
+            }
+            ChunkConfig::Anvil(config) => Arc::new(ChunkFileManager::<
+                AnvilChunkFile<ChunkEntityData>,
+            >::new(config.clone())),
+            ChunkConfig::Pump => Arc::new(ChunkFileManager::<PumpFile<ChunkEntityData>>::new(())),
+        };
+
+        let level_channel = Arc::new(LevelChannel::new());
+        let listener = Arc::new(ChunkListener::new());
+
+        Arc::new(Self {
+            seed,
+            world_portal: ArcSwap::new(Arc::new(None)),
+            world_gen,
+            level_folder,
+            lighting_config: level_config.lighting,
+            light_engine: DynamicLightEngine::new(),
+            chunk_saver,
+            entity_saver,
+            schedule_tick_counts: AtomicU64::new(0),
+            loaded_chunks: Arc::new(DashMap::new()),
+            loaded_entity_chunks: Arc::new(DashMap::new()),
+            chunks_with_scheduled_ticks: Arc::new(dashmap::DashSet::new()),
+            chunk_loading: Mutex::new(ChunkLoading::new(level_channel.clone())),
+            chunk_watchers: Arc::new(DashMap::new()),
+            tasks: TaskTracker::new(),
+            chunk_system_tasks: TaskTracker::new(),
+            cancel_token: CancellationToken::new(),
+            shut_down_chunk_system: AtomicBool::new(false),
+            should_save: AtomicBool::new(false),
+            should_unload: AtomicBool::new(false),
+            autosave_ticks: level_config.autosave_ticks,
+            pending_entity_generations: Arc::new(DashMap::new()),
+            level_channel,
+            thread_tracker: Mutex::new(Vec::new()),
+            chunk_listener: listener,
+            gen_pool: None,
+        })
+    }
+
     #[must_use]
     pub fn from_root_folder(
         level_config: &LevelConfig,

--- a/pumpkin-world/src/lighting/runtime.rs
+++ b/pumpkin-world/src/lighting/runtime.rs
@@ -1,3 +1,4 @@
+use crate::block::RawBlockState;
 use crate::chunk::io::Dirtiable;
 use crate::chunk::palette::BlockPalette;
 use crate::level::Level;
@@ -5,6 +6,7 @@ use crossbeam::queue::SegQueue;
 use pumpkin_config::lighting::LightingEngineConfig;
 use pumpkin_data::BlockDirection;
 use pumpkin_util::math::position::BlockPos;
+use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
 pub struct DynamicLightEngine {
@@ -30,6 +32,7 @@ impl Default for DynamicLightEngine {
         Self::new()
     }
 }
+
 impl DynamicLightEngine {
     /// Checks if there is an open sky above the given position (no opaque blocks blocking sky light).
     fn has_open_sky_above(level: &Arc<Level>, pos: &BlockPos) -> bool {
@@ -59,6 +62,74 @@ impl DynamicLightEngine {
         // Sky Light
         self.check_sky_light_updates(level, pos);
         self.perform_sky_light_updates(level);
+    }
+
+    /// Updates lighting for many block changes at once.
+    ///
+    /// Equivalent in result to calling [`Self::update_lighting_at`] for every
+    /// position, but the expensive propagation-to-convergence pass runs **once**
+    /// for the whole batch instead of once per block. A per-block drain re-walks
+    /// the same overlapping light fields N times; for a large paste (hundreds of
+    /// thousands of blocks) that turns a sub-second relight into tens of seconds.
+    /// Here we seed every position's check first, then drain the shared queues a
+    /// single time.
+    pub fn update_lighting_bulk<I>(&self, level: &Arc<Level>, positions: I)
+    where
+        I: IntoIterator<Item = BlockPos>,
+    {
+        // Seed all block-light + sky-light checks before draining either queue.
+        // The check_* calls only enqueue work (and set the source cell); they do
+        // not propagate, so order between positions does not matter.
+        //
+        // `has_open_sky_above` walks the whole column above a position one
+        // `get_block_state` (chunk-map lookup) at a time. A paste touches many
+        // positions in the same (x, z) column, so instead find the highest
+        // opaque block once per column — with a single chunk read — and answer
+        // the open-sky question for every position in that column from it.
+        let mut highest_opaque_by_column: FxHashMap<(i32, i32), i32> = FxHashMap::default();
+        for pos in positions {
+            self.check_block_light_updates(level, pos);
+
+            let column = (pos.0.x, pos.0.z);
+            let highest_opaque = *highest_opaque_by_column
+                .entry(column)
+                .or_insert_with(|| Self::highest_opaque_y(level, column.0, column.1));
+            self.check_sky_light_updates_with(level, pos, || pos.0.y >= highest_opaque);
+        }
+
+        // Drain to convergence once for the entire batch.
+        self.perform_block_light_updates(level);
+        self.perform_sky_light_updates(level);
+    }
+
+    /// The Y of the highest block with non-zero opacity in the given column, or
+    /// `i32::MIN` when the column has none (open to the sky at every height).
+    ///
+    /// A position has open sky above (in the sense of [`Self::has_open_sky_above`])
+    /// exactly when its Y is at or above this value. Unloaded chunks read as
+    /// all-transparent, matching the per-position scan.
+    fn highest_opaque_y(level: &Arc<Level>, block_x: i32, block_z: i32) -> i32 {
+        let probe = BlockPos::new(block_x, 0, block_z);
+        let (chunk_coordinate, relative) = probe.chunk_and_chunk_relative_position();
+        let max_y = 319;
+
+        level
+            .read_chunk_sync(&chunk_coordinate, |chunk| {
+                for y in (chunk.section.min_y..=max_y).rev() {
+                    let Some(state_id) = chunk.section.get_block_absolute_y(
+                        relative.x as usize,
+                        y,
+                        relative.z as usize,
+                    ) else {
+                        continue;
+                    };
+                    if RawBlockState(state_id).to_state().opacity > 0 {
+                        return y;
+                    }
+                }
+                i32::MIN
+            })
+            .unwrap_or(i32::MIN)
     }
 
     pub fn queue_block_light_decrease(&self, pos: BlockPos, level: u8) {
@@ -97,26 +168,49 @@ impl DynamicLightEngine {
         updates
     }
 
-    fn perform_block_light_decrease_updates(&self, level: &Arc<Level>) -> i32 {
+    /// Drains `queue` to empty, always processing the entry with the highest
+    /// light level first.
+    ///
+    /// Propagation never enqueues an entry brighter than its source, so
+    /// brightest-first order means every cell is written its final value the
+    /// first time a wave reaches it. FIFO order lets a dim wavefront raise a
+    /// cell repeatedly (up to 15 times) as brighter waves arrive late, which
+    /// turns a large paste's shadow refill into minutes of redundant work.
+    fn drain_highest_first(
+        queue: &SegQueue<(BlockPos, u8)>,
+        mut propagate: impl FnMut(&BlockPos, u8),
+    ) -> i32 {
+        const LEVELS: usize = 16;
+        let mut buckets: [Vec<(BlockPos, u8)>; LEVELS] = Default::default();
         let mut updates = 0;
 
-        while let Some((pos, expected_light)) = self.block_decrease.pop() {
-            self.propagate_block_light_decrease(level, &pos, expected_light);
+        loop {
+            while let Some((pos, light)) = queue.pop() {
+                buckets[usize::from(light.min(15))].push((pos, light));
+            }
+
+            let Some((pos, light)) = buckets.iter_mut().rev().find_map(|bucket| bucket.pop())
+            else {
+                break;
+            };
+
+            propagate(&pos, light);
             updates += 1;
         }
 
         updates
     }
 
+    fn perform_block_light_decrease_updates(&self, level: &Arc<Level>) -> i32 {
+        Self::drain_highest_first(&self.block_decrease, |pos, expected_light| {
+            self.propagate_block_light_decrease(level, pos, expected_light);
+        })
+    }
+
     fn perform_block_light_increase_updates(&self, level: &Arc<Level>) -> i32 {
-        let mut updates = 0;
-
-        while let Some((pos, expected_light)) = self.block_increase.pop() {
-            self.propagate_block_light_increase(level, &pos, expected_light);
-            updates += 1;
-        }
-
-        updates
+        Self::drain_highest_first(&self.block_increase, |pos, expected_light| {
+            self.propagate_block_light_increase(level, pos, expected_light);
+        })
     }
 
     fn propagate_block_light_increase(&self, level: &Arc<Level>, pos: &BlockPos, light_level: u8) {
@@ -256,21 +350,15 @@ impl DynamicLightEngine {
     }
 
     fn perform_sky_light_decrease_updates(&self, level: &Arc<Level>) -> i32 {
-        let mut updates = 0;
-        while let Some((pos, expected_light)) = self.sky_decrease.pop() {
-            self.propagate_sky_light_decrease(level, &pos, expected_light);
-            updates += 1;
-        }
-        updates
+        Self::drain_highest_first(&self.sky_decrease, |pos, expected_light| {
+            self.propagate_sky_light_decrease(level, pos, expected_light);
+        })
     }
 
     fn perform_sky_light_increase_updates(&self, level: &Arc<Level>) -> i32 {
-        let mut updates = 0;
-        while let Some((pos, expected_light)) = self.sky_increase.pop() {
-            self.propagate_sky_light_increase(level, &pos, expected_light);
-            updates += 1;
-        }
-        updates
+        Self::drain_highest_first(&self.sky_increase, |pos, expected_light| {
+            self.propagate_sky_light_increase(level, pos, expected_light);
+        })
     }
 
     fn propagate_sky_light_increase(&self, level: &Arc<Level>, pos: &BlockPos, light_level: u8) {
@@ -334,6 +422,18 @@ impl DynamicLightEngine {
     }
 
     pub fn check_sky_light_updates(&self, level: &Arc<Level>, pos: BlockPos) {
+        self.check_sky_light_updates_with(level, pos, || Self::has_open_sky_above(level, &pos));
+    }
+
+    /// [`Self::check_sky_light_updates`] with the open-sky test supplied by the
+    /// caller, so bulk updates can answer it from a per-column cache instead of
+    /// rescanning the column above every position.
+    fn check_sky_light_updates_with(
+        &self,
+        level: &Arc<Level>,
+        pos: BlockPos,
+        has_open_sky_above: impl FnOnce() -> bool,
+    ) {
         match level.lighting_config {
             LightingEngineConfig::Full => {
                 self.set_sky_light_level(level, &pos, 15).ok();
@@ -356,7 +456,7 @@ impl DynamicLightEngine {
             0
         } else {
             // Check if there's open sky above
-            let has_sky = Self::has_open_sky_above(level, &pos);
+            let has_sky = has_open_sky_above();
 
             if has_sky {
                 // Direct sunlight, reduced by opacity
@@ -397,8 +497,8 @@ impl DynamicLightEngine {
             self.queue_sky_light_increase(pos, expected_light);
         }
 
-        // Notify neighbors if light increased or stayed same
-        if expected_light >= current_light {
+        // Increases were already queued above; unchanged lit cells still need to seed neighbors.
+        if expected_light == current_light {
             self.check_neighbors_sky_light_updates(pos, expected_light);
         }
     }
@@ -414,7 +514,8 @@ impl DynamicLightEngine {
         let (chunk_pos, relative) = position.chunk_and_chunk_relative_position();
 
         level.read_chunk_sync(&chunk_pos, |chunk| {
-            let section_idx = (relative.y - chunk.section.min_y) as usize / 16;
+            let relative_y = (relative.y - chunk.section.min_y) as usize;
+            let section_idx = relative_y / BlockPalette::SIZE;
             let light_engine = chunk.light_engine.lock().ok()?;
 
             light_engine
@@ -422,7 +523,7 @@ impl DynamicLightEngine {
                 .get(section_idx)?
                 .get(
                     relative.x as usize,
-                    (relative.y - chunk.section.min_y) as usize % 16,
+                    relative_y % BlockPalette::SIZE,
                     relative.z as usize,
                 )
                 .into()
@@ -459,12 +560,13 @@ impl DynamicLightEngine {
 
         level
             .read_chunk_sync(&chunk_pos, |chunk| {
-                let section_idx = (relative.y - chunk.section.min_y) as usize / 16;
+                let relative_y = (relative.y - chunk.section.min_y) as usize;
+                let section_idx = relative_y / BlockPalette::SIZE;
                 let light_engine = chunk.light_engine.lock().ok()?;
 
                 let light_level = light_engine.block_light.get(section_idx)?.get(
                     relative.x as usize,
-                    (relative.y - chunk.section.min_y) as usize % 16,
+                    relative_y % BlockPalette::SIZE,
                     relative.z as usize,
                 );
 
@@ -562,5 +664,236 @@ impl DynamicLightEngine {
             Ok(())
         });
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    };
+    use std::time::{Duration, Instant};
+
+    use pumpkin_data::{Block, chunk::ChunkStatus, fluid::Fluid};
+    use pumpkin_util::math::{position::BlockPos, vector2::Vector2};
+    use rustc_hash::FxHashMap;
+    use temp_dir::TempDir;
+
+    use crate::chunk::format::LightContainer;
+    use crate::chunk::{ChunkData, ChunkHeightmaps, ChunkLight, ChunkSections};
+    use crate::level::Level;
+    use crate::tick::scheduler::ChunkTickScheduler;
+
+    const MIN_Y: i32 = -64;
+    const SECTION_COUNT: usize = 24;
+    const START_Y: i32 = 64;
+
+    #[derive(Clone, Copy)]
+    struct BenchConfig {
+        width: i32,
+        height: i32,
+        depth: i32,
+        runs: usize,
+        margin: i32,
+        mode: BenchMode,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum BenchMode {
+        Block,
+        Sky,
+    }
+
+    impl BenchConfig {
+        fn from_env() -> Self {
+            let mode = BenchMode::from_env();
+            Self {
+                width: env_i32("PUMPKIN_LIGHT_BENCH_WIDTH", 64),
+                height: env_i32("PUMPKIN_LIGHT_BENCH_HEIGHT", 58),
+                depth: env_i32("PUMPKIN_LIGHT_BENCH_DEPTH", 64),
+                runs: env_usize("PUMPKIN_LIGHT_BENCH_RUNS", 1),
+                margin: env_i32(
+                    "PUMPKIN_LIGHT_BENCH_MARGIN",
+                    match mode {
+                        BenchMode::Block => 16,
+                        BenchMode::Sky => 0,
+                    },
+                ),
+                mode,
+            }
+        }
+
+        fn block_count(self) -> usize {
+            (self.width * self.height * self.depth) as usize
+        }
+    }
+
+    impl BenchMode {
+        fn from_env() -> Self {
+            match std::env::var("PUMPKIN_LIGHT_BENCH_MODE")
+                .unwrap_or_else(|_| "block".to_string())
+                .to_ascii_lowercase()
+                .as_str()
+            {
+                "sky" => Self::Sky,
+                "block" => Self::Block,
+                other => panic!("unknown PUMPKIN_LIGHT_BENCH_MODE {other:?}; use block or sky"),
+            }
+        }
+
+        fn sky_default(self) -> u8 {
+            match self {
+                Self::Block => 0,
+                Self::Sky => 15,
+            }
+        }
+
+        fn placed_state(self) -> u16 {
+            match self {
+                Self::Block => Block::GLOWSTONE.default_state.id,
+                Self::Sky => Block::STONE.default_state.id,
+            }
+        }
+    }
+
+    fn env_i32(name: &str, default: i32) -> i32 {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(default)
+    }
+
+    fn env_usize(name: &str, default: usize) -> usize {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(default)
+    }
+
+    fn make_chunk(chunk_x: i32, chunk_z: i32, sky_default: u8) -> Arc<ChunkData> {
+        Arc::new(ChunkData {
+            section: ChunkSections::new(SECTION_COUNT, MIN_Y),
+            heightmap: Mutex::new(ChunkHeightmaps::default()),
+            x: chunk_x,
+            z: chunk_z,
+            block_ticks: ChunkTickScheduler::<&'static Block>::default(),
+            fluid_ticks: ChunkTickScheduler::<&'static Fluid>::default(),
+            pending_block_entities: Mutex::new(FxHashMap::default()),
+            light_engine: Mutex::new(ChunkLight {
+                sky_light: vec![LightContainer::new_empty(sky_default); SECTION_COUNT]
+                    .into_boxed_slice(),
+                block_light: vec![LightContainer::new_empty(0); SECTION_COUNT].into_boxed_slice(),
+            }),
+            light_populated: AtomicBool::new(true),
+            status: ChunkStatus::Full,
+            blending_data: None,
+            dirty: AtomicBool::new(false),
+        })
+    }
+
+    fn install_chunks(
+        level: &Arc<Level>,
+        min_x: i32,
+        max_x: i32,
+        min_z: i32,
+        max_z: i32,
+        sky_default: u8,
+    ) {
+        level.loaded_chunks.clear();
+
+        let min_chunk_x = min_x.div_euclid(16);
+        let max_chunk_x = max_x.div_euclid(16);
+        let min_chunk_z = min_z.div_euclid(16);
+        let max_chunk_z = max_z.div_euclid(16);
+
+        for chunk_x in min_chunk_x..=max_chunk_x {
+            for chunk_z in min_chunk_z..=max_chunk_z {
+                level.loaded_chunks.insert(
+                    Vector2::new(chunk_x, chunk_z),
+                    make_chunk(chunk_x, chunk_z, sky_default),
+                );
+            }
+        }
+    }
+
+    fn prepare_case(level: &Arc<Level>, config: BenchConfig) -> Vec<BlockPos> {
+        let start_x = -(config.width / 2);
+        let start_z = -(config.depth / 2);
+        let end_x = start_x + config.width - 1;
+        let end_y = START_Y + config.height - 1;
+        let end_z = start_z + config.depth - 1;
+
+        install_chunks(
+            level,
+            start_x - config.margin,
+            end_x + config.margin,
+            start_z - config.margin,
+            end_z + config.margin,
+            config.mode.sky_default(),
+        );
+
+        let placed_state = config.mode.placed_state();
+        let mut positions = Vec::with_capacity(config.block_count());
+
+        for y in START_Y..=end_y {
+            for z in start_z..=end_z {
+                for x in start_x..=end_x {
+                    let pos = BlockPos::new(x, y, z);
+                    level.set_block_state(&pos, placed_state);
+                    positions.push(pos);
+                }
+            }
+        }
+
+        positions
+    }
+
+    fn format_duration(duration: Duration) -> String {
+        format!("{:.3}s", duration.as_secs_f64())
+    }
+
+    #[test]
+    #[ignore = "run manually to measure runtime bulk lighting speed"]
+    fn bulk_lighting_speed() {
+        let config = BenchConfig::from_env();
+        assert!(config.width > 0 && config.height > 0 && config.depth > 0);
+        assert!(config.runs > 0);
+        assert!(START_Y + config.height <= MIN_Y + SECTION_COUNT as i32 * 16);
+
+        let temp_dir = TempDir::new().expect("temporary benchmark world");
+        let level = Level::new_for_lighting_bench(temp_dir.path().to_path_buf());
+
+        println!(
+            "bulk lighting speed case: mode={:?}, {}x{}x{} = {} positions, margin={} blocks, {} run(s)",
+            config.mode,
+            config.width,
+            config.height,
+            config.depth,
+            config.block_count(),
+            config.margin,
+            config.runs
+        );
+
+        let mut total = Duration::ZERO;
+        for run in 1..=config.runs {
+            let positions = prepare_case(&level, config);
+
+            let start = Instant::now();
+            level.light_engine.update_lighting_bulk(&level, positions);
+            let elapsed = start.elapsed();
+
+            total += elapsed;
+            println!("run {run}: {}", format_duration(elapsed));
+        }
+
+        println!(
+            "average: {}",
+            format_duration(total / u32::try_from(config.runs).unwrap())
+        );
+
+        level.cancel_token.cancel();
+        level.should_unload.store(true, Ordering::Relaxed);
+        level.shut_down_chunk_system.store(true, Ordering::Relaxed);
     }
 }

--- a/pumpkin/src/block/entities/chest_like_block_entity.rs
+++ b/pumpkin/src/block/entities/chest_like_block_entity.rs
@@ -86,6 +86,10 @@ macro_rules! impl_block_entity_for_chest {
                 Some(self)
             }
 
+            fn chunk_data_nbt(&self) -> Option<pumpkin_nbt::compound::NbtCompound> {
+                Some(pumpkin_nbt::compound::NbtCompound::new())
+            }
+
             fn is_dirty(&self) -> bool {
                 self.dirty.load(std::sync::atomic::Ordering::Relaxed)
             }

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -104,6 +104,8 @@ pub struct JavaClient {
     outgoing_packet_priority_send: Sender<OutgoingPacket>,
     /// A high-priority queue of serialized packets to send to the network.
     outgoing_packet_priority_recv: Option<Receiver<OutgoingPacket>>,
+    /// Prevents chunk batch start/data/end sequences from interleaving.
+    chunk_batch_send_lock: Mutex<()>,
     /// The packet encoder for outgoing packets.
     network_writer: Arc<Mutex<TCPNetworkEncoder<BufWriter<OwnedWriteHalf>>>>,
     /// The packet decoder for incoming packets.
@@ -124,21 +126,33 @@ pub enum OutgoingPacketType {
 }
 
 struct OutgoingPacket {
-    data: Bytes,
+    data: OutgoingPacketData,
     completion: Option<oneshot::Sender<()>>,
 }
 
+enum OutgoingPacketData {
+    Single(Bytes),
+    Batch(Box<[Bytes]>),
+}
+
 impl OutgoingPacket {
-    const fn normal(data: Bytes) -> Self {
+    fn normal(data: Bytes) -> Self {
         Self {
-            data,
+            data: OutgoingPacketData::Single(data),
             completion: None,
         }
     }
 
-    const fn high_priority(data: Bytes, completion: oneshot::Sender<()>) -> Self {
+    fn high_priority(data: Bytes, completion: oneshot::Sender<()>) -> Self {
         Self {
-            data,
+            data: OutgoingPacketData::Single(data),
+            completion: Some(completion),
+        }
+    }
+
+    fn high_priority_batch(data: Box<[Bytes]>, completion: oneshot::Sender<()>) -> Self {
+        Self {
+            data: OutgoingPacketData::Batch(data),
             completion: Some(completion),
         }
     }
@@ -163,6 +177,7 @@ impl JavaClient {
             outgoing_packet_queue_recv: Some(recv),
             outgoing_packet_priority_send: priority_send,
             outgoing_packet_priority_recv: Some(priority_recv),
+            chunk_batch_send_lock: Mutex::new(()),
             version: AtomicCell::new(CURRENT_MC_VERSION),
             network_writer: Arc::new(Mutex::new(TCPNetworkEncoder::new(BufWriter::new(write)))),
             network_reader: Mutex::new(TCPNetworkDecoder::new(BufReader::new(read))),
@@ -330,7 +345,7 @@ impl JavaClient {
             return;
         };
 
-        self.send_packet_now(&CChunkBatchStart).await;
+        let mut serialized_chunks = Vec::with_capacity(chunks.len());
         for chunk in chunks {
             let event = ChunkSend::new(player.world(), chunk.clone());
             let event = server.plugin_manager.fire(event).await;
@@ -342,12 +357,49 @@ impl JavaClient {
             let version = self.version.load();
             buf.write_var_int(&VarInt(CChunkData::to_id(version)))
                 .unwrap();
-            CChunkData(chunk)
+            let block_entities =
+                player
+                    .world()
+                    .chunk_block_entity_data(pumpkin_util::math::vector2::Vector2::new(
+                        chunk.x, chunk.z,
+                    ));
+            CChunkData::with_block_entities(chunk, &block_entities)
                 .write_packet_data(&mut buf, &version)
                 .unwrap();
-            self.send_packet_now_data(buf.into()).await;
+            serialized_chunks.push(buf.into());
         }
-        self.send_packet_now(&CChunkBatchEnd::new(chunks.len() as u16))
+
+        self.send_serialized_chunk_batch(&serialized_chunks).await;
+    }
+
+    /// Sends already serialized chunk packets as one protocol chunk batch.
+    ///
+    /// The lock covers the complete start/data/end sequence so background chunk
+    /// resends cannot interleave with the player's normal chunk streaming.
+    pub async fn send_serialized_chunk_batch(&self, chunks: &[Bytes]) {
+        if chunks.is_empty() {
+            return;
+        }
+
+        let _batch_guard = self.chunk_batch_send_lock.lock().await;
+        let batch_size = chunks.len().min(usize::from(u16::MAX)) as u16;
+        let version = self.version.load();
+        let Ok(batch_start) = Self::serialize_packet_for_version(&CChunkBatchStart, version) else {
+            error!("Failed to serialize chunk batch start packet");
+            return;
+        };
+        let Ok(batch_end) =
+            Self::serialize_packet_for_version(&CChunkBatchEnd::new(batch_size), version)
+        else {
+            error!("Failed to serialize chunk batch end packet");
+            return;
+        };
+
+        let mut packets = Vec::with_capacity(chunks.len() + 2);
+        packets.push(batch_start);
+        packets.extend_from_slice(chunks);
+        packets.push(batch_end);
+        self.send_packet_batch_now_data(packets.into_boxed_slice())
             .await;
     }
 
@@ -514,6 +566,29 @@ impl JavaClient {
 
         if completion_rx.await.is_err() && !self.close_token.is_cancelled() {
             // The outgoing packet task dropped before confirming the write.
+            self.close();
+        }
+    }
+
+    async fn send_packet_batch_now_data(&self, packets: Box<[Bytes]>) {
+        let (completion_tx, completion_rx) = oneshot::channel();
+
+        if let Err(err) = self
+            .outgoing_packet_priority_send
+            .send(OutgoingPacket::high_priority_batch(packets, completion_tx))
+            .await
+        {
+            if !self.close_token.is_cancelled() {
+                warn!(
+                    "Failed to add high-priority packet batch to the outgoing queue for client {}: {}",
+                    self.id, err
+                );
+                self.close();
+            }
+            return;
+        }
+
+        if completion_rx.await.is_err() && !self.close_token.is_cancelled() {
             self.close();
         }
     }
@@ -687,14 +762,20 @@ impl JavaClient {
                 let send_failed = {
                     let mut writer = writer.lock().await;
                     let mut failed = false;
-                    for packet in &packet_batch {
-                        if let Err(err) = writer.write_packet(packet.data.clone()).await {
-                            failed = true;
-                            // It is expected that the packet will fail if we are closed
-                            if !close_token.is_cancelled() {
-                                warn!("Failed to send packet to client {id}: {err}");
+                    'packet_batch: for packet in &packet_batch {
+                        let packet_data = match &packet.data {
+                            OutgoingPacketData::Single(data) => std::slice::from_ref(data),
+                            OutgoingPacketData::Batch(data) => data,
+                        };
+                        for packet_data in packet_data {
+                            if let Err(err) = writer.write_packet(packet_data.clone()).await {
+                                failed = true;
+                                // It is expected that the packet will fail if we are closed
+                                if !close_token.is_cancelled() {
+                                    warn!("Failed to send packet to client {id}: {err}");
+                                }
+                                break 'packet_batch;
                             }
-                            break;
                         }
                     }
 

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/block_entity.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/block_entity.rs
@@ -9,6 +9,7 @@ use crate::block::entities::mob_spawner::MobSpawnerBlockEntity as InternalMobSpa
 use crate::block::entities::sign::{
     DyeColor as InternalDyeColor, SignBlockEntity as InternalSignBlockEntity, Text as InternalText,
 };
+use crate::block::entities::trapped_chest::TrappedChestBlockEntity as InternalTrappedChestBlockEntity;
 use crate::plugin::loader::wasm::wasm_host::{
     state::{BlockEntityResource, PluginHostState},
     wit::v0_1::pumpkin::{
@@ -21,6 +22,7 @@ use crate::plugin::loader::wasm::wasm_host::{
                 MobSpawnerBlockEntity, SignBlockEntity, SignText,
             },
             common::BlockPos as WitBlockPos,
+            item_stack::ItemStack as WitItemStack,
         },
     },
 };
@@ -465,13 +467,68 @@ impl HostChestBlockEntity for PluginHostState {
 
     async fn viewer_count(&mut self, res: Resource<ChestBlockEntity>) -> wasmtime::Result<u32> {
         let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
+        if let Some(chest) = entity.as_any().downcast_ref::<InternalChestBlockEntity>() {
+            Ok(chest.get_viewer_count() as u32)
+        } else if let Some(chest) = entity
             .as_any()
-            .downcast_ref::<InternalChestBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a chest block entity")),
-                |chest| Ok(chest.get_viewer_count() as u32),
-            )
+            .downcast_ref::<InternalTrappedChestBlockEntity>()
+        {
+            Ok(chest.get_viewer_count() as u32)
+        } else {
+            Err(wasmtime::Error::msg("Not a chest block entity"))
+        }
+    }
+
+    async fn size(&mut self, res: Resource<ChestBlockEntity>) -> wasmtime::Result<u32> {
+        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
+        let inventory = entity
+            .get_inventory()
+            .ok_or_else(|| wasmtime::Error::msg("Chest block entity has no inventory"))?;
+        Ok(inventory.size() as u32)
+    }
+
+    async fn get_item(
+        &mut self,
+        res: Resource<ChestBlockEntity>,
+        slot: u32,
+    ) -> wasmtime::Result<Option<Resource<WitItemStack>>> {
+        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
+        let inventory = entity
+            .get_inventory()
+            .ok_or_else(|| wasmtime::Error::msg("Chest block entity has no inventory"))?;
+        let slot = slot as usize;
+        if slot >= inventory.size() {
+            return Err(wasmtime::Error::msg("Chest inventory slot is out of range"));
+        }
+        let stack = inventory.get_stack(slot).await;
+        if stack.lock().await.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(self.add_item_stack(stack)?))
+        }
+    }
+
+    async fn set_item(
+        &mut self,
+        res: Resource<ChestBlockEntity>,
+        slot: u32,
+        item: Option<Resource<WitItemStack>>,
+    ) -> wasmtime::Result<()> {
+        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
+        let inventory = entity
+            .get_inventory()
+            .ok_or_else(|| wasmtime::Error::msg("Chest block entity has no inventory"))?;
+        let slot = slot as usize;
+        if slot >= inventory.size() {
+            return Err(wasmtime::Error::msg("Chest inventory slot is out of range"));
+        }
+        let stack = if let Some(item) = item {
+            self.get_item_stack(&item)?.lock().await.clone()
+        } else {
+            pumpkin_data::item_stack::ItemStack::EMPTY.clone()
+        };
+        inventory.set_stack(slot, stack).await;
+        Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<ChestBlockEntity>) -> wasmtime::Result<()> {

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
@@ -13,6 +13,7 @@ use crate::block::entities::command_block::CommandBlockEntity as InternalCommand
 use crate::block::entities::jukebox::JukeboxBlockEntity as InternalJukeboxBlockEntity;
 use crate::block::entities::mob_spawner::MobSpawnerBlockEntity as InternalMobSpawnerBlockEntity;
 use crate::block::entities::sign::SignBlockEntity as InternalSignBlockEntity;
+use crate::block::entities::trapped_chest::TrappedChestBlockEntity as InternalTrappedChestBlockEntity;
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::world::{
     BlockChange as WitBlockChange, BlockDirection as WitBlockDirection, BlockEntity,
     BlockEntityType, BlockFlags as WitBlockFlags, BlockPos as WitBlockPos,
@@ -202,6 +203,10 @@ impl PluginHostState {
             .as_any()
             .downcast_ref::<InternalChestBlockEntity>()
             .is_some()
+            || be
+                .as_any()
+                .downcast_ref::<InternalTrappedChestBlockEntity>()
+                .is_some()
         {
             let res: Resource<BlockEntity> = self.add_block_entity(be)?;
             Ok(Some(BlockEntityType::ChestBlockEntity(Resource::new_own(

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
@@ -27,7 +27,6 @@ use crate::plugin::loader::wasm::wasm_host::{
     wit::v0_1::pumpkin::{self, plugin::world::World},
 };
 use crate::world::explosion::Explosion;
-use tracing::warn;
 
 pub(crate) const fn to_wasm_block_direction(dir: InternalBlockDirection) -> WitBlockDirection {
     match dir {
@@ -355,8 +354,6 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         changes: Vec<WitBlockChange>,
         update_flags: WitBlockFlags,
     ) -> wasmtime::Result<()> {
-        let started = std::time::Instant::now();
-        let change_count = changes.len();
         let world_provider = self.get_world_res(&world)?.provider.clone();
         let internal_flags = to_internal_block_flags(update_flags);
         let internal_changes = changes
@@ -368,20 +365,10 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
                 )
             })
             .collect();
-        let converted = started.elapsed();
-        warn!(
-            "Plugin WIT world.set_block_states: converted {change_count} changes in {:?}",
-            converted
-        );
 
         world_provider
             .set_block_states(internal_changes, internal_flags)
             .await;
-        warn!(
-            "Plugin WIT world.set_block_states: world apply returned in {:?} (total {:?})",
-            started.elapsed().saturating_sub(converted),
-            started.elapsed()
-        );
 
         Ok(())
     }

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
@@ -14,10 +14,11 @@ use crate::block::entities::jukebox::JukeboxBlockEntity as InternalJukeboxBlockE
 use crate::block::entities::mob_spawner::MobSpawnerBlockEntity as InternalMobSpawnerBlockEntity;
 use crate::block::entities::sign::SignBlockEntity as InternalSignBlockEntity;
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::world::{
-    BlockDirection as WitBlockDirection, BlockEntity, BlockEntityType, BlockFlags as WitBlockFlags,
-    BlockPos as WitBlockPos, BlockState as WitBlockState, BoundingBox as WitBoundingBox,
-    Chunk as WitChunk, NoteblockInstrument as WitNoteblockInstrument,
-    PistonBehavior as WitPistonBehavior, WorldBorder as WitWorldBorder,
+    BlockChange as WitBlockChange, BlockDirection as WitBlockDirection, BlockEntity,
+    BlockEntityType, BlockFlags as WitBlockFlags, BlockPos as WitBlockPos,
+    BlockState as WitBlockState, BoundingBox as WitBoundingBox, Chunk as WitChunk,
+    NoteblockInstrument as WitNoteblockInstrument, PistonBehavior as WitPistonBehavior,
+    WorldBorder as WitWorldBorder,
 };
 use crate::plugin::loader::wasm::wasm_host::{
     state::{
@@ -26,6 +27,7 @@ use crate::plugin::loader::wasm::wasm_host::{
     wit::v0_1::pumpkin::{self, plugin::world::World},
 };
 use crate::world::explosion::Explosion;
+use tracing::warn;
 
 pub(crate) const fn to_wasm_block_direction(dir: InternalBlockDirection) -> WitBlockDirection {
     match dir {
@@ -79,6 +81,35 @@ pub(crate) const fn to_wit_bounding_box(
         min: (bb.min.x, bb.min.y, bb.min.z),
         max: (bb.max.x, bb.max.y, bb.max.z),
     }
+}
+
+fn to_internal_block_flags(update_flags: WitBlockFlags) -> BlockFlags {
+    let mut internal_flags = BlockFlags::empty();
+    if update_flags.contains(WitBlockFlags::NOTIFY_NEIGHBORS) {
+        internal_flags |= BlockFlags::NOTIFY_NEIGHBORS;
+    }
+    if update_flags.contains(WitBlockFlags::NOTIFY_LISTENERS) {
+        internal_flags |= BlockFlags::NOTIFY_LISTENERS;
+    }
+    if update_flags.contains(WitBlockFlags::FORCE_STATE) {
+        internal_flags |= BlockFlags::FORCE_STATE;
+    }
+    if update_flags.contains(WitBlockFlags::SKIP_DROPS) {
+        internal_flags |= BlockFlags::SKIP_DROPS;
+    }
+    if update_flags.contains(WitBlockFlags::MOVED) {
+        internal_flags |= BlockFlags::MOVED;
+    }
+    if update_flags.contains(WitBlockFlags::SKIP_REDSTONE_WIRE_STATE_REPLACEMENT) {
+        internal_flags |= BlockFlags::SKIP_REDSTONE_WIRE_STATE_REPLACEMENT;
+    }
+    if update_flags.contains(WitBlockFlags::SKIP_BLOCK_ENTITY_REPLACED_CALLBACK) {
+        internal_flags |= BlockFlags::SKIP_BLOCK_ENTITY_REPLACED_CALLBACK;
+    }
+    if update_flags.contains(WitBlockFlags::SKIP_BLOCK_ADDED_CALLBACK) {
+        internal_flags |= BlockFlags::SKIP_BLOCK_ADDED_CALLBACK;
+    }
+    internal_flags
 }
 
 // --- Trapping Helpers ---
@@ -308,38 +339,50 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
     ) -> wasmtime::Result<()> {
         let world_ref = self.get_world_res(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
-
-        let mut internal_flags = BlockFlags::empty();
-        if update_flags.contains(WitBlockFlags::NOTIFY_NEIGHBORS) {
-            internal_flags |= BlockFlags::NOTIFY_NEIGHBORS;
-        }
-        if update_flags.contains(WitBlockFlags::NOTIFY_LISTENERS) {
-            internal_flags |= BlockFlags::NOTIFY_LISTENERS;
-        }
-        if update_flags.contains(WitBlockFlags::FORCE_STATE) {
-            internal_flags |= BlockFlags::FORCE_STATE;
-        }
-        if update_flags.contains(WitBlockFlags::SKIP_DROPS) {
-            internal_flags |= BlockFlags::SKIP_DROPS;
-        }
-        if update_flags.contains(WitBlockFlags::MOVED) {
-            internal_flags |= BlockFlags::MOVED;
-        }
-        if update_flags.contains(WitBlockFlags::SKIP_REDSTONE_WIRE_STATE_REPLACEMENT) {
-            internal_flags |= BlockFlags::SKIP_REDSTONE_WIRE_STATE_REPLACEMENT;
-        }
-        if update_flags.contains(WitBlockFlags::SKIP_BLOCK_ENTITY_REPLACED_CALLBACK) {
-            internal_flags |= BlockFlags::SKIP_BLOCK_ENTITY_REPLACED_CALLBACK;
-        }
-        if update_flags.contains(WitBlockFlags::SKIP_BLOCK_ADDED_CALLBACK) {
-            internal_flags |= BlockFlags::SKIP_BLOCK_ADDED_CALLBACK;
-        }
+        let internal_flags = to_internal_block_flags(update_flags);
 
         world_ref
             .provider
             .clone()
             .set_block_state(&internal_pos, state, internal_flags)
             .await;
+        Ok(())
+    }
+
+    async fn set_block_states(
+        &mut self,
+        world: Resource<World>,
+        changes: Vec<WitBlockChange>,
+        update_flags: WitBlockFlags,
+    ) -> wasmtime::Result<()> {
+        let started = std::time::Instant::now();
+        let change_count = changes.len();
+        let world_provider = self.get_world_res(&world)?.provider.clone();
+        let internal_flags = to_internal_block_flags(update_flags);
+        let internal_changes = changes
+            .into_iter()
+            .map(|change| {
+                (
+                    BlockPos::new(change.pos.x, change.pos.y, change.pos.z),
+                    change.state,
+                )
+            })
+            .collect();
+        let converted = started.elapsed();
+        warn!(
+            "Plugin WIT world.set_block_states: converted {change_count} changes in {:?}",
+            converted
+        );
+
+        world_provider
+            .set_block_states(internal_changes, internal_flags)
+            .await;
+        warn!(
+            "Plugin WIT world.set_block_states: world apply returned in {:?} (total {:?})",
+            started.elapsed().saturating_sub(converted),
+            started.elapsed()
+        );
+
         Ok(())
     }
 

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -497,10 +497,9 @@ impl PluginManager {
             }
         }
 
-        let prompt = format!(
-            "\n{} [y/N]: ",
-            "Do you want to allow these permissions and load the plugin?".bold()
-        );
+        // Rustyline's Windows backend calculates prompt width from unstyled
+        // content and rejects embedded ANSI escape sequences.
+        let prompt = "\nDo you want to allow these permissions and load the plugin? [y/N]: ";
 
         let mut rl_taken = if let Some(logger_option) = crate::LOGGER_IMPL.get()
             && let Some((wrapper, _, _)) = logger_option
@@ -512,13 +511,13 @@ impl PluginManager {
         };
 
         let result = if let Some((_, ref mut rl)) = rl_taken {
-            rl.readline(&prompt).is_ok_and(|line| {
+            rl.readline(prompt).is_ok_and(|line| {
                 let input = line.trim().to_lowercase();
                 input == "y" || input == "yes"
             })
         } else {
             let mut rl = DefaultEditor::new().expect("Failed to create rustyline editor");
-            rl.readline(&prompt).is_ok_and(|line| {
+            rl.readline(prompt).is_ok_and(|line| {
                 let input = line.trim().to_lowercase();
                 input == "y" || input == "yes"
             })

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -42,7 +42,6 @@ use crate::{
     error::PumpkinError,
     net::{ClientPlatform, java::JavaClient},
     plugin::{
-        api::events::world::chunk_send::ChunkSend,
         block::block_break::BlockBreakEvent,
         player::{player_join::PlayerJoinEvent, player_leave::PlayerLeaveEvent},
     },
@@ -80,8 +79,8 @@ use pumpkin_protocol::bedrock::client::set_actor_data::{CSetActorData, PropertyS
 use pumpkin_protocol::bedrock::client::start_game::{CStartGame, ServerTelemetryData};
 use pumpkin_protocol::bedrock::frame_set::FrameSet;
 use pumpkin_protocol::java::client::play::{
-    CBlockUpdate, CChunkBatchEnd, CChunkBatchStart, CChunkData, CDisguisedChatMessage, CExplosion,
-    CRespawn, CSetBlockDestroyStage, CWorldEvent,
+    CBlockUpdate, CChunkData, CDisguisedChatMessage, CExplosion, CLightUpdate, CRespawn,
+    CSetBlockDestroyStage, CWorldEvent, ChunkBlockEntityData,
 };
 use pumpkin_protocol::java::client::play::{
     CPlayerSpawnPosition, CRecipeBookAdd, CRecipeBookSettings, CSystemChatMessage,
@@ -94,7 +93,6 @@ use pumpkin_protocol::{
             add_player::CAddPlayer,
             creative_content::{CCreativeContent, Group},
             gamerules_changed::GameRules,
-            level_chunk::CLevelChunk,
             player_list::{CPlayerList, PlayerListEntry, Skin},
             remove_actor::CRemoveActor,
             start_game::{Experiments, GamePublishSetting, LevelSettings},
@@ -135,14 +133,6 @@ use pumpkin_world::world::{GetBlockError, WorldPortalExt};
 use pumpkin_world::{
     BlockStateId, CURRENT_BEDROCK_MC_VERSION, biome, chunk::io::Dirtiable, inventory::Inventory,
 };
-
-/// When a single chunk column accumulates at least this many queued block
-/// changes in one flush, resend the whole chunk via `CChunkData` instead of
-/// emitting one `CMultiBlockUpdate` per touched 16x16x16 section. The protocol
-/// caps a multi-block-update packet at a single section, so a dense edit (e.g.
-/// a WorldEdit-style paste) would otherwise produce dozens of packets per
-/// column; one chunk packet is cheaper to send and to apply client-side.
-const CHUNK_RESEND_BLOCK_THRESHOLD: usize = 4_096;
 
 /// How many chunks a bulk update writes to concurrently. Each chunk write holds
 /// only that chunk's own locks, so distinct chunks never contend; the real limit
@@ -1097,43 +1087,10 @@ impl World {
             return;
         }
 
-        // Group the flat list of sections back into chunk columns so we can
-        // decide, per column, whether a full-chunk resend is cheaper than
-        // per-section multi-block-update packets.
-        let mut sections_by_chunk: HashMap<Vector2<i32>, Vec<ChunkSectionUpdates>> = HashMap::new();
+        // A full chunk packet participates in client chunk-loading state and is
+        // not safe as a live block-update optimization. Keep live edits on the
+        // section-update path regardless of density.
         for (chunk_section, updates) in block_state_updates_by_chunk_section {
-            if updates.is_empty() {
-                continue;
-            }
-            sections_by_chunk
-                .entry(Vector2::new(chunk_section.x, chunk_section.z))
-                .or_default()
-                .push((chunk_section, updates));
-        }
-
-        let mut sections_to_send: Vec<ChunkSectionUpdates> = Vec::new();
-        for (chunk_pos, sections) in sections_by_chunk {
-            let column_block_count: usize = sections.iter().map(|(_, updates)| updates.len()).sum();
-
-            // Dense column: resend the whole chunk once instead of many
-            // section packets. The chunk is already written and still loaded
-            // (we only just applied the batch to it), so this is a cheap
-            // synchronous clone of the existing `Arc<ChunkData>`.
-            if column_block_count >= CHUNK_RESEND_BLOCK_THRESHOLD
-                && let Some(chunk) = self
-                    .level
-                    .read_chunk_sync(&chunk_pos, std::clone::Clone::clone)
-            {
-                self.broadcast_chunk_resend(chunk_pos, chunk).await;
-                continue;
-            }
-
-            sections_to_send.extend(sections);
-        }
-
-        // TODO: only send packet to players who have the chunks loaded
-        // TODO: Send light updates to update the wire directly next to a broken block
-        for (chunk_section, updates) in sections_to_send {
             self.send_section_block_updates(chunk_section, updates);
         }
     }
@@ -1201,77 +1158,6 @@ impl World {
                     recipients_by_version.clone(),
                 );
             }
-        }
-    }
-
-    /// Resends a whole chunk column to every player who can currently see it.
-    ///
-    /// Used by [`Self::flush_block_updates`] when a chunk accumulated so many
-    /// block changes in one flush that a single `CChunkData` packet is cheaper
-    /// than the per-section `CMultiBlockUpdate` packets it would otherwise send.
-    ///
-    /// The Java chunk packet is serialized **once per protocol version** and the
-    /// resulting bytes are shared across every recipient on that version, so a
-    /// dense paste seen by many players costs one serialization per version
-    /// rather than one per player. The `ChunkSend` plugin event is fired a single
-    /// time for the chunk (broadcast semantics): if a plugin cancels it, the
-    /// resend is skipped for everyone.
-    async fn broadcast_chunk_resend(
-        self: &Arc<Self>,
-        chunk_pos: Vector2<i32>,
-        chunk: Arc<ChunkData>,
-    ) {
-        // Fire the plugin event once for this chunk; honor cancellation.
-        if let Some(server) = self.server.upgrade() {
-            let event = ChunkSend::new(self.clone(), chunk.clone());
-            let event = server.plugin_manager.fire(event).await;
-            if event.cancelled {
-                return;
-            }
-        }
-
-        let players = self.players.load();
-        let mut java_recipients = Vec::new();
-        let mut bedrock_recipients = Vec::new();
-
-        for p in players.iter() {
-            let center = p.get_entity().chunk_pos.load();
-            let view_distance = get_view_distance(p).get() as i32;
-            if !is_within_view_distance(chunk_pos, center, view_distance) {
-                continue;
-            }
-            match &p.client {
-                ClientPlatform::Java(_) => java_recipients.push(p),
-                ClientPlatform::Bedrock(be_client) => bedrock_recipients.push(be_client.clone()),
-            }
-        }
-
-        // Java: one serialization per protocol version, shared across recipients.
-        let recipients_by_version =
-            Self::collect_java_recipients_by_version(java_recipients.into_iter());
-        for (version, recipients) in recipients_by_version {
-            let packet_data =
-                match JavaClient::serialize_packet_for_version(&CChunkData(&chunk), version) {
-                    Ok(packet_data) => packet_data,
-                    Err(err) => {
-                        error!("Failed to serialize chunk resend for version {version:?}: {err}");
-                        continue;
-                    }
-                };
-            for recipient in recipients {
-                recipient.try_enqueue_packet_data(packet_data.clone());
-            }
-        }
-
-        // Bedrock: game-packet framing is per-connection (compression/encryption
-        // state lives on the connection), so it cannot share bytes; enqueue the
-        // chunk packet per recipient.
-        for be_client in bedrock_recipients {
-            be_client.try_enqueue_packet(&CLevelChunk {
-                dimension: 0,
-                cache_enabled: false,
-                chunk: &chunk,
-            });
         }
     }
 
@@ -3350,11 +3236,20 @@ impl World {
                 .level
                 .get_or_fetch_chunk(center_chunk, std::clone::Clone::clone)
                 .await;
-            java_client.send_packet_now(&CChunkBatchStart).await;
-            java_client.send_packet_now(&CChunkData(&chunk)).await;
-            java_client
-                .send_packet_now(&CChunkBatchEnd::new(1u16))
-                .await;
+            let block_entities = target_world.chunk_block_entity_data(center_chunk);
+            match JavaClient::serialize_packet_for_version(
+                &CChunkData::with_block_entities(&chunk, &block_entities),
+                java_client.version.load(),
+            ) {
+                Ok(packet_data) => {
+                    java_client
+                        .send_serialized_chunk_batch(std::slice::from_ref(&packet_data))
+                        .await;
+                }
+                Err(error) => {
+                    error!("Failed to serialize center chunk before teleport: {error}");
+                }
+            }
         }
 
         // Send teleport packet after at least the center chunk was delivered
@@ -5144,6 +5039,24 @@ impl World {
         let entity = block_entity_from_nbt(&nbt)?;
         self.block_entities.insert(*block_pos, entity.clone());
         Some(entity)
+    }
+
+    pub(crate) fn chunk_block_entity_data(
+        &self,
+        chunk_pos: Vector2<i32>,
+    ) -> Vec<ChunkBlockEntityData> {
+        self.block_entities
+            .iter()
+            .filter(|entry| entry.key().chunk_position() == chunk_pos)
+            .filter_map(|entry| {
+                let entity = entry.value();
+                entity.chunk_data_nbt().map(|nbt| ChunkBlockEntityData {
+                    position: entity.get_position(),
+                    type_id: entity.get_id() as i32,
+                    nbt,
+                })
+            })
+            .collect()
     }
 
     pub fn add_block_entity(&self, block_entity: Arc<dyn BlockEntity>) {

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -11,10 +11,11 @@ use pumpkin_protocol::bedrock::network_item::{
 };
 use pumpkin_protocol::codec::data_component::data_to_proto_sound;
 use pumpkin_world::generation::proto_chunk::GenerationCache;
+use std::num::NonZeroUsize;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, LazyLock, Weak};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     sync::atomic::Ordering,
 };
 use tracing::{debug, error, info, trace, warn};
@@ -41,6 +42,7 @@ use crate::{
     error::PumpkinError,
     net::{ClientPlatform, java::JavaClient},
     plugin::{
+        api::events::world::chunk_send::ChunkSend,
         block::block_break::BlockBreakEvent,
         player::{player_join::PlayerJoinEvent, player_leave::PlayerLeaveEvent},
     },
@@ -92,6 +94,7 @@ use pumpkin_protocol::{
             add_player::CAddPlayer,
             creative_content::{CCreativeContent, Group},
             gamerules_changed::GameRules,
+            level_chunk::CLevelChunk,
             player_list::{CPlayerList, PlayerListEntry, Skin},
             remove_actor::CRemoveActor,
             start_game::{Experiments, GamePublishSetting, LevelSettings},
@@ -132,8 +135,82 @@ use pumpkin_world::world::{GetBlockError, WorldPortalExt};
 use pumpkin_world::{
     BlockStateId, CURRENT_BEDROCK_MC_VERSION, biome, chunk::io::Dirtiable, inventory::Inventory,
 };
+
+/// When a single chunk column accumulates at least this many queued block
+/// changes in one flush, resend the whole chunk via `CChunkData` instead of
+/// emitting one `CMultiBlockUpdate` per touched 16x16x16 section. The protocol
+/// caps a multi-block-update packet at a single section, so a dense edit (e.g.
+/// a WorldEdit-style paste) would otherwise produce dozens of packets per
+/// column; one chunk packet is cheaper to send and to apply client-side.
+const CHUNK_RESEND_BLOCK_THRESHOLD: usize = 4_096;
+
+/// How many chunks a bulk update writes to concurrently. Each chunk write holds
+/// only that chunk's own locks, so distinct chunks never contend; the real limit
+/// is CPU. Scale with core count (writes run on the blocking pool) so large
+/// servers parallelize a big paste, while a floor keeps small machines sane.
+static MAX_BULK_BLOCK_WRITE_TASKS: LazyLock<usize> = LazyLock::new(|| {
+    std::thread::available_parallelism()
+        .map_or(4, NonZeroUsize::get)
+        .max(4)
+});
+
+/// How many chunks run per-block side effects (neighbor updates, block-entity
+/// callbacks, relight) concurrently.
+///
+/// Unlike the chunk writers, these tasks are *not* purely async I/O: a single
+/// changed block can recursively trigger `set_block_state` on its neighbors
+/// (redstone, observers, doors, ...), and each of those runs a synchronous,
+/// non-yielding light-convergence pass. Running too many of these at once can
+/// monopolize every tokio worker thread for seconds, starving unrelated tasks
+/// (e.g. a player's inventory lock acquisition) until they hit their timeouts.
+/// Leave at least one worker free for the rest of the server.
+static MAX_BULK_BLOCK_SIDE_EFFECT_TASKS: LazyLock<usize> = LazyLock::new(|| {
+    std::thread::available_parallelism()
+        .map_or(2, NonZeroUsize::get)
+        .saturating_sub(1)
+        .max(2)
+});
+
+/// How many top-level changes a side-effect task processes before yielding to
+/// the runtime. Each change can recursively cascade into many more
+/// `set_block_state` calls (neighbor updates, redstone, lighting convergence),
+/// so this is kept low to give other tasks frequent scheduling chances during
+/// a large bulk update.
+const BULK_BLOCK_SIDE_EFFECT_YIELD_INTERVAL: usize = 16;
+const USE_JAVA_MULTI_BLOCK_UPDATE_PACKET: bool = true;
+
+fn is_valid_block_state_id(block_state_id: BlockStateId) -> bool {
+    let block = Block::from_state_id(block_state_id);
+    block.states.first().is_some_and(|first_state| {
+        block
+            .states
+            .last()
+            .is_some_and(|last_state| (first_state.id..=last_state.id).contains(&block_state_id))
+    })
+}
+
+fn needs_bulk_block_side_effects(flags: BlockFlags) -> bool {
+    flags.intersects(BlockFlags::NOTIFY_NEIGHBORS | BlockFlags::MOVED)
+        || !flags.contains(BlockFlags::FORCE_STATE)
+        || !flags.contains(BlockFlags::SKIP_BLOCK_ENTITY_REPLACED_CALLBACK)
+        || !flags.contains(BlockFlags::SKIP_BLOCK_ADDED_CALLBACK)
+}
+
 use pumpkin_world::{chunk::ChunkData, world::BlockAccessor};
 use pumpkin_world::{level::Level, tick::TickPriority};
+
+/// The pending client-visible block changes within a single 16x16x16 chunk
+/// section: the section position and the `(position, state)` pairs in it.
+type ChunkSectionUpdates = (Vector3<i32>, Vec<(BlockPos, BlockStateId)>);
+
+/// A single block write within a chunk during a bulk update: an index back into
+/// the flat `applied` list, the chunk-relative `(x, y, z)`, and the new state.
+type BulkChunkWrite = (usize, usize, i32, usize, BlockStateId);
+
+/// The result of writing one chunk's worth of bulk changes: the writes that were
+/// requested, paired with the per-write `(index, replaced state)` pairs the chunk
+/// reported back (or `None` if the chunk was not loaded).
+type BulkChunkWriteResult = (Vec<BulkChunkWrite>, Option<Vec<(usize, BlockStateId)>>);
 pub use pumpkin_world::{world::BlockFlags, world_info::LevelData};
 use rand::seq::SliceRandom;
 use rand::{RngExt, rng};
@@ -214,6 +291,7 @@ pub struct World {
     synced_block_event_queue: Mutex<Vec<BlockEvent>>,
     /// A map of unsent block changes, keyed by block position.
     unsent_block_changes: Mutex<HashMap<BlockPos, u16>>,
+    pending_block_update_sections: Mutex<VecDeque<ChunkSectionUpdates>>,
     /// POI storage for fast portal lookups
     pub portal_poi: Mutex<portal::PortalPoiStorage>,
     /// End Dragon fight manager (only present in `THE_END` dimension).
@@ -263,6 +341,7 @@ impl World {
             min_y: i32::from(generation_settings.shape.min_y),
             synced_block_event_queue: Mutex::new(Vec::new()),
             unsent_block_changes: Mutex::new(HashMap::new()),
+            pending_block_update_sections: Mutex::new(VecDeque::new()),
             portal_poi: Mutex::new(portal_poi),
             dragon_fight,
             spawn_state: ArcSwap::new(Arc::new(SpawnState::empty())),
@@ -981,75 +1060,218 @@ impl World {
             .insert(position, block_state_id);
     }
 
-    pub async fn flush_block_updates(&self) {
-        let mut block_state_updates_by_chunk_section: HashMap<
-            Vector3<i32>,
-            Vec<(BlockPos, BlockStateId)>,
-        > = HashMap::new();
+    pub async fn flush_block_updates(self: &Arc<Self>) {
         let changes = {
             let mut guard = self.unsent_block_changes.lock().await;
             std::mem::take(&mut *guard)
         };
-        for (position, block_state_id) in changes {
-            let chunk_section = chunk_section_from_pos(&position);
-            block_state_updates_by_chunk_section
-                .entry(chunk_section)
-                .or_default()
-                .push((position, block_state_id));
+
+        if !changes.is_empty() {
+            let mut block_state_updates_by_chunk_section: HashMap<
+                Vector3<i32>,
+                Vec<(BlockPos, BlockStateId)>,
+            > = HashMap::new();
+
+            for (position, block_state_id) in changes {
+                let chunk_section = chunk_section_from_pos(&position);
+                block_state_updates_by_chunk_section
+                    .entry(chunk_section)
+                    .or_default()
+                    .push((position, block_state_id));
+            }
+
+            let mut pending = self.pending_block_update_sections.lock().await;
+            pending.extend(block_state_updates_by_chunk_section);
         }
 
-        // TODO: only send packet to players who have the chunks loaded
-        // TODO: Send light updates to update the wire directly next to a broken block
+        // Drain the entire pending queue every tick. The per-tick cap that used
+        // to throttle this streamed a large batch (a WorldEdit-style paste) to
+        // clients a few sections at a time over many ticks; now the whole batch
+        // becomes visible on the tick after it was applied.
+        let block_state_updates_by_chunk_section: Vec<ChunkSectionUpdates> = {
+            let mut pending = self.pending_block_update_sections.lock().await;
+            pending.drain(..).collect()
+        };
+
+        if block_state_updates_by_chunk_section.is_empty() {
+            return;
+        }
+
+        // Group the flat list of sections back into chunk columns so we can
+        // decide, per column, whether a full-chunk resend is cheaper than
+        // per-section multi-block-update packets.
+        let mut sections_by_chunk: HashMap<Vector2<i32>, Vec<ChunkSectionUpdates>> = HashMap::new();
         for (chunk_section, updates) in block_state_updates_by_chunk_section {
             if updates.is_empty() {
                 continue;
             }
-            let chunk_pos = Vector2::new(chunk_section.x, chunk_section.z);
-            if updates.len() == 1 {
-                let (block_pos, block_state_id) = updates[0];
-                let be_block_id = BlockState::to_be_network_id(block_state_id);
-                self.broadcast_to_chunk_editioned_sync(
-                    chunk_pos,
-                    &CBlockUpdate::new(block_pos, i32::from(block_state_id).into()),
-                    &pumpkin_protocol::bedrock::client::CUpdateBlock::new(
-                        block_pos,
-                        be_block_id as u32,
-                    ),
-                );
-            } else {
-                let players = self.players.load();
-                let mut java_recipients = Vec::new();
+            sections_by_chunk
+                .entry(Vector2::new(chunk_section.x, chunk_section.z))
+                .or_default()
+                .push((chunk_section, updates));
+        }
 
-                let recipients = players.iter().filter(|p| {
-                    let center = p.get_entity().chunk_pos.load();
-                    let view_distance = get_view_distance(p).get() as i32;
-                    is_within_view_distance(chunk_pos, center, view_distance)
-                });
+        let mut sections_to_send: Vec<ChunkSectionUpdates> = Vec::new();
+        for (chunk_pos, sections) in sections_by_chunk {
+            let column_block_count: usize = sections.iter().map(|(_, updates)| updates.len()).sum();
 
-                for p in recipients {
-                    match &p.client {
-                        ClientPlatform::Java(_) => java_recipients.push(p),
-                        ClientPlatform::Bedrock(be_client) => {
-                            for (block_pos, block_state_id) in &updates {
-                                let be_block_id = BlockState::to_be_network_id(*block_state_id);
-                                be_client.try_enqueue_packet(
-                                    &pumpkin_protocol::bedrock::client::CUpdateBlock::new(
-                                        *block_pos,
-                                        be_block_id as u32,
-                                    ),
-                                );
-                            }
-                        }
+            // Dense column: resend the whole chunk once instead of many
+            // section packets. The chunk is already written and still loaded
+            // (we only just applied the batch to it), so this is a cheap
+            // synchronous clone of the existing `Arc<ChunkData>`.
+            if column_block_count >= CHUNK_RESEND_BLOCK_THRESHOLD
+                && let Some(chunk) = self
+                    .level
+                    .read_chunk_sync(&chunk_pos, std::clone::Clone::clone)
+            {
+                self.broadcast_chunk_resend(chunk_pos, chunk).await;
+                continue;
+            }
+
+            sections_to_send.extend(sections);
+        }
+
+        // TODO: only send packet to players who have the chunks loaded
+        // TODO: Send light updates to update the wire directly next to a broken block
+        for (chunk_section, updates) in sections_to_send {
+            self.send_section_block_updates(chunk_section, updates);
+        }
+    }
+
+    /// Sends the queued block changes within a single chunk section to clients,
+    /// picking the cheapest packet: a single `CBlockUpdate` for one change, or a
+    /// `CMultiBlockUpdate` (Java) / per-block `CUpdateBlock` (Bedrock) otherwise.
+    fn send_section_block_updates(
+        &self,
+        chunk_section: Vector3<i32>,
+        updates: Vec<(BlockPos, BlockStateId)>,
+    ) {
+        if updates.is_empty() {
+            return;
+        }
+        let chunk_pos = Vector2::new(chunk_section.x, chunk_section.z);
+        if updates.len() == 1 {
+            let (block_pos, block_state_id) = updates[0];
+            let be_block_id = BlockState::to_be_network_id(block_state_id);
+            self.broadcast_to_chunk_editioned_sync(
+                chunk_pos,
+                &CBlockUpdate::new(block_pos, i32::from(block_state_id).into()),
+                &pumpkin_protocol::bedrock::client::CUpdateBlock::new(
+                    block_pos,
+                    be_block_id as u32,
+                ),
+            );
+            return;
+        }
+
+        let players = self.players.load();
+        let mut java_recipients = Vec::new();
+
+        let recipients = players.iter().filter(|p| {
+            let center = p.get_entity().chunk_pos.load();
+            let view_distance = get_view_distance(p).get() as i32;
+            is_within_view_distance(chunk_pos, center, view_distance)
+        });
+
+        for p in recipients {
+            match &p.client {
+                ClientPlatform::Java(_) => java_recipients.push(p),
+                ClientPlatform::Bedrock(be_client) => {
+                    for (block_pos, block_state_id) in &updates {
+                        let be_block_id = BlockState::to_be_network_id(*block_state_id);
+                        be_client.try_enqueue_packet(
+                            &pumpkin_protocol::bedrock::client::CUpdateBlock::new(
+                                *block_pos,
+                                be_block_id as u32,
+                            ),
+                        );
                     }
                 }
+            }
+        }
 
-                let recipients_by_version =
-                    Self::collect_java_recipients_by_version(java_recipients.into_iter());
+        let recipients_by_version =
+            Self::collect_java_recipients_by_version(java_recipients.into_iter());
+        if USE_JAVA_MULTI_BLOCK_UPDATE_PACKET {
+            Self::broadcast_java_grouped(&CMultiBlockUpdate::new(&updates), recipients_by_version);
+        } else {
+            for (block_pos, block_state_id) in updates {
                 Self::broadcast_java_grouped(
-                    &CMultiBlockUpdate::new(&updates),
-                    recipients_by_version,
+                    &CBlockUpdate::new(block_pos, i32::from(block_state_id).into()),
+                    recipients_by_version.clone(),
                 );
             }
+        }
+    }
+
+    /// Resends a whole chunk column to every player who can currently see it.
+    ///
+    /// Used by [`Self::flush_block_updates`] when a chunk accumulated so many
+    /// block changes in one flush that a single `CChunkData` packet is cheaper
+    /// than the per-section `CMultiBlockUpdate` packets it would otherwise send.
+    ///
+    /// The Java chunk packet is serialized **once per protocol version** and the
+    /// resulting bytes are shared across every recipient on that version, so a
+    /// dense paste seen by many players costs one serialization per version
+    /// rather than one per player. The `ChunkSend` plugin event is fired a single
+    /// time for the chunk (broadcast semantics): if a plugin cancels it, the
+    /// resend is skipped for everyone.
+    async fn broadcast_chunk_resend(
+        self: &Arc<Self>,
+        chunk_pos: Vector2<i32>,
+        chunk: Arc<ChunkData>,
+    ) {
+        // Fire the plugin event once for this chunk; honor cancellation.
+        if let Some(server) = self.server.upgrade() {
+            let event = ChunkSend::new(self.clone(), chunk.clone());
+            let event = server.plugin_manager.fire(event).await;
+            if event.cancelled {
+                return;
+            }
+        }
+
+        let players = self.players.load();
+        let mut java_recipients = Vec::new();
+        let mut bedrock_recipients = Vec::new();
+
+        for p in players.iter() {
+            let center = p.get_entity().chunk_pos.load();
+            let view_distance = get_view_distance(p).get() as i32;
+            if !is_within_view_distance(chunk_pos, center, view_distance) {
+                continue;
+            }
+            match &p.client {
+                ClientPlatform::Java(_) => java_recipients.push(p),
+                ClientPlatform::Bedrock(be_client) => bedrock_recipients.push(be_client.clone()),
+            }
+        }
+
+        // Java: one serialization per protocol version, shared across recipients.
+        let recipients_by_version =
+            Self::collect_java_recipients_by_version(java_recipients.into_iter());
+        for (version, recipients) in recipients_by_version {
+            let packet_data =
+                match JavaClient::serialize_packet_for_version(&CChunkData(&chunk), version) {
+                    Ok(packet_data) => packet_data,
+                    Err(err) => {
+                        error!("Failed to serialize chunk resend for version {version:?}: {err}");
+                        continue;
+                    }
+                };
+            for recipient in recipients {
+                recipient.try_enqueue_packet_data(packet_data.clone());
+            }
+        }
+
+        // Bedrock: game-packet framing is per-connection (compression/encryption
+        // state lives on the connection), so it cannot share bytes; enqueue the
+        // chunk packet per recipient.
+        for be_client in bedrock_recipients {
+            be_client.try_enqueue_packet(&CLevelChunk {
+                dimension: 0,
+                cache_enabled: false,
+                chunk: &chunk,
+            });
         }
     }
 
@@ -3867,6 +4089,14 @@ impl World {
         block_state_id: BlockStateId,
         flags: BlockFlags,
     ) -> BlockStateId {
+        if !is_valid_block_state_id(block_state_id) {
+            warn!(
+                "Ignoring invalid block state id {} at {:?}",
+                block_state_id, position
+            );
+            return self.get_block_state_id(position);
+        }
+
         let (chunk_coordinate, relative) = position.chunk_and_chunk_relative_position();
         let replaced_block_state_id = self
             .level
@@ -3999,6 +4229,392 @@ impl World {
             .update_lighting_at(&self.level, *position);
 
         replaced_block_state_id
+    }
+
+    /// Sets many blocks before yielding, then queues all client-visible changes at once.
+    ///
+    /// This mirrors [`Self::set_block_state`] side effects, but the raw level writes
+    /// and `unsent_block_changes` updates happen for the whole batch first. That keeps
+    /// a large plugin paste from being flushed to clients a few blocks at a time while
+    /// this async function is still awaiting per-block callbacks.
+    #[expect(clippy::too_many_lines)]
+    pub async fn set_block_states(
+        self: &Arc<Self>,
+        changes: Vec<(BlockPos, BlockStateId)>,
+        flags: BlockFlags,
+    ) {
+        let started = std::time::Instant::now();
+        let original_change_count = changes.len();
+        let mut deduped_changes = HashMap::with_capacity(changes.len());
+        for (position, block_state_id) in changes {
+            deduped_changes.insert(position, block_state_id);
+        }
+        let deduped_change_count = deduped_changes.len();
+        let duplicate_change_count = original_change_count.saturating_sub(deduped_change_count);
+
+        let mut invalid_state_count = 0usize;
+        let mut applied: Vec<(BlockPos, BlockStateId, Option<BlockStateId>)> = deduped_changes
+            .into_iter()
+            .filter(|(_, block_state_id)| {
+                let is_valid = is_valid_block_state_id(*block_state_id);
+                if !is_valid {
+                    invalid_state_count += 1;
+                }
+                is_valid
+            })
+            .map(|(position, block_state_id)| (position, block_state_id, None))
+            .collect();
+        let validated = started.elapsed();
+        debug!(
+            "Bulk block update: received {}, deduped {}, duplicate {}, valid {}, invalid {}, validation {:?}",
+            original_change_count,
+            deduped_change_count,
+            duplicate_change_count,
+            applied.len(),
+            invalid_state_count,
+            validated
+        );
+
+        if invalid_state_count > 0 {
+            warn!(
+                "Ignored {} invalid block state ids in bulk block update",
+                invalid_state_count
+            );
+        }
+
+        if applied.is_empty() {
+            return;
+        }
+
+        let mut changes_by_chunk: HashMap<Vector2<i32>, Vec<BulkChunkWrite>> = HashMap::new();
+        let grouping_started = std::time::Instant::now();
+
+        for (index, (position, block_state_id, _)) in applied.iter().enumerate() {
+            let (chunk_coordinate, relative) = position.chunk_and_chunk_relative_position();
+            changes_by_chunk.entry(chunk_coordinate).or_default().push((
+                index,
+                relative.x as usize,
+                relative.y,
+                relative.z as usize,
+                *block_state_id,
+            ));
+        }
+        let chunk_count = changes_by_chunk.len();
+        debug!(
+            "Bulk block update: grouped {} changes into {} chunks in {:?}",
+            applied.len(),
+            chunk_count,
+            grouping_started.elapsed()
+        );
+
+        let write_started = std::time::Instant::now();
+        let mut write_tasks = JoinSet::new();
+        for (chunk_coordinate, chunk_changes) in changes_by_chunk {
+            while write_tasks.len() >= *MAX_BULK_BLOCK_WRITE_TASKS {
+                if let Some(result) = write_tasks.join_next().await {
+                    Self::apply_bulk_chunk_write_result(result, &mut applied);
+                }
+            }
+
+            let level = self.level.clone();
+            write_tasks.spawn_blocking(move || {
+                let replacements = level.read_chunk_sync(&chunk_coordinate, |chunk| {
+                    let replacements = chunk.set_blocks_absolute_y(&chunk_changes);
+                    if !replacements.is_empty() && !chunk.is_dirty() {
+                        chunk.mark_dirty(true);
+                    }
+                    replacements
+                });
+
+                (chunk_changes, replacements)
+            });
+        }
+
+        while let Some(result) = write_tasks.join_next().await {
+            Self::apply_bulk_chunk_write_result(result, &mut applied);
+        }
+        let write_elapsed = write_started.elapsed();
+
+        let applied: Vec<_> = applied
+            .into_iter()
+            .filter_map(|(position, block_state_id, replaced_block_state_id)| {
+                replaced_block_state_id.map(|replaced_block_state_id| {
+                    (position, replaced_block_state_id, block_state_id)
+                })
+            })
+            .collect();
+        let applied_count = applied.len();
+        debug!(
+            "Bulk block update: chunk writes produced {} changed blocks in {:?}",
+            applied_count, write_elapsed
+        );
+
+        if applied.is_empty() {
+            return;
+        }
+
+        let queue_started = std::time::Instant::now();
+        {
+            let mut unsent_block_changes = self.unsent_block_changes.lock().await;
+            for (position, _, block_state_id) in &applied {
+                unsent_block_changes.insert(*position, *block_state_id);
+            }
+        }
+        debug!(
+            "Bulk block update: queued {} client block changes in {:?}",
+            applied_count,
+            queue_started.elapsed()
+        );
+
+        let lighting_positions: Vec<BlockPos> =
+            applied.iter().map(|(position, _, _)| *position).collect();
+
+        let side_effect_elapsed = if needs_bulk_block_side_effects(flags) {
+            let side_effect_group_started = std::time::Instant::now();
+            let mut applied_by_chunk: HashMap<Vector2<i32>, Vec<_>> = HashMap::new();
+            for change in applied {
+                applied_by_chunk
+                    .entry(change.0.chunk_position())
+                    .or_default()
+                    .push(change);
+            }
+            let side_effect_chunk_count = applied_by_chunk.len();
+            debug!(
+                "Bulk block update: grouped side effects into {} chunks in {:?}",
+                side_effect_chunk_count,
+                side_effect_group_started.elapsed()
+            );
+
+            let side_effect_started = std::time::Instant::now();
+            let mut side_effect_tasks = JoinSet::new();
+            for chunk_changes in applied_by_chunk.into_values() {
+                while side_effect_tasks.len() >= *MAX_BULK_BLOCK_SIDE_EFFECT_TASKS {
+                    if let Some(result) = side_effect_tasks.join_next().await
+                        && let Err(error) = result
+                    {
+                        error!("Bulk block update side-effect task panicked: {error:?}");
+                    }
+                }
+
+                let world = self.clone();
+                side_effect_tasks.spawn(async move {
+                    world
+                        .apply_bulk_block_side_effects(chunk_changes, flags)
+                        .await;
+                });
+            }
+
+            while let Some(result) = side_effect_tasks.join_next().await {
+                if let Err(error) = result {
+                    error!("Bulk block update side-effect task panicked: {error:?}");
+                }
+            }
+            side_effect_started.elapsed()
+        } else {
+            std::time::Duration::ZERO
+        };
+
+        // Relight the whole batch in one pass on the blocking pool, detached
+        // from this call. The propagation drain is synchronous CPU-bound work:
+        // on the runtime workers it starved ticking/keep-alives, and awaited it
+        // held up this call's return — a plugin command runs inline in the
+        // issuing player's packet loop, so a paste whose relight takes longer
+        // than the keep-alive window got that player disconnected even with the
+        // server otherwise healthy. The blocks are already written and queued
+        // for clients at this point; lighting converges in the background.
+        //
+        // `flush_block_updates` may resend dense columns (`CChunkData`) before
+        // this background relight finishes, baking the pre-relight light arrays
+        // into that packet — clients then render the touched area as solid
+        // black until they reload the chunk. Light can propagate up to 15
+        // blocks, so once relighting converges we resend every touched column
+        // plus its neighbors to push the corrected light data out.
+        let mut affected_columns: HashSet<Vector2<i32>> =
+            HashSet::with_capacity(lighting_positions.len());
+        for position in &lighting_positions {
+            let column = position.chunk_position();
+            for dx in -1..=1 {
+                for dz in -1..=1 {
+                    affected_columns.insert(Vector2::new(column.x + dx, column.y + dz));
+                }
+            }
+        }
+
+        let lighting_started = std::time::Instant::now();
+        let lighting_position_count = lighting_positions.len();
+        let level = self.level.clone();
+        let world = self.clone();
+        tokio::task::spawn_blocking(move || {
+            level
+                .light_engine
+                .update_lighting_bulk(&level, lighting_positions);
+            info!(
+                "Bulk block update: relit {} positions in {:?} (background)",
+                lighting_position_count,
+                lighting_started.elapsed()
+            );
+
+            tokio::spawn(async move {
+                for chunk_pos in affected_columns {
+                    if let Some(chunk) = world
+                        .level
+                        .read_chunk_sync(&chunk_pos, std::clone::Clone::clone)
+                    {
+                        world.broadcast_chunk_resend(chunk_pos, chunk).await;
+                    }
+                }
+            });
+        });
+
+        debug!(
+            "Bulk block update: side effects {:?}; applied {} of {} requested changes; total {:?}",
+            side_effect_elapsed,
+            deduped_change_count - invalid_state_count,
+            original_change_count,
+            started.elapsed()
+        );
+    }
+
+    fn apply_bulk_chunk_write_result(
+        result: Result<BulkChunkWriteResult, tokio::task::JoinError>,
+        applied: &mut [(BlockPos, BlockStateId, Option<BlockStateId>)],
+    ) {
+        let Ok((chunk_changes, replacements)) = result else {
+            if let Err(error) = result {
+                error!("Bulk block chunk write task panicked: {error:?}");
+            }
+            return;
+        };
+
+        if let Some(replacements) = replacements {
+            for (index, replaced_block_state_id) in replacements {
+                applied[index].2 = Some(replaced_block_state_id);
+            }
+        } else {
+            for (index, _, _, _, block_state_id) in chunk_changes {
+                if block_state_id != Block::AIR.default_state.id {
+                    applied[index].2 = Some(Block::AIR.default_state.id);
+                }
+            }
+        }
+    }
+
+    /// Per-block side-effect callbacks for one chunk's worth of bulk changes.
+    ///
+    /// The caller has already checked [`needs_bulk_block_side_effects`] and runs
+    /// the batched relight itself once all chunks are done, so this only handles
+    /// the block-entity / neighbor / prepare callbacks.
+    async fn apply_bulk_block_side_effects(
+        self: Arc<Self>,
+        changes: Vec<(BlockPos, BlockStateId, BlockStateId)>,
+        flags: BlockFlags,
+    ) {
+        for (index, (position, replaced_block_state_id, block_state_id)) in
+            changes.into_iter().enumerate()
+        {
+            let old_block = Block::from_state_id(replaced_block_state_id);
+            let new_block = Block::from_state_id(block_state_id);
+
+            let block_moved = flags.contains(BlockFlags::MOVED);
+
+            let is_new_block = old_block != new_block;
+
+            // WorldChunk.java line 305-314
+            if is_new_block
+                && old_block.default_state.block_entity_type != u16::MAX
+                && !flags.contains(BlockFlags::SKIP_BLOCK_ENTITY_REPLACED_CALLBACK)
+                && let Some(entity) = self.get_block_entity(&position)
+            {
+                entity.on_block_replaced(self.clone(), position).await;
+                self.remove_block_entity(&position);
+            }
+
+            // WorldChunk.java line 317
+            if is_new_block && (flags.contains(BlockFlags::NOTIFY_NEIGHBORS) || block_moved) {
+                self.block_registry
+                    .on_state_replaced(
+                        &self,
+                        old_block,
+                        &position,
+                        replaced_block_state_id,
+                        block_moved,
+                    )
+                    .await;
+            }
+
+            // WorldChunk.java line 318
+            if !flags.contains(BlockFlags::SKIP_BLOCK_ADDED_CALLBACK) && new_block != old_block {
+                self.block_registry
+                    .on_placed(
+                        &self,
+                        new_block,
+                        block_state_id,
+                        &position,
+                        replaced_block_state_id,
+                        block_moved,
+                    )
+                    .await;
+                let new_fluid = self.get_fluid(&position);
+                self.block_registry
+                    .on_placed_fluid(
+                        &self,
+                        new_fluid,
+                        block_state_id,
+                        &position,
+                        replaced_block_state_id,
+                        block_moved,
+                    )
+                    .await;
+            }
+
+            // Ig they do this cause it could be modified in chunkPos.setBlockState?
+            if self.get_block_state_id(&position) == block_state_id {
+                if flags.contains(BlockFlags::NOTIFY_LISTENERS) {
+                    // Mob AI update
+                }
+
+                if flags.contains(BlockFlags::NOTIFY_NEIGHBORS) {
+                    self.update_neighbors(&position, None).await;
+                    // TODO: updateComparators
+                }
+
+                if !flags.contains(BlockFlags::FORCE_STATE) {
+                    let mut new_flags = flags;
+                    new_flags.remove(BlockFlags::NOTIFY_NEIGHBORS);
+                    new_flags.remove(BlockFlags::NOTIFY_LISTENERS);
+                    self.block_registry
+                        .prepare(
+                            &self,
+                            &position,
+                            Block::from_state_id(replaced_block_state_id),
+                            replaced_block_state_id,
+                            new_flags,
+                        )
+                        .await;
+                    self.block_registry
+                        .update_neighbors(
+                            &self,
+                            &position,
+                            Block::from_state_id(block_state_id),
+                            new_flags,
+                        )
+                        .await;
+                    self.block_registry
+                        .prepare(
+                            &self,
+                            &position,
+                            Block::from_state_id(block_state_id),
+                            block_state_id,
+                            new_flags,
+                        )
+                        .await;
+                }
+            }
+
+            if (index + 1) % BULK_BLOCK_SIDE_EFFECT_YIELD_INTERVAL == 0 {
+                tokio::task::yield_now().await;
+            }
+        }
     }
 
     pub fn get_max_local_raw_brightness(&self, pos: &BlockPos) -> u8 {

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -4243,14 +4243,10 @@ impl World {
         changes: Vec<(BlockPos, BlockStateId)>,
         flags: BlockFlags,
     ) {
-        let started = std::time::Instant::now();
-        let original_change_count = changes.len();
         let mut deduped_changes = HashMap::with_capacity(changes.len());
         for (position, block_state_id) in changes {
             deduped_changes.insert(position, block_state_id);
         }
-        let deduped_change_count = deduped_changes.len();
-        let duplicate_change_count = original_change_count.saturating_sub(deduped_change_count);
 
         let mut invalid_state_count = 0usize;
         let mut applied: Vec<(BlockPos, BlockStateId, Option<BlockStateId>)> = deduped_changes
@@ -4264,16 +4260,6 @@ impl World {
             })
             .map(|(position, block_state_id)| (position, block_state_id, None))
             .collect();
-        let validated = started.elapsed();
-        debug!(
-            "Bulk block update: received {}, deduped {}, duplicate {}, valid {}, invalid {}, validation {:?}",
-            original_change_count,
-            deduped_change_count,
-            duplicate_change_count,
-            applied.len(),
-            invalid_state_count,
-            validated
-        );
 
         if invalid_state_count > 0 {
             warn!(
@@ -4287,7 +4273,6 @@ impl World {
         }
 
         let mut changes_by_chunk: HashMap<Vector2<i32>, Vec<BulkChunkWrite>> = HashMap::new();
-        let grouping_started = std::time::Instant::now();
 
         for (index, (position, block_state_id, _)) in applied.iter().enumerate() {
             let (chunk_coordinate, relative) = position.chunk_and_chunk_relative_position();
@@ -4299,15 +4284,7 @@ impl World {
                 *block_state_id,
             ));
         }
-        let chunk_count = changes_by_chunk.len();
-        debug!(
-            "Bulk block update: grouped {} changes into {} chunks in {:?}",
-            applied.len(),
-            chunk_count,
-            grouping_started.elapsed()
-        );
 
-        let write_started = std::time::Instant::now();
         let mut write_tasks = JoinSet::new();
         for (chunk_coordinate, chunk_changes) in changes_by_chunk {
             while write_tasks.len() >= *MAX_BULK_BLOCK_WRITE_TASKS {
@@ -4333,7 +4310,6 @@ impl World {
         while let Some(result) = write_tasks.join_next().await {
             Self::apply_bulk_chunk_write_result(result, &mut applied);
         }
-        let write_elapsed = write_started.elapsed();
 
         let applied: Vec<_> = applied
             .into_iter()
@@ -4343,34 +4319,22 @@ impl World {
                 })
             })
             .collect();
-        let applied_count = applied.len();
-        debug!(
-            "Bulk block update: chunk writes produced {} changed blocks in {:?}",
-            applied_count, write_elapsed
-        );
 
         if applied.is_empty() {
             return;
         }
 
-        let queue_started = std::time::Instant::now();
         {
             let mut unsent_block_changes = self.unsent_block_changes.lock().await;
             for (position, _, block_state_id) in &applied {
                 unsent_block_changes.insert(*position, *block_state_id);
             }
         }
-        debug!(
-            "Bulk block update: queued {} client block changes in {:?}",
-            applied_count,
-            queue_started.elapsed()
-        );
 
         let lighting_positions: Vec<BlockPos> =
             applied.iter().map(|(position, _, _)| *position).collect();
 
-        let side_effect_elapsed = if needs_bulk_block_side_effects(flags) {
-            let side_effect_group_started = std::time::Instant::now();
+        if needs_bulk_block_side_effects(flags) {
             let mut applied_by_chunk: HashMap<Vector2<i32>, Vec<_>> = HashMap::new();
             for change in applied {
                 applied_by_chunk
@@ -4378,14 +4342,7 @@ impl World {
                     .or_default()
                     .push(change);
             }
-            let side_effect_chunk_count = applied_by_chunk.len();
-            debug!(
-                "Bulk block update: grouped side effects into {} chunks in {:?}",
-                side_effect_chunk_count,
-                side_effect_group_started.elapsed()
-            );
 
-            let side_effect_started = std::time::Instant::now();
             let mut side_effect_tasks = JoinSet::new();
             for chunk_changes in applied_by_chunk.into_values() {
                 while side_effect_tasks.len() >= *MAX_BULK_BLOCK_SIDE_EFFECT_TASKS {
@@ -4409,10 +4366,7 @@ impl World {
                     error!("Bulk block update side-effect task panicked: {error:?}");
                 }
             }
-            side_effect_started.elapsed()
-        } else {
-            std::time::Duration::ZERO
-        };
+        }
 
         // Relight the whole batch in one pass on the blocking pool, detached
         // from this call. The propagation drain is synchronous CPU-bound work:
@@ -4440,19 +4394,12 @@ impl World {
             }
         }
 
-        let lighting_started = std::time::Instant::now();
-        let lighting_position_count = lighting_positions.len();
         let level = self.level.clone();
         let world = self.clone();
         tokio::task::spawn_blocking(move || {
             level
                 .light_engine
                 .update_lighting_bulk(&level, lighting_positions);
-            info!(
-                "Bulk block update: relit {} positions in {:?} (background)",
-                lighting_position_count,
-                lighting_started.elapsed()
-            );
 
             tokio::spawn(async move {
                 for chunk_pos in affected_columns {
@@ -4465,14 +4412,6 @@ impl World {
                 }
             });
         });
-
-        debug!(
-            "Bulk block update: side effects {:?}; applied {} of {} requested changes; total {:?}",
-            side_effect_elapsed,
-            deduped_change_count - invalid_state_count,
-            original_change_count,
-            started.elapsed()
-        );
     }
 
     fn apply_bulk_chunk_write_result(

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -4272,12 +4272,8 @@ impl World {
         // server otherwise healthy. The blocks are already written and queued
         // for clients at this point; lighting converges in the background.
         //
-        // `flush_block_updates` may resend dense columns (`CChunkData`) before
-        // this background relight finishes, baking the pre-relight light arrays
-        // into that packet — clients then render the touched area as solid
-        // black until they reload the chunk. Light can propagate up to 15
-        // blocks, so once relighting converges we resend every touched column
-        // plus its neighbors to push the corrected light data out.
+        // Light can propagate up to 15 blocks, so once relighting converges send
+        // dedicated light updates for every touched column plus its neighbors.
         let mut affected_columns: HashSet<Vector2<i32>> =
             HashSet::with_capacity(lighting_positions.len());
         for position in &lighting_positions {
@@ -4296,16 +4292,14 @@ impl World {
                 .light_engine
                 .update_lighting_bulk(&level, lighting_positions);
 
-            tokio::spawn(async move {
-                for chunk_pos in affected_columns {
-                    if let Some(chunk) = world
-                        .level
-                        .read_chunk_sync(&chunk_pos, std::clone::Clone::clone)
-                    {
-                        world.broadcast_chunk_resend(chunk_pos, chunk).await;
-                    }
+            for chunk_pos in affected_columns {
+                if let Some(chunk) = world
+                    .level
+                    .read_chunk_sync(&chunk_pos, std::clone::Clone::clone)
+                {
+                    world.broadcast_to_chunk(chunk_pos, &CLightUpdate(&chunk));
                 }
-            });
+            }
         });
     }
 


### PR DESCRIPTION
## Description
This replaces the old per-block update path with a batch block update API (World::set_block_staes, I have it ready, but I am not sure about the structure of this project so please let me know if I should send new code snippets to you on discord or in comments here), designed for large-scale edits like a WorldEdit-style plugin pasting millions of blocks at once. - Important caveat to note here is that actual millions of blocks cannot currently go from a plugin to the engine as the file is too large, so anyone using this API has to make smaller calls to the engine - It is still incredibly fast.

**Problems with current implementation:**
Current implementation allows individual chunk updates or block updates, with re-light for each block as far as I am aware. Client-visible updates are flushed a few sections at a time per tick, so a large paste trickles visually over many ticks.

**What this PR is solving with bulk API:**

- `World::set_block_states(changes, flags)` takes a `Vec<(BlockPos, BlockStateId)>`, dedupes, validates state IDs, and writes all blocks first before running any side effects.
- Chunk writes are parallelized across a bounded task pool (`MAX_BULK_BLOCK_WRITE_TASKS`, scaled to CPU cores) — each chunk only locks its own data, so distinct chunks don't contend.
- Per-block side effects (neighbor updates, block-entity callbacks, redstone, etc.) run on a separate, smaller bounded pool (`MAX_BULK_BLOCK_SIDE_EFFECT_TASKS`), yielding periodically
- Relighting for the whole batch runs once, off the runtime via `update_lighting_bulk`, instead of once per block.
- New chunk write primitve (`pumpkin-world/src/chunk/mod.rs) - `ChunkData::set_blocks_absolute_y` write many blocks while holding the section/heightmap/random-tick locks once, instead of re-acquiring them per block.
**lighting**
- `update_lighting_bulk` seeds light checks for every position first, thgen drains the propagation queues to convergence a single time for the whole batch.
- Added a per-colum "highest opaque block" cache so the open-sky check doesn't rescan the same column repeatedly.
- Propagation queues now drain brightest-first (`drain_highest_first`) instead of FIFO, so each cell is written its final value on the first pass instead of being revisited up to 15 times.
- Added a `#[ignore]` d micro-benchmark test for measuring bulk lighting performance manually.
**Client-side flush changes** (pumpkin/src/world/mod.rs)
- flush_block_updates now drains its entire pending queue each tick (previously throttled), and for chunk columns with ≥ CHUNK_RESEND_BLOCK_THRESHOLD (4096) queued changes, resends the whole chunk via CChunkData/CLevelChunk instead of many per-section CMultiBlockUpdate packets.
- Since the background relight can finish after a dense-column resend (baking stale/black lighting into the packet), affected columns + their neighbors are resent again once the bulk relight converges.
- Fires the ChunkSend plugin event once per resent chunk (broadcast semantics — cancel skips the resend for everyone).
## Testing
`set_block_state` now validates the block state ID and logs+ignores invalid IDs instead of potentially panicking/corrupting state.
Added `Level::new_for_lighting_bench` to support the new lighting benchmark.

I tested the new changes with my worldedit-rs prototype, everything seems to be working just fine, with amazing results as for the speed. The only caveat worth mentioning is when I place or remove very large amounts of blocks - some clusters of blocks seem to have a problem with loading so they're essentially invisible, you can fly closer to them and they appear back again - Relog helps with it so I am guessing it is a client-side issue that I could not resolve due to my limited knowledge of the engine.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
