### PR TITLE
fix(inventory): prevent shield self-deadlock in prepare_hand_item_for_use

### DIFF
--- a/pumpkin-inventory/src/player/player_inventory.rs
+++ b/pumpkin-inventory/src/player/player_inventory.rs
@@ -96,6 +96,23 @@ impl PlayerInventory {
         }
     }
 
+    /// Checks if the given item Arc already points to the target equipment slot's stack.
+    ///
+    /// Use before attempting to re-equip an item to prevent self-deadlock:
+    /// Tokio's `Mutex` is not reentrant, so locking an `Arc<Mutex<T>>` that
+    /// you already hold will deadlock forever.
+    pub async fn is_already_equipped(
+        &self,
+        item_arc: &Arc<Mutex<ItemStack>>,
+        slot: &EquipmentSlot,
+    ) -> bool {
+        match slot {
+            EquipmentSlot::OffHand(_) => Arc::ptr_eq(item_arc, &self.off_hand_item().await),
+            EquipmentSlot::MainHand(_) => Arc::ptr_eq(item_arc, &self.held_item()),
+            _ => false,
+        }
+    }
+
     /// Gets the item in the off-hand.
     ///
     /// Mojang name: `getOffHandStack`

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -2493,6 +2493,17 @@ impl JavaClient {
             }
         }
         if let Some(equippable) = held.get_data_component::<EquippableImpl>() {
+            // Skip if the item is already in the target equipment slot.
+            // This prevents a self-deadlock: `held` already locks the same
+            // Mutex<ItemStack> that `get_or_insert` would return, and
+            // Tokio's Mutex is not reentrant.
+            if inventory
+                .is_already_equipped(item_in_hand, equippable.slot)
+                .await
+            {
+                return;
+            }
+
             // If it can be equipped we want to make sure we can actually equip it
             player
                 .enqueue_equipment_change(equippable.slot, &held)


### PR DESCRIPTION
## Summary

Fixes a server crash when using shields. Right-clicking with a shield already equipped in the off-hand caused a self-deadlock that panics the server 5 seconds later.

Closes #2288

## Root Cause

`prepare_hand_item_for_use` locks the off-hand `ItemStack` Mutex via `held`, then the `EquippableImpl` branch calls `get_or_insert(OFF_HAND)` which returns the **same** `Arc<Mutex<ItemStack>>`. Tokio's Mutex is not reentrant — locking it again deadlocks permanently. The world tick's `send_content_updates` times out 5 seconds later and panics.

## Fix

Added `PlayerInventory::is_already_equipped()` which uses `Arc::ptr_eq` to detect when the item is already in the target slot, skipping the redundant equip logic before any lock is attempted.

## Bug

https://github.com/user-attachments/assets/b12f0827-1334-493b-9e51-a402eaa0ffce

## Fix

https://github.com/user-attachments/assets/3047d6ae-8ec3-4468-b4f1-ee92b8db1359