### PR TITLE
fix(inventory): prevent anvil rename stack duplication

### DIFF
--- a/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
+++ b/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
@@ -203,13 +203,7 @@ impl ScreenHandler for AnvilScreenHandler {
                             }
 
                             // Consume inputs
-                            let input_a = self.inventory.get_stack(0).await;
-                            let mut input_a = input_a.lock().await;
-                            input_a.decrement(1); // Usually consumes 1
-                            if input_a.is_empty() {
-                                *input_a = ItemStack::EMPTY.clone();
-                            }
-                            drop(input_a);
+                            self.inventory.set_stack(0, ItemStack::EMPTY.clone()).await;
                             self.get_behaviour().slots[0].mark_dirty().await;
                         } else {
                             // Cancel click


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Fixes a item duplication bug when renaming a entire stack in anvil it used 1 and created a stack of renamed items thus creating duplicates.

Now the whole stack gets consumed while renaming as per Vanilla.

## Testing
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] Manually tested renaming items in the anvil

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
