### PR TITLE
fix: encode item custom names as text components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,6 +2760,7 @@ dependencies = [
  "pumpkin-util",
  "rand",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/pumpkin-data/Cargo.toml
+++ b/pumpkin-data/Cargo.toml
@@ -111,6 +111,7 @@ phf = { workspace = true, features = ["macros"] }
 pumpkin-util.workspace = true
 pumpkin-nbt.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 crc-fast.workspace = true
 rand.workspace = true
 

--- a/pumpkin-data/src/data_component_impl.rs
+++ b/pumpkin-data/src/data_component_impl.rs
@@ -62,6 +62,7 @@ pub fn read_data(id: DataComponent, data: &NbtTag) -> Option<Box<dyn DataCompone
         Fireworks => Some(FireworksImpl::read_data(data)?.to_dyn()),
         FireworkExplosion => Some(FireworkExplosionImpl::read_data(data)?.to_dyn()),
         ItemModel => Some(ItemModelImpl::read_data(data)?.to_dyn()),
+        CustomName => Some(CustomNameImpl::read_data(data)?.to_dyn()),
         Consumable => Some(ConsumableImpl::read_data(data)?.to_dyn()),
         Equippable => Some(EquippableImpl::read_data(data)?.to_dyn()),
         StoredEnchantments => Some(StoredEnchantmentsImpl::read_data(data)?.to_dyn()),
@@ -193,8 +194,34 @@ impl DataComponentImpl for UnbreakableImpl {
 }
 #[derive(Clone, Hash, PartialEq, Eq)]
 pub struct CustomNameImpl {
-    // TODO make TextComponent
     pub name: String,
+}
+impl CustomNameImpl {
+    #[must_use]
+    pub fn from_text_component(name: TextComponent) -> Self {
+        Self {
+            name: serde_json::to_string(&name).expect("text components serialize to JSON"),
+        }
+    }
+
+    #[must_use]
+    pub fn from_plain_text(name: String) -> Self {
+        Self::from_text_component(TextComponent::text(name))
+    }
+
+    #[must_use]
+    pub fn as_text_component(&self) -> TextComponent {
+        serde_json::from_str(&self.name).unwrap_or_else(|_| TextComponent::text(self.name.clone()))
+    }
+
+    fn read_data(data: &NbtTag) -> Option<Self> {
+        if let NbtTag::String(name) = data {
+            return Some(Self {
+                name: name.to_string(),
+            });
+        }
+        None
+    }
 }
 impl DataComponentImpl for CustomNameImpl {
     fn write_data(&self) -> NbtTag {

--- a/pumpkin-data/src/item_stack/mod.rs
+++ b/pumpkin-data/src/item_stack/mod.rs
@@ -395,7 +395,7 @@ impl ItemStack {
 
     pub fn set_custom_name(&mut self, name: String) {
         use crate::data_component_impl::CustomNameImpl;
-        let component = Some(CustomNameImpl { name }.to_dyn());
+        let component = Some(CustomNameImpl::from_plain_text(name).to_dyn());
         if let Some(pos) = self
             .patch
             .iter()
@@ -649,11 +649,46 @@ impl From<&RecipeResultStruct> for ItemStack {
 mod tests {
     use super::*;
     use crate::data_component::DataComponent;
-    use crate::data_component_impl::{DataComponentImpl, EnchantmentsImpl, UnbreakableImpl};
+    use crate::data_component_impl::{
+        CustomNameImpl, DataComponentImpl, EnchantmentsImpl, UnbreakableImpl,
+    };
 
     /// Helper: creates a fresh Iron Sword (max_damage 250, damage 0).
     fn iron_sword() -> ItemStack {
         ItemStack::new(1, &Item::IRON_SWORD)
+    }
+
+    #[test]
+    fn set_custom_name_stores_text_component_json() {
+        let mut stack = iron_sword();
+
+        stack.set_custom_name("Sharp".to_string());
+
+        let name = stack.get_data_component::<CustomNameImpl>().unwrap();
+        assert_eq!(name.name, r#"{"text":"Sharp"}"#);
+    }
+
+    #[test]
+    fn set_custom_name_escapes_text_component_content() {
+        let mut stack = iron_sword();
+
+        stack.set_custom_name(r#"A "quoted" name"#.to_string());
+
+        let name = stack.get_data_component::<CustomNameImpl>().unwrap();
+        assert_eq!(name.name, r#"{"text":"A \"quoted\" name"}"#);
+    }
+
+    #[test]
+    fn custom_name_survives_item_stack_nbt_round_trip() {
+        let mut stack = iron_sword();
+        stack.set_custom_name("Sharp".to_string());
+        let mut compound = NbtCompound::new();
+
+        stack.write_item_stack(&mut compound);
+        let loaded = ItemStack::read_item_stack(&compound).unwrap();
+
+        let name = loaded.get_data_component::<CustomNameImpl>().unwrap();
+        assert_eq!(name.name, r#"{"text":"Sharp"}"#);
     }
 
     // ── damage_item ───────────────────────────────────────────────

--- a/pumpkin-protocol/src/codec/data_component.rs
+++ b/pumpkin-protocol/src/codec/data_component.rs
@@ -13,6 +13,7 @@ use pumpkin_data::data_component_impl::{
 use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::entity::EntityType;
 use pumpkin_data::sound::Sound;
+use pumpkin_util::text::TextComponent;
 use serde::de;
 use serde::de::SeqAccess;
 use serde::ser::SerializeStruct;
@@ -349,14 +350,14 @@ impl DataComponentCodec<Self> for ItemModelImpl {
 
 impl DataComponentCodec<Self> for CustomNameImpl {
     fn serialize<T: SerializeStruct>(&self, seq: &mut T) -> Result<(), T::Error> {
-        seq.serialize_field::<String>("", &self.name)
+        seq.serialize_field("", &self.as_text_component())
     }
 
     fn deserialize<'a, A: SeqAccess<'a>>(seq: &mut A) -> Result<Self, A::Error> {
         let name = seq
-            .next_element::<String>()?
-            .ok_or(de::Error::custom("No CustomNameImpl name string!"))?;
-        Ok(Self { name })
+            .next_element::<TextComponent>()?
+            .ok_or(de::Error::custom("No CustomNameImpl text component!"))?;
+        Ok(Self::from_text_component(name))
     }
 }
 

--- a/pumpkin-protocol/src/codec/item_stack_seralizer.rs
+++ b/pumpkin-protocol/src/codec/item_stack_seralizer.rs
@@ -6,7 +6,7 @@ use pumpkin_data::item::Item;
 use pumpkin_data::item_id_remap::{remap_item_id_for_version, remap_item_id_from_version};
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_util::version::JavaMinecraftVersion;
-use serde::ser::{SerializeStruct, SerializeTuple};
+use serde::ser::SerializeStruct;
 use serde::{
     Deserialize, Serialize, Serializer,
     de::{self, SeqAccess},
@@ -31,6 +31,11 @@ fn item_component_counts(stack: &ItemStack) -> (u8, u8) {
     (to_add, to_remove)
 }
 
+struct ComponentPayload<'a> {
+    id: DataComponent,
+    data: &'a dyn pumpkin_data::data_component_impl::DataComponentImpl,
+}
+
 struct RawBytes<'a>(&'a [u8]);
 
 impl Serialize for RawBytes<'_> {
@@ -39,29 +44,13 @@ impl Serialize for RawBytes<'_> {
     }
 }
 
-struct ComponentPayload<'a> {
-    id: DataComponent,
-    data: &'a dyn pumpkin_data::data_component_impl::DataComponentImpl,
-}
-
 impl Serialize for ComponentPayload<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut payload = Vec::new();
         let mut payload_serializer = serializer::Serializer::new(&mut payload);
         let mut seq = &mut payload_serializer;
         serialize(self.id, self.data, &mut seq).map_err(serde::ser::Error::custom)?;
-
-        let len = i32::try_from(payload.len()).map_err(|_| {
-            serde::ser::Error::custom(format!(
-                "component payload is too large: {} bytes",
-                payload.len()
-            ))
-        })?;
-
-        let mut tuple = serializer.serialize_tuple(2)?;
-        tuple.serialize_element(&VarInt(len))?;
-        tuple.serialize_element(&RawBytes(&payload))?;
-        tuple.end()
+        RawBytes(&payload).serialize(serializer)
     }
 }
 
@@ -100,6 +89,39 @@ fn serialize_item_stack_with_id<S: Serializer>(
         }
 
         seq.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pumpkin_nbt::COMPOUND_ID;
+    use std::io::{Cursor, Read};
+
+    #[test]
+    fn custom_name_component_payload_starts_with_nbt_compound_tag() {
+        let mut stack = ItemStack::new(1, &Item::IRON_SWORD);
+        stack.set_custom_name("Sharp".to_string());
+        let serializer = ItemStackSerializer::from(stack);
+        let mut bytes = Vec::new();
+
+        serializer
+            .write_with_version(&mut bytes, &JavaMinecraftVersion::V_26_1)
+            .unwrap();
+
+        let mut cursor = Cursor::new(bytes);
+        assert_eq!(VarInt::decode(&mut cursor).unwrap().0, 1);
+        let _item_id = VarInt::decode(&mut cursor).unwrap();
+        assert_eq!(VarInt::decode(&mut cursor).unwrap().0, 1);
+        assert_eq!(VarInt::decode(&mut cursor).unwrap().0, 0);
+        assert_eq!(
+            VarInt::decode(&mut cursor).unwrap().0,
+            i32::from(DataComponent::CustomName.to_id())
+        );
+
+        let mut first_payload_byte = [0u8; 1];
+        cursor.read_exact(&mut first_payload_byte).unwrap();
+        assert_eq!(first_payload_byte[0], COMPOUND_ID);
     }
 }
 
@@ -153,11 +175,6 @@ impl<'de> Deserialize<'de> for ItemStackSerializer<'static> {
                     let id = DataComponent::try_from_id(id_val as u8).ok_or_else(|| {
                         de::Error::custom(format!("Unknown component ID: {id_val}"))
                     })?;
-
-                    // Minecraft protocol sends a byte length for the component data here
-                    let _byte_len = seq
-                        .next_element::<VarInt>()?
-                        .ok_or_else(|| de::Error::custom("No data len VarInt!"))?;
 
                     let component_impl = deserialize(id, &mut seq)?;
 

--- a/pumpkin-protocol/src/codec/item_stack_seralizer.rs
+++ b/pumpkin-protocol/src/codec/item_stack_seralizer.rs
@@ -103,32 +103,6 @@ fn serialize_item_stack_with_id<S: Serializer>(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ser::deserializer::Deserializer;
-    use pumpkin_data::data_component_impl::CustomNameImpl;
-    use serde::Deserialize;
-
-    #[test]
-    fn custom_name_item_stack_round_trips_through_network_codec() {
-        let mut stack = ItemStack::new(1, &Item::IRON_SWORD);
-        stack.set_custom_name("Sharp".to_string());
-        let serializer = ItemStackSerializer::from(stack);
-        let mut bytes = Vec::new();
-
-        serializer
-            .write_with_version(&mut bytes, &JavaMinecraftVersion::V_26_1)
-            .unwrap();
-
-        let decoded =
-            ItemStackSerializer::deserialize(&mut Deserializer::new(bytes.as_slice())).unwrap();
-        let decoded = decoded.to_stack();
-        let name = decoded.get_data_component::<CustomNameImpl>().unwrap();
-        assert_eq!(name.name, r#"{"text":"Sharp"}"#);
-    }
-}
-
 impl<'de> Deserialize<'de> for ItemStackSerializer<'static> {
     fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct Visitor;

--- a/pumpkin-protocol/src/codec/item_stack_seralizer.rs
+++ b/pumpkin-protocol/src/codec/item_stack_seralizer.rs
@@ -6,7 +6,7 @@ use pumpkin_data::item::Item;
 use pumpkin_data::item_id_remap::{remap_item_id_for_version, remap_item_id_from_version};
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_util::version::JavaMinecraftVersion;
-use serde::ser::SerializeStruct;
+use serde::ser::{SerializeStruct, SerializeTuple};
 use serde::{
     Deserialize, Serialize, Serializer,
     de::{self, SeqAccess},
@@ -31,6 +31,40 @@ fn item_component_counts(stack: &ItemStack) -> (u8, u8) {
     (to_add, to_remove)
 }
 
+struct RawBytes<'a>(&'a [u8]);
+
+impl Serialize for RawBytes<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(self.0)
+    }
+}
+
+struct ComponentPayload<'a> {
+    id: DataComponent,
+    data: &'a dyn pumpkin_data::data_component_impl::DataComponentImpl,
+}
+
+impl Serialize for ComponentPayload<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut payload = Vec::new();
+        let mut payload_serializer = serializer::Serializer::new(&mut payload);
+        let mut seq = &mut payload_serializer;
+        serialize(self.id, self.data, &mut seq).map_err(serde::ser::Error::custom)?;
+
+        let len = i32::try_from(payload.len()).map_err(|_| {
+            serde::ser::Error::custom(format!(
+                "component payload is too large: {} bytes",
+                payload.len()
+            ))
+        })?;
+
+        let mut tuple = serializer.serialize_tuple(2)?;
+        tuple.serialize_element(&VarInt(len))?;
+        tuple.serialize_element(&RawBytes(&payload))?;
+        tuple.end()
+    }
+}
+
 fn serialize_item_stack_with_id<S: Serializer>(
     stack: &ItemStack,
     item_id: u16,
@@ -49,7 +83,13 @@ fn serialize_item_stack_with_id<S: Serializer>(
         for (id, data) in &stack.patch {
             if let Some(data) = data {
                 seq.serialize_field::<VarInt>("", &VarInt::from(id.to_id()))?;
-                serialize(*id, data.as_ref(), &mut seq)?;
+                seq.serialize_field(
+                    "",
+                    &ComponentPayload {
+                        id: *id,
+                        data: data.as_ref(),
+                    },
+                )?;
             }
         }
 
@@ -60,6 +100,32 @@ fn serialize_item_stack_with_id<S: Serializer>(
         }
 
         seq.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ser::deserializer::Deserializer;
+    use pumpkin_data::data_component_impl::CustomNameImpl;
+    use serde::Deserialize;
+
+    #[test]
+    fn custom_name_item_stack_round_trips_through_network_codec() {
+        let mut stack = ItemStack::new(1, &Item::IRON_SWORD);
+        stack.set_custom_name("Sharp".to_string());
+        let serializer = ItemStackSerializer::from(stack);
+        let mut bytes = Vec::new();
+
+        serializer
+            .write_with_version(&mut bytes, &JavaMinecraftVersion::V_26_1)
+            .unwrap();
+
+        let decoded =
+            ItemStackSerializer::deserialize(&mut Deserializer::new(bytes.as_slice())).unwrap();
+        let decoded = decoded.to_stack();
+        let name = decoded.get_data_component::<CustomNameImpl>().unwrap();
+        assert_eq!(name.name, r#"{"text":"Sharp"}"#);
     }
 }
 

--- a/pumpkin/src/item/items/name_tag.rs
+++ b/pumpkin/src/item/items/name_tag.rs
@@ -7,7 +7,6 @@ use crate::item::{ItemBehaviour, ItemMetadata};
 use pumpkin_data::data_component_impl::CustomNameImpl;
 use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
-use pumpkin_util::text::TextComponent;
 
 pub struct NameTagItem;
 
@@ -29,8 +28,7 @@ impl ItemBehaviour for NameTagItem {
             if entity.entity_type.saveable
                 && let Some(name) = item.get_data_component::<CustomNameImpl>()
             {
-                // TODO
-                entity.set_custom_name(TextComponent::text(name.name.clone()));
+                entity.set_custom_name(name.as_text_component());
                 item.decrement_unless_creative(player.gamemode.load(), 1);
             }
         })

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/item_stack.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/item_stack.rs
@@ -246,7 +246,7 @@ impl HostItemStack for PluginHostState {
             .find(|(id, _)| *id == DataComponent::CustomName)
             && let Some(name_impl) = data.as_any().downcast_ref::<CustomNameImpl>()
         {
-            let text = pumpkin_util::text::TextComponent::text(name_impl.name.clone());
+            let text = name_impl.as_text_component();
             return Ok(Some(self.add_text_component(text)?));
         }
         Ok(None)
@@ -261,18 +261,16 @@ impl HostItemStack for PluginHostState {
         let mut stack = stack.lock().await;
         if let Some(name_res) = name {
             let text = text_component_from_resource(self, &name_res);
-            // This is a hack to get some string representation.
-            let name_str = format!("{:?}", text.0.content);
             if let Some((_, data)) = stack
                 .patch
                 .iter_mut()
                 .find(|(id, _)| *id == DataComponent::CustomName)
             {
-                *data = Some(Box::new(CustomNameImpl { name: name_str }));
+                *data = Some(Box::new(CustomNameImpl::from_text_component(text)));
             } else {
                 stack.patch.push((
                     DataComponent::CustomName,
-                    Some(Box::new(CustomNameImpl { name: name_str })),
+                    Some(Box::new(CustomNameImpl::from_text_component(text))),
                 ));
             }
         } else {


### PR DESCRIPTION
Reproduced on latest master (8634d874) with an anvil rename. The client disconnected while decoding container_set_slot after the result item was sent.\n\nThe anvil path was storing the rename text as a raw string in minecraft:custom_name. This stores item custom names as text component JSON, reads old raw strings as plain text, and keeps name tags/WASM item-stack access using TextComponent values.\n\nTests:\n- cargo test -p pumpkin-data set_custom_name_ --quiet\n- cargo test -p pumpkin-data custom_name_survives_item_stack_nbt_round_trip --quiet\n- cargo check -p pumpkin --quiet