### PR TITLE
fix(entity): broadcast pose change on death so animation plays

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -1365,7 +1365,11 @@ impl LivingEntity {
                     ExperienceOrbEntity::spawn(&world, self.entity.pos.load(), amount).await;
                 }
             }
-            self.entity.pose.store(EntityPose::Dying);
+            // Use `set_pose` (not a raw store) so the DYING pose is actually
+            // broadcast to clients via entity metadata. Without this, clients
+            // never learn the entity's pose changed and keep rendering it in
+            // its last pose instead of playing the death animation (#2205).
+            self.entity.set_pose(EntityPose::Dying);
 
             self.drop_equipment().await;
 


### PR DESCRIPTION
## What

`LivingEntity`'s death handling set the entity's pose directly via
`self.entity.pose.store(EntityPose::Dying)` instead of calling
`Entity::set_pose(...)`. This change swaps that raw store for the existing
`set_pose` helper.

## Why

`Entity::set_pose` updates the `pose` field **and** marks the corresponding
entity-metadata field dirty so the new pose is broadcast to clients on the
next metadata sync. The raw `AtomicCell::store` used previously only updated
server-side state — clients were never told the pose changed, so they kept
rendering the entity in whatever pose it was already in and never played the
death animation.

## Impact

Killing a living entity (including players) now correctly broadcasts the
`Dying` pose to nearby clients, so the death animation plays instead of the
entity appearing to instantly vanish/stay upright while server-side death
processing runs.

## Limitations

This only addresses the missing pose broadcast described in the issue. It
does not change anything else about death handling, timing, or the
respawn-screen flow.

Note: an earlier PR (#2238) attempted to fix this same issue by zeroing the
entity's health metadata instead; it was closed for failing CI. This PR takes
a different, smaller fix (correcting the pose update to go through the
existing `set_pose` broadcast path) and has been verified locally with
`cargo clippy --all-targets --all-features -- -D warnings` and `cargo test`.

Fixes #2205
