### PR TITLE
fix(pumpkin-world): correct inverted liquid_block_count

### DIFF
--- a/pumpkin-world/src/chunk/palette.rs
+++ b/pumpkin-world/src/chunk/palette.rs
@@ -674,16 +674,16 @@ impl BlockPalette {
         match self {
             Self::Homogeneous(registry_id) => {
                 if is_liquid(*registry_id) {
-                    0
-                } else {
                     Self::VOLUME as u16
+                } else {
+                    0
                 }
             }
             Self::Heterogeneous(data) => data
                 .palette
                 .iter()
                 .zip(data.counts.iter())
-                .filter_map(|(registry_id, count)| (!is_liquid(*registry_id)).then_some(*count))
+                .filter_map(|(registry_id, count)| is_liquid(*registry_id).then_some(*count))
                 .sum(),
         }
     }


### PR DESCRIPTION
## Bug

`BlockPalette::liquid_block_count()` in `pumpkin-world/src/chunk/palette.rs` computed the **inverse** of the liquid count:

- **Homogeneous** arm returned `0` when the single block *was* liquid and `Self::VOLUME` (4096) when it was *not*.
- **Heterogeneous** arm summed the counts of blocks where `!is_liquid(...)`, i.e. it counted **non-liquid** blocks.

Compare the correct sibling `non_air_block_count()` directly above it, which uses the positive sense (`VOLUME` when the block is non-air, and `filter_map` on `!is_air`).

### Why it's reachable

`liquid_block_count()` is the only producer of the per-section fluid count written to clients in `pumpkin-protocol/src/java/client/play/chunk_data.rs:82` for Minecraft 26.1+:

```rust
let liquid_count = block_palette.liquid_block_count() as i16;
blocks_and_biomes_buf.write_i16_be(liquid_count)?;
```

So every chunk section sent to a 26.1+ client reported a wrong fluid count (e.g. a full-water section reported 0, a stone section reported 4096).

## Fix

Flip both arms to count liquids, mirroring `non_air_block_count()` exactly:

- Homogeneous: `if is_liquid(*registry_id) { Self::VOLUME as u16 } else { 0 }`
- Heterogeneous: `filter_map(|(registry_id, count)| is_liquid(*registry_id).then_some(*count))`

`is_liquid` is already imported (line 5: `block_properties::{has_random_ticks, is_air, is_liquid}`). No other changes needed.