### PR TITLE
fix: prevent spectator block toggles

### DIFF
--- a/pumpkin/src/block/blocks/doors.rs
+++ b/pumpkin/src/block/blocks/doors.rs
@@ -28,6 +28,7 @@ use crate::block::OnPlaceArgs;
 use crate::block::OnStateReplacedArgs;
 use crate::block::PlacedArgs;
 use crate::block::blocks::redstone::block_receives_redstone_power;
+use crate::block::can_player_toggle_block;
 use crate::block::registry::BlockActionResult;
 use crate::entity::player::Player;
 use pumpkin_protocol::java::server::play::SUseItemOn;
@@ -202,6 +203,10 @@ impl BlockBehaviour for DoorBlock {
 
     fn normal_use<'a>(&'a self, args: NormalUseArgs<'a>) -> BlockFuture<'a, BlockActionResult> {
         Box::pin(async move {
+            if !can_player_toggle_block(args.player.gamemode.load()) {
+                return BlockActionResult::Pass;
+            }
+
             if !can_open_door(args.block) {
                 return BlockActionResult::Pass;
             }

--- a/pumpkin/src/block/blocks/fence_gates.rs
+++ b/pumpkin/src/block/blocks/fence_gates.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::block::blocks::redstone::block_receives_redstone_power;
+use crate::block::can_player_toggle_block;
 use crate::block::registry::BlockActionResult;
 use crate::block::{
     BlockBehaviour, BlockFuture, GetStateForNeighborUpdateArgs, NormalUseArgs,
@@ -107,6 +108,10 @@ impl BlockBehaviour for FenceGateBlock {
 
     fn normal_use<'a>(&'a self, args: NormalUseArgs<'a>) -> BlockFuture<'a, BlockActionResult> {
         Box::pin(async move {
+            if !can_player_toggle_block(args.player.gamemode.load()) {
+                return BlockActionResult::Pass;
+            }
+
             toggle_fence_gate(args.world, args.position, args.player).await;
 
             BlockActionResult::Success

--- a/pumpkin/src/block/blocks/trapdoor.rs
+++ b/pumpkin/src/block/blocks/trapdoor.rs
@@ -1,4 +1,5 @@
 use crate::block::blocks::redstone::block_receives_redstone_power;
+use crate::block::can_player_toggle_block;
 use crate::block::registry::BlockActionResult;
 use crate::block::{BlockBehaviour, BlockFuture, NormalUseArgs, OnNeighborUpdateArgs, OnPlaceArgs};
 use crate::entity::EntityBase;
@@ -69,6 +70,10 @@ pub struct TrapDoorBlock;
 impl BlockBehaviour for TrapDoorBlock {
     fn normal_use<'a>(&'a self, args: NormalUseArgs<'a>) -> BlockFuture<'a, BlockActionResult> {
         Box::pin(async move {
+            if !can_player_toggle_block(args.player.gamemode.load()) {
+                return BlockActionResult::Pass;
+            }
+
             if !can_open_trapdoor(args.block) {
                 return BlockActionResult::Pass;
             }

--- a/pumpkin/src/block/mod.rs
+++ b/pumpkin/src/block/mod.rs
@@ -24,6 +24,7 @@ use pumpkin_data::BlockDirection;
 use pumpkin_data::block_rotation::{Mirror, Rotation};
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_protocol::java::server::play::SUseItemOn;
+use pumpkin_util::GameMode;
 use pumpkin_util::math::boundingbox::BoundingBox;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_world::world::{BlockAccessor, BlockFlags};
@@ -58,6 +59,27 @@ pub(crate) fn bounce_entity_after_fall(entity: &dyn EntityBase, bounce_multiplie
     }
 
     base_entity.velocity.store(velocity);
+}
+
+pub(crate) fn can_player_toggle_block(gamemode: GameMode) -> bool {
+    gamemode != GameMode::Spectator
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spectators_cannot_toggle_blocks() {
+        assert!(!can_player_toggle_block(GameMode::Spectator));
+    }
+
+    #[test]
+    fn non_spectators_can_toggle_blocks() {
+        assert!(can_player_toggle_block(GameMode::Survival));
+        assert!(can_player_toggle_block(GameMode::Creative));
+        assert!(can_player_toggle_block(GameMode::Adventure));
+    }
 }
 
 pub trait BlockBehaviour: Send + Sync {


### PR DESCRIPTION
Fixes #2253

Spectators could still toggle doors, trapdoors, and fence gates through their normal block use handlers. This adds the same spectator guard for those toggle paths and keeps redstone updates unchanged.

Tested with:

cargo test -p pumpkin block::tests::