### PR TITLE
fix: don't kick player for attacking an entity that no longer exists

### DIFF
--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -1743,12 +1743,16 @@ impl JavaClient {
             .map(|p| Arc::clone(p) as Arc<dyn EntityBase>)
             .or_else(|| world.get_entity_by_id(entity_id.0));
         let Some(target) = target else {
-            self.kick(TextComponent::translate_cross(
-                translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED,
-                translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED,
-                [],
-            ))
-            .await;
+            // The target entity may have died, been unloaded, or otherwise been removed
+            // between the client sending this packet and the server processing it (e.g.
+            // when quickly attacking multiple mobs). This is an expected race condition,
+            // not a sign of a malicious client, so it must not disconnect the player.
+            // See: https://github.com/Pumpkin-MC/Pumpkin/issues/1800
+            debug!(
+                "Player id {} attacked entity id {}, which was not found.",
+                player.entity_id(),
+                entity_id.0
+            );
             return;
         };
         if let Some(player_victim) = &player_target {
@@ -1866,20 +1870,22 @@ impl JavaClient {
                 }
             }}
         } else {
-            // Entity not found
+            // Entity not found. This commonly happens when the target entity died or was
+            // unloaded between the client sending this packet and the server processing it
+            // (e.g. when quickly attacking multiple mobs), which is expected and not a sign
+            // of a malicious client, so it must not disconnect the player.
+            // See: https://github.com/Pumpkin-MC/Pumpkin/issues/1800
             send_cancellable! {{
                 server;
                 PlayerInteractUnknownEntityEvent::new(player, entity_id.0, action);
 
                 'after: {
                     if event.action == ActionType::Attack {
-                        error!(
+                        debug!(
                             "Player id {} interacted with entity id {}, which was not found.",
                             player.entity_id(),
                             event.entity_id
                         );
-                        self.kick(TextComponent::translate_cross(translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED, translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED, [],))
-                        .await;
                     }
                 }
             }}

--- a/pumpkin/src/plugin/api/events/player/player_interact_unknown_entity_event.rs
+++ b/pumpkin/src/plugin/api/events/player/player_interact_unknown_entity_event.rs
@@ -8,8 +8,11 @@ use super::PlayerEvent;
 
 /// Event that is triggered when a player interacts with an entity that was not found in the world.
 ///
-/// This can occur when the target entity has been removed or is otherwise unknown to the server.
-/// It can be cancelled to prevent the default behavior (e.g., kicking the player).
+/// This commonly happens when the target entity died, was unloaded, or was otherwise removed
+/// between the client sending the interaction packet and the server processing it (e.g. when
+/// quickly attacking multiple mobs), and does not by itself indicate a malicious client.
+/// The server takes no punitive action (such as kicking the player) for this by default; the
+/// event exists so plugins can observe or react to these unknown-entity interactions.
 #[cancellable]
 #[derive(Event, Clone)]
 pub struct PlayerInteractUnknownEntityEvent {


### PR DESCRIPTION
## What

When a player's attack/interact packet references an entity ID the server can no longer find (`handle_attack` and the "unknown entity" branch of `handle_interact` in `pumpkin/src/net/java/play.rs`), the server disconnected the player with `MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED` ("attempting to attack an invalid entity"). This PR removes the kick for that specific case and instead logs the mismatch at `debug` level. The unrelated anti-cheat check for a client claiming to attack/interact with its own entity ID is untouched and still kicks, since that is not this bug.

The doc comment on the (already-cancellable) `PlayerInteractUnknownEntityEvent` is also updated to describe the new default (non-punitive) behavior so plugin authors relying on its doc aren't surprised.

## Why

Fixes #1800. Attacking a mob whose entity was already removed on the server (died, unloaded, etc.) by the time the attack packet is processed is a normal, expected race condition in survival play, not a sign of a malicious or modified client. This is easy to reproduce simply by attacking several mobs in quick succession (e.g. a group of zombies), as described in the issue and confirmed independently in the issue comments on a separate build. Kicking the player for this is a false positive.

## Impact

- Players who quickly attack multiple mobs (or attack a mob that dies/despawns right as the packet arrives) are no longer disconnected.
- The server now emits a `debug`-level log line instead of an `error`-level log + kick for this case.
- `PlayerInteractUnknownEntityEvent` still fires and is still cancellable, so plugins that want custom handling (including kicking) for unknown-entity interactions can still do so.
- No changes to the self-attack anti-cheat kick, packet parsing, or any other disconnect path.

## Limitations

- This only addresses the "entity not found" cases; it does not add any new validation to distinguish "target despawned due to a normal race" from "client sent a bogus/never-existed entity ID". If maintainers want detection for the latter, that would need separate, follow-up work.
- I did not change PvP config handling, event ordering, or anything outside the two kick sites and the event doc comment.

## Testing

- `cargo clippy --all-targets --all-features --jobs 2 -- -D warnings`: clean.
- `cargo test --jobs 2`: all tests pass (including `pumpkin`'s own unit tests).
- `cargo fmt --check`: clean.

Fixes #1800