### PR TITLE
fix(loot): animals drop cooked food without fire or Fire Aspect

### DIFF
--- a/pumpkin-codegen/src/loot.rs
+++ b/pumpkin-codegen/src/loot.rs
@@ -312,15 +312,74 @@ pub struct ItemPredicateStruct {
     pub items: Option<StringOrVec>,
 }
 
+/// Entity flags predicate from loot table JSON.
+/// Mirrors vanilla `EntityFlagsPredicate`. Only `is_on_fire` is extracted;
+/// other flags (is_on_ground, is_baby, etc.) are ignored until needed.
+#[derive(Deserialize, Clone, Debug)]
+pub struct EntityFlagsPredicateStruct {
+    /// Whether the entity must be on fire. Mirrors vanilla `isOnFire: Optional<Boolean>`.
+    #[serde(default)]
+    pub is_on_fire: Option<bool>,
+}
+
+/// Entity equipment predicate from loot table JSON.
+/// Mirrors vanilla `EntityEquipmentPredicate`. Only mainhand enchantment tag is extracted;
+/// other slots (head, chest, legs, feet, offhand) and full item predicates are ignored.
+#[derive(Deserialize, Clone, Debug)]
+pub struct EntityEquipmentPredicatesStruct {
+    /// Mainhand slot predicate. Only enchantment tag is forwarded to runtime.
+    /// Mirrors vanilla `EntityEquipmentPredicate.mainhand`.
+    #[serde(default)]
+    pub mainhand: Option<EntityMainhandPredicateStruct>,
+}
+
+/// Mainhand item predicate for equipment slot checks.
+/// Mirrors vanilla `ItemPredicate` used inside `EntityEquipmentPredicate.mainhand`.
+#[derive(Deserialize, Clone, Debug)]
+pub struct EntityMainhandPredicateStruct {
+    /// Component predicates for the item. Mirrors vanilla `DataComponentMatchers`.
+    #[serde(default)]
+    pub predicates: Option<EntityEquipmentPredicatesInner>,
+}
+
+/// Inner predicates structure for equipment slot checks.
+/// Contains the actual enchantment tag to match against.
+#[derive(Deserialize, Clone, Debug)]
+pub struct EntityEquipmentPredicatesInner {
+    /// Enchantment tag to match (e.g. `"minecraft:smelts_loot"` → Fire Aspect).
+    /// Mirrors vanilla `EnchantmentPredicate.enchantments` as a `HolderSet` reference.
+    #[serde(default, rename = "minecraft:enchantments")]
+    pub minecraft_enchantments: Option<Vec<EntityEnchantmentPredicate>>,
+}
+
+/// Single enchantment predicate entry from loot table JSON.
+/// Mirrors one entry in vanilla's `EnchantmentPredicate.enchantments` array.
+#[derive(Deserialize, Clone, Debug)]
+pub struct EntityEnchantmentPredicate {
+    /// The enchantment(s) to check — single ID or tag reference (e.g. `"#minecraft:smelts_loot"`).
+    pub enchantments: Option<StringOrVec>,
+}
+
+/// Entity predicate from loot table JSON.
+/// Mirrors vanilla `EntityPredicate` — a conjunction of sub-predicates.
+/// Currently extracts entity_type, flags.is_on_fire, and equipment.mainhand.
+/// Other sub-predicates (effects, distance, location, nbt) are silently ignored.
 #[derive(Deserialize, Clone, Debug)]
 pub struct EntityPredicateStruct {
-    #[serde(rename = "type")]
+    /// Entity type to match. Mirrors vanilla `EntityTypePredicate`.
+    #[serde(rename = "minecraft:entity_type")]
     pub entity_type: Option<StringOrVec>,
+    /// Entity state flags. Mirrors vanilla `EntityFlagsPredicate`.
+    #[serde(rename = "minecraft:flags")]
+    pub flags: Option<EntityFlagsPredicateStruct>,
+    /// Equipment slot predicates. Mirrors vanilla `EntityEquipmentPredicate`.
+    #[serde(rename = "minecraft:equipment")]
+    pub equipment: Option<EntityEquipmentPredicatesStruct>,
 }
 
 impl ToTokens for EntityPredicateStruct {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.extend(quote! { () });
+        tokens.extend(quote! {});
     }
 }
 
