### PR TITLE
fix(pumpkin-protocol): BossEvent serializer for bedrock v1001

### DIFF
--- a/pumpkin-protocol/src/bedrock/client/boss_event.rs
+++ b/pumpkin-protocol/src/bedrock/client/boss_event.rs
@@ -1,7 +1,7 @@
 use std::io::{Error, Write};
 
 use crate::{
-    codec::{var_int::VarInt, var_long::VarLong},
+    codec::{var_long::VarLong},
     serial::PacketWrite,
 };
 use pumpkin_macros::packet;
@@ -16,15 +16,15 @@ pub enum BossEventAction {
     Add {
         title: String,
         health_percent: f32,
-        color: VarInt,
-        overlay: VarInt,
+        color: u8,
+        overlay: u8,
     },
     Remove,
     UpdateHealth(f32),
     UpdateTitle(String),
     UpdateProperties {
-        color: VarInt,
-        overlay: VarInt,
+        color: u8,
+        overlay: u8,
     },
 }
 
@@ -43,33 +43,33 @@ impl PacketWrite for CBossEvent {
             BossEventAction::Add {
                 title: t,
                 health_percent: hp,
-                color: c,
-                overlay: o,
+                color: _c,
+                overlay: _o,
             } => {
                 event_type = 0;
                 title.clone_from(t);
                 health_percent = *hp;
-                color = c.0 as u8;
-                overlay = o.0 as u8;
+                color = 0;
+                overlay = 0;
             }
             BossEventAction::Remove => {
                 event_type = 2;
             }
             BossEventAction::UpdateHealth(health) => {
-                event_type = 3;
+                event_type = 4;
                 health_percent = *health;
             }
             BossEventAction::UpdateTitle(t) => {
-                event_type = 4;
+                event_type = 5;
                 title.clone_from(t);
             }
             BossEventAction::UpdateProperties {
-                color: c,
-                overlay: o,
+                color: _c,
+                overlay: _o,
             } => {
-                event_type = 5;
-                color = c.0 as u8;
-                overlay = o.0 as u8;
+                event_type = 6;
+                color = 0;
+                overlay = 0;
             }
         }
 

--- a/pumpkin/src/world/bossbar.rs
+++ b/pumpkin/src/world/bossbar.rs
@@ -2,7 +2,6 @@ use crate::entity::player::Player;
 use crate::net::ClientPlatform;
 use bitflags::bitflags;
 use pumpkin_protocol::bedrock::client::boss_event::{BossEventAction, CBossEvent as BBossEvent};
-use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::codec::var_long::VarLong;
 use pumpkin_protocol::java::client::play::{BosseventAction, CBossEvent};
 use pumpkin_util::text::TextComponent;
@@ -21,15 +20,15 @@ pub enum BossbarColor {
 
 impl BossbarColor {
     #[must_use]
-    pub const fn to_bedrock(self) -> VarInt {
+    pub const fn to_bedrock(self) -> u8 {
         match self {
-            Self::Pink => VarInt(0),
-            Self::Blue => VarInt(1),
-            Self::Red => VarInt(2),
-            Self::Green => VarInt(3),
-            Self::Yellow => VarInt(4),
-            Self::Purple => VarInt(5),
-            Self::White => VarInt(6),
+            Self::Pink => 0,
+            Self::Blue => 1,
+            Self::Red => 2,
+            Self::Green => 3,
+            Self::Yellow => 4,
+            Self::Purple => 5,
+            Self::White => 6,
         }
     }
 }
@@ -45,13 +44,13 @@ pub enum BossbarDivisions {
 
 impl BossbarDivisions {
     #[must_use]
-    pub const fn to_bedrock(self) -> VarInt {
+    pub const fn to_bedrock(self) -> u8 {
         match self {
-            Self::NoDivision => VarInt(0),
-            Self::Notches6 => VarInt(1),
-            Self::Notches10 => VarInt(2),
-            Self::Notches12 => VarInt(3),
-            Self::Notches20 => VarInt(4),
+            Self::NoDivision => 0,
+            Self::Notches6 => 1,
+            Self::Notches10 => 2,
+            Self::Notches12 => 3,
+            Self::Notches20 => 4,
         }
     }
 }
@@ -223,8 +222,8 @@ impl Player {
                 let packet = BBossEvent {
                     boss_entity_id: VarLong(uuid.as_u128() as i64),
                     action: BossEventAction::UpdateProperties {
-                        color: VarInt(0),
-                        overlay: VarInt(0),
+                        color: 0,
+                        overlay: 0,
                     },
                 };
                 bedrock.send_game_packet(&packet).await;


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Fixed the incorrect serializer data type for ```BossEventPacket``` in Bedrock client protocol v1001 and corrected the event type value.
Since the v1001 protocol update for ```BossEventPacket```, the overlay and color fields use ```u8```.