### PR TITLE
perf(entity): swap std hashmap for fxhashmap in pathfind

### DIFF
--- a/pumpkin/src/entity/ai/pathfinder/binary_heap.rs
+++ b/pumpkin/src/entity/ai/pathfinder/binary_heap.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use pumpkin_util::math::vector3::Vector3;
 
@@ -12,7 +12,7 @@ use crate::entity::ai::pathfinder::node::{Coordinate, Node};
 #[derive(Debug, Clone)]
 pub struct BinaryHeap {
     heap: Vec<Option<Node>>,
-    position_map: HashMap<Vector3<i32>, usize>,
+    position_map: FxHashMap<Vector3<i32>, usize>,
     size: usize,
 }
 
@@ -24,7 +24,7 @@ impl BinaryHeap {
 
         Self {
             heap,
-            position_map: HashMap::new(),
+            position_map: FxHashMap::default(),
             size: 0,
         }
     }
@@ -36,7 +36,7 @@ impl BinaryHeap {
 
         Self {
             heap,
-            position_map: HashMap::with_capacity(capacity),
+            position_map: FxHashMap::with_capacity_and_hasher(capacity, FxBuildHasher),
             size: 0,
         }
     }

--- a/pumpkin/src/entity/ai/pathfinder/node_evaluator.rs
+++ b/pumpkin/src/entity/ai/pathfinder/node_evaluator.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use pumpkin_util::math::{position::BlockPos, vector3::Vector3};
 
@@ -133,7 +133,7 @@ impl MobData {
 pub struct BaseNodeEvaluator {
     pub context: Option<PathfindingContext>,
     pub mob_data: Option<MobData>,
-    pub nodes: HashMap<Vector3<i32>, Node>,
+    pub nodes: FxHashMap<Vector3<i32>, Node>,
     pub entity_width: i32,
     pub entity_height: i32,
     pub entity_depth: i32, // Same as width?
@@ -155,7 +155,7 @@ impl BaseNodeEvaluator {
         Self {
             context: None,
             mob_data: None,
-            nodes: HashMap::new(),
+            nodes: FxHashMap::default(),
             entity_width: 1,
             entity_height: 2,
             entity_depth: 1,

--- a/pumpkin/src/entity/ai/pathfinder/path_type_cache.rs
+++ b/pumpkin/src/entity/ai/pathfinder/path_type_cache.rs
@@ -1,7 +1,7 @@
 use pumpkin_util::math::vector3::Vector3;
 
 use crate::entity::ai::pathfinder::node::PathType;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 const CACHE_SIZE: usize = 4096;
 const CACHE_MASK: usize = CACHE_SIZE - 1;
@@ -10,7 +10,7 @@ const CACHE_MASK: usize = CACHE_SIZE - 1;
 pub struct PathTypeCache {
     positions: Vec<i64>,
     path_types: Vec<Option<PathType>>,
-    overflow_cache: HashMap<Vector3<i32>, PathType>,
+    overflow_cache: FxHashMap<Vector3<i32>, PathType>,
 }
 
 impl PathTypeCache {
@@ -19,7 +19,7 @@ impl PathTypeCache {
         Self {
             positions: vec![0; CACHE_SIZE],
             path_types: vec![None; CACHE_SIZE],
-            overflow_cache: HashMap::new(),
+            overflow_cache: FxHashMap::default(),
         }
     }
 

--- a/pumpkin/src/entity/ai/pathfinder/pathfinding_context.rs
+++ b/pumpkin/src/entity/ai/pathfinder/pathfinding_context.rs
@@ -13,13 +13,14 @@ use crate::{
     world::World,
 };
 
-use std::{collections::HashMap, sync::Arc};
+use rustc_hash::FxHashMap;
+use std::sync::Arc;
 
 pub struct PathfindingContext {
     path_type_cache: Option<PathTypeCache>,
     mob_position: Vector3<i32>,
     world: Arc<World>,
-    collision_cache: HashMap<Vector3<i32>, bool>,
+    collision_cache: FxHashMap<Vector3<i32>, bool>,
 }
 
 impl PathfindingContext {
@@ -28,7 +29,7 @@ impl PathfindingContext {
             path_type_cache: Some(PathTypeCache::new()),
             mob_position,
             world,
-            collision_cache: HashMap::new(),
+            collision_cache: FxHashMap::default(),
         }
     }
 
@@ -37,7 +38,7 @@ impl PathfindingContext {
             path_type_cache: Some(cache),
             mob_position,
             world,
-            collision_cache: HashMap::new(),
+            collision_cache: FxHashMap::default(),
         }
     }
 

--- a/pumpkin/src/entity/ai/pathfinder/walk_node_evaluator.rs
+++ b/pumpkin/src/entity/ai/pathfinder/walk_node_evaluator.rs
@@ -1,5 +1,5 @@
 use pumpkin_util::math::{position::BlockPos, vector3::Vector3};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::entity::ai::pathfinder::{
     node::{Coordinate, Node, PathType, Target},
@@ -14,7 +14,7 @@ const DEFAULT_MOB_JUMP_HEIGHT: f64 = 1.125;
 
 pub struct WalkNodeEvaluator {
     base: BaseNodeEvaluator,
-    path_types_cache: HashMap<Vector3<i32>, PathType>,
+    path_types_cache: FxHashMap<Vector3<i32>, PathType>,
     reusable_neighbors: [Option<Node>; 4],
 }
 
@@ -23,7 +23,7 @@ impl WalkNodeEvaluator {
     pub fn new() -> Self {
         Self {
             base: BaseNodeEvaluator::new(),
-            path_types_cache: HashMap::new(),
+            path_types_cache: FxHashMap::default(),
             reusable_neighbors: [None, None, None, None],
         }
     }


### PR DESCRIPTION
## Description

Swaps out the usage of std::collections::HashMap to rustc_hash::Fx* in the pathfind module for faster non-cryptographic hashing.

## Testing

I measured a speedup of ~2.8x on average for 64 entries, inserting and looking up Vector3<i32> keys. Existing tests pass. Additionally, no deviation from the preexisting entity behavior was observed ingame. 