### PR TITLE
fix: air supply

### DIFF
--- a/pumpkin/src/entity/breath.rs
+++ b/pumpkin/src/entity/breath.rs
@@ -154,7 +154,7 @@ impl BreathManager {
 
         player.get_entity().send_meta_data(&[Metadata::new(
             TrackedData::AIR_SUPPLY_ID,
-            MetaDataType::INTEGER,
+            MetaDataType::INT,
             VarInt(air),
         )]);
     }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
1. Changed send_air_supply in breath.rs to send a MetaDataType::INT instead of MetaDataType::INTEGER in the send_meta_data function call.

2. This change was necessary because the write function in entity_metadata.rs checks if the remapped_type_id is less than 0 and then returns, if it is. When the MetaDataType is INTEGER, for 26.1 and 26.2, the value becomes negative. This results in the air supply packet not being sent to the client. When swapping MetaDataType to INT, it keeps the id as positive 1 and correctly sends the air supply packet to the client.

4. For 26.1+ clients, players will now see the air bubbles in the hud decrease.

5. The limitations are that anything below 26.1 (1.21.11 and below) still has this bug.
## Testing
I have ran and passed cargo clippy, cargo test, and cargo fmt.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
