### PR TITLE
Expose item data components in the Rust plugin API

### DIFF
--- a/pumpkin-plugin-api/src/lib.rs
+++ b/pumpkin-plugin-api/src/lib.rs
@@ -51,7 +51,7 @@ pub mod command {
 pub use wit::pumpkin::plugin::{
     bedrock_packets, block_entity, boss_bar, command as command_wit, common,
     context::{Context, Server},
-    entity,
+    data_components, entity,
     entity_types::EntityType,
     gui, i18n, java_dialogs, java_packets, particles, permission, player, scoreboard, server, text,
     world,


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

This exposes the generated `data_components` WIT bindings from `pumpkin-plugin-api`.

The WIT API already defines `data-components.wit`, and `item-stack.wit` already exposes `set-component(component, value)`. The host-side implementation for item stack components also already exists. However, Rust plugins could not import `pumpkin_plugin_api::data_components::DataComponent` because the generated module was not publicly re-exported by `pumpkin-plugin-api`.

With this change, plugin authors can write:

```rust
use pumpkin_plugin_api::{player::ItemStack, data_components::DataComponent};

let stack = ItemStack::new("minecraft:wooden_axe", 1);
stack.set_component(DataComponent::Unbreakable, &[]);
```
I did this so I can continue working on my Plugin Worldpumpkin XD
