### PR TITLE
fix: fences crash

### DIFF
--- a/pumpkin/src/block/blocks/glazed_terracotta.rs
+++ b/pumpkin/src/block/blocks/glazed_terracotta.rs
@@ -6,7 +6,7 @@ use pumpkin_world::BlockStateId;
 pub struct GlazedTerracottaBlock;
 impl BlockMetadata for GlazedTerracottaBlock {
     fn ids() -> Box<[u16]> {
-        tag::Item::C_GLAZED_TERRACOTTAS.1.into()
+        tag::Block::C_GLAZED_TERRACOTTAS.1.into()
     }
 }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
1. Changed ids() in glazed_terracotta.rs from **tag::Item** to **tag::Block**.

2. This change was necessary because in the tag.rs, inside the mod Item in the const C_GLAZED_TERRACOTTAS, all the ID's of items are fences and this is the reason of crash.

3. For 26.1+ clients, players will now be able to place/break fences without crash.

4. I saw this issue [#2330](https://github.com/Pumpkin-MC/Pumpkin/issues/2330) and I've decided to test it. Not only the acacia fences but all non oak fences was panicking.

## Testing
I know it's just a simple bug of misstype but just to follow guidelines, I've ran and passed all the tests: cargo clippy, cargo test and cargo fmt.

