### PR TITLE
Fix shulker box losing contents when broken and not dropping in creative

### DIFF
--- a/pumpkin-data/src/data_component_impl.rs
+++ b/pumpkin-data/src/data_component_impl.rs
@@ -2513,6 +2513,30 @@ impl ContainerImpl {
     }
 }
 impl DataComponentImpl for ContainerImpl {
+    fn write_data(&self) -> NbtTag {
+        let mut list = Vec::with_capacity(self.items.len());
+        for (slot, stack) in &self.items {
+            let mut compound = NbtCompound::new();
+            compound.put_int("slot", i32::from(*slot));
+            let mut item_compound = NbtCompound::new();
+            stack.write_item_stack(&mut item_compound);
+            compound.put_compound("item", item_compound);
+            list.push(NbtTag::Compound(compound));
+        }
+        NbtTag::List(list)
+    }
+
+    fn get_hash(&self) -> i32 {
+        let mut digest = Digest::new(Crc32Iscsi);
+        digest.update(&[Container.to_id()]);
+        for (slot, stack) in &self.items {
+            digest.update(&[*slot]);
+            digest.update(&get_str_hash(stack.item.registry_key).to_le_bytes());
+            digest.update(&get_i32_hash(i32::from(stack.item_count)).to_le_bytes());
+        }
+        digest.finalize() as i32
+    }
+
     default_impl!(Container);
 }
 #[derive(Clone, Debug)]

--- a/pumpkin-protocol/src/codec/data_component.rs
+++ b/pumpkin-protocol/src/codec/data_component.rs
@@ -1,17 +1,19 @@
 use std::borrow::Cow;
 
+use crate::codec::item_stack_seralizer::ItemStackSerializer;
 use crate::codec::var_int::VarInt;
 use pumpkin_data::Enchantment;
 use pumpkin_data::data_component::DataComponent;
 use pumpkin_data::data_component_impl::{
-    BundleContentsImpl, ConsumableImpl, ConsumeAnimation, ConsumeEffect, CustomDataImpl,
-    CustomNameImpl, DamageImpl, DataComponentImpl, EnchantmentsImpl, EquipmentSlot, EquippableImpl,
-    FireworkExplosionImpl, FireworkExplosionShape, FireworksImpl, IDSet, IDSetContent, IdOr,
-    ItemModelImpl, MapIdImpl, MaxStackSizeImpl, PotionContentsImpl, SoundEvent,
+    BundleContentsImpl, ConsumableImpl, ConsumeAnimation, ConsumeEffect, ContainerImpl,
+    CustomDataImpl, CustomNameImpl, DamageImpl, DataComponentImpl, EnchantmentsImpl, EquipmentSlot,
+    EquippableImpl, FireworkExplosionImpl, FireworkExplosionShape, FireworksImpl, IDSet,
+    IDSetContent, IdOr, ItemModelImpl, MapIdImpl, MaxStackSizeImpl, PotionContentsImpl, SoundEvent,
     StatusEffectInstance, StoredEnchantmentsImpl, UnbreakableImpl, UseCooldownImpl, get,
 };
 use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::sound::Sound;
 use pumpkin_nbt::{serializer::NbtWriteHelperJava, tag::NbtTag};
 use serde::de;
@@ -889,6 +891,7 @@ pub fn deserialize<'a, A: SeqAccess<'a>>(
         DataComponent::UseCooldown => Ok(UseCooldownImpl::deserialize(seq)?.to_dyn()),
         DataComponent::MapId => Ok(MapIdImpl::deserialize(seq)?.to_dyn()),
         DataComponent::BundleContents => Ok(BundleContentsImpl::deserialize(seq)?.to_dyn()),
+        DataComponent::Container => Ok(ContainerImpl::deserialize(seq)?.to_dyn()),
         _ => Err(serde::de::Error::custom(format!("{id:?} (TODO)"))),
     }
 }
