### PR TITLE
fix(inventory): prevent remote crash from Swap click with negative slot

### DIFF
--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -1223,6 +1223,9 @@ pub trait ScreenHandler: Send + Sync {
             } else if action_type == SlotActionType::Swap && (0..9).contains(&button)
                 || button == 40
             {
+                if slot_index < 0 {
+                    return;
+                }
                 let mut button_stack = player
                     .get_inventory()
                     .get_stack(button as usize)


### PR DESCRIPTION
## Summary

A malicious or malformed client can crash the server with an out-of-bounds panic by sending a `Swap` inventory-click packet carrying a negative slot index.

## The bug

In `pumpkin-inventory/src/screen_handler.rs`, `internal_on_slot_click` handles each `SlotActionType` in a chain of branches. Every branch that indexes the slot vector guards against negative indices first:

- `Pickup` 鈥 `if slot_index < 0 { return; }`
- `QuickMove` 鈥 `if slot_index < 0 { return; }`
- `QuickCraft` 鈥 `if slot_index < 0 { ... return; }`

The `Swap` branch did **not**. It directly evaluated:

```rust
let source_slot = self.get_behaviour().slots[slot_index as usize].clone();
```

`slot_index` is an `i32` derived from the `i16` `slot` field of the client `SClickSlot` packet. When `slot_index` is negative, `slot_index as usize` wraps to a huge value, so indexing the `Vec` panics 鈫 remote server crash.

## Why it is reachable

`Player::on_slot_click` does validate the slot before dispatching, via `ScreenHandler::is_slot_valid`:

```rust
slot == -1 || slot == -999 || slot < self.get_behaviour().slots.len() as i32
```

This does **not** reject arbitrary negative slots: any negative value is always `< slots.len()`, so the check returns `true`. The event-firing code further down guards reads with `if slot >= 0 { ... }`, confirming negative slots do flow through. They reach `internal_on_slot_click`, and for `SlotActionType::Swap` with `button` in `0..9` or `button == 40`, the unguarded index panics.

## The fix

Add the same guard used by the sibling branches at the top of the `Swap` branch:

```rust
} else if action_type == SlotActionType::Swap && (0..9).contains(&button)
    || button == 40
{
    if slot_index < 0 {
        return;
    }
    let mut button_stack = player
        ...
```

Minimal and consistent with surrounding code. `is_slot_valid` is intentionally left untouched to avoid a broader behavioural change. Legitimate Swap clicks always reference a real (non-negative) container slot, so valid gameplay is unaffected.

## Risk

Low. Single-branch early-return mirroring existing siblings; no change for valid input.