### PR TITLE
Default missing Series field when deserializing level.dat WorldVersion

### DIFF
--- a/pumpkin-world/src/world_info/mod.rs
+++ b/pumpkin-world/src/world_info/mod.rs
@@ -273,7 +273,7 @@ impl WorldGenSettings {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-#[serde(rename_all = "PascalCase")]
+#[serde(rename_all = "PascalCase", default)]
 pub struct WorldVersion {
     // The version name as a string, e.g. "15w32b".
     pub name: String,
@@ -282,6 +282,8 @@ pub struct WorldVersion {
     // Whether the version is a snapshot or not.
     pub snapshot: bool,
     // Developing series. In 1.18 experimental snapshots, it was set to "ccpreview". In others, set to "main".
+    // Third-party tools that generate/convert level.dat files (e.g. Bedrock -> Java converters) don't always
+    // include this field, so it must not be required (see #1291).
     pub series: String,
 }
 


### PR DESCRIPTION
## What
`WorldVersion` (the `Version` NBT compound in `level.dat`) required all four fields (`Name`, `Id`, `Snapshot`, `Series`) to be present during deserialization. This change adds `default` to the struct's `serde` container attributes so any field missing from the NBT data falls back to `WorldVersion`'s existing `Default` impl (which already sets `series: "main"`) instead of failing to deserialize.

## Why
World files produced by third-party converters (e.g. a Bedrock -> Java conversion done with Chunker) can omit the `Series` field from the `Version` compound entirely. Because deserialization previously required every field, loading such a world caused Pumpkin to panic on startup:

```
World Error Deserialization error: Serde error: missing field `Series`
```

This made it impossible to start the server with a world converted by an external tool, even though the rest of the level data was otherwise valid.

## Impact
- Only affects deserialization of the `Version` compound in `level.dat`. If `series` (or `name`/`id`/`snapshot`) is absent from the data, it now defaults instead of erroring; well-formed `level.dat` files that already include all four fields deserialize exactly as before, so no behavior change for normal server-generated worlds.
- No new public API, no changes outside `pumpkin-world/src/world_info/mod.rs`.

## Limitations
- This is a defensive-deserialization fix only; it does not add general support for importing external Java/Bedrock worlds, and other parts of a converter-produced save could still be non-standard in ways this doesn't address.
- If `Series` is genuinely missing, the original value can't be recovered, so it defaults to `"main"` (matching the default used for freshly generated worlds) rather than guessing the actual original series.

Fixes #1291