### PR TITLE
feat: Add Overworld Fossil Generation

### DIFF
--- a/pumpkin-codegen/src/configured_feature.rs
+++ b/pumpkin-codegen/src/configured_feature.rs
@@ -204,6 +204,22 @@ pub fn build() -> TokenStream {
     }
 }
 
+fn value_to_fossil_processor(value: &Value) -> TokenStream {
+    let variant = match value
+        .as_str()
+        .expect("fossil processor names must be strings")
+    {
+        "minecraft:fossil_rot" => format_ident!("FossilRot"),
+        "minecraft:fossil_coal" => format_ident!("Coal"),
+        "minecraft:fossil_diamonds" => format_ident!("Diamonds"),
+        processor => panic!("Unsupported fossil processor: {processor}"),
+    };
+
+    quote! {
+        crate::generation::feature::features::fossil::FossilProcessor::#variant
+    }
+}
+
 /// Converts a single configured-feature JSON value into its `ConfiguredFeature` token stream.
 ///
 /// # Arguments
@@ -668,9 +684,45 @@ pub fn value_to_configured_feature(v: &Value) -> TokenStream {
             quote! { ConfiguredFeature::Kelp(crate::generation::feature::features::kelp::KelpFeature {}) }
         }
 
-        // All TODO/empty features
         "minecraft:fossil" => {
-            quote! { ConfiguredFeature::Fossil(crate::generation::feature::features::fossil::FossilFeature {}) }
+            let fossil_structures = config["fossil_structures"]
+                .as_array()
+                .expect("fossil_structures must be an array")
+                .iter()
+                .map(|value| {
+                    let name = value
+                        .as_str()
+                        .expect("fossil structure names must be strings");
+                    quote! { #name }
+                });
+            let overlay_structures = config["overlay_structures"]
+                .as_array()
+                .expect("overlay_structures must be an array")
+                .iter()
+                .map(|value| {
+                    let name = value
+                        .as_str()
+                        .expect("fossil overlay structure names must be strings");
+                    quote! { #name }
+                });
+            let fossil_processor = value_to_fossil_processor(&config["fossil_processors"]);
+            let overlay_processor = value_to_fossil_processor(&config["overlay_processors"]);
+            let max_empty_corners_allowed = config["max_empty_corners_allowed"]
+                .as_u64()
+                .expect("max_empty_corners_allowed must be an unsigned integer")
+                as u8;
+
+            quote! {
+                ConfiguredFeature::Fossil(
+                    crate::generation::feature::features::fossil::FossilFeature {
+                        fossil_structures: vec![#(#fossil_structures),*],
+                        overlay_structures: vec![#(#overlay_structures),*],
+                        fossil_processor: #fossil_processor,
+                        overlay_processor: #overlay_processor,
+                        max_empty_corners_allowed: #max_empty_corners_allowed,
+                    }
+                )
+            }
         }
         "minecraft:lake" => {
             let fluid = value_to_block_state_provider(&config["fluid"]);

--- a/pumpkin-data/src/generated/configured_features_generated.rs
+++ b/pumpkin-data/src/generated/configured_features_generated.rs
@@ -2215,11 +2215,67 @@ fn build_configured_features()
     );
     map.insert(
         pumpkin_data::configured_feature::ConfiguredFeature::FossilCoal,
-        ConfiguredFeature::Fossil(crate::generation::feature::features::fossil::FossilFeature {}),
+        ConfiguredFeature::Fossil(
+            crate::generation::feature::features::fossil::FossilFeature {
+                fossil_structures: vec![
+                    "minecraft:fossil/spine_1",
+                    "minecraft:fossil/spine_2",
+                    "minecraft:fossil/spine_3",
+                    "minecraft:fossil/spine_4",
+                    "minecraft:fossil/skull_1",
+                    "minecraft:fossil/skull_2",
+                    "minecraft:fossil/skull_3",
+                    "minecraft:fossil/skull_4",
+                ],
+                overlay_structures: vec![
+                    "minecraft:fossil/spine_1_coal",
+                    "minecraft:fossil/spine_2_coal",
+                    "minecraft:fossil/spine_3_coal",
+                    "minecraft:fossil/spine_4_coal",
+                    "minecraft:fossil/skull_1_coal",
+                    "minecraft:fossil/skull_2_coal",
+                    "minecraft:fossil/skull_3_coal",
+                    "minecraft:fossil/skull_4_coal",
+                ],
+                fossil_processor:
+                    crate::generation::feature::features::fossil::FossilProcessor::FossilRot,
+                overlay_processor:
+                    crate::generation::feature::features::fossil::FossilProcessor::Coal,
+                max_empty_corners_allowed: 4u8,
+            },
+        ),
     );
     map.insert(
         pumpkin_data::configured_feature::ConfiguredFeature::FossilDiamonds,
-        ConfiguredFeature::Fossil(crate::generation::feature::features::fossil::FossilFeature {}),
+        ConfiguredFeature::Fossil(
+            crate::generation::feature::features::fossil::FossilFeature {
+                fossil_structures: vec![
+                    "minecraft:fossil/spine_1",
+                    "minecraft:fossil/spine_2",
+                    "minecraft:fossil/spine_3",
+                    "minecraft:fossil/spine_4",
+                    "minecraft:fossil/skull_1",
+                    "minecraft:fossil/skull_2",
+                    "minecraft:fossil/skull_3",
+                    "minecraft:fossil/skull_4",
+                ],
+                overlay_structures: vec![
+                    "minecraft:fossil/spine_1_coal",
+                    "minecraft:fossil/spine_2_coal",
+                    "minecraft:fossil/spine_3_coal",
+                    "minecraft:fossil/spine_4_coal",
+                    "minecraft:fossil/skull_1_coal",
+                    "minecraft:fossil/skull_2_coal",
+                    "minecraft:fossil/skull_3_coal",
+                    "minecraft:fossil/skull_4_coal",
+                ],
+                fossil_processor:
+                    crate::generation::feature::features::fossil::FossilProcessor::FossilRot,
+                overlay_processor:
+                    crate::generation::feature::features::fossil::FossilProcessor::Diamonds,
+                max_empty_corners_allowed: 4u8,
+            },
+        ),
     );
     map.insert(
         pumpkin_data::configured_feature::ConfiguredFeature::FreezeTopLayer,

--- a/pumpkin-world/src/generation/feature/configured_features.rs
+++ b/pumpkin-world/src/generation/feature/configured_features.rs
@@ -261,6 +261,7 @@ impl ConfiguredFeature {
             Self::DesertWell(feature) => {
                 feature.generate(chunk, min_y, height, feature_name, random, pos)
             }
+            Self::Fossil(feature) => feature.generate(chunk, min_y, height, random, pos),
             Self::Bamboo(feature) => feature.generate(
                 chunk,
                 block_registry,

--- a/pumpkin-world/src/generation/feature/features/fossil.rs
+++ b/pumpkin-world/src/generation/feature/features/fossil.rs
@@ -1,3 +1,199 @@
+use pumpkin_data::{Block, BlockState, Rotation, tag};
+use pumpkin_util::{
+    HeightMap,
+    math::{block_box::BlockBox, position::BlockPos, vector3::Vector3},
+    random::{RandomGenerator, RandomImpl},
+};
+
+use crate::generation::{
+    proto_chunk::GenerationCache,
+    structure::template::{BlockStateResolver, StructureTemplate, get_template},
+};
+
 pub struct FossilFeature {
-    // TODO
+    pub fossil_structures: Vec<&'static str>,
+    pub overlay_structures: Vec<&'static str>,
+    pub fossil_processor: FossilProcessor,
+    pub overlay_processor: FossilProcessor,
+    pub max_empty_corners_allowed: u8,
+}
+
+#[derive(Clone, Copy)]
+pub enum FossilProcessor {
+    FossilRot,
+    Coal,
+    Diamonds,
+}
+
+impl FossilProcessor {
+    const fn integrity(self) -> f32 {
+        match self {
+            Self::FossilRot => 0.9,
+            Self::Coal | Self::Diamonds => 0.1,
+        }
+    }
+
+    fn process(self, state: &'static BlockState) -> &'static BlockState {
+        if matches!(self, Self::Diamonds) && Block::from_state_id(state.id) == &Block::COAL_ORE {
+            Block::DEEPSLATE_DIAMOND_ORE.default_state
+        } else {
+            state
+        }
+    }
+}
+
+impl FossilFeature {
+    pub fn generate<T: GenerationCache>(
+        &self,
+        chunk: &mut T,
+        min_y: i8,
+        height: u16,
+        random: &mut RandomGenerator,
+        pos: BlockPos,
+    ) -> bool {
+        if self.fossil_structures.is_empty()
+            || self.fossil_structures.len() != self.overlay_structures.len()
+        {
+            return false;
+        }
+
+        let rotation = Rotation::from_index(random.next_bounded_i32(4) as u8);
+        let template_index = random.next_bounded_i32(self.fossil_structures.len() as i32) as usize;
+
+        let Some(fossil_name) = self.fossil_structures.get(template_index) else {
+            return false;
+        };
+        let Some(overlay_name) = self.overlay_structures.get(template_index) else {
+            return false;
+        };
+        let Some(fossil) = get_template(
+            fossil_name
+                .strip_prefix("minecraft:")
+                .unwrap_or(fossil_name),
+        ) else {
+            return false;
+        };
+        let Some(overlay) = get_template(
+            overlay_name
+                .strip_prefix("minecraft:")
+                .unwrap_or(overlay_name),
+        ) else {
+            return false;
+        };
+
+        let rotated_size = rotation.transform_size(fossil.size);
+        let origin_x = pos.0.x - rotated_size.x / 2;
+        let origin_z = pos.0.z - rotated_size.z / 2;
+        let mut ocean_floor = pos.0.y;
+
+        for x in origin_x..origin_x + rotated_size.x {
+            for z in origin_z..origin_z + rotated_size.z {
+                ocean_floor = ocean_floor.min(chunk.get_top_y(&HeightMap::OceanFloorWg, x, z));
+            }
+        }
+
+        let origin_y = (ocean_floor - 15 - random.next_bounded_i32(10)).max(i32::from(min_y) + 10);
+        let origin = Vector3::new(origin_x, origin_y, origin_z);
+        let fossil_box = BlockBox::new(
+            origin.x,
+            origin.y,
+            origin.z,
+            origin.x + rotated_size.x - 1,
+            origin.y + rotated_size.y - 1,
+            origin.z + rotated_size.z - 1,
+        );
+
+        if count_empty_corners(chunk, &fossil_box) > usize::from(self.max_empty_corners_allowed) {
+            return false;
+        }
+
+        let chunk_min_x = (pos.0.x >> 4) << 4;
+        let chunk_min_z = (pos.0.z >> 4) << 4;
+        let placement_box = BlockBox::new(
+            chunk_min_x - 16,
+            i32::from(min_y),
+            chunk_min_z - 16,
+            chunk_min_x + 31,
+            i32::from(min_y) + i32::from(height) - 1,
+            chunk_min_z + 31,
+        );
+
+        place_fossil_template(
+            chunk,
+            &fossil,
+            origin,
+            rotation,
+            self.fossil_processor,
+            random,
+            &placement_box,
+        );
+        place_fossil_template(
+            chunk,
+            &overlay,
+            origin,
+            rotation,
+            self.overlay_processor,
+            random,
+            &placement_box,
+        );
+
+        true
+    }
+}
+
+fn count_empty_corners<T: GenerationCache>(chunk: &T, bounding_box: &BlockBox) -> usize {
+    let mut empty_corners = 0;
+
+    for x in [bounding_box.min.x, bounding_box.max.x] {
+        for y in [bounding_box.min.y, bounding_box.max.y] {
+            for z in [bounding_box.min.z, bounding_box.max.z] {
+                let state =
+                    GenerationCache::get_block_state(chunk, &Vector3::new(x, y, z)).to_state();
+                let block = Block::from_state_id(state.id);
+                if state.is_air() || block == &Block::LAVA || block == &Block::WATER {
+                    empty_corners += 1;
+                }
+            }
+        }
+    }
+
+    empty_corners
+}
+
+fn place_fossil_template<T: GenerationCache>(
+    chunk: &mut T,
+    template: &StructureTemplate,
+    origin: Vector3<i32>,
+    rotation: Rotation,
+    processor: FossilProcessor,
+    random: &mut RandomGenerator,
+    placement_box: &BlockBox,
+) {
+    for block in &template.blocks {
+        let local_pos = rotation.transform_pos(block.pos, template.size);
+        let world_pos = origin + local_pos;
+
+        if !placement_box.contains_pos(&world_pos) || random.next_f32() > processor.integrity() {
+            continue;
+        }
+
+        let current_state = GenerationCache::get_block_state(chunk, &world_pos).to_state();
+        if tag::Block::MINECRAFT_FEATURES_CANNOT_REPLACE
+            .1
+            .contains(&current_state.id)
+        {
+            continue;
+        }
+
+        let palette_entry = &template.palette[block.state as usize];
+        if palette_entry.name == "minecraft:structure_void" {
+            continue;
+        }
+
+        if let Some(state) =
+            BlockStateResolver::resolve(palette_entry, rotation, Default::default())
+        {
+            chunk.set_block_state(&world_pos, processor.process(state));
+        }
+    }
 }


### PR DESCRIPTION
## Description
- Adds overworld fossil generation. I had to add the locate command to make sure it works for testing but removed it since I can see there is a separate PR for the locate command anyway.
- Part of https://github.com/Pumpkin-MC/Pumpkin/issues/36

## Testing
- Tests passed locally, fossils spawned underground in the overworld.