### PR TITLE
fix(net): back off on UDP listener socket errors 🤖🤖🤖

### DIFF
--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -579,7 +579,13 @@ impl PumpkinServer {
                             }
                         }
                     }
-                    Err(e) => error!("UDP socket error: {e}"),
+                    Err(e) => {
+                        error!("UDP socket error: {e}");
+                        // Back off so a persistent socket error (e.g. a surfaced
+                        // ICMP "port unreachable" on Linux) can't spin the worker,
+                        // mirroring the Java/TCP accept arm above.
+                        sleep(Duration::from_millis(50)).await;
+                    }
                 }
             },
 


### PR DESCRIPTION
## Summary

The Bedrock UDP `recv_from` branch of the unified listener (`pumpkin/src/lib.rs`)
only logs on error, unlike the Java/TCP `accept` branch right above it which
backs off with `sleep(Duration::from_millis(50))`.

If `recv_from` keeps returning an error immediately — e.g. a surfaced ICMP
"port unreachable" on Linux after a previous `send_to` to a client that went
away — the `select!` branch completes instantly and the outer `while !SHOULD_STOP`
loop re-enters it right away, a tight loop pegging a worker. This adds the same
50 ms backoff to the UDP arm so the two branches behave symmetrically.

```rust
Err(e) => {
    error!("UDP socket error: {e}");
    sleep(Duration::from_millis(50)).await;
}
```

## Relation to #1965

This is one of the candidates I flagged for the idle-CPU spin in #1965 (Bedrock
is enabled by default on `0.0.0.0:19132`). I can't confirm it's *the* root cause
there without a `top -H` profile from the reporter — it may be the chunk-system
`Schedule` poll or the Ticker sprint branch instead — but the missing backoff on
the UDP arm is a real latent busy-loop and a correct fix regardless.

`cargo clippy --all-targets --all-features` and `cargo fmt --check` are green.
