### PR TITLE
fix(world): avoid underflow panic on corrupt Anvil region offset

### DIFF
--- a/pumpkin-world/src/chunk/format/anvil.rs
+++ b/pumpkin-world/src/chunk/format/anvil.rs
@@ -567,8 +567,10 @@ impl<S: SingleChunkDataSerializer> ChunkSerializer for AnvilChunkFile<S> {
             let sector_offset = (location >> 8) as usize;
             let end_offset = sector_offset + sector_count;
 
-            // If the sector offset or count is 0, the chunk is not present (we should not parse empty chunks)
-            if sector_offset == 0 || sector_count == 0 {
+            // If the sector offset or count is 0, the chunk is not present (we should not parse empty chunks).
+            // Sectors 0 and 1 are the location/timestamp header tables, so a valid chunk never starts before
+            // sector 2; reject offset 1 too, otherwise the `sector_offset - 2` below underflows on a corrupt file.
+            if sector_offset < 2 || sector_count == 0 {
                 continue;
             }
 


### PR DESCRIPTION
## Description

`AnvilChunkFile::from_bytes` (`pumpkin-world/src/chunk/format/anvil.rs`) computes the byte offset of a chunk's data as:

```rust
let bytes_offset = (sector_offset - 2) * SECTOR_BYTES;
```

The only guard before this is `if sector_offset == 0 || sector_count == 0 { continue; }`. A corrupt region file with `sector_offset == 1` therefore reaches the subtraction, and `1 - 2` underflows (`usize`) — a panic in debug builds, and in release a huge wrapping offset.

A `sector_offset` of `0` or `1` can never be valid: sectors 0 and 1 are the location and timestamp header tables, so real chunk data always starts at sector 2 or later. Tightening the guard to skip any offset below 2 makes the `sector_offset - 2` arithmetic always valid and treats the corrupt entry as "not present", consistent with the existing handling of `0`.

## Fix

```rust
if sector_offset < 2 || sector_count == 0 {
    continue;
}
```

Defensive hardening against malformed region files; no behavior change for valid chunks.
