### PR TITLE
fix(entity): correct inverted main/off-hand swing animation

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -3982,9 +3982,17 @@ impl Player {
         let world = self.world();
         let entity_id = self.entity_id();
 
+        // `hand` here is decoded (via `Hand::try_from`) from the gameplay `hand` field of
+        // packets like `SwingArm`/`UseItemOn` (see `handle_swing_arm`/`handle_use_item_on`),
+        // where protocol value `0` means "main hand" and `1` means "off hand". That decode
+        // maps `0 -> Hand::Left` and `1 -> Hand::Right`, which is the inverse of the
+        // player's actual left/right handedness used by `ClientInformation.main_hand`. So,
+        // for this gameplay context, `Hand::Left` means "main hand" and `Hand::Right` means
+        // "off hand". Getting this backwards causes the wrong arm to appear to swing for
+        // other players (see #2196).
         let animation = match hand {
-            Hand::Right => Animation::SwingMainArm,
-            Hand::Left => Animation::SwingOffhand,
+            Hand::Left => Animation::SwingMainArm,
+            Hand::Right => Animation::SwingOffhand,
         };
 
         let je_packet = pumpkin_protocol::java::client::play::CEntityAnimation::new(


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

Fixes #2196.

When a player mines, attacks, or otherwise swings while the action is bound to their main hand, other nearby players currently see the *off*-hand swing instead (and vice versa). `Player::swing_hand` picks the animation with `Hand::Right -> SwingMainArm` and `Hand::Left -> SwingOffhand`, but the `hand` it receives there is decoded via `Hand::try_from` from the raw protocol value sent by the `SwingArm`/`UseItemOn` packets, where `0` means "main hand" and `1` means "off hand" for gameplay purposes. `Hand::try_from` maps `0 -> Hand::Left` and `1 -> Hand::Right`, so for this gameplay case `Hand::Left` is actually "main hand" and `Hand::Right` is "off hand" - the exact inverse of what `swing_hand` assumed.

This is also the convention already used everywhere else this decoded value is consumed: `handle_use_item_on` and `handle_use_item` both already branch on `hand == Hand::Left` to mean "use the held/main-hand item". `swing_hand` was the one place with the mapping backwards, which is why the animation looked wrong while item/block interactions themselves were unaffected.

The fix swaps the two arms in `swing_hand`'s match and adds a comment explaining the Left/Right vs main/off-hand distinction so it doesn't get flipped back by accident. `Hand::try_from` itself, and the `ClientInformation.main_hand` handling that also uses it, are left untouched - that path already uses `0`/`1` to mean literal left/right handedness, which is a different, unrelated meaning of the same wire values, and it's already correct today.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- Traced both call sites (`handle_swing_arm`, `handle_use_item_on`) by hand to confirm the corrected mapping agrees with how `hand` is already used for held-item/slot selection in the same handlers.

I wasn't able to eyeball this with two live clients (would need to watch a second player's arm from a third-person view while the first mines), so this is verified by tracing the protocol value through the code rather than a recording. Happy to adjust if testing turns up a case I missed.
