### PR TITLE
fix: use wolf-specific entity metadata tracker id

### DIFF
--- a/pumpkin-codegen/src/tracked_data.rs
+++ b/pumpkin-codegen/src/tracked_data.rs
@@ -28,8 +28,21 @@ pub(crate) fn build() -> TokenStream {
 
         let content = fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("Failed to read JSON file: {path} {e}"));
-        let parsed: BTreeMap<String, u8> = serde_json::from_str(&content)
+        let mut parsed: BTreeMap<String, u8> = serde_json::from_str(&content)
             .unwrap_or_else(|e| panic!("Failed to parse {path}: {e}"));
+
+        // The upstream flattened asset loses duplicate Mojang field names.
+        // Before 26.1 the wolf tracker was named VARIANT; newer mappings use
+        // DATA_VARIANT_ID, which collides with unrelated entity fields in the
+        // flattened table. Preserve the legacy value and set the entity-scoped
+        // ID for the new mappings explicitly.
+        let wolf_variant_id = match ver {
+            JavaMinecraftVersion::V_26_1 | JavaMinecraftVersion::V_26_2 => Some(23),
+            _ => parsed.get("VARIANT").copied(),
+        };
+        if let Some(id) = wolf_variant_id {
+            parsed.insert("WOLF_VARIANT_ID".to_owned(), id);
+        }
 
         versions.insert(ver, parsed);
     }
@@ -150,5 +163,33 @@ fn normalize_name(name: &str) -> String {
         "CUSTOM_NAME_VISIBLE".to_string()
     } else {
         normalized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build;
+    use quote::quote;
+
+    #[test]
+    fn wolf_variant_keeps_its_entity_specific_v26_2_tracker_id() {
+        let generated = build().to_string();
+
+        assert!(generated.contains("WOLF_VARIANT_ID"));
+        let wolf = generated
+            .split("WOLF_VARIANT_ID")
+            .nth(1)
+            .expect("wolf tracker constant");
+        assert!(wolf.contains("v1_21_11 : 20u8"));
+        assert!(wolf.contains("v26_2 : 23u8"));
+    }
+
+    #[test]
+    fn checked_in_tracker_table_matches_codegen() {
+        let checked_in = std::fs::read_to_string("../pumpkin-data/src/generated/tracked_data.rs")
+            .expect("checked-in tracked data");
+        let parsed = syn::parse_file(&checked_in).expect("valid generated Rust");
+
+        assert_eq!(quote!(#parsed).to_string(), build().to_string());
     }
 }

--- a/pumpkin-data/src/generated/tracked_data.rs
+++ b/pumpkin-data/src/generated/tracked_data.rs
@@ -3960,6 +3960,18 @@ impl TrackedData {
         v26_1: 20u8,
         v26_2: 20u8,
     };
+    pub const WOLF_VARIANT_ID: TrackedId = TrackedId {
+        v1_21: 22u8,
+        v1_21_2: 22u8,
+        v1_21_4: 22u8,
+        v1_21_5: 22u8,
+        v1_21_6: 22u8,
+        v1_21_7: 20u8,
+        v1_21_9: 22u8,
+        v1_21_11: 20u8,
+        v26_1: 23u8,
+        v26_2: 23u8,
+    };
     pub const WOOL_ID: TrackedId = TrackedId {
         v1_21: 255u8,
         v1_21_2: 255u8,

--- a/pumpkin/src/entity/passive/wolf.rs
+++ b/pumpkin/src/entity/passive/wolf.rs
@@ -140,7 +140,7 @@ impl Mob for WolfEntity {
             }
             entity.send_meta_data(
                 &[Metadata::new(
-                    TrackedData::VARIANT,
+                    TrackedData::WOLF_VARIANT_ID,
                     MetaDataType::WOLF_VARIANT,
                     VarInt(self.variant.load(Ordering::Relaxed) as i32),
                 )],


### PR DESCRIPTION
## What changed

Adds an entity-scoped `WOLF_VARIANT_ID` tracker constant and uses it when Pumpkin sends wolf variant
metadata.

Legacy protocol versions preserve their existing wolf `VARIANT` IDs. Minecraft 26.1 and 26.2 use tracker
index 23.

## Why

The flattened tracked-data asset loses duplicate entity field names. In 26.1/26.2, the generic
`TrackedData::VARIANT` resolves to index 18, but vanilla Minecraft expects the wolf variant at index 23.

entity data item type`.

## Impact

Wolf metadata is sent at the correct tracker index for supported protocol versions. Other entity metadata
and protocol behavior are unchanged.

## Tests

- `cargo test --manifest-path pumpkin-codegen/Cargo.toml`
- `cargo test --manifest-path Cargo.toml -p pumpkin --lib`
- `cargo clippy --all-targets -p pumpkin -- -D warnings`
- Rustfmt checks for all changed Rust files

The codegen tests also verify that the checked-in generated tracker table matches generator output.

## Limitations

This patch fixes the known wolf metadata collision. Additional entity-specific aliases may be required if
future mappings contain more duplicate tracked-data names.