### PR TITLE
Implement chunk serialization API for plugins

### DIFF
--- a/pumpkin-plugin-api/src/chunk.rs
+++ b/pumpkin-plugin-api/src/chunk.rs
@@ -1,0 +1,205 @@
+use crate::world;
+
+/// A block entity stored as raw NBT bytes together with its absolute position.
+pub struct BlockEntityData {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+    pub nbt_data: Vec<u8>,
+}
+
+impl From<world::SerializedBlockEntity> for BlockEntityData {
+    fn from(be: world::SerializedBlockEntity) -> Self {
+        Self {
+            x: be.x,
+            y: be.y,
+            z: be.z,
+            nbt_data: be.nbt_data,
+        }
+    }
+}
+
+impl From<BlockEntityData> for world::SerializedBlockEntity {
+    fn from(be: BlockEntityData) -> Self {
+        Self {
+            x: be.x,
+            y: be.y,
+            z: be.z,
+            nbt_data: be.nbt_data,
+        }
+    }
+}
+
+/// A full chunk's data stored as flat arrays in WASM memory.
+///
+/// Blocks are indexed as `[x][y][z]` where `x` and `z` are in `0..16` and
+/// `y` goes from `0` (absolute `min_y`) to `height - 1` (exclusive).
+/// The flat index is `x * (height * 16) + y * 16 + z`.
+///
+/// Biomes use quarter-scale coordinates: `x` and `z` in `0..4`, `y` in
+/// `0..(height/4)`.  The flat index is `x * (biome_height * 4) + y * 4 + z`.
+pub struct ChunkData {
+    pub x: i32,
+    pub z: i32,
+    pub min_y: i32,
+    pub height: i32,
+    blocks: Vec<u16>,
+    biomes: Vec<u8>,
+    pub block_entities: Vec<BlockEntityData>,
+}
+
+impl ChunkData {
+    /// Wrap an existing [`world::SerializedChunk`] received from the host.
+    pub fn from_serialized(chunk: world::SerializedChunk) -> Self {
+        let block_entities = chunk
+            .block_entities
+            .into_iter()
+            .map(BlockEntityData::from)
+            .collect();
+
+        Self {
+            x: chunk.x,
+            z: chunk.z,
+            min_y: chunk.min_y,
+            height: chunk.height,
+            blocks: chunk.blocks,
+            biomes: chunk.biomes,
+            block_entities,
+        }
+    }
+
+    /// Convert this chunk back into the WIT type so it can be sent to the host.
+    pub fn into_serialized(self) -> world::SerializedChunk {
+        world::SerializedChunk {
+            x: self.x,
+            z: self.z,
+            min_y: self.min_y,
+            height: self.height,
+            blocks: self.blocks,
+            biomes: self.biomes,
+            block_entities: self
+                .block_entities
+                .into_iter()
+                .map(world::SerializedBlockEntity::from)
+                .collect(),
+        }
+    }
+
+    /// Create an empty chunk at the given coordinates.
+    ///
+    /// All blocks are initialised to `default_block` (usually `0` = air) and
+    /// all biomes to `default_biome`.
+    pub fn new_empty(
+        x: i32,
+        z: i32,
+        min_y: i32,
+        height: i32,
+        default_block: u16,
+        default_biome: u8,
+    ) -> Self {
+        let block_count = (16 * height * 16) as usize;
+        let biome_height = (height as usize) / 4;
+        let biome_count = 4 * biome_height * 4;
+
+        Self {
+            x,
+            z,
+            min_y,
+            height,
+            blocks: vec![default_block; block_count],
+            biomes: vec![default_biome; biome_count],
+            block_entities: Vec::new(),
+        }
+    }
+
+    // ── block access ──────────────────────────────────────────────
+
+    #[inline]
+    fn block_index(&self, x: i32, y: i32, z: i32) -> usize {
+        (x as usize) * (self.height as usize * 16) + (y as usize) * 16 + (z as usize)
+    }
+
+    /// Get the block state ID at the given local coordinates.
+    ///
+    /// `x` and `z` must be in `0..16`. `y` is relative to `min_y` (i.e.
+    /// `0` is the bottom of the chunk, `height - 1` is the top).
+    #[inline]
+    pub fn get_block(&self, x: i32, y: i32, z: i32) -> u16 {
+        self.blocks[self.block_index(x, y, z)]
+    }
+
+    /// Set the block state ID at the given local coordinates.
+    #[inline]
+    pub fn set_block(&mut self, x: i32, y: i32, z: i32, id: u16) {
+        let idx = self.block_index(x, y, z);
+        self.blocks[idx] = id;
+    }
+
+    /// Fill every block in the chunk with the given state ID.
+    pub fn fill_blocks(&mut self, id: u16) {
+        self.blocks.fill(id);
+    }
+
+    // ── biome access ──────────────────────────────────────────────
+
+    #[inline]
+    fn biome_index(&self, x: i32, y: i32, z: i32) -> usize {
+        let biome_height = (self.height as usize) / 4;
+        (x as usize) * (biome_height * 4) + (y as usize) * 4 + (z as usize)
+    }
+
+    /// Get the biome ID at the given local biome coordinates.
+    ///
+    /// `x` and `z` must be in `0..4`. `y` is relative to `min_y >> 2`
+    /// (i.e. `0` is the bottom biome section, `height/4 - 1` is the top).
+    #[inline]
+    pub fn get_biome(&self, x: i32, y: i32, z: i32) -> u8 {
+        self.biomes[self.biome_index(x, y, z)]
+    }
+
+    /// Set the biome ID at the given local biome coordinates.
+    #[inline]
+    pub fn set_biome(&mut self, x: i32, y: i32, z: i32, id: u8) {
+        let idx = self.biome_index(x, y, z);
+        self.biomes[idx] = id;
+    }
+
+    /// Fill every biome quad in the chunk with the given biome ID.
+    pub fn fill_biomes(&mut self, id: u8) {
+        self.biomes.fill(id);
+    }
+
+    // ── block entity access ───────────────────────────────────────
+
+    /// Add a block entity to this chunk.
+    ///
+    /// Does **not** deduplicate by position – if a block entity with the
+    /// same coordinates already exists, both will be present.  The host
+    /// will use the last one when building the chunk.
+    pub fn add_block_entity(&mut self, entity: BlockEntityData) {
+        self.block_entities.push(entity);
+    }
+
+    /// Remove all block entities at the given position.
+    pub fn remove_block_entities(&mut self, x: i32, y: i32, z: i32) {
+        self.block_entities
+            .retain(|be| be.x != x || be.y != y || be.z != z);
+    }
+
+    /// Clear all block entities from this chunk.
+    pub fn clear_block_entities(&mut self) {
+        self.block_entities.clear();
+    }
+}
+
+impl From<world::SerializedChunk> for ChunkData {
+    fn from(chunk: world::SerializedChunk) -> Self {
+        Self::from_serialized(chunk)
+    }
+}
+
+impl From<ChunkData> for world::SerializedChunk {
+    fn from(chunk: ChunkData) -> Self {
+        chunk.into_serialized()
+    }
+}

