### PR TITLE
Harden the chunk scheduler and fix its stranded-node leak

### DIFF
--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -24,6 +24,16 @@ use std::thread;
 use std::time::Duration;
 use tracing::{debug, error, info, trace, warn};
 
+/// Best-effort extraction of a human-readable message from a caught panic
+/// payload (`catch_unwind` hands back a `Box<dyn Any>`).
+fn panic_reason(payload: &(dyn std::any::Any + Send)) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|s| (*s).to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "unknown cause".to_string())
+}
+
 pub(crate) struct TaskHeapNode(i8, NodeKey);
 impl PartialEq for TaskHeapNode {
     fn eq(&self, other: &Self) -> bool {
@@ -172,7 +182,25 @@ impl GenerationSchedule {
                     lighting_config,
                     last_unload: std::time::Instant::now(),
                 };
-                scheduler.work(level_sched);
+                // This thread owns all chunk loading, generation and unloading.
+                // If `work` panics the thread would just disappear: chunk loads
+                // would hang forever and, worse, unloads would stop, so
+                // `loaded_chunks` (and the entity/block-entity maps keyed off it)
+                // would grow without bound until the server runs out of memory.
+                // Catch the panic, log it loudly and flag the chunk system as down
+                // (waking anyone blocked on it) so the failure is visible instead
+                // of a silent freeze.
+                let level_on_panic = level_sched.clone();
+                if let Err(panic) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+                    move || scheduler.work(level_sched),
+                )) {
+                    error!(
+                        "Chunk scheduler thread panicked and stopped: {}. Chunk loading, saving and unloading are halted for this world.",
+                        panic_reason(&*panic)
+                    );
+                    level_on_panic.shut_down_chunk_system.store(true, Relaxed);
+                    level_on_panic.level_channel.notify();
+                }
             })
             .expect("Failed to spawn Scheduler Thread");
 
@@ -1380,5 +1408,23 @@ impl GenerationSchedule {
             }
         }
         true
+    }
+}
+
+#[cfg(test)]
+mod panic_reason_tests {
+    use super::panic_reason;
+
+    #[test]
+    fn extracts_str_and_string_payloads() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("boom");
+        assert_eq!(panic_reason(&*payload), "boom");
+
+        let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("kaboom"));
+        assert_eq!(panic_reason(&*payload), "kaboom");
+
+        // Anything that isn't a string message falls back to a placeholder.
+        let payload: Box<dyn std::any::Any + Send> = Box::new(42_i32);
+        assert_eq!(panic_reason(&*payload), "unknown cause");
     }
 }

--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -478,6 +478,16 @@ impl GenerationSchedule {
                             self.waiting_for_chunks.remove(task);
                             self.drop_node(*task);
                             *task = NodeKey::null();
+                        } else {
+                            // Diagnostic: an in-flight task is kept across a downgrade
+                            // and relies on its completion to release it. If that
+                            // hand-off is ever missed the node strands (see
+                            // recover_stranded_nodes); log it so the exact sequence
+                            // can be reconstructed from a crash/leak report.
+                            debug!(
+                                "downgrade keeps in-flight node {:?} at pos {:?} stage {} ({:?} -> {:?}); relying on its completion to release it",
+                                *task, pos, i, old_stage, new_stage
+                            );
                         }
                     }
                 }
