### PR TITLE
User networking.java.online_mode for online mode detection

### DIFF
--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
@@ -310,12 +310,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
 
-        Ok(server
-            .advanced_config
-            .networking
-            .java
-            .authentication
-            .enabled)
+        Ok(server.advanced_config.networking.java.online_mode)
     }
 
     async fn get_motd(&mut self, _rep: Resource<Server>) -> wasmtime::Result<String> {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
I recently found that the `server.is_online_mode()` in the plugin API always returned `true`, so I looked into the server side code and found that the wit implementation uses `server.advanced_config.networking.java.authentication.enabled`. While this is technically not wrong, however most users when setting up a offline mode server, will just set `online_mode = false`. This changes a different field, specifically `server.advanced_config.networking.java.online_mode` without affecting the authentication status. For this reason I decided to modify the wit implementation to use the online_mode field.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