@@ -479,13 +538,32 @@ impl ToTokens for LootConditionStruct {
                     .and_then(|p| p.entity_type.as_ref())
                     .map(|t| match t {
                         StringOrVec::String(s) => quote! { Some(#s) },
-                        StringOrVec::Vec(v) => {
-                            let s = &v[0];
-                            quote! { Some(#s) }
-                        }
+                        StringOrVec::Vec(v) => v.first().map_or(quote! { None }, |s| quote! { Some(#s) }),
                     })
                     .unwrap_or(quote! { None });
-                quote! { LootCondition::EntityProperties { entity: #e, expected_type: #expected_type } }
+
+                let is_on_fire = predicate
+                    .as_ref()
+                    .and_then(|p| p.flags.as_ref())
+                    .and_then(|f| f.is_on_fire)
+                    .map(|v| quote! { Some(#v) })
+                    .unwrap_or(quote! { None });
+
+                let mainhand_enchantment_tag = predicate
+                    .as_ref()
+                    .and_then(|p| p.equipment.as_ref())
+                    .and_then(|eq| eq.mainhand.as_ref())
+                    .and_then(|mh| mh.predicates.as_ref())
+                    .and_then(|pred| pred.minecraft_enchantments.as_ref())
+                    .and_then(|enchs| enchs.first())
+                    .and_then(|ench| ench.enchantments.as_ref())
+                    .map(|t| match t {
+                        StringOrVec::String(s) => quote! { Some(#s) },
+                        StringOrVec::Vec(v) => v.first().map_or(quote! { None }, |s| quote! { Some(#s) }),
+                    })
+                    .unwrap_or(quote! { None });
+
+                quote! { LootCondition::EntityProperties { entity: #e, expected_type: #expected_type, is_on_fire: #is_on_fire, mainhand_enchantment_tag: #mainhand_enchantment_tag } }
             }
             Self::KilledByPlayer => quote! { LootCondition::KilledByPlayer },
             Self::EntityScores { entity, scores: _ } => {
@@ -535,10 +613,7 @@ impl ToTokens for LootConditionStruct {
                     .and_then(|e| e.entity_type.as_ref())
                     .map(|t| match t {
                         StringOrVec::String(s) => quote! { Some(#s) },
-                        StringOrVec::Vec(v) => {
-                            let s = &v[0];
-                            quote! { Some(#s) }
-                        }
+                        StringOrVec::Vec(v) => v.first().map_or(quote! { None }, |s| quote! { Some(#s) }),
                     })
                     .unwrap_or(quote! { None });
 
@@ -548,10 +623,7 @@ impl ToTokens for LootConditionStruct {
                     .and_then(|e| e.entity_type.as_ref())
                     .map(|t| match t {
                         StringOrVec::String(s) => quote! { Some(#s) },
-                        StringOrVec::Vec(v) => {
-                            let s = &v[0];
-                            quote! { Some(#s) }
-                        }
+                        StringOrVec::Vec(v) => v.first().map_or(quote! { None }, |s| quote! { Some(#s) }),
                     })
                     .unwrap_or(quote! { None });
 
@@ -571,10 +643,7 @@ impl ToTokens for LootConditionStruct {
                     .and_then(|p| p.biome.as_ref())
                     .map(|b| match b {
                         StringOrVec::String(s) => quote! { Some(#s) },
-                        StringOrVec::Vec(v) => {
-                            let s = &v[0];
-                            quote! { Some(#s) }
-                        }
+                        StringOrVec::Vec(v) => v.first().map_or(quote! { None }, |s| quote! { Some(#s) }),
                     })
                     .unwrap_or(quote! { None });
                 quote! { LootCondition::LocationCheck { offset_x: #ox, offset_y: #oy, offset_z: #oz, expected_biome: #expected_biome } }

--- a/pumpkin-data/src/generated/entity_type.rs
+++ b/pumpkin-data/src/generated/entity_type.rs
@@ -1572,10 +1572,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             },
@@ -1666,10 +1670,14 @@ impl EntityType {
                                 LootCondition::EntityProperties {
                                     entity: "this",
                                     expected_type: None,
+                                    is_on_fire: Some(true),
+                                    mainhand_enchantment_tag: None,
                                 },
                                 LootCondition::EntityProperties {
                                     entity: "direct_attacker",
                                     expected_type: None,
+                                    is_on_fire: None,
+                                    mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                 },
                             ])]),
                         }]),
@@ -1924,10 +1932,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             },
@@ -2112,7 +2124,9 @@ impl EntityType {
                     bonus_rolls: LootNumberProviderTypes::Constant(0f32),
                     conditions: Some(&[LootCondition::EntityProperties {
                         entity: "attacker",
-                        expected_type: None,
+                        expected_type: Some("#minecraft:skeletons"),
+                        is_on_fire: None,
+                        mainhand_enchantment_tag: None,
                     }]),
                     functions: None,
                 },
@@ -2251,10 +2265,14 @@ impl EntityType {
                                 LootCondition::EntityProperties {
                                     entity: "this",
                                     expected_type: None,
+                                    is_on_fire: Some(true),
+                                    mainhand_enchantment_tag: None,
                                 },
                                 LootCondition::EntityProperties {
                                     entity: "direct_attacker",
                                     expected_type: None,
+                                    is_on_fire: None,
+                                    mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                 },
                             ])]),
                         },
@@ -2634,10 +2652,16 @@ impl EntityType {
                                         LootCondition::EntityProperties {
                                             entity: "this",
                                             expected_type: None,
+                                            is_on_fire: Some(true),
+                                            mainhand_enchantment_tag: None,
                                         },
                                         LootCondition::EntityProperties {
                                             entity: "direct_attacker",
                                             expected_type: None,
+                                            is_on_fire: None,
+                                            mainhand_enchantment_tag: Some(
+                                                "#minecraft:smelts_loot",
+                                            ),
                                         },
                                     ])]),
                                 },
@@ -2704,10 +2728,14 @@ impl EntityType {
                                 LootCondition::EntityProperties {
                                     entity: "this",
                                     expected_type: None,
+                                    is_on_fire: Some(true),
+                                    mainhand_enchantment_tag: None,
                                 },
                                 LootCondition::EntityProperties {
                                     entity: "direct_attacker",
                                     expected_type: None,
+                                    is_on_fire: None,
+                                    mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                 },
                             ])]),
                         }]),
@@ -3554,7 +3582,7 @@ impl EntityType {
                     conditions: Some(&[
                         LootCondition::DamageSourceProperties {
                             expected_source_type: None,
-                            expected_direct_type: None,
+                            expected_direct_type: Some("minecraft:fireball"),
                         },
                         LootCondition::KilledByPlayer,
                     ]),
@@ -3909,10 +3937,16 @@ impl EntityType {
                                         LootCondition::EntityProperties {
                                             entity: "this",
                                             expected_type: None,
+                                            is_on_fire: Some(true),
+                                            mainhand_enchantment_tag: None,
                                         },
                                         LootCondition::EntityProperties {
                                             entity: "direct_attacker",
                                             expected_type: None,
+                                            is_on_fire: None,
+                                            mainhand_enchantment_tag: Some(
+                                                "#minecraft:smelts_loot",
+                                            ),
                                         },
                                     ])]),
                                 },
@@ -3964,10 +3998,14 @@ impl EntityType {
                                 LootCondition::EntityProperties {
                                     entity: "this",
                                     expected_type: None,
+                                    is_on_fire: Some(true),
+                                    mainhand_enchantment_tag: None,
                                 },
                                 LootCondition::EntityProperties {
                                     entity: "direct_attacker",
                                     expected_type: None,
+                                    is_on_fire: None,
+                                    mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                 },
                             ])]),
                         }]),
@@ -4120,10 +4158,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             },
@@ -4399,6 +4441,8 @@ impl EntityType {
                         conditions: Some(&[LootCondition::EntityProperties {
                             entity: "this",
                             expected_type: None,
+                            is_on_fire: None,
+                            mainhand_enchantment_tag: None,
                         }]),
                         functions: Some(&[
                             LootFunction {
@@ -4462,10 +4506,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             }]),
@@ -5017,12 +5065,14 @@ impl EntityType {
                         quality: 0i32,
                         conditions: Some(&[
                             LootCondition::Inverted(&LootCondition::DamageSourceProperties {
-                                expected_source_type: None,
+                                expected_source_type: Some("minecraft:frog"),
                                 expected_direct_type: None,
                             }),
                             LootCondition::EntityProperties {
                                 entity: "this",
                                 expected_type: None,
+                                is_on_fire: None,
+                                mainhand_enchantment_tag: None,
                             },
                         ]),
                         functions: Some(&[
@@ -5056,7 +5106,7 @@ impl EntityType {
                         weight: 1i32,
                         quality: 0i32,
                         conditions: Some(&[LootCondition::DamageSourceProperties {
-                            expected_source_type: None,
+                            expected_source_type: Some("minecraft:frog"),
                             expected_direct_type: None,
                         }]),
                         functions: Some(&[LootFunction {
@@ -5074,7 +5124,7 @@ impl EntityType {
                         weight: 1i32,
                         quality: 0i32,
                         conditions: Some(&[LootCondition::DamageSourceProperties {
-                            expected_source_type: None,
+                            expected_source_type: Some("minecraft:frog"),
                             expected_direct_type: None,
                         }]),
                         functions: Some(&[LootFunction {
@@ -5092,7 +5142,7 @@ impl EntityType {
                         weight: 1i32,
                         quality: 0i32,
                         conditions: Some(&[LootCondition::DamageSourceProperties {
-                            expected_source_type: None,
+                            expected_source_type: Some("minecraft:frog"),
                             expected_direct_type: None,
                         }]),
                         functions: Some(&[LootFunction {
@@ -5367,10 +5417,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             },
@@ -6260,10 +6314,14 @@ impl EntityType {
                                 LootCondition::EntityProperties {
                                     entity: "this",
                                     expected_type: None,
+                                    is_on_fire: Some(true),
+                                    mainhand_enchantment_tag: None,
                                 },
                                 LootCondition::EntityProperties {
                                     entity: "direct_attacker",
                                     expected_type: None,
+                                    is_on_fire: None,
+                                    mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                 },
                             ])]),
                         },
@@ -6476,6 +6534,8 @@ impl EntityType {
                 conditions: Some(&[LootCondition::EntityProperties {
                     entity: "this",
                     expected_type: None,
+                    is_on_fire: None,
+                    mainhand_enchantment_tag: None,
                 }]),
                 functions: None,
             }]),
@@ -6576,10 +6636,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             },
@@ -6620,10 +6684,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             },
@@ -6862,10 +6930,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             },
@@ -7052,10 +7124,14 @@ impl EntityType {
                                 LootCondition::EntityProperties {
                                     entity: "this",
                                     expected_type: None,
+                                    is_on_fire: Some(true),
+                                    mainhand_enchantment_tag: None,
                                 },
                                 LootCondition::EntityProperties {
                                     entity: "direct_attacker",
                                     expected_type: None,
+                                    is_on_fire: None,
+                                    mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                 },
                             ])]),
                         }]),
@@ -7161,10 +7237,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             },
@@ -7199,6 +7279,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7211,6 +7293,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7223,6 +7307,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7235,6 +7321,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7247,6 +7335,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7259,6 +7349,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7271,6 +7363,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7283,6 +7377,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7295,6 +7391,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7307,6 +7405,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7319,6 +7419,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7331,6 +7433,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7343,6 +7447,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7355,6 +7461,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7367,6 +7475,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7379,6 +7489,8 @@ impl EntityType {
                                     conditions: Some(&[LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: None,
                                     }]),
                                     functions: None,
                                 },
@@ -7828,7 +7940,7 @@ impl EntityType {
                         quality: 0i32,
                         conditions: Some(&[LootCondition::Inverted(
                             &LootCondition::DamageSourceProperties {
-                                expected_source_type: None,
+                                expected_source_type: Some("minecraft:frog"),
                                 expected_direct_type: None,
                             },
                         )]),
@@ -7863,7 +7975,7 @@ impl EntityType {
                         weight: 1i32,
                         quality: 0i32,
                         conditions: Some(&[LootCondition::DamageSourceProperties {
-                            expected_source_type: None,
+                            expected_source_type: Some("minecraft:frog"),
                             expected_direct_type: None,
                         }]),
                         functions: Some(&[LootFunction {
@@ -7880,6 +7992,8 @@ impl EntityType {
                 conditions: Some(&[LootCondition::EntityProperties {
                     entity: "this",
                     expected_type: None,
+                    is_on_fire: None,
+                    mainhand_enchantment_tag: None,
                 }]),
                 functions: None,
             }]),
@@ -10260,6 +10374,8 @@ impl EntityType {
                         conditions: Some(&[LootCondition::EntityProperties {
                             entity: "this",
                             expected_type: None,
+                            is_on_fire: None,
+                            mainhand_enchantment_tag: None,
                         }]),
                         functions: Some(&[
                             LootFunction {
@@ -10323,10 +10439,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             }]),
@@ -10360,6 +10480,8 @@ impl EntityType {
                         LootCondition::EntityProperties {
                             entity: "this",
                             expected_type: None,
+                            is_on_fire: None,
+                            mainhand_enchantment_tag: None,
                         },
                     ]),
                     functions: None,
@@ -10674,10 +10796,14 @@ impl EntityType {
                                     LootCondition::EntityProperties {
                                         entity: "this",
                                         expected_type: None,
+                                        is_on_fire: Some(true),
+                                        mainhand_enchantment_tag: None,
                                     },
                                     LootCondition::EntityProperties {
                                         entity: "direct_attacker",
                                         expected_type: None,
+                                        is_on_fire: None,
+                                        mainhand_enchantment_tag: Some("#minecraft:smelts_loot"),
                                     },
                                 ])]),
                             }]),

--- a/pumpkin-util/src/loot_table.rs
+++ b/pumpkin-util/src/loot_table.rs
@@ -103,7 +103,7 @@ pub enum LootCondition {
     /// Checks properties of the entity (e.g. type, flags, equipment).
     /// Mirrors vanilla `LootItemEntityPropertyCondition`.
     EntityProperties {
-        /// The entity target to check: "this", "attacker", or "direct_attacker".
+        /// The entity target to check: "this", "attacker", or "`direct_attacker`".
         entity: &'static str,
         /// Expected entity type (e.g. "minecraft:cow").
         expected_type: Option<&'static str>,

--- a/pumpkin-util/src/loot_table.rs
+++ b/pumpkin-util/src/loot_table.rs
@@ -100,10 +100,19 @@ pub enum LootCondition {
         enchantment: &'static str,
         chances: Option<&'static [f32]>,
     },
-    /// Checks properties of the entity (e.g. type, attributes).
+    /// Checks properties of the entity (e.g. type, flags, equipment).
+    /// Mirrors vanilla `LootItemEntityPropertyCondition`.
     EntityProperties {
+        /// The entity target to check: "this", "attacker", or "direct_attacker".
         entity: &'static str,
+        /// Expected entity type (e.g. "minecraft:cow").
         expected_type: Option<&'static str>,
+        /// When `Some`, the entity must be on fire for the condition to pass.
+        /// Mirrors vanilla `EntityFlagsPredicate.isOnFire`.
+        is_on_fire: Option<bool>,
+        /// When `Some`, the entity's mainhand item must have an enchantment in this tag.
+        /// Mirrors vanilla `EntityEquipmentPredicate.mainhand` with enchantment tag lookup.
+        mainhand_enchantment_tag: Option<&'static str>,
     },
     /// Requires the entity to have been killed by a player.
     KilledByPlayer,

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -1350,6 +1350,12 @@ impl LivingEntity {
                 tool,
                 is_raining: Some(is_raining),
                 is_thundering: Some(is_thundering),
+                is_on_fire: Some(
+                    self.entity
+                        .fire_ticks
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                        > 0,
+                ),
                 ..Default::default()
             };
 

--- a/pumpkin/src/world/loot.rs
+++ b/pumpkin/src/world/loot.rs
@@ -27,6 +27,9 @@ pub struct LootContextParameters {
     pub tool: Option<ItemStack>,
     pub is_raining: Option<bool>,
     pub is_thundering: Option<bool>,
+    /// Whether the killed entity was on fire at death time.
+    /// Computed from `Entity.fire_ticks > 0`.
+    pub is_on_fire: Option<bool>,
 }
 
 pub trait LootTableExt {
@@ -518,15 +521,48 @@ impl LootConditionExt for LootCondition {
             Self::EntityProperties {
                 entity,
                 expected_type,
+                is_on_fire,
+                mainhand_enchantment_tag,
             } => {
+                // Mirrors vanilla `EntityTarget` resolution from `LootContext.java:148-186`.
                 let target = match *entity {
                     "this" => params.this_entity,
-                    "killer" | "direct_killer" => params.killer_entity,
+                    "attacker" | "killer" => params.killer_entity,
+                    "direct_attacker" | "direct_killer" => params.direct_killer_entity,
+                    "attacking_player" => params.killer_entity,
                     _ => None,
                 };
                 if let Some(target) = target {
-                    if let Some(expected_type) = expected_type {
-                        return compare_entity_type(expected_type, target);
+                    if let Some(expected) = expected_type {
+                        if !compare_entity_type(expected, target) {
+                            return false;
+                        }
+                    }
+                    // Mirrors vanilla `EntityFlagsPredicate.isOnFire` check.
+                    if let Some(expected_fire) = is_on_fire {
+                        let actual_fire = params.is_on_fire.unwrap_or(false);
+                        if actual_fire != *expected_fire {
+                            return false;
+                        }
+                    }
+                    // Mirrors vanilla enchantment tag lookup for smelts_loot.
+                    if let Some(tag_name) = mainhand_enchantment_tag {
+                        let tag = tag_name.strip_prefix('#').unwrap_or(tag_name);
+                        let has_enchant = params.tool.as_ref().is_some_and(|tool| {
+                            pumpkin_data::tag::get_tag_ids(
+                                pumpkin_data::tag::RegistryKey::Enchantment,
+                                tag,
+                            )
+                            .is_some_and(|tag_ids| {
+                                tag_ids.iter().any(|&ench_id| {
+                                    pumpkin_data::Enchantment::from_id(ench_id as u8)
+                                        .is_some_and(|enc| tool.get_enchantment_level(enc) > 0)
+                                })
+                            })
+                        });
+                        if !has_enchant {
+                            return false;
+                        }
                     }
                     true
                 } else {
@@ -807,5 +843,317 @@ fn shuffle_and_split_items(
     for i in (1..n).rev() {
         let j = rng.next_bounded_i32((i + 1) as i32) as usize;
         result.swap(i, j);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pumpkin_data::Enchantment;
+    use pumpkin_data::damage::DamageType;
+    use pumpkin_data::entity::EntityType;
+    use pumpkin_data::item::Item;
+    use pumpkin_data::item_stack::ItemStack;
+
+    fn base_params() -> LootContextParameters {
+        LootContextParameters {
+            killed_by_player: Some(true),
+            this_entity: Some(&EntityType::PIG),
+            killer_entity: Some(&EntityType::PLAYER),
+            direct_killer_entity: Some(&EntityType::PLAYER),
+            damage_type: Some(DamageType::GENERIC),
+            ..Default::default()
+        }
+    }
+
+    fn fire_aspect_sword(level: i32) -> ItemStack {
+        let mut sword = ItemStack::new(1, &Item::DIAMOND_SWORD);
+        sword.enchant(&Enchantment::FIRE_ASPECT, level);
+        sword
+    }
+
+    #[test]
+    fn entity_properties_this_matches_expected_type() {
+        let params = base_params();
+        let cond = LootCondition::EntityProperties {
+            entity: "this",
+            expected_type: Some("minecraft:pig"),
+            is_on_fire: None,
+            mainhand_enchantment_tag: None,
+        };
+        assert!(cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn entity_properties_this_rejects_wrong_type() {
+        let params = base_params();
+        let cond = LootCondition::EntityProperties {
+            entity: "this",
+            expected_type: Some("minecraft:cow"),
+            is_on_fire: None,
+            mainhand_enchantment_tag: None,
+        };
+        assert!(!cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn entity_properties_direct_attacker_resolves() {
+        let params = base_params();
+        let cond = LootCondition::EntityProperties {
+            entity: "direct_attacker",
+            expected_type: None,
+            is_on_fire: None,
+            mainhand_enchantment_tag: None,
+        };
+        assert!(cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn entity_properties_direct_attacker_no_direct_killer() {
+        let mut params = base_params();
+        params.direct_killer_entity = None;
+        let cond = LootCondition::EntityProperties {
+            entity: "direct_attacker",
+            expected_type: None,
+            is_on_fire: None,
+            mainhand_enchantment_tag: None,
+        };
+        assert!(!cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn entity_properties_unknown_entity_returns_false() {
+        let params = base_params();
+        let cond = LootCondition::EntityProperties {
+            entity: "target_entity",
+            expected_type: None,
+            is_on_fire: None,
+            mainhand_enchantment_tag: None,
+        };
+        assert!(!cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn is_on_fire_true_when_burning() {
+        let params = LootContextParameters {
+            is_on_fire: Some(true),
+            ..base_params()
+        };
+        let cond = LootCondition::EntityProperties {
+            entity: "this",
+            expected_type: None,
+            is_on_fire: Some(true),
+            mainhand_enchantment_tag: None,
+        };
+        assert!(cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn is_on_fire_true_fails_when_not_burning() {
+        let params = LootContextParameters {
+            is_on_fire: Some(false),
+            ..base_params()
+        };
+        let cond = LootCondition::EntityProperties {
+            entity: "this",
+            expected_type: None,
+            is_on_fire: Some(true),
+            mainhand_enchantment_tag: None,
+        };
+        assert!(!cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn is_on_fire_false_matches_not_burning() {
+        let params = LootContextParameters {
+            is_on_fire: Some(false),
+            ..base_params()
+        };
+        let cond = LootCondition::EntityProperties {
+            entity: "this",
+            expected_type: None,
+            is_on_fire: Some(false),
+            mainhand_enchantment_tag: None,
+        };
+        assert!(cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn is_on_fire_true_fails_when_context_none() {
+        let params = LootContextParameters {
+            is_on_fire: None,
+            ..base_params()
+        };
+        let cond = LootCondition::EntityProperties {
+            entity: "this",
+            expected_type: None,
+            is_on_fire: Some(true),
+            mainhand_enchantment_tag: None,
+        };
+        assert!(!cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn none_is_on_fire_skips_check() {
+        let params = LootContextParameters {
+            is_on_fire: Some(true),
+            ..base_params()
+        };
+        let cond = LootCondition::EntityProperties {
+            entity: "this",
+            expected_type: None,
+            is_on_fire: None,
+            mainhand_enchantment_tag: None,
+        };
+        assert!(cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn enchantment_tag_matches_fire_aspect() {
+        let params = LootContextParameters {
+            tool: Some(fire_aspect_sword(1)),
+            ..base_params()
+        };
+        let cond = LootCondition::EntityProperties {
+            entity: "direct_attacker",
+            expected_type: None,
+            is_on_fire: None,
+            mainhand_enchantment_tag: Some("minecraft:smelts_loot"),
+        };
+        assert!(cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn enchantment_tag_fails_without_enchantment() {
+        let params = LootContextParameters {
+            tool: Some(ItemStack::new(1, &Item::DIAMOND_SWORD)),
+            ..base_params()
+        };
+        let cond = LootCondition::EntityProperties {
+            entity: "direct_attacker",
+            expected_type: None,
+            is_on_fire: None,
+            mainhand_enchantment_tag: Some("minecraft:smelts_loot"),
+        };
+        assert!(!cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn enchantment_tag_rejects_unrelated_enchantment() {
+        let mut sword = ItemStack::new(1, &Item::DIAMOND_SWORD);
+        sword.enchant(&Enchantment::SHARPNESS, 5);
+        let params = LootContextParameters {
+            tool: Some(sword),
+            ..base_params()
+        };
+        let cond = LootCondition::EntityProperties {
+            entity: "direct_attacker",
+            expected_type: None,
+            is_on_fire: None,
+            mainhand_enchantment_tag: Some("minecraft:smelts_loot"),
+        };
+        assert!(!cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn enchantment_tag_fails_with_no_tool() {
+        let params = LootContextParameters {
+            tool: None,
+            ..base_params()
+        };
+        let cond = LootCondition::EntityProperties {
+            entity: "direct_attacker",
+            expected_type: None,
+            is_on_fire: None,
+            mainhand_enchantment_tag: Some("minecraft:smelts_loot"),
+        };
+        assert!(!cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn none_enchantment_tag_skips_check() {
+        let params = LootContextParameters {
+            tool: Some(fire_aspect_sword(2)),
+            ..base_params()
+        };
+        let cond = LootCondition::EntityProperties {
+            entity: "direct_attacker",
+            expected_type: None,
+            is_on_fire: None,
+            mainhand_enchantment_tag: None,
+        };
+        assert!(cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn anyof_passes_when_entity_on_fire() {
+        let params = LootContextParameters {
+            is_on_fire: Some(true),
+            tool: Some(ItemStack::new(1, &Item::DIAMOND_SWORD)),
+            ..base_params()
+        };
+        let cond = LootCondition::AnyOf(&[
+            LootCondition::EntityProperties {
+                entity: "this",
+                expected_type: None,
+                is_on_fire: Some(true),
+                mainhand_enchantment_tag: None,
+            },
+            LootCondition::EntityProperties {
+                entity: "direct_attacker",
+                expected_type: None,
+                is_on_fire: None,
+                mainhand_enchantment_tag: Some("minecraft:smelts_loot"),
+            },
+        ]);
+        assert!(cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn anyof_passes_when_weapon_has_fire_aspect() {
+        let params = LootContextParameters {
+            is_on_fire: Some(false),
+            tool: Some(fire_aspect_sword(1)),
+            ..base_params()
+        };
+        let cond = LootCondition::AnyOf(&[
+            LootCondition::EntityProperties {
+                entity: "this",
+                expected_type: None,
+                is_on_fire: Some(true),
+                mainhand_enchantment_tag: None,
+            },
+            LootCondition::EntityProperties {
+                entity: "direct_attacker",
+                expected_type: None,
+                is_on_fire: None,
+                mainhand_enchantment_tag: Some("minecraft:smelts_loot"),
+            },
+        ]);
+        assert!(cond.is_fulfilled(&params));
+    }
+
+    #[test]
+    fn anyof_fails_without_fire_or_fire_aspect() {
+        let params = LootContextParameters {
+            is_on_fire: Some(false),
+            tool: Some(ItemStack::new(1, &Item::DIAMOND_SWORD)),
+            ..base_params()
+        };
+        let cond = LootCondition::AnyOf(&[
+            LootCondition::EntityProperties {
+                entity: "this",
+                expected_type: None,
+                is_on_fire: Some(true),
+                mainhand_enchantment_tag: None,
+            },
+            LootCondition::EntityProperties {
+                entity: "direct_attacker",
+                expected_type: None,
+                is_on_fire: None,
+                mainhand_enchantment_tag: Some("minecraft:smelts_loot"),
+            },
+        ]);
+        assert!(!cond.is_fulfilled(&params));
     }
 }

--- a/pumpkin/src/world/loot.rs
+++ b/pumpkin/src/world/loot.rs
@@ -527,16 +527,15 @@ impl LootConditionExt for LootCondition {
                 // Mirrors vanilla `EntityTarget` resolution from `LootContext.java:148-186`.
                 let target = match *entity {
                     "this" => params.this_entity,
-                    "attacker" | "killer" => params.killer_entity,
+                    "attacker" | "killer" | "attacking_player" => params.killer_entity,
                     "direct_attacker" | "direct_killer" => params.direct_killer_entity,
-                    "attacking_player" => params.killer_entity,
                     _ => None,
                 };
                 if let Some(target) = target {
-                    if let Some(expected) = expected_type {
-                        if !compare_entity_type(expected, target) {
-                            return false;
-                        }
+                    if let Some(expected) = expected_type
+                        && !compare_entity_type(expected, target)
+                    {
+                        return false;
                     }
                     // Mirrors vanilla `EntityFlagsPredicate.isOnFire` check.
                     if let Some(expected_fire) = is_on_fire {


### PR DESCRIPTION
## Summary

Fixes animals dropping cooked food when killed without fire or a Fire Aspect enchantment (#2366).

When a player kills a farm animal (pig, cow, chicken, sheep, rabbit, cod, salmon, etc.) without the entity being on fire and without using a weapon enchanted with Fire Aspect, the animal incorrectly drops cooked meat instead of raw meat.

This bug affects **16 entity types** across the game.

The fix adds proper predicate evaluation to the loot system, matching vanilla Minecraft behavior where the `FurnaceSmelt` loot function is only applied when **either** of the following conditions is true:

- The entity is on fire.
- The direct attacker is holding a weapon with an enchantment in the `#minecraft:smelts_loot` tag (Fire Aspect).

---

## Problem

In vanilla Minecraft, the `FurnaceSmelt` loot function is guarded by an `AnyOf` loot predicate with two subconditions:

1. The killed entity is currently on fire (`minecraft:flags.is_on_fire`).
2. The direct attacker's mainhand weapon has an enchantment in the `#minecraft:smelts_loot` tag (`minecraft:equipment.mainhand.predicates.minecraft:enchantments`).

Pumpkin's implementation of `LootCondition::EntityProperties` lacked the data model, code generation support, and runtime evaluation required to process these predicates. As a result, `FurnaceSmelt` was effectively applied **unconditionally**.

Consequently, every farm animal dropped cooked meat regardless of how it was killed:

- Bare hand
- Non-enchanted weapon
- No fire source present

---

## Root Cause

The loot system contained three independent issues that together prevented proper predicate evaluation.

### 1. Missing Data Model

`LootCondition::EntityProperties` in `pumpkin-util/src/loot_table.rs` only stored:

- `entity: &'static str`
- `expected_type: Option<&'static str>`

It had no representation for:

- Entity state flags (`is_on_fire`)
- Equipment predicates
- Mainhand enchantment tag checks

Without these fields, the condition could not express the predicates required by vanilla's `FurnaceSmelt` implementation.

---

### 2. Code Generation Discards Predicate Data

`EntityPredicateStruct` in `pumpkin-codegen/src/loot.rs` only deserializes the `type` field from vanilla's entity predicate JSON.

Its `ToTokens` implementation emits `()`, meaning all predicate information is discarded during code generation, including:

- `minecraft:flags`
- `minecraft:equipment`
- `minecraft:enchantments`

Additionally, the serde rename used `"type"` instead of `"minecraft:entity_type"`, causing every entity type check to deserialize as `None`.

---

### 3. Runtime Evaluator Bugs

The evaluator in `pumpkin/src/world/loot.rs` contained several logic errors:

- `"direct_attacker"` was missing from the entity name match and fell through to `_ => None`, always evaluating to `false`.
- `"direct_killer"` incorrectly resolved to `params.killer_entity` instead of `params.direct_killer_entity`.
- When `expected_type` was `None`, the evaluator returned `true` whenever the entity existed.

The combined result was:

```text
AnyOf(true, false) == true
```

which caused `FurnaceSmelt` to execute for every entity death.

---

## Testing

### Before (bug)


https://github.com/user-attachments/assets/150b617d-5442-4e75-ad3d-9e2b47fca31c



### After (fix)

https://github.com/user-attachments/assets/f478d04e-bcb5-464d-af92-0d30fd67279c




### Validation

Added **18 unit tests** covering:

- Entity resolution
- Fire state predicates
- Enchantment tag predicates
- `AnyOf` evaluation logic

All checks pass:

```bash
cargo fmt
cargo clippy
cargo test
```