### PR TITLE
fix(protocol): recipe book packet

### DIFF
--- a/pumpkin-protocol/src/codec/item_stack_seralizer.rs
+++ b/pumpkin-protocol/src/codec/item_stack_seralizer.rs
@@ -502,15 +502,32 @@ impl<'de> Deserialize<'de> for ItemComponentHash {
     }
 }
 
-pub struct ItemStackTemplate<'a>(pub Cow<'a, ItemStack>);
+pub struct ItemStackTemplateSerializer<'a>(pub Cow<'a, ItemStack>);
 
-impl From<ItemStack> for ItemStackTemplate<'_> {
-    fn from(item: ItemStack) -> Self {
-        ItemStackTemplate(Cow::Owned(item))
+impl ItemStackTemplateSerializer<'_> {
+    pub fn write_with_version(
+        &self,
+        write: impl std::io::Write,
+        version: &JavaMinecraftVersion,
+    ) -> Result<(), WritingError> {
+        let remapped_item_id = remap_item_id_for_version(self.0.item.id, *version);
+        let mut network_serializer = serializer::Serializer::new(write);
+        serialize_any_item_stack_with_id(
+            self.0.as_ref(),
+            remapped_item_id,
+            *version >= JavaMinecraftVersion::V_26_1,
+            &mut network_serializer,
+        )
     }
 }
 
-impl Serialize for ItemStackTemplate<'_> {
+impl From<ItemStack> for ItemStackTemplateSerializer<'_> {
+    fn from(item: ItemStack) -> Self {
+        ItemStackTemplateSerializer(Cow::Owned(item))
+    }
+}
+
+impl Serialize for ItemStackTemplateSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/pumpkin-protocol/src/java/client/play/recipe_book_add.rs
+++ b/pumpkin-protocol/src/java/client/play/recipe_book_add.rs
@@ -1,5 +1,3 @@
-use std::{collections::HashMap, io::Write};
-
 use pumpkin_data::item::Item;
 use pumpkin_data::item_id_remap::remap_item_id_for_version;
 use pumpkin_data::item_stack::ItemStack;
@@ -10,11 +8,11 @@ use pumpkin_data::recipes::{
 };
 use pumpkin_macros::java_packet;
 use pumpkin_util::version::JavaMinecraftVersion;
+use std::borrow::Cow;
+use std::{collections::HashMap, io::Write};
 
-use crate::{
-    ClientPacket, VarInt, WritingError, codec::item_stack_seralizer::ItemStackSerializer,
-    ser::NetworkWriteExt,
-};
+use crate::codec::item_stack_seralizer::ItemStackTemplateSerializer;
+use crate::{ClientPacket, VarInt, WritingError, ser::NetworkWriteExt};
 
 // Recipe Display type IDs
 const RECIPE_DISPLAY_SHAPELESS: i32 = 0;
@@ -116,7 +114,7 @@ fn write_item_stack_slot_display(
     write.write_var_int(&VarInt(slot_display_item_stack_type(version)))?;
     let static_item = Item::from_id(item.id)
         .ok_or_else(|| WritingError::Message(format!("item id {} must exist", item.id)))?;
-    ItemStackSerializer::from(ItemStack::new(count, static_item))
+    ItemStackTemplateSerializer::from(ItemStack::new(count, static_item))
         .write_with_version(write, &version)
 }
 
@@ -454,8 +452,6 @@ fn write_entry(
 
     Ok(false)
 }
-
-use std::borrow::Cow;
 
 #[allow(clippy::too_many_lines)]
 impl ClientPacket for CRecipeBookAdd<'_> {

--- a/pumpkin-protocol/src/java/client/play/update_advancement.rs
+++ b/pumpkin-protocol/src/java/client/play/update_advancement.rs
@@ -1,4 +1,4 @@
-use crate::codec::item_stack_seralizer::ItemStackTemplate;
+use crate::codec::item_stack_seralizer::ItemStackTemplateSerializer;
 use crate::codec::var_int::VarInt;
 use pumpkin_data::Advancement;
 use pumpkin_data::advancement_data::{AdvancementDisplay, AdvancementProgressData};
@@ -53,7 +53,10 @@ impl Serialize for DisplaySerializer<'_> {
 
         state.serialize_field("title", &display.get_title())?;
         state.serialize_field("description", &display.get_description())?;
-        state.serialize_field("icon", &ItemStackTemplate::from(display.item_icon.clone()))?;
+        state.serialize_field(
+            "icon",
+            &ItemStackTemplateSerializer::from(display.item_icon.clone()),
+        )?;
         state.serialize_field("frame_type", &VarInt(display.frame_type as i32))?;
         let flags = (display.has_background() as i32)
             | ((display.show_toast as i32) << 1)


### PR DESCRIPTION
## Description
fix the recipe book packet by changing the serialisation from ItemStack to ItemStackTemplate because it has change in 26.1
## Testing
 - [x] tested ingame
Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
