### PR TITLE
Add ServerLoadEvent

### DIFF
--- a/pumpkin-plugin-api/src/events/server/mod.rs
+++ b/pumpkin-plugin-api/src/events/server/mod.rs
@@ -1,11 +1,13 @@
 pub mod server_broadcast;
 pub mod server_command;
+pub mod server_load;
 pub mod server_tick_end;
 pub mod server_tick_start;
 pub mod spawn_change;
 
 pub use server_broadcast::*;
 pub use server_command::*;
+pub use server_load::*;
 pub use server_tick_end::*;
 pub use server_tick_start::*;
 pub use spawn_change::*;

--- a/pumpkin-plugin-api/src/events/server/server_load.rs
+++ b/pumpkin-plugin-api/src/events/server/server_load.rs
@@ -1,0 +1,24 @@
+use crate::wit::pumpkin::plugin::event::{Event, EventType, ServerLoadEventData};
+
+use super::super::FromIntoEvent;
+
+/// An event that fires once the server has finished loading.
+///
+/// The associated [`ServerLoadEventData`] contains the load reason:
+/// startup or a full server reload.
+pub struct ServerLoadEvent;
+impl FromIntoEvent for ServerLoadEvent {
+    const EVENT_TYPE: EventType = EventType::ServerLoadEvent;
+    type Data = ServerLoadEventData;
+
+    fn data_from_event(event: Event) -> Self::Data {
+        match event {
+            Event::ServerLoadEvent(data) => data,
+            _ => panic!("unexpected event"),
+        }
+    }
+
+    fn data_into_event(data: Self::Data) -> Event {
+        Event::ServerLoadEvent(data)
+    }
+}

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -319,21 +319,13 @@ impl PumpkinServer {
             .plugin_manager
             .set_server(self.server.clone())
             .await;
-        let duration = match self.server.plugin_manager.load_plugins().await {
+        match self.server.plugin_manager.load_plugins().await {
             Ok(duration) => duration,
             Err(err) => {
                 error!("{err}");
                 std::time::Duration::ZERO
             }
-        };
-
-        let _ = self
-            .server
-            .plugin_manager
-            .fire(ServerLoadEvent::new(LoadType::Startup))
-            .await;
-
-        duration
+        }
     }
 
     pub async fn unload_plugins(&self) {
@@ -363,6 +355,12 @@ impl PumpkinServer {
         let tasks = Arc::new(TaskTracker::new());
         let mut master_client_id: u64 = 0;
         let bedrock_clients = Arc::new(Mutex::new(HashMap::new()));
+
+        let _ = self
+            .server
+            .plugin_manager
+            .fire(ServerLoadEvent::new(LoadType::Startup))
+            .await;
 
         while !SHOULD_STOP.load(Ordering::Relaxed) {
             if !self

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -10,6 +10,7 @@ use crate::net::{ClientPlatform, DisconnectReason, PacketHandlerResult};
 use crate::net::{lan_broadcast::LANBroadcast, query, rcon::RCONServer};
 use crate::server::{Server, ticker::Ticker};
 use plugin::server::server_command::ServerCommandEvent;
+use plugin::server::server_load::{LoadType, ServerLoadEvent};
 use pumpkin_config::{AdvancedConfiguration, BasicConfiguration};
 use pumpkin_macros::send_cancellable;
 use pumpkin_util::text::TextComponent;
@@ -318,13 +319,21 @@ impl PumpkinServer {
             .plugin_manager
             .set_server(self.server.clone())
             .await;
-        match self.server.plugin_manager.load_plugins().await {
+        let duration = match self.server.plugin_manager.load_plugins().await {
             Ok(duration) => duration,
             Err(err) => {
                 error!("{err}");
                 std::time::Duration::ZERO
             }
-        }
+        };
+
+        let _ = self
+            .server
+            .plugin_manager
+            .fire(ServerLoadEvent::new(LoadType::Startup))
+            .await;
+
+        duration
     }
 
     pub async fn unload_plugins(&self) {

--- a/pumpkin/src/plugin/api/events/server/mod.rs
+++ b/pumpkin/src/plugin/api/events/server/mod.rs
@@ -1,5 +1,6 @@
 pub mod packet;
 pub mod server_broadcast;
 pub mod server_command;
+pub mod server_load;
 pub mod server_tick_end;
 pub mod server_tick_start;

--- a/pumpkin/src/plugin/api/events/server/server_load.rs
+++ b/pumpkin/src/plugin/api/events/server/server_load.rs
@@ -1,0 +1,25 @@
+use pumpkin_macros::Event;
+
+/// The reason a [`ServerLoadEvent`] fired.
+#[derive(Clone, Copy, Debug)]
+pub enum LoadType {
+    /// The server finished its normal startup sequence.
+    Startup,
+    /// The server finished a full reload sequence.
+    Reload,
+}
+
+/// An event that fires once the server has finished loading.
+#[derive(Event, Clone)]
+pub struct ServerLoadEvent {
+    /// Why the server load event was emitted.
+    pub load_type: LoadType,
+}
+
+impl ServerLoadEvent {
+    /// Creates a new `ServerLoadEvent`.
+    #[must_use]
+    pub const fn new(load_type: LoadType) -> Self {
+        Self { load_type }
+    }
+}

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/context.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/context.rs
@@ -240,6 +240,7 @@ async fn register_server_event(
         packet::{PacketReceivedEvent, PacketSentEvent},
         server_broadcast::ServerBroadcastEvent,
         server_command::ServerCommandEvent,
+        server_load::ServerLoadEvent,
         server_tick_end::ServerTickEndEvent,
         server_tick_start::ServerTickStartEvent,
     };
@@ -258,6 +259,9 @@ async fn register_server_event(
         EventType::ServerBroadcastEvent => {
             register_typed_event::<ServerBroadcastEvent>(resource, handler, priority, blocking)
                 .await;
+        }
+        EventType::ServerLoadEvent => {
+            register_typed_event::<ServerLoadEvent>(resource, handler, priority, blocking).await;
         }
         EventType::ServerTickEndEvent => {
             register_typed_event::<ServerTickEndEvent>(resource, handler, priority, blocking).await;
@@ -335,6 +339,7 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             | EventType::PacketSentEvent
             | EventType::ServerCommandEvent
             | EventType::ServerBroadcastEvent
+            | EventType::ServerLoadEvent
             | EventType::ServerTickEndEvent
             | EventType::ServerTickStartEvent) => {
                 register_server_event(resource, &handler, priority, blocking, event_type).await;

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/server.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/server.rs
@@ -7,8 +7,9 @@ use crate::plugin::{
             generated_packets,
             pumpkin::plugin::event::{
                 ClientboundPacket, Event, PacketReceivedEventData, PacketSentEventData,
-                ServerBroadcastEventData, ServerCommandEventData, ServerTickEndEventData,
-                ServerTickStartEventData, ServerboundPacket,
+                ServerBroadcastEventData, ServerCommandEventData, ServerLoadEventData,
+                ServerLoadType, ServerTickEndEventData, ServerTickStartEventData,
+                ServerboundPacket,
             },
         },
     },
@@ -16,6 +17,7 @@ use crate::plugin::{
         packet::{PacketReceivedEvent, PacketSentEvent},
         server_broadcast::ServerBroadcastEvent,
         server_command::ServerCommandEvent,
+        server_load::{LoadType, ServerLoadEvent},
         server_tick_end::ServerTickEndEvent,
         server_tick_start::ServerTickStartEvent,
     },
@@ -146,6 +148,29 @@ impl ToFromWasmEvent for ServerBroadcastEvent {
                 message: consume_text_component(state, &data.message),
                 sender: consume_text_component(state, &data.sender),
                 cancelled: data.cancelled,
+            },
+            _ => panic!("unexpected event type"),
+        }
+    }
+}
+
+impl ToFromWasmEvent for ServerLoadEvent {
+    fn to_wasm_event(&self, _state: &mut PluginHostState) -> Event {
+        Event::ServerLoadEvent(ServerLoadEventData {
+            load_type: match self.load_type {
+                LoadType::Startup => ServerLoadType::Startup,
+                LoadType::Reload => ServerLoadType::Reload,
+            },
+        })
+    }
+
+    fn from_wasm_event(event: Event, _state: &mut PluginHostState) -> Self {
+        match event {
+            Event::ServerLoadEvent(data) => Self {
+                load_type: match data.load_type {
+                    ServerLoadType::Startup => LoadType::Startup,
+                    ServerLoadType::Reload => LoadType::Reload,
+                },
             },
             _ => panic!("unexpected event type"),
         }

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -32,7 +32,7 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Bump this whenever the public plugin API or any event layout changes in a way
 /// that makes old binary plugins incompatible.
-pub const PLUGIN_API_VERSION: u32 = 2;
+pub const PLUGIN_API_VERSION: u32 = 3;
 
 const PLUGIN_DIR: &str = "./plugins";
 

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -32,7 +32,7 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Bump this whenever the public plugin API or any event layout changes in a way
 /// that makes old binary plugins incompatible.
-pub const PLUGIN_API_VERSION: u32 = 3;
+pub const PLUGIN_API_VERSION: u32 = 2;
 
 const PLUGIN_DIR: &str = "./plugins";
 


### PR DESCRIPTION
Adds ServerLoadEvent to Pumpkins plugin event system and exposes it through the WASM/plugin API.

# What changed?

- Added ServerLoadEvent and LoadType
- Fired it after plugin loading completes on normal startup
- Wired it through the WASM host, WIT definitions, and pumpkin-plugin-api

# Why was this needed?

- Plugins need a proper post-load lifecycle event
- This improves Bukkit/Paper parity

# Impact

- Plugins can now listen for ServerLoadEvent
- Binary plugins may need to be rebuilt because the plugin API/ABI changed
- Updates the pumpkin-plugin-wit submodule pointer

# Known limitation

- Currently only fires with LoadType::Startup
- LoadType::Reload exists for parity, but Pumpkin does not yet emit it

# Validation

- cargo fmt --all
- cargo check --workspace
- CARGO_INCREMENTAL=0 cargo clippy --workspace --all-features -- -D warnings
