### PR TITLE
fix(protocol): correct ZigZag decode in VarInt PacketRead

### DIFF
--- a/pumpkin-protocol/src/codec/var_int.rs
+++ b/pumpkin-protocol/src/codec/var_int.rs
@@ -221,9 +221,46 @@ impl PacketRead for VarInt {
             let byte = u8::read(read)?;
             val |= (i32::from(byte) & 0x7F) << (i * 7);
             if byte & 0x80 == 0 {
-                return Ok(Self((val >> 1) ^ (val << 31)));
+                // ZigZag decode: logical shift right, then XOR with -(low bit).
+                // Mirrors the correct `PacketRead for VarLong` impl. The previous
+                // `(val >> 1) ^ (val << 31)` was wrong: `>>` sign-extended and
+                // `<< 31` only flipped the sign bit, so negative values (and large
+                // positives) decoded incorrectly and didn't round-trip the encoder.
+                let val = val as u32;
+                return Ok(Self(((val >> 1) as i32) ^ -((val & 1) as i32)));
             }
         }
         Err(Error::new(ErrorKind::InvalidData, ""))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The `PacketRead`/`PacketWrite` impls use zig-zag encoding; every value
+    /// must survive a write/read round-trip, including negatives and bounds.
+    #[test]
+    fn zigzag_packet_roundtrip() {
+        let cases = [
+            0,
+            1,
+            -1,
+            2,
+            -2,
+            63,
+            -64,
+            123_456,
+            -123_456,
+            i32::MAX,
+            i32::MIN,
+        ];
+        for n in cases {
+            let mut buf = Vec::new();
+            PacketWrite::write(&VarInt(n), &mut buf).unwrap();
+            let mut slice = buf.as_slice();
+            let decoded = <VarInt as PacketRead>::read(&mut slice).unwrap();
+            assert_eq!(decoded.0, n, "ZigZag VarInt round-trip failed for {n}");
+        }
     }
 }


### PR DESCRIPTION
## Description

`PacketRead for VarInt` (the bedrock zig-zag path in `pumpkin-protocol/src/codec/var_int.rs`) decodes incorrectly:

```rust
return Ok(Self((val >> 1) ^ (val << 31)));
```

with `val: i32`. Two problems:

1. `val >> 1` is an **arithmetic** (sign-propagating) shift; zig-zag decode needs a **logical** shift.
2. `val << 31` only moves the low bit into the sign bit; zig-zag decode needs to XOR with `-(val & 1)` (an all-ones mask when the low bit is set).

As a result, negative values — and any value whose raw encoding has bit 31 set — decode incorrectly, and decoding does not even round-trip `PacketWrite for VarInt`, which uses the standard correct zig-zag encode. For example, `-1` encodes to raw `1`, but the old decode returns `i32::MIN` instead of `-1`.

The sibling `PacketRead for VarLong` already does this correctly:

```rust
let decoded = ((val >> 1) as i64) ^ -((val & 1) as i64);
```

## Fix

Mirror the `VarLong` impl: reinterpret the accumulator as `u32` (logical shift) and XOR with the negated low bit:

```rust
let val = val as u32;
return Ok(Self(((val >> 1) as i32) ^ -((val & 1) as i32)));
```

## Test

Adds a `write`/`read` round-trip test over the `PacketRead`/`PacketWrite` impls covering `0`, `±1`, `±2`, `63`, `-64`, `±123_456`, and `i32::MAX`/`i32::MIN`. It fails on the old code (e.g. `-1` → `i32::MIN`) and passes with the fix.

## Reachability

`VarInt::read` is used on serverbound bedrock packets (e.g. `BlockPos::read` decoding negative block coordinates, and inventory / item-stack-request fields), so corrupted values are reachable from normal bedrock input. Scope is limited to the bedrock module — Java edition uses the separate serde-based path.
