### PR TITLE
feat(entity): snow golems throw snowballs at their target 🤖🤖🤖

### DIFF
--- a/pumpkin/src/entity/ai/goal/mod.rs
+++ b/pumpkin/src/entity/ai/goal/mod.rs
@@ -24,6 +24,7 @@ pub mod owner_hurt_target;
 pub mod pick_up_block;
 pub mod place_block;
 pub mod revenge;
+pub mod snowball_attack;
 pub mod step_and_destroy_block;
 pub mod swim;
 pub mod teleport_towards_player;

--- a/pumpkin/src/entity/ai/goal/snowball_attack.rs
+++ b/pumpkin/src/entity/ai/goal/snowball_attack.rs
@@ -1,0 +1,162 @@
+use super::{Controls, Goal, GoalFuture};
+use crate::entity::ai::pathfinder::NavigatorGoal;
+use crate::entity::mob::Mob;
+use crate::entity::projectile::snowball::SnowballEntity;
+use crate::entity::{Entity, EntityBase};
+use pumpkin_data::entity::EntityType;
+use pumpkin_data::sound::{Sound, SoundCategory};
+use std::sync::Arc;
+
+/// Ranged snowball-throwing behavior for the snow golem.
+///
+/// Mirrors vanilla `ProjectileAttackGoal`: the golem approaches until the target
+/// is in range, holds position, and lobs a snowball on a fixed interval. Mob
+/// line of sight isn't modelled upstream yet (see `BlazeShootFireballGoal`), so
+/// the target counts as visible while the goal runs.
+pub struct SnowballAttackGoal {
+    /// Movement speed multiplier while approaching the target.
+    speed: f64,
+    /// Squared maximum throwing range.
+    squared_range: f64,
+    /// Ticks between two throws.
+    interval: i32,
+    /// Ticks until the next throw (`<= 0` means ready).
+    cooldown: i32,
+    /// How long the target has been continuously visible.
+    target_seeing_ticks: i32,
+}
+
+impl SnowballAttackGoal {
+    /// `speed` is the approach speed multiplier, `interval` the ticks between
+    /// throws, and `range` the maximum throwing distance in blocks.
+    #[must_use]
+    pub fn new(speed: f64, interval: i32, range: f32) -> Box<Self> {
+        Box::new(Self {
+            speed,
+            squared_range: f64::from(range * range),
+            interval,
+            cooldown: -1,
+            target_seeing_ticks: 0,
+        })
+    }
+
+    /// Lobs a snowball from the golem toward `target`, matching vanilla
+    /// `SnowGolemEntity::shootAt` ballistics: aim at `eyeY - 1.1` and
+    /// `velocity(dx, dy + horizontal * 0.2, dz, 1.6, 12.0)`.
+    async fn shoot_at(mob: &dyn Mob, target: &dyn EntityBase) {
+        let shooter = mob.get_entity();
+        let world = shooter.world.load();
+
+        let mut spawn_pos = shooter.pos.load();
+        spawn_pos.y = shooter.get_eye_y() - 0.1;
+        let snowball_entity = Entity::from_uuid(
+            uuid::Uuid::new_v4(),
+            world.clone(),
+            spawn_pos,
+            &EntityType::SNOWBALL,
+        );
+        let snowball = SnowballEntity::new_shot(snowball_entity, shooter);
+
+        let shooter_pos = shooter.pos.load();
+        let target_entity = target.get_entity();
+        let target_pos = target_entity.pos.load();
+
+        let dx = target_pos.x - shooter_pos.x;
+        // Aim at the target's upper body, like vanilla's `getEyeY() - 1.1`.
+        let dy = (target_entity.get_eye_y() - 1.1) - spawn_pos.y;
+        let dz = target_pos.z - shooter_pos.z;
+        let horizontal = dx.hypot(dz);
+
+        snowball
+            .thrown
+            .set_velocity(dx, horizontal.mul_add(0.2, dy), dz, 1.6, 12.0);
+
+        world.play_sound(
+            Sound::EntitySnowGolemShoot,
+            SoundCategory::Neutral,
+            &shooter_pos,
+        );
+        world.spawn_entity(Arc::new(snowball)).await;
+    }
+}
+
+impl Goal for SnowballAttackGoal {
+    fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
+        Box::pin(async {
+            let target = mob.get_mob_entity().target.lock().await;
+            target.as_ref().is_some_and(|t| t.get_entity().is_alive())
+        })
+    }
+
+    fn should_continue<'a>(&'a self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
+        Box::pin(async {
+            let target = mob.get_mob_entity().target.lock().await;
+            target.as_ref().is_some_and(|t| t.get_entity().is_alive())
+        })
+    }
+
+    fn start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async {
+            mob.get_mob_entity().set_attacking(true);
+        })
+    }
+
+    fn stop<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async {
+            mob.get_mob_entity().set_attacking(false);
+            mob.get_mob_entity().navigator.lock().unwrap().stop();
+            self.cooldown = -1;
+            self.target_seeing_ticks = 0;
+        })
+    }
+
+    fn tick<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async {
+            let target = mob.get_mob_entity().target.lock().await.clone();
+            let Some(target) = target else {
+                return;
+            };
+
+            let mob_pos = mob.get_entity().pos.load();
+            let target_pos = target.get_entity().pos.load();
+            let distance_sq = mob_pos.squared_distance_to_vec(&target_pos);
+
+            // Upstream has no mob line-of-sight raycast yet, so the target counts
+            // as continuously visible while this goal runs.
+            self.target_seeing_ticks += 1;
+
+            let in_range = distance_sq <= self.squared_range && self.target_seeing_ticks >= 5;
+            {
+                let mut navigator = mob.get_mob_entity().navigator.lock().unwrap();
+                if in_range {
+                    navigator.stop();
+                } else {
+                    navigator.set_progress(NavigatorGoal::new(mob_pos, target_pos, self.speed));
+                }
+            }
+
+            mob.get_mob_entity()
+                .look_control
+                .lock()
+                .unwrap()
+                .look_at_entity_with_range(&target, 30.0, 30.0);
+
+            if in_range {
+                if self.cooldown > 0 {
+                    self.cooldown -= 1;
+                } else {
+                    Self::shoot_at(mob, target.as_ref()).await;
+                    self.cooldown = self.interval;
+                }
+            }
+        })
+    }
+
+    fn should_run_every_tick(&self) -> bool {
+        true
+    }
+
+    fn controls(&self) -> Controls {
+        Controls::MOVE | Controls::LOOK
+    }
+}

