### PR TITLE
fix: prevent statistic overflow panics

### DIFF
--- a/pumpkin/src/entity/player/statistics.rs
+++ b/pumpkin/src/entity/player/statistics.rs
@@ -12,7 +12,7 @@ pub struct Statistics {
 impl Statistics {
     pub fn increment(&mut self, category: StatisticCategory, stat: i32, amount: i32) {
         let entry = self.stats.entry((category as i32, stat)).or_insert(0);
-        *entry += amount;
+        *entry = entry.saturating_add(amount);
     }
 
     pub fn increment_custom(&mut self, stat: CustomStatistic, amount: i32) {


### PR DESCRIPTION
Reproduced on latest master (8634d874) by running /kill on a player, which panicked at player/statistics.rs while incrementing a stat.\n\nThis changes statistic increments to saturate instead of overflowing. Stats are counters, so hitting an integer bound should not take the server down.\n\nTests:\n- cargo test -p pumpkin increment_saturates_when_stat_is_at_i32_ --quiet