@@ -1301,8 +1311,10 @@ impl GenerationSchedule {
                         self.queue_dirty = false;
                     }
                 } else {
-                    // No tasks in flight, wait indefinitely for LevelChannel changes
-                    debug_assert!(self.debug_check());
+                    // No tasks in flight, wait indefinitely for LevelChannel changes.
+                    // Anything still in the graph now is stranded; clean it up
+                    // instead of leaking (or, in debug, crashing).
+                    self.recover_stranded_nodes();
                     debug_assert_eq!(self.running_task_count, 0);
                     self.resort_work(self.send_level.wait_and_get(&level));
                     if self.queue_dirty {
@@ -1380,31 +1392,61 @@ impl GenerationSchedule {
         self.graph.edges.clear();
     }
 
-    fn debug_check(&self) -> bool {
-        if !self.graph.nodes.is_empty() {
-            for (key, value) in &self.graph.nodes {
-                error!("unrelease node {key:?}: {value:?}");
-            }
-            panic!("nodes count error");
+    /// Called when the scheduler has gone fully idle (nothing queued, in flight,
+    /// or waiting on chunk data). Any nodes still in the graph at that point are
+    /// stranded: with no work left to run, nothing will ever advance or release
+    /// them. That happens when a chunk is downgraded, or its generation fails,
+    /// while a task is in flight and the node bookkeeping is left dangling.
+    ///
+    /// Debug builds keep aborting on this — it's a real desync worth catching
+    /// during development — but first dump every stranded node with its holder
+    /// state so the crash report is actionable. Release builds neither crash nor
+    /// leak: the stranded nodes are unreachable, so they're dropped and the
+    /// holder references cleared, and chunks that are still wanted are
+    /// rescheduled the next time their ticket level changes.
+    fn recover_stranded_nodes(&mut self) -> bool {
+        if self.graph.nodes.is_empty() {
+            return false;
         }
-        for (pos, holder) in &self.chunk_map {
-            for i in &holder.tasks {
-                debug_assert!(i.is_null());
-            }
-            debug_assert_eq!(
-                holder.target_stage,
-                StagedChunkEnum::level_to_stage(
-                    *self.last_level.get(pos).unwrap_or(&ChunkLoading::MAX_LEVEL)
+        let stranded = self.graph.nodes.len();
+        // Dump each stranded node together with its holder state. The holder's
+        // target/current/dependency stages reveal why the node was orphaned
+        // (e.g. a chunk downgraded to target=None while this task was in flight),
+        // which is what's needed to pin down the underlying bookkeeping bug.
+        for (key, value) in &self.graph.nodes {
+            let holder = self.chunk_map.get(&value.pos);
+            warn!(
+                "stranded generation node {key:?}: {value:?} | holder {}",
+                holder.map_or_else(
+                    || "missing".to_string(),
+                    |h| format!(
+                        "target={:?} current={:?} dep={:?} occupied_null={}",
+                        h.target_stage,
+                        h.current_stage,
+                        h.dependency_stage,
+                        h.occupied.is_null()
+                    )
                 )
             );
-            let effective = holder.target_stage.max(holder.dependency_stage);
-            debug_assert!(holder.current_stage >= effective);
-            debug_assert!(holder.occupied.is_null());
-            if holder.current_stage != StagedChunkEnum::None {
-                debug_assert_eq!(
-                    holder.chunk.as_ref().unwrap().get_stage_id(),
-                    holder.current_stage as u8
-                );
+        }
+        if cfg!(debug_assertions) {
+            // Keep failing loudly in debug so the desync is noticed immediately;
+            // the per-node dump above is in the crash report.
+            panic!(
+                "chunk scheduler left {stranded} stranded generation node(s); see the dump above"
+            );
+        }
+
+        // Release: recover instead of leaking or taking the server down.
+        warn!(
+            "Chunk scheduler was idle with {stranded} stranded generation node(s); cleaning them up. This points to a generation bookkeeping desync."
+        );
+        self.graph.nodes.clear();
+        self.graph.edges.clear();
+        for holder in self.chunk_map.values_mut() {
+            holder.occupied = NodeKey::null();
+            for task in &mut holder.tasks {
+                *task = NodeKey::null();
             }
         }
         true

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -162,7 +162,7 @@ use weather::Weather;
 
 type FlowingFluidProperties = pumpkin_data::fluid::FlowingWaterLikeFluidProperties;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 impl PumpkinError for GetBlockError {
     fn is_kick(&self) -> bool {
@@ -222,9 +222,7 @@ pub struct World {
     pub dragon_fight: Option<Mutex<dragon_fight::DragonFight>>,
     pub spawn_state: ArcSwap<SpawnState>,
     pub active_chunks: ArcSwap<FxHashSet<Vector2<i32>>>,
-    /// Block entities indexed by chunk, so ticking only visits the currently
-    /// active chunks instead of scanning every loaded block entity each tick.
-    pub block_entities: DashMap<Vector2<i32>, FxHashMap<BlockPos, Arc<dyn BlockEntity>>>,
+    pub block_entities: DashMap<BlockPos, Arc<dyn BlockEntity>>,
 }
 
 impl PartialEq for World {
@@ -967,12 +965,12 @@ impl World {
         };
 
         let active_chunks = self.active_chunks.load();
-        let mut block_entities: Vec<Arc<dyn BlockEntity>> = Vec::new();
-        for chunk_pos in active_chunks.iter() {
-            if let Some(chunk_block_entities) = self.block_entities.get(chunk_pos) {
-                block_entities.extend(chunk_block_entities.values().cloned());
-            }
-        }
+        let block_entities: Vec<Arc<dyn BlockEntity>> = self
+            .block_entities
+            .iter()
+            .filter(|e| active_chunks.contains(&e.key().chunk_position()))
+            .map(|e| e.value().clone())
+            .collect();
         let block_entity_count = block_entities.len();
 
         let world_for_be = self.clone();
@@ -4163,9 +4161,8 @@ impl World {
             self.spawn_state.load().remove_entity(self, entity.as_ref());
         }
 
-        for chunk_pos in &chunks_set {
-            self.block_entities.remove(chunk_pos);
-        }
+        self.block_entities
+            .retain(|pos, _| !chunks_set.contains(&pos.chunk_position()));
     }
 
     pub async fn set_block_breaking(&self, from: &Entity, location: BlockPos, progress: i32) {
@@ -4928,16 +4925,13 @@ impl World {
     }
 
     pub fn get_block_entity(&self, block_pos: &BlockPos) -> Option<Arc<dyn BlockEntity>> {
-        let chunk_pos = block_pos.chunk_position();
-        if let Some(chunk_block_entities) = self.block_entities.get(&chunk_pos)
-            && let Some(entity) = chunk_block_entities.get(block_pos)
-        {
-            return Some(entity.clone());
+        if let Some(entry) = self.block_entities.get(block_pos) {
+            return Some(entry.value().clone());
         }
 
         let nbt = self
             .level
-            .read_chunk_sync(&chunk_pos, |chunk| {
+            .read_chunk_sync(&block_pos.chunk_position(), |chunk| {
                 chunk
                     .pending_block_entities
                     .lock()
@@ -4946,10 +4940,7 @@ impl World {
             })
             .flatten()?;
         let entity = block_entity_from_nbt(&nbt)?;
-        self.block_entities
-            .entry(chunk_pos)
-            .or_default()
-            .insert(*block_pos, entity.clone());
+        self.block_entities.insert(*block_pos, entity.clone());
         Some(entity)
     }
 
@@ -4971,10 +4962,7 @@ impl World {
             );
         }
 
-        self.block_entities
-            .entry(chunk_pos)
-            .or_default()
-            .insert(block_pos, block_entity);
+        self.block_entities.insert(block_pos, block_entity);
         self.level.read_chunk_sync(&chunk_pos, |chunk| {
             chunk.mark_dirty(true);
         });
@@ -4993,20 +4981,11 @@ impl World {
     }
 
     pub fn remove_block_entity(&self, block_pos: &BlockPos) {
-        let chunk_pos = block_pos.chunk_position();
-        let removed =
-            self.block_entities
-                .get_mut(&chunk_pos)
-                .is_some_and(|mut chunk_block_entities| {
-                    chunk_block_entities.remove(block_pos).is_some()
+        if self.block_entities.remove(block_pos).is_some() {
+            self.level
+                .read_chunk_sync(&block_pos.chunk_position(), |chunk| {
+                    chunk.mark_dirty(true);
                 });
-        if removed {
-            // Drop the chunk's map once its last block entity is gone.
-            self.block_entities
-                .remove_if(&chunk_pos, |_, entities| entities.is_empty());
-            self.level.read_chunk_sync(&chunk_pos, |chunk| {
-                chunk.mark_dirty(true);
-            });
         }
     }
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -162,7 +162,7 @@ use weather::Weather;
 
 type FlowingFluidProperties = pumpkin_data::fluid::FlowingWaterLikeFluidProperties;
 
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 impl PumpkinError for GetBlockError {
     fn is_kick(&self) -> bool {
@@ -222,7 +222,9 @@ pub struct World {
     pub dragon_fight: Option<Mutex<dragon_fight::DragonFight>>,
     pub spawn_state: ArcSwap<SpawnState>,
     pub active_chunks: ArcSwap<FxHashSet<Vector2<i32>>>,
-    pub block_entities: DashMap<BlockPos, Arc<dyn BlockEntity>>,
+    /// Block entities indexed by chunk, so ticking only visits the currently
+    /// active chunks instead of scanning every loaded block entity each tick.
+    pub block_entities: DashMap<Vector2<i32>, FxHashMap<BlockPos, Arc<dyn BlockEntity>>>,
 }
 
 impl PartialEq for World {
@@ -965,12 +967,12 @@ impl World {
         };
 
         let active_chunks = self.active_chunks.load();
-        let block_entities: Vec<Arc<dyn BlockEntity>> = self
-            .block_entities
-            .iter()
-            .filter(|e| active_chunks.contains(&e.key().chunk_position()))
-            .map(|e| e.value().clone())
-            .collect();
+        let mut block_entities: Vec<Arc<dyn BlockEntity>> = Vec::new();
+        for chunk_pos in active_chunks.iter() {
+            if let Some(chunk_block_entities) = self.block_entities.get(chunk_pos) {
+                block_entities.extend(chunk_block_entities.values().cloned());
+            }
+        }
         let block_entity_count = block_entities.len();
 
         let world_for_be = self.clone();
@@ -4161,8 +4163,9 @@ impl World {
             self.spawn_state.load().remove_entity(self, entity.as_ref());
         }
 
-        self.block_entities
-            .retain(|pos, _| !chunks_set.contains(&pos.chunk_position()));
+        for chunk_pos in &chunks_set {
+            self.block_entities.remove(chunk_pos);
+        }
     }
 
     pub async fn set_block_breaking(&self, from: &Entity, location: BlockPos, progress: i32) {
@@ -4925,13 +4928,16 @@ impl World {
     }
 
     pub fn get_block_entity(&self, block_pos: &BlockPos) -> Option<Arc<dyn BlockEntity>> {
-        if let Some(entry) = self.block_entities.get(block_pos) {
-            return Some(entry.value().clone());
+        let chunk_pos = block_pos.chunk_position();
+        if let Some(chunk_block_entities) = self.block_entities.get(&chunk_pos)
+            && let Some(entity) = chunk_block_entities.get(block_pos)
+        {
+            return Some(entity.clone());
         }
 
         let nbt = self
             .level
-            .read_chunk_sync(&block_pos.chunk_position(), |chunk| {
+            .read_chunk_sync(&chunk_pos, |chunk| {
                 chunk
                     .pending_block_entities
                     .lock()
@@ -4940,7 +4946,10 @@ impl World {
             })
             .flatten()?;
         let entity = block_entity_from_nbt(&nbt)?;
-        self.block_entities.insert(*block_pos, entity.clone());
+        self.block_entities
+            .entry(chunk_pos)
+            .or_default()
+            .insert(*block_pos, entity.clone());
         Some(entity)
     }
 
@@ -4962,7 +4971,10 @@ impl World {
             );
         }
 
-        self.block_entities.insert(block_pos, block_entity);
+        self.block_entities
+            .entry(chunk_pos)
+            .or_default()
+            .insert(block_pos, block_entity);
         self.level.read_chunk_sync(&chunk_pos, |chunk| {
             chunk.mark_dirty(true);
         });
@@ -4981,11 +4993,20 @@ impl World {
     }
 
     pub fn remove_block_entity(&self, block_pos: &BlockPos) {
-        if self.block_entities.remove(block_pos).is_some() {
-            self.level
-                .read_chunk_sync(&block_pos.chunk_position(), |chunk| {
-                    chunk.mark_dirty(true);
+        let chunk_pos = block_pos.chunk_position();
+        let removed =
+            self.block_entities
+                .get_mut(&chunk_pos)
+                .is_some_and(|mut chunk_block_entities| {
+                    chunk_block_entities.remove(block_pos).is_some()
                 });
+        if removed {
+            // Drop the chunk's map once its last block entity is gone.
+            self.block_entities
+                .remove_if(&chunk_pos, |_, entities| entities.is_empty());
+            self.level.read_chunk_sync(&chunk_pos, |chunk| {
+                chunk.mark_dirty(true);
+            });
         }
     }
 


### PR DESCRIPTION
Keeps long-running worlds from slowly leaking memory (and, in debug builds, crashing) by making the single chunk-generation scheduler thread crash-safe and stopping a generation-graph node leak.

## Background

A real crash report from a long session pointed straight here: the `Schedule` thread panicked in a debug node-count assertion (`nodes count error`) after accumulating dozens of "unreleased" generation graph nodes.

## 1. Don't let a scheduler panic silently freeze the world

Chunk loading, generation and unloading all run on one dedicated `Schedule` thread, spawned with no panic handling. If its work loop panicked the thread just vanished: chunk loads would await forever and — worse — unloads would stop, so `loaded_chunks` and the entity/block-entity maps keyed off it would grow without bound until the process ran out of memory.

The thread body is now wrapped in `catch_unwind`. On a panic it logs the cause loudly, flags the chunk system as shut down and wakes anyone blocked on it, so the failure is visible and the server stops waiting on a thread that is never coming back instead of leaking until it OOMs. (This is what turned the crash report above into a clean, logged shutdown.)

## 2. Don't leak stranded generation nodes

When a chunk is downgraded, or its generation fails, while one of its tasks is in flight, some graph nodes can be left dangling — never advanced, never released. Once the scheduler next goes fully idle they are provably stranded: nothing queued, in flight or waiting can ever touch them again.

- **Debug** builds still abort on this (it is a real desync worth catching), but now first dump every stranded node together with its holder's target/current/dependency stages so the crash report is actionable.
- **Release** builds no longer leak or go down: the stranded nodes are dropped and the holder references cleared, and chunks that are still wanted are rescheduled on the next ticket level change.

I could not pin down the exact interleaving that strands the nodes from static reading alone, so rather than risk a wrong change to core generation this fixes the symptom safely and adds the diagnostics above (plus a debug log when a downgrade keeps an in-flight node) to pinpoint the root cause from the next report.

## Not included here

The block-entity per-chunk ticking perf change that was originally on this branch has moved to its own PR: Pumpkin-MC/Pumpkin#2340. This branch stays focused on scheduler stability.

## Checks

`cargo fmt --check` and `cargo clippy --all-targets --all-features` (debug and release) are clean; the existing `pumpkin` / `pumpkin-world` suites pass.
