### PR TITLE
fix(world): persist end portal block entities

### DIFF
--- a/pumpkin-protocol/src/java/client/play/chunk_data.rs
+++ b/pumpkin-protocol/src/java/client/play/chunk_data.rs
@@ -213,7 +213,13 @@ impl ClientPacket for CChunkData<'_> {
             });
 
             write.write_var_int(&VarInt(id as i32))?;
-            write.write_nbt(nbt.clone().into())?;
+
+            let mut client_nbt = nbt.clone();
+            client_nbt.child_tags.remove("id");
+            client_nbt.child_tags.remove("x");
+            client_nbt.child_tags.remove("y");
+            client_nbt.child_tags.remove("z");
+            write.write_nbt(client_nbt.into())?;
         }
 
         {

--- a/pumpkin/src/block/blocks/end_portal.rs
+++ b/pumpkin/src/block/blocks/end_portal.rs
@@ -37,6 +37,9 @@ impl BlockBehaviour for EndPortalBlock {
 
     fn placed<'a>(&'a self, args: PlacedArgs<'a>) -> BlockFuture<'a, ()> {
         Box::pin(async move {
+            let nbt = EndPortalBlockEntity::create_nbt(*args.position);
+            args.world.add_block_entity_nbt(*args.position, &nbt);
+
             args.world
                 .add_block_entity(Arc::new(EndPortalBlockEntity::new(*args.position)));
         })

--- a/pumpkin/src/block/entities/end_portal.rs
+++ b/pumpkin/src/block/entities/end_portal.rs
@@ -15,6 +15,16 @@ impl EndPortalBlockEntity {
     pub const fn new(position: BlockPos) -> Self {
         Self { position }
     }
+
+    #[must_use]
+    pub fn create_nbt(position: BlockPos) -> NbtCompound {
+        let mut nbt = NbtCompound::new();
+        nbt.put_string("id", Self::ID.to_string());
+        nbt.put_int("x", position.0.x);
+        nbt.put_int("y", position.0.y);
+        nbt.put_int("z", position.0.z);
+        nbt
+    }
 }
 
 impl BlockEntity for EndPortalBlockEntity {

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -4751,6 +4751,18 @@ impl World {
         });
     }
 
+    pub fn add_block_entity_nbt(&self, block_pos: BlockPos, nbt: &NbtCompound) {
+        self.level
+            .read_chunk_sync(&block_pos.chunk_position(), |chunk| {
+                chunk
+                    .pending_block_entities
+                    .lock()
+                    .unwrap()
+                    .insert(block_pos, nbt.clone());
+                chunk.mark_dirty(true);
+            });
+    }
+
     pub fn remove_block_entity(&self, block_pos: &BlockPos) {
         if self.block_entities.remove(block_pos).is_some() {
             self.level


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

Fixes #2231.

Fixes end portals losing their rendered portal surface after a player rejoins.(only the render, the block is still there)

End portal blocks render through their block entity renderer, so the block entity must be present when the chunk is sent back to the client. This stores the minimal end portal block entity NBT when an end portal block is created, while keeping the runtime block entity registration intact.

Also strips save-only block entity fields (`id`, `x`, `y`, `z`) from Java chunk block entity payloads, since the chunk packet already sends type and position separately.

I'm new to the project, so I'm happy to adjust this if there is a preferred pattern for handling block entity persistence.

## Testing

- `cargo clippy --all-targets`
- `cargo test`