@@ -914,6 +917,7 @@ pub fn serialize<T: SerializeStruct>(
         DataComponent::UseCooldown => get::<UseCooldownImpl>(value).serialize(seq),
         DataComponent::MapId => get::<MapIdImpl>(value).serialize(seq),
         DataComponent::BundleContents => get::<BundleContentsImpl>(value).serialize(seq),
+        DataComponent::Container => get::<ContainerImpl>(value).serialize(seq),
         _ => Err(serde::ser::Error::custom(format!(
             "{} not yet implemented",
             id.to_name()
@@ -1084,6 +1088,57 @@ impl DataComponentCodec<Self> for BundleContentsImpl {
         let mut items = Vec::with_capacity(len);
         for _ in 0..len {
             items.push(deserialize_item_stack_template(seq)?);
+        }
+        Ok(Self { items })
+    }
+}
+
+impl DataComponentCodec<Self> for ContainerImpl {
+    fn serialize<T: SerializeStruct>(&self, seq: &mut T) -> Result<(), T::Error> {
+        // Mirrors vanilla's `ItemContainerContents`: a positional list padded with empty
+        // slots up to the highest occupied slot index, so the item retains slot positions.
+        let size = self
+            .items
+            .iter()
+            .map(|(slot, _)| usize::from(*slot) + 1)
+            .max()
+            .unwrap_or(0);
+
+        seq.serialize_field::<VarInt>("", &VarInt::from(size as i32))?;
+
+        let mut slots = vec![ItemStack::EMPTY.clone(); size];
+        for (slot, stack) in &self.items {
+            if let Some(entry) = slots.get_mut(usize::from(*slot)) {
+                *entry = stack.clone();
+            }
+        }
+        for stack in slots {
+            seq.serialize_field::<ItemStackSerializer>("", &ItemStackSerializer::from(stack))?;
+        }
+        Ok(())
+    }
+
+    fn deserialize<'a, A: SeqAccess<'a>>(seq: &mut A) -> Result<Self, A::Error> {
+        const MAX_CONTAINER_ITEMS: usize = 256;
+
+        let len = seq
+            .next_element::<VarInt>()?
+            .ok_or(de::Error::custom("No ContainerImpl len VarInt!"))?
+            .0 as usize;
+
+        if len > MAX_CONTAINER_ITEMS {
+            return Err(de::Error::custom("Too many items in Container"));
+        }
+
+        let mut items = Vec::new();
+        for slot in 0..len {
+            let stack = seq
+                .next_element::<ItemStackSerializer>()?
+                .ok_or(de::Error::custom("No ContainerImpl item stack"))?
+                .to_stack();
+            if !stack.is_empty() {
+                items.push((slot as u8, stack));
+            }
         }
         Ok(Self { items })
     }

--- a/pumpkin/src/block/blocks/shulker_box.rs
+++ b/pumpkin/src/block/blocks/shulker_box.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use crate::block::{BlockFuture, OnPlaceArgs, OnSyncedBlockEventArgs, PlacedArgs};
+use crate::block::{
+    BlockFuture, OnPlaceArgs, OnSyncedBlockEventArgs, PlacedArgs, PlayerPlacedArgs,
+};
 use crate::block::{
     registry::BlockActionResult,
     {BlockBehaviour, NormalUseArgs},
@@ -9,6 +11,7 @@ use crate::block::{
 use crate::block::entities::shulker_box::ShulkerBoxBlockEntity;
 use pumpkin_data::BlockStateId;
 use pumpkin_data::block_properties::BlockProperties;
+use pumpkin_data::data_component_impl::ContainerImpl;
 use pumpkin_data::translation;
 use pumpkin_inventory::generic_container_screen_handler::create_generic_9x3;
 use pumpkin_inventory::player::player_inventory::PlayerInventory;
@@ -75,6 +78,31 @@ impl BlockBehaviour for ShulkerBoxBlock {
         Box::pin(async move {
             let barrel_block_entity = ShulkerBoxBlockEntity::new(*args.position);
             args.world.add_block_entity(Arc::new(barrel_block_entity));
+        })
+    }
+
+    /// Restores the contents a shulker box was holding as an item (vanilla keeps them on the
+    /// item's `minecraft:container` component instead of scattering them like a chest) into
+    /// the freshly created block entity's inventory.
+    fn player_placed<'a>(&'a self, args: PlayerPlacedArgs<'a>) -> BlockFuture<'a, ()> {
+        Box::pin(async move {
+            let Some(container) = args
+                .placed_item
+                .and_then(|stack| stack.get_data_component::<ContainerImpl>())
+            else {
+                return;
+            };
+
+            if let Some(block_entity) = args.world.get_block_entity(args.position)
+                && let Some(inventory) = block_entity.get_inventory()
+            {
+                for (slot, stack) in &container.items {
+                    let slot = *slot as usize;
+                    if slot < inventory.size() {
+                        inventory.set_stack(slot, stack.clone()).await;
+                    }
+                }
+            }
         })
     }
 

--- a/pumpkin/src/block/mod.rs
+++ b/pumpkin/src/block/mod.rs
@@ -341,6 +341,9 @@ pub struct PlayerPlacedArgs<'a> {
     pub position: &'a BlockPos,
     pub direction: BlockDirection,
     pub player: &'a Player,
+    /// The item stack that was consumed to place this block, if known. Used to restore
+    /// state (e.g. a shulker box's contents) that vanilla carries on the item itself.
+    pub placed_item: Option<&'a ItemStack>,
 }
 
 pub struct OnLandedUponArgs<'a> {

--- a/pumpkin/src/block/registry.rs
+++ b/pumpkin/src/block/registry.rs
@@ -441,6 +441,7 @@ impl BlockRegistry {
     }
 
     #[expect(clippy::too_many_lines)]
+    #[expect(clippy::too_many_arguments)]
     pub async fn place_block(
         &self,
         player: &Arc<Player>,
@@ -449,6 +450,7 @@ impl BlockRegistry {
         use_item_on: &SUseItemOn,
         location: BlockPos,
         face: BlockDirection,
+        placed_item: Option<&ItemStack>,
     ) -> Result<Option<(BlockPos, BlockStateId)>, BlockPlacingError> {
         let entity = &player.get_entity();
 
@@ -616,6 +618,7 @@ impl BlockRegistry {
             &final_block_pos,
             face,
             player,
+            placed_item,
         )
         .await;
 
@@ -886,6 +889,7 @@ impl BlockRegistry {
         block.default_state.id
     }
 
+    #[expect(clippy::too_many_arguments)]
     pub async fn player_placed(
         &self,
         world: &Arc<World>,
@@ -894,6 +898,7 @@ impl BlockRegistry {
         position: &BlockPos,
         direction: BlockDirection,
         player: &Player,
+        placed_item: Option<&ItemStack>,
     ) {
         let pumpkin_block = self.get_pumpkin_block(block.id);
         if let Some(pumpkin_block) = pumpkin_block {
@@ -905,6 +910,7 @@ impl BlockRegistry {
                     position,
                     direction,
                     player,
+                    placed_item,
                 })
                 .await;
         }

--- a/pumpkin/src/net/bedrock/play.rs
+++ b/pumpkin/src/net/bedrock/play.rs
@@ -724,6 +724,7 @@ impl BedrockClient {
                                     &dummy_use_item_on,
                                     data.block_position,
                                     face,
+                                    Some(&*stack),
                                 )
                                 .await
                             {

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -2313,7 +2313,15 @@ impl JavaClient {
         let item_id = stack.item.id;
         if let Some(block) = Block::from_item_id(item_id) {
             should_try_decrement = self
-                .run_is_block_place(player, block, server, use_item_on, position, face)
+                .run_is_block_place(
+                    player,
+                    block,
+                    server,
+                    use_item_on,
+                    position,
+                    face,
+                    Some(&*stack),
+                )
                 .await?;
         }
 
@@ -2766,6 +2774,7 @@ impl JavaClient {
         );
     }
 
+    #[expect(clippy::too_many_arguments)]
     async fn run_is_block_place(
         &self,
         player: &Arc<Player>,
@@ -2774,10 +2783,19 @@ impl JavaClient {
         use_item_on: SUseItemOn,
         location: BlockPos,
         face: BlockDirection,
+        placed_item: Option<&ItemStack>,
     ) -> Result<bool, BlockPlacingError> {
         match server
             .block_registry
-            .place_block(player, block, server, &use_item_on, location, face)
+            .place_block(
+                player,
+                block,
+                server,
+                &use_item_on,
+                location,
+                face,
+                placed_item,
+            )
             .await
         {
             Ok(Some((final_block_pos, new_state))) => {

--- a/pumpkin/src/world/loot.rs
+++ b/pumpkin/src/world/loot.rs
@@ -1,4 +1,6 @@
 use pumpkin_data::damage::DamageType;
+use pumpkin_data::data_component::DataComponent;
+use pumpkin_data::data_component_impl::{ContainerImpl, DataComponentImpl};
 use pumpkin_data::entity::EntityType;
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::tag;
@@ -27,6 +29,10 @@ pub struct LootContextParameters {
     pub tool: Option<ItemStack>,
     pub is_raining: Option<bool>,
     pub is_thundering: Option<bool>,
+    /// Non-empty `(slot, stack)` pairs snapshotted from a block entity's inventory (e.g. a
+    /// shulker box) right before it was torn down, for the `minecraft:container` include of a
+    /// `CopyComponents { source: "block_entity", .. }` loot function to copy onto the drop.
+    pub container_items: Option<Vec<(u8, ItemStack)>>,
 }
 
 pub trait LootTableExt {
@@ -230,11 +236,38 @@ impl LootFunctionExt for LootFunction {
                 }
             }
             LootFunctionTypes::CopyComponents { source, include } => {
-                tracing::warn!(
-                    "CopyComponents not supported from source: {} for {:?}",
-                    source,
-                    include
-                );
+                if *source == "block_entity" {
+                    if include.contains(&"minecraft:container")
+                        && let Some(items) = &params.container_items
+                        && !items.is_empty()
+                    {
+                        let container = ContainerImpl {
+                            items: items.clone(),
+                        };
+                        for stack in stacks.iter_mut() {
+                            stack
+                                .patch
+                                .push((DataComponent::Container, Some(container.clone().to_dyn())));
+                        }
+                    }
+
+                    let unhandled: Vec<&&str> = include
+                        .iter()
+                        .filter(|name| **name != "minecraft:container")
+                        .collect();
+                    if !unhandled.is_empty() {
+                        tracing::warn!(
+                            "CopyComponents from block_entity: unsupported includes {:?}",
+                            unhandled
+                        );
+                    }
+                } else {
+                    tracing::warn!(
+                        "CopyComponents not supported from source: {} for {:?}",
+                        source,
+                        include
+                    );
+                }
             }
             LootFunctionTypes::CopyState {
                 block: _,

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -62,6 +62,7 @@ use pumpkin_data::dimension::Dimension;
 use pumpkin_data::entity::MobCategory;
 use pumpkin_data::fluid::{Falling, FluidProperties, FluidState};
 use pumpkin_data::meta_data_type::MetaDataType;
+use pumpkin_data::tag::{self, Taggable};
 use pumpkin_data::tracked_data::TrackedData;
 use pumpkin_data::{
     Block, BlockStateId,
@@ -4527,6 +4528,26 @@ impl World {
                 BlockStateId::AIR
             };
 
+            // Snapshot a shulker box's inventory before its block entity is torn down by
+            // `set_block_state` below. Vanilla copies these contents onto the dropped item
+            // (instead of scattering them like a chest) and still drops a non-empty shulker
+            // box in creative mode, so both need the contents captured up front.
+            let container_items = if broken_block.has_tag(&tag::Block::MINECRAFT_SHULKER_BOXES)
+                && let Some(block_entity) = self.get_block_entity(position)
+                && let Some(inventory) = block_entity.get_inventory()
+            {
+                let mut items = Vec::new();
+                for slot in 0..inventory.size() {
+                    let stack = inventory.get_stack(slot).await.lock().await.clone();
+                    if !stack.is_empty() {
+                        items.push((slot as u8, stack));
+                    }
+                }
+                Some(items)
+            } else {
+                None
+            };
+
             let broken_state_id = self.set_block_state(position, new_state_id, flags).await;
 
             // Close container screens for any players viewing this block
@@ -4555,7 +4576,16 @@ impl World {
                     None => self.broadcast_to_chunk(chunk_pos, &particles_packet),
                 }
             }
-            if !flags.contains(BlockFlags::SKIP_DROPS) {
+            // Vanilla still drops a shulker box that has items in it even when a creative
+            // player breaks it, unlike ordinary blocks (which drop nothing in creative).
+            let force_shulker_drop = container_items.as_ref().is_some_and(|items| {
+                !items.is_empty()
+                    && cause
+                        .as_ref()
+                        .is_some_and(|player| player.gamemode.load() == GameMode::Creative)
+            });
+
+            if !flags.contains(BlockFlags::SKIP_DROPS) || force_shulker_drop {
                 let tool = if let Some(player) = &cause {
                     let hand_stack = player
                         .inventory
@@ -4582,6 +4612,7 @@ impl World {
                     tool,
                     is_raining: Some(is_raining),
                     is_thundering: Some(is_thundering),
+                    container_items,
                     ..Default::default()
                 };
                 block::drop_loot(self, broken_block, position, true, params).await;


### PR DESCRIPTION
## Description

Shulker boxes lost their inventory when broken and placed again, and unlike vanilla they didn't drop at all when broken in creative mode with items still inside.

**What was changed**
- Implemented `write_data`/`get_hash` for `ContainerImpl` (the `minecraft:container` data component) so it actually round-trips through NBT instead of silently falling back to the trait defaults (`NbtTag::End` / `todo!()`).
- Added network (de)serialization for `DataComponent::Container` in `pumpkin-protocol`, mirroring vanilla's format: a positional item list padded with empty slots up to the highest occupied slot.
- `World::break_block` now snapshots a shulker box's inventory (tagged via `minecraft:shulker_boxes`) before its block entity is torn down, and forces a drop in creative mode when that snapshot is non-empty (vanilla always drops a shulker box that has items, even in creative).
- Implemented the previously unhandled `CopyComponents { source: "block_entity", include: [...] }` loot function for the `minecraft:container` include, attaching the snapshotted items onto the dropped item stack as its `Container` component. Other `block_entity` includes still log a warning and are left as follow-up work, same as before.
- Threaded the placed `ItemStack` through `BlockRegistry::place_block` / `player_placed` (both Java and Bedrock placement paths) so `ShulkerBoxBlock::player_placed` can read the `Container` component off the just-placed item and restore its contents into the freshly created block entity's inventory.

**Why these changes were necessary**

The `minecraft:container` component existed in name (struct + NBT read) but was never written back out and had no packet codec, so any contents attached to a dropped shulker box item were silently dropped on every serialization boundary (saving to disk, sending to a client). Separately, nothing in the break/place path ever populated or consumed that component in the first place, and creative-mode breaking used the same no-drop path as every other block instead of vanilla's shulker-box-specific override.

**Impact**

Breaking a shulker box with items now keeps those items on the dropped item (visible in the item's tooltip/model like vanilla) and restores them to the block entity's inventory when the item is placed down again, for both Java and Bedrock clients. Breaking a non-empty shulker box in creative mode now drops it instead of destroying its contents.

**Known limitations**
- Only the `minecraft:container` include of `CopyComponents { source: "block_entity" }` is implemented; any other include from that source still just logs a warning (pre-existing behavior, unchanged for those cases).
- This only covers the shulker box family (blocks tagged `minecraft:shulker_boxes`); no other block currently relies on this data path in vanilla.

## Testing

- `cargo clippy --all-targets --all-features --jobs 2 -- -D warnings` — clean, no warnings.
- `cargo test --jobs 2` — full suite passes (0 failures).
- Manually reasoned through the break → drop → pick up → place → open flow for both the survival and creative-mode cases against vanilla's documented behavior; I don't have a way to attach an in-game recording in this environment, so I'd appreciate an in-game sanity check from a reviewer before merge.

Fixes #1569