### PR TITLE
fix: make SNBT operation `bool()` return `true` for all non-zero values

### DIFF
--- a/pumpkin-codecs/src/dynamic_ops.rs
+++ b/pumpkin-codecs/src/dynamic_ops.rs
@@ -70,9 +70,7 @@ pub trait DynamicOps {
     create_number_impl!(double, f64, Double, create_double);
 
     /// Returns how a boolean is represented by this `DynamicOps`.
-    fn create_bool(&self, data: bool) -> Self::Value {
-        self.create_byte(i8::from(data))
-    }
+    fn create_bool(&self, data: bool) -> Self::Value;
 
     /// Returns how a string is represented by this `DynamicOps`.
     fn create_string(&self, data: &str) -> Self::Value;
@@ -88,9 +86,7 @@ pub trait DynamicOps {
         I: IntoIterator<Item = (Self::Value, Self::Value)>;
 
     /// Tries to get a `bool` represented by this `DynamicOps`.
-    fn get_bool(&self, input: &Self::Value) -> DataResult<bool> {
-        self.get_number(input).map(|n| i8::from(n) != 0)
-    }
+    fn get_bool(&self, input: &Self::Value) -> DataResult<bool>;
 
     /// Tries to get a number represented by this `DynamicOps`.
     fn get_number(&self, input: &Self::Value) -> DataResult<Number>;

--- a/pumpkin-nbt/src/nbt_ops.rs
+++ b/pumpkin-nbt/src/nbt_ops.rs
@@ -83,6 +83,10 @@ impl DynamicOps for NbtOps {
         compound.into()
     }
 
+    fn get_bool(&self, input: &Self::Value) -> DataResult<bool> {
+        self.get_number(input).map(|n| f64::from(n) != 0.0)
+    }
+
     fn get_number(&self, input: &Self::Value) -> DataResult<Number> {
         match input {
             NbtTag::Byte(b) => DataResult::new_success(Number::Byte(*b)),

--- a/pumpkin/src/command/snbt/tests.rs
+++ b/pumpkin/src/command/snbt/tests.rs
@@ -286,7 +286,7 @@ fn operations() {
     assert_parse_ok!("bool(0)", NbtTag::Byte(0));
     assert_parse_ok!("bool( 1 )", NbtTag::Byte(1));
     assert_parse_ok!("bool (2.5  )", NbtTag::Byte(1));
-    assert_parse_ok!("bool ( -4.3412e+12  )", NbtTag::Byte(0));
+    assert_parse_ok!("bool ( -4.3412e+12  )", NbtTag::Byte(1));
 
     assert_parse_err!("bool(", "Expected a valid unquoted string", 5, [")"]);
     assert_parse_err!("bool()", "No such operation: bool/0", 6, []);


### PR DESCRIPTION
## Description

Fixes the `bool` SNBT operation to return `true` for all non-zero values after Mojang has fixed the bug described in [MC-307774](https://bugs.mojang.com/browse/MC/issues/MC-307774).

## Testing

Edited a test to make it succeed again for the one test case affected by the bug, which confirms that it works as intended.