--- a/pumpkin-plugin-api/src/lib.rs
+++ b/pumpkin-plugin-api/src/lib.rs
@@ -33,6 +33,7 @@ use crate::{
     scheduler::TASK_HANDLERS, text::TextComponent,
 };
 
+pub mod chunk;
 pub mod commands;
 pub mod events;
 pub mod forms;

--- a/pumpkin-world/src/chunk/palette.rs
+++ b/pumpkin-world/src/chunk/palette.rs
@@ -140,7 +140,8 @@ impl<V: Hash + Eq + Copy + Default, const DIM: usize> PalettedContainer<V, DIM> 
     pub const SIZE: usize = DIM;
     pub const VOLUME: usize = DIM * DIM * DIM;
 
-    fn from_cube(cube: Box<AbstractCube<V, DIM>>) -> Self {
+    #[must_use]
+    pub fn from_cube(cube: Box<AbstractCube<V, DIM>>) -> Self {
         let mut palette: Vec<V> = Vec::new();
         let mut counts: Vec<u16> = Vec::new();
 

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
@@ -1,9 +1,12 @@
 use pumpkin_data::block_properties::NoteblockInstrument as InternalNoteblockInstrument;
 use pumpkin_data::block_state::PistonBehavior;
 use pumpkin_data::{BlockDirection as InternalBlockDirection, BlockStateId};
+use pumpkin_nbt::from_bytes_unnamed;
+use pumpkin_nbt::to_bytes_unnamed;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::chunk::ChunkHeightmapType;
 use pumpkin_world::chunk::io::Dirtiable;
+use pumpkin_world::tick::scheduler::ChunkTickScheduler;
 use pumpkin_world::world::BlockFlags;
 use std::sync::Arc;
 use wasmtime::component::Resource;
@@ -17,7 +20,8 @@ use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::world::{
     BlockDirection as WitBlockDirection, BlockEntity, BlockEntityType, BlockFlags as WitBlockFlags,
     BlockPos as WitBlockPos, BlockState as WitBlockState, BoundingBox as WitBoundingBox,
     Chunk as WitChunk, NoteblockInstrument as WitNoteblockInstrument,
-    PistonBehavior as WitPistonBehavior, WorldBorder as WitWorldBorder,
+    PistonBehavior as WitPistonBehavior, SerializedBlockEntity as WitSerializedBlockEntity,
+    SerializedChunk as WitSerializedChunk, WorldBorder as WitWorldBorder,
 };
 use crate::plugin::loader::wasm::wasm_host::{
     state::{
@@ -26,6 +30,13 @@ use crate::plugin::loader::wasm::wasm_host::{
     wit::v0_1::pumpkin::{self, plugin::world::World},
 };
 use crate::world::explosion::Explosion;
+use pumpkin_data::chunk::ChunkStatus;
+use pumpkin_world::chunk::format::LightContainer;
+use pumpkin_world::chunk::palette::{BiomePalette, BlockPalette};
+use pumpkin_world::chunk::{ChunkData, ChunkHeightmaps, ChunkLight, ChunkSections};
+use rustc_hash::FxHashMap;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
 
 pub(crate) const fn to_wasm_block_direction(dir: InternalBlockDirection) -> WitBlockDirection {
     match dir {
@@ -675,6 +686,207 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         }
 
         Ok(entities)
+    }
+
+    async fn get_serialized_chunk(
+        &mut self,
+        world: Resource<World>,
+        x: i32,
+        z: i32,
+    ) -> wasmtime::Result<Option<WitSerializedChunk>> {
+        let world_res = self.get_world_res(&world)?;
+        let world_provider = world_res.provider.clone();
+        let pos = pumpkin_util::math::vector2::Vector2::new(x, z);
+
+        let chunk = world_provider
+            .level
+            .loaded_chunks
+            .get(&pos)
+            .map(|c| c.value().clone());
+
+        let Some(chunk) = chunk else {
+            return Ok(None);
+        };
+
+        let min_y = chunk.section.min_y;
+        let height = (chunk.section.count * 16) as i32;
+        let section_count = chunk.section.count;
+
+        let block_guard = chunk.section.block_sections.read().unwrap();
+        let biome_guard = chunk.section.biome_sections.read().unwrap();
+
+        // Blocks: 16 × height × 16
+        let mut blocks = Vec::with_capacity(16 * height as usize * 16);
+        for section_idx in 0..section_count {
+            let section = &block_guard[section_idx];
+            for bx in 0..16usize {
+                for by in 0..16usize {
+                    for bz in 0..16usize {
+                        blocks.push(section.get(bx, by, bz).as_u16());
+                    }
+                }
+            }
+        }
+        drop(block_guard);
+
+        // Biomes: 4 × (height/4) × 4
+        let biome_height = (height as usize) / 4;
+        let mut biomes = Vec::with_capacity(4 * biome_height * 4);
+        for section_idx in 0..section_count {
+            let section = &biome_guard[section_idx];
+            for bx in 0..4usize {
+                for by in 0..4usize {
+                    for bz in 0..4usize {
+                        biomes.push(section.get(bx, by, bz));
+                    }
+                }
+            }
+        }
+        drop(biome_guard);
+
+        // Block entities
+        let entities_guard = chunk.pending_block_entities.lock().unwrap();
+        let mut block_entities: Vec<WitSerializedBlockEntity> =
+            Vec::with_capacity(entities_guard.len());
+        for (block_pos, nbt) in entities_guard.iter() {
+            let mut nbt_bytes = Vec::new();
+            to_bytes_unnamed(nbt, &mut nbt_bytes).map_err(|e| {
+                wasmtime::Error::msg(format!("Failed to serialize block entity: {e}"))
+            })?;
+            block_entities.push(WitSerializedBlockEntity {
+                x: block_pos.0.x,
+                y: block_pos.0.y,
+                z: block_pos.0.z,
+                nbt_data: nbt_bytes,
+            });
+        }
+        drop(entities_guard);
+
+        Ok(Some(WitSerializedChunk {
+            x,
+            z,
+            min_y,
+            height,
+            blocks,
+            biomes,
+            block_entities,
+        }))
+    }
+
+    async fn set_serialized_chunk(
+        &mut self,
+        world: Resource<World>,
+        chunk_data: WitSerializedChunk,
+    ) -> wasmtime::Result<()> {
+        let world_res = self.get_world_res(&world)?;
+        let world_provider = world_res.provider.clone();
+
+        let min_y = chunk_data.min_y;
+        let height = chunk_data.height as usize;
+        let section_count = height / 16;
+        let biome_height = height / 4;
+
+        // Validate sizes
+        let expected_blocks = 16 * height * 16;
+        if chunk_data.blocks.len() != expected_blocks {
+            return Err(wasmtime::Error::msg(format!(
+                "Invalid block count: expected {expected_blocks}, got {}",
+                chunk_data.blocks.len()
+            )));
+        }
+        let expected_biomes = 4 * biome_height * 4;
+        if chunk_data.biomes.len() != expected_biomes {
+            return Err(wasmtime::Error::msg(format!(
+                "Invalid biome count: expected {expected_biomes}, got {}",
+                chunk_data.biomes.len()
+            )));
+        }
+
+        // Build block sections from flat arrays
+        let mut block_sections = Vec::with_capacity(section_count);
+        for section_idx in 0..section_count {
+            let mut cube = Box::new([[[BlockStateId::AIR; 16]; 16]; 16]);
+            let section_base_y = section_idx * 16;
+            for bx in 0..16usize {
+                for by in 0..16usize {
+                    for bz in 0..16usize {
+                        let flat_y = section_base_y + by;
+                        let idx = bx * (height * 16) + flat_y * 16 + bz;
+                        cube[bx][by][bz] = BlockStateId::new_or_air(chunk_data.blocks[idx]);
+                    }
+                }
+            }
+            block_sections.push(BlockPalette::from_cube(cube));
+        }
+
+        // Build biome sections from flat arrays
+        let mut biome_sections = Vec::with_capacity(section_count);
+        for section_idx in 0..section_count {
+            let mut cube = Box::new([[[0u8; 4]; 4]; 4]);
+            let section_biome_base_y = section_idx * 4;
+            for bx in 0..4usize {
+                for by in 0..4usize {
+                    for bz in 0..4usize {
+                        let flat_biome_y = section_biome_base_y + by;
+                        let idx = bx * (biome_height * 4) + flat_biome_y * 4 + bz;
+                        cube[bx][by][bz] = chunk_data.biomes[idx];
+                    }
+                }
+            }
+            biome_sections.push(BiomePalette::from_cube(cube));
+        }
+
+        let (random_tick_sections, randomly_ticking_mask) =
+            ChunkSections::build_random_tick_sections_cache(&block_sections);
+
+        let sections = ChunkSections {
+            count: section_count,
+            block_sections: std::sync::RwLock::new(block_sections.into_boxed_slice()),
+            random_tick_sections: std::sync::RwLock::new(random_tick_sections),
+            randomly_ticking_mask: std::sync::atomic::AtomicU32::new(randomly_ticking_mask),
+            biome_sections: std::sync::RwLock::new(biome_sections.into_boxed_slice()),
+            min_y,
+        };
+
+        // Deserialize block entities
+        let mut pending_block_entities = FxHashMap::default();
+        for be in &chunk_data.block_entities {
+            let pos = BlockPos::new(be.x, be.y, be.z);
+            let nbt: pumpkin_nbt::compound::NbtCompound =
+                from_bytes_unnamed(std::io::Cursor::new(&be.nbt_data)).map_err(|e| {
+                    wasmtime::Error::msg(format!("Failed to deserialize block entity: {e}"))
+                })?;
+            pending_block_entities.insert(pos, nbt);
+        }
+
+        // Construct the heightmap from the block data
+        let chunk = Arc::new(ChunkData {
+            section: sections,
+            heightmap: Mutex::new(ChunkHeightmaps::default()),
+            x: chunk_data.x,
+            z: chunk_data.z,
+            block_ticks: ChunkTickScheduler::default(),
+            fluid_ticks: ChunkTickScheduler::default(),
+            pending_block_entities: Mutex::new(pending_block_entities),
+            light_engine: Mutex::new(ChunkLight {
+                sky_light: vec![LightContainer::Empty(15); section_count].into_boxed_slice(),
+                block_light: vec![LightContainer::Empty(0); section_count].into_boxed_slice(),
+            }),
+            light_populated: AtomicBool::new(false),
+            status: ChunkStatus::Full,
+            blending_data: None,
+            dirty: AtomicBool::new(true),
+        });
+
+        // Calculate heightmaps
+        {
+            let heightmaps = chunk.calculate_heightmap();
+            *chunk.heightmap.lock().unwrap() = heightmaps;
+        };
+
+        world_provider.replace_chunk(&chunk);
+
+        Ok(())
     }
 
     async fn get_block_entity(

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -135,7 +135,7 @@ use pumpkin_world::{
     CURRENT_BEDROCK_MC_VERSION, biome, chunk::io::Dirtiable, inventory::Inventory,
 };
 use pumpkin_world::{chunk::ChunkData, world::BlockAccessor};
-use pumpkin_world::{level::Level, tick::TickPriority};
+use pumpkin_world::{level::Level, level::SyncChunk, tick::TickPriority};
 pub use pumpkin_world::{world::BlockFlags, world_info::LevelData};
 use rand::seq::SliceRandom;
 use rand::{RngExt, rng};
@@ -5048,6 +5048,15 @@ impl World {
         self.level.read_chunk_sync(&chunk_pos, |chunk| {
             chunk.mark_dirty(true);
         });
+    }
+
+    /// Replaces a chunk in `loaded_chunks` and broadcasts the new data to
+    /// every player currently watching the chunk.
+    pub fn replace_chunk(&self, chunk: &SyncChunk) {
+        let pos = Vector2::new(chunk.x, chunk.z);
+        self.level.loaded_chunks.insert(pos, chunk.clone());
+        let chunk_data = CChunkData(chunk);
+        self.broadcast_to_chunk(pos, &chunk_data);
     }
 
     fn intersects_aabb_with_direction(


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Implementation of https://github.com/Pumpkin-MC/pumpkin-plugin-wit/pull/14, adds a new API to plugins which allows plugins to request a specific chunk by calling `world.get_serialized_chunk(x,z)`, which gets serialized to a custom flat format and is returned to the plugin. The plugin can then read and write to this copy of the chunk without needing to make any calls to the host. Once the plugin is done, it can send the modified serialized data back using `world.set_serialized_chunk(chunk_data)`, which the server will deserialize and create a new chunk from, this chunk then gets placed into the world and clients should receive a packet about the chunk being updated.

This API is only faster when the plugin is reading or modifying large amounts of blocks in a chunk (like setting the whole block to air, or copying a structure into several chunks), that's why it is not replacing the current chunk API. I am adding a screenshot of a small benchmark I did to show how fast this new API can be:
<img width="614" height="982" alt="image" src="https://github.com/user-attachments/assets/39cf3a15-aed8-4003-86b5-2cdf3e125e31" />


## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
