### PR TITLE
fix: exclude Ender Dragon from generic corpse-removal so the exit portal opens

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -2588,7 +2588,16 @@ impl EntityBase for LivingEntity {
             if self.hurt_cooldown.load(Relaxed) > 0 {
                 self.hurt_cooldown.fetch_sub(1, Relaxed);
             }
-            if self.health.load() <= 0.0 {
+            // The Ender Dragon drives its own multi-second death sequence via
+            // `DyingPhase`, which must keep ticking for `DEATH_TIMER_MAX` (200)
+            // ticks so it can activate the exit portal, place the egg, and
+            // spawn a gateway (see `DragonFight::set_dragon_killed`) before it
+            // removes itself. The generic 20-tick corpse-removal below would
+            // otherwise delete it from `world.entities` long before that
+            // completes — a removed entity is never ticked again — silently
+            // skipping the exit-portal activation and leaving the fight
+            // unresolved forever, so it is excluded here.
+            if self.health.load() <= 0.0 && self.entity.entity_type != &EntityType::ENDER_DRAGON {
                 let time = self.death_time.fetch_add(1, Relaxed);
                 // Only send death particles once (on the exact tick death_time reaches 20)
                 // and then remove the entity, preventing entity_event spam.


### PR DESCRIPTION
## What

`LivingEntity::tick()` has a generic "corpse removal" step: once an entity's health drops to 0, a `death_time` counter increments each tick, and at `death_time == 20` the entity is removed from the world (`self.entity.remove().await`) after sending the death status/particles.

The Ender Dragon is a normal `LivingEntity` internally, so it went through this same generic path. This change excludes `EntityType::ENDER_DRAGON` from that generic 20-tick removal, since the dragon already manages its own removal at the end of its death sequence (see Why).

## Why

The Ender Dragon drives its death animation through `DyingPhase::tick()` (`pumpkin/src/entity/boss/ender_dragon/phase/dying.rs`), which runs for `DEATH_TIMER_MAX` (200) ticks. Only when the counter reaches 200 does it call `DragonFight::set_dragon_killed(...)`, which is what activates the end exit portal, places the dragon egg, and spawns the exit end gateway — then it removes the dragon and its parts.

But the generic removal in `LivingEntity::tick()` fires much earlier, at `death_time == 20`, and calls `world.remove_entity(...)` (via `Entity::remove()`), which drops the entity from `world.entities` immediately. A removed entity is never ticked again, so `DyingPhase::tick()` stops running right after tick 20 and never reaches the `t >= DEATH_TIMER_MAX` branch. The result: the dragon visually "dies" (particles/sound already played by tick 20) but the fight is never marked resolved, so the exit portal never opens, no egg is placed, and no gateway spawns — matching the reported behavior in #2065.

## Impact

- Fixes the Ender Dragon fight so that defeating the dragon reliably opens the exit portal, places the egg, and spawns the exit gateway, since `DyingPhase` can now run to completion instead of being cut off at tick 20.
- No behavior change for any other entity type — the added condition only excludes `EntityType::ENDER_DRAGON` from the existing generic removal branch; every other mob/player still follows the same 20-tick removal path as before.
- The dragon's own death sequence already removes it (and its body parts) once `DyingPhase` finishes, so this doesn't leave the dragon un-removed — it's removed at the correct time instead of prematurely.

## Limitations

- I could not test this against a live, playable dragon fight end-to-end (spawning/defeating an actual Ender Dragon in a running server) in this environment; the fix is based on tracing the tick/removal code paths (`LivingEntity::tick`, `DyingPhase::tick`, `DragonFight::set_dragon_killed`, `World::remove_entity`) to confirm the generic removal was the only thing preventing `DyingPhase` from reaching `DEATH_TIMER_MAX`.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test` both pass locally with this change.

Fixes #2065