### PR TITLE
fix(plugin-api): expose missing WIT types for plugin development

### DIFF
--- a/pumpkin-plugin-api/src/lib.rs
+++ b/pumpkin-plugin-api/src/lib.rs
@@ -44,7 +44,7 @@ pub mod scheduler;
 
 pub mod command {
     pub use crate::wit::pumpkin::plugin::command::{
-        Command, CommandError, CommandNode, CommandSender, ConsumedArgs,
+        Arg, ArgumentType, Command, CommandError, CommandNode, CommandSender, ConsumedArgs, StringType,
     };
 }
 
@@ -53,9 +53,16 @@ pub use wit::pumpkin::plugin::{
     context::{Context, Server},
     data_components, entity,
     entity_types::EntityType,
-    gui, i18n, java_dialogs, java_packets, particles, permission, player, scoreboard, server, text,
+    event::{self as events_wit, EventType},
+    gui, i18n, item_stack, java_dialogs, java_packets, particles, permission, player, scoreboard, server, text,
+    uuid,
     world,
 };
+
+// Convenience re-exports for commonly used types
+pub use wit::pumpkin::plugin::item_stack::ItemStack;
+pub use events::EventHandler;
+pub use events::FromIntoEvent;
 
 pub mod java_dialog {
     pub use crate::wit::pumpkin::plugin::java_dialogs::{ActionButton, DialogBody, DialogType};


### PR DESCRIPTION
## Summary

Add missing `pub use` exports to `pumpkin-plugin-api` so WASM plugins can access essential WIT types through the public API.

## Changes (all additive, backward-compatible)

- **`item_stack` module** — so plugins can create `ItemStack` objects
- **`uuid` module** — so plugins can convert player UUIDs to strings
- **`event::{self as events_wit, EventType}`** — so plugins can define custom event handlers with typed event data
- **`ItemStack`, `EventHandler`, `FromIntoEvent`** — convenience re-exports at crate root
- **`Arg`, `ArgumentType`, `StringType`** — command argument types for plugin commands

## Motivation

Currently `mod wit` is private, and many WIT-generated types are inaccessible to plugin crates. This forces plugins to use workarounds or modify pumpkin-plugin-api locally. These exports follow the same pattern as the existing public exports (`gui`, `player`, `text`, etc.).

## Testing

- `cargo check -p pumpkin-plugin-api` passes with no errors
- Existing WASM plugin (`easymenu`) compiles against the updated API
- All changes are purely additive — no existing behavior is modified