### PR TITLE
fix(plugin): `inherit_stdout` and `inherit_stderr` in Wasm plugins.

### DIFF
--- a/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
@@ -152,6 +152,9 @@ impl WasmPlugin {
 
         let mut builder = WasiCtxBuilder::new();
 
+        builder.inherit_stdout();
+        builder.inherit_stderr();
+
         let metadata = context.get_metadata();
         let blocked_permissions = &context.server.advanced_config.plugins.blocked_permissions;
 

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/state.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/state.rs
@@ -83,7 +83,10 @@ impl PluginHostState {
     pub fn new() -> Self {
         let resource_table = ResourceTable::new();
         Self {
-            wasi_ctx: WasiCtxBuilder::new().build(),
+            wasi_ctx: WasiCtxBuilder::new()
+                .inherit_stdout() // allow messages & errors to be printed
+                .inherit_stderr() // before `on_load`, e.g. during metadata retrieval
+                .build(),
             wasi_http_ctx: WasiHttpCtx::new(),
             wasi_http_hooks: PluginHttpHooks::new(),
             resource_table,


### PR DESCRIPTION
## Description

Enables `inherit_stdout` and `inherit_stderr` to allow plugins to successfully write to standard WASI stdout/stderr (without Pumpkin logging API).

Plugin authors don't always have control to force everything through the logging API, so this allows stdout/stderr writes outside of their control to work properly.

## Testing

Testing was done by creating some example Python plugins. Using `print` during `get_metadata` (early, before permissions) and `on_load` (after permissions), which writes to stdout. Also, an error (missing parameter for PluginMetadata constructor) was introduced, to verify that the Python error backtrace was correctly dumped to the terminal before aborting.