### PR TITLE
perf(pumpkin): only tick entities in active chunks

### DIFF
--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -127,7 +127,7 @@ use pumpkin_util::{
     math::{boundingbox::BoundingBox, position::BlockPos, vector3::Vector3},
 };
 use pumpkin_util::{
-    math::{position::chunk_section_from_pos, vector2::Vector2},
+    math::{get_section_cord, position::chunk_section_from_pos, vector2::Vector2},
     random::{RandomImpl, get_seed, xoroshiro128::Xoroshiro},
 };
 use pumpkin_world::inventory::Clearable;
@@ -927,11 +927,27 @@ impl World {
         let entities_to_tick = self.entities.load();
         let entity_count = entities_to_tick.len();
         let server_for_entities = server.clone();
+        let active_chunks = self.active_chunks.load();
 
         let entity_future = async move {
             let t = tokio::time::Instant::now();
             let mut tasks = tokio::task::JoinSet::new();
             for entity in entities_to_tick.iter() {
+                // Only tick entities that sit in an active (ticking) chunk — the
+                // same set block-entity ticking and mob spawning already use, and
+                // like vanilla, which ticks entities only within the simulation
+                // distance. Use the live position: fast movers such as minecarts
+                // and projectiles write `pos` directly and leave the cached
+                // chunk_pos stale.
+                let entity_pos = entity.get_entity().pos.load();
+                let entity_chunk = Vector2::new(
+                    get_section_cord(entity_pos.x.floor() as i32),
+                    get_section_cord(entity_pos.z.floor() as i32),
+                );
+                if !active_chunks.contains(&entity_chunk) {
+                    continue;
+                }
+
                 let e_clone = entity.clone();
                 let s_clone = server_for_entities.clone();
                 let p_cache = players_cache.clone();


### PR DESCRIPTION
The world tick iterated `World::entities` — every entity in the world — and ticked all of them each tick (AI, movement, and a per-entity player-collision scan), no matter where they were. Entities in loaded-but-not-active chunks were ticked too, so the cost is O(all loaded entities) and grows as a world is explored, quietly eating TPS on long-running servers.

Now an entity is only ticked if its chunk is in the active (ticking) set — the same `active_chunks` that block-entity ticking and mob spawning already use, and matching vanilla, which ticks entities only within the simulation distance.

## Notes

- The check uses the entity's **live** position (`pos`), not its cached `chunk_pos`: some fast movers (minecarts, projectiles) write `pos` directly and leave `chunk_pos` stale, so filtering on the cache could wrongly freeze them.
- **Players are unaffected** — they're ticked separately (`World::players`) and aren't in the entity list.
- Entities outside active chunks freeze until they're active again, which is exactly how vanilla treats entities outside the simulation distance (no AI, no despawn timer).
- `active_chunks` is currently a hardcoded 17×17 (radius 8) per player, slightly tighter than the default simulation distance (10) — a pre-existing limitation shared with block-entity ticking and spawning; once that radius respects the configured simulation distance, entity ticking follows automatically.

## Checks

`cargo fmt --check` and `cargo clippy --all-targets --all-features` (debug and release) are clean; the `pumpkin` suite passes.
