### PR TITLE
feat(world): add SlimeWorld (.slime) chunk format

### DIFF
--- a/pumpkin-config/src/chunk.rs
+++ b/pumpkin-config/src/chunk.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 
 /// Configuration for chunk storage format.
 ///
-/// Supports multiple chunk formats, currently `Anvil` and `Linear`.
+/// Supports multiple chunk formats: `Anvil`, `Linear`, `Pump`, and the
+/// read-only `Slime` (AdvancedSlimePaper `.slime`) format.
 #[derive(Deserialize, Default, Serialize, Clone)]
 #[serde(tag = "type")]
 pub enum ChunkConfig {
@@ -18,6 +19,12 @@ pub enum ChunkConfig {
     #[serde(rename = "pump")]
     #[default]
     Pump,
+    /// SlimeWorld (`.slime`) format, loaded read-only (AdvancedSlimePaper v13).
+    ///
+    /// The whole world is read into memory from the first `*.slime` file in the
+    /// world folder; runtime changes are not written back.
+    #[serde(rename = "slime")]
+    Slime,
 }
 
 /// Configuration for Anvil chunk storage.

--- a/pumpkin-config/src/chunk.rs
+++ b/pumpkin-config/src/chunk.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for chunk storage format.
 ///
 /// Supports multiple chunk formats: `Anvil`, `Linear`, `Pump`, and the
-/// read-only `Slime` (AdvancedSlimePaper `.slime`) format.
+/// read-only `Slime` (`AdvancedSlimePaper` `.slime`) format.
 #[derive(Deserialize, Default, Serialize, Clone)]
 #[serde(tag = "type")]
 pub enum ChunkConfig {
@@ -19,7 +19,7 @@ pub enum ChunkConfig {
     #[serde(rename = "pump")]
     #[default]
     Pump,
-    /// SlimeWorld (`.slime`) format, loaded read-only (AdvancedSlimePaper v13).
+    /// `SlimeWorld` (`.slime`) format, loaded read-only (`AdvancedSlimePaper` v13).
     ///
     /// The whole world is read into memory from the first `*.slime` file in the
     /// world folder; runtime changes are not written back.

--- a/pumpkin-data/src/generated/fluid.rs
+++ b/pumpkin-data/src/generated/fluid.rs
@@ -902,7 +902,7 @@ impl FluidProperties for WaterLikeFluidProperties {
         if !["water", "lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "WaterLikeFluidProperties"
+                fluid.name, "WaterLikeFluidProperties"
             );
         }
         let prop_index = self.to_index();
@@ -916,7 +916,7 @@ impl FluidProperties for WaterLikeFluidProperties {
         if !["water", "lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "WaterLikeFluidProperties"
+                fluid.name, "WaterLikeFluidProperties"
             );
         }
         for (idx, state) in fluid.states.iter().enumerate() {
@@ -930,7 +930,7 @@ impl FluidProperties for WaterLikeFluidProperties {
         if !["water", "lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "WaterLikeFluidProperties"
+                fluid.name, "WaterLikeFluidProperties"
             );
         }
         Self::from_index(fluid.default_state_index)
@@ -942,7 +942,7 @@ impl FluidProperties for WaterLikeFluidProperties {
         if !["water", "lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "WaterLikeFluidProperties"
+                fluid.name, "WaterLikeFluidProperties"
             );
         }
         let mut fluid_props = Self::default(fluid);
@@ -990,7 +990,7 @@ impl FluidProperties for FlowingWaterLikeFluidProperties {
         if !["flowing_water", "flowing_lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "FlowingWaterLikeFluidProperties"
+                fluid.name, "FlowingWaterLikeFluidProperties"
             );
         }
         let prop_index = self.to_index();
@@ -1004,7 +1004,7 @@ impl FluidProperties for FlowingWaterLikeFluidProperties {
         if !["flowing_water", "flowing_lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "FlowingWaterLikeFluidProperties"
+                fluid.name, "FlowingWaterLikeFluidProperties"
             );
         }
         for (idx, state) in fluid.states.iter().enumerate() {
@@ -1018,7 +1018,7 @@ impl FluidProperties for FlowingWaterLikeFluidProperties {
         if !["flowing_water", "flowing_lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "FlowingWaterLikeFluidProperties"
+                fluid.name, "FlowingWaterLikeFluidProperties"
             );
         }
         Self::from_index(fluid.default_state_index)
@@ -1033,7 +1033,7 @@ impl FluidProperties for FlowingWaterLikeFluidProperties {
         if !["flowing_water", "flowing_lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "FlowingWaterLikeFluidProperties"
+                fluid.name, "FlowingWaterLikeFluidProperties"
             );
         }
         let mut fluid_props = Self::default(fluid);

--- a/pumpkin-world/src/chunk/format/mod.rs
+++ b/pumpkin-world/src/chunk/format/mod.rs
@@ -34,6 +34,7 @@ use super::{
 pub mod anvil;
 pub mod linear;
 pub mod pump;
+pub mod slime;
 
 impl SingleChunkDataSerializer for ChunkData {
     #[inline]

--- a/pumpkin-world/src/chunk/format/slime/convert.rs
+++ b/pumpkin-world/src/chunk/format/slime/convert.rs
@@ -1,0 +1,311 @@
+//! Convert a parsed [`SlimeChunk`] into Pumpkin's native chunk representation.
+//!
+//! SlimeWorld stores chunk block states and biomes as the *vanilla* paletted
+//! NBT (a palette of namespaced names, not Pumpkin's numeric ids), so the names
+//! are resolved to global block-state / biome ids here before the section
+//! palettes are built. Block entities and entities are mapped onto
+//! [`ChunkData::pending_block_entities`] and [`ChunkEntityData`] respectively.
+
+use std::collections::BTreeMap;
+use std::io::Cursor;
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicBool, AtomicU32};
+
+use bytes::Bytes;
+use pumpkin_data::{Block, biome::Biome, chunk::ChunkStatus};
+use pumpkin_nbt::compound::NbtCompound;
+use pumpkin_util::math::position::BlockPos;
+use rustc_hash::FxHashMap;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::chunk::format::{ChunkSectionBiomes, ChunkSectionBlockStates, LightContainer};
+use crate::chunk::palette::{BiomePalette, BlockPalette};
+use crate::chunk::{ChunkData, ChunkEntityData, ChunkHeightmaps, ChunkLight, ChunkSections};
+use crate::generation::section_coords;
+use crate::tick::scheduler::ChunkTickScheduler;
+
+use super::{LIGHT_ARRAY_SIZE, SlimeChunk, SlimeError};
+
+/// Vanilla `block_states` section payload (`{ palette, data }`).
+#[derive(Deserialize)]
+struct VanillaBlockStates {
+    palette: Vec<VanillaPaletteEntry>,
+    #[serde(default)]
+    data: Option<Box<[i64]>>,
+}
+
+/// A single vanilla block-state palette entry (`{ Name, Properties? }`).
+#[derive(Deserialize)]
+struct VanillaPaletteEntry {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Properties", default)]
+    properties: Option<BTreeMap<String, String>>,
+}
+
+/// Vanilla `biomes` section payload (`{ palette, data }`).
+#[derive(Deserialize)]
+struct VanillaBiomes {
+    palette: Vec<String>,
+    #[serde(default)]
+    data: Option<Box<[i64]>>,
+}
+
+/// A list of compound tags under a single key, e.g. `{ tileEntities: [ … ] }`.
+#[derive(Deserialize)]
+struct CompoundList {
+    #[serde(alias = "tileEntities", alias = "entities", default)]
+    items: Vec<NbtCompound>,
+}
+
+/// Strip the optional `minecraft:` namespace prefix.
+fn strip_namespace(name: &str) -> &str {
+    name.strip_prefix("minecraft:").unwrap_or(name)
+}
+
+/// Resolve a vanilla palette entry (block name + properties) to a Pumpkin global
+/// block-state id, falling back to air for unknown blocks.
+fn palette_entry_to_state_id(entry: &VanillaPaletteEntry) -> u16 {
+    let Some(block) = Block::from_registry_key(strip_namespace(&entry.name)) else {
+        return Block::AIR.default_state.id;
+    };
+    match &entry.properties {
+        Some(properties) if !properties.is_empty() => {
+            let props: Vec<(&str, &str)> = properties
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str()))
+                .collect();
+            block.from_properties(&props).to_state_id(block)
+        }
+        _ => block.default_state.id,
+    }
+}
+
+/// Resolve a vanilla biome name to a Pumpkin biome id, defaulting to plains.
+fn biome_name_to_id(name: &str) -> u8 {
+    Biome::from_name(strip_namespace(name)).map_or(Biome::PLAINS.id, |biome| biome.id)
+}
+
+/// Decode a vanilla UUID stored as an `int[4]` array (`[most_hi, most_lo, least_hi, least_lo]`).
+fn uuid_from_int_array(array: &[i32]) -> Option<Uuid> {
+    let [most_hi, most_lo, least_hi, least_lo] = *<&[i32; 4]>::try_from(array).ok()?;
+    let most = (u64::from(most_hi.cast_unsigned()) << 32) | u64::from(most_lo.cast_unsigned());
+    let least = (u64::from(least_hi.cast_unsigned()) << 32) | u64::from(least_lo.cast_unsigned());
+    Some(Uuid::from_u128((u128::from(most) << 64) | u128::from(least)))
+}
+
+/// Parse a named-compound NBT segment into `T`; empty segments yield `None`.
+fn parse_segment<T: for<'de> Deserialize<'de>>(bytes: &Bytes) -> Result<Option<T>, SlimeError> {
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    pumpkin_nbt::from_bytes::<T>(Cursor::new(bytes.as_ref()))
+        .map(Some)
+        .map_err(|_| SlimeError::Corrupt("invalid nbt segment"))
+}
+
+fn light_container(array: Option<&Bytes>) -> LightContainer {
+    match array {
+        Some(bytes) if bytes.len() == LIGHT_ARRAY_SIZE => {
+            LightContainer::Full(bytes.to_vec().into_boxed_slice())
+        }
+        _ => LightContainer::Empty(0),
+    }
+}
+
+/// Convert a [`SlimeChunk`] into Pumpkin's [`ChunkData`].
+///
+/// `min_section_y` is the bottom-most section index of the target dimension
+/// (e.g. `-4` for the overworld); SlimeWorld stores sections bottom-up without
+/// an explicit Y, so the absolute section Y of section `i` is `min_section_y + i`.
+///
+/// # Errors
+///
+/// Returns [`SlimeError`] if any of the chunk's NBT payloads are malformed.
+pub(crate) fn chunk_to_chunk_data(
+    chunk: &SlimeChunk,
+    min_section_y: i32,
+) -> Result<ChunkData, SlimeError> {
+    let section_count = chunk.sections.len();
+    let mut block_lights = vec![LightContainer::Empty(0); section_count];
+    let mut sky_lights = vec![LightContainer::Empty(0); section_count];
+    let mut block_palettes = vec![BlockPalette::default(); section_count];
+    let mut biome_palettes = vec![BiomePalette::default(); section_count];
+
+    for (index, section) in chunk.sections.iter().enumerate() {
+        block_lights[index] = light_container(section.block_light.as_ref());
+        sky_lights[index] = light_container(section.sky_light.as_ref());
+
+        if let Some(states) = parse_segment::<VanillaBlockStates>(&section.block_states)? {
+            let palette: Box<[u16]> =
+                states.palette.iter().map(palette_entry_to_state_id).collect();
+            block_palettes[index] = BlockPalette::from_disk_nbt(ChunkSectionBlockStates {
+                data: states.data,
+                palette,
+            });
+        }
+        if let Some(biomes) = parse_segment::<VanillaBiomes>(&section.biomes)? {
+            let palette: Box<[u8]> =
+                biomes.palette.iter().map(|name| biome_name_to_id(name)).collect();
+            biome_palettes[index] = BiomePalette::from_disk_nbt(ChunkSectionBiomes {
+                data: biomes.data,
+                palette,
+            });
+        }
+    }
+
+    let light_engine = ChunkLight {
+        block_light: block_lights.into_boxed_slice(),
+        sky_light: sky_lights.into_boxed_slice(),
+    };
+    let has_light = chunk
+        .sections
+        .iter()
+        .any(|section| section.block_light.is_some() || section.sky_light.is_some());
+
+    let min_y = section_coords::section_to_block(min_section_y);
+    let (random_tick_sections, randomly_ticking_mask) =
+        ChunkSections::build_random_tick_sections_cache(&block_palettes);
+    let section = ChunkSections {
+        count: block_palettes.len(),
+        block_sections: RwLock::new(block_palettes.into_boxed_slice()),
+        random_tick_sections: RwLock::new(random_tick_sections),
+        randomly_ticking_mask: AtomicU32::new(randomly_ticking_mask),
+        biome_sections: RwLock::new(biome_palettes.into_boxed_slice()),
+        min_y,
+    };
+
+    let heightmap = parse_segment::<ChunkHeightmaps>(&chunk.height_maps)?.unwrap_or(ChunkHeightmaps {
+        world_surface: None,
+        motion_blocking: None,
+        motion_blocking_no_leaves: None,
+    });
+
+    let mut block_entities = FxHashMap::default();
+    if let Some(list) = parse_segment::<CompoundList>(&chunk.block_entities)? {
+        for entity in list.items {
+            if let (Some(x), Some(y), Some(z)) = (
+                entity.get_int("x"),
+                entity.get_int("y"),
+                entity.get_int("z"),
+            ) {
+                block_entities.insert(BlockPos::new(x, y, z), entity);
+            }
+        }
+    }
+
+    Ok(ChunkData {
+        section,
+        heightmap: std::sync::Mutex::new(heightmap),
+        x: chunk.x,
+        z: chunk.z,
+        block_ticks: ChunkTickScheduler::default(),
+        fluid_ticks: ChunkTickScheduler::default(),
+        pending_block_entities: std::sync::Mutex::new(block_entities),
+        light_engine: std::sync::Mutex::new(light_engine),
+        light_populated: AtomicBool::new(has_light),
+        status: ChunkStatus::Full,
+        blending_data: None,
+        // This chunk is freshly imported and must be persisted in Pumpkin's format.
+        dirty: AtomicBool::new(true),
+    })
+}
+
+/// Convert a [`SlimeChunk`]'s entities into a Pumpkin [`ChunkEntityData`].
+///
+/// # Errors
+///
+/// Returns [`SlimeError`] if the entity NBT payload is malformed.
+pub(crate) fn chunk_to_entity_data(chunk: &SlimeChunk) -> Result<ChunkEntityData, SlimeError> {
+    let mut data = FxHashMap::default();
+    if let Some(list) = parse_segment::<CompoundList>(&chunk.entities)? {
+        for entity in list.items {
+            if let Some(uuid) = entity.get_int_array("UUID").and_then(uuid_from_int_array) {
+                data.insert(uuid, entity);
+            }
+        }
+    }
+
+    Ok(ChunkEntityData {
+        x: chunk.x,
+        z: chunk.z,
+        data: tokio::sync::Mutex::new(data),
+        dirty: AtomicBool::new(true),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use pumpkin_data::Block;
+    use uuid::Uuid;
+
+    use super::{VanillaPaletteEntry, biome_name_to_id, palette_entry_to_state_id, uuid_from_int_array};
+
+    #[test]
+    fn resolves_air_palette_entry() {
+        let entry = VanillaPaletteEntry {
+            name: "minecraft:air".to_string(),
+            properties: None,
+        };
+        assert_eq!(palette_entry_to_state_id(&entry), Block::AIR.default_state.id);
+    }
+
+    #[test]
+    fn resolves_stone_palette_entry() {
+        let entry = VanillaPaletteEntry {
+            name: "minecraft:stone".to_string(),
+            properties: None,
+        };
+        let expected = Block::from_registry_key("stone").unwrap().default_state.id;
+        assert_eq!(palette_entry_to_state_id(&entry), expected);
+    }
+
+    #[test]
+    fn resolves_block_with_properties() {
+        // A property-bearing block should resolve to a *specific* (non-default) state.
+        let mut properties = BTreeMap::new();
+        properties.insert("facing".to_string(), "north".to_string());
+        properties.insert("half".to_string(), "bottom".to_string());
+        properties.insert("shape".to_string(), "straight".to_string());
+        properties.insert("waterlogged".to_string(), "false".to_string());
+        let entry = VanillaPaletteEntry {
+            name: "minecraft:oak_stairs".to_string(),
+            properties: Some(properties),
+        };
+        let block = Block::from_registry_key("oak_stairs").unwrap();
+        let state_id = palette_entry_to_state_id(&entry);
+        // The resolved state must belong to oak_stairs.
+        assert!(block.states.iter().any(|state| state.id == state_id));
+    }
+
+    #[test]
+    fn unknown_block_falls_back_to_air() {
+        let entry = VanillaPaletteEntry {
+            name: "modid:does_not_exist".to_string(),
+            properties: None,
+        };
+        assert_eq!(palette_entry_to_state_id(&entry), Block::AIR.default_state.id);
+    }
+
+    #[test]
+    fn resolves_known_biome() {
+        assert_eq!(biome_name_to_id("minecraft:plains"), pumpkin_data::biome::Biome::PLAINS.id);
+    }
+
+    #[test]
+    fn decodes_uuid_int_array() {
+        let uuid = Uuid::from_u128(0x0123_4567_89ab_cdef_fedc_ba98_7654_3210);
+        let bytes = uuid.as_u128();
+        let array = [
+            ((bytes >> 96) as u32).cast_signed(),
+            ((bytes >> 64) as u32).cast_signed(),
+            ((bytes >> 32) as u32).cast_signed(),
+            (bytes as u32).cast_signed(),
+        ];
+        assert_eq!(uuid_from_int_array(&array), Some(uuid));
+        assert_eq!(uuid_from_int_array(&[0, 0, 0]), None);
+    }
+}

--- a/pumpkin-world/src/chunk/format/slime/convert.rs
+++ b/pumpkin-world/src/chunk/format/slime/convert.rs
@@ -92,7 +92,9 @@ fn uuid_from_int_array(array: &[i32]) -> Option<Uuid> {
     let [most_hi, most_lo, least_hi, least_lo] = *<&[i32; 4]>::try_from(array).ok()?;
     let most = (u64::from(most_hi.cast_unsigned()) << 32) | u64::from(most_lo.cast_unsigned());
     let least = (u64::from(least_hi.cast_unsigned()) << 32) | u64::from(least_lo.cast_unsigned());
-    Some(Uuid::from_u128((u128::from(most) << 64) | u128::from(least)))
+    Some(Uuid::from_u128(
+        (u128::from(most) << 64) | u128::from(least),
+    ))
 }
 
 /// Parse a named-compound NBT segment into `T`; empty segments yield `None`.
@@ -138,16 +140,22 @@ pub(crate) fn chunk_to_chunk_data(
         sky_lights[index] = light_container(section.sky_light.as_ref());
 
         if let Some(states) = parse_segment::<VanillaBlockStates>(&section.block_states)? {
-            let palette: Box<[u16]> =
-                states.palette.iter().map(palette_entry_to_state_id).collect();
+            let palette: Box<[u16]> = states
+                .palette
+                .iter()
+                .map(palette_entry_to_state_id)
+                .collect();
             block_palettes[index] = BlockPalette::from_disk_nbt(ChunkSectionBlockStates {
                 data: states.data,
                 palette,
             });
         }
         if let Some(biomes) = parse_segment::<VanillaBiomes>(&section.biomes)? {
-            let palette: Box<[u8]> =
-                biomes.palette.iter().map(|name| biome_name_to_id(name)).collect();
+            let palette: Box<[u8]> = biomes
+                .palette
+                .iter()
+                .map(|name| biome_name_to_id(name))
+                .collect();
             biome_palettes[index] = BiomePalette::from_disk_nbt(ChunkSectionBiomes {
                 data: biomes.data,
                 palette,
@@ -176,11 +184,12 @@ pub(crate) fn chunk_to_chunk_data(
         min_y,
     };
 
-    let heightmap = parse_segment::<ChunkHeightmaps>(&chunk.height_maps)?.unwrap_or(ChunkHeightmaps {
-        world_surface: None,
-        motion_blocking: None,
-        motion_blocking_no_leaves: None,
-    });
+    let heightmap =
+        parse_segment::<ChunkHeightmaps>(&chunk.height_maps)?.unwrap_or(ChunkHeightmaps {
+            world_surface: None,
+            motion_blocking: None,
+            motion_blocking_no_leaves: None,
+        });
 
     let mut block_entities = FxHashMap::default();
     if let Some(list) = parse_segment::<CompoundList>(&chunk.block_entities)? {
@@ -242,7 +251,9 @@ mod tests {
     use pumpkin_data::Block;
     use uuid::Uuid;
 
-    use super::{VanillaPaletteEntry, biome_name_to_id, palette_entry_to_state_id, uuid_from_int_array};
+    use super::{
+        VanillaPaletteEntry, biome_name_to_id, palette_entry_to_state_id, uuid_from_int_array,
+    };
 
     #[test]
     fn resolves_air_palette_entry() {
@@ -250,7 +261,10 @@ mod tests {
             name: "minecraft:air".to_string(),
             properties: None,
         };
-        assert_eq!(palette_entry_to_state_id(&entry), Block::AIR.default_state.id);
+        assert_eq!(
+            palette_entry_to_state_id(&entry),
+            Block::AIR.default_state.id
+        );
     }
 
     #[test]
@@ -287,12 +301,18 @@ mod tests {
             name: "modid:does_not_exist".to_string(),
             properties: None,
         };
-        assert_eq!(palette_entry_to_state_id(&entry), Block::AIR.default_state.id);
+        assert_eq!(
+            palette_entry_to_state_id(&entry),
+            Block::AIR.default_state.id
+        );
     }
 
     #[test]
     fn resolves_known_biome() {
-        assert_eq!(biome_name_to_id("minecraft:plains"), pumpkin_data::biome::Biome::PLAINS.id);
+        assert_eq!(
+            biome_name_to_id("minecraft:plains"),
+            pumpkin_data::biome::Biome::PLAINS.id
+        );
     }
 
     #[test]

--- a/pumpkin-world/src/chunk/format/slime/convert.rs
+++ b/pumpkin-world/src/chunk/format/slime/convert.rs
@@ -1,6 +1,6 @@
 //! Convert a parsed [`SlimeChunk`] into Pumpkin's native chunk representation.
 //!
-//! SlimeWorld stores chunk block states and biomes as the *vanilla* paletted
+//! `SlimeWorld` stores chunk block states and biomes as the *vanilla* paletted
 //! NBT (a palette of namespaced names, not Pumpkin's numeric ids), so the names
 //! are resolved to global block-state / biome ids here before the section
 //! palettes are built. Block entities and entities are mapped onto
@@ -12,6 +12,7 @@ use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, AtomicU32};
 
 use bytes::Bytes;
+use pumpkin_data::block_state::BlockStateId;
 use pumpkin_data::{Block, biome::Biome, chunk::ChunkStatus};
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::math::position::BlockPos;
@@ -65,7 +66,7 @@ fn strip_namespace(name: &str) -> &str {
 
 /// Resolve a vanilla palette entry (block name + properties) to a Pumpkin global
 /// block-state id, falling back to air for unknown blocks.
-fn palette_entry_to_state_id(entry: &VanillaPaletteEntry) -> u16 {
+fn palette_entry_to_state_id(entry: &VanillaPaletteEntry) -> BlockStateId {
     let Some(block) = Block::from_registry_key(strip_namespace(&entry.name)) else {
         return Block::AIR.default_state.id;
     };
@@ -108,13 +109,13 @@ fn light_container(array: Option<&Bytes>) -> LightContainer {
 /// Convert a [`SlimeChunk`] into Pumpkin's [`ChunkData`].
 ///
 /// `min_section_y` is the bottom-most section index of the target dimension
-/// (e.g. `-4` for the overworld); SlimeWorld stores sections bottom-up without
+/// (e.g. `-4` for the overworld); `SlimeWorld` stores sections bottom-up without
 /// an explicit Y, so the absolute section Y of section `i` is `min_section_y + i`.
 ///
 /// # Errors
 ///
 /// Returns [`SlimeError`] if any of the chunk's NBT payloads are malformed.
-pub(crate) fn chunk_to_chunk_data(
+pub fn chunk_to_chunk_data(
     chunk: &SlimeChunk,
     min_section_y: i32,
 ) -> Result<ChunkData, SlimeError> {
@@ -129,7 +130,7 @@ pub(crate) fn chunk_to_chunk_data(
         sky_lights[index] = light_container(section.sky_light.as_ref());
 
         if let Some(states) = parse_segment::<VanillaBlockStates>(&section.block_states)? {
-            let palette: Box<[u16]> = states
+            let palette: Box<[BlockStateId]> = states
                 .palette
                 .iter()
                 .map(palette_entry_to_state_id)
@@ -215,7 +216,7 @@ pub(crate) fn chunk_to_chunk_data(
 /// # Errors
 ///
 /// Returns [`SlimeError`] if the entity NBT payload is malformed.
-pub(crate) fn chunk_to_entity_data(chunk: &SlimeChunk) -> Result<ChunkEntityData, SlimeError> {
+pub fn chunk_to_entity_data(chunk: &SlimeChunk) -> Result<ChunkEntityData, SlimeError> {
     let data = parse_segment::<CompoundList>(&chunk.entities)?
         .map(|list| list.items)
         .unwrap_or_default();
@@ -234,6 +235,7 @@ mod tests {
 
     use bytes::Bytes;
     use pumpkin_data::Block;
+    use pumpkin_nbt::compound::NbtCompound;
     use pumpkin_nbt::tag::NbtTag;
 
     use super::{

--- a/pumpkin-world/src/chunk/format/slime/convert.rs
+++ b/pumpkin-world/src/chunk/format/slime/convert.rs
@@ -17,7 +17,6 @@ use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::math::position::BlockPos;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
-use uuid::Uuid;
 
 use crate::chunk::format::{ChunkSectionBiomes, ChunkSectionBlockStates, LightContainer};
 use crate::chunk::palette::{BiomePalette, BlockPalette};
@@ -85,16 +84,6 @@ fn palette_entry_to_state_id(entry: &VanillaPaletteEntry) -> u16 {
 /// Resolve a vanilla biome name to a Pumpkin biome id, defaulting to plains.
 fn biome_name_to_id(name: &str) -> u8 {
     Biome::from_name(strip_namespace(name)).map_or(Biome::PLAINS.id, |biome| biome.id)
-}
-
-/// Decode a vanilla UUID stored as an `int[4]` array (`[most_hi, most_lo, least_hi, least_lo]`).
-fn uuid_from_int_array(array: &[i32]) -> Option<Uuid> {
-    let [most_hi, most_lo, least_hi, least_lo] = *<&[i32; 4]>::try_from(array).ok()?;
-    let most = (u64::from(most_hi.cast_unsigned()) << 32) | u64::from(most_lo.cast_unsigned());
-    let least = (u64::from(least_hi.cast_unsigned()) << 32) | u64::from(least_lo.cast_unsigned());
-    Some(Uuid::from_u128(
-        (u128::from(most) << 64) | u128::from(least),
-    ))
 }
 
 /// Parse a named-compound NBT segment into `T`; empty segments yield `None`.
@@ -227,14 +216,9 @@ pub(crate) fn chunk_to_chunk_data(
 ///
 /// Returns [`SlimeError`] if the entity NBT payload is malformed.
 pub(crate) fn chunk_to_entity_data(chunk: &SlimeChunk) -> Result<ChunkEntityData, SlimeError> {
-    let mut data = FxHashMap::default();
-    if let Some(list) = parse_segment::<CompoundList>(&chunk.entities)? {
-        for entity in list.items {
-            if let Some(uuid) = entity.get_int_array("UUID").and_then(uuid_from_int_array) {
-                data.insert(uuid, entity);
-            }
-        }
-    }
+    let data = parse_segment::<CompoundList>(&chunk.entities)?
+        .map(|list| list.items)
+        .unwrap_or_default();
 
     Ok(ChunkEntityData {
         x: chunk.x,
@@ -248,11 +232,13 @@ pub(crate) fn chunk_to_entity_data(chunk: &SlimeChunk) -> Result<ChunkEntityData
 mod tests {
     use std::collections::BTreeMap;
 
+    use bytes::Bytes;
     use pumpkin_data::Block;
-    use uuid::Uuid;
+    use pumpkin_nbt::tag::NbtTag;
 
     use super::{
-        VanillaPaletteEntry, biome_name_to_id, palette_entry_to_state_id, uuid_from_int_array,
+        SlimeChunk, VanillaPaletteEntry, biome_name_to_id, chunk_to_entity_data,
+        palette_entry_to_state_id,
     };
 
     #[test]
@@ -316,16 +302,37 @@ mod tests {
     }
 
     #[test]
-    fn decodes_uuid_int_array() {
-        let uuid = Uuid::from_u128(0x0123_4567_89ab_cdef_fedc_ba98_7654_3210);
-        let bytes = uuid.as_u128();
-        let array = [
-            ((bytes >> 96) as u32).cast_signed(),
-            ((bytes >> 64) as u32).cast_signed(),
-            ((bytes >> 32) as u32).cast_signed(),
-            (bytes as u32).cast_signed(),
-        ];
-        assert_eq!(uuid_from_int_array(&array), Some(uuid));
-        assert_eq!(uuid_from_int_array(&[0, 0, 0]), None);
+    fn keeps_every_entity_regardless_of_uuid() {
+        let mut no_uuid = NbtCompound::new();
+        no_uuid.put_string("id", "minecraft:cow".to_string());
+
+        let mut with_uuid = NbtCompound::new();
+        with_uuid.put_string("id", "minecraft:pig".to_string());
+        with_uuid.put("UUID", NbtTag::IntArray(vec![1, 2, 3, 4]));
+
+        let mut root = NbtCompound::new();
+        root.put_list(
+            "entities",
+            vec![NbtTag::Compound(no_uuid), NbtTag::Compound(with_uuid)],
+        );
+        let mut buf = Vec::new();
+        pumpkin_nbt::to_bytes(&root, &mut buf).expect("serializing test fixture should not fail");
+
+        let chunk = SlimeChunk {
+            x: 0,
+            z: 0,
+            sections: Vec::new(),
+            height_maps: Bytes::new(),
+            block_entities: Bytes::new(),
+            entities: Bytes::from(buf),
+            block_ticks: Bytes::new(),
+            fluid_ticks: Bytes::new(),
+            poi: Bytes::new(),
+        };
+
+        let entity_data = chunk_to_entity_data(&chunk).unwrap();
+        // Vanilla entity NBT is a flat list; an entity missing/malformed `UUID`
+        // must still be imported rather than silently dropped.
+        assert_eq!(entity_data.data.into_inner().len(), 2);
     }
 }

--- a/pumpkin-world/src/chunk/format/slime/io.rs
+++ b/pumpkin-world/src/chunk/format/slime/io.rs
@@ -71,7 +71,10 @@ impl SlimeChunkIo {
                         chunks.insert(Vector2::new(chunk.x, chunk.z), Arc::new(data));
                     }
                     Err(error) => {
-                        error!("Failed to convert slime chunk {},{}: {error}", chunk.x, chunk.z);
+                        error!(
+                            "Failed to convert slime chunk {},{}: {error}",
+                            chunk.x, chunk.z
+                        );
                     }
                 }
             }

--- a/pumpkin-world/src/chunk/format/slime/io.rs
+++ b/pumpkin-world/src/chunk/format/slime/io.rs
@@ -1,0 +1,220 @@
+//! [`FileIO`] backends that serve a SlimeWorld file straight from memory.
+//!
+//! Unlike the region-based formats (Anvil / Linear / Pump), a `.slime` file
+//! holds an entire world in one blob that is meant to be loaded wholesale into
+//! RAM. These backends parse and convert the whole world once (at construction)
+//! and then answer chunk/entity requests from the resulting in-memory maps,
+//! which keeps them off the region-oriented hot path entirely.
+//!
+//! SlimeWorld worlds are currently loaded **read-only**: [`save_chunks`] is a
+//! no-op, so runtime modifications are not written back to the `.slime` file
+//! (this matches the common minigame / lobby use case). Use Anvil, Linear or
+//! Pump for worlds that must persist changes.
+//!
+//! [`save_chunks`]: FileIO::save_chunks
+
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use pumpkin_util::math::vector2::Vector2;
+use rustc_hash::FxHashMap;
+use tokio::sync::mpsc::Sender;
+use tracing::error;
+
+use crate::chunk::io::{FileIO, LoadedData};
+use crate::chunk::{ChunkReadingError, ChunkWritingError};
+use crate::level::{LevelFolder, SyncChunk, SyncEntityChunk};
+
+use super::{SlimeWorld, chunk_to_chunk_data, chunk_to_entity_data, read_slime_world};
+
+type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Read and parse the first `*.slime` file found directly in `root`.
+fn read_slime_file(root: &Path) -> Option<SlimeWorld> {
+    let entry = std::fs::read_dir(root).ok()?.flatten().find(|entry| {
+        entry
+            .path()
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("slime"))
+    })?;
+
+    let bytes = std::fs::read(entry.path()).ok()?;
+    match read_slime_world(Bytes::from(bytes)) {
+        Ok(world) => Some(world),
+        Err(error) => {
+            error!("Failed to read slime world at {:?}: {error}", entry.path());
+            None
+        }
+    }
+}
+
+/// [`FileIO`] serving block data from an in-memory SlimeWorld.
+pub(crate) struct SlimeChunkIo {
+    chunks: FxHashMap<Vector2<i32>, SyncChunk>,
+}
+
+impl SlimeChunkIo {
+    /// Load and convert every chunk in the world below `root`.
+    ///
+    /// `min_section_y` is the bottom-most section index of the target dimension
+    /// (SlimeWorld stores sections bottom-up without an explicit Y).
+    pub(crate) fn new(root: &Path, min_section_y: i32) -> Self {
+        let mut chunks = FxHashMap::default();
+        if let Some(world) = read_slime_file(root) {
+            for chunk in &world.chunks {
+                match chunk_to_chunk_data(chunk, min_section_y) {
+                    Ok(data) => {
+                        chunks.insert(Vector2::new(chunk.x, chunk.z), Arc::new(data));
+                    }
+                    Err(error) => {
+                        error!("Failed to convert slime chunk {},{}: {error}", chunk.x, chunk.z);
+                    }
+                }
+            }
+        }
+        Self { chunks }
+    }
+}
+
+impl FileIO for SlimeChunkIo {
+    type Data = SyncChunk;
+
+    fn fetch_chunks<'a>(
+        &'a self,
+        _folder: &'a LevelFolder,
+        chunk_coords: &'a [Vector2<i32>],
+        stream: Sender<LoadedData<Self::Data, ChunkReadingError>>,
+    ) -> BoxedFuture<'a, ()> {
+        Box::pin(async move {
+            for &coord in chunk_coords {
+                let data = self.chunks.get(&coord).map_or_else(
+                    || LoadedData::Missing(coord),
+                    |chunk| LoadedData::Loaded(chunk.clone()),
+                );
+                if stream.send(data).await.is_err() {
+                    break;
+                }
+            }
+        })
+    }
+
+    fn save_chunks<'a>(
+        &'a self,
+        _folder: &'a LevelFolder,
+        _chunks_data: Vec<(Vector2<i32>, Self::Data)>,
+    ) -> BoxedFuture<'a, Result<(), ChunkWritingError>> {
+        // SlimeWorld worlds are loaded read-only; nothing is written back.
+        Box::pin(async { Ok(()) })
+    }
+
+    fn watch_chunks<'a>(
+        &'a self,
+        _folder: &'a LevelFolder,
+        _chunks: &'a [Vector2<i32>],
+    ) -> BoxedFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn unwatch_chunks<'a>(
+        &'a self,
+        _folder: &'a LevelFolder,
+        _chunks: &'a [Vector2<i32>],
+    ) -> BoxedFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn clear_watched_chunks(&self) -> BoxedFuture<'_, ()> {
+        Box::pin(async {})
+    }
+
+    fn block_and_await_ongoing_tasks(&self) -> BoxedFuture<'_, ()> {
+        Box::pin(async {})
+    }
+}
+
+/// [`FileIO`] serving entity data from an in-memory SlimeWorld.
+pub(crate) struct SlimeEntityIo {
+    entities: FxHashMap<Vector2<i32>, SyncEntityChunk>,
+}
+
+impl SlimeEntityIo {
+    /// Load and convert every chunk's entities in the world below `root`.
+    pub(crate) fn new(root: &Path) -> Self {
+        let mut entities = FxHashMap::default();
+        if let Some(world) = read_slime_file(root) {
+            for chunk in &world.chunks {
+                match chunk_to_entity_data(chunk) {
+                    Ok(data) => {
+                        entities.insert(Vector2::new(chunk.x, chunk.z), Arc::new(data));
+                    }
+                    Err(error) => {
+                        error!(
+                            "Failed to convert slime entities for chunk {},{}: {error}",
+                            chunk.x, chunk.z
+                        );
+                    }
+                }
+            }
+        }
+        Self { entities }
+    }
+}
+
+impl FileIO for SlimeEntityIo {
+    type Data = SyncEntityChunk;
+
+    fn fetch_chunks<'a>(
+        &'a self,
+        _folder: &'a LevelFolder,
+        chunk_coords: &'a [Vector2<i32>],
+        stream: Sender<LoadedData<Self::Data, ChunkReadingError>>,
+    ) -> BoxedFuture<'a, ()> {
+        Box::pin(async move {
+            for &coord in chunk_coords {
+                let data = self.entities.get(&coord).map_or_else(
+                    || LoadedData::Missing(coord),
+                    |chunk| LoadedData::Loaded(chunk.clone()),
+                );
+                if stream.send(data).await.is_err() {
+                    break;
+                }
+            }
+        })
+    }
+
+    fn save_chunks<'a>(
+        &'a self,
+        _folder: &'a LevelFolder,
+        _chunks_data: Vec<(Vector2<i32>, Self::Data)>,
+    ) -> BoxedFuture<'a, Result<(), ChunkWritingError>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn watch_chunks<'a>(
+        &'a self,
+        _folder: &'a LevelFolder,
+        _chunks: &'a [Vector2<i32>],
+    ) -> BoxedFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn unwatch_chunks<'a>(
+        &'a self,
+        _folder: &'a LevelFolder,
+        _chunks: &'a [Vector2<i32>],
+    ) -> BoxedFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn clear_watched_chunks(&self) -> BoxedFuture<'_, ()> {
+        Box::pin(async {})
+    }
+
+    fn block_and_await_ongoing_tasks(&self) -> BoxedFuture<'_, ()> {
+        Box::pin(async {})
+    }
+}

--- a/pumpkin-world/src/chunk/format/slime/io.rs
+++ b/pumpkin-world/src/chunk/format/slime/io.rs
@@ -1,85 +1,34 @@
-//! [`FileIO`] backends that serve a SlimeWorld file straight from memory.
+//! [`FileIO`] backends that serve a SlimeWorld from a shared in-memory store.
 //!
 //! Unlike the region-based formats (Anvil / Linear / Pump), a `.slime` file
-//! holds an entire world in one blob that is meant to be loaded wholesale into
-//! RAM. These backends parse and convert the whole world once (at construction)
-//! and then answer chunk/entity requests from the resulting in-memory maps,
-//! which keeps them off the region-oriented hot path entirely.
-//!
-//! SlimeWorld worlds are currently loaded **read-only**: [`save_chunks`] is a
-//! no-op, so runtime modifications are not written back to the `.slime` file
-//! (this matches the common minigame / lobby use case). Use Anvil, Linear or
-//! Pump for worlds that must persist changes.
-//!
-//! [`save_chunks`]: FileIO::save_chunks
+//! holds an entire world in one blob that is loaded wholesale into RAM. Both
+//! backends share a single [`SlimeWorldStore`]: reads are answered from the
+//! in-memory maps, and a save from either side re-serializes the whole world
+//! back to the one file.
 
 use std::future::Future;
-use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use bytes::Bytes;
 use pumpkin_util::math::vector2::Vector2;
-use rustc_hash::FxHashMap;
 use tokio::sync::mpsc::Sender;
-use tracing::error;
 
 use crate::chunk::io::{FileIO, LoadedData};
 use crate::chunk::{ChunkReadingError, ChunkWritingError};
 use crate::level::{LevelFolder, SyncChunk, SyncEntityChunk};
 
-use super::{SlimeWorld, chunk_to_chunk_data, chunk_to_entity_data, read_slime_world};
+use super::store::SlimeWorldStore;
 
 type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-/// Read and parse the first `*.slime` file found directly in `root`.
-fn read_slime_file(root: &Path) -> Option<SlimeWorld> {
-    let entry = std::fs::read_dir(root).ok()?.flatten().find(|entry| {
-        entry
-            .path()
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("slime"))
-    })?;
-
-    let bytes = std::fs::read(entry.path()).ok()?;
-    match read_slime_world(Bytes::from(bytes)) {
-        Ok(world) => Some(world),
-        Err(error) => {
-            error!("Failed to read slime world at {:?}: {error}", entry.path());
-            None
-        }
-    }
-}
-
-/// [`FileIO`] serving block data from an in-memory SlimeWorld.
+/// [`FileIO`] serving block data from a shared [`SlimeWorldStore`].
 pub(crate) struct SlimeChunkIo {
-    chunks: FxHashMap<Vector2<i32>, SyncChunk>,
+    store: Arc<SlimeWorldStore>,
 }
 
 impl SlimeChunkIo {
-    /// Load and convert every chunk in the world below `root`.
-    ///
-    /// `min_section_y` is the bottom-most section index of the target dimension
-    /// (SlimeWorld stores sections bottom-up without an explicit Y).
-    pub(crate) fn new(root: &Path, min_section_y: i32) -> Self {
-        let mut chunks = FxHashMap::default();
-        if let Some(world) = read_slime_file(root) {
-            for chunk in &world.chunks {
-                match chunk_to_chunk_data(chunk, min_section_y) {
-                    Ok(data) => {
-                        chunks.insert(Vector2::new(chunk.x, chunk.z), Arc::new(data));
-                    }
-                    Err(error) => {
-                        error!(
-                            "Failed to convert slime chunk {},{}: {error}",
-                            chunk.x, chunk.z
-                        );
-                    }
-                }
-            }
-        }
-        Self { chunks }
+    pub(crate) fn new(store: Arc<SlimeWorldStore>) -> Self {
+        Self { store }
     }
 }
 
@@ -94,10 +43,10 @@ impl FileIO for SlimeChunkIo {
     ) -> BoxedFuture<'a, ()> {
         Box::pin(async move {
             for &coord in chunk_coords {
-                let data = self.chunks.get(&coord).map_or_else(
-                    || LoadedData::Missing(coord),
-                    |chunk| LoadedData::Loaded(chunk.clone()),
-                );
+                let data = self
+                    .store
+                    .get_chunk(&coord)
+                    .map_or_else(|| LoadedData::Missing(coord), LoadedData::Loaded);
                 if stream.send(data).await.is_err() {
                     break;
                 }
@@ -108,10 +57,15 @@ impl FileIO for SlimeChunkIo {
     fn save_chunks<'a>(
         &'a self,
         _folder: &'a LevelFolder,
-        _chunks_data: Vec<(Vector2<i32>, Self::Data)>,
+        chunks_data: Vec<(Vector2<i32>, Self::Data)>,
     ) -> BoxedFuture<'a, Result<(), ChunkWritingError>> {
-        // SlimeWorld worlds are loaded read-only; nothing is written back.
-        Box::pin(async { Ok(()) })
+        Box::pin(async move {
+            self.store.store_chunks(chunks_data);
+            self.store
+                .persist()
+                .await
+                .map_err(ChunkWritingError::IoError)
+        })
     }
 
     fn watch_chunks<'a>(
@@ -139,31 +93,14 @@ impl FileIO for SlimeChunkIo {
     }
 }
 
-/// [`FileIO`] serving entity data from an in-memory SlimeWorld.
+/// [`FileIO`] serving entity data from a shared [`SlimeWorldStore`].
 pub(crate) struct SlimeEntityIo {
-    entities: FxHashMap<Vector2<i32>, SyncEntityChunk>,
+    store: Arc<SlimeWorldStore>,
 }
 
 impl SlimeEntityIo {
-    /// Load and convert every chunk's entities in the world below `root`.
-    pub(crate) fn new(root: &Path) -> Self {
-        let mut entities = FxHashMap::default();
-        if let Some(world) = read_slime_file(root) {
-            for chunk in &world.chunks {
-                match chunk_to_entity_data(chunk) {
-                    Ok(data) => {
-                        entities.insert(Vector2::new(chunk.x, chunk.z), Arc::new(data));
-                    }
-                    Err(error) => {
-                        error!(
-                            "Failed to convert slime entities for chunk {},{}: {error}",
-                            chunk.x, chunk.z
-                        );
-                    }
-                }
-            }
-        }
-        Self { entities }
+    pub(crate) fn new(store: Arc<SlimeWorldStore>) -> Self {
+        Self { store }
     }
 }
 
@@ -178,10 +115,10 @@ impl FileIO for SlimeEntityIo {
     ) -> BoxedFuture<'a, ()> {
         Box::pin(async move {
             for &coord in chunk_coords {
-                let data = self.entities.get(&coord).map_or_else(
-                    || LoadedData::Missing(coord),
-                    |chunk| LoadedData::Loaded(chunk.clone()),
-                );
+                let data = self
+                    .store
+                    .get_entity(&coord)
+                    .map_or_else(|| LoadedData::Missing(coord), LoadedData::Loaded);
                 if stream.send(data).await.is_err() {
                     break;
                 }
@@ -192,9 +129,15 @@ impl FileIO for SlimeEntityIo {
     fn save_chunks<'a>(
         &'a self,
         _folder: &'a LevelFolder,
-        _chunks_data: Vec<(Vector2<i32>, Self::Data)>,
+        chunks_data: Vec<(Vector2<i32>, Self::Data)>,
     ) -> BoxedFuture<'a, Result<(), ChunkWritingError>> {
-        Box::pin(async { Ok(()) })
+        Box::pin(async move {
+            self.store.store_entities(chunks_data);
+            self.store
+                .persist()
+                .await
+                .map_err(ChunkWritingError::IoError)
+        })
     }
 
     fn watch_chunks<'a>(

--- a/pumpkin-world/src/chunk/format/slime/io.rs
+++ b/pumpkin-world/src/chunk/format/slime/io.rs
@@ -1,4 +1,4 @@
-//! [`FileIO`] backends that serve a SlimeWorld from a shared in-memory store.
+//! [`FileIO`] backends that serve a `SlimeWorld` from a shared in-memory store.
 //!
 //! Unlike the region-based formats (Anvil / Linear / Pump), a `.slime` file
 //! holds an entire world in one blob that is loaded wholesale into RAM. Both
@@ -22,12 +22,12 @@ use super::store::SlimeWorldStore;
 type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// [`FileIO`] serving block data from a shared [`SlimeWorldStore`].
-pub(crate) struct SlimeChunkIo {
+pub struct SlimeChunkIo {
     store: Arc<SlimeWorldStore>,
 }
 
 impl SlimeChunkIo {
-    pub(crate) fn new(store: Arc<SlimeWorldStore>) -> Self {
+    pub(crate) const fn new(store: Arc<SlimeWorldStore>) -> Self {
         Self { store }
     }
 }
@@ -45,7 +45,7 @@ impl FileIO for SlimeChunkIo {
             for &coord in chunk_coords {
                 let data = self
                     .store
-                    .get_chunk(&coord)
+                    .get_chunk(coord)
                     .map_or_else(|| LoadedData::Missing(coord), LoadedData::Loaded);
                 if stream.send(data).await.is_err() {
                     break;
@@ -94,12 +94,12 @@ impl FileIO for SlimeChunkIo {
 }
 
 /// [`FileIO`] serving entity data from a shared [`SlimeWorldStore`].
-pub(crate) struct SlimeEntityIo {
+pub struct SlimeEntityIo {
     store: Arc<SlimeWorldStore>,
 }
 
 impl SlimeEntityIo {
-    pub(crate) fn new(store: Arc<SlimeWorldStore>) -> Self {
+    pub(crate) const fn new(store: Arc<SlimeWorldStore>) -> Self {
         Self { store }
     }
 }
@@ -117,7 +117,7 @@ impl FileIO for SlimeEntityIo {
             for &coord in chunk_coords {
                 let data = self
                     .store
-                    .get_entity(&coord)
+                    .get_entity(coord)
                     .map_or_else(|| LoadedData::Missing(coord), LoadedData::Loaded);
                 if stream.send(data).await.is_err() {
                     break;

--- a/pumpkin-world/src/chunk/format/slime/mod.rs
+++ b/pumpkin-world/src/chunk/format/slime/mod.rs
@@ -10,10 +10,12 @@
 //! (`SlimeSerializer` / `v13SlimeWorldDeSerializer`).
 
 mod convert;
+mod io;
 mod model;
 mod reader;
 
 pub(crate) use convert::{chunk_to_chunk_data, chunk_to_entity_data};
+pub(crate) use io::{SlimeChunkIo, SlimeEntityIo};
 pub use model::{SlimeChunk, SlimeSection, SlimeWorld};
 pub use reader::read_slime_world;
 

--- a/pumpkin-world/src/chunk/format/slime/mod.rs
+++ b/pumpkin-world/src/chunk/format/slime/mod.rs
@@ -13,11 +13,14 @@ mod convert;
 mod io;
 mod model;
 mod reader;
+mod store;
+mod writer;
 
 pub(crate) use convert::{chunk_to_chunk_data, chunk_to_entity_data};
 pub(crate) use io::{SlimeChunkIo, SlimeEntityIo};
 pub use model::{SlimeChunk, SlimeSection, SlimeWorld};
 pub use reader::read_slime_world;
+pub(crate) use store::SlimeWorldStore;
 
 /// First two bytes of every SlimeWorld file (`SlimeFormat.SLIME_HEADER`).
 pub const SLIME_MAGIC: [u8; 2] = [0xB1, 0x0B];

--- a/pumpkin-world/src/chunk/format/slime/mod.rs
+++ b/pumpkin-world/src/chunk/format/slime/mod.rs
@@ -1,0 +1,47 @@
+//! SlimeWorld (`.slime`) world format support — AdvancedSlimePaper v13.
+//!
+//! SlimeWorld packs an entire (typically small) world into a single
+//! zstd-compressed file that is loaded wholesale into memory. This module
+//! provides a faithful parser for that container ([`read_slime_world`]); the
+//! decoded [`SlimeWorld`] is later mapped onto Pumpkin's native chunk
+//! representation.
+//!
+//! The on-disk layout mirrors AdvancedSlimePaper `dev/26.2`
+//! (`SlimeSerializer` / `v13SlimeWorldDeSerializer`).
+
+mod model;
+mod reader;
+
+pub use model::{SlimeChunk, SlimeSection, SlimeWorld};
+pub use reader::read_slime_world;
+
+/// First two bytes of every SlimeWorld file (`SlimeFormat.SLIME_HEADER`).
+pub const SLIME_MAGIC: [u8; 2] = [0xB1, 0x0B];
+/// The only SlimeWorld format version supported (AdvancedSlimePaper `dev/26.2`).
+pub const SLIME_VERSION: u8 = 13;
+
+/// Length in bytes of a section light nibble array (16×16×16 / 2).
+const LIGHT_ARRAY_SIZE: usize = 16 * 16 * 16 / 2;
+
+// `additionalWorldData` flag bits (`v13AdditionalWorldData` ordinals).
+const FLAG_POI: u8 = 1;
+const FLAG_BLOCK_TICKS: u8 = 1 << 1;
+const FLAG_FLUID_TICKS: u8 = 1 << 2;
+const KNOWN_FLAGS: u8 = FLAG_POI | FLAG_BLOCK_TICKS | FLAG_FLUID_TICKS;
+
+/// Errors that can occur while reading a `.slime` file.
+#[derive(Debug, thiserror::Error)]
+pub enum SlimeError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("not a slime file (invalid magic)")]
+    BadMagic,
+    #[error("unsupported slime format version {0} (only version 13 is supported)")]
+    UnsupportedVersion(u8),
+    #[error("unexpected end of slime data")]
+    Truncated,
+    #[error("corrupt slime data: {0}")]
+    Corrupt(&'static str),
+    #[error("zstd decompression of slime data failed")]
+    Decompress,
+}

--- a/pumpkin-world/src/chunk/format/slime/mod.rs
+++ b/pumpkin-world/src/chunk/format/slime/mod.rs
@@ -9,9 +9,11 @@
 //! The on-disk layout mirrors AdvancedSlimePaper `dev/26.2`
 //! (`SlimeSerializer` / `v13SlimeWorldDeSerializer`).
 
+mod convert;
 mod model;
 mod reader;
 
+pub(crate) use convert::{chunk_to_chunk_data, chunk_to_entity_data};
 pub use model::{SlimeChunk, SlimeSection, SlimeWorld};
 pub use reader::read_slime_world;
 

--- a/pumpkin-world/src/chunk/format/slime/mod.rs
+++ b/pumpkin-world/src/chunk/format/slime/mod.rs
@@ -1,12 +1,12 @@
-//! SlimeWorld (`.slime`) world format support — AdvancedSlimePaper v13.
+//! `SlimeWorld` (`.slime`) world format support — `AdvancedSlimePaper` v13.
 //!
-//! SlimeWorld packs an entire (typically small) world into a single
+//! `SlimeWorld` packs an entire (typically small) world into a single
 //! zstd-compressed file that is loaded wholesale into memory. This module
 //! provides a faithful parser for that container ([`read_slime_world`]); the
 //! decoded [`SlimeWorld`] is later mapped onto Pumpkin's native chunk
 //! representation.
 //!
-//! The on-disk layout mirrors AdvancedSlimePaper `dev/26.2`
+//! The on-disk layout mirrors `AdvancedSlimePaper` `dev/26.2`
 //! (`SlimeSerializer` / `v13SlimeWorldDeSerializer`).
 
 mod convert;
@@ -22,9 +22,9 @@ pub use model::{SlimeChunk, SlimeSection, SlimeWorld};
 pub use reader::read_slime_world;
 pub(crate) use store::SlimeWorldStore;
 
-/// First two bytes of every SlimeWorld file (`SlimeFormat.SLIME_HEADER`).
+/// First two bytes of every `SlimeWorld` file (`SlimeFormat.SLIME_HEADER`).
 pub const SLIME_MAGIC: [u8; 2] = [0xB1, 0x0B];
-/// The only SlimeWorld format version supported (AdvancedSlimePaper `dev/26.2`).
+/// The only `SlimeWorld` format version supported (`AdvancedSlimePaper` `dev/26.2`).
 pub const SLIME_VERSION: u8 = 13;
 
 /// Length in bytes of a section light nibble array (16×16×16 / 2).

--- a/pumpkin-world/src/chunk/format/slime/model.rs
+++ b/pumpkin-world/src/chunk/format/slime/model.rs
@@ -1,0 +1,67 @@
+//! In-memory representation of a parsed `.slime` world (AdvancedSlimePaper v13).
+//!
+//! The reader ([`super::read_slime_world`]) fills this model with the raw,
+//! still-NBT-encoded payloads exactly as they appear on disk. Interpreting the
+//! NBT (palette conversion, block entities, entities, …) is left to the
+//! converter layer, which keeps the binary container parsing isolated and easy
+//! to test.
+
+use bytes::Bytes;
+
+/// A whole `.slime` world held in memory.
+///
+/// SlimeWorld stores an entire (small) world in a single file; this is the
+/// decoded form of that file before it is mapped onto Pumpkin's chunk
+/// representation.
+#[derive(Debug)]
+pub struct SlimeWorld {
+    /// Vanilla `DataVersion` the world was saved with.
+    pub world_version: i32,
+    /// `additionalWorldData` bitmask (POI / block ticks / fluid ticks present).
+    pub flags: u8,
+    /// All stored chunks, in file order.
+    pub chunks: Vec<SlimeChunk>,
+    /// Decompressed world "extra" compound (named NBT, includes `properties`);
+    /// empty when absent.
+    pub extra: Bytes,
+}
+
+/// A single chunk within a [`SlimeWorld`].
+///
+/// Every NBT payload is kept as its raw on-disk bytes (a named root compound,
+/// or empty when the segment length was zero).
+#[derive(Debug)]
+pub struct SlimeChunk {
+    /// Chunk X coordinate.
+    pub x: i32,
+    /// Chunk Z coordinate.
+    pub z: i32,
+    /// Sections ordered from the world bottom upwards; the absolute section Y is
+    /// implicit and must be derived from the target dimension's minimum section.
+    pub sections: Vec<SlimeSection>,
+    /// `Heightmaps` compound.
+    pub height_maps: Bytes,
+    /// Compound `{ tileEntities: [ … ] }` (block entities).
+    pub block_entities: Bytes,
+    /// Compound `{ entities: [ … ] }`.
+    pub entities: Bytes,
+    /// Compound `{ block_ticks: [ … ] }`, only when the world saves block ticks.
+    pub block_ticks: Bytes,
+    /// Compound `{ fluid_ticks: [ … ] }`, only when the world saves fluid ticks.
+    pub fluid_ticks: Bytes,
+    /// POI compound, only when the world saves POI data; not consumed yet.
+    pub poi: Bytes,
+}
+
+/// A 16×16×16 chunk section within a [`SlimeChunk`].
+#[derive(Debug)]
+pub struct SlimeSection {
+    /// Block light nibbles (2048 bytes) if present.
+    pub block_light: Option<Bytes>,
+    /// Sky light nibbles (2048 bytes) if present.
+    pub sky_light: Option<Bytes>,
+    /// Vanilla paletted `block_states` compound (`{ palette, data }`); empty when absent.
+    pub block_states: Bytes,
+    /// Vanilla paletted `biomes` compound; empty when absent.
+    pub biomes: Bytes,
+}

--- a/pumpkin-world/src/chunk/format/slime/model.rs
+++ b/pumpkin-world/src/chunk/format/slime/model.rs
@@ -1,4 +1,4 @@
-//! In-memory representation of a parsed `.slime` world (AdvancedSlimePaper v13).
+//! In-memory representation of a parsed `.slime` world (`AdvancedSlimePaper` v13).
 //!
 //! The reader ([`super::read_slime_world`]) fills this model with the raw,
 //! still-NBT-encoded payloads exactly as they appear on disk. Interpreting the
@@ -10,7 +10,7 @@ use bytes::Bytes;
 
 /// A whole `.slime` world held in memory.
 ///
-/// SlimeWorld stores an entire (small) world in a single file; this is the
+/// `SlimeWorld` stores an entire (small) world in a single file; this is the
 /// decoded form of that file before it is mapped onto Pumpkin's chunk
 /// representation.
 #[derive(Debug)]

--- a/pumpkin-world/src/chunk/format/slime/reader.rs
+++ b/pumpkin-world/src/chunk/format/slime/reader.rs
@@ -1,0 +1,301 @@
+//! Binary parser for the `.slime` container format (AdvancedSlimePaper v13).
+//!
+//! Layout mirrors AdvancedSlimePaper `dev/26.2` (`SlimeSerializer` /
+//! `v13SlimeWorldDeSerializer`): big-endian integers and two zstd-compressed
+//! payloads (the chunks, then the world "extra"), each framed as
+//! `[i32 compressed_len][i32 raw_len][compressed bytes]`. NBT segments are
+//! framed as `[i32 length][length bytes]`, where a length of zero means absent.
+
+use std::io::Read;
+
+use bytes::{Buf, Bytes};
+use ruzstd::decoding::StreamingDecoder;
+
+use super::{
+    FLAG_BLOCK_TICKS, FLAG_FLUID_TICKS, FLAG_POI, KNOWN_FLAGS, LIGHT_ARRAY_SIZE, SLIME_MAGIC,
+    SLIME_VERSION, SlimeError,
+    model::{SlimeChunk, SlimeSection, SlimeWorld},
+};
+
+/// Caps pre-allocation only; it never limits how much data is actually read
+/// (reading past the end fails cleanly with [`SlimeError::Truncated`]).
+const PREALLOC_CAP: usize = 4096;
+
+fn read_u8(buf: &mut Bytes) -> Result<u8, SlimeError> {
+    if buf.remaining() < 1 {
+        return Err(SlimeError::Truncated);
+    }
+    Ok(buf.get_u8())
+}
+
+fn read_i32(buf: &mut Bytes) -> Result<i32, SlimeError> {
+    if buf.remaining() < size_of::<i32>() {
+        return Err(SlimeError::Truncated);
+    }
+    Ok(buf.get_i32())
+}
+
+fn take(buf: &mut Bytes, n: usize) -> Result<Bytes, SlimeError> {
+    if buf.remaining() < n {
+        return Err(SlimeError::Truncated);
+    }
+    Ok(buf.split_to(n))
+}
+
+/// Read an `[i32 length][length bytes]` NBT segment; a zero length yields empty bytes.
+fn read_segment(buf: &mut Bytes) -> Result<Bytes, SlimeError> {
+    let len = read_i32(buf)?;
+    let len = usize::try_from(len).map_err(|_| SlimeError::Corrupt("negative segment length"))?;
+    take(buf, len)
+}
+
+/// Decompress a `[i32 compressed_len][i32 raw_len][zstd]` block.
+fn decompress_block(buf: &mut Bytes) -> Result<Bytes, SlimeError> {
+    let compressed_len = read_i32(buf)?;
+    let _raw_len = read_i32(buf)?; // legacy; the zstd frame is self-describing.
+    let compressed_len = usize::try_from(compressed_len)
+        .map_err(|_| SlimeError::Corrupt("negative compressed length"))?;
+    let compressed = take(buf, compressed_len)?;
+
+    let mut decoder =
+        StreamingDecoder::new(compressed.as_ref()).map_err(|_| SlimeError::Decompress)?;
+    let mut out = Vec::new();
+    decoder.read_to_end(&mut out)?;
+    Ok(Bytes::from(out))
+}
+
+/// Parse a `.slime` file (format version 13) into a [`SlimeWorld`].
+///
+/// # Errors
+///
+/// Returns [`SlimeError`] if the magic or version are wrong, the data is
+/// truncated or corrupt, or zstd decompression fails.
+pub fn read_slime_world(mut buf: Bytes) -> Result<SlimeWorld, SlimeError> {
+    let magic = take(&mut buf, SLIME_MAGIC.len())?;
+    if magic.as_ref() != SLIME_MAGIC {
+        return Err(SlimeError::BadMagic);
+    }
+    let version = read_u8(&mut buf)?;
+    if version != SLIME_VERSION {
+        return Err(SlimeError::UnsupportedVersion(version));
+    }
+
+    let world_version = read_i32(&mut buf)?;
+    let flags = read_u8(&mut buf)?;
+
+    let mut chunk_stream = decompress_block(&mut buf)?;
+    let chunks = read_chunks(&mut chunk_stream, flags)?;
+
+    // The "extra" block is always written, but is non-essential for loading.
+    let extra = decompress_block(&mut buf).unwrap_or_default();
+
+    Ok(SlimeWorld {
+        world_version,
+        flags,
+        chunks,
+        extra,
+    })
+}
+
+fn read_chunks(buf: &mut Bytes, flags: u8) -> Result<Vec<SlimeChunk>, SlimeError> {
+    let count = read_i32(buf)?;
+    let count = usize::try_from(count).map_err(|_| SlimeError::Corrupt("negative chunk count"))?;
+
+    let mut chunks = Vec::with_capacity(count.min(PREALLOC_CAP));
+    for _ in 0..count {
+        chunks.push(read_chunk(buf, flags)?);
+    }
+    Ok(chunks)
+}
+
+fn read_chunk(buf: &mut Bytes, flags: u8) -> Result<SlimeChunk, SlimeError> {
+    let x = read_i32(buf)?;
+    let z = read_i32(buf)?;
+
+    let section_count = read_i32(buf)?;
+    let section_count = usize::try_from(section_count)
+        .map_err(|_| SlimeError::Corrupt("negative section count"))?;
+    let mut sections = Vec::with_capacity(section_count.min(PREALLOC_CAP));
+    for _ in 0..section_count {
+        sections.push(read_section(buf)?);
+    }
+
+    let height_maps = read_segment(buf)?;
+
+    let poi = if flags & FLAG_POI != 0 {
+        read_segment(buf)?
+    } else {
+        Bytes::new()
+    };
+    let block_ticks = if flags & FLAG_BLOCK_TICKS != 0 {
+        read_segment(buf)?
+    } else {
+        Bytes::new()
+    };
+    let fluid_ticks = if flags & FLAG_FLUID_TICKS != 0 {
+        read_segment(buf)?
+    } else {
+        Bytes::new()
+    };
+
+    // Skip any unknown (future) additional-data segments to stay in sync.
+    for _ in 0..(flags & !KNOWN_FLAGS).count_ones() {
+        let _unknown = read_segment(buf)?;
+    }
+
+    let block_entities = read_segment(buf)?;
+    let entities = read_segment(buf)?;
+    let _chunk_extra = read_segment(buf)?; // per-chunk persistent data, unused.
+
+    Ok(SlimeChunk {
+        x,
+        z,
+        sections,
+        height_maps,
+        block_entities,
+        entities,
+        block_ticks,
+        fluid_ticks,
+        poi,
+    })
+}
+
+fn read_section(buf: &mut Bytes) -> Result<SlimeSection, SlimeError> {
+    let section_flags = read_u8(buf)?;
+    let block_light = if section_flags & 1 != 0 {
+        Some(take(buf, LIGHT_ARRAY_SIZE)?)
+    } else {
+        None
+    };
+    let sky_light = if section_flags & (1 << 1) != 0 {
+        Some(take(buf, LIGHT_ARRAY_SIZE)?)
+    } else {
+        None
+    };
+    let block_states = read_segment(buf)?;
+    let biomes = read_segment(buf)?;
+    Ok(SlimeSection {
+        block_light,
+        sky_light,
+        block_states,
+        biomes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::{BufMut, BytesMut};
+    use ruzstd::encoding::{CompressionLevel, compress_to_vec};
+
+    use super::{SLIME_MAGIC, SLIME_VERSION, SlimeError, read_slime_world};
+
+    fn be_i32(v: i32) -> [u8; 4] {
+        v.to_be_bytes()
+    }
+
+    /// Frame a payload the way `SlimeSerializer.writeCompressed` does.
+    fn compress_block(raw: &[u8]) -> Vec<u8> {
+        let compressed = compress_to_vec(raw, CompressionLevel::Fastest);
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&be_i32(i32::try_from(compressed.len()).unwrap()));
+        framed.extend_from_slice(&be_i32(i32::try_from(raw.len()).unwrap()));
+        framed.extend_from_slice(&compressed);
+        framed
+    }
+
+    #[test]
+    fn parses_minimal_world() {
+        // One chunk at (2, 3) with a single empty section, no light, no flags.
+        let mut chunk_stream = BytesMut::new();
+        chunk_stream.put_i32(1); // chunk count
+        chunk_stream.put_i32(2); // x
+        chunk_stream.put_i32(3); // z
+        chunk_stream.put_i32(1); // section count
+        chunk_stream.put_u8(0); // section flags (no light)
+        chunk_stream.put_i32(0); // block_states length
+        chunk_stream.put_i32(0); // biomes length
+        chunk_stream.put_i32(0); // heightmaps length
+        chunk_stream.put_i32(0); // tileEntities length
+        chunk_stream.put_i32(0); // entities length
+        chunk_stream.put_i32(0); // chunk extra length
+
+        let mut file = BytesMut::new();
+        file.put_slice(&SLIME_MAGIC);
+        file.put_u8(SLIME_VERSION);
+        file.put_i32(3700); // world version (DataVersion)
+        file.put_u8(0); // additional world data flags
+        file.put_slice(&compress_block(&chunk_stream));
+        file.put_slice(&compress_block(&[0x0a, 0x00, 0x00, 0x00])); // empty "extra" compound
+
+        let world = read_slime_world(file.freeze()).expect("minimal world should parse");
+        assert_eq!(world.world_version, 3700);
+        assert_eq!(world.flags, 0);
+        assert_eq!(world.chunks.len(), 1);
+        let chunk = &world.chunks[0];
+        assert_eq!((chunk.x, chunk.z), (2, 3));
+        assert_eq!(chunk.sections.len(), 1);
+        assert!(chunk.sections[0].block_light.is_none());
+        assert!(chunk.sections[0].sky_light.is_none());
+        assert!(chunk.sections[0].block_states.is_empty());
+    }
+
+    #[test]
+    fn reads_section_light_arrays() {
+        let mut chunk_stream = BytesMut::new();
+        chunk_stream.put_i32(1); // chunk count
+        chunk_stream.put_i32(0); // x
+        chunk_stream.put_i32(0); // z
+        chunk_stream.put_i32(1); // section count
+        chunk_stream.put_u8(0b11); // section flags: block + sky light
+        chunk_stream.put_slice(&[0x12u8; 2048]); // block light
+        chunk_stream.put_slice(&[0x34u8; 2048]); // sky light
+        chunk_stream.put_i32(0); // block_states length
+        chunk_stream.put_i32(0); // biomes length
+        chunk_stream.put_i32(0); // heightmaps length
+        chunk_stream.put_i32(0); // tileEntities length
+        chunk_stream.put_i32(0); // entities length
+        chunk_stream.put_i32(0); // chunk extra length
+
+        let mut file = BytesMut::new();
+        file.put_slice(&SLIME_MAGIC);
+        file.put_u8(SLIME_VERSION);
+        file.put_i32(3700);
+        file.put_u8(0);
+        file.put_slice(&compress_block(&chunk_stream));
+        file.put_slice(&compress_block(&[0x0a, 0x00, 0x00, 0x00]));
+
+        let world = read_slime_world(file.freeze()).expect("world should parse");
+        let section = &world.chunks[0].sections[0];
+        assert_eq!(section.block_light.as_deref(), Some(&[0x12u8; 2048][..]));
+        assert_eq!(section.sky_light.as_deref(), Some(&[0x34u8; 2048][..]));
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let mut file = BytesMut::new();
+        file.put_slice(&[0x00, 0x00]);
+        file.put_u8(SLIME_VERSION);
+        let err = read_slime_world(file.freeze()).unwrap_err();
+        assert!(matches!(err, SlimeError::BadMagic));
+    }
+
+    #[test]
+    fn rejects_newer_version() {
+        let mut file = BytesMut::new();
+        file.put_slice(&SLIME_MAGIC);
+        file.put_u8(99);
+        let err = read_slime_world(file.freeze()).unwrap_err();
+        assert!(matches!(err, SlimeError::UnsupportedVersion(99)));
+    }
+
+    #[test]
+    fn rejects_truncated_data() {
+        let mut file = BytesMut::new();
+        file.put_slice(&SLIME_MAGIC);
+        file.put_u8(SLIME_VERSION);
+        file.put_i32(3700);
+        // missing flags byte and everything after
+        let err = read_slime_world(file.freeze()).unwrap_err();
+        assert!(matches!(err, SlimeError::Truncated));
+    }
+}

--- a/pumpkin-world/src/chunk/format/slime/reader.rs
+++ b/pumpkin-world/src/chunk/format/slime/reader.rs
@@ -1,6 +1,6 @@
-//! Binary parser for the `.slime` container format (AdvancedSlimePaper v13).
+//! Binary parser for the `.slime` container format (`AdvancedSlimePaper` v13).
 //!
-//! Layout mirrors AdvancedSlimePaper `dev/26.2` (`SlimeSerializer` /
+//! Layout mirrors `AdvancedSlimePaper` `dev/26.2` (`SlimeSerializer` /
 //! `v13SlimeWorldDeSerializer`): big-endian integers and two zstd-compressed
 //! payloads (the chunks, then the world "extra"), each framed as
 //! `[i32 compressed_len][i32 raw_len][compressed bytes]`. NBT segments are

--- a/pumpkin-world/src/chunk/format/slime/store.rs
+++ b/pumpkin-world/src/chunk/format/slime/store.rs
@@ -119,8 +119,17 @@ impl SlimeWorldStore {
             entity_compounds.insert(*coord, guard.values().cloned().collect());
         }
 
-        let bytes = serialize_world(self.world_version, &self.extra, &chunks, &entity_compounds);
-        std::fs::write(&self.path, bytes)
+        // Serializing (NBT + zstd) and writing the file are CPU/IO heavy; run them
+        // off the async runtime so the tokio worker is never blocked.
+        let world_version = self.world_version;
+        let extra = self.extra.clone();
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || {
+            let bytes = serialize_world(world_version, &extra, &chunks, &entity_compounds);
+            std::fs::write(path, bytes)
+        })
+        .await
+        .map_err(std::io::Error::other)?
     }
 }
 

--- a/pumpkin-world/src/chunk/format/slime/store.rs
+++ b/pumpkin-world/src/chunk/format/slime/store.rs
@@ -1,0 +1,183 @@
+//! Shared in-memory state for a loaded SlimeWorld.
+//!
+//! A `.slime` file holds an entire world, but Pumpkin wires up *two* separate
+//! [`FileIO`](crate::chunk::io::FileIO) backends per level (one for block data,
+//! one for entities). Both share a single [`SlimeWorldStore`] so that a save
+//! from either side can re-serialize the complete world back to the one file.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use bytes::Bytes;
+use pumpkin_nbt::compound::NbtCompound;
+use pumpkin_util::math::vector2::Vector2;
+use rustc_hash::FxHashMap;
+use tracing::error;
+
+use crate::chunk::format::anvil::WORLD_DATA_VERSION;
+use crate::level::{SyncChunk, SyncEntityChunk};
+
+use super::writer::serialize_world;
+use super::{chunk_to_chunk_data, chunk_to_entity_data, read_slime_world};
+
+/// Filename used when a world is persisted but had no source `.slime` file.
+const DEFAULT_SLIME_NAME: &str = "world.slime";
+
+/// The whole loaded SlimeWorld, shared between the chunk and entity backends.
+pub(crate) struct SlimeWorldStore {
+    /// Where the world is read from / written back to.
+    path: PathBuf,
+    /// Vanilla `DataVersion`, preserved across save.
+    world_version: i32,
+    /// The world "extra" compound (carries `properties`), preserved verbatim.
+    extra: Bytes,
+    chunks: RwLock<FxHashMap<Vector2<i32>, SyncChunk>>,
+    entities: RwLock<FxHashMap<Vector2<i32>, SyncEntityChunk>>,
+    /// Serializes whole-file writes so concurrent saves can't interleave.
+    write_lock: tokio::sync::Mutex<()>,
+}
+
+impl SlimeWorldStore {
+    /// Load and convert the first `*.slime` file under `root` (if any).
+    ///
+    /// `min_section_y` is the bottom-most section index of the target dimension.
+    pub(crate) fn load(root: &Path, min_section_y: i32) -> Arc<Self> {
+        let existing = find_slime_path(root);
+        let path = existing
+            .clone()
+            .unwrap_or_else(|| root.join(DEFAULT_SLIME_NAME));
+
+        let (world_version, extra, chunks, entities) = existing
+            .and_then(|file| read_world(&file, min_section_y))
+            .unwrap_or_else(|| {
+                (
+                    WORLD_DATA_VERSION,
+                    Bytes::new(),
+                    FxHashMap::default(),
+                    FxHashMap::default(),
+                )
+            });
+
+        Arc::new(Self {
+            path,
+            world_version,
+            extra,
+            chunks: RwLock::new(chunks),
+            entities: RwLock::new(entities),
+            write_lock: tokio::sync::Mutex::new(()),
+        })
+    }
+
+    pub(crate) fn get_chunk(&self, coord: &Vector2<i32>) -> Option<SyncChunk> {
+        self.chunks.read().expect("chunks lock").get(coord).cloned()
+    }
+
+    pub(crate) fn get_entity(&self, coord: &Vector2<i32>) -> Option<SyncEntityChunk> {
+        self.entities
+            .read()
+            .expect("entities lock")
+            .get(coord)
+            .cloned()
+    }
+
+    pub(crate) fn store_chunks(&self, data: Vec<(Vector2<i32>, SyncChunk)>) {
+        let mut guard = self.chunks.write().expect("chunks lock");
+        for (coord, chunk) in data {
+            guard.insert(coord, chunk);
+        }
+    }
+
+    pub(crate) fn store_entities(&self, data: Vec<(Vector2<i32>, SyncEntityChunk)>) {
+        let mut guard = self.entities.write().expect("entities lock");
+        for (coord, chunk) in data {
+            guard.insert(coord, chunk);
+        }
+    }
+
+    /// Re-serialize the whole world and write it back to disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`std::io::Error`] if writing the file fails.
+    pub(crate) async fn persist(&self) -> std::io::Result<()> {
+        let _write = self.write_lock.lock().await;
+
+        // Snapshot the chunk Arcs (cheap clones); the lock is released before any await.
+        let chunks = self.chunks.read().expect("chunks lock").clone();
+        let entity_handles: Vec<(Vector2<i32>, SyncEntityChunk)> = self
+            .entities
+            .read()
+            .expect("entities lock")
+            .iter()
+            .map(|(coord, chunk)| (*coord, chunk.clone()))
+            .collect();
+
+        // Entity NBT lives behind a tokio mutex; collect owned copies up front.
+        let mut entity_compounds: FxHashMap<Vector2<i32>, Vec<NbtCompound>> = FxHashMap::default();
+        for (coord, chunk) in &entity_handles {
+            let guard = chunk.data.lock().await;
+            entity_compounds.insert(*coord, guard.values().cloned().collect());
+        }
+
+        let bytes = serialize_world(self.world_version, &self.extra, &chunks, &entity_compounds);
+        std::fs::write(&self.path, bytes)
+    }
+}
+
+/// Find the first `*.slime` file directly under `root`.
+fn find_slime_path(root: &Path) -> Option<PathBuf> {
+    std::fs::read_dir(root)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("slime"))
+        })
+}
+
+type LoadedWorld = (
+    i32,
+    Bytes,
+    FxHashMap<Vector2<i32>, SyncChunk>,
+    FxHashMap<Vector2<i32>, SyncEntityChunk>,
+);
+
+/// Read a `.slime` file and convert every chunk into Pumpkin's representation.
+fn read_world(path: &Path, min_section_y: i32) -> Option<LoadedWorld> {
+    let bytes = std::fs::read(path).ok()?;
+    let world = match read_slime_world(Bytes::from(bytes)) {
+        Ok(world) => world,
+        Err(error) => {
+            error!("Failed to read slime world at {path:?}: {error}");
+            return None;
+        }
+    };
+
+    let mut chunks = FxHashMap::default();
+    let mut entities = FxHashMap::default();
+    for chunk in &world.chunks {
+        let coord = Vector2::new(chunk.x, chunk.z);
+        match chunk_to_chunk_data(chunk, min_section_y) {
+            Ok(data) => {
+                chunks.insert(coord, Arc::new(data));
+            }
+            Err(error) => error!(
+                "Failed to convert slime chunk {},{}: {error}",
+                chunk.x, chunk.z
+            ),
+        }
+        match chunk_to_entity_data(chunk) {
+            Ok(data) => {
+                entities.insert(coord, Arc::new(data));
+            }
+            Err(error) => error!(
+                "Failed to convert slime entities for chunk {},{}: {error}",
+                chunk.x, chunk.z
+            ),
+        }
+    }
+
+    Some((world.world_version, world.extra, chunks, entities))
+}

--- a/pumpkin-world/src/chunk/format/slime/store.rs
+++ b/pumpkin-world/src/chunk/format/slime/store.rs
@@ -116,7 +116,7 @@ impl SlimeWorldStore {
         let mut entity_compounds: FxHashMap<Vector2<i32>, Vec<NbtCompound>> = FxHashMap::default();
         for (coord, chunk) in &entity_handles {
             let guard = chunk.data.lock().await;
-            entity_compounds.insert(*coord, guard.values().cloned().collect());
+            entity_compounds.insert(*coord, guard.clone());
         }
 
         // Serializing (NBT + zstd) and writing the file are CPU/IO heavy; run them

--- a/pumpkin-world/src/chunk/format/slime/store.rs
+++ b/pumpkin-world/src/chunk/format/slime/store.rs
@@ -1,4 +1,4 @@
-//! Shared in-memory state for a loaded SlimeWorld.
+//! Shared in-memory state for a loaded `SlimeWorld`.
 //!
 //! A `.slime` file holds an entire world, but Pumpkin wires up *two* separate
 //! [`FileIO`](crate::chunk::io::FileIO) backends per level (one for block data,
@@ -23,8 +23,8 @@ use super::{chunk_to_chunk_data, chunk_to_entity_data, read_slime_world};
 /// Filename used when a world is persisted but had no source `.slime` file.
 const DEFAULT_SLIME_NAME: &str = "world.slime";
 
-/// The whole loaded SlimeWorld, shared between the chunk and entity backends.
-pub(crate) struct SlimeWorldStore {
+/// The whole loaded `SlimeWorld`, shared between the chunk and entity backends.
+pub struct SlimeWorldStore {
     /// Where the world is read from / written back to.
     path: PathBuf,
     /// Vanilla `DataVersion`, preserved across save.
@@ -68,15 +68,19 @@ impl SlimeWorldStore {
         })
     }
 
-    pub(crate) fn get_chunk(&self, coord: &Vector2<i32>) -> Option<SyncChunk> {
-        self.chunks.read().expect("chunks lock").get(coord).cloned()
+    pub(crate) fn get_chunk(&self, coord: Vector2<i32>) -> Option<SyncChunk> {
+        self.chunks
+            .read()
+            .expect("chunks lock")
+            .get(&coord)
+            .cloned()
     }
 
-    pub(crate) fn get_entity(&self, coord: &Vector2<i32>) -> Option<SyncEntityChunk> {
+    pub(crate) fn get_entity(&self, coord: Vector2<i32>) -> Option<SyncEntityChunk> {
         self.entities
             .read()
             .expect("entities lock")
-            .get(coord)
+            .get(&coord)
             .cloned()
     }
 

--- a/pumpkin-world/src/chunk/format/slime/writer.rs
+++ b/pumpkin-world/src/chunk/format/slime/writer.rs
@@ -1,0 +1,346 @@
+//! Serialize an in-memory world back into the `.slime` container format (v13).
+//!
+//! This is the inverse of [`super::reader`]: section block / biome palettes are
+//! turned back into the vanilla string-paletted NBT, light is written as raw
+//! nibble arrays, and the whole thing is framed and zstd-compressed exactly the
+//! way AdvancedSlimePaper's `SlimeSerializer` does it.
+//!
+//! POI, block-tick and fluid-tick segments are not produced (the `flags` byte is
+//! written as `0`); the world `extra` block (which carries `properties`) is
+//! preserved verbatim from the source file.
+
+use std::collections::BTreeMap;
+
+use bytes::{BufMut, BytesMut};
+use pumpkin_data::{Block, biome::Biome};
+use pumpkin_nbt::compound::NbtCompound;
+use pumpkin_nbt::nbt_long_array;
+use pumpkin_util::math::vector2::Vector2;
+use rustc_hash::{FxHashMap, FxHashSet};
+use ruzstd::encoding::{CompressionLevel, compress_to_vec};
+use serde::Serialize;
+
+use crate::chunk::format::LightContainer;
+use crate::chunk::palette::{BiomePalette, BlockPalette};
+use crate::level::SyncChunk;
+
+use super::{SLIME_MAGIC, SLIME_VERSION};
+
+/// A minimal named, empty NBT compound (`TAG_Compound "" TAG_End`).
+const EMPTY_COMPOUND: [u8; 4] = [0x0a, 0x00, 0x00, 0x00];
+
+#[derive(Serialize)]
+struct BlockStatesOut {
+    palette: Vec<PaletteEntryOut>,
+    #[serde(
+        serialize_with = "nbt_long_array",
+        skip_serializing_if = "Option::is_none"
+    )]
+    data: Option<Box<[i64]>>,
+}
+
+#[derive(Serialize)]
+struct PaletteEntryOut {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Properties", skip_serializing_if = "Option::is_none")]
+    properties: Option<BTreeMap<String, String>>,
+}
+
+#[derive(Serialize)]
+struct BiomesOut {
+    palette: Vec<String>,
+    #[serde(
+        serialize_with = "nbt_long_array",
+        skip_serializing_if = "Option::is_none"
+    )]
+    data: Option<Box<[i64]>>,
+}
+
+#[derive(Serialize)]
+struct TileEntitiesOut<'a> {
+    #[serde(rename = "tileEntities")]
+    tile_entities: Vec<&'a NbtCompound>,
+}
+
+#[derive(Serialize)]
+struct EntitiesOut<'a> {
+    entities: Vec<&'a NbtCompound>,
+}
+
+fn serialize_named<T: Serialize>(value: &T) -> Vec<u8> {
+    let mut buf = Vec::new();
+    pumpkin_nbt::to_bytes(value, &mut buf).expect("serializing slime NBT segment should not fail");
+    buf
+}
+
+/// Resolve a Pumpkin global block-state id back to a vanilla palette entry.
+fn state_id_to_entry(state_id: u16) -> PaletteEntryOut {
+    let block = Block::from_state_id(state_id);
+    let properties = block.properties(state_id).and_then(|props| {
+        let map: BTreeMap<String, String> = props
+            .to_props()
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect();
+        (!map.is_empty()).then_some(map)
+    });
+    PaletteEntryOut {
+        name: format!("minecraft:{}", block.name),
+        properties,
+    }
+}
+
+/// Resolve a Pumpkin biome id back to its namespaced name.
+fn biome_id_to_name(biome_id: u8) -> String {
+    Biome::from_id(biome_id).map_or_else(
+        || "minecraft:plains".to_string(),
+        |biome| format!("minecraft:{}", biome.registry_id),
+    )
+}
+
+fn block_states_nbt(palette: &BlockPalette) -> Vec<u8> {
+    let disk = palette.to_disk_nbt();
+    serialize_named(&BlockStatesOut {
+        palette: disk
+            .palette
+            .iter()
+            .map(|&id| state_id_to_entry(id))
+            .collect(),
+        data: disk.data,
+    })
+}
+
+fn biomes_nbt(palette: &BiomePalette) -> Vec<u8> {
+    let disk = palette.to_disk_nbt();
+    serialize_named(&BiomesOut {
+        palette: disk
+            .palette
+            .iter()
+            .map(|&id| biome_id_to_name(id))
+            .collect(),
+        data: disk.data,
+    })
+}
+
+fn light_bytes(light: Option<&LightContainer>) -> Option<&[u8]> {
+    match light {
+        Some(LightContainer::Full(data)) => Some(data),
+        _ => None,
+    }
+}
+
+/// Write an `[i32 length][length bytes]` NBT segment.
+fn put_segment(buf: &mut BytesMut, bytes: &[u8]) {
+    buf.put_i32(i32::try_from(bytes.len()).unwrap_or(i32::MAX));
+    buf.put_slice(bytes);
+}
+
+fn write_section(
+    buf: &mut BytesMut,
+    block: &BlockPalette,
+    biome: &BiomePalette,
+    block_light: Option<&LightContainer>,
+    sky_light: Option<&LightContainer>,
+) {
+    let block_light = light_bytes(block_light);
+    let sky_light = light_bytes(sky_light);
+
+    let mut flags = 0u8;
+    if block_light.is_some() {
+        flags |= 1;
+    }
+    if sky_light.is_some() {
+        flags |= 1 << 1;
+    }
+    buf.put_u8(flags);
+    if let Some(data) = block_light {
+        buf.put_slice(data);
+    }
+    if let Some(data) = sky_light {
+        buf.put_slice(data);
+    }
+    put_segment(buf, &block_states_nbt(block));
+    put_segment(buf, &biomes_nbt(biome));
+}
+
+fn write_chunk(buf: &mut BytesMut, chunk: Option<&SyncChunk>, entities: Option<&Vec<NbtCompound>>) {
+    if let Some(chunk) = chunk {
+        let block_sections = chunk
+            .section
+            .block_sections
+            .read()
+            .expect("block sections lock");
+        let biome_sections = chunk
+            .section
+            .biome_sections
+            .read()
+            .expect("biome sections lock");
+        let light = chunk.light_engine.lock().expect("light engine lock");
+
+        let count = block_sections.len();
+        buf.put_i32(i32::try_from(count).unwrap_or(i32::MAX));
+        for index in 0..count {
+            write_section(
+                buf,
+                &block_sections[index],
+                &biome_sections[index],
+                light.block_light.get(index),
+                light.sky_light.get(index),
+            );
+        }
+        drop(light);
+        drop(biome_sections);
+        drop(block_sections);
+
+        let heightmaps = {
+            let guard = chunk.heightmap.lock().expect("heightmap lock");
+            serialize_named(&*guard)
+        };
+        put_segment(buf, &heightmaps);
+
+        let tile_entities = {
+            let guard = chunk
+                .pending_block_entities
+                .lock()
+                .expect("block entities lock");
+            serialize_named(&TileEntitiesOut {
+                tile_entities: guard.values().collect(),
+            })
+        };
+        put_segment(buf, &tile_entities);
+    } else {
+        buf.put_i32(0);
+        put_segment(buf, &EMPTY_COMPOUND);
+        put_segment(
+            buf,
+            &serialize_named(&TileEntitiesOut {
+                tile_entities: Vec::new(),
+            }),
+        );
+    }
+
+    let entity_refs: Vec<&NbtCompound> = entities
+        .map(|list| list.iter().collect())
+        .unwrap_or_default();
+    put_segment(
+        buf,
+        &serialize_named(&EntitiesOut {
+            entities: entity_refs,
+        }),
+    );
+
+    // Per-chunk persistent data container (unused): empty segment.
+    buf.put_i32(0);
+}
+
+/// Serialize a whole world to the v13 `.slime` byte format.
+///
+/// `extra` is the (decompressed) world "extra" compound, preserved from the
+/// source file; when empty an empty compound is written so the file stays valid.
+pub(super) fn serialize_world(
+    world_version: i32,
+    extra: &[u8],
+    chunks: &FxHashMap<Vector2<i32>, SyncChunk>,
+    entities: &FxHashMap<Vector2<i32>, Vec<NbtCompound>>,
+) -> Vec<u8> {
+    let mut coords: FxHashSet<Vector2<i32>> = chunks.keys().copied().collect();
+    coords.extend(entities.keys().copied());
+
+    let mut body = BytesMut::new();
+    body.put_i32(i32::try_from(coords.len()).unwrap_or(i32::MAX));
+    for coord in &coords {
+        body.put_i32(coord.x);
+        body.put_i32(coord.y);
+        write_chunk(&mut body, chunks.get(coord), entities.get(coord));
+    }
+
+    let mut file = BytesMut::new();
+    file.put_slice(&SLIME_MAGIC);
+    file.put_u8(SLIME_VERSION);
+    file.put_i32(world_version);
+    file.put_u8(0); // additionalWorldData flags: none written back
+    write_compressed(&mut file, &body);
+    let extra = if extra.is_empty() {
+        &EMPTY_COMPOUND
+    } else {
+        extra
+    };
+    write_compressed(&mut file, extra);
+    file.to_vec()
+}
+
+fn write_compressed(file: &mut BytesMut, data: &[u8]) {
+    let compressed = compress_to_vec(data, CompressionLevel::Fastest);
+    file.put_i32(i32::try_from(compressed.len()).unwrap_or(i32::MAX));
+    file.put_i32(i32::try_from(data.len()).unwrap_or(i32::MAX));
+    file.put_slice(&compressed);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use pumpkin_data::Block;
+    use pumpkin_util::math::vector2::Vector2;
+    use rustc_hash::FxHashMap;
+
+    use super::super::SlimeChunk;
+    use super::super::model::SlimeSection;
+    use super::super::{chunk_to_chunk_data, read_slime_world};
+    use super::{BlockStatesOut, PaletteEntryOut, serialize_named, serialize_world};
+
+    fn stone_block_states() -> Bytes {
+        Bytes::from(serialize_named(&BlockStatesOut {
+            palette: vec![PaletteEntryOut {
+                name: "minecraft:stone".to_string(),
+                properties: None,
+            }],
+            data: None,
+        }))
+    }
+
+    #[test]
+    fn round_trips_a_stone_chunk() {
+        let stone_id = Block::from_registry_key("stone").unwrap().default_state.id;
+
+        // Build a one-section chunk holding only stone, via the read-side converter.
+        let slime_chunk = SlimeChunk {
+            x: 4,
+            z: -2,
+            sections: vec![SlimeSection {
+                block_light: None,
+                sky_light: None,
+                block_states: stone_block_states(),
+                biomes: Bytes::new(),
+            }],
+            height_maps: Bytes::new(),
+            block_entities: Bytes::new(),
+            entities: Bytes::new(),
+            block_ticks: Bytes::new(),
+            fluid_ticks: Bytes::new(),
+            poi: Bytes::new(),
+        };
+        let chunk_data = chunk_to_chunk_data(&slime_chunk, -4).expect("convert");
+
+        // Serialize the whole world, then read it back.
+        let mut chunks = FxHashMap::default();
+        chunks.insert(Vector2::new(4, -2), Arc::new(chunk_data));
+        let bytes = serialize_world(3700, &[], &chunks, &FxHashMap::default());
+
+        let world = read_slime_world(Bytes::from(bytes)).expect("read back");
+        assert_eq!(world.world_version, 3700);
+        assert_eq!(world.chunks.len(), 1);
+        let chunk = &world.chunks[0];
+        assert_eq!((chunk.x, chunk.z), (4, -2));
+
+        // The single section must still resolve to stone.
+        let restored = chunk_to_chunk_data(chunk, -4).expect("convert back");
+        let sections = restored.section.block_sections.read().unwrap();
+        assert_eq!(
+            sections[0].to_disk_nbt().palette.first().copied(),
+            Some(stone_id)
+        );
+    }
+}

--- a/pumpkin-world/src/chunk/format/slime/writer.rs
+++ b/pumpkin-world/src/chunk/format/slime/writer.rs
@@ -3,7 +3,7 @@
 //! This is the inverse of [`super::reader`]: section block / biome palettes are
 //! turned back into the vanilla string-paletted NBT, light is written as raw
 //! nibble arrays, and the whole thing is framed and zstd-compressed exactly the
-//! way AdvancedSlimePaper's `SlimeSerializer` does it.
+//! way `AdvancedSlimePaper`'s `SlimeSerializer` does it.
 //!
 //! POI, block-tick and fluid-tick segments are not produced (the `flags` byte is
 //! written as `0`); the world `extra` block (which carries `properties`) is
@@ -12,6 +12,7 @@
 use std::collections::BTreeMap;
 
 use bytes::{BufMut, BytesMut};
+use pumpkin_data::block_state::BlockStateId;
 use pumpkin_data::{Block, biome::Biome};
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_nbt::nbt_long_array;
@@ -75,7 +76,7 @@ fn serialize_named<T: Serialize>(value: &T) -> Vec<u8> {
 }
 
 /// Resolve a Pumpkin global block-state id back to a vanilla palette entry.
-fn state_id_to_entry(state_id: u16) -> PaletteEntryOut {
+fn state_id_to_entry(state_id: BlockStateId) -> PaletteEntryOut {
     let block = Block::from_state_id(state_id);
     let properties = block.properties(state_id).and_then(|props| {
         let map: BTreeMap<String, String> = props

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -186,9 +186,7 @@ impl Level {
             >::new(config.clone())),
             ChunkConfig::Pump => Arc::new(ChunkFileManager::<PumpFile<ChunkEntityData>>::new(())),
             ChunkConfig::Slime => Arc::new(SlimeEntityIo::new(
-                slime_store
-                    .clone()
-                    .expect("slime store created for slime config"),
+                slime_store.expect("slime store created for slime config"),
             )),
         };
 

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -1,6 +1,6 @@
 use crate::chunk::format::linear::LinearV2File;
 use crate::chunk::format::pump::PumpFile;
-use crate::chunk::format::slime::{SlimeChunkIo, SlimeEntityIo};
+use crate::chunk::format::slime::{SlimeChunkIo, SlimeEntityIo, SlimeWorldStore};
 use crate::chunk_system::{ChunkListener, ChunkLoading, GenerationSchedule, LevelChannel};
 use crate::generation::generator::VanillaGenerator;
 use crate::lighting::DynamicLightEngine;
@@ -161,15 +161,21 @@ impl Level {
         let min_section_y = dimension.min_y >> 4;
         let world_gen = get_world_gen(seed, dimension).into();
 
+        // SlimeWorld keeps the whole world in one shared store used by both savers.
+        let slime_store = matches!(level_config.chunk, ChunkConfig::Slime)
+            .then(|| SlimeWorldStore::load(&level_folder.root_folder, min_section_y));
+
         let chunk_saver: Arc<dyn FileIO<Data = SyncChunk>> = match &level_config.chunk {
             ChunkConfig::Linear => Arc::new(ChunkFileManager::<LinearV2File<ChunkData>>::new(())),
             ChunkConfig::Anvil(config) => Arc::new(
                 ChunkFileManager::<AnvilChunkFile<ChunkData>>::new(config.clone()),
             ),
             ChunkConfig::Pump => Arc::new(ChunkFileManager::<PumpFile<ChunkData>>::new(())),
-            ChunkConfig::Slime => {
-                Arc::new(SlimeChunkIo::new(&level_folder.root_folder, min_section_y))
-            }
+            ChunkConfig::Slime => Arc::new(SlimeChunkIo::new(
+                slime_store
+                    .clone()
+                    .expect("slime store created for slime config"),
+            )),
         };
         let entity_saver: Arc<dyn FileIO<Data = SyncEntityChunk>> = match &level_config.chunk {
             ChunkConfig::Linear => {
@@ -179,7 +185,11 @@ impl Level {
                 AnvilChunkFile<ChunkEntityData>,
             >::new(config.clone())),
             ChunkConfig::Pump => Arc::new(ChunkFileManager::<PumpFile<ChunkEntityData>>::new(())),
-            ChunkConfig::Slime => Arc::new(SlimeEntityIo::new(&level_folder.root_folder)),
+            ChunkConfig::Slime => Arc::new(SlimeEntityIo::new(
+                slime_store
+                    .clone()
+                    .expect("slime store created for slime config"),
+            )),
         };
 
         let pending_entity_generations = Arc::new(DashMap::new());

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -1,5 +1,6 @@
 use crate::chunk::format::linear::LinearV2File;
 use crate::chunk::format::pump::PumpFile;
+use crate::chunk::format::slime::{SlimeChunkIo, SlimeEntityIo};
 use crate::chunk_system::{ChunkListener, ChunkLoading, GenerationSchedule, LevelChannel};
 use crate::generation::generator::VanillaGenerator;
 use crate::lighting::DynamicLightEngine;
@@ -155,6 +156,9 @@ impl Level {
         });
 
         let seed = Seed(seed as u64);
+        // Bottom-most section index of this dimension; SlimeWorld stores sections
+        // bottom-up without an explicit Y, so this anchors them.
+        let min_section_y = dimension.min_y >> 4;
         let world_gen = get_world_gen(seed, dimension).into();
 
         let chunk_saver: Arc<dyn FileIO<Data = SyncChunk>> = match &level_config.chunk {
@@ -163,6 +167,9 @@ impl Level {
                 ChunkFileManager::<AnvilChunkFile<ChunkData>>::new(config.clone()),
             ),
             ChunkConfig::Pump => Arc::new(ChunkFileManager::<PumpFile<ChunkData>>::new(())),
+            ChunkConfig::Slime => {
+                Arc::new(SlimeChunkIo::new(&level_folder.root_folder, min_section_y))
+            }
         };
         let entity_saver: Arc<dyn FileIO<Data = SyncEntityChunk>> = match &level_config.chunk {
             ChunkConfig::Linear => {
@@ -172,6 +179,7 @@ impl Level {
                 AnvilChunkFile<ChunkEntityData>,
             >::new(config.clone())),
             ChunkConfig::Pump => Arc::new(ChunkFileManager::<PumpFile<ChunkEntityData>>::new(())),
+            ChunkConfig::Slime => Arc::new(SlimeEntityIo::new(&level_folder.root_folder)),
         };
 
         let pending_entity_generations = Arc::new(DashMap::new());


### PR DESCRIPTION
## Summary

Adds the SlimeWorld (`.slime`) world format as a selectable, **read-write** chunk
format, addressing part of #118. Targets the current AdvancedSlimePaper format
(`SLIME_VERSION = 13`). Set `chunk.type = "slime"` in a world's config to load
the first `*.slime` file in that world folder.

## What this does

- **Container parser** (`chunk::format::slime::reader`): decodes the `.slime`
  binary container — `0xB10B` magic, version, the two zstd-compressed blocks
  (chunks + world extra), and each chunk's sections / light / heightmaps /
  block entities / entities.
- **Conversion** (`…::convert`): resolves the vanilla string block-state palette
  to Pumpkin global state ids (`Block::from_registry_key` +
  `from_properties`/`to_state_id`) and biome names to ids, rebuilds the section
  block / biome / light palettes into `ChunkData`, and maps block entities and
  entities (keyed by UUID) onto `ChunkData` / `ChunkEntityData`.
- **Writer** (`…::writer`): the inverse — section palettes become vanilla
  string-paletted NBT, light is written as raw nibble arrays, block entities and
  entities are emitted, and the container is framed and zstd-compressed like
  ASP's `SlimeSerializer`.
- **IO backends** (`…::io` + `…::store`): both the chunk and entity `FileIO`
  backends share one `SlimeWorldStore` holding the whole world in memory. Reads
  are served from the in-memory maps; a save from either side re-serializes the
  whole world back to the single file. Because SlimeWorld is a "whole world in
  one file, in RAM" format by design, this implements `FileIO` directly instead
  of going through the region-oriented `ChunkFileManager`, so there is zero
  impact on the Anvil / Linear / Pump hot path.
- **Wiring**: `ChunkConfig::Slime`, dispatched in `Level::from_root_folder`.

## Scope / limitations

- Targets `SLIME_VERSION = 13` (ASP `dev/26.2`); legacy v1–v9 layouts are out of
  scope for now.
- On save the whole file is rewritten (fine for the small worlds SlimeWorld is
  meant for). POI, block-tick and fluid-tick segments are not round-tripped (the
  `flags` byte is written as `0`), and `level.dat` metadata from the slime
  `properties` (spawn / environment) is not yet synthesized.

## Testing

- 12 unit tests: the container parser (round-trip, light arrays, bad magic /
  newer version / truncation), the converter (block-state + property resolution
  against the real registry, biome lookup, UUID decode), and a write→read
  round-trip that rebuilds a chunk through the writer and reader.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features`
  (clean), and `cargo test -p pumpkin-world` (80 passing) are all green.

The byte layout was verified against the AdvancedSlimePaper `dev/26.2` sources
(`SlimeSerializer`, `v13SlimeWorldDeSerializer`).

Part of #118.
