### PR TITLE
Fix sky light propagation hanging on unloaded chunks

### DIFF
--- a/pumpkin-world/src/lighting/runtime.rs
+++ b/pumpkin-world/src/lighting/runtime.rs
@@ -277,6 +277,16 @@ impl DynamicLightEngine {
         for dir in BlockDirection::all() {
             let neighbor_pos = pos.offset(dir.to_offset());
 
+            // Never propagate into an unloaded chunk. Writes to an unloaded
+            // chunk are dropped silently, so the "brighter than neighbor" check
+            // below would stay true forever and keep re-queuing the same
+            // position, spinning this loop indefinitely at the border between
+            // loaded and unloaded chunks.
+            let (neighbor_chunk, _) = neighbor_pos.chunk_and_chunk_relative_position();
+            if level.read_chunk_sync(&neighbor_chunk, |_| ()).is_none() {
+                continue;
+            }
+
             let neighbor_light = self.get_sky_light_level(level, &neighbor_pos);
             let neighbor_state = level.get_block_state(&neighbor_pos).to_state();
             let opacity = neighbor_state.opacity;
@@ -305,6 +315,13 @@ impl DynamicLightEngine {
     fn propagate_sky_light_decrease(&self, level: &Arc<Level>, pos: &BlockPos, removed_light: u8) {
         for dir in BlockDirection::all() {
             let neighbor_pos = pos.offset(dir.to_offset());
+
+            // See `propagate_sky_light_increase`: skip unloaded chunks so sky
+            // light updates never spin at loaded/unloaded chunk borders.
+            let (neighbor_chunk, _) = neighbor_pos.chunk_and_chunk_relative_position();
+            if level.read_chunk_sync(&neighbor_chunk, |_| ()).is_none() {
+                continue;
+            }
 
             let neighbor_light = self.get_sky_light_level(level, &neighbor_pos);
             if neighbor_light == 0 {

--- a/pumpkin-world/src/lighting/runtime.rs
+++ b/pumpkin-world/src/lighting/runtime.rs
@@ -283,7 +283,7 @@ impl DynamicLightEngine {
             // position, spinning this loop indefinitely at the border between
             // loaded and unloaded chunks.
             let (neighbor_chunk, _) = neighbor_pos.chunk_and_chunk_relative_position();
-            if level.read_chunk_sync(&neighbor_chunk, |_| ()).is_none() {
+            if !level.is_chunk_loaded(&neighbor_chunk) {
                 continue;
             }
 
@@ -319,7 +319,7 @@ impl DynamicLightEngine {
             // See `propagate_sky_light_increase`: skip unloaded chunks so sky
             // light updates never spin at loaded/unloaded chunk borders.
             let (neighbor_chunk, _) = neighbor_pos.chunk_and_chunk_relative_position();
-            if level.read_chunk_sync(&neighbor_chunk, |_| ()).is_none() {
+            if !level.is_chunk_loaded(&neighbor_chunk) {
                 continue;
             }
 


### PR DESCRIPTION
### Problem

`DynamicLightEngine`'s sky light propagation can loop forever when a light update happens next to a chunk that isn't loaded.

`get_sky_light_level` returns `0` for a position in an unloaded chunk (`read_chunk_sync` returns `None`, then `unwrap_or(0)`), while `set_sky_light_level` silently does nothing there (the write also goes through `read_chunk_sync`, which is a no-op when the chunk is missing). So in `propagate_sky_light_increase` the "only propagate if we're brighter than the neighbour" check stays true on every pass: the neighbour keeps reading back as `0`, we try to raise it, the write is dropped, and the same position gets queued again. The `sky_increase` queue never drains and the ticking thread hangs.

It is easy to hit when a block is broken (which re-opens a column to the sky) near the edge of the loaded area.

### Fix

Skip neighbours whose chunk isn't loaded, in both the increase and decrease passes. This mirrors what the block light path already does — it only continues `if let Some(neighbor_light) = self.get_block_light_level(...)` and checks that the write succeeded — and it matches the game not bleeding light into chunks that aren't there yet (they compute their own light when they load).

There is no behavioural change when the neighbours are loaded; the guard only short-circuits propagation at the loaded/unloaded border.
