### PR TITLE
fix: Ender Dragon collision knockback/damage on every tick of overlap

### DIFF
--- a/pumpkin/src/entity/boss/ender_dragon.rs
+++ b/pumpkin/src/entity/boss/ender_dragon.rs
@@ -233,6 +233,12 @@ pub struct EnderDragonEntity {
     pub ticks_sitting: Mutex<i32>,
     pub sit_attack_timer: Mutex<i32>,
     pub breathing_timer: Mutex<i32>,
+
+    /// Players currently intersecting the dragon's hitbox that have already
+    /// received a collision knockback/hit for the current contact. Used so
+    /// `handle_player_collisions` only hits a player once per contact instead
+    /// of every tick they remain inside the dragon.
+    pub colliding_players: Mutex<std::collections::HashSet<uuid::Uuid>>,
 }
 
 impl EnderDragonEntity {
@@ -284,6 +290,7 @@ impl EnderDragonEntity {
             ticks_sitting: Mutex::new(0),
             sit_attack_timer: Mutex::new(0),
             breathing_timer: Mutex::new(0),
+            colliding_players: Mutex::new(std::collections::HashSet::new()),
         })
     }
 
@@ -557,30 +564,61 @@ impl EnderDragonEntity {
         let xm = f64::midpoint(dragon_bbox.min.x, dragon_bbox.max.x);
         let zm = f64::midpoint(dragon_bbox.min.z, dragon_bbox.max.z);
 
+        let mut colliding_players = self.colliding_players.lock().await;
+        let mut still_colliding = std::collections::HashSet::new();
+
         for player in world.players.load().iter() {
-            if player
+            if !player
                 .living_entity
                 .entity
                 .bounding_box
                 .load()
                 .intersects(&dragon_bbox)
             {
-                let player_pos = player.get_entity().pos.load();
-                let xd = player_pos.x - xm;
-                let zd = player_pos.z - zm;
-                let dd = (xd * xd + zd * zd).max(0.1);
+                continue;
+            }
 
-                player
-                    .living_entity
-                    .entity
-                    .apply_knockback(4.0, xd / dd, zd / dd);
-                player.get_entity().send_velocity();
+            // Invulnerable players (e.g. creative/spectator mode) are never
+            // pushed around by the dragon: vanilla only ever applies the
+            // collision knockback alongside a successful hit, and an
+            // invulnerable target can't be hit.
+            if player
+                .living_entity
+                .entity
+                .is_invulnerable_to(&DamageType::MOB_ATTACK)
+                .await
+            {
+                continue;
+            }
 
-                if !self.phase.lock().await.is_sitting() {
-                    player.damage(self, 5.0, DamageType::MOB_ATTACK).await;
-                }
+            let uuid = player.living_entity.entity.entity_uuid;
+            still_colliding.insert(uuid);
+
+            // Only knock the player back on the tick contact begins.
+            // Otherwise every tick of continued overlap re-applies knockback
+            // and damage, flinging the player around instead of hitting them
+            // once on contact.
+            if colliding_players.contains(&uuid) {
+                continue;
+            }
+
+            let player_pos = player.get_entity().pos.load();
+            let xd = player_pos.x - xm;
+            let zd = player_pos.z - zm;
+            let dd = (xd * xd + zd * zd).max(0.1);
+
+            player
+                .living_entity
+                .entity
+                .apply_knockback(4.0, xd / dd, zd / dd);
+            player.get_entity().send_velocity();
+
+            if !self.phase.lock().await.is_sitting() {
+                player.damage(self, 5.0, DamageType::MOB_ATTACK).await;
             }
         }
+
+        *colliding_players = still_colliding;
     }
 
     fn tick_crystal_healing(&self) {


### PR DESCRIPTION
## What

Fixes the Ender Dragon's player-collision handling in `EnderDragonEntity::handle_player_collisions`:

- Players who are invulnerable to `DamageType::MOB_ATTACK` (e.g. creative/spectator mode) are no longer knocked back when standing inside the dragon's hitbox. Vanilla only ever applies the collision knockback together with a successful hit, and an invulnerable target can never be hit, so it should never be pushed around either.
- For vulnerable players, the knockback + damage is now applied once per contact (on the tick the player's hitbox starts intersecting the dragon's), instead of being re-applied every single tick the player remains overlapping the dragon. A new `colliding_players: Mutex<HashSet<Uuid>>` field on `EnderDragonEntity` tracks who was already colliding on the previous tick so repeat overlap in the following ticks is skipped until the player separates and re-enters.

## Why

Fixes #2220. As reported: standing "inside" the Ender Dragon (flying into it in creative, or jumping into it in survival) caused the player to be flung around and damaged every tick for as long as the overlap lasted, and this happened even in creative mode where the player can't actually take damage. Expected behavior (from the issue):

- Invulnerable (creative): no collision knockback at all.
- Vulnerable (survival/adventure): knockback once on contact, not continuously while overlapping.

## Impact

- Behavior change is scoped to `EnderDragonEntity::handle_player_collisions`; no protocol, API, or config changes.
- Adds one small `Mutex<HashSet<Uuid>>` field to `EnderDragonEntity`, cleared/rebuilt each tick from the current set of colliding players, so it can't grow unbounded or leak entries for players who log off/despawn.
- Sitting-phase behavior (no damage while sitting) is unchanged; only the repeated-hit and invulnerable-knockback behavior is fixed.

## Limitations

- This only addresses the dragon's own body-collision handling. It does not touch dragon breath, other AoE damage sources, or any other mob's collision logic.
- "Once per contact" is tracked per-tick via hitbox intersection; a player who is knocked back but immediately re-enters the hitbox within the same continuous overlap will not be hit again until they fully separate first (matching the vanilla-like "hit on contact" behavior described in the issue).
