### PR TITLE
fix(world): respect mobGriefing for Creeper and Ghast fireball explosions 🤖🤖🤖

### DIFF
--- a/pumpkin/src/entity/mob/creeper.rs
+++ b/pumpkin/src/entity/mob/creeper.rs
@@ -110,7 +110,7 @@ impl CreeperEntity {
             .store(true, Ordering::Relaxed);
         let world = entity.world.load();
         let pos = entity.pos.load();
-        world.explode(pos, radius * multiplier).await;
+        world.explode_as_mob(pos, radius * multiplier).await;
         // TODO: spawn area effect cloud with potion effects
         entity.remove().await;
     }

--- a/pumpkin/src/entity/projectile/fireball.rs
+++ b/pumpkin/src/entity/projectile/fireball.rs
@@ -93,8 +93,7 @@ impl EntityBase for FireballEntity {
             }
 
             let hit_pos = hit.hit_pos();
-            // Explosion sets fire if mob griefing is enabled (assuming true for now)
-            world.explode(hit_pos, self.explosion_power).await;
+            world.explode_as_mob(hit_pos, self.explosion_power).await;
         })
     }
 }

--- a/pumpkin/src/world/explosion.rs
+++ b/pumpkin/src/world/explosion.rs
@@ -279,8 +279,8 @@ impl Explosion {
 
     /// Returns the removed block count
     pub async fn explode(&self, world: &Arc<World>) -> u32 {
-        let should_destroy_blocks = !self.mob_griefing_gated
-            || world.level_info.load().game_rules.mob_griefing;
+        let should_destroy_blocks =
+            !self.mob_griefing_gated || world.level_info.load().game_rules.mob_griefing;
 
         let blocks = if should_destroy_blocks {
             self.get_blocks_to_destroy(world)

--- a/pumpkin/src/world/explosion.rs
+++ b/pumpkin/src/world/explosion.rs
@@ -18,12 +18,26 @@ use super::{BlockFlags, World};
 pub struct Explosion {
     power: f32,
     pos: Vector3<f64>,
+    mob_griefing_gated: bool,
 }
 
 impl Explosion {
     #[must_use]
     pub const fn new(power: f32, pos: Vector3<f64>) -> Self {
-        Self { power, pos }
+        Self {
+            power,
+            pos,
+            mob_griefing_gated: false,
+        }
+    }
+
+    /// Marks this explosion as caused by a mob (e.g. a Creeper or a Ghast
+    /// fireball), so block destruction respects the `mobGriefing` game rule.
+    /// Entities are still damaged either way; only block destruction is gated.
+    #[must_use]
+    pub const fn with_mob_griefing_gate(mut self) -> Self {
+        self.mob_griefing_gated = true;
+        self
     }
 
     fn get_blocks_to_destroy(
@@ -265,7 +279,14 @@ impl Explosion {
 
     /// Returns the removed block count
     pub async fn explode(&self, world: &Arc<World>) -> u32 {
-        let blocks = self.get_blocks_to_destroy(world);
+        let should_destroy_blocks = !self.mob_griefing_gated
+            || world.level_info.load().game_rules.mob_griefing;
+
+        let blocks = if should_destroy_blocks {
+            self.get_blocks_to_destroy(world)
+        } else {
+            FxHashMap::default()
+        };
         self.damage_entities(world).await;
         for (pos, (block, state)) in &blocks {
             world

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -3223,7 +3223,27 @@ impl World {
     }
 
     pub async fn explode(self: &Arc<Self>, position: Vector3<f64>, power: f32) {
-        let explosion = Explosion::new(power, position);
+        self.explode_inner(position, power, false).await;
+    }
+
+    /// Like [`Self::explode`], but marks the explosion as mob-caused (e.g. a
+    /// Creeper or a Ghast fireball) so block destruction respects the
+    /// `mobGriefing` game rule. Entities are still damaged either way.
+    pub async fn explode_as_mob(self: &Arc<Self>, position: Vector3<f64>, power: f32) {
+        self.explode_inner(position, power, true).await;
+    }
+
+    async fn explode_inner(
+        self: &Arc<Self>,
+        position: Vector3<f64>,
+        power: f32,
+        mob_griefing_gated: bool,
+    ) {
+        let explosion = if mob_griefing_gated {
+            Explosion::new(power, position).with_mob_griefing_gate()
+        } else {
+            Explosion::new(power, position)
+        };
         let block_count = explosion.explode(self).await;
         let particle = if power < 2.0 {
             Particle::Explosion


### PR DESCRIPTION
## What

Creeper and Ghast fireball explosions destroyed blocks unconditionally, never checking the `mobGriefing` game rule. Entities were (and still are) damaged either way — only block destruction was missing the gate.

## Why these two, and not the others

`World::explode` is shared by every explosion source (Creeper, Ghast fireball, TNT, TNT minecart, End Crystal, bed/respawn-anchor). In vanilla, only *mob-caused* explosions are gated by `mobGriefing` — TNT, crystals and beds intentionally always destroy blocks regardless of the rule. So this PR only changes behavior for the two mob-caused sources; the other call sites are untouched (zero behavior change, zero regression risk there). `fireball.rs` already had a comment flagging this exact gap (`// Explosion sets fire if mob griefing is enabled (assuming true for now)`).

## How

- `Explosion` gets a `mob_griefing_gated` flag (default `false`, set via a new `with_mob_griefing_gate()` builder) — when set, block destruction is skipped if the rule is off, but entity damage still runs unconditionally.
- `World::explode_as_mob(pos, power)` is added alongside the existing `World::explode(pos, power)`, wired through a shared private `explode_inner`.
- `CreeperEntity::explode` and `FireballEntity::on_hit` now call `explode_as_mob`; every other call site (`tnt.rs`, `minecart.rs`, `end_crystal.rs`, `bed.rs`, `wind_charge.rs`, the WASM plugin API) is untouched.

## Test plan

- [x] `cargo clippy -p pumpkin --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual: set `mobGriefing` to `false`, let a Creeper explode near blocks — blocks should survive, player should still take damage.