### PR TITLE
feat(entity): witches throw splash potions of Harming 🤖🤖🤖

### DIFF
--- a/pumpkin/src/entity/ai/goal/mod.rs
+++ b/pumpkin/src/entity/ai/goal/mod.rs
@@ -30,6 +30,7 @@ pub mod teleport_towards_player;
 pub mod tempt;
 pub(crate) mod track_target;
 pub mod wander_around;
+pub mod witch_attack;
 pub mod zombie_attack;
 
 #[must_use]

--- a/pumpkin/src/entity/ai/goal/witch_attack.rs
+++ b/pumpkin/src/entity/ai/goal/witch_attack.rs
@@ -1,0 +1,184 @@
+use super::{Controls, Goal, GoalFuture};
+use crate::entity::ai::pathfinder::NavigatorGoal;
+use crate::entity::mob::Mob;
+use crate::entity::projectile::splash_potion::SplashPotionEntity;
+use crate::entity::{Entity, EntityBase};
+use pumpkin_data::data_component::DataComponent;
+use pumpkin_data::data_component_impl::{DataComponentImpl, PotionContentsImpl};
+use pumpkin_data::entity::EntityType;
+use pumpkin_data::item::Item;
+use pumpkin_data::item_stack::ItemStack;
+use pumpkin_data::potion::Potion;
+use pumpkin_data::sound::{Sound, SoundCategory};
+use std::sync::Arc;
+
+/// Ranged potion-throwing behavior for the witch.
+///
+/// Mirrors vanilla `WitchEntity::shootAt`: the witch approaches until the target
+/// is in range, holds position, and throws a splash potion of Harming on a fixed
+/// interval. Mob line of sight isn't modelled upstream yet (see
+/// `BlazeShootFireballGoal`), so the target counts as visible while the goal
+/// runs.
+pub struct WitchAttackGoal {
+    /// Movement speed multiplier while approaching the target.
+    speed: f64,
+    /// Squared maximum throwing range.
+    squared_range: f64,
+    /// Ticks between two throws.
+    interval: i32,
+    /// Ticks until the next throw (`<= 0` means ready).
+    cooldown: i32,
+    /// How long the target has been continuously visible.
+    target_seeing_ticks: i32,
+}
+
+impl WitchAttackGoal {
+    /// `speed` is the approach speed multiplier, `interval` the ticks between
+    /// throws, and `range` the maximum throwing distance in blocks.
+    #[must_use]
+    pub fn new(speed: f64, interval: i32, range: f32) -> Box<Self> {
+        Box::new(Self {
+            speed,
+            squared_range: f64::from(range * range),
+            interval,
+            cooldown: -1,
+            target_seeing_ticks: 0,
+        })
+    }
+
+    /// Throws a splash potion of Harming toward `target`, matching vanilla
+    /// `WitchEntity::shootAt`: lead the target by its velocity, aim at
+    /// `eyeY - 1.1`, and `velocity(dx, dy + horizontal * 0.2, dz, 0.75, 8.0)`.
+    /// The `SplashPotionEntity` applies the potion's effects on impact.
+    async fn shoot_at(mob: &dyn Mob, target: &dyn EntityBase) {
+        let shooter = mob.get_entity();
+        let world = shooter.world.load();
+
+        let mut spawn_pos = shooter.pos.load();
+        spawn_pos.y = shooter.get_eye_y() - 0.1;
+        let potion_entity = Entity::from_uuid(
+            uuid::Uuid::new_v4(),
+            world.clone(),
+            spawn_pos,
+            &EntityType::SPLASH_POTION,
+        );
+        let potion = SplashPotionEntity::new_shot(potion_entity, shooter);
+
+        // Load the thrown potion with a splash potion of Harming.
+        let contents = PotionContentsImpl {
+            potion_id: Some(i32::from(Potion::HARMING.id)),
+            custom_color: None,
+            custom_effects: Vec::new(),
+            custom_name: None,
+        };
+        let stack = ItemStack::new_with_component(
+            1,
+            &Item::SPLASH_POTION,
+            vec![(DataComponent::PotionContents, Some(contents.to_dyn()))],
+        );
+        potion.set_item_stack(stack).await;
+
+        let shooter_pos = shooter.pos.load();
+        let target_entity = target.get_entity();
+        let target_pos = target_entity.pos.load();
+        let target_velocity = target_entity.velocity.load();
+
+        // Lead the target by its velocity, like vanilla.
+        let dx = (target_pos.x + target_velocity.x) - shooter_pos.x;
+        let dy = (target_entity.get_eye_y() - 1.1) - spawn_pos.y;
+        let dz = (target_pos.z + target_velocity.z) - shooter_pos.z;
+        let horizontal = dx.hypot(dz);
+
+        potion
+            .thrown
+            .set_velocity(dx, horizontal.mul_add(0.2, dy), dz, 0.75, 8.0);
+
+        world.play_sound(
+            Sound::EntityWitchThrow,
+            SoundCategory::Hostile,
+            &shooter_pos,
+        );
+        world.spawn_entity(Arc::new(potion)).await;
+    }
+}
+
+impl Goal for WitchAttackGoal {
+    fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
+        Box::pin(async {
+            let target = mob.get_mob_entity().target.lock().await;
+            target.as_ref().is_some_and(|t| t.get_entity().is_alive())
+        })
+    }
+
+    fn should_continue<'a>(&'a self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
+        Box::pin(async {
+            let target = mob.get_mob_entity().target.lock().await;
+            target.as_ref().is_some_and(|t| t.get_entity().is_alive())
+        })
+    }
+
+    fn start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async {
+            mob.get_mob_entity().set_attacking(true);
+        })
+    }
+
+    fn stop<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async {
+            mob.get_mob_entity().set_attacking(false);
+            mob.get_mob_entity().navigator.lock().unwrap().stop();
+            self.cooldown = -1;
+            self.target_seeing_ticks = 0;
+        })
+    }
+
+    fn tick<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async {
+            let target = mob.get_mob_entity().target.lock().await.clone();
+            let Some(target) = target else {
+                return;
+            };
+
+            let mob_pos = mob.get_entity().pos.load();
+            let target_pos = target.get_entity().pos.load();
+            let distance_sq = mob_pos.squared_distance_to_vec(&target_pos);
+
+            // Upstream has no mob line-of-sight raycast yet, so the target counts
+            // as continuously visible while this goal runs.
+            self.target_seeing_ticks += 1;
+
+            let in_range = distance_sq <= self.squared_range && self.target_seeing_ticks >= 5;
+            {
+                let mut navigator = mob.get_mob_entity().navigator.lock().unwrap();
+                if in_range {
+                    navigator.stop();
+                } else {
+                    navigator.set_progress(NavigatorGoal::new(mob_pos, target_pos, self.speed));
+                }
+            }
+
+            mob.get_mob_entity()
+                .look_control
+                .lock()
+                .unwrap()
+                .look_at_entity_with_range(&target, 30.0, 30.0);
+
+            if in_range {
+                if self.cooldown > 0 {
+                    self.cooldown -= 1;
+                } else {
+                    Self::shoot_at(mob, target.as_ref()).await;
+                    self.cooldown = self.interval;
+                }
+            }
+        })
+    }
+
+    fn should_run_every_tick(&self) -> bool {
+        true
+    }
+
+    fn controls(&self) -> Controls {
+        Controls::MOVE | Controls::LOOK
+    }
+}

