### PR TITLE
fix(net): avoid panics on malformed encryption/velocity login responses

### DIFF
--- a/pumpkin/src/net/java/login.rs
+++ b/pumpkin/src/net/java/login.rs
@@ -114,10 +114,11 @@ impl JavaClient {
         encryption_response: SEncryptionResponse,
     ) {
         debug!("Handling encryption");
-        let shared_secret = server
-            .decrypt(&encryption_response.shared_secret)
-            .await
-            .unwrap();
+        let Ok(shared_secret) = server.decrypt(&encryption_response.shared_secret).await else {
+            self.kick(TextComponent::text("Failed to decrypt shared secret"))
+                .await;
+            return;
+        };
 
         if let Err(error) = self.set_encryption(&shared_secret).await {
             self.kick(TextComponent::text(error.to_string())).await;

--- a/pumpkin/src/net/proxy/velocity.rs
+++ b/pumpkin/src/net/proxy/velocity.rs
@@ -112,6 +112,9 @@ pub fn receive_velocity_plugin_response(
 ) -> Result<(GameProfile, SocketAddr), VelocityError> {
     debug!("Received velocity response");
     if let Some(data) = response.data {
+        if data.len() < 32 {
+            return Err(VelocityError::FailedVerifyIntegrity);
+        }
         let (signature, mut data_without_signature) = data.split_at(32);
 
         if !check_integrity((signature, data_without_signature), &config.secret) {


### PR DESCRIPTION
## Description

Two panics in the login flow that are triggerable by malformed / untrusted input:

### 1. RSA decrypt `unwrap()` — `pumpkin/src/net/java/login.rs`

`handle_encryption_response` did:

```rust
let shared_secret = server
    .decrypt(&encryption_response.shared_secret)
    .await
    .unwrap();
```

`encryption_response.shared_secret` is client-supplied, so a malformed value makes RSA decryption fail and panics the connection task. Replaced with graceful handling that mirrors the adjacent `set_encryption` error branch — kick the client instead of panicking.

### 2. `split_at(32)` on velocity response — `pumpkin/src/net/proxy/velocity.rs`

`receive_velocity_plugin_response` called `data.split_at(32)` without checking the length first, so a velocity forwarding response shorter than 32 bytes panics. Added a length guard that returns `VelocityError::FailedVerifyIntegrity` (a payload under 32 bytes cannot carry the 32-byte HMAC the integrity check expects, which is the same error that check would otherwise produce).

Both are small defensive fixes with no behavior change for valid input.
