### PR TITLE
fix: send correct block state ID when cancelling interact event

### DIFF
--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -2251,9 +2251,10 @@ impl JavaClient {
             server;
             event;
             'cancelled: {
+                let state_id = world.get_block_state_id(&position);
                 self.enqueue_packet(&CBlockUpdate::new(
                     position,
-                    VarInt(block.id.as_u16() as i32),
+                    VarInt(i32::from(state_id.as_u16())),
                 ))
                 .await;
                 return Ok(());


### PR DESCRIPTION
## Summary

`handle_use_item_on` sends a `CBlockUpdate` to the client when a `PlayerInteractEvent` is cancelled (right-click). The packet was using `block.id` (BlockId) instead of the actual `BlockStateId` at the position. This caused clients to see incorrect block states when plugins cancel right-click interactions.

## Changes

- Use `world.get_block_state_id(&position)` instead of `block.id` in the cancelled handler, matching the pattern used everywhere else in the file (e.g. `sync_block_state_to_client`, `StartedDigging` can't-mine check).

## Testing

- Registered a `PlayerInteractEvent` handler in a WASM plugin that cancels right-click when holding a wooden axe
- Without fix: right-clicking stone/leaves with axe shows wrong block state on client (snow block, waterlogged leaves)
- With fix: cancelled right-click correctly preserves the original block state on the client