### PR TITLE
fix(data): remove redundant references flagged by newer clippy in panic! args 🤖🤖🤖

### DIFF
--- a/pumpkin-data/src/generated/fluid.rs
+++ b/pumpkin-data/src/generated/fluid.rs
@@ -902,7 +902,7 @@ impl FluidProperties for WaterLikeFluidProperties {
         if !["water", "lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "WaterLikeFluidProperties"
+                fluid.name, "WaterLikeFluidProperties"
             );
         }
         let prop_index = self.to_index();
@@ -916,7 +916,7 @@ impl FluidProperties for WaterLikeFluidProperties {
         if !["water", "lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "WaterLikeFluidProperties"
+                fluid.name, "WaterLikeFluidProperties"
             );
         }
         for (idx, state) in fluid.states.iter().enumerate() {
@@ -930,7 +930,7 @@ impl FluidProperties for WaterLikeFluidProperties {
         if !["water", "lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "WaterLikeFluidProperties"
+                fluid.name, "WaterLikeFluidProperties"
             );
         }
         Self::from_index(fluid.default_state_index)
@@ -942,7 +942,7 @@ impl FluidProperties for WaterLikeFluidProperties {
         if !["water", "lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "WaterLikeFluidProperties"
+                fluid.name, "WaterLikeFluidProperties"
             );
         }
         let mut fluid_props = Self::default(fluid);
@@ -990,7 +990,7 @@ impl FluidProperties for FlowingWaterLikeFluidProperties {
         if !["flowing_water", "flowing_lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "FlowingWaterLikeFluidProperties"
+                fluid.name, "FlowingWaterLikeFluidProperties"
             );
         }
         let prop_index = self.to_index();
@@ -1004,7 +1004,7 @@ impl FluidProperties for FlowingWaterLikeFluidProperties {
         if !["flowing_water", "flowing_lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "FlowingWaterLikeFluidProperties"
+                fluid.name, "FlowingWaterLikeFluidProperties"
             );
         }
         for (idx, state) in fluid.states.iter().enumerate() {
@@ -1018,7 +1018,7 @@ impl FluidProperties for FlowingWaterLikeFluidProperties {
         if !["flowing_water", "flowing_lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "FlowingWaterLikeFluidProperties"
+                fluid.name, "FlowingWaterLikeFluidProperties"
             );
         }
         Self::from_index(fluid.default_state_index)
@@ -1033,7 +1033,7 @@ impl FluidProperties for FlowingWaterLikeFluidProperties {
         if !["flowing_water", "flowing_lava"].contains(&fluid.name) {
             panic!(
                 "{} is not a valid fluid for {}",
-                &fluid.name, "FlowingWaterLikeFluidProperties"
+                fluid.name, "FlowingWaterLikeFluidProperties"
             );
         }
         let mut fluid_props = Self::default(fluid);


### PR DESCRIPTION
## Summary

A newer stable Rust/clippy release (1.97) newly flags `clippy::useless_borrows_in_formatting` at 123 call sites in
`pumpkin-data/src/generated/block.rs` and `fluid.rs`: `panic!("...", &block.name)` / `panic!("...", &fluid.name)`
borrow a field that's already passed by reference to the formatting machinery, so the `&` is redundant.

This isn't specific to any one PR — because CI's `rust-toolchain.toml` tracks `channel = "stable"` and the runner
always installs the current latest stable, **every open PR that touches `pumpkin-data` (directly or transitively)
is currently failing `Run lints (debug)` / `Run lints (release)`** with the exact same 123 errors, regardless of
what the PR itself changes. I found this while chasing down what looked like CI failures on my own PRs and traced
it to this pre-existing latent issue in checked-in generated code that only a newer toolchain surfaces.

## What changed

Purely mechanical: for each of the 123 sites clippy flagged, removed exactly the `&` it pointed at. Nothing else
touched. No behavior change — `panic!`/`format!` already format the value through a reference internally, so
`&block.name` and `block.name` produce identical output.

## Testing

Applied precisely at the (file, line, column) clippy itself reported, with a script-level assertion that the
character at each position was actually `&` before removing it (verified no mismatches — all 123 applied cleanly).
Diff reviewed by hand: every changed line is a `panic!` argument list, nothing outside that context was touched,
and brace/paren balance across both files is unchanged. I was not able to run a local `cargo test`/`clippy` pass
against Rust 1.97 due to a local toolchain install issue on my end (unrelated to this repo) — CI will be the
first real verification of this diff; happy to iterate if it surfaces anything.