### PR TITLE
Fix incorrect world spawn defaulting to (0, 0) in oceans

### DIFF
--- a/pumpkin-codegen/src/biome.rs
+++ b/pumpkin-codegen/src/biome.rs
@@ -501,6 +501,16 @@ pub fn build() -> TokenStream {
         }
 
         impl ParameterRange {
+            /// Constructs a parameter range directly. Not used by the biome
+            /// codegen output itself (which builds ranges as struct literals),
+            /// but needed by hand-written code that builds standalone climate
+            /// targets outside of the generated biome tree, such as the
+            /// world-spawn search.
+            #[must_use]
+            pub const fn new(min: i64, max: i64) -> Self {
+                Self { min, max }
+            }
+
             pub fn calc_distance(&self, noise: i64) -> i64 {
                 if noise > self.max {
                     noise - self.max

--- a/pumpkin-data/src/generated/biome.rs
+++ b/pumpkin-data/src/generated/biome.rs
@@ -9032,6 +9032,15 @@ pub struct ParameterRange {
     max: i64,
 }
 impl ParameterRange {
+    /// Constructs a parameter range directly. Not used by the biome codegen
+    /// output itself (which builds ranges as struct literals), but needed by
+    /// hand-written code that builds standalone climate targets outside of
+    /// the generated biome tree, such as the world-spawn search.
+    #[must_use]
+    pub const fn new(min: i64, max: i64) -> Self {
+        Self { min, max }
+    }
+
     pub fn calc_distance(&self, noise: i64) -> i64 {
         if noise > self.max {
             noise - self.max

--- a/pumpkin-world/src/biome/position_finder.rs
+++ b/pumpkin-world/src/biome/position_finder.rs
@@ -1,6 +1,42 @@
 use pumpkin_data::chunk::ParameterRange;
 use pumpkin_util::math::vector2::Vector2;
 
+/// Vanilla's world-spawn climate target (`OverworldBiomeBuilder#spawnTarget()`).
+///
+/// Expressed as `[temperature, humidity, continentalness, erosion, depth,
+/// weirdness, offset]` ranges on the same x10000 fixed-point scale used
+/// elsewhere in the biome parameter tree (see [`crate::biome::multi_noise::to_long`]).
+///
+/// Vanilla accepts weirdness in either a wide-negative or wide-positive band
+/// (never near zero), so this is two alternative target points; the search
+/// keeps whichever is closer for a given sample. Continentalness is
+/// restricted to `-1100..=10000` (roughly "coast or further inland"), which
+/// is what keeps the search out of oceans. Depth is pinned to the surface.
+///
+/// Values verified against the independently-maintained, vanilla-accurate
+/// `Cubitect/cubiomes` reimplementation (`spawn_np` in `finders.c`), since
+/// they aren't derived from any registry/datapack asset we generate from.
+pub const OVERWORLD_SPAWN_TARGET: [[ParameterRange; 7]; 2] = [
+    [
+        ParameterRange::new(-10_000, 10_000), // temperature
+        ParameterRange::new(-10_000, 10_000), // humidity
+        ParameterRange::new(-1_100, 10_000),  // continentalness
+        ParameterRange::new(-10_000, 10_000), // erosion
+        ParameterRange::new(0, 0),            // depth
+        ParameterRange::new(-10_000, -1_600), // weirdness, band A
+        ParameterRange::new(0, 0),            // offset
+    ],
+    [
+        ParameterRange::new(-10_000, 10_000), // temperature
+        ParameterRange::new(-10_000, 10_000), // humidity
+        ParameterRange::new(-1_100, 10_000),  // continentalness
+        ParameterRange::new(-10_000, 10_000), // erosion
+        ParameterRange::new(0, 0),            // depth
+        ParameterRange::new(1_600, 10_000),   // weirdness, band B
+        ParameterRange::new(0, 0),            // offset
+    ],
+];
+
 pub struct FittestPositionFinderResult {
     pub location: Vector2<i32>,
     pub fitness: i64,

--- a/pumpkin-world/src/generation/generator/mod.rs
+++ b/pumpkin-world/src/generation/generator/mod.rs
@@ -4,10 +4,15 @@ use pumpkin_data::dimension::Dimension;
 use pumpkin_data::noise_router::{
     END_BASE_NOISE_ROUTER, NETHER_BASE_NOISE_ROUTER, OVERWORLD_BASE_NOISE_ROUTER,
 };
+use pumpkin_util::math::vector2::Vector2;
 
+use super::noise::router::multi_noise_sampler::{
+    MultiNoiseSampler, MultiNoiseSamplerBuilderOptions,
+};
 use super::noise::router::proto_noise_router::ProtoNoiseRouters;
+use crate::biome::position_finder::{FittestPositionFinder, OVERWORLD_SPAWN_TARGET};
 use crate::generation::proto_chunk::TerrainCache;
-use crate::generation::{GlobalRandomConfig, Seed};
+use crate::generation::{GlobalRandomConfig, Seed, biome_coords};
 
 pub mod structure_finder;
 
@@ -79,4 +84,37 @@ impl GeneratorInit for VanillaGenerator {
             structure_allowed_biomes,
         }
     }
+}
+
+/// Finds the horizontal world-spawn position for a freshly created Overworld by climate.
+///
+/// Mirrors vanilla's spawn search (`Climate.Sampler`'s `findSpawnPosition`)
+/// instead of blindly defaulting to `(0, 0)` regardless of what's actually
+/// there, e.g. open ocean (Pumpkin-MC/Pumpkin#1303).
+///
+/// This reproduces vanilla's noise-based search only: it looks for a
+/// position whose climate (temperature/humidity/continentalness/erosion/
+/// weirdness) resembles ordinary dry land and is closest to the origin
+/// among those. It does not perform vanilla's follow-up per-chunk scan for
+/// an actual non-waterlogged block, so a small lake or river can still very
+/// rarely be chosen. The Y coordinate is intentionally not resolved here:
+/// callers already re-derive it from the generated terrain at the chosen
+/// (x, z) once chunks are loaded (see `World::get_top_block`).
+#[must_use]
+pub fn find_overworld_spawn_position(seed: Seed) -> Vector2<i32> {
+    let generator = VanillaGenerator::new(seed, Dimension::OVERWORLD);
+
+    let sampler = |x: i32, z: i32| -> [i64; 7] {
+        let biome_x = biome_coords::from_block(x);
+        let biome_z = biome_coords::from_block(z);
+        // A single-point sampler: build a throwaway `MultiNoiseSampler` scoped
+        // to just this one biome-coord column instead of a whole chunk, since
+        // the search below queries scattered points up to 2048 blocks apart.
+        let options = MultiNoiseSamplerBuilderOptions::new(biome_x, biome_z, 0);
+        let mut noise_sampler =
+            MultiNoiseSampler::generate(&generator.base_router.multi_noise, &options);
+        noise_sampler.sample(biome_x, 0, biome_z).convert_to_list()
+    };
+
+    FittestPositionFinder::find_best_spawn_position(&OVERWORLD_SPAWN_TARGET, &sampler)
 }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -26,6 +26,7 @@ use pumpkin_data::entity::EntityType;
 use pumpkin_util::permission::{PermissionManager, PermissionRegistry};
 use pumpkin_util::text::color::NamedColor;
 use pumpkin_world::dimension::into_level;
+use pumpkin_world::generation::generator::find_overworld_spawn_position;
 use pumpkin_world::world::WorldPortalExt;
 use tracing::{debug, error, info, warn};
 
@@ -189,7 +190,17 @@ impl Server {
         }
         let level_info = level_info.unwrap_or_else(|err| {
             warn!("Failed to get level_info, using default instead: {err}");
-            let default_data = LevelData::default(basic_config.seed);
+            let mut default_data = LevelData::default(basic_config.seed);
+
+            // Pick a real vanilla-style spawn point instead of leaving the
+            // world spawn at the default (0, 0), which can just as easily be
+            // in the middle of an ocean as on dry land (see #1303).
+            // Note: `Vector2::y` holds the world Z coordinate here, matching
+            // the `Vector2::new(x, z)` convention used throughout the spawn
+            // search and its other callers.
+            let spawn_position = find_overworld_spawn_position(basic_config.seed);
+            default_data.set_pos(spawn_position.x, spawn_position.y);
+
             if let Err(err) = AnvilLevelInfo.write_world_info(&default_data, &world_path) {
                 error!("Failed to save level.dat: {err}");
             }


### PR DESCRIPTION
## Description

**What was changed**

New Overworld levels now get a real spawn point instead of a hardcoded `(0, 0)`:

- Added `OVERWORLD_SPAWN_TARGET` (`pumpkin-world/src/biome/position_finder.rs`): vanilla's world-spawn climate target (`OverworldBiomeBuilder#spawnTarget()`), expressed as parameter ranges on the same scale used elsewhere in the biome parameter tree.
- Added `find_overworld_spawn_position()` (`pumpkin-world/src/generation/generator/mod.rs`), which reuses the existing `FittestPositionFinder` (already used for structures) against that climate target to locate the nearest position whose climate resembles ordinary dry land.
- Wired this into `Server` (`pumpkin/src/server/mod.rs`): when a world's `level.dat` is missing and a default `LevelData` has to be created, its spawn position is now set from the search above instead of staying at `(0, 0)`.
- Added `ParameterRange::new()` (codegen + generated output) since hand-written code building a standalone climate target needs a constructor; the biome codegen itself still only ever builds `ParameterRange`s as struct literals.

**Why**

Reported in #1303: a brand-new world's spawn is always `(0, 0)`, even when that point happens to be open ocean (e.g. seed `118823198`). Vanilla instead searches outward from the origin for the closest point that looks like normal land (checking temperature/humidity/continentalness/erosion/weirdness), which is what this PR reproduces.

**Impact**

Only affects world *creation*, i.e. the path taken when `level.dat` doesn't exist yet and a default `LevelData` is generated. Existing worlds with an existing `level.dat` are untouched. New Overworld levels get a spawn point chosen the same way vanilla picks one, instead of unconditionally `(0, 0)`.

**Known limitations**

- This reproduces vanilla's noise/climate-based search only. Vanilla also does a follow-up per-chunk scan for an actual non-waterlogged surface block, which is not implemented here, so on rare seeds a small lake or river could still be picked.
- The Y coordinate is intentionally not resolved by this search; that is left to the existing code path that re-derives it from generated terrain at the chosen `(x, z)` once chunks are loaded.
- The climate target values aren't derived from any registry/datapack asset generated by this repo, so they were cross-checked against the independently-maintained, vanilla-accurate `Cubitect/cubiomes` reimplementation (`spawn_np` in `finders.c`) rather than against an in-repo source of truth.

Fixes #1303

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` passes.
- `cargo test` passes (all suites green, no failures).
- Not verified: manually booting a server on the exact seed from the issue to confirm the resulting spawn coordinates client-side; the fix was validated via the checks above plus reasoning about parity with vanilla's algorithm and climate target values.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
