### PR TITLE
fix: resume arrow falling when the block it's stuck in is broken

### DIFF
--- a/pumpkin/src/entity/projectile/arrow.rs
+++ b/pumpkin/src/entity/projectile/arrow.rs
@@ -210,6 +210,20 @@ impl EntityBase for ArrowEntity {
             }
 
             if self.in_ground.load(Ordering::Relaxed) {
+                // The block we stuck into may have been broken (or otherwise turned
+                // non-solid) since last tick. Re-check for collision at our current
+                // position and, if there is none anymore, resume falling instead of
+                // staying frozen in place forever.
+                let stuck_pos = entity.pos.load();
+                let stuck_box = BoundingBox::new(stuck_pos, stuck_pos).expand(0.06, 0.06, 0.06);
+                if world.is_space_empty(stuck_box) {
+                    self.in_ground.store(false, Ordering::Relaxed);
+                    self.in_ground_time.store(0, Ordering::Relaxed);
+                    self.life.store(0, Ordering::Relaxed);
+                    *self.last_block_pos.write().unwrap() = None;
+                    return;
+                }
+
                 // Increment in-ground time and life
                 let _in_ground_time = self.in_ground_time.fetch_add(1, Ordering::Relaxed);
                 let life = self.life.fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
## Description

**What**: `ArrowEntity::tick()` now re-checks for a solid collision at the arrow's current position on every tick while it is in the "stuck in ground" state. If that space is no longer solid (e.g. the block was mined), the arrow clears its stuck state (`in_ground`, `in_ground_time`, `life`, `last_block_pos`) and returns early so normal projectile physics (gravity, motion) takes over again on the next tick, instead of the arrow staying frozen in place.

**Why**: Previously, once an arrow set `in_ground = true` after lodging in a block, the "in ground" branch of `tick()` only incremented `in_ground_time` / `life` and checked the despawn timer — it never looked at the world again. Breaking the block a stuck arrow was resting in left the arrow visually frozen in mid-air (until it eventually despawned), which is exactly what issue #2180 reports: shoot an arrow into a block, break the block, arrow doesn't fall.

**Impact**: Small, self-contained change to `pumpkin/src/entity/projectile/arrow.rs` only. It only affects arrows already in the "stuck" state; arrows still flying, or stuck in blocks that remain solid, behave exactly as before. No public API / protocol changes.

**Limitations**:
- The "is this space still solid" check uses a small epsilon-expanded bounding box (`expand(0.06, 0.06, 0.06)`) around the arrow's stored position via `world.is_space_empty(...)`, the same pattern already used elsewhere in the codebase for this kind of check (e.g. `entity/mob/enderman.rs`, `entity/player.rs`). It does not re-run full projectile collision/raycasting logic — it only decides whether to resume falling.
- I did not add a dedicated unit test: `ArrowEntity::tick` needs a live `World`/`Server`/`Entity` to run, and this module has no existing harness for that kind of integration test. Verified manually instead via `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test`, both green with no regressions.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` — passes, no warnings
- `cargo test` — passes, all existing tests green (no failures, no regressions)

Fixes #2180