--- a/pumpkin/src/entity/passive/snow_golem.rs
+++ b/pumpkin/src/entity/passive/snow_golem.rs
@@ -6,7 +6,8 @@ use crate::entity::{
     Entity, NBTStorage,
     ai::goal::{
         active_target::ActiveTargetGoal, look_around::RandomLookAroundGoal,
-        look_at_entity::LookAtEntityGoal, wander_around::WanderAroundGoal,
+        look_at_entity::LookAtEntityGoal, snowball_attack::SnowballAttackGoal,
+        wander_around::WanderAroundGoal,
     },
     mob::{Mob, MobEntity},
 };
@@ -29,7 +30,7 @@ impl SnowGolemEntity {
             let mut goal_selector = mob_arc.mob_entity.goals_selector.lock().unwrap();
             let mut target_selector = mob_arc.mob_entity.target_selector.lock().unwrap();
 
-            // TODO: SnowballAttackGoal
+            goal_selector.add_goal(1, SnowballAttackGoal::new(1.25, 20, 10.0));
             goal_selector.add_goal(5, Box::new(WanderAroundGoal::new(1.0)));
             goal_selector.add_goal(
                 6,


### PR DESCRIPTION
## What was changed?

Adds `SnowballAttackGoal` and gives it to the **snow golem** so it actually defends itself by throwing snowballs, instead of only wandering (it had a `// TODO: SnowballAttackGoal` and no attack goal at all).

- **New `pumpkin/src/entity/ai/goal/snowball_attack.rs`** — vanilla `ProjectileAttackGoal` style:
  - approaches until the target is within range, then holds position,
  - lobs a snowball every 20 ticks with vanilla ballistics: aim at `eyeY - 1.1`, `velocity(dx, dy + horizontal * 0.2, dz, 1.6, 12.0)`,
  - plays the snow golem shoot sound.
- **Snow golem** registers the goal at priority 1.

## Why were these changes necessary?

Snow golems are meant to pelt hostile mobs with snowballs (knocking them back, and damaging blazes). Without an attack goal they were passive wanderers.

## Impact

Snow golems now throw snowballs at their target from range and close the distance when too far. No other mob changes.

## Known limitations

- Mob line-of-sight raycasting doesn't exist upstream yet (`BlazeShootFireballGoal` has the same limitation), so the target is treated as visible while the goal runs.
- Part of a small series filling in ranged-attack AI (skeleton bows and pillager/piglin crossbows landed separately; witch potions can follow).

## Testing

`cargo clippy -p pumpkin --all-targets` passes with no warnings. The change is additive and isolated to the snow golem AI; in-game verification of the throwing behavior is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
