### PR TITLE
fix(item): consume armor stand on placement

### DIFF
--- a/pumpkin/src/item/items/armor_stand.rs
+++ b/pumpkin/src/item/items/armor_stand.rs
@@ -40,7 +40,7 @@ impl ItemMetadata for ArmorStandItem {
 impl ItemBehaviour for ArmorStandItem {
     fn use_on_block<'a>(
         &'a self,
-        _item: &'a mut ItemStack,
+        item: &'a mut ItemStack,
         player: &'a Player,
         location: BlockPos,
         face: BlockDirection,
@@ -90,6 +90,7 @@ impl ItemBehaviour for ArmorStandItem {
                 let armor_stand = ArmorStandEntity::new(entity);
 
                 world.spawn_entity(Arc::new(armor_stand)).await;
+                item.decrement_unless_creative(player.gamemode.load(), 1);
             }
         })
     }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

Fixes armor stands not being consumed after successful placement in Survival

Now armor stand stack is now decremented after the entity is successfully spawned.

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] Manually tested placing armor stands.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
