### PR TITLE
fix(command): gate tab-complete suggestions on command permissions

### DIFF
--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -287,6 +287,19 @@ impl CommandDispatcher {
             return Vec::new();
         };
 
+        // Gate suggestions on command permissions, mirroring `dispatch`. Many
+        // legacy commands store their permission only in `self.permissions` and
+        // have no in-tree `Require` node, so without this check their argument
+        // consumers would leak privileged data (e.g. banned/op/whitelisted
+        // player names) to unprivileged players via tab-complete.
+        let Some(permission) = self.permissions.get(key) else {
+            return Vec::new();
+        };
+
+        if !src.has_permission(server, permission.as_str()).await {
+            return Vec::new();
+        }
+
         let mut suggestions = HashSet::new();
 
         // try paths and collect the nodes that fail


### PR DESCRIPTION
## Summary

Server-side command suggestions (tab-complete) were produced without any
permission check, leaking privileged data to unprivileged players.

`CommandDispatcher::find_suggestions` (`pumpkin/src/command/dispatcher.rs`)
resolves the command tree and traverses its paths to gather argument
suggestions, but it never checks the command's permission. By contrast,
`dispatch` gates execution on:

```rust
let Some(permission) = self.permissions.get(key) else { /* ... */ };
if !src.has_permission(server, permission.as_str()).await {
    return Err(PermissionDenied);
}
```

## Why it's reachable / impactful

Many legacy commands (`pardon`, `deop`, `whitelist`, ...) register their
permission **only** in `self.permissions` and have **no** in-tree `Require`
node. Because `find_suggestions` skips the `self.permissions` gate, an
unprivileged player can trigger the argument consumers of these commands via
tab-complete and receive suggestions populated from privileged sources --
e.g. banned player names, op'd player names, and whitelisted player names --
despite being unable to actually run the command. This is a security
information-leak.

## Fix

Add the exact permission gate used by `dispatch`, right after the command
key is resolved and before the tree is traversed. If no permission is
registered for the command, or the sender lacks it, return an empty
suggestion list:

```rust
let Some(permission) = self.permissions.get(key) else {
    return Vec::new();
};

if !src.has_permission(server, permission.as_str()).await {
    return Vec::new();
}
```

This mirrors `dispatch` (same raw `key` lookup, same
`src.has_permission(server, permission.as_str()).await` call, same async
context), so suggestion visibility now matches execution authorization.
Aliases are unaffected: `command_dispatcher` registers permissions for both
the alias name and the primary name, and the lookup uses the same raw key as
`dispatch`.

## Risk

Low. The change only suppresses suggestions for commands the caller is not
authorized to run; it does not alter execution behavior or any path that was
already permission-gated by an in-tree `Require` node.