### PR TITLE
fix(entity): reset fall distance on Spectator/Creative gamemode switch

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -2935,6 +2935,26 @@ impl Player {
                     }
                 }
 
+                // Reset fall distance when switching to Spectator or Creative to prevent
+                // fall damage upon switching back to Survival.
+                //
+                // This is a pragmatic workaround: vanilla does NOT reset fallDistance in
+                // setGameMode(). Instead, vanilla relies on multiple defense layers:
+                //   1. noPhysics=true for Spectator — Entity.move() skips checkFallDamage()
+                //   2. abilities.flying=true → Player.aiStep() resets fallDistance every tick
+                //   3. setOnGround(false) forced for Spectators — prevents fallOn() invocation
+                //   4. abilities.mayfly=true → Player.causeFallDamage() returns false
+                //
+                // Pumpkin currently lacks layers 1-4. This explicit reset compensates for
+                // their absence until the full vanilla fall-damage pipeline is implemented.
+                // TODO: Implement vanilla's noPhysics path for Spectator in Entity::move()
+                // TODO: Add per-tick fall_distance reset when abilities.flying is true (mirrors Player.aiStep())
+                // TODO: Force on_ground=false for Spectator players each tick (mirrors Player.tick())
+                // TODO: Add abilities.allow_flying check in LivingEntity::handle_fall_damage() as defense-in-depth
+                if matches!(gamemode, GameMode::Creative | GameMode::Spectator) {
+                    self.living_entity.fall_distance.store(0.0);
+                }
+
                 if gamemode != GameMode::Spectator && self.camera_target_id.load().is_some() {
                     self.camera_target_id.store(None);
                     self.client.send_packet_now(&CSetCamera::new(

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -2951,6 +2951,10 @@ impl Player {
                 // TODO: Add per-tick fall_distance reset when abilities.flying is true (mirrors Player.aiStep())
                 // TODO: Force on_ground=false for Spectator players each tick (mirrors Player.tick())
                 // TODO: Add abilities.allow_flying check in LivingEntity::handle_fall_damage() as defense-in-depth
+                // TODO: Once layers 1-4 above are implemented, restrict this reset to Spectator only.
+                //       In vanilla, a Creative player falling without flight keeps their fallDistance
+                //       across a Survival switch (layer 4/abilities.mayfly guards damage server-side);
+                //       resetting here over-forgives that edge case for Creative.
                 if matches!(gamemode, GameMode::Creative | GameMode::Spectator) {
                     self.living_entity.fall_distance.store(0.0);
                 }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -2935,26 +2935,13 @@ impl Player {
                     }
                 }
 
-                // Reset fall distance when switching to Spectator or Creative to prevent
-                // fall damage upon switching back to Survival.
-                //
-                // This is a pragmatic workaround: vanilla does NOT reset fallDistance in
-                // setGameMode(). Instead, vanilla relies on multiple defense layers:
-                //   1. noPhysics=true for Spectator — Entity.move() skips checkFallDamage()
-                //   2. abilities.flying=true → Player.aiStep() resets fallDistance every tick
-                //   3. setOnGround(false) forced for Spectators — prevents fallOn() invocation
-                //   4. abilities.mayfly=true → Player.causeFallDamage() returns false
-                //
-                // Pumpkin currently lacks layers 1-4. This explicit reset compensates for
-                // their absence until the full vanilla fall-damage pipeline is implemented.
-                // TODO: Implement vanilla's noPhysics path for Spectator in Entity::move()
-                // TODO: Add per-tick fall_distance reset when abilities.flying is true (mirrors Player.aiStep())
-                // TODO: Force on_ground=false for Spectator players each tick (mirrors Player.tick())
-                // TODO: Add abilities.allow_flying check in LivingEntity::handle_fall_damage() as defense-in-depth
-                // TODO: Once layers 1-4 above are implemented, restrict this reset to Spectator only.
-                //       In vanilla, a Creative player falling without flight keeps their fallDistance
-                //       across a Survival switch (layer 4/abilities.mayfly guards damage server-side);
-                //       resetting here over-forgives that edge case for Creative.
+                /* Vanilla doesn't reset fallDistance in setGameMode(), instead relies on
+                 * Player.aiStep() resetting when abilities.flying=true and
+                 * Player.causeFallDamage() returning false when abilities.mayfly=true.
+                 * TODO: Reset fall_distance each tick when abilities.flying=true (mirrors Player.aiStep())
+                 * TODO: Add abilities.allow_flying check in LivingEntity::handle_fall_damage() (mirrors Player.causeFallDamage())
+                 * TODO: Once implemented, restrict this reset to Spectator only.
+                 */
                 if matches!(gamemode, GameMode::Creative | GameMode::Spectator) {
                     self.living_entity.fall_distance.store(0.0);
                 }


### PR DESCRIPTION
## Summary
Fixes fall damage when switching between Survival and Spectator modes during a fall (#2372).

## Problem
When a player falls from a height, switches to Spectator mode before landing, and then switches back to Survival mode, they take full fall damage and die. Original Minecraft does not apply fall damage in this case.

## Root Cause
Pumpkin lacks the multiple layers of defense that the original version uses to prevent fall damage for Spectator/Creative players:
1. **No Physics**: Spectators ignore physics in `Entity.move()`.

2. **Reset on Tick**: `Player.aiStep()` resets `fallDistance` on every tick when `abilities.flying=true`.

3. **Force on Ground**: `Player.tick()` forces `onGround=false` for Spectators. 

4. **Mayfly Verification**: `Player.causeFallDamage()` returns false when `abilities.mayfly=true`.

## Workaround
Reset `fall_distance` to 0 when switching to Spectator or Creative mode. This is a temporary solution to compensate for the missing layers until the full original version is implemented. 

## Testing

**Before (bug):**

https://github.com/user-attachments/assets/c3da30ae-ff0a-44d7-8e51-dbec2a06c706



**After (fix):**

https://github.com/user-attachments/assets/4a435b7b-f4cc-465b-871c-48ada8d67b42



## Notes
This fix addresses the immediate issue. The pending tasks in the code indicate remaining deficiencies for a full and faithful implementation of the original fall damage prevention system.