### PR TITLE
feat(plugin-api): Forced use of setters

### DIFF
--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
@@ -329,10 +329,7 @@ impl HostEntity for PluginHostState {
             )
             .map_err(|_| wasmtime::Error::msg("invalid text component resource handle"))?;
         let text = text_res.provider.clone();
-        entity_base
-            .get_entity()
-            .custom_name
-            .store(std::sync::Arc::new(Some(text)));
+        entity_base.get_entity().set_custom_name(text);
         Ok(())
     }
 
@@ -357,10 +354,7 @@ impl HostEntity for PluginHostState {
         visible: bool,
     ) -> wasmtime::Result<()> {
         let entity = entity_from_resource(self, &entity)?;
-        entity
-            .get_entity()
-            .custom_name_visible
-            .store(visible, std::sync::atomic::Ordering::Relaxed);
+        entity.get_entity().set_custom_name_visible(visible);
         Ok(())
     }
 


### PR DESCRIPTION
## Description
As far as my testing goes, the Plugin API doesn't send the metadata to the client, which causes the existing clients to not get the updated custom name.

This uses the setters which also sends the associated metadata, even if it is in two separate packets (seems related to the fact that we cannot provide multi-type packets for entity metadata updates)

## Testing
- Tested on 26.2 and 1.21.8 with #2332

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
