### PR TITLE
fix: creative fire ticks

### DIFF
--- a/pumpkin/src/block/blocks/fire/mod.rs
+++ b/pumpkin/src/block/blocks/fire/mod.rs
@@ -142,7 +142,7 @@ impl FireBlockBase {
 
                 // Apply fire ticks
                 if base_entity.fire_ticks.load(Ordering::Relaxed) >= 0 {
-                    base_entity.set_on_fire_for(8.0);
+                    args.entity.set_on_fire_for(8.0);
                 }
 
                 // Regular fire vs soul fire damage

--- a/pumpkin/src/block/fluid/lava.rs
+++ b/pumpkin/src/block/fluid/lava.rs
@@ -196,7 +196,7 @@ impl FluidBehaviour for FlowingLava {
             if !base_entity.entity_type.fire_immune
                 && !base_entity.fire_immune.load(Ordering::Relaxed)
             {
-                base_entity.set_on_fire_for(15.0);
+                entity.set_on_fire_for(15.0);
 
                 // Also apply lava damage
                 base_entity.damage(entity, 4.0, DamageType::LAVA).await;

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -315,6 +315,22 @@ pub trait EntityBase: Send + Sync + NBTStorage + std::any::Any {
         Box::pin(async { false })
     }
 
+    fn set_on_fire_for(&self, seconds: f32) {
+        let entity = self.get_entity();
+        // Exclude fire-immune entities (ex. certain items) from burn damage
+        if !entity.fire_immune.load(Ordering::Relaxed) {
+            self.set_on_fire_for_ticks((seconds * 20.0).floor() as u32);
+        }
+    }
+
+    fn set_on_fire_for_ticks(&self, ticks: u32) {
+        let entity = self.get_entity();
+        if entity.fire_ticks.load(Ordering::Relaxed) < ticks as i32 {
+            entity.fire_ticks.store(ticks as i32, Ordering::Relaxed);
+        }
+        // TODO: defrost
+    }
+
     /// Called when a player collides with a entity
     fn on_player_collision<'a>(&'a self, _player: &'a Arc<Player>) -> EntityBaseFuture<'a, ()> {
         Box::pin(async {})
@@ -2293,20 +2309,6 @@ impl Entity {
     /// Extinguishes this entity.
     pub fn extinguish(&self) {
         self.fire_ticks.store(0, Ordering::Relaxed);
-    }
-
-    pub fn set_on_fire_for(&self, seconds: f32) {
-        // Exclude fire-immune entities (ex. certain items) from burn damage
-        if !self.fire_immune.load(Ordering::Relaxed) {
-            self.set_on_fire_for_ticks((seconds * 20.0).floor() as u32);
-        }
-    }
-
-    pub fn set_on_fire_for_ticks(&self, ticks: u32) {
-        if self.fire_ticks.load(Ordering::Relaxed) < ticks as i32 {
-            self.fire_ticks.store(ticks as i32, Ordering::Relaxed);
-        }
-        // TODO: defrost
     }
 
     /// Maximum freeze ticks (7 seconds at 20 tps)

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -4497,6 +4497,18 @@ impl EntityBase for Player {
         self.gamemode.load() == GameMode::Spectator
     }
 
+    fn set_on_fire_for_ticks(&self, ticks: u32) {
+        let entity = self.get_entity();
+        let ticks = if entity.invulnerable.load(Ordering::Relaxed) {
+            1
+        } else {
+            ticks
+        };
+        if entity.fire_ticks.load(Ordering::Relaxed) < ticks as i32 {
+            entity.fire_ticks.store(ticks as i32, Ordering::Relaxed);
+        }
+    }
+
     fn is_pushable(&self) -> bool {
         self.gamemode.load() != GameMode::Spectator && self.gamemode.load() != GameMode::Creative
     }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
1. Moved set_on_fire_for and set_on_fire_for_ticks to EntityBase trait so player.rs can override set_on_fire_for_ticks with its own logic. Also changed lava and fire collision to call set_on_fire_for and set_on_fire_for_ticks through EntityBase so player entities can use its own function.
2. This is what vanilla does, and currently, even when players are in creative, fire ticks is set to the default 160 ticks, when it should be 1.
3. Players in creative mode now correctly have fire ticks set to 1.


## Testing
I ran and passed cargo clippy --all-targets, cargo test, and cargo fmt
Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
