### PR TITLE
perf(pumpkin-world): smaller pump chunk saves and lighter in-memory chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,6 +2816,7 @@ dependencies = [
  "pumpkin-nbt",
  "pumpkin-util",
  "pumpkin-world",
+ "rustc-hash",
  "serde",
  "thiserror 2.0.18",
  "tokio",

--- a/pumpkin-protocol/Cargo.toml
+++ b/pumpkin-protocol/Cargo.toml
@@ -37,6 +37,7 @@ bitflags.workspace = true
 
 [dev-dependencies]
 # Validate correctness
+rustc-hash.workspace = true
 
 [lints]
 workspace = true

--- a/pumpkin-protocol/src/java/client/play/chunk_data.rs
+++ b/pumpkin-protocol/src/java/client/play/chunk_data.rs
@@ -245,13 +245,16 @@ impl ClientPacket for CChunkData<'_> {
             for section_index in 0..num_sections {
                 let bit_index = section_index + 1; // Offset by 1 for the below-world section
 
-                if let LightContainer::Full(_) = &light_engine.sky_light[section_index] {
+                // A compacted uniform section (`Empty(level != 0)`) still carries
+                // light and must be sent as an array, so key off `has_light()`
+                // rather than only matching `Full`.
+                if light_engine.sky_light[section_index].has_light() {
                     sky_light_mask |= 1 << bit_index;
                 } else {
                     sky_light_empty_mask |= 1 << bit_index;
                 }
 
-                if let LightContainer::Full(_) = &light_engine.block_light[section_index] {
+                if light_engine.block_light[section_index].has_light() {
                     block_light_mask |= 1 << bit_index;
                 } else {
                     block_light_empty_mask |= 1 << bit_index;
@@ -276,7 +279,7 @@ impl ClientPacket for CChunkData<'_> {
             // Write Sky Light arrays
             write.write_var_int(&VarInt(sky_light_mask.count_ones() as i32))?;
             for section_index in 0..num_sections {
-                if let LightContainer::Full(data) = &light_engine.sky_light[section_index] {
+                if let Some(data) = light_engine.sky_light[section_index].to_full_bytes() {
                     write.write_var_int(&light_data_size)?;
                     write.write_slice(data.as_ref())?;
                 }
@@ -285,12 +288,105 @@ impl ClientPacket for CChunkData<'_> {
             // Write Block Light arrays
             write.write_var_int(&VarInt(block_light_mask.count_ones() as i32))?;
             for section_index in 0..num_sections {
-                if let LightContainer::Full(data) = &light_engine.block_light[section_index] {
+                if let Some(data) = light_engine.block_light[section_index].to_full_bytes() {
                     write.write_var_int(&light_data_size)?;
                     write.write_slice(data.as_ref())?;
                 }
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::java::client::play::light_update::CLightUpdate;
+    use pumpkin_world::chunk::{ChunkHeightmaps, ChunkLight, ChunkSections};
+    use pumpkin_world::tick::scheduler::ChunkTickScheduler;
+    use rustc_hash::FxHashMap;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicBool;
+
+    /// An overworld chunk lit the way generation leaves it: dark sky below the
+    /// terrain, one genuinely non-uniform section at the surface, and full-bright
+    /// sky above. With `compact` set, the uniform sky sections are collapsed the
+    /// same way a live chunk's light is, so the two variants must still produce
+    /// byte-identical packets.
+    fn chunk_with_sky_light(compact: bool) -> ChunkData {
+        let count = 24usize;
+        let min_y = -64i32;
+
+        let mut sky = Vec::with_capacity(count);
+        let mut block = Vec::with_capacity(count);
+        for i in 0..count {
+            block.push(LightContainer::Empty(0));
+            match i.cmp(&8) {
+                std::cmp::Ordering::Less => sky.push(LightContainer::Empty(0)),
+                std::cmp::Ordering::Equal => {
+                    let mut lc = LightContainer::new_filled(0);
+                    lc.set(1, 2, 3, 7);
+                    sky.push(lc);
+                }
+                std::cmp::Ordering::Greater => sky.push(LightContainer::new_filled(15)),
+            }
+        }
+
+        let mut light = ChunkLight {
+            sky_light: sky.into_boxed_slice(),
+            block_light: block.into_boxed_slice(),
+        };
+        if compact {
+            light.compact();
+        }
+
+        ChunkData {
+            section: ChunkSections::new(count, min_y),
+            heightmap: Mutex::new(ChunkHeightmaps::default()),
+            x: 0,
+            z: 0,
+            block_ticks: ChunkTickScheduler::default(),
+            fluid_ticks: ChunkTickScheduler::default(),
+            pending_block_entities: Mutex::new(FxHashMap::default()),
+            light_engine: Mutex::new(light),
+            light_populated: AtomicBool::new(true),
+            status: pumpkin_data::chunk::ChunkStatus::Full,
+            blending_data: None,
+            dirty: AtomicBool::new(true),
+        }
+    }
+
+    #[test]
+    fn compaction_keeps_chunk_data_packet_identical() {
+        let version = JavaMinecraftVersion::V_1_21_4;
+        let mut uncompacted = Vec::new();
+        let mut compacted = Vec::new();
+        CChunkData(&chunk_with_sky_light(false))
+            .write_packet_data(&mut uncompacted, &version)
+            .unwrap();
+        CChunkData(&chunk_with_sky_light(true))
+            .write_packet_data(&mut compacted, &version)
+            .unwrap();
+        assert_eq!(
+            uncompacted, compacted,
+            "in-memory light compaction must not change the chunk-data packet a client receives"
+        );
+    }
+
+    #[test]
+    fn compaction_keeps_light_update_packet_identical() {
+        let version = JavaMinecraftVersion::V_1_21_4;
+        let mut uncompacted = Vec::new();
+        let mut compacted = Vec::new();
+        CLightUpdate(&chunk_with_sky_light(false))
+            .write_packet_data(&mut uncompacted, &version)
+            .unwrap();
+        CLightUpdate(&chunk_with_sky_light(true))
+            .write_packet_data(&mut compacted, &version)
+            .unwrap();
+        assert_eq!(
+            uncompacted, compacted,
+            "in-memory light compaction must not change the light-update packet a client receives"
+        );
     }
 }

--- a/pumpkin-protocol/src/java/client/play/light_update.rs
+++ b/pumpkin-protocol/src/java/client/play/light_update.rs
@@ -46,13 +46,16 @@ impl ClientPacket for CLightUpdate<'_> {
         for section_index in 0..num_sections {
             let bit_index = section_index;
 
-            if let LightContainer::Full(_) = &light_engine.sky_light[section_index] {
+            // A compacted uniform section (`Empty(level != 0)`) still carries
+            // light and must be sent as an array, so key off `has_light()` rather
+            // than only matching `Full`.
+            if light_engine.sky_light[section_index].has_light() {
                 sky_light_mask |= 1 << bit_index;
             } else {
                 sky_light_empty_mask |= 1 << bit_index;
             }
 
-            if let LightContainer::Full(_) = &light_engine.block_light[section_index] {
+            if light_engine.block_light[section_index].has_light() {
                 block_light_mask |= 1 << bit_index;
             } else {
                 block_light_empty_mask |= 1 << bit_index;
@@ -73,12 +76,12 @@ impl ClientPacket for CLightUpdate<'_> {
         // Write Sky Light arrays
         write.write_var_int(&VarInt(sky_light_mask.count_ones() as i32))?;
         for section_index in 0..num_sections {
-            if let LightContainer::Full(data) = &light_engine.sky_light[section_index] {
+            if let Some(data) = light_engine.sky_light[section_index].to_full_bytes() {
                 // Ensure network nibble ordering matches client expectations
                 // by swapping high/low nibbles per byte.
                 write.write_var_int(&light_data_size)?;
                 let mut swapped = Vec::with_capacity(data.len());
-                for &b in data {
+                for &b in data.iter() {
                     swapped.push(b.rotate_right(4));
                 }
                 write.write_slice(&swapped)?;
@@ -88,10 +91,10 @@ impl ClientPacket for CLightUpdate<'_> {
         // Write Block Light arrays
         write.write_var_int(&VarInt(block_light_mask.count_ones() as i32))?;
         for section_index in 0..num_sections {
-            if let LightContainer::Full(data) = &light_engine.block_light[section_index] {
+            if let Some(data) = light_engine.block_light[section_index].to_full_bytes() {
                 write.write_var_int(&light_data_size)?;
                 let mut swapped = Vec::with_capacity(data.len());
-                for &b in data {
+                for &b in data.iter() {
                     swapped.push(b.rotate_right(4));
                 }
                 write.write_slice(&swapped)?;

--- a/pumpkin-world/src/chunk/format/mod.rs
+++ b/pumpkin-world/src/chunk/format/mod.rs
@@ -128,10 +128,14 @@ impl ChunkData {
         }
 
         // Assemble the LightEngine
-        let light_engine = ChunkLight {
+        let mut light_engine = ChunkLight {
             block_light: block_lights.into_boxed_slice(),
             sky_light: sky_lights.into_boxed_slice(),
         };
+        // Collapse the full-bright sky arrays we just read back into the compact
+        // in-memory form so loaded chunks don't hold ~30 KB of redundant light
+        // each. They are re-expanded on save.
+        light_engine.compact();
 
         // Assemble the ChunkSections
         let min_y = section_coords::section_to_block(chunk_data.min_y_section);
@@ -183,13 +187,6 @@ impl ChunkData {
             entities_guard.values().cloned().collect::<Vec<_>>()
         };
 
-        fn extract_light_ref(light: Option<&LightContainer>) -> Option<&[u8]> {
-            match light {
-                Some(LightContainer::Full(data)) => Some(data.as_ref()),
-                _ => None,
-            }
-        }
-
         let light_lock = self.light_engine.lock().unwrap();
         let heightmap_lock = self.heightmap.lock().unwrap();
         let block_lock = self.section.block_sections.read().unwrap();
@@ -197,13 +194,33 @@ impl ChunkData {
 
         let min_section_y = (self.section.min_y >> 4) as i8;
 
+        // Re-expand any sections that were compacted in memory so the bytes we
+        // write match what a non-compacted chunk would have produced (`Empty(0)`
+        // still means "no data" and is dropped). See `LightContainer::to_full_bytes`.
+        let block_light: Vec<Option<std::borrow::Cow<[u8]>>> = (0..self.section.count)
+            .map(|i| {
+                light_lock
+                    .block_light
+                    .get(i)
+                    .and_then(LightContainer::to_full_bytes)
+            })
+            .collect();
+        let sky_light: Vec<Option<std::borrow::Cow<[u8]>>> = (0..self.section.count)
+            .map(|i| {
+                light_lock
+                    .sky_light
+                    .get(i)
+                    .and_then(LightContainer::to_full_bytes)
+            })
+            .collect();
+
         let sections = (0..self.section.count)
             .map(|i| ChunkSectionNbtRef {
                 y: i as i8 + min_section_y,
                 block_states: Some(block_lock[i].to_disk_nbt()),
                 biomes: Some(biome_lock[i].to_disk_nbt()),
-                block_light: extract_light_ref(light_lock.block_light.get(i)),
-                sky_light: extract_light_ref(light_lock.sky_light.get(i)),
+                block_light: block_light[i].as_deref(),
+                sky_light: sky_light[i].as_deref(),
             })
             .collect::<Vec<_>>();
 
@@ -431,6 +448,54 @@ impl LightContainer {
     pub fn fill(&mut self, value: u8) {
         *self = Self::new_filled(value);
     }
+
+    /// Collapse a `Full` array that holds a single uniform, non-zero light level
+    /// back into the compact `Empty` form. This is what freshly generated sky
+    /// light looks like for every section above the terrain (a full-bright
+    /// 2048-byte array), so collapsing it keeps resident chunks much smaller.
+    ///
+    /// Level 0 is deliberately left alone: `Empty(0)` is the "no data" sentinel
+    /// that is dropped on save, so collapsing a uniform-dark array into it would
+    /// change what ends up on disk. Everything else is re-expanded at
+    /// serialization time (see `internal_to_bytes`), so this stays a pure
+    /// in-memory optimisation and the stored bytes are unaffected.
+    pub fn compact(&mut self) {
+        if let Self::Full(data) = self {
+            let first = data[0];
+            let low = first & 0x0F;
+            let high = first >> 4;
+            if low == high && low != 0 && data.iter().all(|&b| b == first) {
+                *self = Self::Empty(low);
+            }
+        }
+    }
+
+    /// Whether this section carries light that has to be written out as an array
+    /// rather than flagged empty. Everything except the `Empty(0)` "no data"
+    /// sentinel does. Cheap counterpart to [`Self::to_full_bytes`] — the two must
+    /// always agree so light masks and the arrays that follow them stay in sync.
+    #[must_use]
+    pub fn has_light(&self) -> bool {
+        !matches!(self, Self::Empty(0))
+    }
+
+    /// The full 2048-byte light array for this section, or `None` for `Empty(0)`.
+    ///
+    /// A section compacted by [`Self::compact`] (`Empty(level)`, level != 0) is
+    /// rebuilt into its full array here, so every consumer that reads light —
+    /// the on-disk format and the clientbound chunk/light packets — sees exactly
+    /// the bytes a non-compacted chunk would have produced.
+    #[must_use]
+    pub fn to_full_bytes(&self) -> Option<std::borrow::Cow<'_, [u8]>> {
+        match self {
+            Self::Full(data) => Some(std::borrow::Cow::Borrowed(data)),
+            Self::Empty(level) if *level != 0 => {
+                let packed = (level << 4) | level;
+                Some(std::borrow::Cow::Owned(vec![packed; Self::ARRAY_SIZE]))
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Default for LightContainer {
@@ -493,4 +558,112 @@ struct EntityNbt {
     data_version: i32,
     position: [i32; 2],
     entities: Vec<NbtCompound>,
+}
+
+#[cfg(test)]
+mod light_compaction {
+    use super::LightContainer;
+    use crate::chunk::{ChunkData, ChunkHeightmaps, ChunkLight, ChunkSections};
+    use crate::tick::scheduler::ChunkTickScheduler;
+    use pumpkin_data::chunk::ChunkStatus;
+    use pumpkin_util::math::vector2::Vector2;
+    use rustc_hash::FxHashMap;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicBool;
+
+    /// An overworld chunk laid out the way generation leaves it: dark sky below
+    /// the terrain, one genuinely non-uniform section at the surface, and
+    /// full-bright sky arrays for every section above.
+    fn build_lit_chunk() -> ChunkData {
+        let count = 24usize;
+        let min_y = -64i32;
+
+        let block_light = (0..count)
+            .map(|_| LightContainer::Empty(0))
+            .collect::<Vec<_>>();
+        let mut sky_light = Vec::with_capacity(count);
+        for i in 0..count {
+            match i.cmp(&8) {
+                std::cmp::Ordering::Less => sky_light.push(LightContainer::Empty(0)),
+                std::cmp::Ordering::Equal => {
+                    // Non-uniform: must survive serialization byte-for-byte.
+                    let mut lc = LightContainer::new_filled(0);
+                    lc.set(1, 2, 3, 7);
+                    sky_light.push(lc);
+                }
+                std::cmp::Ordering::Greater => sky_light.push(LightContainer::new_filled(15)),
+            }
+        }
+
+        ChunkData {
+            section: ChunkSections::new(count, min_y),
+            heightmap: Mutex::new(ChunkHeightmaps::default()),
+            x: 0,
+            z: 0,
+            block_ticks: ChunkTickScheduler::default(),
+            fluid_ticks: ChunkTickScheduler::default(),
+            pending_block_entities: Mutex::new(FxHashMap::default()),
+            light_engine: Mutex::new(ChunkLight {
+                sky_light: sky_light.into_boxed_slice(),
+                block_light: block_light.into_boxed_slice(),
+            }),
+            light_populated: AtomicBool::new(true),
+            status: ChunkStatus::Full,
+            blending_data: None,
+            dirty: AtomicBool::new(true),
+        }
+    }
+
+    #[tokio::test]
+    async fn compaction_shrinks_memory_but_keeps_disk_bytes() {
+        let full = build_lit_chunk();
+        let compacted = build_lit_chunk();
+        compacted.light_engine.lock().unwrap().compact();
+
+        // The uniform full-bright sections must collapse to `Empty`...
+        {
+            let light = compacted.light_engine.lock().unwrap();
+            assert!(
+                matches!(light.sky_light[20], LightContainer::Empty(15)),
+                "uniform full-bright sky should compact to Empty(15)"
+            );
+            // ...while the non-uniform surface section stays a full array.
+            assert!(matches!(light.sky_light[8], LightContainer::Full(_)));
+        }
+
+        // ...but the serialized bytes must be identical either way.
+        let bytes_full = full.internal_to_bytes().await.unwrap();
+        let bytes_compact = compacted.internal_to_bytes().await.unwrap();
+        assert_eq!(
+            bytes_full, bytes_compact,
+            "compaction must not change the on-disk bytes"
+        );
+
+        // A round-trip preserves the light values.
+        let reloaded = ChunkData::internal_from_bytes(&bytes_compact, Vector2::new(0, 0)).unwrap();
+        let light = reloaded.light_engine.lock().unwrap();
+        assert_eq!(light.sky_light[20].get(0, 0, 0), 15);
+        assert_eq!(light.sky_light[0].get(0, 0, 0), 0);
+        assert_eq!(light.sky_light[8].get(1, 2, 3), 7);
+    }
+
+    #[test]
+    fn compacted_section_reads_identically_to_full() {
+        // This is what keeps the on-disk format and the clientbound light packets
+        // unchanged: a compacted uniform section must report the same "has light"
+        // flag and the same array bytes as the full section it replaced.
+        let full = LightContainer::new_filled(15);
+        let compacted = LightContainer::Empty(15);
+        assert!(full.has_light() && compacted.has_light());
+        assert_eq!(
+            full.to_full_bytes().unwrap().as_ref(),
+            compacted.to_full_bytes().unwrap().as_ref(),
+            "compacted section must serialize/transmit the same bytes as the full array"
+        );
+
+        // Empty(0) is the "no light" sentinel: flagged empty, no array emitted.
+        let dark = LightContainer::Empty(0);
+        assert!(!dark.has_light());
+        assert!(dark.to_full_bytes().is_none());
+    }
 }

--- a/pumpkin-world/src/chunk/format/pump.rs
+++ b/pumpkin-world/src/chunk/format/pump.rs
@@ -4,12 +4,15 @@ use std::path::PathBuf;
 
 use crate::chunk::format::anvil::SingleChunkDataSerializer;
 use crate::chunk::io::{ChunkSerializer, LoadedData};
-use crate::chunk::{ChunkReadingError, ChunkWritingError};
+use crate::chunk::{ChunkReadingError, ChunkWritingError, CompressionError};
 use bytes::Bytes;
+use flate2::Compression;
+use flate2::read::ZlibDecoder;
+use flate2::write::ZlibEncoder;
 use pumpkin_util::math::vector2::Vector2;
 use ruzstd::decoding::StreamingDecoder;
-use ruzstd::encoding::{CompressionLevel, compress_to_vec};
 use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
 
 pub struct PumpFile<D> {
     pub data: PumpData,
@@ -30,6 +33,37 @@ impl<D> Default for PumpFile<D> {
             _phantom: PhantomData,
         }
     }
+}
+
+/// Magic bytes of a zstd frame (little-endian `0xFD2FB528`). Chunk blobs saved
+/// before the switch to zlib start with these, so we sniff them on read and
+/// keep decoding old worlds; everything written from now on is zlib.
+const ZSTD_FRAME_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+
+/// Deflate level for chunk blobs. `ruzstd`'s pure-Rust encoder can only emit its
+/// weakest ("Fastest") level, which on chunk NBT ends up roughly 55% larger than
+/// zlib level 6, while level 9 saves practically nothing more on this data for
+/// noticeably more CPU. `flate2` is already a workspace dependency and keeps the
+/// pure-Rust `miniz_oxide` backend, so switching costs us no native build.
+const CHUNK_DEFLATE_LEVEL: u32 = 6;
+
+fn compress_chunk(bytes: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::new(CHUNK_DEFLATE_LEVEL));
+    encoder.write_all(bytes)?;
+    encoder.finish()
+}
+
+fn decompress_chunk(blob: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut decompressed = Vec::new();
+    if blob.len() >= ZSTD_FRAME_MAGIC.len() && blob[..ZSTD_FRAME_MAGIC.len()] == ZSTD_FRAME_MAGIC {
+        // Legacy blob: decode the zstd frame with the pure-Rust reader.
+        let mut decoder =
+            StreamingDecoder::new(blob).map_err(|e| std::io::Error::other(e.to_string()))?;
+        decoder.read_to_end(&mut decompressed)?;
+    } else {
+        ZlibDecoder::new(blob).read_to_end(&mut decompressed)?;
+    }
+    Ok(decompressed)
 }
 
 impl<D> ChunkSerializer for PumpFile<D>
@@ -89,7 +123,8 @@ where
             .await
             .map_err(|e| ChunkWritingError::ChunkSerializingError(e.to_string()))?;
 
-        let compressed = compress_to_vec(&bytes[..], CompressionLevel::Fastest);
+        let compressed = compress_chunk(&bytes)
+            .map_err(|e| ChunkWritingError::Compression(CompressionError::ZlibError(e)))?;
 
         self.data.chunks.insert(index.to_string(), compressed);
 
@@ -107,25 +142,15 @@ where
             let index = (rel_x + rel_z * 32) as usize;
 
             if let Some(chunk_bytes) = self.data.chunks.get(&index.to_string()) {
-                let mut decoder = match StreamingDecoder::new(&chunk_bytes[..]) {
-                    Ok(d) => d,
+                let decompressed = match decompress_chunk(chunk_bytes) {
+                    Ok(data) => data,
                     Err(e) => {
                         let _ = stream
-                            .send(LoadedData::Error((
-                                pos,
-                                ChunkReadingError::IoError(std::io::Error::other(e.to_string())),
-                            )))
+                            .send(LoadedData::Error((pos, ChunkReadingError::IoError(e))))
                             .await;
                         continue;
                     }
                 };
-                let mut decompressed = Vec::new();
-                if let Err(e) = std::io::Read::read_to_end(&mut decoder, &mut decompressed) {
-                    let _ = stream
-                        .send(LoadedData::Error((pos, ChunkReadingError::IoError(e))))
-                        .await;
-                    continue;
-                }
 
                 let bytes = Bytes::from(decompressed);
                 match D::from_bytes(&bytes, pos) {
@@ -228,6 +253,34 @@ mod tests {
                 assert_eq!(c.data, vec![1, 2, 3]);
             }
             _ => panic!("Expected LoadedData::Loaded"),
+        }
+    }
+
+    /// Worlds saved before the zlib switch hold zstd-compressed blobs; make sure
+    /// the magic-byte sniffing in `decompress_chunk` still reads them back.
+    #[tokio::test]
+    async fn test_reads_legacy_zstd_blob() {
+        use ruzstd::encoding::{CompressionLevel, compress_to_vec};
+
+        let chunk = MockChunk {
+            x: 0,
+            z: 0,
+            data: vec![7, 8, 9],
+        };
+        let raw = chunk.to_bytes().await.unwrap();
+        let legacy_blob = compress_to_vec(&raw[..], CompressionLevel::Fastest);
+
+        let mut pump_file: PumpFile<MockChunk> = PumpFile::default();
+        pump_file.data.chunks.insert("0".to_string(), legacy_blob);
+
+        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::channel(1);
+        pump_file
+            .get_chunks(vec![Vector2::new(0, 0)], stream_tx)
+            .await;
+
+        match stream_rx.recv().await.unwrap() {
+            LoadedData::Loaded(c) => assert_eq!(c.data, vec![7, 8, 9]),
+            _ => panic!("legacy zstd blob failed to load"),
         }
     }
 }

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -152,6 +152,19 @@ pub struct ChunkLight {
     pub block_light: Box<[LightContainer]>,
 }
 
+impl ChunkLight {
+    /// Compact every section in place, collapsing uniform full-bright light into
+    /// the cheap `Empty` representation. See [`LightContainer::compact`].
+    pub fn compact(&mut self) {
+        for section in &mut self.sky_light {
+            section.compact();
+        }
+        for section in &mut self.block_light {
+            section.compact();
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum ChunkHeightmapType {
     WorldSurface = 0,

--- a/pumpkin-world/src/chunk_system/chunk_state.rs
+++ b/pumpkin-world/src/chunk_system/chunk_state.rs
@@ -300,7 +300,11 @@ impl Chunk {
         // Move the light data instead of cloning it
         // By taking ownership of proto_chunk, we can move the light data directly
         // This prevents keeping duplicate lighting data in memory
-        let light_data = proto_chunk.light;
+        let mut light_data = proto_chunk.light;
+        // Generation fills a full-bright 2048-byte sky array for every section
+        // above the terrain. Collapse those uniform sections so a resident chunk
+        // doesn't carry ~30 KB of redundant light; they are re-expanded on save.
+        light_data.compact();
 
         // Only mark lit if past the lighting stage, and the lighting config is "default" ("full" and "dark" modes skip proper lighting)
         let is_lit = proto_chunk.stage >= StagedChunkEnum::Lighting


### PR DESCRIPTION
Two related changes to how the default `pump` world format handles chunks — one cuts what we write to disk, the other cuts what we hold in memory. Neither changes a single byte of what a client or an existing save sees.

## 1. Compress chunk blobs with zlib instead of zstd

`pump` compresses every chunk blob with `ruzstd`, whose pure-Rust encoder only supports its weakest "Fastest" level. On chunk NBT that lands about 55% larger than plain zlib at level 6 (measured ~744 vs ~476 bytes on a freshly generated, untouched chunk, where the payload is mostly light data — roughly -36%).

Bumping the zstd level would mean pulling in a native encoder, so the blobs now go through zlib via `flate2`, already a workspace dependency and pure Rust through `miniz_oxide`. Level 6 is the sweet spot: level 9 saved next to nothing here for more CPU.

Old worlds keep loading — a blob is sniffed for the zstd frame magic on read and decoded with `ruzstd` when it's an old one; everything written from now on is zlib, so re-saving migrates a world over.

## 2. Keep uniform sky light compact in memory

Generation fills a full-bright 2048-byte sky-light array for every section above the terrain, and those arrays sit in memory for as long as the chunk is loaded — about 30 KB of identical bytes per chunk. Once lighting is computed (after generation and after a chunk is read from disk) those uniform sections collapse back into the existing `Empty(level)` representation.

This is lossless, run-length style: a uniform array carries a single value, which is exactly what `Empty(level)` already stores. Only genuinely uniform, non-zero sections are collapsed; a non-uniform section (e.g. the gradient right at the surface) stays a full array and is written verbatim. `Empty(0)` is left alone because it's the "no data" sentinel that both disk and the light packets intentionally drop.

### Why this changes nothing a client or a save sees

Every place that turns light back into raw arrays now goes through `LightContainer::to_full_bytes` / `has_light`, which re-expand a compacted section on demand. That covers all three consumers:

- the on-disk chunk format,
- the clientbound chunk-data packet (`CChunkData`), and
- the clientbound light-update packet (`CLightUpdate`), sent when a block change relights a chunk.

I went through every reader of `LightContainer` for this. The light engine, mob spawning, the daylight sensor and the plugin light getters all read via `get()`, which already returns the right level for a compacted section, so they're untouched. The only readers that inspected the `Full`/`Empty` variant directly were those two packets, and they now key off `has_light()` + `to_full_bytes()`.

### How it's verified

- `compaction_shrinks_memory_but_keeps_disk_bytes` — serialises a chunk with and without compaction, asserts the on-disk bytes are identical, then round-trips the light values.
- `compacted_section_reads_identically_to_full` — a compacted section and the full array it replaced report the same `has_light()` and the same `to_full_bytes()`.
- `compaction_keeps_chunk_data_packet_identical` / `compaction_keeps_light_update_packet_identical` — build a lit chunk both ways and assert the actual `CChunkData` / `CLightUpdate` bytes a client receives are byte-for-byte identical.

## Tests

- pump: `test_pump_file_roundtrip` (zlib path), `test_reads_legacy_zstd_blob` (old zstd still decodes).
- light: the four tests above.

## Scope

Only the `pump` format (the default) is touched for compression. `linear` uses the same `ruzstd`-Fastest encoder and could get the same change in a follow-up.
