### PR TITLE
fix(entity): store first_loaded_chunk_position in chunk coordinates

### DIFF
--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -3323,7 +3323,17 @@ impl NBTStorage for Entity {
             let pos = Vector3::new(x, y, z);
             self.set_pos(pos);
             self.last_sent_pos.store(pos);
-            self.first_loaded_chunk_position.store(Some(pos.to_i32()));
+            // Store CHUNK coordinates here. Every consumer reads this field via
+            // `Vector3::to_vec2_i32()` (which only drops Y, *without* dividing by 16) and
+            // compares it against `block_pos.chunk_position()` (which divides by 16).
+            // Storing raw block coordinates makes the value 16x too large in chunk-space,
+            // causing entity duplication and spurious far-away entity-region writes on save.
+            let loaded_block_pos = pos.to_i32();
+            self.first_loaded_chunk_position.store(Some(Vector3::new(
+                loaded_block_pos.x.div_euclid(16),
+                loaded_block_pos.y,
+                loaded_block_pos.z.div_euclid(16),
+            )));
             let velocity = nbt.get_list("Motion").unwrap();
             let x = velocity[0].extract_double().unwrap_or(0.0);
             let y = velocity[1].extract_double().unwrap_or(0.0);


### PR DESCRIPTION
## Summary

`Entity::read_nbt_non_mut` (`pumpkin/src/entity/mod.rs`) stored
`first_loaded_chunk_position` as `pos.to_i32()` 鈥 raw **block**
coordinates 鈥 but every consumer treats this field as **chunk**
coordinates. The unit mismatch makes the stored value 16x too large in
chunk-space and corrupts entity persistence on disk.

## The bug

Producer (`pumpkin/src/entity/mod.rs`):
```rust
let pos = Vector3::new(x, y, z); // block coords read from the "Pos" NBT
...
self.first_loaded_chunk_position.store(Some(pos.to_i32())); // BLOCK coords
```
`Vector3::to_i32()` merely rounds each component to `i32`; it does **not**
divide by 16.

Consumers (`pumpkin/src/world/mod.rs`, in `save_entity`,
`remove_entity_data`, and the first-load dedup path) all do:
```rust
let old_chunk = old_chunk.to_vec2_i32();          // drops Y only, NO /16
let chunk = self.level.get_entity_chunk(old_chunk).await; // expects CHUNK coords
...
let current_chunk_coordinate = base_entity.block_pos.load().chunk_position(); // /16
if old_chunk == current_chunk_coordinate { ... }
```
- `Vector3::to_vec2_i32()` only drops the Y component (no divide-by-16), so it
  preserves the block magnitude.
- `BlockPos::chunk_position()` divides by 16 (`div_euclid(16)`).
- `Level::get_entity_chunk(pos: Vector2<i32>)` keys its
  `loaded_entity_chunks` map by **chunk** coordinates.

So `first_loaded_chunk_position` is 16x larger than it should be in
chunk-space, and the `old_chunk == current_chunk_coordinate` guard almost
never holds (only for entities at block coords `< 16`).

## Why it's reachable

Any entity loaded from an entity-region file on disk hits this path
(`read_nbt_non_mut` 鈫 `first_loaded_chunk_position`). On the next save:
- `get_entity_chunk(old_chunk)` loads and marks dirty a bogus chunk at a
  ~16x offset, producing **spurious far-away entity-region writes**; and
- because the guard fails, removal from the "old" chunk targets the wrong
  coordinate. When an entity has moved to another chunk, its original
  entity chunk is never cleaned, so the entity is written in **both** the
  old and new chunks 鈥 **entity duplication**.

## The fix

Convert the loaded block position to chunk coordinates at the producer,
mirroring `BlockPos::chunk_position()`:
```rust
let loaded_block_pos = pos.to_i32();
self.first_loaded_chunk_position.store(Some(Vector3::new(
    loaded_block_pos.x.div_euclid(16),
    loaded_block_pos.y,
    loaded_block_pos.z.div_euclid(16),
)));
```
`to_vec2_i32()` then yields proper chunk coordinates, matching what the
consumers and `get_entity_chunk` expect. The Y component is irrelevant
(every consumer drops it via `to_vec2_i32`), so it is left untouched.

## Risk

Low. The field has a single producer and three consumers, all verified;
none expect block coordinates. The change is a localized unit correction
with no API or signature changes.

## Verification

`cargo -p pumpkin check` (a human will build/test; not run here).