### PR TITLE
Added fix for water bouncing.

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -991,7 +991,12 @@ impl LivingEntity {
 
         let mut velo = self.entity.velocity.load();
 
+        let descending_in_fluid = self.entity.entity_type == &EntityType::PLAYER
+            && self.entity.is_sneaking()
+            && (self.entity.touching_water.load(SeqCst) || self.entity.touching_lava.load(SeqCst));
+
         if self.entity.horizontal_collision.load(SeqCst)
+            && !descending_in_fluid
             && !self
                 .entity
                 .world

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -991,17 +991,14 @@ impl LivingEntity {
 
         let mut velo = self.entity.velocity.load();
 
-        let descending_in_fluid = self.entity.entity_type == &EntityType::PLAYER
-            && self.entity.is_sneaking()
-            && (self.entity.touching_water.load(SeqCst) || self.entity.touching_lava.load(SeqCst));
+        let colliding_with_fluid = self
+            .entity
+            .world
+            .load()
+            .check_fluid_collision(self.entity.bounding_box.load().shift(velo));
 
         if self.entity.horizontal_collision.load(SeqCst)
-            && !descending_in_fluid
-            && !self
-                .entity
-                .world
-                .load()
-                .check_fluid_collision(self.entity.bounding_box.load().shift(velo))
+            && !colliding_with_fluid
         {
             velo.y = 0.3;
 


### PR DESCRIPTION
## Fix for water bouncing: #2262 
---
### Description:

The issue was that the the water “step out” boost still fired while a player would sneak to descend.
The water “step out” boost now skips players who are sneaking while in fluid, so swimming downward should no longer get converted into an upward bounce.

---

here is a recording of me testing the changes, and there seems to be no bounce. (the recording was too large to upload here)
https://drive.google.com/file/d/1DqLUmaQTvr562D_72JY-_9MPwSvRtVdj/view?usp=drive_link