--- a/pumpkin/src/entity/mob/witch.rs
+++ b/pumpkin/src/entity/mob/witch.rs
@@ -7,7 +7,7 @@ use crate::entity::{
     ai::goal::{
         active_target::ActiveTargetGoal, look_around::RandomLookAroundGoal,
         look_at_entity::LookAtEntityGoal, revenge::RevengeGoal, swim::SwimGoal,
-        wander_around::WanderAroundGoal,
+        wander_around::WanderAroundGoal, witch_attack::WitchAttackGoal,
     },
     mob::{Mob, MobEntity},
 };
@@ -31,8 +31,8 @@ impl WitchEntity {
             let mut target_selector = mob_arc.mob_entity.target_selector.lock().unwrap();
 
             goal_selector.add_goal(1, Box::new(SwimGoal::default()));
-            // TODO: WitchAttackGoal (potions)
-            goal_selector.add_goal(2, Box::new(WanderAroundGoal::new(1.0)));
+            goal_selector.add_goal(2, WitchAttackGoal::new(1.0, 60, 10.0));
+            goal_selector.add_goal(3, Box::new(WanderAroundGoal::new(1.0)));
             goal_selector.add_goal(
                 3,
                 LookAtEntityGoal::with_default(mob_weak, &EntityType::PLAYER, 8.0),


### PR DESCRIPTION
## What was changed?

Adds `WitchAttackGoal` and gives it to the **witch** so it actually attacks by throwing splash potions, instead of only wandering (it had a `// TODO: WitchAttackGoal (potions)` and no attack goal).

- **New `pumpkin/src/entity/ai/goal/witch_attack.rs`** — mirrors vanilla `WitchEntity::shootAt`:
  - approaches until the target is within range, then holds position,
  - throws a **splash potion of Harming** every 60 ticks, leading the target by its velocity, aiming at `eyeY - 1.1`, with vanilla ballistics `velocity(dx, dy + horizontal * 0.2, dz, 0.75, 8.0)`,
  - plays the witch throw sound. The existing `SplashPotionEntity` applies the potion effects (an AoE splash) on impact.
- **Witch** registers the goal at priority 2; the wander goal moves to priority 3 to match vanilla and avoid a `MOVE`-control conflict with the attack goal.

## Why were these changes necessary?

Witches attack by lobbing harmful splash potions, but the witch registered no attack goal, so it just wandered and never fought back.

## Impact

Witches now throw splash potions of Harming at their target from range and close the distance when too far. No other mob changes.

## Known limitations

- Only Harming is thrown for now. Vanilla also picks Slowness (target far), Poison (healthy target) or Weakness (target close); dynamic selection is left as a follow-up.
- Self-buff drinking (`isDrinking`) and witch potion immunity aren't modelled here.
- Mob line-of-sight raycasting doesn't exist upstream yet (`BlazeShootFireballGoal` has the same limitation), so the target is treated as visible while the goal runs.
- Final of a small series filling in ranged-attack AI (skeleton bows, pillager/piglin crossbows and snow golem snowballs landed separately).

## Testing

`cargo clippy -p pumpkin --all-targets` passes with no warnings. The change is additive and isolated to the witch AI; in-game verification of the throwing behavior is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
