### PR TITLE
Fix: set client player before spawn to prevent invisible chunks on first join

### DIFF
--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -471,11 +471,15 @@ impl PumpkinServer {
                                      .add_player(Arc::new(ClientPlatform::Java(java_client)), profile, Some(config))
                                           .await
                                 {
+                                    // Set the player on the client BEFORE spawning so that chunk
+                                    // sends during spawn_java_player don't get silently dropped.
+                                    if let ClientPlatform::Java(client) = player.client.as_ref() {
+                                        *client.player.lock().await = Some(player.clone());
+                                    }
                                     world
                                         .spawn_java_player(&server_clone.basic_config, &player, &server_clone)
                                         .await;
                                     if let ClientPlatform::Java(client) = player.client.as_ref() {
-                                        *client.player.lock().await = Some(player.clone());
                                         client.progress_player_packets(&player, &server_clone).await;
 
                                         // Close when done

--- a/pumpkin/src/net/bedrock/mod.rs
+++ b/pumpkin/src/net/bedrock/mod.rs
@@ -336,6 +336,10 @@ impl BedrockClient {
     pub async fn send_chunks(&self, chunks: &[SyncChunk]) {
         let player = self.player.lock().await.clone();
         let Some(player) = player.as_ref() else {
+            warn!(
+                "send_chunks: player not set yet, dropping {} chunks",
+                chunks.len()
+            );
             return;
         };
         let Some(server) = player.world().server.upgrade() else {

--- a/pumpkin/src/net/bedrock/mod.rs
+++ b/pumpkin/src/net/bedrock/mod.rs
@@ -336,7 +336,7 @@ impl BedrockClient {
     pub async fn send_chunks(&self, chunks: &[SyncChunk]) {
         let player = self.player.lock().await.clone();
         let Some(player) = player.as_ref() else {
-            warn!(
+            debug!(
                 "send_chunks: player not set yet, dropping {} chunks",
                 chunks.len()
             );

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -341,6 +341,10 @@ impl JavaClient {
     pub async fn send_chunks(&self, chunks: &[SyncChunk]) {
         let player = self.player.lock().await.clone();
         let Some(player) = player.as_ref() else {
+            warn!(
+                "send_chunks: player not set yet, dropping {} chunks",
+                chunks.len()
+            );
             return;
         };
         let Some(server) = player.world().server.upgrade() else {

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -341,7 +341,7 @@ impl JavaClient {
     pub async fn send_chunks(&self, chunks: &[SyncChunk]) {
         let player = self.player.lock().await.clone();
         let Some(player) = player.as_ref() else {
-            warn!(
+            debug!(
                 "send_chunks: player not set yet, dropping {} chunks",
                 chunks.len()
             );


### PR DESCRIPTION
## Description
The client.player was set after spawn_java_player, causing the first few chunk sends to silently drop because the client didn't know about the player yet — and since those chunks were marked as sent, they were never re-delivered.