### PR TITLE
perf(pumpkin): tick block entities per active chunk instead of scanning all

### DIFF
--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -162,7 +162,7 @@ use weather::Weather;
 
 type FlowingFluidProperties = pumpkin_data::fluid::FlowingWaterLikeFluidProperties;
 
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 impl PumpkinError for GetBlockError {
     fn is_kick(&self) -> bool {
@@ -222,7 +222,9 @@ pub struct World {
     pub dragon_fight: Option<Mutex<dragon_fight::DragonFight>>,
     pub spawn_state: ArcSwap<SpawnState>,
     pub active_chunks: ArcSwap<FxHashSet<Vector2<i32>>>,
-    pub block_entities: DashMap<BlockPos, Arc<dyn BlockEntity>>,
+    /// Block entities indexed by chunk, so ticking only visits the currently
+    /// active chunks instead of scanning every loaded block entity each tick.
+    pub block_entities: DashMap<Vector2<i32>, FxHashMap<BlockPos, Arc<dyn BlockEntity>>>,
 }
 
 impl PartialEq for World {
@@ -965,12 +967,12 @@ impl World {
         };
 
         let active_chunks = self.active_chunks.load();
-        let block_entities: Vec<Arc<dyn BlockEntity>> = self
-            .block_entities
-            .iter()
-            .filter(|e| active_chunks.contains(&e.key().chunk_position()))
-            .map(|e| e.value().clone())
-            .collect();
+        let mut block_entities: Vec<Arc<dyn BlockEntity>> = Vec::new();
+        for chunk_pos in active_chunks.iter() {
+            if let Some(chunk_block_entities) = self.block_entities.get(chunk_pos) {
+                block_entities.extend(chunk_block_entities.values().cloned());
+            }
+        }
         let block_entity_count = block_entities.len();
 
         let world_for_be = self.clone();
@@ -4161,8 +4163,9 @@ impl World {
             self.spawn_state.load().remove_entity(self, entity.as_ref());
         }
 
-        self.block_entities
-            .retain(|pos, _| !chunks_set.contains(&pos.chunk_position()));
+        for chunk_pos in &chunks_set {
+            self.block_entities.remove(chunk_pos);
+        }
     }
 
     pub async fn set_block_breaking(&self, from: &Entity, location: BlockPos, progress: i32) {
@@ -4925,13 +4928,16 @@ impl World {
     }
 
     pub fn get_block_entity(&self, block_pos: &BlockPos) -> Option<Arc<dyn BlockEntity>> {
-        if let Some(entry) = self.block_entities.get(block_pos) {
-            return Some(entry.value().clone());
+        let chunk_pos = block_pos.chunk_position();
+        if let Some(chunk_block_entities) = self.block_entities.get(&chunk_pos)
+            && let Some(entity) = chunk_block_entities.get(block_pos)
+        {
+            return Some(entity.clone());
         }
 
         let nbt = self
             .level
-            .read_chunk_sync(&block_pos.chunk_position(), |chunk| {
+            .read_chunk_sync(&chunk_pos, |chunk| {
                 chunk
                     .pending_block_entities
                     .lock()
@@ -4940,7 +4946,10 @@ impl World {
             })
             .flatten()?;
         let entity = block_entity_from_nbt(&nbt)?;
-        self.block_entities.insert(*block_pos, entity.clone());
+        self.block_entities
+            .entry(chunk_pos)
+            .or_default()
+            .insert(*block_pos, entity.clone());
         Some(entity)
     }
 
@@ -4962,7 +4971,10 @@ impl World {
             );
         }
 
-        self.block_entities.insert(block_pos, block_entity);
+        self.block_entities
+            .entry(chunk_pos)
+            .or_default()
+            .insert(block_pos, block_entity);
         self.level.read_chunk_sync(&chunk_pos, |chunk| {
             chunk.mark_dirty(true);
         });
@@ -4981,11 +4993,20 @@ impl World {
     }
 
     pub fn remove_block_entity(&self, block_pos: &BlockPos) {
-        if self.block_entities.remove(block_pos).is_some() {
-            self.level
-                .read_chunk_sync(&block_pos.chunk_position(), |chunk| {
-                    chunk.mark_dirty(true);
+        let chunk_pos = block_pos.chunk_position();
+        let removed =
+            self.block_entities
+                .get_mut(&chunk_pos)
+                .is_some_and(|mut chunk_block_entities| {
+                    chunk_block_entities.remove(block_pos).is_some()
                 });
+        if removed {
+            // Drop the chunk's map once its last block entity is gone.
+            self.block_entities
+                .remove_if(&chunk_pos, |_, entities| entities.is_empty());
+            self.level.read_chunk_sync(&chunk_pos, |chunk| {
+                chunk.mark_dirty(true);
+            });
         }
     }
 


### PR DESCRIPTION
Block entities were stored in one flat `DashMap<BlockPos, _>`, and every world tick rebuilt the tick list by iterating the entire map and filtering it down to the active chunks — O(all loaded block entities). The more of the world that has been explored, the more chests/signs/hoppers/... are loaded, and the longer every tick spends walking block entities it will not tick, so TPS slowly bleeds away on long-running worlds.

The map is now keyed by chunk (`chunk -> its block entities`). Ticking walks only the active chunks and their entries; inserts, removals and lookups compute the chunk key up front; unloading a chunk drops its whole bucket. The same block entities get ticked — it just stops scanning the ones that are loaded but nowhere near a player.
