### PR TITLE
fix(entity): split the types of wind charges

### DIFF
--- a/pumpkin/src/entity/projectile/wind_charge.rs
+++ b/pumpkin/src/entity/projectile/wind_charge.rs
@@ -19,26 +19,48 @@ const EXPLOSION_POWER: f32 = 1.2;
 const DEFAULT_DEFLECT_COOLDOWN: u8 = 5;
 pub const WIND_CHARGE_GRAVITY: f64 = 0.0;
 
+/// A kind to differentiate both types of wind charges from each other.
+enum WindChargeKind {
+    /// Represents a wind charge spawned by a player or dispenser.
+    /// This wind charge also has a deflect cooldown counter.
+    Normal { deflect_cooldown: AtomicU8 },
+    /// Represents a wind charge spawned by a breeze.
+    Breeze,
+}
+
 pub struct WindChargeEntity {
-    deflect_cooldown: AtomicU8,
+    kind: WindChargeKind,
     thrown_item_entity: ThrownItemEntity,
 }
 
 impl WindChargeEntity {
     #[must_use]
-    pub const fn new(thrown_item_entity: ThrownItemEntity) -> Self {
+    pub const fn new_normal(thrown_item_entity: ThrownItemEntity) -> Self {
         Self {
-            deflect_cooldown: AtomicU8::new(DEFAULT_DEFLECT_COOLDOWN),
+            kind: WindChargeKind::Normal {
+                deflect_cooldown: AtomicU8::new(DEFAULT_DEFLECT_COOLDOWN),
+            },
             thrown_item_entity,
         }
     }
 
-    pub fn get_deflect_cooldown(&self) -> u8 {
-        self.deflect_cooldown.load(Ordering::Relaxed)
+    #[must_use]
+    pub const fn new_breeze(thrown_item_entity: ThrownItemEntity) -> Self {
+        Self {
+            kind: WindChargeKind::Breeze,
+            thrown_item_entity,
+        }
     }
 
-    pub fn set_deflect_cooldown(&self, value: u8) {
-        self.deflect_cooldown.store(value, Ordering::Relaxed);
+    pub const fn deflect_cooldown(&self) -> Option<&AtomicU8> {
+        if let WindChargeKind::Normal {
+            deflect_cooldown, ..
+        } = &self.kind
+        {
+            Some(deflect_cooldown)
+        } else {
+            None
+        }
     }
 
     pub async fn create_explosion(&self, position: Vector3<f64>) {
@@ -55,7 +77,9 @@ impl WindChargeEntity {
         deflector: Option<&dyn EntityBase>,
         _from_attack: bool,
     ) -> bool {
-        if self.deflect_cooldown.load(Ordering::Relaxed) > 0 {
+        if let Some(cooldown) = self.deflect_cooldown()
+            && cooldown.load(Ordering::Relaxed) > 0
+        {
             return false;
         }
 
@@ -82,8 +106,11 @@ impl EntityBase for WindChargeEntity {
         Box::pin(async move {
             self.thrown_item_entity.process_tick(caller, server).await;
 
-            if self.get_deflect_cooldown() > 0 {
-                self.set_deflect_cooldown(self.get_deflect_cooldown() - 1);
+            if let Some(cooldown) = self.deflect_cooldown() {
+                let cooldown_ticks = cooldown.load(Ordering::Relaxed);
+                if cooldown_ticks > 0 {
+                    cooldown.store(cooldown_ticks - 1, Ordering::Relaxed);
+                }
             }
         })
     }

--- a/pumpkin/src/entity/type.rs
+++ b/pumpkin/src/entity/type.rs
@@ -261,7 +261,7 @@ pub fn from_type(
                 has_hit: AtomicBool::new(false),
                 gravity: WIND_CHARGE_GRAVITY,
             };
-            Arc::new(WindChargeEntity::new(thrown))
+            Arc::new(WindChargeEntity::new_normal(thrown))
         }
         id if id == EntityType::BREEZE_WIND_CHARGE.id => {
             let thrown = ThrownItemEntity {
@@ -271,7 +271,7 @@ pub fn from_type(
                 has_hit: AtomicBool::new(false),
                 gravity: WIND_CHARGE_GRAVITY,
             };
-            Arc::new(WindChargeEntity::new(thrown))
+            Arc::new(WindChargeEntity::new_breeze(thrown))
         }
         id if id == EntityType::FIREWORK_ROCKET.id => Arc::new(FireworkRocketEntity::new(entity)),
         id if id == EntityType::SPLASH_POTION.id => Arc::new(SplashPotionEntity::new(entity)),

--- a/pumpkin/src/item/items/wind_charge.rs
+++ b/pumpkin/src/item/items/wind_charge.rs
@@ -49,7 +49,7 @@ impl ItemBehaviour for WindChargeItem {
 
             // TODO: Implement that the projectile will explode on impact
             world
-                .spawn_entity(Arc::new(WindChargeEntity::new(wind_charge)))
+                .spawn_entity(Arc::new(WindChargeEntity::new_normal(wind_charge)))
                 .await;
         })
     }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Minecraft has two separate entities for wind charges: normal ones from players and dispensers, and breeze ones from breezes. Only normal wind charges have a deflection cooldown, so some slightly different tick logic is required.

## Testing
Verified that both types exist independently using the `/summon` command.