### PR TITLE
fix: preserve stacked buckets when collecting fluids

### DIFF
--- a/pumpkin/src/item/items/bucket.rs
+++ b/pumpkin/src/item/items/bucket.rs
@@ -112,10 +112,19 @@ async fn give_player_bucket_item(player: &Player, item: &'static Item) {
             .await;
     } else {
         let item_stack = ItemStack::new(1, item);
-        player
-            .inventory
-            .set_stack(player.inventory.get_selected_slot().into(), item_stack)
-            .await;
+        let held_item = player.inventory.held_item();
+        let mut held_stack = held_item.lock().await;
+
+        if held_stack.item_count == 1 {
+            *held_stack = item_stack;
+        } else {
+            held_stack.decrement(1);
+            drop(held_stack);
+            player
+                .inventory
+                .offer_or_drop_stack(item_stack, player)
+                .await;
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

Picking up fluid while holding stack of empty bucket replaced the entire stack with 1 filled bucket deleting the other buckets.

Now it works as intended in Vanilla.

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] Manually tested collecting water, lava, and powder snow with stacked buckets

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
