### PR TITLE
fix(protocol): bound bedrock RakNet split-fragment and ACK allocations

### DIFF
--- a/pumpkin-protocol/src/bedrock/ack.rs
+++ b/pumpkin-protocol/src/bedrock/ack.rs
@@ -1,6 +1,11 @@
 use std::io::{Error, ErrorKind, Read, Write};
 
 const MAX_ACK_RECORDS: u16 = 4096;
+/// Upper bound on the total number of sequence numbers a single ACK/NACK
+/// packet may expand to. Range records (`start..=end`) cover 24-bit values, so
+/// without this cap a handful of records could expand to hundreds of millions
+/// of entries and exhaust memory.
+const MAX_ACK_SEQUENCES: usize = 4096;
 
 use crate::{
     codec::u24,
@@ -41,14 +46,26 @@ impl Acknowledge {
         let mut sequences = Vec::with_capacity(size as usize);
         for _ in 0..size {
             let single = bool::read(reader)?;
-            if single {
-                sequences.push(u24::read(reader)?.0);
+            let (start, end) = if single {
+                let seq = u24::read(reader)?.0;
+                (seq, seq)
             } else {
-                let start = u24::read(reader)?.0;
-                let end = u24::read(reader)?.0;
-                for i in start..=end {
-                    sequences.push(i);
-                }
+                (u24::read(reader)?.0, u24::read(reader)?.0)
+            };
+
+            // Bound the total expanded sequences before growing the vector so a
+            // record (or a few range records) cannot blow up into hundreds of
+            // millions of entries. `end < start` yields an empty range below.
+            let span = (end.saturating_sub(start) as usize).saturating_add(1);
+            if sequences.len().saturating_add(span) > MAX_ACK_SEQUENCES {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "Acknowledge packet expands to too many sequences.",
+                ));
+            }
+
+            for i in start..=end {
+                sequences.push(i);
             }
         }
         Ok(Self { sequences })

--- a/pumpkin-protocol/src/bedrock/frame_set.rs
+++ b/pumpkin-protocol/src/bedrock/frame_set.rs
@@ -4,6 +4,16 @@ use crate::bedrock::{MTU, RAKNET_SPLIT, RakReliability};
 use crate::codec::u24;
 use crate::serial::{PacketRead, PacketWrite};
 
+/// Maximum number of fragments a single split message may declare.
+///
+/// `split_size` is attacker-controlled and the receiver pre-allocates a
+/// `Vec<Option<Frame>>` of this length before validating any fragment index
+/// (see `handle_frame`). Split fragments carry at most
+/// `SPLIT_FRAME_MAX_CONTENT` (~1346) bytes each, so 1024 fragments already
+/// allow a ~1.3 MB reassembled message — far above any legitimate inbound
+/// Bedrock packet — while bounding the pre-allocation to a few tens of KB.
+const MAX_FRAGMENTS: u32 = 1024;
+
 pub struct FrameSet {
     pub sequence: u24,
     pub frames: Vec<Frame>,
@@ -106,6 +116,9 @@ impl Frame {
 
             if split {
                 frame.split_size = u32::read_be(reader)?;
+                if frame.split_size == 0 || frame.split_size > MAX_FRAGMENTS {
+                    return Err(Error::other("Frame split size out of bounds"));
+                }
                 frame.split_id = u16::read_be(reader)?;
                 frame.split_index = u32::read_be(reader)?;
             }


### PR DESCRIPTION
## Summary

Fixes two unbounded-allocation (memory-exhaustion) DoS vulnerabilities in the Bedrock RakNet read path inside `pumpkin-protocol`. Both are reachable from a single, unauthenticated UDP datagram, before any login handshake completes.

## Bug A 鈥 unbounded `split_size` in `Frame::read`

`pumpkin-protocol/src/bedrock/frame_set.rs` reads the split header field with no validation:

```rust
if split {
    frame.split_size = u32::read_be(reader)?; // attacker-controlled, unbounded
    ...
}
```

The consumer in `pumpkin/src/net/bedrock/mod.rs` (`handle_frame`) then pre-allocates from that value **before** the fragment-index bounds check:

```rust
let entry = compounds.entry(compound_id).or_insert_with(|| {
    let mut vec = Vec::with_capacity(frame.split_size as usize);
    vec.resize_with(frame.split_size as usize, || None);
    vec
});
if fragment_index >= entry.len() { /* checked only AFTER the alloc */ }
```

A datagram declaring the split flag with `split_size` near `u32::MAX` makes the server try to allocate ~4 billion `Option<Frame>` slots (tens of GB) 鈫 OOM / crash.

**Fix:** reject `split_size == 0` (a split frame must declare at least one fragment) or `split_size > MAX_FRAGMENTS` right after reading it, returning `InvalidData` via the file's existing `Error::other(..)` style.

## Bug B 鈥 range expansion in `Acknowledge::read`

`pumpkin-protocol/src/bedrock/ack.rs` caps the record **count** but not the expanded total:

```rust
if size > MAX_ACK_RECORDS { return Err(..); } // count bounded to 4096
...
let start = u24::read(reader)?.0;
let end = u24::read(reader)?.0;
for i in start..=end { sequences.push(i); } // 24-bit range 鈫 up to ~16.7M each
```

Each of up to 4096 range records can span the full 24-bit sequence space (~16.7M values), so a few records push hundreds of millions of `u32` into `sequences` 鈫 OOM.

**Fix:** introduce `MAX_ACK_SEQUENCES` and track the running expanded total, validating each record's span **before** growing the vector (so the huge allocation never happens, not just detected afterward). `end < start` is handled gracefully (empty range).

## Constants chosen

- `MAX_FRAGMENTS = 1024`: RakNet fragments carry at most `SPLIT_FRAME_MAX_CONTENT` (~1346) bytes, so 1024 fragments allow a ~1.3 MB reassembled message. This is the inbound (client鈫抯erver) path, where messages are small (movement, commands, acks); 1.3 MB is comfortably above any legitimate value while capping the pre-allocation to a few tens of KB. Conservative and tunable.
- `MAX_ACK_SEQUENCES = 4096`: matches the spirit of `MAX_ACK_RECORDS` and bounds the vector to ~16 KB per packet. RakNet's in-flight/sliding window is far smaller than this in practice, so legitimate ACK/NACK ranges are unaffected.

## Why it's low-risk

- Read-path only; no behavioral change for well-formed packets within the (generous) bounds.
- Errors use the same `Error::other` / `ErrorKind::InvalidData` types already returned in these functions, so callers handle them unchanged (the connection's existing error path).
- No new dependencies; all imports already present.

## Verification

`cargo -p pumpkin-protocol build` / `clippy` (human to run).