### PR TITLE
fix(worldgen): attach loot tables to Desert Pyramid and Buried Treasure chests 🤖🤖🤖

### DIFF
--- a/pumpkin-world/src/generation/structure/structures/buried_treasure.rs
+++ b/pumpkin-world/src/generation/structure/structures/buried_treasure.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
 use pumpkin_data::{Block, BlockDirection, BlockId};
+use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::{
     HeightMap,
     math::{block_box::BlockBox, position::BlockPos},
-    random::RandomGenerator,
+    random::{RandomGenerator, RandomImpl},
 };
 
 use crate::{
@@ -58,7 +59,7 @@ impl StructurePieceBase for BuriedTreasurePiece {
         &mut self,
         chunk: &mut ProtoChunk,
         _block_registry: &dyn WorldPortalExt,
-        _random: &mut RandomGenerator,
+        random: &mut RandomGenerator,
         _seed: i64,
         _chunk_box: &BlockBox,
     ) {
@@ -117,9 +118,18 @@ impl StructurePieceBase for BuriedTreasurePiece {
                     chunk.set_block_state(offset_pos.0.x, offset_pos.0.y, offset_pos.0.z, state1);
                 }
 
-                // Place the Chest
-                // TODO: Add loot table logic here (requires seed)
+                // Place the Chest, deferring its contents to the loot table
+                // (rolled lazily the first time a player opens it).
                 chunk.set_block_state(pos.0.x, pos.0.y, pos.0.z, Block::CHEST.default_state);
+
+                let mut chest_nbt = NbtCompound::new();
+                chest_nbt.put_string("id", "minecraft:chest".to_string());
+                chest_nbt.put_int("x", pos.0.x);
+                chest_nbt.put_int("y", pos.0.y);
+                chest_nbt.put_int("z", pos.0.z);
+                chest_nbt.put_string("LootTable", "minecraft:chests/buried_treasure".to_string());
+                chest_nbt.put_long("LootTableSeed", random.next_i64());
+                chunk.add_block_entity(chest_nbt);
                 return;
             }
             pos = pos.down();

--- a/pumpkin-world/src/generation/structure/structures/desert_pyramid.rs
+++ b/pumpkin-world/src/generation/structure/structures/desert_pyramid.rs
@@ -166,10 +166,12 @@ impl DesertPyramidPiece {
         // the structure-level afterPlace pass when brushable support exists.
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn try_place_chest(
         &mut self,
         chunk: &mut ProtoChunk,
         bb: &BlockBox,
+        random: &mut RandomGenerator,
         index: usize,
         x: i32,
         y: i32,
@@ -192,7 +194,8 @@ impl DesertPyramidPiece {
         nbt.put_int("y", world_pos.y);
         nbt.put_int("z", world_pos.z);
         nbt.put_string("id", "minecraft:chest".to_string());
-        // TODO: attach desert_pyramid loot table once structure container loot exists.
+        nbt.put_string("LootTable", "minecraft:chests/desert_pyramid".to_string());
+        nbt.put_long("LootTableSeed", random.next_i64());
         chunk.add_block_entity(nbt);
         self.has_placed_chest[index] = true;
     }
@@ -788,7 +791,7 @@ impl StructurePieceBase for DesertPyramidPiece {
         self.piece.add_block(chunk, cut, 10, -11, 13, bb);
 
         for (index, x, z) in [(0, 10, 12), (1, 8, 10), (2, 10, 8), (3, 12, 10)] {
-            self.try_place_chest(chunk, bb, index, x, -11, z);
+            self.try_place_chest(chunk, bb, random, index, x, -11, z);
         }
 
         self.add_cellar(chunk, bb, &mut level_random);


### PR DESCRIPTION
## What

Desert Pyramid and Buried Treasure both place a chest block during structure generation, but neither ever attaches a loot table — the chests generate permanently empty. Buried Treasure's chest didn't even register a block entity at all, so it's not clear it could even be opened as a container.

## How

Mirrors the pattern already used (and working) by the dungeon/monster-room feature (`pumpkin-world/src/generation/feature/features/monster_room.rs`): write a `LootTable` resource location + `LootTableSeed` into the chest's block-entity NBT at generation time. The existing chest block entity (`pumpkin/src/block/entities/chest_like_block_entity.rs`) already knows how to lazily roll a pending `LootTable` into real items the first time a player opens the container — no new loot-resolution logic needed, just wiring the two structures into the mechanism that already exists.

- `desert_pyramid.rs`: `try_place_chest` now takes the piece's `RandomGenerator` and writes `LootTable = "minecraft:chests/desert_pyramid"` + a seed instead of leaving the NBT loot-less.
- `buried_treasure.rs`: now registers a block entity at all (previously it only set the block state), with `LootTable = "minecraft:chests/buried_treasure"`.

## Test plan

- [x] `cargo clippy -p pumpkin-world --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual: generate/locate a Desert Pyramid and a Buried Treasure, open the chests, confirm they're populated instead of empty.