### PR TITLE
Test framework for vanilla-parity checks (WIP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,10 +2832,19 @@ dependencies = [
  "pumpkin-config",
  "pumpkin-data",
  "pumpkin-protocol",
+ "pumpkin-test-macros",
  "pumpkin-util",
  "pumpkin-world",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "pumpkin-test-macros"
+version = "0.1.0-dev+26.2"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,6 +2833,7 @@ dependencies = [
  "pumpkin-data",
  "pumpkin-protocol",
  "pumpkin-util",
+ "pumpkin-world",
  "tempfile",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,6 +2823,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pumpkin-test"
+version = "0.1.0-dev+26.2"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "pumpkin",
+ "pumpkin-config",
+ "pumpkin-data",
+ "pumpkin-protocol",
+ "pumpkin-util",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "pumpkin-util"
 version = "0.1.0-dev+26.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ members = [
     "pumpkin-data",
     "pumpkin-plugin-api",
     "pumpkin-codecs",
-    "pumpkin-test"
+    "pumpkin-test",
+    "pumpkin-test-macros"
 ]
 exclude = ["pumpkin-codegen"]
 
@@ -159,6 +160,7 @@ pumpkin-nbt = { path = "pumpkin-nbt", default-features = false }
 pumpkin-protocol = { path = "pumpkin-protocol", default-features = false }
 pumpkin-util = { path = "pumpkin-util", default-features = false }
 pumpkin-world = { path = "pumpkin-world", default-features = false }
+pumpkin-test-macros = { path = "pumpkin-test-macros" }
 quote = { version = "1.0", default-features = false, features = ["proc-macro"] }
 rand = { version = "0.10.1", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 rsa = { version = "=0.10.0-rc.18", default-features = false, features = ["std", "encoding"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ members = [
     "pumpkin/",
     "pumpkin-data",
     "pumpkin-plugin-api",
-    "pumpkin-codecs"
+    "pumpkin-codecs",
+    "pumpkin-test"
 ]
 exclude = ["pumpkin-codegen"]
 
@@ -148,6 +149,7 @@ num-traits = { version = "0.2", default-features = false, features = ["std"] }
 p384 = { version = "0.13.1", default-features = false, features = ["std", "arithmetic", "pkcs8"] }
 phf = { version = "0.14.0", default-features = false, features = ["std"] }
 proc-macro2 = { version = "1.0", default-features = false, features = ["proc-macro"] }
+pumpkin = { path = "pumpkin", default-features = false }
 pumpkin-codecs = { path = "pumpkin-codecs", default-features = false }
 pumpkin-config = { path = "pumpkin-config", default-features = false }
 pumpkin-data = { path = "pumpkin-data", default-features = false }

--- a/pumpkin-protocol/Cargo.toml
+++ b/pumpkin-protocol/Cargo.toml
@@ -10,6 +10,8 @@ default = ["query"]
 serverbound = []
 clientbound = []
 query = []
+# Adds encode derives to serverbound packets so tests can send them as bytes. Off in normal builds.
+test-harness = []
 
 [dependencies]
 pumpkin-nbt.workspace = true

--- a/pumpkin-protocol/src/java/server/play/player_action.rs
+++ b/pumpkin-protocol/src/java/server/play/player_action.rs
@@ -5,6 +5,7 @@ use pumpkin_util::math::position::BlockPos;
 use crate::VarInt;
 
 #[derive(serde::Deserialize)]
+#[cfg_attr(feature = "test-harness", derive(serde::Serialize))]
 #[java_packet(PLAY_PLAYER_ACTION)]
 pub struct SPlayerAction {
     pub status: VarInt,

--- a/pumpkin-test-macros/Cargo.toml
+++ b/pumpkin-test-macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pumpkin-test-macros"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Attribute macro for pumpkin-test integration tests."
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true
+
+[dependencies]
+quote.workspace = true
+syn = { workspace = true, features = ["full", "parsing", "proc-macro"] }

--- a/pumpkin-test-macros/src/lib.rs
+++ b/pumpkin-test-macros/src/lib.rs
@@ -1,0 +1,68 @@
+//! Attribute macro for `pumpkin-test` integration tests.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{FnArg, ItemFn, parse_macro_input};
+
+/// Turns an `async fn` into a single-threaded Tokio test, replacing
+/// `#[tokio::test]`.
+///
+/// If the function declares a first parameter, a fresh `TestServer` is built
+/// (with the optional `seed`, default `0`) and bound to it before the body
+/// runs. `TestServer` must be in scope at the call site.
+///
+/// ```ignore
+/// #[pumpkin_test]
+/// async fn no_fixture() { /* build your own TestServer */ }
+///
+/// #[pumpkin_test(seed = 12345)]
+/// async fn with_fixture(mut t: TestServer) { /* use t */ }
+/// ```
+#[proc_macro_attribute]
+pub fn pumpkin_test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Seed defaults to 0; captured as tokens so negative literals work, since
+    // Minecraft world seeds are signed (Java i64).
+    let mut seed = quote! { 0 };
+    let seed_parser = syn::meta::parser(|meta| {
+        if meta.path.is_ident("seed") {
+            let value: syn::Expr = meta.value()?.parse()?;
+            seed = quote! { #value };
+            Ok(())
+        } else {
+            Err(meta.error("unsupported `pumpkin_test` argument (expected `seed = <int>`)"))
+        }
+    });
+    parse_macro_input!(attr with seed_parser);
+
+    let func = parse_macro_input!(item as ItemFn);
+    let attrs = &func.attrs;
+    let vis = &func.vis;
+    let name = &func.sig.ident;
+    let statements = &func.block.stmts;
+
+    // If the test takes a parameter, inject a freshly built `TestServer`.
+    let setup = match func.sig.inputs.first() {
+        Some(FnArg::Typed(arg)) => {
+            let binding = &arg.pat;
+            quote! { let #binding = TestServer::new(#seed).await; }
+        }
+        _ => quote! {},
+    };
+
+    quote! {
+        #(#attrs)*
+        #[test]
+        #vis fn #name() {
+            let runtime = ::tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .expect("failed to build the test runtime");
+            runtime.block_on(async move {
+                #setup
+                #(#statements)*
+            });
+        }
+    }
+    .into()
+}

--- a/pumpkin-test/Cargo.toml
+++ b/pumpkin-test/Cargo.toml
@@ -22,4 +22,5 @@ tempfile.workspace = true
 tokio = { workspace = true, features = ["net", "sync"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+pumpkin-test-macros.workspace = true
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }

--- a/pumpkin-test/Cargo.toml
+++ b/pumpkin-test/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 pumpkin = { workspace = true, features = ["test-harness"] }
 pumpkin-config.workspace = true
-pumpkin-data.workspace = true
+pumpkin-data = { workspace = true, features = ["item", "block", "recipes", "tag"] }
 pumpkin-protocol = { workspace = true, features = ["test-harness"] }
 pumpkin-util.workspace = true
 pumpkin-world = { workspace = true, features = ["test-harness"] }

--- a/pumpkin-test/Cargo.toml
+++ b/pumpkin-test/Cargo.toml
@@ -19,7 +19,7 @@ pumpkin-world = { workspace = true, features = ["test-harness"] }
 arc-swap.workspace = true
 bytes.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["net", "sync"] }
+tokio = { workspace = true, features = ["net", "sync", "rt"] }
 
 [dev-dependencies]
 pumpkin-test-macros.workspace = true

--- a/pumpkin-test/Cargo.toml
+++ b/pumpkin-test/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "pumpkin-test"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "In-memory test harness for the Pumpkin server."
+
+[lints]
+workspace = true
+
+[dependencies]
+pumpkin = { workspace = true, features = ["test-harness"] }
+pumpkin-config.workspace = true
+pumpkin-data.workspace = true
+pumpkin-protocol.workspace = true
+pumpkin-util.workspace = true
+arc-swap.workspace = true
+bytes.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["net", "sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }

--- a/pumpkin-test/Cargo.toml
+++ b/pumpkin-test/Cargo.toml
@@ -15,6 +15,7 @@ pumpkin-config.workspace = true
 pumpkin-data.workspace = true
 pumpkin-protocol.workspace = true
 pumpkin-util.workspace = true
+pumpkin-world = { workspace = true, features = ["test-harness"] }
 arc-swap.workspace = true
 bytes.workspace = true
 tempfile.workspace = true

--- a/pumpkin-test/Cargo.toml
+++ b/pumpkin-test/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 pumpkin = { workspace = true, features = ["test-harness"] }
 pumpkin-config.workspace = true
 pumpkin-data.workspace = true
-pumpkin-protocol.workspace = true
+pumpkin-protocol = { workspace = true, features = ["test-harness"] }
 pumpkin-util.workspace = true
 pumpkin-world = { workspace = true, features = ["test-harness"] }
 arc-swap.workspace = true

--- a/pumpkin-test/src/lib.rs
+++ b/pumpkin-test/src/lib.rs
@@ -60,10 +60,12 @@ impl TestServer {
     /// Boots a server on a fresh temporary directory with the given world seed,
     /// in offline mode, with only the overworld enabled and a small view
     /// distance to keep on-demand chunk generation cheap.
-    pub async fn new(seed: u64) -> Self {
+    pub async fn new(seed: i64) -> Self {
         let temp_dir = tempfile::tempdir().expect("failed to create temp world dir");
         let basic = BasicConfiguration {
-            seed: Seed(seed),
+            // Minecraft world seeds are signed (Java i64); Pumpkin stores the
+            // same bits as u64 and casts back with `seed.0 as i64`.
+            seed: Seed(seed as u64),
             online_mode: false,
             encryption: false,
             allow_chat_reports: false,

--- a/pumpkin-test/src/lib.rs
+++ b/pumpkin-test/src/lib.rs
@@ -29,20 +29,26 @@ use pumpkin_data::Block;
 use pumpkin_data::dimension::Dimension;
 use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
+use pumpkin_data::packet::CURRENT_MC_VERSION;
 use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_protocol::codec::var_int::VarInt;
+use pumpkin_protocol::java::packet_decoder::TCPNetworkDecoder;
+use pumpkin_protocol::java::packet_encoder::TCPNetworkEncoder;
 use pumpkin_protocol::java::server::play::{
     SPlayerAction, SPlayerPosition, SSetCreativeSlot, SUseItemOn,
 };
+use pumpkin_protocol::ser::NetworkWriteExt;
 use pumpkin_protocol::{ClientPacket, ConnectionState, RawPacket};
 use pumpkin_util::GameMode;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::math::vector3::Vector3;
+use pumpkin_util::version::JavaMinecraftVersion;
 use pumpkin_util::world_seed::Seed;
 use pumpkin_world::chunk::ChunkData;
 use pumpkin_world::world::BlockFlags;
 use tempfile::TempDir;
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::{TcpListener, TcpStream};
 
 /// A running in-memory server plus the temporary world directory backing it.
@@ -99,6 +105,34 @@ impl TestServer {
     #[must_use]
     pub fn world(&self) -> Arc<World> {
         self.server.get_world_from_dimension(&Dimension::OVERWORLD)
+    }
+
+    /// Binds a real loopback TCP listener and drives each accepted Java
+    /// connection through the real handshake/login handling, returning the bound
+    /// address. A [`TestBot`] connects to it to exercise the full socket +
+    /// protocol stack end to end.
+    pub async fn spawn_java_listener(&self) -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind java listener");
+        let addr = listener.local_addr().expect("java listener address");
+        let server = self.server.clone();
+        tokio::spawn(async move {
+            let mut next_id = 1000u64;
+            while let Ok((connection, peer)) = listener.accept().await {
+                connection.set_nodelay(true).ok();
+                let server = server.clone();
+                let id = next_id;
+                next_id += 1;
+                tokio::spawn(async move {
+                    let mut java = JavaClient::new(connection, peer, id);
+                    java.start_outgoing_packet_task();
+                    let _ = java.handle_login_sequence(&server).await;
+                    java.await_tasks().await;
+                });
+            }
+        });
+        addr
     }
 
     /// Advances the full server tick (world logic, then player/network flush)
@@ -360,6 +394,60 @@ impl TestPlayer {
             "expected clientbound packet was not among the {} captured frame(s)",
             frames.len()
         );
+    }
+}
+
+/// A minimal headless client that speaks the real Java protocol over TCP,
+/// reusing `pumpkin-protocol`'s framing. Used for end-to-end (L3) tests.
+pub struct TestBot {
+    encoder: TCPNetworkEncoder<OwnedWriteHalf>,
+    decoder: TCPNetworkDecoder<OwnedReadHalf>,
+    version: JavaMinecraftVersion,
+}
+
+impl TestBot {
+    /// Connects to a server address (see [`TestServer::spawn_java_listener`]).
+    pub async fn connect(addr: SocketAddr) -> Self {
+        let stream = TcpStream::connect(addr).await.expect("bot connect");
+        stream.set_nodelay(true).ok();
+        let (read, write) = stream.into_split();
+        Self {
+            encoder: TCPNetworkEncoder::new(write),
+            decoder: TCPNetworkDecoder::new(read),
+            version: CURRENT_MC_VERSION,
+        }
+    }
+
+    /// The protocol version the bot speaks (the server's current version).
+    #[must_use]
+    pub const fn version(&self) -> JavaMinecraftVersion {
+        self.version
+    }
+
+    /// Sends a serverbound packet framed with an explicit packet id. Use this
+    /// for the handshake, which the server handles state-independently at a
+    /// literal id 0 and which has no entry in the versioned packet map.
+    pub async fn send_raw<P: ClientPacket>(&mut self, id: i32, packet: &P) {
+        let mut body = Vec::new();
+        body.write_var_int(&VarInt(id)).expect("write packet id");
+        packet
+            .write_packet_data(&mut body, &self.version)
+            .expect("write packet body");
+        self.encoder
+            .write_packet(body.into())
+            .await
+            .expect("send frame");
+        self.encoder.flush().await.expect("flush frame");
+    }
+
+    /// Encodes a serverbound packet with its versioned id and sends it framed.
+    pub async fn send<P: ClientPacket>(&mut self, packet: &P) {
+        self.send_raw(P::to_id(self.version), packet).await;
+    }
+
+    /// Reads the next clientbound frame as a raw `{ id, payload }` packet.
+    pub async fn recv(&mut self) -> RawPacket {
+        self.decoder.get_raw_packet().await.expect("receive frame")
     }
 }
 

--- a/pumpkin-test/src/lib.rs
+++ b/pumpkin-test/src/lib.rs
@@ -205,6 +205,29 @@ impl TestServer {
     }
 }
 
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        // Stop each world's generation threads so a finished test doesn't leave
+        // background threads running, which can stall CI runner cleanup.
+        for world in self.server.worlds.load().iter() {
+            let level = &world.level;
+            level.cancel_token.cancel();
+            level
+                .shut_down_chunk_system
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            level.level_channel.notify();
+            let handles: Vec<_> = level
+                .thread_tracker
+                .lock()
+                .map(|mut guard| guard.drain(..).collect())
+                .unwrap_or_default();
+            for handle in handles {
+                let _ = handle.join();
+            }
+        }
+    }
+}
+
 /// A player attached to a [`TestServer`].
 pub struct TestPlayer {
     /// The live player entity.

--- a/pumpkin-test/src/lib.rs
+++ b/pumpkin-test/src/lib.rs
@@ -1,0 +1,148 @@
+//! In-memory test harness for the Pumpkin server (level L1).
+//!
+//! Builds a real [`Server`] on a temporary directory with a fixed world seed,
+//! attaches players backed by a real `JavaClient` over a loopback socket, and
+//! advances game logic deterministically by driving `Server` ticks directly
+//! (bypassing the sleeping `Ticker`). No production code paths are altered; the
+//! server exposes only additive helpers behind its `test-harness` feature.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use bytes::Bytes;
+use pumpkin::data::VanillaData;
+use pumpkin::entity::player::Player;
+use pumpkin::net::java::JavaClient;
+use pumpkin::net::{ClientPlatform, GameProfile, PlayerConfig, offline_uuid};
+use pumpkin::server::Server;
+use pumpkin_config::{AdvancedConfiguration, BasicConfiguration};
+use pumpkin_data::dimension::Dimension;
+use pumpkin_protocol::ConnectionState;
+use pumpkin_util::GameMode;
+use pumpkin_util::world_seed::Seed;
+use tempfile::TempDir;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc::UnboundedReceiver;
+
+/// A running in-memory server plus the temporary world directory backing it.
+pub struct TestServer {
+    /// The real server instance under test.
+    pub server: Arc<Server>,
+    /// Kept alive so the temporary world directory is removed on drop.
+    _temp_dir: TempDir,
+    /// Monotonic id handed to each mock client.
+    next_client_id: u64,
+}
+
+impl TestServer {
+    /// Boots a server on a fresh temporary directory with the given world seed,
+    /// in offline mode and with only the overworld dimension enabled.
+    pub async fn new(seed: u64) -> Self {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp world dir");
+        let basic = BasicConfiguration {
+            seed: Seed(seed),
+            online_mode: false,
+            encryption: false,
+            allow_chat_reports: false,
+            allow_nether: false,
+            allow_end: false,
+            java_edition: false,
+            bedrock_edition: false,
+            default_level_name: temp_dir.path().to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        let server = Server::new(
+            basic,
+            AdvancedConfiguration::default(),
+            VanillaData::for_test(),
+        )
+        .await;
+        Self {
+            server,
+            _temp_dir: temp_dir,
+            next_client_id: 0,
+        }
+    }
+
+    /// Advances the full server tick (world logic, then player/network flush)
+    /// `n` times. This replaces the sleeping `Ticker` loop with deterministic,
+    /// synchronous stepping.
+    pub async fn tick_n(&self, n: u32) {
+        for _ in 0..n {
+            self.server.tick_worlds().await;
+            self.server.tick_players_and_network().await;
+        }
+    }
+
+    /// Attaches a new player to the overworld, backed by a real `JavaClient`
+    /// over a loopback socket whose clientbound frames are captured instead of
+    /// being written to the wire.
+    pub async fn add_player(&mut self, name: &str, gamemode: GameMode) -> TestPlayer {
+        let (server_stream, client_stream, peer) = loopback_pair().await;
+
+        let id = self.next_client_id;
+        self.next_client_id += 1;
+
+        let mut java = JavaClient::new(server_stream, peer, id);
+        java.connection_state.store(ConnectionState::Play);
+        let clientbound = java.start_test_capture();
+
+        let client = Arc::new(ClientPlatform::Java(java));
+
+        let profile = GameProfile {
+            id: offline_uuid(name).expect("valid offline uuid"),
+            name: name.to_owned(),
+            properties: ArcSwap::new(Arc::new(Vec::new())),
+            profile_actions: None,
+        };
+
+        let world = self.server.get_world_from_dimension(&Dimension::OVERWORLD);
+        let player = Arc::new(
+            Player::new(
+                client.clone(),
+                profile,
+                PlayerConfig::default(),
+                world.clone(),
+                gamemode,
+            )
+            .await,
+        );
+
+        // Link the client back to its player, mirroring the real login flow.
+        if let Some(java) = client.java() {
+            *java.player.lock().await = Some(player.clone());
+        }
+        world.add_player(&player).expect("add player to world");
+        player.set_client_loaded(true);
+
+        TestPlayer {
+            player,
+            clientbound,
+            _client_stream: client_stream,
+        }
+    }
+}
+
+/// A player attached to a [`TestServer`].
+pub struct TestPlayer {
+    /// The live player entity.
+    pub player: Arc<Player>,
+    /// Raw serialized clientbound frames the server tried to send this player.
+    pub clientbound: UnboundedReceiver<Bytes>,
+    /// The client end of the loopback socket, kept open for the connection's life.
+    _client_stream: TcpStream,
+}
+
+/// Creates a connected loopback TCP pair, returning the server half, the client
+/// half, and the server-perceived peer address.
+async fn loopback_pair() -> (TcpStream, TcpStream, SocketAddr) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback listener");
+    let addr = listener.local_addr().expect("listener local addr");
+    let (connect_res, accept_res) = tokio::join!(TcpStream::connect(addr), listener.accept());
+    let client_stream = connect_res.expect("connect loopback client");
+    let (server_stream, peer) = accept_res.expect("accept loopback server");
+    (server_stream, client_stream, peer)
+}

--- a/pumpkin-test/src/lib.rs
+++ b/pumpkin-test/src/lib.rs
@@ -3,24 +3,45 @@
 //! Builds a real [`Server`] on a temporary directory with a fixed world seed,
 //! attaches players backed by a real `JavaClient` over a loopback socket, and
 //! advances game logic deterministically by driving `Server` ticks directly
-//! (bypassing the sleeping `Ticker`). No production code paths are altered; the
-//! server exposes only additive helpers behind its `test-harness` feature.
+//! (bypassing the sleeping `Ticker`). Player actions are pushed through the
+//! real public serverbound handlers, not through shortcuts. No production code
+//! paths are altered; the server exposes only additive helpers behind its
+//! `test-harness` feature.
 
 use std::net::SocketAddr;
+use std::num::NonZeroU8;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
 use pumpkin::data::VanillaData;
+use pumpkin::entity::EntityBase;
+use pumpkin::entity::item::ItemEntity;
 use pumpkin::entity::player::Player;
 use pumpkin::net::java::JavaClient;
 use pumpkin::net::{ClientPlatform, GameProfile, PlayerConfig, offline_uuid};
 use pumpkin::server::Server;
+use pumpkin::world::World;
+use pumpkin_config::lighting::LightingEngineConfig;
+use pumpkin_config::world::LevelConfig;
 use pumpkin_config::{AdvancedConfiguration, BasicConfiguration};
+use pumpkin_data::Block;
 use pumpkin_data::dimension::Dimension;
+use pumpkin_data::item::Item;
+use pumpkin_data::item_stack::ItemStack;
 use pumpkin_protocol::ConnectionState;
+use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
+use pumpkin_protocol::codec::var_int::VarInt;
+use pumpkin_protocol::java::server::play::{
+    SPlayerAction, SPlayerPosition, SSetCreativeSlot, SUseItemOn,
+};
 use pumpkin_util::GameMode;
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::vector2::Vector2;
+use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::world_seed::Seed;
+use pumpkin_world::chunk::ChunkData;
+use pumpkin_world::world::BlockFlags;
 use tempfile::TempDir;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -37,7 +58,8 @@ pub struct TestServer {
 
 impl TestServer {
     /// Boots a server on a fresh temporary directory with the given world seed,
-    /// in offline mode and with only the overworld dimension enabled.
+    /// in offline mode, with only the overworld enabled and a small view
+    /// distance to keep on-demand chunk generation cheap.
     pub async fn new(seed: u64) -> Self {
         let temp_dir = tempfile::tempdir().expect("failed to create temp world dir");
         let basic = BasicConfiguration {
@@ -49,20 +71,33 @@ impl TestServer {
             allow_end: false,
             java_edition: false,
             bedrock_edition: false,
+            view_distance: NonZeroU8::new(2).expect("nonzero"),
+            simulation_distance: NonZeroU8::new(2).expect("nonzero"),
             default_level_name: temp_dir.path().to_string_lossy().into_owned(),
             ..Default::default()
         };
-        let server = Server::new(
-            basic,
-            AdvancedConfiguration::default(),
-            VanillaData::for_test(),
-        )
-        .await;
+        let advanced = AdvancedConfiguration {
+            world: LevelConfig {
+                // Skip sky/block light propagation: it keeps block edits O(1)
+                // and avoids spinning on the empty test chunks, whose light
+                // arrays are not populated.
+                lighting: LightingEngineConfig::Full,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let server = Server::new(basic, advanced, VanillaData::for_test()).await;
         Self {
             server,
             _temp_dir: temp_dir,
             next_client_id: 0,
         }
+    }
+
+    /// The overworld world.
+    #[must_use]
+    pub fn world(&self) -> Arc<World> {
+        self.server.get_world_from_dimension(&Dimension::OVERWORLD)
     }
 
     /// Advances the full server tick (world logic, then player/network flush)
@@ -73,6 +108,50 @@ impl TestServer {
             self.server.tick_worlds().await;
             self.server.tick_players_and_network().await;
         }
+    }
+
+    /// Runs real vanilla world generation for the chunk at the given
+    /// coordinates and loads it. Slow (terrain plus structures); use it only
+    /// when a test actually needs generated terrain. For tests that only rely
+    /// on blocks they set themselves, prefer [`Self::insert_empty_chunk`].
+    pub async fn load_chunk(&self, chunk_x: i32, chunk_z: i32) {
+        self.world()
+            .level
+            .get_or_fetch_chunk(Vector2::new(chunk_x, chunk_z), |_| ())
+            .await;
+    }
+
+    /// Inserts an empty (all-air) chunk at the given coordinates without running
+    /// world generation. This is the fast path: no terrain, no structures, no
+    /// generation threads. The test sets whatever blocks it needs afterwards.
+    pub fn insert_empty_chunk(&self, chunk_x: i32, chunk_z: i32) {
+        self.world().level.loaded_chunks.insert(
+            Vector2::new(chunk_x, chunk_z),
+            Arc::new(ChunkData::empty_overworld(chunk_x, chunk_z)),
+        );
+    }
+
+    /// Sets the block state at `pos` to `block`'s default state.
+    pub async fn set_block(&self, pos: BlockPos, block: &'static Block) {
+        self.world()
+            .set_block_state(&pos, block.default_state.id, BlockFlags::NOTIFY_ALL)
+            .await;
+    }
+
+    /// Reads the block at `pos`.
+    #[must_use]
+    pub fn block_at(&self, pos: BlockPos) -> &'static Block {
+        self.world().get_block(&pos)
+    }
+
+    /// Collects the item entities within `radius` of `center`.
+    #[must_use]
+    pub fn item_entities_near(&self, center: Vector3<f64>, radius: f64) -> Vec<Arc<ItemEntity>> {
+        self.world()
+            .get_nearby_entities(center, radius)
+            .into_values()
+            .filter_map(EntityBase::get_item_entity)
+            .collect()
     }
 
     /// Attaches a new player to the overworld, backed by a real `JavaClient`
@@ -97,7 +176,7 @@ impl TestServer {
             profile_actions: None,
         };
 
-        let world = self.server.get_world_from_dimension(&Dimension::OVERWORLD);
+        let world = self.world();
         let player = Arc::new(
             Player::new(
                 client.clone(),
@@ -118,6 +197,7 @@ impl TestServer {
 
         TestPlayer {
             player,
+            server: self.server.clone(),
             clientbound,
             _client_stream: client_stream,
         }
@@ -128,10 +208,91 @@ impl TestServer {
 pub struct TestPlayer {
     /// The live player entity.
     pub player: Arc<Player>,
+    /// The server the player belongs to (needed to invoke real handlers).
+    server: Arc<Server>,
     /// Raw serialized clientbound frames the server tried to send this player.
     pub clientbound: UnboundedReceiver<Bytes>,
     /// The client end of the loopback socket, kept open for the connection's life.
     _client_stream: TcpStream,
+}
+
+impl TestPlayer {
+    /// The underlying mock Java client.
+    fn client(&self) -> &JavaClient {
+        self.player.client.java().expect("java test client")
+    }
+
+    /// Directly sets the item in the player's selected hotbar slot (test setup).
+    pub async fn set_main_hand(&self, item: &'static Item, count: u8) {
+        *self.player.inventory().held_item().lock().await = ItemStack::new(count, item);
+    }
+
+    /// Returns a clone of the item in the selected hotbar slot.
+    pub async fn held_item(&self) -> ItemStack {
+        self.player.inventory().held_item().lock().await.clone()
+    }
+
+    /// The player's current position.
+    #[must_use]
+    pub fn position(&self) -> Vector3<f64> {
+        self.player.get_entity().pos.load()
+    }
+
+    /// Breaks the block at `pos` by sending a `FinishedDigging` action through
+    /// the real `handle_player_action` pipeline.
+    pub async fn break_block(&self, pos: BlockPos) {
+        let action = SPlayerAction {
+            status: VarInt(2), // FinishedDigging
+            position: pos,
+            face: 1, // Up
+            sequence: VarInt(0),
+        };
+        self.client()
+            .handle_player_action(&self.player, action, self.server.as_ref())
+            .await;
+    }
+
+    /// Places the held block against the top face of the block at `pos`,
+    /// through the real `handle_use_item_on` pipeline.
+    pub async fn place_block_on_top(&self, pos: BlockPos) {
+        let packet = SUseItemOn {
+            hand: VarInt(0), // main hand
+            position: pos,
+            face: VarInt(1), // Up
+            cursor_pos: Vector3::new(0.5f32, 1.0, 0.5),
+            inside_block: false,
+            is_against_world_border: false,
+            sequence: VarInt(0),
+        };
+        let _ = self
+            .client()
+            .handle_use_item_on(&self.player, packet, &self.server)
+            .await;
+    }
+
+    /// Moves the player to `pos` through the real `handle_position` pipeline.
+    pub async fn move_to(&self, pos: Vector3<f64>) {
+        let packet = SPlayerPosition {
+            position: pos,
+            collision: 1, // on-ground flag
+        };
+        self.client()
+            .handle_position(&self.player, &self.server, packet)
+            .await;
+    }
+
+    /// Sets a creative-mode container slot to the given item, through the real
+    /// `handle_set_creative_slot` pipeline (player must be in creative mode).
+    pub async fn set_creative_slot(&self, slot: i16, item: &'static Item, count: u8) {
+        let packet = SSetCreativeSlot {
+            slot,
+            clicked_item: ItemStackSerializer::from(ItemStack::new(count, item)),
+        };
+        self.client()
+            .handle_set_creative_slot(&self.player, packet)
+            .await
+            .expect("creative slot set");
+    }
 }
 
 /// Creates a connected loopback TCP pair, returning the server half, the client

--- a/pumpkin-test/src/lib.rs
+++ b/pumpkin-test/src/lib.rs
@@ -18,7 +18,7 @@ use pumpkin::data::VanillaData;
 use pumpkin::entity::EntityBase;
 use pumpkin::entity::item::ItemEntity;
 use pumpkin::entity::player::Player;
-use pumpkin::net::java::JavaClient;
+use pumpkin::net::java::{ClientboundCapture, JavaClient};
 use pumpkin::net::{ClientPlatform, GameProfile, PlayerConfig, offline_uuid};
 use pumpkin::server::Server;
 use pumpkin::world::World;
@@ -29,12 +29,12 @@ use pumpkin_data::Block;
 use pumpkin_data::dimension::Dimension;
 use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
-use pumpkin_protocol::ConnectionState;
 use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::java::server::play::{
     SPlayerAction, SPlayerPosition, SSetCreativeSlot, SUseItemOn,
 };
+use pumpkin_protocol::{ClientPacket, ConnectionState, RawPacket};
 use pumpkin_util::GameMode;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector2::Vector2;
@@ -44,7 +44,6 @@ use pumpkin_world::chunk::ChunkData;
 use pumpkin_world::world::BlockFlags;
 use tempfile::TempDir;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc::UnboundedReceiver;
 
 /// A running in-memory server plus the temporary world directory backing it.
 pub struct TestServer {
@@ -212,8 +211,8 @@ pub struct TestPlayer {
     pub player: Arc<Player>,
     /// The server the player belongs to (needed to invoke real handlers).
     server: Arc<Server>,
-    /// Raw serialized clientbound frames the server tried to send this player.
-    pub clientbound: UnboundedReceiver<Bytes>,
+    /// Captures the clientbound frames the server queued for this player.
+    clientbound: ClientboundCapture,
     /// The client end of the loopback socket, kept open for the connection's life.
     _client_stream: TcpStream,
 }
@@ -294,6 +293,50 @@ impl TestPlayer {
             .handle_set_creative_slot(&self.player, packet)
             .await
             .expect("creative slot set");
+    }
+
+    /// Encodes `packet` and feeds it through the real serverbound byte pipeline
+    /// (`handle_play_packet`), so the actual decode and dispatch run — unlike the
+    /// typed action helpers above, which call the handlers directly. The packet
+    /// must be encodable (a `ClientPacket`, i.e. it derives `Serialize`).
+    pub async fn send_serverbound<P: ClientPacket>(&self, packet: &P) {
+        let version = self.client().version.load();
+        let mut body = Vec::new();
+        packet
+            .write_packet_data(&mut body, &version)
+            .expect("encode serverbound packet");
+        let raw = RawPacket {
+            id: P::to_id(version),
+            payload: body.into(),
+        };
+        if let Err(error) = self
+            .client()
+            .handle_play_packet(&self.player, &self.server, &raw)
+            .await
+        {
+            panic!("handle_play_packet returned an error: {error}");
+        }
+    }
+
+    /// Returns the raw clientbound frames the server has queued for this player
+    /// so far, in send order.
+    #[must_use]
+    pub fn clientbound_frames(&self) -> Vec<Bytes> {
+        self.clientbound.drain()
+    }
+
+    /// Asserts the server sent a clientbound packet byte-identical to `expected`
+    /// (re-serialized with the client's protocol version).
+    pub fn assert_clientbound_sent<P: ClientPacket>(&self, expected: &P) {
+        let version = self.client().version.load();
+        let expected_bytes = JavaClient::serialize_packet_for_version(expected, version)
+            .expect("serialize expected clientbound packet");
+        let frames = self.clientbound_frames();
+        assert!(
+            frames.iter().any(|frame| frame == &expected_bytes),
+            "expected clientbound packet was not among the {} captured frame(s)",
+            frames.len()
+        );
     }
 }
 

--- a/pumpkin-test/tests/data.rs
+++ b/pumpkin-test/tests/data.rs
@@ -1,0 +1,62 @@
+//! Data-driven pilots: assert known vanilla facts against Pumpkin's compiled
+//! data (recipes, tags, block loot). These are pure static queries — no server,
+//! no world — so the expected values act as an independent vanilla oracle.
+
+use pumpkin::world::loot::{LootContextParameters, LootTableExt};
+use pumpkin_data::Block;
+use pumpkin_data::item::Item;
+use pumpkin_data::recipes::{CraftingRecipeTypes, RECIPES_CRAFTING};
+use pumpkin_data::tag::{self, Taggable};
+
+/// One oak log crafts into four oak planks (a shapeless vanilla recipe).
+#[test]
+fn oak_log_makes_four_oak_planks() {
+    let result = RECIPES_CRAFTING
+        .iter()
+        .find_map(|recipe| match recipe {
+            CraftingRecipeTypes::CraftingShapeless {
+                ingredients,
+                result,
+                ..
+            } if ingredients.iter().any(|i| i.match_item(&Item::OAK_LOG)) => Some(result),
+            _ => None,
+        })
+        .expect("a shapeless recipe consuming an oak log should exist");
+
+    assert_eq!(
+        Item::from_registry_key(result.id).map(|item| item.id),
+        Some(Item::OAK_PLANKS.id)
+    );
+    assert_eq!(result.count, 4);
+}
+
+/// Oak planks belong to the `minecraft:planks` item tag.
+#[test]
+fn oak_planks_are_planks() {
+    assert_eq!(
+        Item::OAK_PLANKS.is_tagged_with("minecraft:planks"),
+        Some(true)
+    );
+    assert!(Item::OAK_PLANKS.has_tag(&tag::Item::MINECRAFT_PLANKS));
+}
+
+/// Stone is mineable with a pickaxe.
+#[test]
+fn stone_is_mineable_with_pickaxe() {
+    assert_eq!(
+        Block::STONE.is_tagged_with("minecraft:mineable/pickaxe"),
+        Some(true)
+    );
+    assert!(Block::STONE.has_tag(&tag::Block::MINECRAFT_MINEABLE_PICKAXE));
+}
+
+/// Breaking stone with no tool (no silk touch) yields exactly one cobblestone.
+#[test]
+fn stone_loot_is_one_cobblestone() {
+    let table = Block::STONE.loot_table.expect("stone has a loot table");
+    let drops = table.get_loot(LootContextParameters::default());
+
+    assert_eq!(drops.len(), 1, "stone should drop a single item");
+    assert_eq!(drops[0].item.id, Item::COBBLESTONE.id);
+    assert_eq!(drops[0].item_count, 1);
+}

--- a/pumpkin-test/tests/e2e.rs
+++ b/pumpkin-test/tests/e2e.rs
@@ -1,0 +1,50 @@
+//! L3 end-to-end pilot: a headless bot speaks the real Java protocol over a
+//! real loopback TCP socket against a running server, and completes the
+//! server-list status exchange (handshake -> status -> ping/pong).
+
+use pumpkin_data::packet::CURRENT_MC_VERSION;
+use pumpkin_protocol::codec::var_int::VarInt;
+use pumpkin_protocol::java::client::status::{CPingResponse, CStatusResponse};
+use pumpkin_protocol::java::server::handshake::SHandShake;
+use pumpkin_protocol::java::server::status::{SStatusPingRequest, SStatusRequest};
+use pumpkin_protocol::{ConnectionState, MultiVersionJavaPacket, ServerPacket};
+use pumpkin_test::{TestBot, TestServer};
+use pumpkin_test_macros::pumpkin_test;
+
+/// A headless bot completes the status exchange with a real server over TCP.
+#[pumpkin_test]
+async fn status_ping_roundtrips(t: TestServer) {
+    let addr = t.spawn_java_listener().await;
+    let mut bot = TestBot::connect(addr).await;
+    let version = CURRENT_MC_VERSION;
+
+    // Handshake requesting the Status state. The handshake is always id 0.
+    bot.send_raw(
+        0,
+        &SHandShake {
+            protocol_version: VarInt(version.protocol_version()),
+            server_address: "127.0.0.1".into(),
+            server_port: addr.port(),
+            next_state: ConnectionState::Status,
+        },
+    )
+    .await;
+
+    // Status request -> status response carrying the server-list JSON.
+    bot.send(&SStatusRequest {}).await;
+    let raw = bot.recv().await;
+    assert_eq!(raw.id, CStatusResponse::to_id(version));
+    let status = CStatusResponse::read(&raw.payload[..], &version).expect("decode status response");
+    assert!(
+        status.json_response.contains("version"),
+        "status json should describe the version: {}",
+        status.json_response
+    );
+
+    // Ping -> pong echoing the same payload.
+    bot.send(&SStatusPingRequest { payload: 424_242 }).await;
+    let raw = bot.recv().await;
+    assert_eq!(raw.id, CPingResponse::to_id(version));
+    let pong = CPingResponse::read(&raw.payload[..], &version).expect("decode pong");
+    assert_eq!(pong.payload, 424_242);
+}

--- a/pumpkin-test/tests/pilots.rs
+++ b/pumpkin-test/tests/pilots.rs
@@ -4,14 +4,14 @@
 use pumpkin_data::Block;
 use pumpkin_data::item::Item;
 use pumpkin_test::TestServer;
+use pumpkin_test_macros::pumpkin_test;
 use pumpkin_util::GameMode;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 
 /// Breaking a stone block with a pickaxe in survival drops one cobblestone.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn break_stone_drops_cobblestone() {
-    let mut t = TestServer::new(12345).await;
+#[pumpkin_test(seed = 12345)]
+async fn break_stone_drops_cobblestone(mut t: TestServer) {
     t.insert_empty_chunk(0, 0);
 
     let player = t.add_player("Miner", GameMode::Survival).await;
@@ -42,9 +42,8 @@ async fn break_stone_drops_cobblestone() {
 }
 
 /// Using a block item on the top face of a block places a new block above it.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn place_block_on_top_of_stone() {
-    let mut t = TestServer::new(12345).await;
+#[pumpkin_test(seed = 12345)]
+async fn place_block_on_top_of_stone(mut t: TestServer) {
     t.insert_empty_chunk(0, 0);
 
     let player = t.add_player("Builder", GameMode::Survival).await;
@@ -66,9 +65,8 @@ async fn place_block_on_top_of_stone() {
 }
 
 /// A position packet moves the player's entity to the requested coordinates.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn player_position_updates() {
-    let mut t = TestServer::new(12345).await;
+#[pumpkin_test(seed = 12345)]
+async fn player_position_updates(mut t: TestServer) {
     let player = t.add_player("Walker", GameMode::Survival).await;
 
     let target = Vector3::new(1.0, 100.0, 2.0);
@@ -85,9 +83,8 @@ async fn player_position_updates() {
 }
 
 /// Setting a creative hotbar slot updates the player's held item.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn creative_set_slot_updates_held_item() {
-    let mut t = TestServer::new(12345).await;
+#[pumpkin_test(seed = 12345)]
+async fn creative_set_slot_updates_held_item(mut t: TestServer) {
     let player = t.add_player("Creator", GameMode::Creative).await;
 
     // Container slot 36 is the first hotbar slot; the selected slot defaults to 0.

--- a/pumpkin-test/tests/pilots.rs
+++ b/pumpkin-test/tests/pilots.rs
@@ -1,0 +1,105 @@
+//! M1 pilot tests: each drives a real public serverbound handler and asserts
+//! the resulting game state, deterministically and without real networking.
+
+use pumpkin_data::Block;
+use pumpkin_data::item::Item;
+use pumpkin_test::TestServer;
+use pumpkin_util::GameMode;
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::vector3::Vector3;
+
+/// Breaking a stone block with a pickaxe in survival drops one cobblestone.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn break_stone_drops_cobblestone() {
+    let mut t = TestServer::new(12345).await;
+    t.insert_empty_chunk(0, 0);
+
+    let player = t.add_player("Miner", GameMode::Survival).await;
+    player.set_main_hand(&Item::DIAMOND_PICKAXE, 1).await;
+
+    let pos = BlockPos::new(0, 99, 0);
+    t.set_block(pos, &Block::STONE).await;
+    assert_eq!(
+        t.block_at(pos).id,
+        Block::STONE.id,
+        "stone should be placed"
+    );
+
+    player.break_block(pos).await;
+    t.tick_n(1).await;
+
+    assert_eq!(t.block_at(pos).id, Block::AIR.id, "block should be broken");
+
+    let drops = t.item_entities_near(Vector3::new(0.5, 99.5, 0.5), 2.0);
+    assert_eq!(drops.len(), 1, "expected exactly one dropped item entity");
+    let stack = drops[0].stack().await;
+    assert_eq!(
+        stack.item.id,
+        Item::COBBLESTONE.id,
+        "should drop cobblestone"
+    );
+    assert_eq!(stack.item_count, 1);
+}
+
+/// Using a block item on the top face of a block places a new block above it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn place_block_on_top_of_stone() {
+    let mut t = TestServer::new(12345).await;
+    t.insert_empty_chunk(0, 0);
+
+    let player = t.add_player("Builder", GameMode::Survival).await;
+    player.set_main_hand(&Item::STONE, 64).await;
+
+    let base = BlockPos::new(2, 99, 0);
+    let target = BlockPos::new(2, 100, 0);
+    t.set_block(base, &Block::STONE).await;
+    t.set_block(target, &Block::AIR).await;
+
+    player.place_block_on_top(base).await;
+    t.tick_n(1).await;
+
+    assert_eq!(
+        t.block_at(target).id,
+        Block::STONE.id,
+        "a stone block should be placed on top"
+    );
+}
+
+/// A position packet moves the player's entity to the requested coordinates.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn player_position_updates() {
+    let mut t = TestServer::new(12345).await;
+    let player = t.add_player("Walker", GameMode::Survival).await;
+
+    let target = Vector3::new(1.0, 100.0, 2.0);
+    player.move_to(target).await;
+
+    let pos = player.position();
+    assert!((pos.x - 1.0).abs() < 1e-6, "x should update, got {}", pos.x);
+    assert!(
+        (pos.y - 100.0).abs() < 1e-6,
+        "y should update, got {}",
+        pos.y
+    );
+    assert!((pos.z - 2.0).abs() < 1e-6, "z should update, got {}", pos.z);
+}
+
+/// Setting a creative hotbar slot updates the player's held item.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn creative_set_slot_updates_held_item() {
+    let mut t = TestServer::new(12345).await;
+    let player = t.add_player("Creator", GameMode::Creative).await;
+
+    // Container slot 36 is the first hotbar slot; the selected slot defaults to 0.
+    player
+        .set_creative_slot(36, &Item::DIAMOND_PICKAXE, 1)
+        .await;
+
+    let held = player.held_item().await;
+    assert_eq!(
+        held.item.id,
+        Item::DIAMOND_PICKAXE.id,
+        "held item should be set"
+    );
+    assert_eq!(held.item_count, 1);
+}

--- a/pumpkin-test/tests/protocol.rs
+++ b/pumpkin-test/tests/protocol.rs
@@ -1,0 +1,74 @@
+//! L2 protocol-conformance pilots: drive serverbound packets as real bytes
+//! through `handle_play_packet` (the actual decode + dispatch), then assert on
+//! decoded server state or on captured clientbound frames.
+
+use pumpkin_data::Block;
+use pumpkin_data::item::Item;
+use pumpkin_protocol::codec::var_int::VarInt;
+use pumpkin_protocol::java::client::play::CPingResponse;
+use pumpkin_protocol::java::server::play::{SPlayPingRequest, SPlayerAction, SPlayerPosition};
+use pumpkin_test::TestServer;
+use pumpkin_test_macros::pumpkin_test;
+use pumpkin_util::GameMode;
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::vector3::Vector3;
+
+/// A ping request decoded from bytes produces a matching pong, captured as a
+/// real clientbound frame.
+#[pumpkin_test(seed = 12345)]
+async fn ping_request_gets_a_pong(mut t: TestServer) {
+    let player = t.add_player("Pinger", GameMode::Survival).await;
+
+    player
+        .send_serverbound(&SPlayPingRequest { payload: 987_654 })
+        .await;
+
+    player.assert_clientbound_sent(&CPingResponse::new(987_654));
+}
+
+/// A position packet decoded from bytes moves the player.
+#[pumpkin_test(seed = 12345)]
+async fn position_packet_moves_player(mut t: TestServer) {
+    let player = t.add_player("Walker", GameMode::Survival).await;
+
+    player
+        .send_serverbound(&SPlayerPosition {
+            position: Vector3::new(3.0, 100.0, 4.0),
+            collision: 1,
+        })
+        .await;
+
+    let pos = player.position();
+    assert!((pos.x - 3.0).abs() < 1e-6, "x should update, got {}", pos.x);
+    assert!(
+        (pos.y - 100.0).abs() < 1e-6,
+        "y should update, got {}",
+        pos.y
+    );
+    assert!((pos.z - 4.0).abs() < 1e-6, "z should update, got {}", pos.z);
+}
+
+/// A player-action packet decoded from bytes breaks a block. `SPlayerAction` is
+/// serializable only under the `test-harness` feature, which is how a
+/// deserialize-only serverbound packet becomes drivable from a test.
+#[pumpkin_test(seed = 12345)]
+async fn player_action_breaks_block(mut t: TestServer) {
+    t.insert_empty_chunk(0, 0);
+    let player = t.add_player("Miner", GameMode::Survival).await;
+    player.set_main_hand(&Item::DIAMOND_PICKAXE, 1).await;
+
+    let pos = BlockPos::new(0, 99, 0);
+    t.set_block(pos, &Block::STONE).await;
+
+    player
+        .send_serverbound(&SPlayerAction {
+            status: VarInt(2), // FinishedDigging
+            position: pos,
+            face: 1,
+            sequence: VarInt(0),
+        })
+        .await;
+    t.tick_n(1).await;
+
+    assert_eq!(t.block_at(pos).id, Block::AIR.id, "block should be broken");
+}

--- a/pumpkin-test/tests/smoke.rs
+++ b/pumpkin-test/tests/smoke.rs
@@ -1,0 +1,20 @@
+//! M0 smoke test: boot a server on a temp dir, attach a player, and tick.
+
+use pumpkin_test::TestServer;
+use pumpkin_util::GameMode;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn create_world_add_player_and_tick() {
+    let mut server = TestServer::new(12345).await;
+
+    let player = server.add_player("Tester", GameMode::Survival).await;
+    assert_eq!(player.player.gameprofile.name, "Tester");
+    assert!(player.player.has_client_loaded());
+
+    // Advancing ticks must not panic and must leave the player registered.
+    server.tick_n(3).await;
+
+    let worlds = server.server.worlds.load();
+    let player_count: usize = worlds.iter().map(|w| w.players.load().len()).sum();
+    assert_eq!(player_count, 1);
+}

--- a/pumpkin-test/tests/smoke.rs
+++ b/pumpkin-test/tests/smoke.rs
@@ -1,20 +1,19 @@
 //! M0 smoke test: boot a server on a temp dir, attach a player, and tick.
 
 use pumpkin_test::TestServer;
+use pumpkin_test_macros::pumpkin_test;
 use pumpkin_util::GameMode;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn create_world_add_player_and_tick() {
-    let mut server = TestServer::new(12345).await;
-
-    let player = server.add_player("Tester", GameMode::Survival).await;
+#[pumpkin_test(seed = -22837152948219)]
+async fn create_world_add_player_and_tick(mut t: TestServer) {
+    let player = t.add_player("Tester", GameMode::Survival).await;
     assert_eq!(player.player.gameprofile.name, "Tester");
     assert!(player.player.has_client_loaded());
 
     // Advancing ticks must not panic and must leave the player registered.
-    server.tick_n(3).await;
+    t.tick_n(3).await;
 
-    let worlds = server.server.worlds.load();
+    let worlds = t.server.worlds.load();
     let player_count: usize = worlds.iter().map(|w| w.players.load().len()).sum();
     assert_eq!(player_count, 1);
 }

--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -58,6 +58,10 @@ rustc-hash.workspace = true
 slotmap.workspace = true
 crossfire.workspace = true
 
+[features]
+# Enables in-crate test helpers (e.g. the empty-chunk constructor). Off in normal builds.
+test-harness = []
+
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports", "async_tokio"] }
 temp-dir.workspace = true

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -84,6 +84,32 @@ pub struct ChunkData {
     pub dirty: AtomicBool,
 }
 
+#[cfg(feature = "test-harness")]
+impl ChunkData {
+    /// Builds an empty (all-air) overworld chunk without running world
+    /// generation. Light arrays are empty and blocks/biomes are the default
+    /// palette entry. Insert it into `Level::loaded_chunks` to make the chunk
+    /// available to block reads and writes in fast tests.
+    #[must_use]
+    pub fn empty_overworld(x: i32, z: i32) -> Self {
+        // Overworld dimensions: min_y = -64, height = 384 -> 24 sections.
+        Self {
+            section: ChunkSections::new(24, -64),
+            heightmap: std::sync::Mutex::new(ChunkHeightmaps::default()),
+            x,
+            z,
+            block_ticks: ChunkTickScheduler::default(),
+            fluid_ticks: ChunkTickScheduler::default(),
+            pending_block_entities: std::sync::Mutex::new(FxHashMap::default()),
+            light_engine: std::sync::Mutex::new(ChunkLight::default()),
+            light_populated: AtomicBool::new(false),
+            status: ChunkStatus::Full,
+            blending_data: None,
+            dirty: AtomicBool::new(false),
+        }
+    }
+}
+
 pub struct ChunkEntityData {
     /// Chunk X
     pub x: i32,

--- a/pumpkin-world/src/lighting/runtime.rs
+++ b/pumpkin-world/src/lighting/runtime.rs
@@ -277,6 +277,16 @@ impl DynamicLightEngine {
         for dir in BlockDirection::all() {
             let neighbor_pos = pos.offset(dir.to_offset());
 
+            // Never propagate into an unloaded chunk. Writes to an unloaded
+            // chunk are dropped silently, so the "brighter than neighbor" check
+            // below would stay true forever and keep re-queuing the same
+            // position, spinning this loop indefinitely at the border between
+            // loaded and unloaded chunks.
+            let (neighbor_chunk, _) = neighbor_pos.chunk_and_chunk_relative_position();
+            if level.read_chunk_sync(&neighbor_chunk, |_| ()).is_none() {
+                continue;
+            }
+
             let neighbor_light = self.get_sky_light_level(level, &neighbor_pos);
             let neighbor_state = level.get_block_state(&neighbor_pos).to_state();
             let opacity = neighbor_state.opacity;
@@ -305,6 +315,13 @@ impl DynamicLightEngine {
     fn propagate_sky_light_decrease(&self, level: &Arc<Level>, pos: &BlockPos, removed_light: u8) {
         for dir in BlockDirection::all() {
             let neighbor_pos = pos.offset(dir.to_offset());
+
+            // See `propagate_sky_light_increase`: skip unloaded chunks so sky
+            // light updates never spin at loaded/unloaded chunk borders.
+            let (neighbor_chunk, _) = neighbor_pos.chunk_and_chunk_relative_position();
+            if level.read_chunk_sync(&neighbor_chunk, |_| ()).is_none() {
+                continue;
+            }
 
             let neighbor_light = self.get_sky_light_level(level, &neighbor_pos);
             if neighbor_light == 0 {

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -118,6 +118,8 @@ tempfile.workspace = true
 
 [features]
 console-subscriber = ["dep:console-subscriber"]
+# Enables in-crate test helpers (mock client capture, no-disk data). Never enabled in release builds.
+test-harness = []
 
 [lints]
 workspace = true

--- a/pumpkin/src/data/mod.rs
+++ b/pumpkin/src/data/mod.rs
@@ -35,6 +35,20 @@ impl VanillaData {
             whitelist_config: RwLock::new(whitelist::WhitelistConfig::load()),
         }
     }
+
+    /// Builds in-memory default data lists without touching the filesystem, so
+    /// tests stay isolated and deterministic.
+    #[cfg(feature = "test-harness")]
+    #[must_use]
+    pub fn for_test() -> Self {
+        Self {
+            banned_ip_list: RwLock::new(banned_ip::BannedIpList::default()),
+            banned_player_list: RwLock::new(banned_player::BannedPlayerList::default()),
+            operator_config: RwLock::new(op::OperatorConfig::default()),
+            user_cache: RwLock::new(usercache::UserCache::default()),
+            whitelist_config: RwLock::new(whitelist::WhitelistConfig::default()),
+        }
+    }
 }
 
 pub trait LoadJSONConfiguration {

--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -39,6 +39,15 @@ pub struct ItemEntity {
     never_pickup: AtomicBool,
 }
 
+#[cfg(feature = "test-harness")]
+impl ItemEntity {
+    /// Returns a clone of the carried stack, for test assertions.
+    #[must_use]
+    pub async fn stack(&self) -> ItemStack {
+        self.item_stack.lock().await.clone()
+    }
+}
+
 impl ItemEntity {
     pub fn new(entity: Entity, item_stack: ItemStack) -> Self {
         entity.velocity.store(Vector3::new(

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -1156,3 +1156,48 @@ impl JavaClient {
         Ok(())
     }
 }
+
+#[cfg(feature = "test-harness")]
+impl JavaClient {
+    /// Test-only replacement for [`Self::start_outgoing_packet_task`].
+    ///
+    /// Drains both outgoing packet queues into the returned channel, yielding the
+    /// raw serialized clientbound frames instead of writing them to a socket, and
+    /// resolves the completion signal of high-priority sends so that
+    /// `send_packet_now` does not block. Call once, before the client is shared,
+    /// in place of `start_outgoing_packet_task`.
+    #[must_use]
+    pub fn start_test_capture(&mut self) -> tokio::sync::mpsc::UnboundedReceiver<Bytes> {
+        let mut packet_receiver = self
+            .outgoing_packet_queue_recv
+            .take()
+            .expect("This was set in the new fn");
+        let mut priority_packet_receiver = self
+            .outgoing_packet_priority_recv
+            .take()
+            .expect("This was set in the new fn");
+        let close_token = self.close_token.clone();
+        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        self.spawn_task(async move {
+            loop {
+                let recv_result = tokio::select! {
+                    biased;
+                    () = close_token.cancelled() => None,
+                    res = priority_packet_receiver.recv() => res,
+                    res = packet_receiver.recv() => res,
+                };
+
+                let Some(packet) = recv_result else {
+                    break;
+                };
+
+                // Forward the serialized clientbound frame to the test sink.
+                let _ = sender.send(packet.data);
+                if let Some(completion) = packet.completion {
+                    let _ = completion.send(());
+                }
+            }
+        });
+        receiver
+    }
+}

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -1157,47 +1157,74 @@ impl JavaClient {
     }
 }
 
+/// Captures the clientbound frames a test client would have received.
+///
+/// High-priority (`send_packet_now`) frames are drained by a background task
+/// that also resolves their completion so `send_packet_now` doesn't block;
+/// normal (`enqueue_packet`) frames are drained on demand. [`Self::drain`]
+/// returns everything queued so far, in send order.
+#[cfg(feature = "test-harness")]
+pub struct ClientboundCapture {
+    normal: std::sync::Mutex<Receiver<OutgoingPacket>>,
+    priority: Arc<std::sync::Mutex<Vec<Bytes>>>,
+}
+
+#[cfg(feature = "test-harness")]
+impl ClientboundCapture {
+    /// Returns and clears the raw clientbound frames captured so far.
+    #[must_use]
+    pub fn drain(&self) -> Vec<Bytes> {
+        let mut frames = std::mem::take(&mut *self.priority.lock().unwrap());
+        let mut normal = self.normal.lock().unwrap();
+        while let Ok(packet) = normal.try_recv() {
+            frames.push(packet.data);
+        }
+        frames
+    }
+}
+
 #[cfg(feature = "test-harness")]
 impl JavaClient {
     /// Test-only replacement for [`Self::start_outgoing_packet_task`].
     ///
-    /// Drains both outgoing packet queues into the returned channel, yielding the
-    /// raw serialized clientbound frames instead of writing them to a socket, and
-    /// resolves the completion signal of high-priority sends so that
-    /// `send_packet_now` does not block. Call once, before the client is shared,
-    /// in place of `start_outgoing_packet_task`.
+    /// Instead of writing to a socket it captures clientbound frames. A
+    /// background task drains the high-priority queue (resolving each send's
+    /// completion so `send_packet_now` doesn't block); the normal queue is
+    /// drained synchronously by [`ClientboundCapture::drain`]. This split keeps
+    /// capture deterministic without depending on task scheduling. Call once,
+    /// before the client is shared, in place of `start_outgoing_packet_task`.
     #[must_use]
-    pub fn start_test_capture(&mut self) -> tokio::sync::mpsc::UnboundedReceiver<Bytes> {
-        let mut packet_receiver = self
+    pub fn start_test_capture(&mut self) -> ClientboundCapture {
+        let normal = self
             .outgoing_packet_queue_recv
             .take()
             .expect("This was set in the new fn");
-        let mut priority_packet_receiver = self
+        let mut priority = self
             .outgoing_packet_priority_recv
             .take()
             .expect("This was set in the new fn");
         let close_token = self.close_token.clone();
-        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        let buffer = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let task_buffer = buffer.clone();
         self.spawn_task(async move {
             loop {
-                let recv_result = tokio::select! {
+                let packet = tokio::select! {
                     biased;
-                    () = close_token.cancelled() => None,
-                    res = priority_packet_receiver.recv() => res,
-                    res = packet_receiver.recv() => res,
+                    () = close_token.cancelled() => break,
+                    res = priority.recv() => res,
                 };
-
-                let Some(packet) = recv_result else {
+                let Some(packet) = packet else {
                     break;
                 };
-
-                // Forward the serialized clientbound frame to the test sink.
-                let _ = sender.send(packet.data);
+                task_buffer.lock().unwrap().push(packet.data);
                 if let Some(completion) = packet.completion {
                     let _ = completion.send(());
                 }
             }
         });
-        receiver
+        ClientboundCapture {
+            normal: std::sync::Mutex::new(normal),
+            priority: buffer,
+        }
     }
 }


### PR DESCRIPTION
## What this is

An early, work-in-progress test framework for checking that Pumpkin behaves like a vanilla Minecraft: Java Edition server. The goal is to make it easy to add tests at increasing levels of fidelity:

- **L1 — in-memory game logic:** spin up a real `Server` in RAM, attach a player, drive real actions and assert on world/entity state. No sockets, no sleeps, deterministic.
- **L2 — protocol conformance:** feed serverbound packets through the real decode/handle path and check the clientbound packets that come back.
- **L3 — end-to-end:** a headless bot speaking the real protocol against a running server.
- **L4 — differential:** run the same scenario against Pumpkin and a real vanilla server and diff the results.

I'm opening this as a **draft** to share the direction early and get feedback on the approach before building out the higher levels. It's nowhere near finished.

## What's here so far (L1 + L2)

A new `pumpkin-test` crate with an in-memory harness:

- Boots a real `Server` on a temp dir with a fixed (signed) world seed, offline mode, overworld only.
- Attaches players backed by a real `JavaClient` over a loopback socket; clientbound frames are captured instead of going to the wire.
- Player actions go through the **real public serverbound handlers** (`handle_player_action`, `handle_use_item_on`, `handle_position`, creative slot set, …), not shortcuts.
- Deterministic ticking by calling the server tick directly (no `Ticker`, no sleep).
- Fast fixtures: an all-air chunk can be inserted instantly instead of paying for full world generation (~0.1s per test instead of ~13s), with `load_chunk` still there when real terrain is actually needed.
- A `#[pumpkin_test]` attribute macro that replaces `#[tokio::test]`, injects a `TestServer`, and takes an optional `seed`.

**L1 pilots (5):** break a stone block and check the cobblestone drop, place a block, move the player, set a creative slot, and a boot + tick smoke test.

**L2 (protocol conformance):** the harness can also drive packets as real bytes. `send_serverbound` encodes a packet and runs it through the real `handle_play_packet` decode + dispatch; `assert_clientbound_sent` re-serialises the expected clientbound packet and matches it against the captured frames. Clientbound capture is deterministic (it doesn't rely on task scheduling). Three L2 pilots so far: a ping/pong round-trip, a position packet that moves the player, and a player-action packet that breaks a block. A deserialize-only serverbound packet is made drivable by gating a `Serialize` derive behind the `test-harness` feature.

**Data-driven:** a few tests assert known vanilla facts against Pumpkin's compiled data as pure static queries — a shapeless recipe (oak log to four planks), tag memberships (planks tag, mineable-with-pickaxe), and a block loot table (stone to one cobblestone). The expected values are hand-written vanilla truth, so they act as an independent oracle rather than re-checking the data the tables were generated from. A fully independent runtime oracle (a real vanilla server's reports) is left for the L4 differential work.

**L3 (end-to-end):** a headless `TestBot` connects to a real server over a loopback TCP socket, reuses `pumpkin-protocol`'s framing, and completes the server-list status exchange (handshake → status → ping/pong). Unlike L1/L2, which stay in memory, this drives the full socket + protocol stack. The full login → play join is the next L3 step.

Everything the server exposes for this sits behind a `test-harness` cargo feature and doesn't change production behaviour. The harness crate pulls the feature in transitively, so the tests run under a plain `cargo nextest run` with no extra flags.

## A bug this shook out

While writing the block-break test I hit an infinite loop in the dynamic light engine: sky-light propagation into an unloaded chunk never converges (writes to an unloaded chunk are dropped, reads come back as 0, so the "brighter than the neighbour" check stays true forever). It's fixed on this branch and also sent as a focused standalone PR in #2334.

## Roadmap

- [x] L1 in-memory harness (`pumpkin-test`) with real-handler player actions
- [x] `#[pumpkin_test]` macro + `TestServer` fixture injection
- [x] Fast empty-chunk fixtures + deterministic ticking
- [x] Five L1 pilot tests, green in CI
- [x] Fix the sky-light propagation loop on unloaded chunks (also #2334)
- [x] L2 protocol conformance (serverbound bytes in, assert clientbound out)
- [x] Data-driven checks against known vanilla facts (recipes / tags / block loot)
- [x] L3 status exchange over real TCP (headless bot reusing `pumpkin-protocol`)
- [ ] L3 full login → play join (offline, no encryption)
- [ ] L4 differential testing against a real vanilla server
- [ ] More test categories + a short "how to write a test" guide
- [ ] Dedicated CI jobs for the heavier levels (nightly / label-gated)

## Notes

- No production code paths change; all test hooks are `#[cfg(feature = "test-harness")]`.
- L1/L2 are meant to stay fast and hermetic (no Docker, no network); L3/L4 will be opt-in.

Feedback on the overall shape is very welcome while the rest gets built out.
