### PR TITLE
fix: prevent capacity overflow crash

### DIFF
--- a/pumpkin-world/src/generation/feature/placed_features.rs
+++ b/pumpkin-world/src/generation/feature/placed_features.rs
@@ -516,7 +516,7 @@ pub trait CountPlacementModifierBase {
         random: &mut RandomGenerator,
         pos: BlockPos,
     ) -> Box<dyn Iterator<Item = BlockPos>> {
-        let count = self.get_count(random, pos);
+        let count = self.get_count(random, pos).max(0);
         Box::new(std::iter::repeat_n(pos, count as usize))
     }
 

--- a/pumpkin-world/src/generation/feature/placed_features.rs
+++ b/pumpkin-world/src/generation/feature/placed_features.rs
@@ -516,7 +516,7 @@ pub trait CountPlacementModifierBase {
         random: &mut RandomGenerator,
         pos: BlockPos,
     ) -> Box<dyn Iterator<Item = BlockPos>> {
-        let count = self.get_count(random, pos).max(0);
+        let count = self.get_count(random, pos).max(0); // Vanilla treats negative counts as 0, but `i32 as usize` in Rust would wrap.
         Box::new(std::iter::repeat_n(pos, count as usize))
     }
 


### PR DESCRIPTION
This fixes a crash in chunk generation caused by a negative feature count being converted into an enormous `usize`, which then overflows allocation in `Vec` construction.

### Root cause

`NoiseBasedCountPlacementModifier::get_count()` can return a negative `i32` after noise sampling and scaling. That value was then used as a count without clamping, so when it reached allocation or iteration code it became an invalidly large size request.

In Java, the equivalent pattern is safe because a `for` loop whose condition is false from the start executes zero iterations. For example, `for (int i = 0; i < -5; i++)` does nothing because the condition is false immediately.

### Fix

Clamp negative counts to zero before using them:

```rust
// Before
let count = self.get_count(random, pos);

// After
let count = self.get_count(random, pos).max(0);
```

This preserves the intended behavior: when noise indicates no feature placements, the loop performs zero iterations instead of attempting an impossible allocation.

### Why this is correct

The Java version relies on control-flow semantics to produce zero iterations when the bound is negative or otherwise unreachable. In Rust, an unchecked cast from a negative integer to `usize` does not panic by itself, but it does produce a very large unsigned value, which is unsafe to use as a count.

Clamping to zero makes the behavior explicit and matches the vanilla outcome more safely.

### Verification

- Before: chunk generation could panic with `capacity overflow` during feature placement.

- After: negative counts are treated as zero, chunk generation completes normally

Closes #2345