### PR TITLE
fix: require on_ground for sweep attack classification

### DIFF
--- a/pumpkin/src/entity/combat.rs
+++ b/pumpkin/src/entity/combat.rs
@@ -53,7 +53,13 @@ impl AttackType {
             return Self::Critical;
         }
 
-        if sword && is_strong {
+        // Vanilla only awards a sweep attack while the attacker is standing on the ground.
+        // Without this check, a strong-charged sword swing performed while airborne but not
+        // yet falling (e.g. during the rising part of a jump, where `fall_distance` is still
+        // 0.0 so the `Critical` branch above doesn't match) was incorrectly classified as a
+        // sweep attack instead of a plain hit, which players observed as a crit "turning into"
+        // a sweep (see #1330).
+        if sword && is_strong && on_ground {
             return Self::Sweeping;
         }
 


### PR DESCRIPTION
## Description

**What:** `AttackType::new` (in `pumpkin/src/entity/combat.rs`) classified a strong-charged sword swing as `Sweeping` as soon as it wasn't in the fall-based `Critical` state, without checking whether the attacker was actually standing on the ground:

```rust
if sword && is_strong {
    return Self::Sweeping;
}
```

This adds the missing `on_ground` condition:

```rust
if sword && is_strong && on_ground {
    return Self::Sweeping;
}
```

**Why:** In vanilla, a sweep attack is only awarded while the attacker is on the ground. The `Critical` branch right above only matches when the attacker is airborne *and* `fall_distance > 0.0`. `fall_distance` stays `0.0` while an entity is still rising (e.g. the upward part of a jump), so a strong hit landed during that window was neither a ground hit nor a valid crit under the old check, and fell through into `Sweeping` purely because `on_ground` wasn't part of the condition. Players experienced this as a fully-charged crit attempt occasionally turning into a sweep attack instead.

**Impact:** Only affects `AttackType` classification for sword hits in `pumpkin/src/entity/combat.rs`. A strong-charged sword swing thrown while airborne but not yet falling (`fall_distance == 0.0`) now correctly falls through to `Strong`/`Weak` instead of being misclassified as `Sweeping`, matching vanilla's ground requirement for sweep attacks. Grounded and falling-crit behavior is unchanged.

**Known limitations:** One comment on the issue suggested the reported inconsistency may also be explained by server-side lag affecting attack-cooldown timing; that is a separate, unverified factor this PR does not address. This PR only fixes the concrete logic gap where `Sweeping` had no `on_ground` requirement, which is an independently reproducible divergence from vanilla regardless of lag.

Fixes #1330

## Testing

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

All pass locally on top of current `master`.
