### PR TITLE
fix(entity): stop hostile mobs from targeting Creative/Spectator players

### DIFF
--- a/pumpkin/src/entity/ai/target_predicate.rs
+++ b/pumpkin/src/entity/ai/target_predicate.rs
@@ -1,4 +1,5 @@
-use pumpkin_util::Difficulty;
+use pumpkin_data::entity::EntityType;
+use pumpkin_util::{Difficulty, GameMode};
 
 use crate::entity::living::LivingEntity;
 use crate::world::World;
@@ -105,6 +106,18 @@ impl TargetPredicate {
             return false;
         }
 
+        // Vanilla parity (`EntityPredicates.EXCEPT_CREATIVE_OR_SPECTATOR`): hostile AI
+        // must never acquire, nor keep tracking, a Creative/Spectator player. `target`
+        // is a bare `LivingEntity`, which has no way to answer "am I a Player in
+        // Creative mode" by itself (that state only lives on `Player`), so it's
+        // resolved via a fresh world lookup instead. This runs on every call to
+        // `test`, not just on first acquisition: `TrackTargetGoal::can_track` re-runs
+        // it for the currently tracked target on every `should_continue` check, so an
+        // in-progress chase is dropped as soon as the target leaves Survival/Adventure.
+        if is_untargetable_player(world, target) {
+            return false;
+        }
+
         if self.attackable
             && (!target.can_take_damage()
                 || world.level_info.load().difficulty == Difficulty::Peaceful)
@@ -130,5 +143,36 @@ impl TargetPredicate {
         }
 
         true
+    }
+}
+
+/// Returns `true` if `target` is a player currently in a gamemode that vanilla
+/// excludes from hostile targeting (Creative or Spectator).
+fn is_untargetable_player(world: &World, target: &LivingEntity) -> bool {
+    target.entity.entity_type == &EntityType::PLAYER
+        && world
+            .get_player_by_uuid(target.entity.entity_uuid)
+            .is_some_and(|player| is_untargetable_gamemode(player.gamemode.load()))
+}
+
+/// Returns `true` for the gamemodes vanilla excludes from hostile targeting.
+const fn is_untargetable_gamemode(mode: GameMode) -> bool {
+    matches!(mode, GameMode::Creative | GameMode::Spectator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn survival_and_adventure_remain_targetable() {
+        assert!(!is_untargetable_gamemode(GameMode::Survival));
+        assert!(!is_untargetable_gamemode(GameMode::Adventure));
+    }
+
+    #[test]
+    fn creative_and_spectator_are_untargetable() {
+        assert!(is_untargetable_gamemode(GameMode::Creative));
+        assert!(is_untargetable_gamemode(GameMode::Spectator));
     }
 }


### PR DESCRIPTION
## Description

**What was changed?**

`TargetPredicate::test` (used by every hostile-mob targeting/tracking goal, e.g. `TrackTargetGoal`, `ActiveTargetGoal`, `RevengeGoal`) now rejects a target if it is a player currently in Creative or Spectator gamemode. This mirrors vanilla's `EntityPredicates.EXCEPT_CREATIVE_OR_SPECTATOR`, which vanilla applies in the same spot.

Since `test` receives a bare `LivingEntity` (gamemode is state that only lives on `Player`), the new check resolves the target back to a `Player` via `World::get_player_by_uuid` and reads `Player::gamemode` from there.

**Why were these changes necessary?**

Fixes #1760: a hostile mob (e.g. a zombie) that had already started attacking a player kept attacking after that player switched from Survival to Creative (and the reverse case — switching into Creative did not stop an in-progress chase either). Vanilla immediately drops/refuses such targets; Pumpkin had no equivalent check anywhere in the targeting path.

**What is the impact of this change?**

- `TargetPredicate::test` is re-evaluated continuously by `TrackTargetGoal::can_track` (called from `should_continue` every tick for the currently-tracked target), not just at acquisition time, so an in-progress chase is dropped as soon as the target switches into Creative/Spectator, and a Creative/Spectator player can no longer be newly targeted either — matching vanilla behavior in both directions.
- The added check is a cheap `UUID` lookup in the world's player map plus an enum comparison, gated behind an `EntityType` equality check so it's a no-op for the overwhelmingly common case of non-player targets (other mobs).
- No public API signatures changed; this is a behavioral fix contained to `pumpkin/src/entity/ai/target_predicate.rs`.

**Are there any known issues or limitations?**

- This only covers the generic `TargetPredicate` path used by the goal-based targeting/tracking system. It does not touch any other place a mob might otherwise acquire or keep a target (if one exists outside this predicate).
- Two unit tests were added for the new gamemode-classification helper (`is_untargetable_gamemode`). Exercising the full path end-to-end would need a running world/player fixture, which is outside the scope of this minimal fix.

Fixes #1760
