### PR TITLE
fix: Made (CUSTOM_)NAME_VISIBLE work across versions

### DIFF
--- a/pumpkin-codegen/src/tracked_data.rs
+++ b/pumpkin-codegen/src/tracked_data.rs
@@ -109,6 +109,11 @@ fn generate_consts(versions: &BTreeMap<JavaMinecraftVersion, BTreeMap<String, u8
         // Some versions prefix keys with DATA_ (Bedrock), others don't (Java)
         // Try both forms so every version resolves correctly
         let prefixed = format!("DATA_{final_name}");
+        let aliases: &[&str] = if final_name == "CUSTOM_NAME_VISIBLE" {
+            &["NAME_VISIBLE"]
+        } else {
+            &[]
+        };
 
         let mut fields = TokenStream::new();
         for (ver, data) in versions.iter() {
@@ -116,6 +121,7 @@ fn generate_consts(versions: &BTreeMap<JavaMinecraftVersion, BTreeMap<String, u8
             let id = data
                 .get(final_name.as_str())
                 .or_else(|| data.get(prefixed.as_str()))
+                .or_else(|| aliases.iter().find_map(|alias| data.get(*alias)))
                 .copied()
                 .unwrap_or(255);
             fields.extend(quote! {
@@ -133,7 +139,16 @@ fn generate_consts(versions: &BTreeMap<JavaMinecraftVersion, BTreeMap<String, u8
 
 fn normalize_name(name: &str) -> String {
     let upper = name.to_uppercase();
-    upper
+    let normalized = upper
         .strip_prefix("DATA_")
-        .map_or(upper.clone(), str::to_string)
+        .map_or(upper.clone(), str::to_string);
+
+    // Mojang renamed the shared entity custom-name visibility tracker from
+    // NAME_VISIBLE to DATA_CUSTOM_NAME_VISIBLE in newer mappings. Keep one
+    // generated constant usable across both naming schemes.
+    if normalized == "NAME_VISIBLE" {
+        "CUSTOM_NAME_VISIBLE".to_string()
+    } else {
+        normalized
+    }
 }

--- a/pumpkin-data/src/generated/tracked_data.rs
+++ b/pumpkin-data/src/generated/tracked_data.rs
@@ -853,14 +853,14 @@ impl TrackedData {
         v26_2: 2u8,
     };
     pub const CUSTOM_NAME_VISIBLE: TrackedId = TrackedId {
-        v1_21: 255u8,
-        v1_21_2: 255u8,
-        v1_21_4: 255u8,
-        v1_21_5: 255u8,
-        v1_21_6: 255u8,
-        v1_21_7: 255u8,
-        v1_21_9: 255u8,
-        v1_21_11: 255u8,
+        v1_21: 3u8,
+        v1_21_2: 3u8,
+        v1_21_4: 3u8,
+        v1_21_5: 3u8,
+        v1_21_6: 3u8,
+        v1_21_7: 3u8,
+        v1_21_9: 3u8,
+        v1_21_11: 3u8,
         v26_1: 3u8,
         v26_2: 3u8,
     };
@@ -2339,18 +2339,6 @@ impl TrackedData {
         v1_21_11: 255u8,
         v26_1: 19u8,
         v26_2: 19u8,
-    };
-    pub const NAME_VISIBLE: TrackedId = TrackedId {
-        v1_21: 3u8,
-        v1_21_2: 3u8,
-        v1_21_4: 3u8,
-        v1_21_5: 3u8,
-        v1_21_6: 3u8,
-        v1_21_7: 3u8,
-        v1_21_9: 3u8,
-        v1_21_11: 3u8,
-        v26_1: 255u8,
-        v26_2: 255u8,
     };
     pub const NO_GRAVITY: TrackedId = TrackedId {
         v1_21: 5u8,


### PR DESCRIPTION
## Description

I'm trying to experiment with pumpkin plugins on an old idea of mine, and I had issues making name tags on armor stands work. After some looking around, it seems that the metadata name changed between 1.21 and later versions, as they are now supported by more entities.

This PR is a workaround to make it work on older versions.

In relation with the other PR in this set (#2333), it should make this feature work.


## Testing
- [x] Tested on version 1.21.8 (originally had the issue, fixed after changes)
- [x] No regressions on 26.2


Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
