### PR TITLE
feat: Add villager trading and professions

### DIFF
--- a/crates/pumpkin-data/src/data_component_impl/basic.rs
+++ b/crates/pumpkin-data/src/data_component_impl/basic.rs
@@ -2,6 +2,7 @@ use crate::data_component_impl::{DataComponentImpl, get_i32_hash, get_str_hash};
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_nbt::tag::NbtTag;
 use pumpkin_util::text::TextComponent;
+use std::borrow::Cow;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CustomDataImpl {
@@ -117,13 +118,34 @@ impl DataComponentImpl for CustomNameImpl {
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ItemNameImpl {
-    pub name: &'static str,
+    pub name: Cow<'static, str>,
+}
+impl ItemNameImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        let name = match data {
+            NbtTag::String(name) => name.to_string(),
+            NbtTag::Compound(component) => component
+                .get_string("translate")
+                .or_else(|| component.get_string("text"))?
+                .to_owned(),
+            _ => return None,
+        };
+        Some(Self {
+            name: Cow::Owned(name),
+        })
+    }
 }
 impl DataComponentImpl for ItemNameImpl {
+    fn write_data(&self) -> NbtTag {
+        let mut component = NbtCompound::new();
+        component.put_string("translate", self.name.to_string());
+        NbtTag::Compound(component)
+    }
+    fn get_hash(&self) -> i32 {
+        get_str_hash(&self.name) as i32
+    }
     default_impl!(ItemName);
 }
-
-use std::borrow::Cow;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ItemModelImpl {

--- a/crates/pumpkin-data/src/data_component_impl/food.rs
+++ b/crates/pumpkin-data/src/data_component_impl/food.rs
@@ -590,7 +590,58 @@ mod tests {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct SuspiciousStewEffectsImpl;
+pub struct SuspiciousStewEffect {
+    pub effect: Cow<'static, str>,
+    pub duration: i32,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct SuspiciousStewEffectsImpl {
+    pub effects: Cow<'static, [SuspiciousStewEffect]>,
+}
+impl SuspiciousStewEffectsImpl {
+    pub const EMPTY: Self = Self {
+        effects: Cow::Borrowed(&[]),
+    };
+
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        Some(Self {
+            effects: Cow::Owned(
+                data.extract_list()?
+                    .iter()
+                    .filter_map(|tag| {
+                        let effect = tag.extract_compound()?;
+                        Some(SuspiciousStewEffect {
+                            effect: Cow::Owned(effect.get_string("id")?.to_owned()),
+                            duration: effect.get_int("duration").unwrap_or(160),
+                        })
+                    })
+                    .collect(),
+            ),
+        })
+    }
+}
 impl DataComponentImpl for SuspiciousStewEffectsImpl {
+    fn write_data(&self) -> NbtTag {
+        NbtTag::List(
+            self.effects
+                .iter()
+                .map(|effect| {
+                    let mut nbt = NbtCompound::new();
+                    nbt.put_string("id", effect.effect.to_string());
+                    nbt.put_int("duration", effect.duration);
+                    NbtTag::Compound(nbt)
+                })
+                .collect(),
+        )
+    }
+    fn get_hash(&self) -> i32 {
+        let mut digest = Digest::new(Crc32Iscsi);
+        for effect in self.effects.iter() {
+            digest.update(&get_str_hash(&effect.effect).to_le_bytes());
+            digest.update(&get_i32_hash(effect.duration).to_le_bytes());
+        }
+        digest.finalize() as i32
+    }
     default_impl!(SuspiciousStewEffects);
 }

--- a/crates/pumpkin-data/src/data_component_impl/mod.rs
+++ b/crates/pumpkin-data/src/data_component_impl/mod.rs
@@ -529,9 +529,13 @@ pub fn read_data(id: DataComponent, data: &NbtTag) -> Option<Box<dyn DataCompone
         DataComponent::PotionDurationScale => {
             Some(PotionDurationScaleImpl::read_data(data)?.to_dyn())
         }
+        DataComponent::SuspiciousStewEffects => {
+            Some(SuspiciousStewEffectsImpl::read_data(data)?.to_dyn())
+        }
         DataComponent::Fireworks => Some(FireworksImpl::read_data(data)?.to_dyn()),
         DataComponent::FireworkExplosion => Some(FireworkExplosionImpl::read_data(data)?.to_dyn()),
         DataComponent::CustomName => Some(CustomNameImpl::read_data(data)?.to_dyn()),
+        DataComponent::ItemName => Some(ItemNameImpl::read_data(data)?.to_dyn()),
         DataComponent::ItemModel => Some(ItemModelImpl::read_data(data)?.to_dyn()),
         DataComponent::Consumable => Some(ConsumableImpl::read_data(data)?.to_dyn()),
         DataComponent::Equippable => Some(EquippableImpl::read_data(data)?.to_dyn()),

--- a/crates/pumpkin-data/src/generated/item.rs
+++ b/crates/pumpkin-data/src/generated/item.rs
@@ -87,7 +87,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.acacia_boat",
+                    name: Cow::Borrowed("item.minecraft.acacia_boat"),
                 },
             ),
             (
@@ -125,7 +125,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_button",
+                    name: Cow::Borrowed("block.minecraft.acacia_button"),
                 },
             ),
             (
@@ -163,7 +163,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.acacia_chest_boat",
+                    name: Cow::Borrowed("item.minecraft.acacia_chest_boat"),
                 },
             ),
             (
@@ -201,7 +201,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_door",
+                    name: Cow::Borrowed("block.minecraft.acacia_door"),
                 },
             ),
             (
@@ -239,7 +239,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_fence",
+                    name: Cow::Borrowed("block.minecraft.acacia_fence"),
                 },
             ),
             (
@@ -277,7 +277,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.acacia_fence_gate"),
                 },
             ),
             (
@@ -315,7 +315,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.acacia_hanging_sign"),
                 },
             ),
             (
@@ -353,7 +353,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_leaves",
+                    name: Cow::Borrowed("block.minecraft.acacia_leaves"),
                 },
             ),
             (
@@ -391,7 +391,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_log",
+                    name: Cow::Borrowed("block.minecraft.acacia_log"),
                 },
             ),
             (
@@ -429,7 +429,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_planks",
+                    name: Cow::Borrowed("block.minecraft.acacia_planks"),
                 },
             ),
             (
@@ -467,7 +467,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.acacia_pressure_plate"),
                 },
             ),
             (
@@ -505,7 +505,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_sapling",
+                    name: Cow::Borrowed("block.minecraft.acacia_sapling"),
                 },
             ),
             (
@@ -543,7 +543,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_shelf",
+                    name: Cow::Borrowed("block.minecraft.acacia_shelf"),
                 },
             ),
             (
@@ -582,7 +582,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_sign",
+                    name: Cow::Borrowed("block.minecraft.acacia_sign"),
                 },
             ),
             (
@@ -620,7 +620,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_slab",
+                    name: Cow::Borrowed("block.minecraft.acacia_slab"),
                 },
             ),
             (
@@ -658,7 +658,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_stairs",
+                    name: Cow::Borrowed("block.minecraft.acacia_stairs"),
                 },
             ),
             (
@@ -696,7 +696,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.acacia_trapdoor"),
                 },
             ),
             (
@@ -734,7 +734,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.acacia_wood",
+                    name: Cow::Borrowed("block.minecraft.acacia_wood"),
                 },
             ),
             (
@@ -772,7 +772,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.activator_rail",
+                    name: Cow::Borrowed("block.minecraft.activator_rail"),
                 },
             ),
             (
@@ -810,7 +810,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.air",
+                    name: Cow::Borrowed("block.minecraft.air"),
                 },
             ),
             (
@@ -848,7 +848,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.allay_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.allay_spawn_egg"),
                 },
             ),
             (
@@ -887,7 +887,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.allium",
+                    name: Cow::Borrowed("block.minecraft.allium"),
                 },
             ),
             (
@@ -925,7 +925,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.amethyst_block",
+                    name: Cow::Borrowed("block.minecraft.amethyst_block"),
                 },
             ),
             (
@@ -963,7 +963,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.amethyst_cluster",
+                    name: Cow::Borrowed("block.minecraft.amethyst_cluster"),
                 },
             ),
             (
@@ -1001,7 +1001,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.amethyst_shard",
+                    name: Cow::Borrowed("item.minecraft.amethyst_shard"),
                 },
             ),
             (
@@ -1040,7 +1040,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.ancient_debris",
+                    name: Cow::Borrowed("block.minecraft.ancient_debris"),
                 },
             ),
             (
@@ -1084,7 +1084,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.andesite",
+                    name: Cow::Borrowed("block.minecraft.andesite"),
                 },
             ),
             (
@@ -1122,7 +1122,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.andesite_slab",
+                    name: Cow::Borrowed("block.minecraft.andesite_slab"),
                 },
             ),
             (
@@ -1160,7 +1160,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.andesite_stairs",
+                    name: Cow::Borrowed("block.minecraft.andesite_stairs"),
                 },
             ),
             (
@@ -1198,7 +1198,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.andesite_wall",
+                    name: Cow::Borrowed("block.minecraft.andesite_wall"),
                 },
             ),
             (
@@ -1236,7 +1236,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.angler_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.angler_pottery_sherd"),
                 },
             ),
             (
@@ -1274,7 +1274,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.anvil",
+                    name: Cow::Borrowed("block.minecraft.anvil"),
                 },
             ),
             (
@@ -1312,7 +1312,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.apple",
+                    name: Cow::Borrowed("item.minecraft.apple"),
                 },
             ),
             (
@@ -1368,7 +1368,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.archer_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.archer_pottery_sherd"),
                 },
             ),
             (
@@ -1406,7 +1406,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.armadillo_scute",
+                    name: Cow::Borrowed("item.minecraft.armadillo_scute"),
                 },
             ),
             (
@@ -1444,7 +1444,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.armadillo_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.armadillo_spawn_egg"),
                 },
             ),
             (
@@ -1483,7 +1483,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.armor_stand",
+                    name: Cow::Borrowed("item.minecraft.armor_stand"),
                 },
             ),
             (
@@ -1521,7 +1521,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.arms_up_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.arms_up_pottery_sherd"),
                 },
             ),
             (
@@ -1559,7 +1559,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.arrow",
+                    name: Cow::Borrowed("item.minecraft.arrow"),
                 },
             ),
             (
@@ -1597,7 +1597,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.axolotl_bucket",
+                    name: Cow::Borrowed("item.minecraft.axolotl_bucket"),
                 },
             ),
             (
@@ -1636,7 +1636,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.axolotl_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.axolotl_spawn_egg"),
                 },
             ),
             (
@@ -1675,7 +1675,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.azalea",
+                    name: Cow::Borrowed("block.minecraft.azalea"),
                 },
             ),
             (
@@ -1713,7 +1713,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.azalea_leaves",
+                    name: Cow::Borrowed("block.minecraft.azalea_leaves"),
                 },
             ),
             (
@@ -1751,7 +1751,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.azure_bluet",
+                    name: Cow::Borrowed("block.minecraft.azure_bluet"),
                 },
             ),
             (
@@ -1789,7 +1789,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.baked_potato",
+                    name: Cow::Borrowed("item.minecraft.baked_potato"),
                 },
             ),
             (
@@ -1845,7 +1845,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo",
+                    name: Cow::Borrowed("block.minecraft.bamboo"),
                 },
             ),
             (
@@ -1883,7 +1883,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_block",
+                    name: Cow::Borrowed("block.minecraft.bamboo_block"),
                 },
             ),
             (
@@ -1921,7 +1921,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_button",
+                    name: Cow::Borrowed("block.minecraft.bamboo_button"),
                 },
             ),
             (
@@ -1959,7 +1959,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bamboo_chest_raft",
+                    name: Cow::Borrowed("item.minecraft.bamboo_chest_raft"),
                 },
             ),
             (
@@ -1997,7 +1997,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_door",
+                    name: Cow::Borrowed("block.minecraft.bamboo_door"),
                 },
             ),
             (
@@ -2035,7 +2035,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_fence",
+                    name: Cow::Borrowed("block.minecraft.bamboo_fence"),
                 },
             ),
             (
@@ -2073,7 +2073,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.bamboo_fence_gate"),
                 },
             ),
             (
@@ -2111,7 +2111,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.bamboo_hanging_sign"),
                 },
             ),
             (
@@ -2149,7 +2149,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_mosaic",
+                    name: Cow::Borrowed("block.minecraft.bamboo_mosaic"),
                 },
             ),
             (
@@ -2187,7 +2187,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_mosaic_slab",
+                    name: Cow::Borrowed("block.minecraft.bamboo_mosaic_slab"),
                 },
             ),
             (
@@ -2225,7 +2225,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_mosaic_stairs",
+                    name: Cow::Borrowed("block.minecraft.bamboo_mosaic_stairs"),
                 },
             ),
             (
@@ -2263,7 +2263,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_planks",
+                    name: Cow::Borrowed("block.minecraft.bamboo_planks"),
                 },
             ),
             (
@@ -2301,7 +2301,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.bamboo_pressure_plate"),
                 },
             ),
             (
@@ -2339,7 +2339,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bamboo_raft",
+                    name: Cow::Borrowed("item.minecraft.bamboo_raft"),
                 },
             ),
             (
@@ -2377,7 +2377,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_shelf",
+                    name: Cow::Borrowed("block.minecraft.bamboo_shelf"),
                 },
             ),
             (
@@ -2416,7 +2416,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_sign",
+                    name: Cow::Borrowed("block.minecraft.bamboo_sign"),
                 },
             ),
             (
@@ -2454,7 +2454,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_slab",
+                    name: Cow::Borrowed("block.minecraft.bamboo_slab"),
                 },
             ),
             (
@@ -2492,7 +2492,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_stairs",
+                    name: Cow::Borrowed("block.minecraft.bamboo_stairs"),
                 },
             ),
             (
@@ -2530,7 +2530,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bamboo_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.bamboo_trapdoor"),
                 },
             ),
             (
@@ -2568,7 +2568,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.barrel",
+                    name: Cow::Borrowed("block.minecraft.barrel"),
                 },
             ),
             (
@@ -2607,7 +2607,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.barrier",
+                    name: Cow::Borrowed("block.minecraft.barrier"),
                 },
             ),
             (
@@ -2645,7 +2645,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.basalt",
+                    name: Cow::Borrowed("block.minecraft.basalt"),
                 },
             ),
             (
@@ -2683,7 +2683,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bat_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.bat_spawn_egg"),
                 },
             ),
             (
@@ -2722,7 +2722,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.beacon",
+                    name: Cow::Borrowed("block.minecraft.beacon"),
                 },
             ),
             (
@@ -2760,7 +2760,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bedrock",
+                    name: Cow::Borrowed("block.minecraft.bedrock"),
                 },
             ),
             (
@@ -2798,7 +2798,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bee_nest",
+                    name: Cow::Borrowed("block.minecraft.bee_nest"),
                 },
             ),
             (
@@ -2846,7 +2846,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bee_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.bee_spawn_egg"),
                 },
             ),
             (
@@ -2885,7 +2885,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.beef",
+                    name: Cow::Borrowed("item.minecraft.beef"),
                 },
             ),
             (
@@ -2941,7 +2941,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.beehive",
+                    name: Cow::Borrowed("block.minecraft.beehive"),
                 },
             ),
             (
@@ -2989,7 +2989,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.beetroot",
+                    name: Cow::Borrowed("item.minecraft.beetroot"),
                 },
             ),
             (
@@ -3045,7 +3045,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.beetroot_seeds",
+                    name: Cow::Borrowed("item.minecraft.beetroot_seeds"),
                 },
             ),
             (
@@ -3083,7 +3083,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.beetroot_soup",
+                    name: Cow::Borrowed("item.minecraft.beetroot_soup"),
                 },
             ),
             (
@@ -3140,7 +3140,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bell",
+                    name: Cow::Borrowed("block.minecraft.bell"),
                 },
             ),
             (
@@ -3178,7 +3178,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.big_dripleaf",
+                    name: Cow::Borrowed("block.minecraft.big_dripleaf"),
                 },
             ),
             (
@@ -3216,7 +3216,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.birch_boat",
+                    name: Cow::Borrowed("item.minecraft.birch_boat"),
                 },
             ),
             (
@@ -3254,7 +3254,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_button",
+                    name: Cow::Borrowed("block.minecraft.birch_button"),
                 },
             ),
             (
@@ -3292,7 +3292,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.birch_chest_boat",
+                    name: Cow::Borrowed("item.minecraft.birch_chest_boat"),
                 },
             ),
             (
@@ -3330,7 +3330,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_door",
+                    name: Cow::Borrowed("block.minecraft.birch_door"),
                 },
             ),
             (
@@ -3368,7 +3368,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_fence",
+                    name: Cow::Borrowed("block.minecraft.birch_fence"),
                 },
             ),
             (
@@ -3406,7 +3406,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.birch_fence_gate"),
                 },
             ),
             (
@@ -3444,7 +3444,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.birch_hanging_sign"),
                 },
             ),
             (
@@ -3482,7 +3482,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_leaves",
+                    name: Cow::Borrowed("block.minecraft.birch_leaves"),
                 },
             ),
             (
@@ -3520,7 +3520,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_log",
+                    name: Cow::Borrowed("block.minecraft.birch_log"),
                 },
             ),
             (
@@ -3558,7 +3558,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_planks",
+                    name: Cow::Borrowed("block.minecraft.birch_planks"),
                 },
             ),
             (
@@ -3596,7 +3596,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.birch_pressure_plate"),
                 },
             ),
             (
@@ -3634,7 +3634,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_sapling",
+                    name: Cow::Borrowed("block.minecraft.birch_sapling"),
                 },
             ),
             (
@@ -3672,7 +3672,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_shelf",
+                    name: Cow::Borrowed("block.minecraft.birch_shelf"),
                 },
             ),
             (
@@ -3711,7 +3711,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_sign",
+                    name: Cow::Borrowed("block.minecraft.birch_sign"),
                 },
             ),
             (
@@ -3749,7 +3749,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_slab",
+                    name: Cow::Borrowed("block.minecraft.birch_slab"),
                 },
             ),
             (
@@ -3787,7 +3787,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_stairs",
+                    name: Cow::Borrowed("block.minecraft.birch_stairs"),
                 },
             ),
             (
@@ -3825,7 +3825,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.birch_trapdoor"),
                 },
             ),
             (
@@ -3863,7 +3863,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.birch_wood",
+                    name: Cow::Borrowed("block.minecraft.birch_wood"),
                 },
             ),
             (
@@ -3901,7 +3901,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_banner",
+                    name: Cow::Borrowed("block.minecraft.black_banner"),
                 },
             ),
             (
@@ -3940,7 +3940,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_bed",
+                    name: Cow::Borrowed("block.minecraft.black_bed"),
                 },
             ),
             (
@@ -3978,7 +3978,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.black_bundle",
+                    name: Cow::Borrowed("item.minecraft.black_bundle"),
                 },
             ),
             (
@@ -4017,7 +4017,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_candle",
+                    name: Cow::Borrowed("block.minecraft.black_candle"),
                 },
             ),
             (
@@ -4055,7 +4055,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_carpet",
+                    name: Cow::Borrowed("block.minecraft.black_carpet"),
                 },
             ),
             (
@@ -4112,7 +4112,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_concrete",
+                    name: Cow::Borrowed("block.minecraft.black_concrete"),
                 },
             ),
             (
@@ -4150,7 +4150,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.black_concrete_powder"),
                 },
             ),
             (
@@ -4188,7 +4188,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.black_dye",
+                    name: Cow::Borrowed("item.minecraft.black_dye"),
                 },
             ),
             (
@@ -4227,7 +4227,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.black_glazed_terracotta"),
                 },
             ),
             (
@@ -4265,7 +4265,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.black_harness",
+                    name: Cow::Borrowed("item.minecraft.black_harness"),
                 },
             ),
             (
@@ -4319,7 +4319,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.black_shulker_box"),
                 },
             ),
             (
@@ -4358,7 +4358,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.black_stained_glass"),
                 },
             ),
             (
@@ -4396,7 +4396,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.black_stained_glass_pane"),
                 },
             ),
             (
@@ -4434,7 +4434,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_terracotta",
+                    name: Cow::Borrowed("block.minecraft.black_terracotta"),
                 },
             ),
             (
@@ -4472,7 +4472,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.black_wool",
+                    name: Cow::Borrowed("block.minecraft.black_wool"),
                 },
             ),
             (
@@ -4510,7 +4510,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blackstone",
+                    name: Cow::Borrowed("block.minecraft.blackstone"),
                 },
             ),
             (
@@ -4548,7 +4548,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blackstone_slab",
+                    name: Cow::Borrowed("block.minecraft.blackstone_slab"),
                 },
             ),
             (
@@ -4586,7 +4586,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blackstone_stairs",
+                    name: Cow::Borrowed("block.minecraft.blackstone_stairs"),
                 },
             ),
             (
@@ -4624,7 +4624,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blackstone_wall",
+                    name: Cow::Borrowed("block.minecraft.blackstone_wall"),
                 },
             ),
             (
@@ -4662,7 +4662,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.blade_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.blade_pottery_sherd"),
                 },
             ),
             (
@@ -4700,7 +4700,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blast_furnace",
+                    name: Cow::Borrowed("block.minecraft.blast_furnace"),
                 },
             ),
             (
@@ -4739,7 +4739,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.blaze_powder",
+                    name: Cow::Borrowed("item.minecraft.blaze_powder"),
                 },
             ),
             (
@@ -4777,7 +4777,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.blaze_rod",
+                    name: Cow::Borrowed("item.minecraft.blaze_rod"),
                 },
             ),
             (
@@ -4815,7 +4815,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.blaze_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.blaze_spawn_egg"),
                 },
             ),
             (
@@ -4854,7 +4854,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_banner",
+                    name: Cow::Borrowed("block.minecraft.blue_banner"),
                 },
             ),
             (
@@ -4893,7 +4893,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_bed",
+                    name: Cow::Borrowed("block.minecraft.blue_bed"),
                 },
             ),
             (
@@ -4931,7 +4931,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.blue_bundle",
+                    name: Cow::Borrowed("item.minecraft.blue_bundle"),
                 },
             ),
             (
@@ -4970,7 +4970,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_candle",
+                    name: Cow::Borrowed("block.minecraft.blue_candle"),
                 },
             ),
             (
@@ -5008,7 +5008,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_carpet",
+                    name: Cow::Borrowed("block.minecraft.blue_carpet"),
                 },
             ),
             (
@@ -5065,7 +5065,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_concrete",
+                    name: Cow::Borrowed("block.minecraft.blue_concrete"),
                 },
             ),
             (
@@ -5103,7 +5103,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.blue_concrete_powder"),
                 },
             ),
             (
@@ -5141,7 +5141,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.blue_dye",
+                    name: Cow::Borrowed("item.minecraft.blue_dye"),
                 },
             ),
             (
@@ -5180,7 +5180,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.blue_egg",
+                    name: Cow::Borrowed("item.minecraft.blue_egg"),
                 },
             ),
             (
@@ -5224,7 +5224,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.blue_glazed_terracotta"),
                 },
             ),
             (
@@ -5262,7 +5262,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.blue_harness",
+                    name: Cow::Borrowed("item.minecraft.blue_harness"),
                 },
             ),
             (
@@ -5316,7 +5316,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_ice",
+                    name: Cow::Borrowed("block.minecraft.blue_ice"),
                 },
             ),
             (
@@ -5354,7 +5354,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_orchid",
+                    name: Cow::Borrowed("block.minecraft.blue_orchid"),
                 },
             ),
             (
@@ -5392,7 +5392,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.blue_shulker_box"),
                 },
             ),
             (
@@ -5431,7 +5431,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.blue_stained_glass"),
                 },
             ),
             (
@@ -5469,7 +5469,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.blue_stained_glass_pane"),
                 },
             ),
             (
@@ -5507,7 +5507,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_terracotta",
+                    name: Cow::Borrowed("block.minecraft.blue_terracotta"),
                 },
             ),
             (
@@ -5545,7 +5545,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.blue_wool",
+                    name: Cow::Borrowed("block.minecraft.blue_wool"),
                 },
             ),
             (
@@ -5583,7 +5583,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bogged_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.bogged_spawn_egg"),
                 },
             ),
             (
@@ -5622,7 +5622,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bolt_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.bolt_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -5660,7 +5660,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bone",
+                    name: Cow::Borrowed("item.minecraft.bone"),
                 },
             ),
             (
@@ -5698,7 +5698,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bone_block",
+                    name: Cow::Borrowed("block.minecraft.bone_block"),
                 },
             ),
             (
@@ -5736,7 +5736,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bone_meal",
+                    name: Cow::Borrowed("item.minecraft.bone_meal"),
                 },
             ),
             (
@@ -5774,7 +5774,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.book",
+                    name: Cow::Borrowed("item.minecraft.book"),
                 },
             ),
             (
@@ -5813,7 +5813,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bookshelf",
+                    name: Cow::Borrowed("block.minecraft.bookshelf"),
                 },
             ),
             (
@@ -5851,7 +5851,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bordure_indented_banner_pattern",
+                    name: Cow::Borrowed("item.minecraft.bordure_indented_banner_pattern"),
                 },
             ),
             (
@@ -5890,7 +5890,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bow",
+                    name: Cow::Borrowed("item.minecraft.bow"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -5931,7 +5931,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bowl",
+                    name: Cow::Borrowed("item.minecraft.bowl"),
                 },
             ),
             (
@@ -5969,7 +5969,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brain_coral",
+                    name: Cow::Borrowed("block.minecraft.brain_coral"),
                 },
             ),
             (
@@ -6007,7 +6007,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brain_coral_block",
+                    name: Cow::Borrowed("block.minecraft.brain_coral_block"),
                 },
             ),
             (
@@ -6045,7 +6045,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brain_coral_fan",
+                    name: Cow::Borrowed("block.minecraft.brain_coral_fan"),
                 },
             ),
             (
@@ -6083,7 +6083,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bread",
+                    name: Cow::Borrowed("item.minecraft.bread"),
                 },
             ),
             (
@@ -6139,7 +6139,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.breeze_rod",
+                    name: Cow::Borrowed("item.minecraft.breeze_rod"),
                 },
             ),
             (
@@ -6177,7 +6177,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.breeze_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.breeze_spawn_egg"),
                 },
             ),
             (
@@ -6216,7 +6216,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.brewer_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.brewer_pottery_sherd"),
                 },
             ),
             (
@@ -6254,7 +6254,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brewing_stand",
+                    name: Cow::Borrowed("block.minecraft.brewing_stand"),
                 },
             ),
             (
@@ -6293,7 +6293,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.brick",
+                    name: Cow::Borrowed("item.minecraft.brick"),
                 },
             ),
             (
@@ -6331,7 +6331,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brick_slab",
+                    name: Cow::Borrowed("block.minecraft.brick_slab"),
                 },
             ),
             (
@@ -6369,7 +6369,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.brick_stairs"),
                 },
             ),
             (
@@ -6407,7 +6407,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brick_wall",
+                    name: Cow::Borrowed("block.minecraft.brick_wall"),
                 },
             ),
             (
@@ -6445,7 +6445,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bricks",
+                    name: Cow::Borrowed("block.minecraft.bricks"),
                 },
             ),
             (
@@ -6483,7 +6483,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_banner",
+                    name: Cow::Borrowed("block.minecraft.brown_banner"),
                 },
             ),
             (
@@ -6522,7 +6522,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_bed",
+                    name: Cow::Borrowed("block.minecraft.brown_bed"),
                 },
             ),
             (
@@ -6560,7 +6560,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.brown_bundle",
+                    name: Cow::Borrowed("item.minecraft.brown_bundle"),
                 },
             ),
             (
@@ -6599,7 +6599,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_candle",
+                    name: Cow::Borrowed("block.minecraft.brown_candle"),
                 },
             ),
             (
@@ -6637,7 +6637,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_carpet",
+                    name: Cow::Borrowed("block.minecraft.brown_carpet"),
                 },
             ),
             (
@@ -6694,7 +6694,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_concrete",
+                    name: Cow::Borrowed("block.minecraft.brown_concrete"),
                 },
             ),
             (
@@ -6732,7 +6732,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.brown_concrete_powder"),
                 },
             ),
             (
@@ -6770,7 +6770,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.brown_dye",
+                    name: Cow::Borrowed("item.minecraft.brown_dye"),
                 },
             ),
             (
@@ -6809,7 +6809,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.brown_egg",
+                    name: Cow::Borrowed("item.minecraft.brown_egg"),
                 },
             ),
             (
@@ -6853,7 +6853,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.brown_glazed_terracotta"),
                 },
             ),
             (
@@ -6891,7 +6891,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.brown_harness",
+                    name: Cow::Borrowed("item.minecraft.brown_harness"),
                 },
             ),
             (
@@ -6945,7 +6945,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_mushroom",
+                    name: Cow::Borrowed("block.minecraft.brown_mushroom"),
                 },
             ),
             (
@@ -6983,7 +6983,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_mushroom_block",
+                    name: Cow::Borrowed("block.minecraft.brown_mushroom_block"),
                 },
             ),
             (
@@ -7021,7 +7021,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.brown_shulker_box"),
                 },
             ),
             (
@@ -7060,7 +7060,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.brown_stained_glass"),
                 },
             ),
             (
@@ -7098,7 +7098,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.brown_stained_glass_pane"),
                 },
             ),
             (
@@ -7136,7 +7136,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_terracotta",
+                    name: Cow::Borrowed("block.minecraft.brown_terracotta"),
                 },
             ),
             (
@@ -7174,7 +7174,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.brown_wool",
+                    name: Cow::Borrowed("block.minecraft.brown_wool"),
                 },
             ),
             (
@@ -7212,7 +7212,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.brush",
+                    name: Cow::Borrowed("item.minecraft.brush"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -7252,7 +7252,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bubble_coral",
+                    name: Cow::Borrowed("block.minecraft.bubble_coral"),
                 },
             ),
             (
@@ -7290,7 +7290,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bubble_coral_block",
+                    name: Cow::Borrowed("block.minecraft.bubble_coral_block"),
                 },
             ),
             (
@@ -7328,7 +7328,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bubble_coral_fan",
+                    name: Cow::Borrowed("block.minecraft.bubble_coral_fan"),
                 },
             ),
             (
@@ -7366,7 +7366,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bucket",
+                    name: Cow::Borrowed("item.minecraft.bucket"),
                 },
             ),
             (
@@ -7404,7 +7404,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.budding_amethyst",
+                    name: Cow::Borrowed("block.minecraft.budding_amethyst"),
                 },
             ),
             (
@@ -7442,7 +7442,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.bundle",
+                    name: Cow::Borrowed("item.minecraft.bundle"),
                 },
             ),
             (
@@ -7481,7 +7481,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.burn_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.burn_pottery_sherd"),
                 },
             ),
             (
@@ -7519,7 +7519,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.bush",
+                    name: Cow::Borrowed("block.minecraft.bush"),
                 },
             ),
             (
@@ -7557,7 +7557,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cactus",
+                    name: Cow::Borrowed("block.minecraft.cactus"),
                 },
             ),
             (
@@ -7595,7 +7595,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cactus_flower",
+                    name: Cow::Borrowed("block.minecraft.cactus_flower"),
                 },
             ),
             (
@@ -7633,7 +7633,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cake",
+                    name: Cow::Borrowed("block.minecraft.cake"),
                 },
             ),
             (
@@ -7671,7 +7671,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.calcite",
+                    name: Cow::Borrowed("block.minecraft.calcite"),
                 },
             ),
             (
@@ -7709,7 +7709,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.calibrated_sculk_sensor",
+                    name: Cow::Borrowed("block.minecraft.calibrated_sculk_sensor"),
                 },
             ),
             (
@@ -7747,7 +7747,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.camel_husk_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.camel_husk_spawn_egg"),
                 },
             ),
             (
@@ -7786,7 +7786,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.camel_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.camel_spawn_egg"),
                 },
             ),
             (
@@ -7825,7 +7825,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.campfire",
+                    name: Cow::Borrowed("block.minecraft.campfire"),
                 },
             ),
             (
@@ -7864,7 +7864,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.candle",
+                    name: Cow::Borrowed("block.minecraft.candle"),
                 },
             ),
             (
@@ -7902,7 +7902,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.carrot",
+                    name: Cow::Borrowed("item.minecraft.carrot"),
                 },
             ),
             (
@@ -7958,7 +7958,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.carrot_on_a_stick",
+                    name: Cow::Borrowed("item.minecraft.carrot_on_a_stick"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -7998,7 +7998,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cartography_table",
+                    name: Cow::Borrowed("block.minecraft.cartography_table"),
                 },
             ),
             (
@@ -8036,7 +8036,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.carved_pumpkin",
+                    name: Cow::Borrowed("block.minecraft.carved_pumpkin"),
                 },
             ),
             (
@@ -8096,7 +8096,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cat_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.cat_spawn_egg"),
                 },
             ),
             (
@@ -8135,7 +8135,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cauldron",
+                    name: Cow::Borrowed("block.minecraft.cauldron"),
                 },
             ),
             (
@@ -8173,7 +8173,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cave_spider_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.cave_spider_spawn_egg"),
                 },
             ),
             (
@@ -8212,7 +8212,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chain_command_block",
+                    name: Cow::Borrowed("block.minecraft.chain_command_block"),
                 },
             ),
             (
@@ -8250,7 +8250,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.chainmail_boots",
+                    name: Cow::Borrowed("item.minecraft.chainmail_boots"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -8323,7 +8323,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.chainmail_chestplate",
+                    name: Cow::Borrowed("item.minecraft.chainmail_chestplate"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -8396,7 +8396,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.chainmail_helmet",
+                    name: Cow::Borrowed("item.minecraft.chainmail_helmet"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -8469,7 +8469,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.chainmail_leggings",
+                    name: Cow::Borrowed("item.minecraft.chainmail_leggings"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -8542,7 +8542,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.charcoal",
+                    name: Cow::Borrowed("item.minecraft.charcoal"),
                 },
             ),
             (
@@ -8580,7 +8580,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cherry_boat",
+                    name: Cow::Borrowed("item.minecraft.cherry_boat"),
                 },
             ),
             (
@@ -8618,7 +8618,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_button",
+                    name: Cow::Borrowed("block.minecraft.cherry_button"),
                 },
             ),
             (
@@ -8656,7 +8656,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cherry_chest_boat",
+                    name: Cow::Borrowed("item.minecraft.cherry_chest_boat"),
                 },
             ),
             (
@@ -8694,7 +8694,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_door",
+                    name: Cow::Borrowed("block.minecraft.cherry_door"),
                 },
             ),
             (
@@ -8732,7 +8732,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_fence",
+                    name: Cow::Borrowed("block.minecraft.cherry_fence"),
                 },
             ),
             (
@@ -8770,7 +8770,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.cherry_fence_gate"),
                 },
             ),
             (
@@ -8808,7 +8808,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.cherry_hanging_sign"),
                 },
             ),
             (
@@ -8846,7 +8846,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_leaves",
+                    name: Cow::Borrowed("block.minecraft.cherry_leaves"),
                 },
             ),
             (
@@ -8884,7 +8884,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_log",
+                    name: Cow::Borrowed("block.minecraft.cherry_log"),
                 },
             ),
             (
@@ -8922,7 +8922,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_planks",
+                    name: Cow::Borrowed("block.minecraft.cherry_planks"),
                 },
             ),
             (
@@ -8960,7 +8960,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.cherry_pressure_plate"),
                 },
             ),
             (
@@ -8998,7 +8998,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_sapling",
+                    name: Cow::Borrowed("block.minecraft.cherry_sapling"),
                 },
             ),
             (
@@ -9036,7 +9036,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_shelf",
+                    name: Cow::Borrowed("block.minecraft.cherry_shelf"),
                 },
             ),
             (
@@ -9075,7 +9075,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_sign",
+                    name: Cow::Borrowed("block.minecraft.cherry_sign"),
                 },
             ),
             (
@@ -9113,7 +9113,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_slab",
+                    name: Cow::Borrowed("block.minecraft.cherry_slab"),
                 },
             ),
             (
@@ -9151,7 +9151,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_stairs",
+                    name: Cow::Borrowed("block.minecraft.cherry_stairs"),
                 },
             ),
             (
@@ -9189,7 +9189,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.cherry_trapdoor"),
                 },
             ),
             (
@@ -9227,7 +9227,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cherry_wood",
+                    name: Cow::Borrowed("block.minecraft.cherry_wood"),
                 },
             ),
             (
@@ -9265,7 +9265,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chest",
+                    name: Cow::Borrowed("block.minecraft.chest"),
                 },
             ),
             (
@@ -9304,7 +9304,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.chest_minecart",
+                    name: Cow::Borrowed("item.minecraft.chest_minecart"),
                 },
             ),
             (
@@ -9342,7 +9342,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.chicken",
+                    name: Cow::Borrowed("item.minecraft.chicken"),
                 },
             ),
             (
@@ -9408,7 +9408,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.chicken_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.chicken_spawn_egg"),
                 },
             ),
             (
@@ -9447,7 +9447,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chipped_anvil",
+                    name: Cow::Borrowed("block.minecraft.chipped_anvil"),
                 },
             ),
             (
@@ -9485,7 +9485,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_bookshelf",
+                    name: Cow::Borrowed("block.minecraft.chiseled_bookshelf"),
                 },
             ),
             (
@@ -9524,7 +9524,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_cinnabar",
+                    name: Cow::Borrowed("block.minecraft.chiseled_cinnabar"),
                 },
             ),
             (
@@ -9562,7 +9562,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_copper",
+                    name: Cow::Borrowed("block.minecraft.chiseled_copper"),
                 },
             ),
             (
@@ -9600,7 +9600,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_deepslate",
+                    name: Cow::Borrowed("block.minecraft.chiseled_deepslate"),
                 },
             ),
             (
@@ -9638,7 +9638,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_nether_bricks",
+                    name: Cow::Borrowed("block.minecraft.chiseled_nether_bricks"),
                 },
             ),
             (
@@ -9676,7 +9676,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_polished_blackstone",
+                    name: Cow::Borrowed("block.minecraft.chiseled_polished_blackstone"),
                 },
             ),
             (
@@ -9714,7 +9714,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_quartz_block",
+                    name: Cow::Borrowed("block.minecraft.chiseled_quartz_block"),
                 },
             ),
             (
@@ -9752,7 +9752,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_red_sandstone",
+                    name: Cow::Borrowed("block.minecraft.chiseled_red_sandstone"),
                 },
             ),
             (
@@ -9790,7 +9790,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_resin_bricks",
+                    name: Cow::Borrowed("block.minecraft.chiseled_resin_bricks"),
                 },
             ),
             (
@@ -9828,7 +9828,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_sandstone",
+                    name: Cow::Borrowed("block.minecraft.chiseled_sandstone"),
                 },
             ),
             (
@@ -9866,7 +9866,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_stone_bricks",
+                    name: Cow::Borrowed("block.minecraft.chiseled_stone_bricks"),
                 },
             ),
             (
@@ -9904,7 +9904,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_sulfur",
+                    name: Cow::Borrowed("block.minecraft.chiseled_sulfur"),
                 },
             ),
             (
@@ -9942,7 +9942,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_tuff",
+                    name: Cow::Borrowed("block.minecraft.chiseled_tuff"),
                 },
             ),
             (
@@ -9980,7 +9980,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chiseled_tuff_bricks",
+                    name: Cow::Borrowed("block.minecraft.chiseled_tuff_bricks"),
                 },
             ),
             (
@@ -10018,7 +10018,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chorus_flower",
+                    name: Cow::Borrowed("block.minecraft.chorus_flower"),
                 },
             ),
             (
@@ -10063,7 +10063,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.chorus_fruit",
+                    name: Cow::Borrowed("item.minecraft.chorus_fruit"),
                 },
             ),
             (
@@ -10119,7 +10119,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.chorus_plant",
+                    name: Cow::Borrowed("block.minecraft.chorus_plant"),
                 },
             ),
             (
@@ -10157,7 +10157,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cinnabar",
+                    name: Cow::Borrowed("block.minecraft.cinnabar"),
                 },
             ),
             (
@@ -10195,7 +10195,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cinnabar_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.cinnabar_brick_slab"),
                 },
             ),
             (
@@ -10233,7 +10233,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cinnabar_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.cinnabar_brick_stairs"),
                 },
             ),
             (
@@ -10271,7 +10271,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cinnabar_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.cinnabar_brick_wall"),
                 },
             ),
             (
@@ -10309,7 +10309,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cinnabar_bricks",
+                    name: Cow::Borrowed("block.minecraft.cinnabar_bricks"),
                 },
             ),
             (
@@ -10347,7 +10347,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cinnabar_slab",
+                    name: Cow::Borrowed("block.minecraft.cinnabar_slab"),
                 },
             ),
             (
@@ -10385,7 +10385,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cinnabar_stairs",
+                    name: Cow::Borrowed("block.minecraft.cinnabar_stairs"),
                 },
             ),
             (
@@ -10423,7 +10423,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cinnabar_wall",
+                    name: Cow::Borrowed("block.minecraft.cinnabar_wall"),
                 },
             ),
             (
@@ -10461,7 +10461,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.clay",
+                    name: Cow::Borrowed("block.minecraft.clay"),
                 },
             ),
             (
@@ -10499,7 +10499,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.clay_ball",
+                    name: Cow::Borrowed("item.minecraft.clay_ball"),
                 },
             ),
             (
@@ -10537,7 +10537,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.clock",
+                    name: Cow::Borrowed("item.minecraft.clock"),
                 },
             ),
             (
@@ -10575,7 +10575,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.closed_eyeblossom",
+                    name: Cow::Borrowed("block.minecraft.closed_eyeblossom"),
                 },
             ),
             (
@@ -10613,7 +10613,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.coal",
+                    name: Cow::Borrowed("item.minecraft.coal"),
                 },
             ),
             (
@@ -10651,7 +10651,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.coal_block",
+                    name: Cow::Borrowed("block.minecraft.coal_block"),
                 },
             ),
             (
@@ -10689,7 +10689,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.coal_ore",
+                    name: Cow::Borrowed("block.minecraft.coal_ore"),
                 },
             ),
             (
@@ -10727,7 +10727,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.coarse_dirt",
+                    name: Cow::Borrowed("block.minecraft.coarse_dirt"),
                 },
             ),
             (
@@ -10765,7 +10765,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.coast_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.coast_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -10803,7 +10803,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cobbled_deepslate",
+                    name: Cow::Borrowed("block.minecraft.cobbled_deepslate"),
                 },
             ),
             (
@@ -10841,7 +10841,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cobbled_deepslate_slab",
+                    name: Cow::Borrowed("block.minecraft.cobbled_deepslate_slab"),
                 },
             ),
             (
@@ -10879,7 +10879,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cobbled_deepslate_stairs",
+                    name: Cow::Borrowed("block.minecraft.cobbled_deepslate_stairs"),
                 },
             ),
             (
@@ -10917,7 +10917,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cobbled_deepslate_wall",
+                    name: Cow::Borrowed("block.minecraft.cobbled_deepslate_wall"),
                 },
             ),
             (
@@ -10955,7 +10955,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cobblestone",
+                    name: Cow::Borrowed("block.minecraft.cobblestone"),
                 },
             ),
             (
@@ -10993,7 +10993,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cobblestone_slab",
+                    name: Cow::Borrowed("block.minecraft.cobblestone_slab"),
                 },
             ),
             (
@@ -11031,7 +11031,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cobblestone_stairs",
+                    name: Cow::Borrowed("block.minecraft.cobblestone_stairs"),
                 },
             ),
             (
@@ -11069,7 +11069,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cobblestone_wall",
+                    name: Cow::Borrowed("block.minecraft.cobblestone_wall"),
                 },
             ),
             (
@@ -11107,7 +11107,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cobweb",
+                    name: Cow::Borrowed("block.minecraft.cobweb"),
                 },
             ),
             (
@@ -11145,7 +11145,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cocoa_beans",
+                    name: Cow::Borrowed("item.minecraft.cocoa_beans"),
                 },
             ),
             (
@@ -11183,7 +11183,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cod",
+                    name: Cow::Borrowed("item.minecraft.cod"),
                 },
             ),
             (
@@ -11239,7 +11239,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cod_bucket",
+                    name: Cow::Borrowed("item.minecraft.cod_bucket"),
                 },
             ),
             (
@@ -11286,7 +11286,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cod_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.cod_spawn_egg"),
                 },
             ),
             (
@@ -11325,7 +11325,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.command_block",
+                    name: Cow::Borrowed("block.minecraft.command_block"),
                 },
             ),
             (
@@ -11363,7 +11363,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.command_block_minecart",
+                    name: Cow::Borrowed("item.minecraft.command_block_minecart"),
                 },
             ),
             (
@@ -11401,7 +11401,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.comparator",
+                    name: Cow::Borrowed("block.minecraft.comparator"),
                 },
             ),
             (
@@ -11439,7 +11439,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.compass",
+                    name: Cow::Borrowed("item.minecraft.compass"),
                 },
             ),
             (
@@ -11477,7 +11477,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.composter",
+                    name: Cow::Borrowed("block.minecraft.composter"),
                 },
             ),
             (
@@ -11515,7 +11515,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.conduit",
+                    name: Cow::Borrowed("block.minecraft.conduit"),
                 },
             ),
             (
@@ -11553,7 +11553,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cooked_beef",
+                    name: Cow::Borrowed("item.minecraft.cooked_beef"),
                 },
             ),
             (
@@ -11609,7 +11609,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cooked_chicken",
+                    name: Cow::Borrowed("item.minecraft.cooked_chicken"),
                 },
             ),
             (
@@ -11665,7 +11665,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cooked_cod",
+                    name: Cow::Borrowed("item.minecraft.cooked_cod"),
                 },
             ),
             (
@@ -11721,7 +11721,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cooked_mutton",
+                    name: Cow::Borrowed("item.minecraft.cooked_mutton"),
                 },
             ),
             (
@@ -11777,7 +11777,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cooked_porkchop",
+                    name: Cow::Borrowed("item.minecraft.cooked_porkchop"),
                 },
             ),
             (
@@ -11833,7 +11833,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cooked_rabbit",
+                    name: Cow::Borrowed("item.minecraft.cooked_rabbit"),
                 },
             ),
             (
@@ -11889,7 +11889,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cooked_salmon",
+                    name: Cow::Borrowed("item.minecraft.cooked_salmon"),
                 },
             ),
             (
@@ -11945,7 +11945,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cookie",
+                    name: Cow::Borrowed("item.minecraft.cookie"),
                 },
             ),
             (
@@ -12001,7 +12001,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_axe",
+                    name: Cow::Borrowed("item.minecraft.copper_axe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -12084,7 +12084,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_bars",
+                    name: Cow::Borrowed("block.minecraft.copper_bars"),
                 },
             ),
             (
@@ -12122,7 +12122,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_block",
+                    name: Cow::Borrowed("block.minecraft.copper_block"),
                 },
             ),
             (
@@ -12160,7 +12160,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_boots",
+                    name: Cow::Borrowed("item.minecraft.copper_boots"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -12233,7 +12233,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_bulb",
+                    name: Cow::Borrowed("block.minecraft.copper_bulb"),
                 },
             ),
             (
@@ -12271,7 +12271,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_chain",
+                    name: Cow::Borrowed("block.minecraft.copper_chain"),
                 },
             ),
             (
@@ -12309,7 +12309,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_chest",
+                    name: Cow::Borrowed("block.minecraft.copper_chest"),
                 },
             ),
             (
@@ -12347,7 +12347,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_chestplate",
+                    name: Cow::Borrowed("item.minecraft.copper_chestplate"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -12420,7 +12420,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_door",
+                    name: Cow::Borrowed("block.minecraft.copper_door"),
                 },
             ),
             (
@@ -12458,7 +12458,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_golem_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.copper_golem_spawn_egg"),
                 },
             ),
             (
@@ -12497,7 +12497,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_golem_statue",
+                    name: Cow::Borrowed("block.minecraft.copper_golem_statue"),
                 },
             ),
             (
@@ -12544,7 +12544,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_grate",
+                    name: Cow::Borrowed("block.minecraft.copper_grate"),
                 },
             ),
             (
@@ -12582,7 +12582,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_helmet",
+                    name: Cow::Borrowed("item.minecraft.copper_helmet"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -12655,7 +12655,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_hoe",
+                    name: Cow::Borrowed("item.minecraft.copper_hoe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -12738,7 +12738,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_horse_armor",
+                    name: Cow::Borrowed("item.minecraft.copper_horse_armor"),
                 },
             ),
             (
@@ -12807,7 +12807,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_ingot",
+                    name: Cow::Borrowed("item.minecraft.copper_ingot"),
                 },
             ),
             (
@@ -12846,7 +12846,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_lantern",
+                    name: Cow::Borrowed("block.minecraft.copper_lantern"),
                 },
             ),
             (
@@ -12884,7 +12884,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_leggings",
+                    name: Cow::Borrowed("item.minecraft.copper_leggings"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -12957,7 +12957,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_nautilus_armor",
+                    name: Cow::Borrowed("item.minecraft.copper_nautilus_armor"),
                 },
             ),
             (
@@ -13026,7 +13026,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_nugget",
+                    name: Cow::Borrowed("item.minecraft.copper_nugget"),
                 },
             ),
             (
@@ -13064,7 +13064,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_ore",
+                    name: Cow::Borrowed("block.minecraft.copper_ore"),
                 },
             ),
             (
@@ -13102,7 +13102,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_pickaxe",
+                    name: Cow::Borrowed("item.minecraft.copper_pickaxe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -13185,7 +13185,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_shovel",
+                    name: Cow::Borrowed("item.minecraft.copper_shovel"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -13268,7 +13268,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_spear",
+                    name: Cow::Borrowed("item.minecraft.copper_spear"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -13336,7 +13336,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.copper_sword",
+                    name: Cow::Borrowed("item.minecraft.copper_sword"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -13424,7 +13424,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_torch",
+                    name: Cow::Borrowed("block.minecraft.copper_torch"),
                 },
             ),
             (
@@ -13462,7 +13462,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.copper_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.copper_trapdoor"),
                 },
             ),
             (
@@ -13500,7 +13500,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cornflower",
+                    name: Cow::Borrowed("block.minecraft.cornflower"),
                 },
             ),
             (
@@ -13538,7 +13538,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cow_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.cow_spawn_egg"),
                 },
             ),
             (
@@ -13577,7 +13577,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cracked_deepslate_bricks",
+                    name: Cow::Borrowed("block.minecraft.cracked_deepslate_bricks"),
                 },
             ),
             (
@@ -13615,7 +13615,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cracked_deepslate_tiles",
+                    name: Cow::Borrowed("block.minecraft.cracked_deepslate_tiles"),
                 },
             ),
             (
@@ -13653,7 +13653,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cracked_nether_bricks",
+                    name: Cow::Borrowed("block.minecraft.cracked_nether_bricks"),
                 },
             ),
             (
@@ -13691,7 +13691,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cracked_polished_blackstone_bricks",
+                    name: Cow::Borrowed("block.minecraft.cracked_polished_blackstone_bricks"),
                 },
             ),
             (
@@ -13729,7 +13729,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cracked_stone_bricks",
+                    name: Cow::Borrowed("block.minecraft.cracked_stone_bricks"),
                 },
             ),
             (
@@ -13767,7 +13767,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crafter",
+                    name: Cow::Borrowed("block.minecraft.crafter"),
                 },
             ),
             (
@@ -13806,7 +13806,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crafting_table",
+                    name: Cow::Borrowed("block.minecraft.crafting_table"),
                 },
             ),
             (
@@ -13844,7 +13844,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.creaking_heart",
+                    name: Cow::Borrowed("block.minecraft.creaking_heart"),
                 },
             ),
             (
@@ -13882,7 +13882,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.creaking_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.creaking_spawn_egg"),
                 },
             ),
             (
@@ -13921,7 +13921,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.creeper_banner_pattern",
+                    name: Cow::Borrowed("item.minecraft.creeper_banner_pattern"),
                 },
             ),
             (
@@ -13960,7 +13960,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.creeper_head",
+                    name: Cow::Borrowed("block.minecraft.creeper_head"),
                 },
             ),
             (
@@ -14020,7 +14020,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.creeper_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.creeper_spawn_egg"),
                 },
             ),
             (
@@ -14059,7 +14059,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_button",
+                    name: Cow::Borrowed("block.minecraft.crimson_button"),
                 },
             ),
             (
@@ -14097,7 +14097,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_door",
+                    name: Cow::Borrowed("block.minecraft.crimson_door"),
                 },
             ),
             (
@@ -14135,7 +14135,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_fence",
+                    name: Cow::Borrowed("block.minecraft.crimson_fence"),
                 },
             ),
             (
@@ -14173,7 +14173,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.crimson_fence_gate"),
                 },
             ),
             (
@@ -14211,7 +14211,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_fungus",
+                    name: Cow::Borrowed("block.minecraft.crimson_fungus"),
                 },
             ),
             (
@@ -14249,7 +14249,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.crimson_hanging_sign"),
                 },
             ),
             (
@@ -14287,7 +14287,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_hyphae",
+                    name: Cow::Borrowed("block.minecraft.crimson_hyphae"),
                 },
             ),
             (
@@ -14325,7 +14325,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_nylium",
+                    name: Cow::Borrowed("block.minecraft.crimson_nylium"),
                 },
             ),
             (
@@ -14363,7 +14363,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_planks",
+                    name: Cow::Borrowed("block.minecraft.crimson_planks"),
                 },
             ),
             (
@@ -14401,7 +14401,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.crimson_pressure_plate"),
                 },
             ),
             (
@@ -14439,7 +14439,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_roots",
+                    name: Cow::Borrowed("block.minecraft.crimson_roots"),
                 },
             ),
             (
@@ -14477,7 +14477,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_shelf",
+                    name: Cow::Borrowed("block.minecraft.crimson_shelf"),
                 },
             ),
             (
@@ -14516,7 +14516,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_sign",
+                    name: Cow::Borrowed("block.minecraft.crimson_sign"),
                 },
             ),
             (
@@ -14554,7 +14554,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_slab",
+                    name: Cow::Borrowed("block.minecraft.crimson_slab"),
                 },
             ),
             (
@@ -14592,7 +14592,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_stairs",
+                    name: Cow::Borrowed("block.minecraft.crimson_stairs"),
                 },
             ),
             (
@@ -14630,7 +14630,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_stem",
+                    name: Cow::Borrowed("block.minecraft.crimson_stem"),
                 },
             ),
             (
@@ -14668,7 +14668,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crimson_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.crimson_trapdoor"),
                 },
             ),
             (
@@ -14706,7 +14706,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.crossbow",
+                    name: Cow::Borrowed("item.minecraft.crossbow"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -14753,7 +14753,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.crying_obsidian",
+                    name: Cow::Borrowed("block.minecraft.crying_obsidian"),
                 },
             ),
             (
@@ -14791,7 +14791,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cut_copper",
+                    name: Cow::Borrowed("block.minecraft.cut_copper"),
                 },
             ),
             (
@@ -14829,7 +14829,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cut_copper_slab",
+                    name: Cow::Borrowed("block.minecraft.cut_copper_slab"),
                 },
             ),
             (
@@ -14867,7 +14867,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cut_copper_stairs",
+                    name: Cow::Borrowed("block.minecraft.cut_copper_stairs"),
                 },
             ),
             (
@@ -14905,7 +14905,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cut_red_sandstone",
+                    name: Cow::Borrowed("block.minecraft.cut_red_sandstone"),
                 },
             ),
             (
@@ -14943,7 +14943,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cut_red_sandstone_slab",
+                    name: Cow::Borrowed("block.minecraft.cut_red_sandstone_slab"),
                 },
             ),
             (
@@ -14981,7 +14981,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cut_sandstone",
+                    name: Cow::Borrowed("block.minecraft.cut_sandstone"),
                 },
             ),
             (
@@ -15019,7 +15019,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cut_sandstone_slab",
+                    name: Cow::Borrowed("block.minecraft.cut_sandstone_slab"),
                 },
             ),
             (
@@ -15057,7 +15057,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_banner",
+                    name: Cow::Borrowed("block.minecraft.cyan_banner"),
                 },
             ),
             (
@@ -15096,7 +15096,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_bed",
+                    name: Cow::Borrowed("block.minecraft.cyan_bed"),
                 },
             ),
             (
@@ -15134,7 +15134,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cyan_bundle",
+                    name: Cow::Borrowed("item.minecraft.cyan_bundle"),
                 },
             ),
             (
@@ -15173,7 +15173,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_candle",
+                    name: Cow::Borrowed("block.minecraft.cyan_candle"),
                 },
             ),
             (
@@ -15211,7 +15211,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_carpet",
+                    name: Cow::Borrowed("block.minecraft.cyan_carpet"),
                 },
             ),
             (
@@ -15268,7 +15268,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_concrete",
+                    name: Cow::Borrowed("block.minecraft.cyan_concrete"),
                 },
             ),
             (
@@ -15306,7 +15306,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.cyan_concrete_powder"),
                 },
             ),
             (
@@ -15344,7 +15344,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cyan_dye",
+                    name: Cow::Borrowed("item.minecraft.cyan_dye"),
                 },
             ),
             (
@@ -15383,7 +15383,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.cyan_glazed_terracotta"),
                 },
             ),
             (
@@ -15421,7 +15421,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.cyan_harness",
+                    name: Cow::Borrowed("item.minecraft.cyan_harness"),
                 },
             ),
             (
@@ -15475,7 +15475,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.cyan_shulker_box"),
                 },
             ),
             (
@@ -15514,7 +15514,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.cyan_stained_glass"),
                 },
             ),
             (
@@ -15552,7 +15552,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.cyan_stained_glass_pane"),
                 },
             ),
             (
@@ -15590,7 +15590,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_terracotta",
+                    name: Cow::Borrowed("block.minecraft.cyan_terracotta"),
                 },
             ),
             (
@@ -15628,7 +15628,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.cyan_wool",
+                    name: Cow::Borrowed("block.minecraft.cyan_wool"),
                 },
             ),
             (
@@ -15666,7 +15666,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.damaged_anvil",
+                    name: Cow::Borrowed("block.minecraft.damaged_anvil"),
                 },
             ),
             (
@@ -15704,7 +15704,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dandelion",
+                    name: Cow::Borrowed("block.minecraft.dandelion"),
                 },
             ),
             (
@@ -15742,7 +15742,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.danger_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.danger_pottery_sherd"),
                 },
             ),
             (
@@ -15780,7 +15780,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.dark_oak_boat",
+                    name: Cow::Borrowed("item.minecraft.dark_oak_boat"),
                 },
             ),
             (
@@ -15818,7 +15818,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_button",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_button"),
                 },
             ),
             (
@@ -15856,7 +15856,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.dark_oak_chest_boat",
+                    name: Cow::Borrowed("item.minecraft.dark_oak_chest_boat"),
                 },
             ),
             (
@@ -15894,7 +15894,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_door",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_door"),
                 },
             ),
             (
@@ -15932,7 +15932,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_fence",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_fence"),
                 },
             ),
             (
@@ -15970,7 +15970,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_fence_gate"),
                 },
             ),
             (
@@ -16008,7 +16008,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_hanging_sign"),
                 },
             ),
             (
@@ -16046,7 +16046,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_leaves",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_leaves"),
                 },
             ),
             (
@@ -16084,7 +16084,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_log",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_log"),
                 },
             ),
             (
@@ -16122,7 +16122,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_planks",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_planks"),
                 },
             ),
             (
@@ -16160,7 +16160,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_pressure_plate"),
                 },
             ),
             (
@@ -16198,7 +16198,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_sapling",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_sapling"),
                 },
             ),
             (
@@ -16236,7 +16236,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_shelf",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_shelf"),
                 },
             ),
             (
@@ -16275,7 +16275,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_sign",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_sign"),
                 },
             ),
             (
@@ -16313,7 +16313,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_slab",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_slab"),
                 },
             ),
             (
@@ -16351,7 +16351,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_stairs",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_stairs"),
                 },
             ),
             (
@@ -16389,7 +16389,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_trapdoor"),
                 },
             ),
             (
@@ -16427,7 +16427,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_oak_wood",
+                    name: Cow::Borrowed("block.minecraft.dark_oak_wood"),
                 },
             ),
             (
@@ -16465,7 +16465,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_prismarine",
+                    name: Cow::Borrowed("block.minecraft.dark_prismarine"),
                 },
             ),
             (
@@ -16503,7 +16503,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_prismarine_slab",
+                    name: Cow::Borrowed("block.minecraft.dark_prismarine_slab"),
                 },
             ),
             (
@@ -16541,7 +16541,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dark_prismarine_stairs",
+                    name: Cow::Borrowed("block.minecraft.dark_prismarine_stairs"),
                 },
             ),
             (
@@ -16579,7 +16579,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.daylight_detector",
+                    name: Cow::Borrowed("block.minecraft.daylight_detector"),
                 },
             ),
             (
@@ -16617,7 +16617,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_brain_coral",
+                    name: Cow::Borrowed("block.minecraft.dead_brain_coral"),
                 },
             ),
             (
@@ -16655,7 +16655,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_brain_coral_block",
+                    name: Cow::Borrowed("block.minecraft.dead_brain_coral_block"),
                 },
             ),
             (
@@ -16693,7 +16693,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_brain_coral_fan",
+                    name: Cow::Borrowed("block.minecraft.dead_brain_coral_fan"),
                 },
             ),
             (
@@ -16731,7 +16731,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_bubble_coral",
+                    name: Cow::Borrowed("block.minecraft.dead_bubble_coral"),
                 },
             ),
             (
@@ -16769,7 +16769,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_bubble_coral_block",
+                    name: Cow::Borrowed("block.minecraft.dead_bubble_coral_block"),
                 },
             ),
             (
@@ -16807,7 +16807,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_bubble_coral_fan",
+                    name: Cow::Borrowed("block.minecraft.dead_bubble_coral_fan"),
                 },
             ),
             (
@@ -16845,7 +16845,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_bush",
+                    name: Cow::Borrowed("block.minecraft.dead_bush"),
                 },
             ),
             (
@@ -16883,7 +16883,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_fire_coral",
+                    name: Cow::Borrowed("block.minecraft.dead_fire_coral"),
                 },
             ),
             (
@@ -16921,7 +16921,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_fire_coral_block",
+                    name: Cow::Borrowed("block.minecraft.dead_fire_coral_block"),
                 },
             ),
             (
@@ -16959,7 +16959,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_fire_coral_fan",
+                    name: Cow::Borrowed("block.minecraft.dead_fire_coral_fan"),
                 },
             ),
             (
@@ -16997,7 +16997,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_horn_coral",
+                    name: Cow::Borrowed("block.minecraft.dead_horn_coral"),
                 },
             ),
             (
@@ -17035,7 +17035,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_horn_coral_block",
+                    name: Cow::Borrowed("block.minecraft.dead_horn_coral_block"),
                 },
             ),
             (
@@ -17073,7 +17073,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_horn_coral_fan",
+                    name: Cow::Borrowed("block.minecraft.dead_horn_coral_fan"),
                 },
             ),
             (
@@ -17111,7 +17111,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_tube_coral",
+                    name: Cow::Borrowed("block.minecraft.dead_tube_coral"),
                 },
             ),
             (
@@ -17149,7 +17149,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_tube_coral_block",
+                    name: Cow::Borrowed("block.minecraft.dead_tube_coral_block"),
                 },
             ),
             (
@@ -17187,7 +17187,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dead_tube_coral_fan",
+                    name: Cow::Borrowed("block.minecraft.dead_tube_coral_fan"),
                 },
             ),
             (
@@ -17225,7 +17225,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.debug_stick",
+                    name: Cow::Borrowed("item.minecraft.debug_stick"),
                 },
             ),
             (
@@ -17265,7 +17265,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.decorated_pot",
+                    name: Cow::Borrowed("block.minecraft.decorated_pot"),
                 },
             ),
             (
@@ -17305,7 +17305,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate",
+                    name: Cow::Borrowed("block.minecraft.deepslate"),
                 },
             ),
             (
@@ -17343,7 +17343,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.deepslate_brick_slab"),
                 },
             ),
             (
@@ -17381,7 +17381,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.deepslate_brick_stairs"),
                 },
             ),
             (
@@ -17419,7 +17419,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.deepslate_brick_wall"),
                 },
             ),
             (
@@ -17457,7 +17457,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_bricks",
+                    name: Cow::Borrowed("block.minecraft.deepslate_bricks"),
                 },
             ),
             (
@@ -17495,7 +17495,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_coal_ore",
+                    name: Cow::Borrowed("block.minecraft.deepslate_coal_ore"),
                 },
             ),
             (
@@ -17533,7 +17533,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_copper_ore",
+                    name: Cow::Borrowed("block.minecraft.deepslate_copper_ore"),
                 },
             ),
             (
@@ -17571,7 +17571,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_diamond_ore",
+                    name: Cow::Borrowed("block.minecraft.deepslate_diamond_ore"),
                 },
             ),
             (
@@ -17609,7 +17609,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_emerald_ore",
+                    name: Cow::Borrowed("block.minecraft.deepslate_emerald_ore"),
                 },
             ),
             (
@@ -17647,7 +17647,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_gold_ore",
+                    name: Cow::Borrowed("block.minecraft.deepslate_gold_ore"),
                 },
             ),
             (
@@ -17685,7 +17685,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_iron_ore",
+                    name: Cow::Borrowed("block.minecraft.deepslate_iron_ore"),
                 },
             ),
             (
@@ -17723,7 +17723,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_lapis_ore",
+                    name: Cow::Borrowed("block.minecraft.deepslate_lapis_ore"),
                 },
             ),
             (
@@ -17761,7 +17761,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_redstone_ore",
+                    name: Cow::Borrowed("block.minecraft.deepslate_redstone_ore"),
                 },
             ),
             (
@@ -17799,7 +17799,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_tile_slab",
+                    name: Cow::Borrowed("block.minecraft.deepslate_tile_slab"),
                 },
             ),
             (
@@ -17837,7 +17837,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_tile_stairs",
+                    name: Cow::Borrowed("block.minecraft.deepslate_tile_stairs"),
                 },
             ),
             (
@@ -17875,7 +17875,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_tile_wall",
+                    name: Cow::Borrowed("block.minecraft.deepslate_tile_wall"),
                 },
             ),
             (
@@ -17913,7 +17913,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.deepslate_tiles",
+                    name: Cow::Borrowed("block.minecraft.deepslate_tiles"),
                 },
             ),
             (
@@ -17951,7 +17951,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.detector_rail",
+                    name: Cow::Borrowed("block.minecraft.detector_rail"),
                 },
             ),
             (
@@ -17989,7 +17989,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond",
+                    name: Cow::Borrowed("item.minecraft.diamond"),
                 },
             ),
             (
@@ -18028,7 +18028,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_axe",
+                    name: Cow::Borrowed("item.minecraft.diamond_axe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -18111,7 +18111,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.diamond_block",
+                    name: Cow::Borrowed("block.minecraft.diamond_block"),
                 },
             ),
             (
@@ -18149,7 +18149,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_boots",
+                    name: Cow::Borrowed("item.minecraft.diamond_boots"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -18222,7 +18222,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_chestplate",
+                    name: Cow::Borrowed("item.minecraft.diamond_chestplate"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -18295,7 +18295,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_helmet",
+                    name: Cow::Borrowed("item.minecraft.diamond_helmet"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -18368,7 +18368,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_hoe",
+                    name: Cow::Borrowed("item.minecraft.diamond_hoe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -18451,7 +18451,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_horse_armor",
+                    name: Cow::Borrowed("item.minecraft.diamond_horse_armor"),
                 },
             ),
             (
@@ -18520,7 +18520,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_leggings",
+                    name: Cow::Borrowed("item.minecraft.diamond_leggings"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -18593,7 +18593,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_nautilus_armor",
+                    name: Cow::Borrowed("item.minecraft.diamond_nautilus_armor"),
                 },
             ),
             (
@@ -18662,7 +18662,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.diamond_ore",
+                    name: Cow::Borrowed("block.minecraft.diamond_ore"),
                 },
             ),
             (
@@ -18700,7 +18700,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_pickaxe",
+                    name: Cow::Borrowed("item.minecraft.diamond_pickaxe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -18783,7 +18783,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_shovel",
+                    name: Cow::Borrowed("item.minecraft.diamond_shovel"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -18866,7 +18866,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_spear",
+                    name: Cow::Borrowed("item.minecraft.diamond_spear"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -18934,7 +18934,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.diamond_sword",
+                    name: Cow::Borrowed("item.minecraft.diamond_sword"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -19022,7 +19022,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.diorite",
+                    name: Cow::Borrowed("block.minecraft.diorite"),
                 },
             ),
             (
@@ -19060,7 +19060,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.diorite_slab",
+                    name: Cow::Borrowed("block.minecraft.diorite_slab"),
                 },
             ),
             (
@@ -19098,7 +19098,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.diorite_stairs",
+                    name: Cow::Borrowed("block.minecraft.diorite_stairs"),
                 },
             ),
             (
@@ -19136,7 +19136,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.diorite_wall",
+                    name: Cow::Borrowed("block.minecraft.diorite_wall"),
                 },
             ),
             (
@@ -19174,7 +19174,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dirt",
+                    name: Cow::Borrowed("block.minecraft.dirt"),
                 },
             ),
             (
@@ -19212,7 +19212,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dirt_path",
+                    name: Cow::Borrowed("block.minecraft.dirt_path"),
                 },
             ),
             (
@@ -19250,7 +19250,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.disc_fragment_5",
+                    name: Cow::Borrowed("item.minecraft.disc_fragment_5"),
                 },
             ),
             (
@@ -19288,7 +19288,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dispenser",
+                    name: Cow::Borrowed("block.minecraft.dispenser"),
                 },
             ),
             (
@@ -19327,7 +19327,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.dolphin_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.dolphin_spawn_egg"),
                 },
             ),
             (
@@ -19366,7 +19366,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.donkey_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.donkey_spawn_egg"),
                 },
             ),
             (
@@ -19405,7 +19405,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.dragon_breath",
+                    name: Cow::Borrowed("item.minecraft.dragon_breath"),
                 },
             ),
             (
@@ -19443,7 +19443,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dragon_egg",
+                    name: Cow::Borrowed("block.minecraft.dragon_egg"),
                 },
             ),
             (
@@ -19481,7 +19481,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dragon_head",
+                    name: Cow::Borrowed("block.minecraft.dragon_head"),
                 },
             ),
             (
@@ -19541,7 +19541,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dried_ghast",
+                    name: Cow::Borrowed("block.minecraft.dried_ghast"),
                 },
             ),
             (
@@ -19579,7 +19579,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.dried_kelp",
+                    name: Cow::Borrowed("item.minecraft.dried_kelp"),
                 },
             ),
             (
@@ -19635,7 +19635,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dried_kelp_block",
+                    name: Cow::Borrowed("block.minecraft.dried_kelp_block"),
                 },
             ),
             (
@@ -19673,7 +19673,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dripstone_block",
+                    name: Cow::Borrowed("block.minecraft.dripstone_block"),
                 },
             ),
             (
@@ -19711,7 +19711,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.dropper",
+                    name: Cow::Borrowed("block.minecraft.dropper"),
                 },
             ),
             (
@@ -19750,7 +19750,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.drowned_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.drowned_spawn_egg"),
                 },
             ),
             (
@@ -19789,7 +19789,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.dune_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.dune_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -19827,7 +19827,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.echo_shard",
+                    name: Cow::Borrowed("item.minecraft.echo_shard"),
                 },
             ),
             (
@@ -19865,7 +19865,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.egg",
+                    name: Cow::Borrowed("item.minecraft.egg"),
                 },
             ),
             (
@@ -19909,7 +19909,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.elder_guardian_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.elder_guardian_spawn_egg"),
                 },
             ),
             (
@@ -19948,7 +19948,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.elytra",
+                    name: Cow::Borrowed("item.minecraft.elytra"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -20006,7 +20006,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.emerald",
+                    name: Cow::Borrowed("item.minecraft.emerald"),
                 },
             ),
             (
@@ -20045,7 +20045,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.emerald_block",
+                    name: Cow::Borrowed("block.minecraft.emerald_block"),
                 },
             ),
             (
@@ -20083,7 +20083,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.emerald_ore",
+                    name: Cow::Borrowed("block.minecraft.emerald_ore"),
                 },
             ),
             (
@@ -20121,7 +20121,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.enchanted_book",
+                    name: Cow::Borrowed("item.minecraft.enchanted_book"),
                 },
             ),
             (
@@ -20166,7 +20166,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.enchanted_golden_apple",
+                    name: Cow::Borrowed("item.minecraft.enchanted_golden_apple"),
                 },
             ),
             (
@@ -20259,7 +20259,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.enchanting_table",
+                    name: Cow::Borrowed("block.minecraft.enchanting_table"),
                 },
             ),
             (
@@ -20297,7 +20297,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.end_crystal",
+                    name: Cow::Borrowed("item.minecraft.end_crystal"),
                 },
             ),
             (
@@ -20336,7 +20336,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.end_portal_frame",
+                    name: Cow::Borrowed("block.minecraft.end_portal_frame"),
                 },
             ),
             (
@@ -20374,7 +20374,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.end_rod",
+                    name: Cow::Borrowed("block.minecraft.end_rod"),
                 },
             ),
             (
@@ -20412,7 +20412,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.end_stone",
+                    name: Cow::Borrowed("block.minecraft.end_stone"),
                 },
             ),
             (
@@ -20450,7 +20450,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.end_stone_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.end_stone_brick_slab"),
                 },
             ),
             (
@@ -20488,7 +20488,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.end_stone_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.end_stone_brick_stairs"),
                 },
             ),
             (
@@ -20526,7 +20526,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.end_stone_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.end_stone_brick_wall"),
                 },
             ),
             (
@@ -20564,7 +20564,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.end_stone_bricks",
+                    name: Cow::Borrowed("block.minecraft.end_stone_bricks"),
                 },
             ),
             (
@@ -20602,7 +20602,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.ender_chest",
+                    name: Cow::Borrowed("block.minecraft.ender_chest"),
                 },
             ),
             (
@@ -20640,7 +20640,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ender_dragon_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.ender_dragon_spawn_egg"),
                 },
             ),
             (
@@ -20679,7 +20679,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ender_eye",
+                    name: Cow::Borrowed("item.minecraft.ender_eye"),
                 },
             ),
             (
@@ -20724,7 +20724,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ender_pearl",
+                    name: Cow::Borrowed("item.minecraft.ender_pearl"),
                 },
             ),
             (
@@ -20762,7 +20762,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.enderman_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.enderman_spawn_egg"),
                 },
             ),
             (
@@ -20801,7 +20801,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.endermite_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.endermite_spawn_egg"),
                 },
             ),
             (
@@ -20840,7 +20840,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.evoker_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.evoker_spawn_egg"),
                 },
             ),
             (
@@ -20879,7 +20879,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.experience_bottle",
+                    name: Cow::Borrowed("item.minecraft.experience_bottle"),
                 },
             ),
             (
@@ -20918,7 +20918,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.explorer_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.explorer_pottery_sherd"),
                 },
             ),
             (
@@ -20956,7 +20956,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_chiseled_copper",
+                    name: Cow::Borrowed("block.minecraft.exposed_chiseled_copper"),
                 },
             ),
             (
@@ -20994,7 +20994,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_copper",
+                    name: Cow::Borrowed("block.minecraft.exposed_copper"),
                 },
             ),
             (
@@ -21032,7 +21032,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_copper_bars",
+                    name: Cow::Borrowed("block.minecraft.exposed_copper_bars"),
                 },
             ),
             (
@@ -21070,7 +21070,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_copper_bulb",
+                    name: Cow::Borrowed("block.minecraft.exposed_copper_bulb"),
                 },
             ),
             (
@@ -21108,7 +21108,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_copper_chain",
+                    name: Cow::Borrowed("block.minecraft.exposed_copper_chain"),
                 },
             ),
             (
@@ -21146,7 +21146,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_copper_chest",
+                    name: Cow::Borrowed("block.minecraft.exposed_copper_chest"),
                 },
             ),
             (
@@ -21184,7 +21184,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_copper_door",
+                    name: Cow::Borrowed("block.minecraft.exposed_copper_door"),
                 },
             ),
             (
@@ -21222,7 +21222,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_copper_golem_statue",
+                    name: Cow::Borrowed("block.minecraft.exposed_copper_golem_statue"),
                 },
             ),
             (
@@ -21269,7 +21269,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_copper_grate",
+                    name: Cow::Borrowed("block.minecraft.exposed_copper_grate"),
                 },
             ),
             (
@@ -21307,7 +21307,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_copper_lantern",
+                    name: Cow::Borrowed("block.minecraft.exposed_copper_lantern"),
                 },
             ),
             (
@@ -21345,7 +21345,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_copper_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.exposed_copper_trapdoor"),
                 },
             ),
             (
@@ -21383,7 +21383,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_cut_copper",
+                    name: Cow::Borrowed("block.minecraft.exposed_cut_copper"),
                 },
             ),
             (
@@ -21421,7 +21421,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_cut_copper_slab",
+                    name: Cow::Borrowed("block.minecraft.exposed_cut_copper_slab"),
                 },
             ),
             (
@@ -21459,7 +21459,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_cut_copper_stairs",
+                    name: Cow::Borrowed("block.minecraft.exposed_cut_copper_stairs"),
                 },
             ),
             (
@@ -21497,7 +21497,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.exposed_lightning_rod",
+                    name: Cow::Borrowed("block.minecraft.exposed_lightning_rod"),
                 },
             ),
             (
@@ -21535,7 +21535,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.eye_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.eye_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -21573,7 +21573,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.farmland",
+                    name: Cow::Borrowed("block.minecraft.farmland"),
                 },
             ),
             (
@@ -21611,7 +21611,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.feather",
+                    name: Cow::Borrowed("item.minecraft.feather"),
                 },
             ),
             (
@@ -21649,7 +21649,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.fermented_spider_eye",
+                    name: Cow::Borrowed("item.minecraft.fermented_spider_eye"),
                 },
             ),
             (
@@ -21687,7 +21687,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.fern",
+                    name: Cow::Borrowed("block.minecraft.fern"),
                 },
             ),
             (
@@ -21725,7 +21725,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.field_masoned_banner_pattern",
+                    name: Cow::Borrowed("item.minecraft.field_masoned_banner_pattern"),
                 },
             ),
             (
@@ -21764,7 +21764,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.filled_map",
+                    name: Cow::Borrowed("item.minecraft.filled_map"),
                 },
             ),
             (
@@ -21804,7 +21804,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.fire_charge",
+                    name: Cow::Borrowed("item.minecraft.fire_charge"),
                 },
             ),
             (
@@ -21842,7 +21842,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.fire_coral",
+                    name: Cow::Borrowed("block.minecraft.fire_coral"),
                 },
             ),
             (
@@ -21880,7 +21880,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.fire_coral_block",
+                    name: Cow::Borrowed("block.minecraft.fire_coral_block"),
                 },
             ),
             (
@@ -21918,7 +21918,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.fire_coral_fan",
+                    name: Cow::Borrowed("block.minecraft.fire_coral_fan"),
                 },
             ),
             (
@@ -21956,7 +21956,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.firefly_bush",
+                    name: Cow::Borrowed("block.minecraft.firefly_bush"),
                 },
             ),
             (
@@ -21994,7 +21994,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.firework_rocket",
+                    name: Cow::Borrowed("item.minecraft.firework_rocket"),
                 },
             ),
             (
@@ -22039,7 +22039,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.firework_star",
+                    name: Cow::Borrowed("item.minecraft.firework_star"),
                 },
             ),
             (
@@ -22077,7 +22077,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.fishing_rod",
+                    name: Cow::Borrowed("item.minecraft.fishing_rod"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -22118,7 +22118,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.fletching_table",
+                    name: Cow::Borrowed("block.minecraft.fletching_table"),
                 },
             ),
             (
@@ -22156,7 +22156,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.flint",
+                    name: Cow::Borrowed("item.minecraft.flint"),
                 },
             ),
             (
@@ -22194,7 +22194,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.flint_and_steel",
+                    name: Cow::Borrowed("item.minecraft.flint_and_steel"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -22234,7 +22234,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.flow_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.flow_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -22272,7 +22272,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.flow_banner_pattern",
+                    name: Cow::Borrowed("item.minecraft.flow_banner_pattern"),
                 },
             ),
             (
@@ -22311,7 +22311,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.flow_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.flow_pottery_sherd"),
                 },
             ),
             (
@@ -22349,7 +22349,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.flower_banner_pattern",
+                    name: Cow::Borrowed("item.minecraft.flower_banner_pattern"),
                 },
             ),
             (
@@ -22388,7 +22388,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.flower_pot",
+                    name: Cow::Borrowed("block.minecraft.flower_pot"),
                 },
             ),
             (
@@ -22426,7 +22426,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.flowering_azalea",
+                    name: Cow::Borrowed("block.minecraft.flowering_azalea"),
                 },
             ),
             (
@@ -22464,7 +22464,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.flowering_azalea_leaves",
+                    name: Cow::Borrowed("block.minecraft.flowering_azalea_leaves"),
                 },
             ),
             (
@@ -22502,7 +22502,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.fox_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.fox_spawn_egg"),
                 },
             ),
             (
@@ -22541,7 +22541,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.friend_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.friend_pottery_sherd"),
                 },
             ),
             (
@@ -22579,7 +22579,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.frog_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.frog_spawn_egg"),
                 },
             ),
             (
@@ -22618,7 +22618,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.frogspawn",
+                    name: Cow::Borrowed("block.minecraft.frogspawn"),
                 },
             ),
             (
@@ -22656,7 +22656,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.furnace",
+                    name: Cow::Borrowed("block.minecraft.furnace"),
                 },
             ),
             (
@@ -22695,7 +22695,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.furnace_minecart",
+                    name: Cow::Borrowed("item.minecraft.furnace_minecart"),
                 },
             ),
             (
@@ -22733,7 +22733,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ghast_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.ghast_spawn_egg"),
                 },
             ),
             (
@@ -22772,7 +22772,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ghast_tear",
+                    name: Cow::Borrowed("item.minecraft.ghast_tear"),
                 },
             ),
             (
@@ -22810,7 +22810,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gilded_blackstone",
+                    name: Cow::Borrowed("block.minecraft.gilded_blackstone"),
                 },
             ),
             (
@@ -22848,7 +22848,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.glass",
+                    name: Cow::Borrowed("block.minecraft.glass"),
                 },
             ),
             (
@@ -22886,7 +22886,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.glass_bottle",
+                    name: Cow::Borrowed("item.minecraft.glass_bottle"),
                 },
             ),
             (
@@ -22924,7 +22924,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.glass_pane",
+                    name: Cow::Borrowed("block.minecraft.glass_pane"),
                 },
             ),
             (
@@ -22962,7 +22962,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.glistering_melon_slice",
+                    name: Cow::Borrowed("item.minecraft.glistering_melon_slice"),
                 },
             ),
             (
@@ -23000,7 +23000,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.globe_banner_pattern",
+                    name: Cow::Borrowed("item.minecraft.globe_banner_pattern"),
                 },
             ),
             (
@@ -23039,7 +23039,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.glow_berries",
+                    name: Cow::Borrowed("item.minecraft.glow_berries"),
                 },
             ),
             (
@@ -23095,7 +23095,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.glow_ink_sac",
+                    name: Cow::Borrowed("item.minecraft.glow_ink_sac"),
                 },
             ),
             (
@@ -23133,7 +23133,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.glow_item_frame",
+                    name: Cow::Borrowed("item.minecraft.glow_item_frame"),
                 },
             ),
             (
@@ -23171,7 +23171,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.glow_lichen",
+                    name: Cow::Borrowed("block.minecraft.glow_lichen"),
                 },
             ),
             (
@@ -23209,7 +23209,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.glow_squid_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.glow_squid_spawn_egg"),
                 },
             ),
             (
@@ -23248,7 +23248,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.glowstone",
+                    name: Cow::Borrowed("block.minecraft.glowstone"),
                 },
             ),
             (
@@ -23286,7 +23286,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.glowstone_dust",
+                    name: Cow::Borrowed("item.minecraft.glowstone_dust"),
                 },
             ),
             (
@@ -23324,7 +23324,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.goat_horn",
+                    name: Cow::Borrowed("item.minecraft.goat_horn"),
                 },
             ),
             (
@@ -23363,7 +23363,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.goat_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.goat_spawn_egg"),
                 },
             ),
             (
@@ -23402,7 +23402,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gold_block",
+                    name: Cow::Borrowed("block.minecraft.gold_block"),
                 },
             ),
             (
@@ -23440,7 +23440,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.gold_ingot",
+                    name: Cow::Borrowed("item.minecraft.gold_ingot"),
                 },
             ),
             (
@@ -23479,7 +23479,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.gold_nugget",
+                    name: Cow::Borrowed("item.minecraft.gold_nugget"),
                 },
             ),
             (
@@ -23517,7 +23517,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gold_ore",
+                    name: Cow::Borrowed("block.minecraft.gold_ore"),
                 },
             ),
             (
@@ -23555,7 +23555,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_apple",
+                    name: Cow::Borrowed("item.minecraft.golden_apple"),
                 },
             ),
             (
@@ -23631,7 +23631,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_axe",
+                    name: Cow::Borrowed("item.minecraft.golden_axe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -23714,7 +23714,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_boots",
+                    name: Cow::Borrowed("item.minecraft.golden_boots"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -23787,7 +23787,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_carrot",
+                    name: Cow::Borrowed("item.minecraft.golden_carrot"),
                 },
             ),
             (
@@ -23843,7 +23843,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_chestplate",
+                    name: Cow::Borrowed("item.minecraft.golden_chestplate"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -23916,7 +23916,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.golden_dandelion",
+                    name: Cow::Borrowed("block.minecraft.golden_dandelion"),
                 },
             ),
             (
@@ -23954,7 +23954,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_helmet",
+                    name: Cow::Borrowed("item.minecraft.golden_helmet"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -24027,7 +24027,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_hoe",
+                    name: Cow::Borrowed("item.minecraft.golden_hoe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -24110,7 +24110,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_horse_armor",
+                    name: Cow::Borrowed("item.minecraft.golden_horse_armor"),
                 },
             ),
             (
@@ -24179,7 +24179,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_leggings",
+                    name: Cow::Borrowed("item.minecraft.golden_leggings"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -24252,7 +24252,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_nautilus_armor",
+                    name: Cow::Borrowed("item.minecraft.golden_nautilus_armor"),
                 },
             ),
             (
@@ -24321,7 +24321,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_pickaxe",
+                    name: Cow::Borrowed("item.minecraft.golden_pickaxe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -24404,7 +24404,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_shovel",
+                    name: Cow::Borrowed("item.minecraft.golden_shovel"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -24487,7 +24487,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_spear",
+                    name: Cow::Borrowed("item.minecraft.golden_spear"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -24555,7 +24555,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.golden_sword",
+                    name: Cow::Borrowed("item.minecraft.golden_sword"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -24643,7 +24643,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.granite",
+                    name: Cow::Borrowed("block.minecraft.granite"),
                 },
             ),
             (
@@ -24681,7 +24681,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.granite_slab",
+                    name: Cow::Borrowed("block.minecraft.granite_slab"),
                 },
             ),
             (
@@ -24719,7 +24719,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.granite_stairs",
+                    name: Cow::Borrowed("block.minecraft.granite_stairs"),
                 },
             ),
             (
@@ -24757,7 +24757,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.granite_wall",
+                    name: Cow::Borrowed("block.minecraft.granite_wall"),
                 },
             ),
             (
@@ -24795,7 +24795,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.grass_block",
+                    name: Cow::Borrowed("block.minecraft.grass_block"),
                 },
             ),
             (
@@ -24833,7 +24833,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gravel",
+                    name: Cow::Borrowed("block.minecraft.gravel"),
                 },
             ),
             (
@@ -24871,7 +24871,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_banner",
+                    name: Cow::Borrowed("block.minecraft.gray_banner"),
                 },
             ),
             (
@@ -24910,7 +24910,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_bed",
+                    name: Cow::Borrowed("block.minecraft.gray_bed"),
                 },
             ),
             (
@@ -24948,7 +24948,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.gray_bundle",
+                    name: Cow::Borrowed("item.minecraft.gray_bundle"),
                 },
             ),
             (
@@ -24987,7 +24987,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_candle",
+                    name: Cow::Borrowed("block.minecraft.gray_candle"),
                 },
             ),
             (
@@ -25025,7 +25025,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_carpet",
+                    name: Cow::Borrowed("block.minecraft.gray_carpet"),
                 },
             ),
             (
@@ -25082,7 +25082,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_concrete",
+                    name: Cow::Borrowed("block.minecraft.gray_concrete"),
                 },
             ),
             (
@@ -25120,7 +25120,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.gray_concrete_powder"),
                 },
             ),
             (
@@ -25158,7 +25158,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.gray_dye",
+                    name: Cow::Borrowed("item.minecraft.gray_dye"),
                 },
             ),
             (
@@ -25197,7 +25197,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.gray_glazed_terracotta"),
                 },
             ),
             (
@@ -25235,7 +25235,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.gray_harness",
+                    name: Cow::Borrowed("item.minecraft.gray_harness"),
                 },
             ),
             (
@@ -25289,7 +25289,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.gray_shulker_box"),
                 },
             ),
             (
@@ -25328,7 +25328,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.gray_stained_glass"),
                 },
             ),
             (
@@ -25366,7 +25366,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.gray_stained_glass_pane"),
                 },
             ),
             (
@@ -25404,7 +25404,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_terracotta",
+                    name: Cow::Borrowed("block.minecraft.gray_terracotta"),
                 },
             ),
             (
@@ -25442,7 +25442,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.gray_wool",
+                    name: Cow::Borrowed("block.minecraft.gray_wool"),
                 },
             ),
             (
@@ -25480,7 +25480,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_banner",
+                    name: Cow::Borrowed("block.minecraft.green_banner"),
                 },
             ),
             (
@@ -25519,7 +25519,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_bed",
+                    name: Cow::Borrowed("block.minecraft.green_bed"),
                 },
             ),
             (
@@ -25557,7 +25557,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.green_bundle",
+                    name: Cow::Borrowed("item.minecraft.green_bundle"),
                 },
             ),
             (
@@ -25596,7 +25596,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_candle",
+                    name: Cow::Borrowed("block.minecraft.green_candle"),
                 },
             ),
             (
@@ -25634,7 +25634,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_carpet",
+                    name: Cow::Borrowed("block.minecraft.green_carpet"),
                 },
             ),
             (
@@ -25691,7 +25691,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_concrete",
+                    name: Cow::Borrowed("block.minecraft.green_concrete"),
                 },
             ),
             (
@@ -25729,7 +25729,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.green_concrete_powder"),
                 },
             ),
             (
@@ -25767,7 +25767,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.green_dye",
+                    name: Cow::Borrowed("item.minecraft.green_dye"),
                 },
             ),
             (
@@ -25806,7 +25806,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.green_glazed_terracotta"),
                 },
             ),
             (
@@ -25844,7 +25844,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.green_harness",
+                    name: Cow::Borrowed("item.minecraft.green_harness"),
                 },
             ),
             (
@@ -25898,7 +25898,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.green_shulker_box"),
                 },
             ),
             (
@@ -25937,7 +25937,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.green_stained_glass"),
                 },
             ),
             (
@@ -25975,7 +25975,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.green_stained_glass_pane"),
                 },
             ),
             (
@@ -26013,7 +26013,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_terracotta",
+                    name: Cow::Borrowed("block.minecraft.green_terracotta"),
                 },
             ),
             (
@@ -26051,7 +26051,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.green_wool",
+                    name: Cow::Borrowed("block.minecraft.green_wool"),
                 },
             ),
             (
@@ -26089,7 +26089,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.grindstone",
+                    name: Cow::Borrowed("block.minecraft.grindstone"),
                 },
             ),
             (
@@ -26127,7 +26127,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.guardian_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.guardian_spawn_egg"),
                 },
             ),
             (
@@ -26166,7 +26166,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.gunpowder",
+                    name: Cow::Borrowed("item.minecraft.gunpowder"),
                 },
             ),
             (
@@ -26204,7 +26204,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.guster_banner_pattern",
+                    name: Cow::Borrowed("item.minecraft.guster_banner_pattern"),
                 },
             ),
             (
@@ -26243,7 +26243,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.guster_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.guster_pottery_sherd"),
                 },
             ),
             (
@@ -26281,7 +26281,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.hanging_roots",
+                    name: Cow::Borrowed("block.minecraft.hanging_roots"),
                 },
             ),
             (
@@ -26319,7 +26319,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.happy_ghast_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.happy_ghast_spawn_egg"),
                 },
             ),
             (
@@ -26358,7 +26358,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.hay_block",
+                    name: Cow::Borrowed("block.minecraft.hay_block"),
                 },
             ),
             (
@@ -26396,7 +26396,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.heart_of_the_sea",
+                    name: Cow::Borrowed("item.minecraft.heart_of_the_sea"),
                 },
             ),
             (
@@ -26434,7 +26434,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.heart_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.heart_pottery_sherd"),
                 },
             ),
             (
@@ -26472,7 +26472,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.heartbreak_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.heartbreak_pottery_sherd"),
                 },
             ),
             (
@@ -26510,7 +26510,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.heavy_core",
+                    name: Cow::Borrowed("block.minecraft.heavy_core"),
                 },
             ),
             (
@@ -26548,7 +26548,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.heavy_weighted_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.heavy_weighted_pressure_plate"),
                 },
             ),
             (
@@ -26586,7 +26586,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.hoglin_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.hoglin_spawn_egg"),
                 },
             ),
             (
@@ -26625,7 +26625,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.honey_block",
+                    name: Cow::Borrowed("block.minecraft.honey_block"),
                 },
             ),
             (
@@ -26663,7 +26663,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.honey_bottle",
+                    name: Cow::Borrowed("item.minecraft.honey_bottle"),
                 },
             ),
             (
@@ -26722,7 +26722,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.honeycomb",
+                    name: Cow::Borrowed("item.minecraft.honeycomb"),
                 },
             ),
             (
@@ -26760,7 +26760,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.honeycomb_block",
+                    name: Cow::Borrowed("block.minecraft.honeycomb_block"),
                 },
             ),
             (
@@ -26798,7 +26798,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.hopper",
+                    name: Cow::Borrowed("block.minecraft.hopper"),
                 },
             ),
             (
@@ -26837,7 +26837,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.hopper_minecart",
+                    name: Cow::Borrowed("item.minecraft.hopper_minecart"),
                 },
             ),
             (
@@ -26875,7 +26875,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.horn_coral",
+                    name: Cow::Borrowed("block.minecraft.horn_coral"),
                 },
             ),
             (
@@ -26913,7 +26913,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.horn_coral_block",
+                    name: Cow::Borrowed("block.minecraft.horn_coral_block"),
                 },
             ),
             (
@@ -26951,7 +26951,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.horn_coral_fan",
+                    name: Cow::Borrowed("block.minecraft.horn_coral_fan"),
                 },
             ),
             (
@@ -26989,7 +26989,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.horse_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.horse_spawn_egg"),
                 },
             ),
             (
@@ -27028,7 +27028,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.host_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.host_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -27066,7 +27066,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.howl_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.howl_pottery_sherd"),
                 },
             ),
             (
@@ -27104,7 +27104,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.husk_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.husk_spawn_egg"),
                 },
             ),
             (
@@ -27143,7 +27143,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.ice",
+                    name: Cow::Borrowed("block.minecraft.ice"),
                 },
             ),
             (
@@ -27181,7 +27181,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.infested_chiseled_stone_bricks",
+                    name: Cow::Borrowed("block.minecraft.infested_chiseled_stone_bricks"),
                 },
             ),
             (
@@ -27219,7 +27219,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.infested_cobblestone",
+                    name: Cow::Borrowed("block.minecraft.infested_cobblestone"),
                 },
             ),
             (
@@ -27257,7 +27257,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.infested_cracked_stone_bricks",
+                    name: Cow::Borrowed("block.minecraft.infested_cracked_stone_bricks"),
                 },
             ),
             (
@@ -27295,7 +27295,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.infested_deepslate",
+                    name: Cow::Borrowed("block.minecraft.infested_deepslate"),
                 },
             ),
             (
@@ -27333,7 +27333,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.infested_mossy_stone_bricks",
+                    name: Cow::Borrowed("block.minecraft.infested_mossy_stone_bricks"),
                 },
             ),
             (
@@ -27371,7 +27371,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.infested_stone",
+                    name: Cow::Borrowed("block.minecraft.infested_stone"),
                 },
             ),
             (
@@ -27409,7 +27409,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.infested_stone_bricks",
+                    name: Cow::Borrowed("block.minecraft.infested_stone_bricks"),
                 },
             ),
             (
@@ -27447,7 +27447,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ink_sac",
+                    name: Cow::Borrowed("item.minecraft.ink_sac"),
                 },
             ),
             (
@@ -27485,7 +27485,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_axe",
+                    name: Cow::Borrowed("item.minecraft.iron_axe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -27568,7 +27568,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.iron_bars",
+                    name: Cow::Borrowed("block.minecraft.iron_bars"),
                 },
             ),
             (
@@ -27606,7 +27606,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.iron_block",
+                    name: Cow::Borrowed("block.minecraft.iron_block"),
                 },
             ),
             (
@@ -27644,7 +27644,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_boots",
+                    name: Cow::Borrowed("item.minecraft.iron_boots"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -27717,7 +27717,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.iron_chain",
+                    name: Cow::Borrowed("block.minecraft.iron_chain"),
                 },
             ),
             (
@@ -27755,7 +27755,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_chestplate",
+                    name: Cow::Borrowed("item.minecraft.iron_chestplate"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -27828,7 +27828,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.iron_door",
+                    name: Cow::Borrowed("block.minecraft.iron_door"),
                 },
             ),
             (
@@ -27866,7 +27866,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_golem_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.iron_golem_spawn_egg"),
                 },
             ),
             (
@@ -27905,7 +27905,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_helmet",
+                    name: Cow::Borrowed("item.minecraft.iron_helmet"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -27978,7 +27978,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_hoe",
+                    name: Cow::Borrowed("item.minecraft.iron_hoe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -28061,7 +28061,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_horse_armor",
+                    name: Cow::Borrowed("item.minecraft.iron_horse_armor"),
                 },
             ),
             (
@@ -28130,7 +28130,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_ingot",
+                    name: Cow::Borrowed("item.minecraft.iron_ingot"),
                 },
             ),
             (
@@ -28169,7 +28169,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_leggings",
+                    name: Cow::Borrowed("item.minecraft.iron_leggings"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -28242,7 +28242,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_nautilus_armor",
+                    name: Cow::Borrowed("item.minecraft.iron_nautilus_armor"),
                 },
             ),
             (
@@ -28311,7 +28311,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_nugget",
+                    name: Cow::Borrowed("item.minecraft.iron_nugget"),
                 },
             ),
             (
@@ -28349,7 +28349,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.iron_ore",
+                    name: Cow::Borrowed("block.minecraft.iron_ore"),
                 },
             ),
             (
@@ -28387,7 +28387,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_pickaxe",
+                    name: Cow::Borrowed("item.minecraft.iron_pickaxe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -28470,7 +28470,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_shovel",
+                    name: Cow::Borrowed("item.minecraft.iron_shovel"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -28553,7 +28553,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_spear",
+                    name: Cow::Borrowed("item.minecraft.iron_spear"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -28621,7 +28621,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.iron_sword",
+                    name: Cow::Borrowed("item.minecraft.iron_sword"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -28709,7 +28709,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.iron_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.iron_trapdoor"),
                 },
             ),
             (
@@ -28747,7 +28747,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.item_frame",
+                    name: Cow::Borrowed("item.minecraft.item_frame"),
                 },
             ),
             (
@@ -28785,7 +28785,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jack_o_lantern",
+                    name: Cow::Borrowed("block.minecraft.jack_o_lantern"),
                 },
             ),
             (
@@ -28823,7 +28823,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jigsaw",
+                    name: Cow::Borrowed("block.minecraft.jigsaw"),
                 },
             ),
             (
@@ -28861,7 +28861,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jukebox",
+                    name: Cow::Borrowed("block.minecraft.jukebox"),
                 },
             ),
             (
@@ -28899,7 +28899,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.jungle_boat",
+                    name: Cow::Borrowed("item.minecraft.jungle_boat"),
                 },
             ),
             (
@@ -28937,7 +28937,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_button",
+                    name: Cow::Borrowed("block.minecraft.jungle_button"),
                 },
             ),
             (
@@ -28975,7 +28975,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.jungle_chest_boat",
+                    name: Cow::Borrowed("item.minecraft.jungle_chest_boat"),
                 },
             ),
             (
@@ -29013,7 +29013,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_door",
+                    name: Cow::Borrowed("block.minecraft.jungle_door"),
                 },
             ),
             (
@@ -29051,7 +29051,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_fence",
+                    name: Cow::Borrowed("block.minecraft.jungle_fence"),
                 },
             ),
             (
@@ -29089,7 +29089,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.jungle_fence_gate"),
                 },
             ),
             (
@@ -29127,7 +29127,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.jungle_hanging_sign"),
                 },
             ),
             (
@@ -29165,7 +29165,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_leaves",
+                    name: Cow::Borrowed("block.minecraft.jungle_leaves"),
                 },
             ),
             (
@@ -29203,7 +29203,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_log",
+                    name: Cow::Borrowed("block.minecraft.jungle_log"),
                 },
             ),
             (
@@ -29241,7 +29241,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_planks",
+                    name: Cow::Borrowed("block.minecraft.jungle_planks"),
                 },
             ),
             (
@@ -29279,7 +29279,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.jungle_pressure_plate"),
                 },
             ),
             (
@@ -29317,7 +29317,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_sapling",
+                    name: Cow::Borrowed("block.minecraft.jungle_sapling"),
                 },
             ),
             (
@@ -29355,7 +29355,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_shelf",
+                    name: Cow::Borrowed("block.minecraft.jungle_shelf"),
                 },
             ),
             (
@@ -29394,7 +29394,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_sign",
+                    name: Cow::Borrowed("block.minecraft.jungle_sign"),
                 },
             ),
             (
@@ -29432,7 +29432,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_slab",
+                    name: Cow::Borrowed("block.minecraft.jungle_slab"),
                 },
             ),
             (
@@ -29470,7 +29470,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_stairs",
+                    name: Cow::Borrowed("block.minecraft.jungle_stairs"),
                 },
             ),
             (
@@ -29508,7 +29508,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.jungle_trapdoor"),
                 },
             ),
             (
@@ -29546,7 +29546,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.jungle_wood",
+                    name: Cow::Borrowed("block.minecraft.jungle_wood"),
                 },
             ),
             (
@@ -29584,7 +29584,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.kelp",
+                    name: Cow::Borrowed("block.minecraft.kelp"),
                 },
             ),
             (
@@ -29622,7 +29622,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.knowledge_book",
+                    name: Cow::Borrowed("item.minecraft.knowledge_book"),
                 },
             ),
             (
@@ -29661,7 +29661,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.ladder",
+                    name: Cow::Borrowed("block.minecraft.ladder"),
                 },
             ),
             (
@@ -29699,7 +29699,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lantern",
+                    name: Cow::Borrowed("block.minecraft.lantern"),
                 },
             ),
             (
@@ -29737,7 +29737,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lapis_block",
+                    name: Cow::Borrowed("block.minecraft.lapis_block"),
                 },
             ),
             (
@@ -29775,7 +29775,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.lapis_lazuli",
+                    name: Cow::Borrowed("item.minecraft.lapis_lazuli"),
                 },
             ),
             (
@@ -29814,7 +29814,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lapis_ore",
+                    name: Cow::Borrowed("block.minecraft.lapis_ore"),
                 },
             ),
             (
@@ -29852,7 +29852,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.large_amethyst_bud",
+                    name: Cow::Borrowed("block.minecraft.large_amethyst_bud"),
                 },
             ),
             (
@@ -29890,7 +29890,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.large_fern",
+                    name: Cow::Borrowed("block.minecraft.large_fern"),
                 },
             ),
             (
@@ -29928,7 +29928,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.lava_bucket",
+                    name: Cow::Borrowed("item.minecraft.lava_bucket"),
                 },
             ),
             (
@@ -29966,7 +29966,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.lead",
+                    name: Cow::Borrowed("item.minecraft.lead"),
                 },
             ),
             (
@@ -30004,7 +30004,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.leaf_litter",
+                    name: Cow::Borrowed("block.minecraft.leaf_litter"),
                 },
             ),
             (
@@ -30042,7 +30042,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.leather",
+                    name: Cow::Borrowed("item.minecraft.leather"),
                 },
             ),
             (
@@ -30080,7 +30080,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.leather_boots",
+                    name: Cow::Borrowed("item.minecraft.leather_boots"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -30153,7 +30153,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.leather_chestplate",
+                    name: Cow::Borrowed("item.minecraft.leather_chestplate"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -30226,7 +30226,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.leather_helmet",
+                    name: Cow::Borrowed("item.minecraft.leather_helmet"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -30299,7 +30299,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.leather_horse_armor",
+                    name: Cow::Borrowed("item.minecraft.leather_horse_armor"),
                 },
             ),
             (
@@ -30368,7 +30368,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.leather_leggings",
+                    name: Cow::Borrowed("item.minecraft.leather_leggings"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -30441,7 +30441,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lectern",
+                    name: Cow::Borrowed("block.minecraft.lectern"),
                 },
             ),
             (
@@ -30479,7 +30479,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lever",
+                    name: Cow::Borrowed("block.minecraft.lever"),
                 },
             ),
             (
@@ -30517,7 +30517,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light",
+                    name: Cow::Borrowed("block.minecraft.light"),
                 },
             ),
             (
@@ -30561,7 +30561,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_banner",
+                    name: Cow::Borrowed("block.minecraft.light_blue_banner"),
                 },
             ),
             (
@@ -30600,7 +30600,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_bed",
+                    name: Cow::Borrowed("block.minecraft.light_blue_bed"),
                 },
             ),
             (
@@ -30638,7 +30638,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.light_blue_bundle",
+                    name: Cow::Borrowed("item.minecraft.light_blue_bundle"),
                 },
             ),
             (
@@ -30677,7 +30677,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_candle",
+                    name: Cow::Borrowed("block.minecraft.light_blue_candle"),
                 },
             ),
             (
@@ -30715,7 +30715,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_carpet",
+                    name: Cow::Borrowed("block.minecraft.light_blue_carpet"),
                 },
             ),
             (
@@ -30772,7 +30772,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_concrete",
+                    name: Cow::Borrowed("block.minecraft.light_blue_concrete"),
                 },
             ),
             (
@@ -30810,7 +30810,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.light_blue_concrete_powder"),
                 },
             ),
             (
@@ -30848,7 +30848,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.light_blue_dye",
+                    name: Cow::Borrowed("item.minecraft.light_blue_dye"),
                 },
             ),
             (
@@ -30887,7 +30887,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.light_blue_glazed_terracotta"),
                 },
             ),
             (
@@ -30925,7 +30925,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.light_blue_harness",
+                    name: Cow::Borrowed("item.minecraft.light_blue_harness"),
                 },
             ),
             (
@@ -30979,7 +30979,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.light_blue_shulker_box"),
                 },
             ),
             (
@@ -31018,7 +31018,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.light_blue_stained_glass"),
                 },
             ),
             (
@@ -31056,7 +31056,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.light_blue_stained_glass_pane"),
                 },
             ),
             (
@@ -31094,7 +31094,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_terracotta",
+                    name: Cow::Borrowed("block.minecraft.light_blue_terracotta"),
                 },
             ),
             (
@@ -31132,7 +31132,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_blue_wool",
+                    name: Cow::Borrowed("block.minecraft.light_blue_wool"),
                 },
             ),
             (
@@ -31170,7 +31170,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_banner",
+                    name: Cow::Borrowed("block.minecraft.light_gray_banner"),
                 },
             ),
             (
@@ -31209,7 +31209,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_bed",
+                    name: Cow::Borrowed("block.minecraft.light_gray_bed"),
                 },
             ),
             (
@@ -31247,7 +31247,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.light_gray_bundle",
+                    name: Cow::Borrowed("item.minecraft.light_gray_bundle"),
                 },
             ),
             (
@@ -31286,7 +31286,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_candle",
+                    name: Cow::Borrowed("block.minecraft.light_gray_candle"),
                 },
             ),
             (
@@ -31324,7 +31324,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_carpet",
+                    name: Cow::Borrowed("block.minecraft.light_gray_carpet"),
                 },
             ),
             (
@@ -31381,7 +31381,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_concrete",
+                    name: Cow::Borrowed("block.minecraft.light_gray_concrete"),
                 },
             ),
             (
@@ -31419,7 +31419,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.light_gray_concrete_powder"),
                 },
             ),
             (
@@ -31457,7 +31457,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.light_gray_dye",
+                    name: Cow::Borrowed("item.minecraft.light_gray_dye"),
                 },
             ),
             (
@@ -31496,7 +31496,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.light_gray_glazed_terracotta"),
                 },
             ),
             (
@@ -31534,7 +31534,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.light_gray_harness",
+                    name: Cow::Borrowed("item.minecraft.light_gray_harness"),
                 },
             ),
             (
@@ -31588,7 +31588,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.light_gray_shulker_box"),
                 },
             ),
             (
@@ -31627,7 +31627,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.light_gray_stained_glass"),
                 },
             ),
             (
@@ -31665,7 +31665,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.light_gray_stained_glass_pane"),
                 },
             ),
             (
@@ -31703,7 +31703,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_terracotta",
+                    name: Cow::Borrowed("block.minecraft.light_gray_terracotta"),
                 },
             ),
             (
@@ -31741,7 +31741,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_gray_wool",
+                    name: Cow::Borrowed("block.minecraft.light_gray_wool"),
                 },
             ),
             (
@@ -31779,7 +31779,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.light_weighted_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.light_weighted_pressure_plate"),
                 },
             ),
             (
@@ -31817,7 +31817,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lightning_rod",
+                    name: Cow::Borrowed("block.minecraft.lightning_rod"),
                 },
             ),
             (
@@ -31855,7 +31855,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lilac",
+                    name: Cow::Borrowed("block.minecraft.lilac"),
                 },
             ),
             (
@@ -31893,7 +31893,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lily_of_the_valley",
+                    name: Cow::Borrowed("block.minecraft.lily_of_the_valley"),
                 },
             ),
             (
@@ -31931,7 +31931,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lily_pad",
+                    name: Cow::Borrowed("block.minecraft.lily_pad"),
                 },
             ),
             (
@@ -31969,7 +31969,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_banner",
+                    name: Cow::Borrowed("block.minecraft.lime_banner"),
                 },
             ),
             (
@@ -32008,7 +32008,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_bed",
+                    name: Cow::Borrowed("block.minecraft.lime_bed"),
                 },
             ),
             (
@@ -32046,7 +32046,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.lime_bundle",
+                    name: Cow::Borrowed("item.minecraft.lime_bundle"),
                 },
             ),
             (
@@ -32085,7 +32085,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_candle",
+                    name: Cow::Borrowed("block.minecraft.lime_candle"),
                 },
             ),
             (
@@ -32123,7 +32123,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_carpet",
+                    name: Cow::Borrowed("block.minecraft.lime_carpet"),
                 },
             ),
             (
@@ -32180,7 +32180,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_concrete",
+                    name: Cow::Borrowed("block.minecraft.lime_concrete"),
                 },
             ),
             (
@@ -32218,7 +32218,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.lime_concrete_powder"),
                 },
             ),
             (
@@ -32256,7 +32256,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.lime_dye",
+                    name: Cow::Borrowed("item.minecraft.lime_dye"),
                 },
             ),
             (
@@ -32295,7 +32295,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.lime_glazed_terracotta"),
                 },
             ),
             (
@@ -32333,7 +32333,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.lime_harness",
+                    name: Cow::Borrowed("item.minecraft.lime_harness"),
                 },
             ),
             (
@@ -32387,7 +32387,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.lime_shulker_box"),
                 },
             ),
             (
@@ -32426,7 +32426,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.lime_stained_glass"),
                 },
             ),
             (
@@ -32464,7 +32464,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.lime_stained_glass_pane"),
                 },
             ),
             (
@@ -32502,7 +32502,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_terracotta",
+                    name: Cow::Borrowed("block.minecraft.lime_terracotta"),
                 },
             ),
             (
@@ -32540,7 +32540,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lime_wool",
+                    name: Cow::Borrowed("block.minecraft.lime_wool"),
                 },
             ),
             (
@@ -32578,7 +32578,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.lingering_potion",
+                    name: Cow::Borrowed("item.minecraft.lingering_potion"),
                 },
             ),
             (
@@ -32629,7 +32629,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.llama_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.llama_spawn_egg"),
                 },
             ),
             (
@@ -32668,7 +32668,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.lodestone",
+                    name: Cow::Borrowed("block.minecraft.lodestone"),
                 },
             ),
             (
@@ -32706,7 +32706,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.loom",
+                    name: Cow::Borrowed("block.minecraft.loom"),
                 },
             ),
             (
@@ -32744,7 +32744,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.mace",
+                    name: Cow::Borrowed("item.minecraft.mace"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -32816,7 +32816,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_banner",
+                    name: Cow::Borrowed("block.minecraft.magenta_banner"),
                 },
             ),
             (
@@ -32855,7 +32855,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_bed",
+                    name: Cow::Borrowed("block.minecraft.magenta_bed"),
                 },
             ),
             (
@@ -32893,7 +32893,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.magenta_bundle",
+                    name: Cow::Borrowed("item.minecraft.magenta_bundle"),
                 },
             ),
             (
@@ -32932,7 +32932,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_candle",
+                    name: Cow::Borrowed("block.minecraft.magenta_candle"),
                 },
             ),
             (
@@ -32970,7 +32970,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_carpet",
+                    name: Cow::Borrowed("block.minecraft.magenta_carpet"),
                 },
             ),
             (
@@ -33027,7 +33027,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_concrete",
+                    name: Cow::Borrowed("block.minecraft.magenta_concrete"),
                 },
             ),
             (
@@ -33065,7 +33065,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.magenta_concrete_powder"),
                 },
             ),
             (
@@ -33103,7 +33103,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.magenta_dye",
+                    name: Cow::Borrowed("item.minecraft.magenta_dye"),
                 },
             ),
             (
@@ -33142,7 +33142,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.magenta_glazed_terracotta"),
                 },
             ),
             (
@@ -33180,7 +33180,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.magenta_harness",
+                    name: Cow::Borrowed("item.minecraft.magenta_harness"),
                 },
             ),
             (
@@ -33234,7 +33234,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.magenta_shulker_box"),
                 },
             ),
             (
@@ -33273,7 +33273,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.magenta_stained_glass"),
                 },
             ),
             (
@@ -33311,7 +33311,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.magenta_stained_glass_pane"),
                 },
             ),
             (
@@ -33349,7 +33349,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_terracotta",
+                    name: Cow::Borrowed("block.minecraft.magenta_terracotta"),
                 },
             ),
             (
@@ -33387,7 +33387,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magenta_wool",
+                    name: Cow::Borrowed("block.minecraft.magenta_wool"),
                 },
             ),
             (
@@ -33425,7 +33425,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.magma_block",
+                    name: Cow::Borrowed("block.minecraft.magma_block"),
                 },
             ),
             (
@@ -33463,7 +33463,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.magma_cream",
+                    name: Cow::Borrowed("item.minecraft.magma_cream"),
                 },
             ),
             (
@@ -33501,7 +33501,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.magma_cube_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.magma_cube_spawn_egg"),
                 },
             ),
             (
@@ -33540,7 +33540,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.mangrove_boat",
+                    name: Cow::Borrowed("item.minecraft.mangrove_boat"),
                 },
             ),
             (
@@ -33578,7 +33578,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_button",
+                    name: Cow::Borrowed("block.minecraft.mangrove_button"),
                 },
             ),
             (
@@ -33616,7 +33616,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.mangrove_chest_boat",
+                    name: Cow::Borrowed("item.minecraft.mangrove_chest_boat"),
                 },
             ),
             (
@@ -33654,7 +33654,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_door",
+                    name: Cow::Borrowed("block.minecraft.mangrove_door"),
                 },
             ),
             (
@@ -33692,7 +33692,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_fence",
+                    name: Cow::Borrowed("block.minecraft.mangrove_fence"),
                 },
             ),
             (
@@ -33730,7 +33730,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.mangrove_fence_gate"),
                 },
             ),
             (
@@ -33768,7 +33768,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.mangrove_hanging_sign"),
                 },
             ),
             (
@@ -33806,7 +33806,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_leaves",
+                    name: Cow::Borrowed("block.minecraft.mangrove_leaves"),
                 },
             ),
             (
@@ -33844,7 +33844,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_log",
+                    name: Cow::Borrowed("block.minecraft.mangrove_log"),
                 },
             ),
             (
@@ -33882,7 +33882,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_planks",
+                    name: Cow::Borrowed("block.minecraft.mangrove_planks"),
                 },
             ),
             (
@@ -33920,7 +33920,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.mangrove_pressure_plate"),
                 },
             ),
             (
@@ -33958,7 +33958,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_propagule",
+                    name: Cow::Borrowed("block.minecraft.mangrove_propagule"),
                 },
             ),
             (
@@ -33996,7 +33996,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_roots",
+                    name: Cow::Borrowed("block.minecraft.mangrove_roots"),
                 },
             ),
             (
@@ -34034,7 +34034,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_shelf",
+                    name: Cow::Borrowed("block.minecraft.mangrove_shelf"),
                 },
             ),
             (
@@ -34073,7 +34073,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_sign",
+                    name: Cow::Borrowed("block.minecraft.mangrove_sign"),
                 },
             ),
             (
@@ -34111,7 +34111,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_slab",
+                    name: Cow::Borrowed("block.minecraft.mangrove_slab"),
                 },
             ),
             (
@@ -34149,7 +34149,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_stairs",
+                    name: Cow::Borrowed("block.minecraft.mangrove_stairs"),
                 },
             ),
             (
@@ -34187,7 +34187,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.mangrove_trapdoor"),
                 },
             ),
             (
@@ -34225,7 +34225,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mangrove_wood",
+                    name: Cow::Borrowed("block.minecraft.mangrove_wood"),
                 },
             ),
             (
@@ -34263,7 +34263,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.map",
+                    name: Cow::Borrowed("item.minecraft.map"),
                 },
             ),
             (
@@ -34301,7 +34301,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.medium_amethyst_bud",
+                    name: Cow::Borrowed("block.minecraft.medium_amethyst_bud"),
                 },
             ),
             (
@@ -34339,7 +34339,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.melon",
+                    name: Cow::Borrowed("block.minecraft.melon"),
                 },
             ),
             (
@@ -34377,7 +34377,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.melon_seeds",
+                    name: Cow::Borrowed("item.minecraft.melon_seeds"),
                 },
             ),
             (
@@ -34415,7 +34415,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.melon_slice",
+                    name: Cow::Borrowed("item.minecraft.melon_slice"),
                 },
             ),
             (
@@ -34471,7 +34471,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.milk_bucket",
+                    name: Cow::Borrowed("item.minecraft.milk_bucket"),
                 },
             ),
             (
@@ -34520,7 +34520,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.minecart",
+                    name: Cow::Borrowed("item.minecraft.minecart"),
                 },
             ),
             (
@@ -34558,7 +34558,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.miner_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.miner_pottery_sherd"),
                 },
             ),
             (
@@ -34596,7 +34596,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.mojang_banner_pattern",
+                    name: Cow::Borrowed("item.minecraft.mojang_banner_pattern"),
                 },
             ),
             (
@@ -34635,7 +34635,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.mooshroom_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.mooshroom_spawn_egg"),
                 },
             ),
             (
@@ -34674,7 +34674,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.moss_block",
+                    name: Cow::Borrowed("block.minecraft.moss_block"),
                 },
             ),
             (
@@ -34712,7 +34712,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.moss_carpet",
+                    name: Cow::Borrowed("block.minecraft.moss_carpet"),
                 },
             ),
             (
@@ -34750,7 +34750,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mossy_cobblestone",
+                    name: Cow::Borrowed("block.minecraft.mossy_cobblestone"),
                 },
             ),
             (
@@ -34788,7 +34788,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mossy_cobblestone_slab",
+                    name: Cow::Borrowed("block.minecraft.mossy_cobblestone_slab"),
                 },
             ),
             (
@@ -34826,7 +34826,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mossy_cobblestone_stairs",
+                    name: Cow::Borrowed("block.minecraft.mossy_cobblestone_stairs"),
                 },
             ),
             (
@@ -34864,7 +34864,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mossy_cobblestone_wall",
+                    name: Cow::Borrowed("block.minecraft.mossy_cobblestone_wall"),
                 },
             ),
             (
@@ -34902,7 +34902,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mossy_stone_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.mossy_stone_brick_slab"),
                 },
             ),
             (
@@ -34940,7 +34940,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mossy_stone_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.mossy_stone_brick_stairs"),
                 },
             ),
             (
@@ -34978,7 +34978,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mossy_stone_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.mossy_stone_brick_wall"),
                 },
             ),
             (
@@ -35016,7 +35016,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mossy_stone_bricks",
+                    name: Cow::Borrowed("block.minecraft.mossy_stone_bricks"),
                 },
             ),
             (
@@ -35054,7 +35054,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.mourner_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.mourner_pottery_sherd"),
                 },
             ),
             (
@@ -35092,7 +35092,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mud",
+                    name: Cow::Borrowed("block.minecraft.mud"),
                 },
             ),
             (
@@ -35130,7 +35130,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mud_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.mud_brick_slab"),
                 },
             ),
             (
@@ -35168,7 +35168,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mud_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.mud_brick_stairs"),
                 },
             ),
             (
@@ -35206,7 +35206,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mud_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.mud_brick_wall"),
                 },
             ),
             (
@@ -35244,7 +35244,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mud_bricks",
+                    name: Cow::Borrowed("block.minecraft.mud_bricks"),
                 },
             ),
             (
@@ -35282,7 +35282,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.muddy_mangrove_roots",
+                    name: Cow::Borrowed("block.minecraft.muddy_mangrove_roots"),
                 },
             ),
             (
@@ -35320,7 +35320,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.mule_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.mule_spawn_egg"),
                 },
             ),
             (
@@ -35359,7 +35359,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mushroom_stem",
+                    name: Cow::Borrowed("block.minecraft.mushroom_stem"),
                 },
             ),
             (
@@ -35397,7 +35397,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.mushroom_stew",
+                    name: Cow::Borrowed("item.minecraft.mushroom_stew"),
                 },
             ),
             (
@@ -35460,7 +35460,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_11",
+                    name: Cow::Borrowed("item.minecraft.music_disc_11"),
                 },
             ),
             (
@@ -35504,7 +35504,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_13",
+                    name: Cow::Borrowed("item.minecraft.music_disc_13"),
                 },
             ),
             (
@@ -35548,7 +35548,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_5",
+                    name: Cow::Borrowed("item.minecraft.music_disc_5"),
                 },
             ),
             (
@@ -35592,7 +35592,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_blocks",
+                    name: Cow::Borrowed("item.minecraft.music_disc_blocks"),
                 },
             ),
             (
@@ -35636,7 +35636,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_bounce",
+                    name: Cow::Borrowed("item.minecraft.music_disc_bounce"),
                 },
             ),
             (
@@ -35680,7 +35680,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_cat",
+                    name: Cow::Borrowed("item.minecraft.music_disc_cat"),
                 },
             ),
             (
@@ -35724,7 +35724,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_chirp",
+                    name: Cow::Borrowed("item.minecraft.music_disc_chirp"),
                 },
             ),
             (
@@ -35768,7 +35768,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_creator",
+                    name: Cow::Borrowed("item.minecraft.music_disc_creator"),
                 },
             ),
             (
@@ -35812,7 +35812,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_creator_music_box",
+                    name: Cow::Borrowed("item.minecraft.music_disc_creator_music_box"),
                 },
             ),
             (
@@ -35856,7 +35856,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_far",
+                    name: Cow::Borrowed("item.minecraft.music_disc_far"),
                 },
             ),
             (
@@ -35900,7 +35900,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_lava_chicken",
+                    name: Cow::Borrowed("item.minecraft.music_disc_lava_chicken"),
                 },
             ),
             (
@@ -35944,7 +35944,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_mall",
+                    name: Cow::Borrowed("item.minecraft.music_disc_mall"),
                 },
             ),
             (
@@ -35988,7 +35988,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_mellohi",
+                    name: Cow::Borrowed("item.minecraft.music_disc_mellohi"),
                 },
             ),
             (
@@ -36032,7 +36032,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_otherside",
+                    name: Cow::Borrowed("item.minecraft.music_disc_otherside"),
                 },
             ),
             (
@@ -36076,7 +36076,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_pigstep",
+                    name: Cow::Borrowed("item.minecraft.music_disc_pigstep"),
                 },
             ),
             (
@@ -36120,7 +36120,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_precipice",
+                    name: Cow::Borrowed("item.minecraft.music_disc_precipice"),
                 },
             ),
             (
@@ -36164,7 +36164,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_relic",
+                    name: Cow::Borrowed("item.minecraft.music_disc_relic"),
                 },
             ),
             (
@@ -36208,7 +36208,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_stal",
+                    name: Cow::Borrowed("item.minecraft.music_disc_stal"),
                 },
             ),
             (
@@ -36252,7 +36252,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_strad",
+                    name: Cow::Borrowed("item.minecraft.music_disc_strad"),
                 },
             ),
             (
@@ -36296,7 +36296,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_tears",
+                    name: Cow::Borrowed("item.minecraft.music_disc_tears"),
                 },
             ),
             (
@@ -36340,7 +36340,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_wait",
+                    name: Cow::Borrowed("item.minecraft.music_disc_wait"),
                 },
             ),
             (
@@ -36384,7 +36384,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.music_disc_ward",
+                    name: Cow::Borrowed("item.minecraft.music_disc_ward"),
                 },
             ),
             (
@@ -36422,7 +36422,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.mutton",
+                    name: Cow::Borrowed("item.minecraft.mutton"),
                 },
             ),
             (
@@ -36478,7 +36478,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.mycelium",
+                    name: Cow::Borrowed("block.minecraft.mycelium"),
                 },
             ),
             (
@@ -36516,7 +36516,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.name_tag",
+                    name: Cow::Borrowed("item.minecraft.name_tag"),
                 },
             ),
             (
@@ -36554,7 +36554,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.nautilus_shell",
+                    name: Cow::Borrowed("item.minecraft.nautilus_shell"),
                 },
             ),
             (
@@ -36592,7 +36592,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.nautilus_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.nautilus_spawn_egg"),
                 },
             ),
             (
@@ -36631,7 +36631,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.nether_brick",
+                    name: Cow::Borrowed("item.minecraft.nether_brick"),
                 },
             ),
             (
@@ -36669,7 +36669,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.nether_brick_fence",
+                    name: Cow::Borrowed("block.minecraft.nether_brick_fence"),
                 },
             ),
             (
@@ -36707,7 +36707,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.nether_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.nether_brick_slab"),
                 },
             ),
             (
@@ -36745,7 +36745,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.nether_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.nether_brick_stairs"),
                 },
             ),
             (
@@ -36783,7 +36783,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.nether_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.nether_brick_wall"),
                 },
             ),
             (
@@ -36821,7 +36821,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.nether_bricks",
+                    name: Cow::Borrowed("block.minecraft.nether_bricks"),
                 },
             ),
             (
@@ -36859,7 +36859,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.nether_gold_ore",
+                    name: Cow::Borrowed("block.minecraft.nether_gold_ore"),
                 },
             ),
             (
@@ -36897,7 +36897,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.nether_quartz_ore",
+                    name: Cow::Borrowed("block.minecraft.nether_quartz_ore"),
                 },
             ),
             (
@@ -36935,7 +36935,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.nether_sprouts",
+                    name: Cow::Borrowed("block.minecraft.nether_sprouts"),
                 },
             ),
             (
@@ -36973,7 +36973,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.nether_star",
+                    name: Cow::Borrowed("item.minecraft.nether_star"),
                 },
             ),
             (
@@ -37018,7 +37018,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.nether_wart",
+                    name: Cow::Borrowed("item.minecraft.nether_wart"),
                 },
             ),
             (
@@ -37056,7 +37056,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.nether_wart_block",
+                    name: Cow::Borrowed("block.minecraft.nether_wart_block"),
                 },
             ),
             (
@@ -37094,7 +37094,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_axe",
+                    name: Cow::Borrowed("item.minecraft.netherite_axe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -37183,7 +37183,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.netherite_block",
+                    name: Cow::Borrowed("block.minecraft.netherite_block"),
                 },
             ),
             (
@@ -37227,7 +37227,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_boots",
+                    name: Cow::Borrowed("item.minecraft.netherite_boots"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -37313,7 +37313,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_chestplate",
+                    name: Cow::Borrowed("item.minecraft.netherite_chestplate"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -37399,7 +37399,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_helmet",
+                    name: Cow::Borrowed("item.minecraft.netherite_helmet"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -37485,7 +37485,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_hoe",
+                    name: Cow::Borrowed("item.minecraft.netherite_hoe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -37574,7 +37574,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_horse_armor",
+                    name: Cow::Borrowed("item.minecraft.netherite_horse_armor"),
                 },
             ),
             (
@@ -37656,7 +37656,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_ingot",
+                    name: Cow::Borrowed("item.minecraft.netherite_ingot"),
                 },
             ),
             (
@@ -37701,7 +37701,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_leggings",
+                    name: Cow::Borrowed("item.minecraft.netherite_leggings"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -37787,7 +37787,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_nautilus_armor",
+                    name: Cow::Borrowed("item.minecraft.netherite_nautilus_armor"),
                 },
             ),
             (
@@ -37869,7 +37869,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_pickaxe",
+                    name: Cow::Borrowed("item.minecraft.netherite_pickaxe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -37958,7 +37958,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_scrap",
+                    name: Cow::Borrowed("item.minecraft.netherite_scrap"),
                 },
             ),
             (
@@ -38002,7 +38002,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_shovel",
+                    name: Cow::Borrowed("item.minecraft.netherite_shovel"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -38091,7 +38091,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_spear",
+                    name: Cow::Borrowed("item.minecraft.netherite_spear"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -38165,7 +38165,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_sword",
+                    name: Cow::Borrowed("item.minecraft.netherite_sword"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -38259,7 +38259,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.netherite_upgrade_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.netherite_upgrade_smithing_template"),
                 },
             ),
             (
@@ -38297,7 +38297,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.netherrack",
+                    name: Cow::Borrowed("block.minecraft.netherrack"),
                 },
             ),
             (
@@ -38335,7 +38335,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.note_block",
+                    name: Cow::Borrowed("block.minecraft.note_block"),
                 },
             ),
             (
@@ -38373,7 +38373,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.oak_boat",
+                    name: Cow::Borrowed("item.minecraft.oak_boat"),
                 },
             ),
             (
@@ -38411,7 +38411,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_button",
+                    name: Cow::Borrowed("block.minecraft.oak_button"),
                 },
             ),
             (
@@ -38449,7 +38449,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.oak_chest_boat",
+                    name: Cow::Borrowed("item.minecraft.oak_chest_boat"),
                 },
             ),
             (
@@ -38487,7 +38487,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_door",
+                    name: Cow::Borrowed("block.minecraft.oak_door"),
                 },
             ),
             (
@@ -38525,7 +38525,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_fence",
+                    name: Cow::Borrowed("block.minecraft.oak_fence"),
                 },
             ),
             (
@@ -38563,7 +38563,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.oak_fence_gate"),
                 },
             ),
             (
@@ -38601,7 +38601,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.oak_hanging_sign"),
                 },
             ),
             (
@@ -38639,7 +38639,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_leaves",
+                    name: Cow::Borrowed("block.minecraft.oak_leaves"),
                 },
             ),
             (
@@ -38677,7 +38677,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_log",
+                    name: Cow::Borrowed("block.minecraft.oak_log"),
                 },
             ),
             (
@@ -38715,7 +38715,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_planks",
+                    name: Cow::Borrowed("block.minecraft.oak_planks"),
                 },
             ),
             (
@@ -38753,7 +38753,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.oak_pressure_plate"),
                 },
             ),
             (
@@ -38791,7 +38791,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_sapling",
+                    name: Cow::Borrowed("block.minecraft.oak_sapling"),
                 },
             ),
             (
@@ -38829,7 +38829,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_shelf",
+                    name: Cow::Borrowed("block.minecraft.oak_shelf"),
                 },
             ),
             (
@@ -38868,7 +38868,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_sign",
+                    name: Cow::Borrowed("block.minecraft.oak_sign"),
                 },
             ),
             (
@@ -38906,7 +38906,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_slab",
+                    name: Cow::Borrowed("block.minecraft.oak_slab"),
                 },
             ),
             (
@@ -38944,7 +38944,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_stairs",
+                    name: Cow::Borrowed("block.minecraft.oak_stairs"),
                 },
             ),
             (
@@ -38982,7 +38982,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.oak_trapdoor"),
                 },
             ),
             (
@@ -39020,7 +39020,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oak_wood",
+                    name: Cow::Borrowed("block.minecraft.oak_wood"),
                 },
             ),
             (
@@ -39058,7 +39058,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.observer",
+                    name: Cow::Borrowed("block.minecraft.observer"),
                 },
             ),
             (
@@ -39096,7 +39096,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.obsidian",
+                    name: Cow::Borrowed("block.minecraft.obsidian"),
                 },
             ),
             (
@@ -39134,7 +39134,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ocelot_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.ocelot_spawn_egg"),
                 },
             ),
             (
@@ -39173,7 +39173,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.ochre_froglight",
+                    name: Cow::Borrowed("block.minecraft.ochre_froglight"),
                 },
             ),
             (
@@ -39211,7 +39211,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ominous_bottle",
+                    name: Cow::Borrowed("item.minecraft.ominous_bottle"),
                 },
             ),
             (
@@ -39265,7 +39265,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ominous_trial_key",
+                    name: Cow::Borrowed("item.minecraft.ominous_trial_key"),
                 },
             ),
             (
@@ -39303,7 +39303,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.open_eyeblossom",
+                    name: Cow::Borrowed("block.minecraft.open_eyeblossom"),
                 },
             ),
             (
@@ -39341,7 +39341,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_banner",
+                    name: Cow::Borrowed("block.minecraft.orange_banner"),
                 },
             ),
             (
@@ -39380,7 +39380,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_bed",
+                    name: Cow::Borrowed("block.minecraft.orange_bed"),
                 },
             ),
             (
@@ -39418,7 +39418,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.orange_bundle",
+                    name: Cow::Borrowed("item.minecraft.orange_bundle"),
                 },
             ),
             (
@@ -39457,7 +39457,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_candle",
+                    name: Cow::Borrowed("block.minecraft.orange_candle"),
                 },
             ),
             (
@@ -39495,7 +39495,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_carpet",
+                    name: Cow::Borrowed("block.minecraft.orange_carpet"),
                 },
             ),
             (
@@ -39552,7 +39552,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_concrete",
+                    name: Cow::Borrowed("block.minecraft.orange_concrete"),
                 },
             ),
             (
@@ -39590,7 +39590,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.orange_concrete_powder"),
                 },
             ),
             (
@@ -39628,7 +39628,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.orange_dye",
+                    name: Cow::Borrowed("item.minecraft.orange_dye"),
                 },
             ),
             (
@@ -39667,7 +39667,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.orange_glazed_terracotta"),
                 },
             ),
             (
@@ -39705,7 +39705,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.orange_harness",
+                    name: Cow::Borrowed("item.minecraft.orange_harness"),
                 },
             ),
             (
@@ -39759,7 +39759,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.orange_shulker_box"),
                 },
             ),
             (
@@ -39798,7 +39798,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.orange_stained_glass"),
                 },
             ),
             (
@@ -39836,7 +39836,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.orange_stained_glass_pane"),
                 },
             ),
             (
@@ -39874,7 +39874,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_terracotta",
+                    name: Cow::Borrowed("block.minecraft.orange_terracotta"),
                 },
             ),
             (
@@ -39912,7 +39912,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_tulip",
+                    name: Cow::Borrowed("block.minecraft.orange_tulip"),
                 },
             ),
             (
@@ -39950,7 +39950,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.orange_wool",
+                    name: Cow::Borrowed("block.minecraft.orange_wool"),
                 },
             ),
             (
@@ -39988,7 +39988,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxeye_daisy",
+                    name: Cow::Borrowed("block.minecraft.oxeye_daisy"),
                 },
             ),
             (
@@ -40026,7 +40026,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_chiseled_copper",
+                    name: Cow::Borrowed("block.minecraft.oxidized_chiseled_copper"),
                 },
             ),
             (
@@ -40064,7 +40064,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_copper",
+                    name: Cow::Borrowed("block.minecraft.oxidized_copper"),
                 },
             ),
             (
@@ -40102,7 +40102,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_copper_bars",
+                    name: Cow::Borrowed("block.minecraft.oxidized_copper_bars"),
                 },
             ),
             (
@@ -40140,7 +40140,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_copper_bulb",
+                    name: Cow::Borrowed("block.minecraft.oxidized_copper_bulb"),
                 },
             ),
             (
@@ -40178,7 +40178,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_copper_chain",
+                    name: Cow::Borrowed("block.minecraft.oxidized_copper_chain"),
                 },
             ),
             (
@@ -40216,7 +40216,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_copper_chest",
+                    name: Cow::Borrowed("block.minecraft.oxidized_copper_chest"),
                 },
             ),
             (
@@ -40254,7 +40254,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_copper_door",
+                    name: Cow::Borrowed("block.minecraft.oxidized_copper_door"),
                 },
             ),
             (
@@ -40292,7 +40292,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_copper_golem_statue",
+                    name: Cow::Borrowed("block.minecraft.oxidized_copper_golem_statue"),
                 },
             ),
             (
@@ -40339,7 +40339,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_copper_grate",
+                    name: Cow::Borrowed("block.minecraft.oxidized_copper_grate"),
                 },
             ),
             (
@@ -40377,7 +40377,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_copper_lantern",
+                    name: Cow::Borrowed("block.minecraft.oxidized_copper_lantern"),
                 },
             ),
             (
@@ -40415,7 +40415,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_copper_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.oxidized_copper_trapdoor"),
                 },
             ),
             (
@@ -40453,7 +40453,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_cut_copper",
+                    name: Cow::Borrowed("block.minecraft.oxidized_cut_copper"),
                 },
             ),
             (
@@ -40491,7 +40491,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_cut_copper_slab",
+                    name: Cow::Borrowed("block.minecraft.oxidized_cut_copper_slab"),
                 },
             ),
             (
@@ -40529,7 +40529,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_cut_copper_stairs",
+                    name: Cow::Borrowed("block.minecraft.oxidized_cut_copper_stairs"),
                 },
             ),
             (
@@ -40567,7 +40567,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.oxidized_lightning_rod",
+                    name: Cow::Borrowed("block.minecraft.oxidized_lightning_rod"),
                 },
             ),
             (
@@ -40605,7 +40605,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.packed_ice",
+                    name: Cow::Borrowed("block.minecraft.packed_ice"),
                 },
             ),
             (
@@ -40643,7 +40643,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.packed_mud",
+                    name: Cow::Borrowed("block.minecraft.packed_mud"),
                 },
             ),
             (
@@ -40681,7 +40681,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.painting",
+                    name: Cow::Borrowed("item.minecraft.painting"),
                 },
             ),
             (
@@ -40719,7 +40719,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_hanging_moss",
+                    name: Cow::Borrowed("block.minecraft.pale_hanging_moss"),
                 },
             ),
             (
@@ -40757,7 +40757,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_moss_block",
+                    name: Cow::Borrowed("block.minecraft.pale_moss_block"),
                 },
             ),
             (
@@ -40795,7 +40795,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_moss_carpet",
+                    name: Cow::Borrowed("block.minecraft.pale_moss_carpet"),
                 },
             ),
             (
@@ -40833,7 +40833,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pale_oak_boat",
+                    name: Cow::Borrowed("item.minecraft.pale_oak_boat"),
                 },
             ),
             (
@@ -40871,7 +40871,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_button",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_button"),
                 },
             ),
             (
@@ -40909,7 +40909,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pale_oak_chest_boat",
+                    name: Cow::Borrowed("item.minecraft.pale_oak_chest_boat"),
                 },
             ),
             (
@@ -40947,7 +40947,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_door",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_door"),
                 },
             ),
             (
@@ -40985,7 +40985,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_fence",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_fence"),
                 },
             ),
             (
@@ -41023,7 +41023,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_fence_gate"),
                 },
             ),
             (
@@ -41061,7 +41061,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_hanging_sign"),
                 },
             ),
             (
@@ -41099,7 +41099,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_leaves",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_leaves"),
                 },
             ),
             (
@@ -41137,7 +41137,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_log",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_log"),
                 },
             ),
             (
@@ -41175,7 +41175,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_planks",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_planks"),
                 },
             ),
             (
@@ -41213,7 +41213,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_pressure_plate"),
                 },
             ),
             (
@@ -41251,7 +41251,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_sapling",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_sapling"),
                 },
             ),
             (
@@ -41289,7 +41289,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_shelf",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_shelf"),
                 },
             ),
             (
@@ -41328,7 +41328,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_sign",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_sign"),
                 },
             ),
             (
@@ -41366,7 +41366,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_slab",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_slab"),
                 },
             ),
             (
@@ -41404,7 +41404,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_stairs",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_stairs"),
                 },
             ),
             (
@@ -41442,7 +41442,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_trapdoor"),
                 },
             ),
             (
@@ -41480,7 +41480,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pale_oak_wood",
+                    name: Cow::Borrowed("block.minecraft.pale_oak_wood"),
                 },
             ),
             (
@@ -41518,7 +41518,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.panda_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.panda_spawn_egg"),
                 },
             ),
             (
@@ -41557,7 +41557,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.paper",
+                    name: Cow::Borrowed("item.minecraft.paper"),
                 },
             ),
             (
@@ -41595,7 +41595,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.parched_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.parched_spawn_egg"),
                 },
             ),
             (
@@ -41634,7 +41634,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.parrot_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.parrot_spawn_egg"),
                 },
             ),
             (
@@ -41673,7 +41673,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pearlescent_froglight",
+                    name: Cow::Borrowed("block.minecraft.pearlescent_froglight"),
                 },
             ),
             (
@@ -41711,7 +41711,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.peony",
+                    name: Cow::Borrowed("block.minecraft.peony"),
                 },
             ),
             (
@@ -41749,7 +41749,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.petrified_oak_slab",
+                    name: Cow::Borrowed("block.minecraft.petrified_oak_slab"),
                 },
             ),
             (
@@ -41787,7 +41787,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.phantom_membrane",
+                    name: Cow::Borrowed("item.minecraft.phantom_membrane"),
                 },
             ),
             (
@@ -41825,7 +41825,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.phantom_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.phantom_spawn_egg"),
                 },
             ),
             (
@@ -41864,7 +41864,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pig_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.pig_spawn_egg"),
                 },
             ),
             (
@@ -41903,7 +41903,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.piglin_banner_pattern",
+                    name: Cow::Borrowed("item.minecraft.piglin_banner_pattern"),
                 },
             ),
             (
@@ -41942,7 +41942,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.piglin_brute_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.piglin_brute_spawn_egg"),
                 },
             ),
             (
@@ -41981,7 +41981,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.piglin_head",
+                    name: Cow::Borrowed("block.minecraft.piglin_head"),
                 },
             ),
             (
@@ -42041,7 +42041,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.piglin_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.piglin_spawn_egg"),
                 },
             ),
             (
@@ -42080,7 +42080,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pillager_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.pillager_spawn_egg"),
                 },
             ),
             (
@@ -42119,7 +42119,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_banner",
+                    name: Cow::Borrowed("block.minecraft.pink_banner"),
                 },
             ),
             (
@@ -42158,7 +42158,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_bed",
+                    name: Cow::Borrowed("block.minecraft.pink_bed"),
                 },
             ),
             (
@@ -42196,7 +42196,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pink_bundle",
+                    name: Cow::Borrowed("item.minecraft.pink_bundle"),
                 },
             ),
             (
@@ -42235,7 +42235,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_candle",
+                    name: Cow::Borrowed("block.minecraft.pink_candle"),
                 },
             ),
             (
@@ -42273,7 +42273,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_carpet",
+                    name: Cow::Borrowed("block.minecraft.pink_carpet"),
                 },
             ),
             (
@@ -42330,7 +42330,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_concrete",
+                    name: Cow::Borrowed("block.minecraft.pink_concrete"),
                 },
             ),
             (
@@ -42368,7 +42368,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.pink_concrete_powder"),
                 },
             ),
             (
@@ -42406,7 +42406,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pink_dye",
+                    name: Cow::Borrowed("item.minecraft.pink_dye"),
                 },
             ),
             (
@@ -42445,7 +42445,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.pink_glazed_terracotta"),
                 },
             ),
             (
@@ -42483,7 +42483,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pink_harness",
+                    name: Cow::Borrowed("item.minecraft.pink_harness"),
                 },
             ),
             (
@@ -42537,7 +42537,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_petals",
+                    name: Cow::Borrowed("block.minecraft.pink_petals"),
                 },
             ),
             (
@@ -42575,7 +42575,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.pink_shulker_box"),
                 },
             ),
             (
@@ -42614,7 +42614,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.pink_stained_glass"),
                 },
             ),
             (
@@ -42652,7 +42652,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.pink_stained_glass_pane"),
                 },
             ),
             (
@@ -42690,7 +42690,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_terracotta",
+                    name: Cow::Borrowed("block.minecraft.pink_terracotta"),
                 },
             ),
             (
@@ -42728,7 +42728,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_tulip",
+                    name: Cow::Borrowed("block.minecraft.pink_tulip"),
                 },
             ),
             (
@@ -42766,7 +42766,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pink_wool",
+                    name: Cow::Borrowed("block.minecraft.pink_wool"),
                 },
             ),
             (
@@ -42804,7 +42804,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.piston",
+                    name: Cow::Borrowed("block.minecraft.piston"),
                 },
             ),
             (
@@ -42842,7 +42842,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pitcher_plant",
+                    name: Cow::Borrowed("block.minecraft.pitcher_plant"),
                 },
             ),
             (
@@ -42880,7 +42880,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pitcher_pod",
+                    name: Cow::Borrowed("item.minecraft.pitcher_pod"),
                 },
             ),
             (
@@ -42918,7 +42918,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.player_head",
+                    name: Cow::Borrowed("block.minecraft.player_head"),
                 },
             ),
             (
@@ -42978,7 +42978,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.plenty_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.plenty_pottery_sherd"),
                 },
             ),
             (
@@ -43016,7 +43016,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.podzol",
+                    name: Cow::Borrowed("block.minecraft.podzol"),
                 },
             ),
             (
@@ -43054,7 +43054,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pointed_dripstone",
+                    name: Cow::Borrowed("block.minecraft.pointed_dripstone"),
                 },
             ),
             (
@@ -43092,7 +43092,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.poisonous_potato",
+                    name: Cow::Borrowed("item.minecraft.poisonous_potato"),
                 },
             ),
             (
@@ -43158,7 +43158,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.polar_bear_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.polar_bear_spawn_egg"),
                 },
             ),
             (
@@ -43197,7 +43197,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_andesite",
+                    name: Cow::Borrowed("block.minecraft.polished_andesite"),
                 },
             ),
             (
@@ -43235,7 +43235,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_andesite_slab",
+                    name: Cow::Borrowed("block.minecraft.polished_andesite_slab"),
                 },
             ),
             (
@@ -43273,7 +43273,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_andesite_stairs",
+                    name: Cow::Borrowed("block.minecraft.polished_andesite_stairs"),
                 },
             ),
             (
@@ -43311,7 +43311,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_basalt",
+                    name: Cow::Borrowed("block.minecraft.polished_basalt"),
                 },
             ),
             (
@@ -43349,7 +43349,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_blackstone",
+                    name: Cow::Borrowed("block.minecraft.polished_blackstone"),
                 },
             ),
             (
@@ -43387,7 +43387,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_blackstone_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.polished_blackstone_brick_slab"),
                 },
             ),
             (
@@ -43425,7 +43425,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_blackstone_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.polished_blackstone_brick_stairs"),
                 },
             ),
             (
@@ -43463,7 +43463,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_blackstone_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.polished_blackstone_brick_wall"),
                 },
             ),
             (
@@ -43501,7 +43501,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_blackstone_bricks",
+                    name: Cow::Borrowed("block.minecraft.polished_blackstone_bricks"),
                 },
             ),
             (
@@ -43539,7 +43539,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_blackstone_button",
+                    name: Cow::Borrowed("block.minecraft.polished_blackstone_button"),
                 },
             ),
             (
@@ -43577,7 +43577,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_blackstone_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.polished_blackstone_pressure_plate"),
                 },
             ),
             (
@@ -43615,7 +43615,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_blackstone_slab",
+                    name: Cow::Borrowed("block.minecraft.polished_blackstone_slab"),
                 },
             ),
             (
@@ -43653,7 +43653,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_blackstone_stairs",
+                    name: Cow::Borrowed("block.minecraft.polished_blackstone_stairs"),
                 },
             ),
             (
@@ -43691,7 +43691,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_blackstone_wall",
+                    name: Cow::Borrowed("block.minecraft.polished_blackstone_wall"),
                 },
             ),
             (
@@ -43729,7 +43729,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_cinnabar",
+                    name: Cow::Borrowed("block.minecraft.polished_cinnabar"),
                 },
             ),
             (
@@ -43767,7 +43767,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_cinnabar_slab",
+                    name: Cow::Borrowed("block.minecraft.polished_cinnabar_slab"),
                 },
             ),
             (
@@ -43805,7 +43805,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_cinnabar_stairs",
+                    name: Cow::Borrowed("block.minecraft.polished_cinnabar_stairs"),
                 },
             ),
             (
@@ -43843,7 +43843,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_cinnabar_wall",
+                    name: Cow::Borrowed("block.minecraft.polished_cinnabar_wall"),
                 },
             ),
             (
@@ -43881,7 +43881,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_deepslate",
+                    name: Cow::Borrowed("block.minecraft.polished_deepslate"),
                 },
             ),
             (
@@ -43919,7 +43919,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_deepslate_slab",
+                    name: Cow::Borrowed("block.minecraft.polished_deepslate_slab"),
                 },
             ),
             (
@@ -43957,7 +43957,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_deepslate_stairs",
+                    name: Cow::Borrowed("block.minecraft.polished_deepslate_stairs"),
                 },
             ),
             (
@@ -43995,7 +43995,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_deepslate_wall",
+                    name: Cow::Borrowed("block.minecraft.polished_deepslate_wall"),
                 },
             ),
             (
@@ -44033,7 +44033,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_diorite",
+                    name: Cow::Borrowed("block.minecraft.polished_diorite"),
                 },
             ),
             (
@@ -44071,7 +44071,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_diorite_slab",
+                    name: Cow::Borrowed("block.minecraft.polished_diorite_slab"),
                 },
             ),
             (
@@ -44109,7 +44109,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_diorite_stairs",
+                    name: Cow::Borrowed("block.minecraft.polished_diorite_stairs"),
                 },
             ),
             (
@@ -44147,7 +44147,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_granite",
+                    name: Cow::Borrowed("block.minecraft.polished_granite"),
                 },
             ),
             (
@@ -44185,7 +44185,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_granite_slab",
+                    name: Cow::Borrowed("block.minecraft.polished_granite_slab"),
                 },
             ),
             (
@@ -44223,7 +44223,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_granite_stairs",
+                    name: Cow::Borrowed("block.minecraft.polished_granite_stairs"),
                 },
             ),
             (
@@ -44261,7 +44261,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_sulfur",
+                    name: Cow::Borrowed("block.minecraft.polished_sulfur"),
                 },
             ),
             (
@@ -44299,7 +44299,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_sulfur_slab",
+                    name: Cow::Borrowed("block.minecraft.polished_sulfur_slab"),
                 },
             ),
             (
@@ -44337,7 +44337,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_sulfur_stairs",
+                    name: Cow::Borrowed("block.minecraft.polished_sulfur_stairs"),
                 },
             ),
             (
@@ -44375,7 +44375,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_sulfur_wall",
+                    name: Cow::Borrowed("block.minecraft.polished_sulfur_wall"),
                 },
             ),
             (
@@ -44413,7 +44413,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_tuff",
+                    name: Cow::Borrowed("block.minecraft.polished_tuff"),
                 },
             ),
             (
@@ -44451,7 +44451,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_tuff_slab",
+                    name: Cow::Borrowed("block.minecraft.polished_tuff_slab"),
                 },
             ),
             (
@@ -44489,7 +44489,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_tuff_stairs",
+                    name: Cow::Borrowed("block.minecraft.polished_tuff_stairs"),
                 },
             ),
             (
@@ -44527,7 +44527,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.polished_tuff_wall",
+                    name: Cow::Borrowed("block.minecraft.polished_tuff_wall"),
                 },
             ),
             (
@@ -44565,7 +44565,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.popped_chorus_fruit",
+                    name: Cow::Borrowed("item.minecraft.popped_chorus_fruit"),
                 },
             ),
             (
@@ -44603,7 +44603,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.poppy",
+                    name: Cow::Borrowed("block.minecraft.poppy"),
                 },
             ),
             (
@@ -44641,7 +44641,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.porkchop",
+                    name: Cow::Borrowed("item.minecraft.porkchop"),
                 },
             ),
             (
@@ -44697,7 +44697,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.potato",
+                    name: Cow::Borrowed("item.minecraft.potato"),
                 },
             ),
             (
@@ -44753,7 +44753,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.potent_sulfur",
+                    name: Cow::Borrowed("block.minecraft.potent_sulfur"),
                 },
             ),
             (
@@ -44791,7 +44791,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.potion",
+                    name: Cow::Borrowed("item.minecraft.potion"),
                 },
             ),
             (
@@ -44849,7 +44849,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.powder_snow_bucket",
+                    name: Cow::Borrowed("item.minecraft.powder_snow_bucket"),
                 },
             ),
             (
@@ -44887,7 +44887,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.powered_rail",
+                    name: Cow::Borrowed("block.minecraft.powered_rail"),
                 },
             ),
             (
@@ -44925,7 +44925,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.prismarine",
+                    name: Cow::Borrowed("block.minecraft.prismarine"),
                 },
             ),
             (
@@ -44963,7 +44963,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.prismarine_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.prismarine_brick_slab"),
                 },
             ),
             (
@@ -45001,7 +45001,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.prismarine_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.prismarine_brick_stairs"),
                 },
             ),
             (
@@ -45039,7 +45039,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.prismarine_bricks",
+                    name: Cow::Borrowed("block.minecraft.prismarine_bricks"),
                 },
             ),
             (
@@ -45077,7 +45077,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.prismarine_crystals",
+                    name: Cow::Borrowed("item.minecraft.prismarine_crystals"),
                 },
             ),
             (
@@ -45115,7 +45115,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.prismarine_shard",
+                    name: Cow::Borrowed("item.minecraft.prismarine_shard"),
                 },
             ),
             (
@@ -45153,7 +45153,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.prismarine_slab",
+                    name: Cow::Borrowed("block.minecraft.prismarine_slab"),
                 },
             ),
             (
@@ -45191,7 +45191,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.prismarine_stairs",
+                    name: Cow::Borrowed("block.minecraft.prismarine_stairs"),
                 },
             ),
             (
@@ -45229,7 +45229,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.prismarine_wall",
+                    name: Cow::Borrowed("block.minecraft.prismarine_wall"),
                 },
             ),
             (
@@ -45267,7 +45267,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.prize_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.prize_pottery_sherd"),
                 },
             ),
             (
@@ -45305,7 +45305,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pufferfish",
+                    name: Cow::Borrowed("item.minecraft.pufferfish"),
                 },
             ),
             (
@@ -45389,7 +45389,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pufferfish_bucket",
+                    name: Cow::Borrowed("item.minecraft.pufferfish_bucket"),
                 },
             ),
             (
@@ -45436,7 +45436,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pufferfish_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.pufferfish_spawn_egg"),
                 },
             ),
             (
@@ -45475,7 +45475,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.pumpkin",
+                    name: Cow::Borrowed("block.minecraft.pumpkin"),
                 },
             ),
             (
@@ -45513,7 +45513,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pumpkin_pie",
+                    name: Cow::Borrowed("item.minecraft.pumpkin_pie"),
                 },
             ),
             (
@@ -45569,7 +45569,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.pumpkin_seeds",
+                    name: Cow::Borrowed("item.minecraft.pumpkin_seeds"),
                 },
             ),
             (
@@ -45607,7 +45607,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_banner",
+                    name: Cow::Borrowed("block.minecraft.purple_banner"),
                 },
             ),
             (
@@ -45646,7 +45646,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_bed",
+                    name: Cow::Borrowed("block.minecraft.purple_bed"),
                 },
             ),
             (
@@ -45684,7 +45684,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.purple_bundle",
+                    name: Cow::Borrowed("item.minecraft.purple_bundle"),
                 },
             ),
             (
@@ -45723,7 +45723,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_candle",
+                    name: Cow::Borrowed("block.minecraft.purple_candle"),
                 },
             ),
             (
@@ -45761,7 +45761,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_carpet",
+                    name: Cow::Borrowed("block.minecraft.purple_carpet"),
                 },
             ),
             (
@@ -45818,7 +45818,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_concrete",
+                    name: Cow::Borrowed("block.minecraft.purple_concrete"),
                 },
             ),
             (
@@ -45856,7 +45856,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.purple_concrete_powder"),
                 },
             ),
             (
@@ -45894,7 +45894,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.purple_dye",
+                    name: Cow::Borrowed("item.minecraft.purple_dye"),
                 },
             ),
             (
@@ -45933,7 +45933,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.purple_glazed_terracotta"),
                 },
             ),
             (
@@ -45971,7 +45971,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.purple_harness",
+                    name: Cow::Borrowed("item.minecraft.purple_harness"),
                 },
             ),
             (
@@ -46025,7 +46025,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.purple_shulker_box"),
                 },
             ),
             (
@@ -46064,7 +46064,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.purple_stained_glass"),
                 },
             ),
             (
@@ -46102,7 +46102,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.purple_stained_glass_pane"),
                 },
             ),
             (
@@ -46140,7 +46140,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_terracotta",
+                    name: Cow::Borrowed("block.minecraft.purple_terracotta"),
                 },
             ),
             (
@@ -46178,7 +46178,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purple_wool",
+                    name: Cow::Borrowed("block.minecraft.purple_wool"),
                 },
             ),
             (
@@ -46216,7 +46216,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purpur_block",
+                    name: Cow::Borrowed("block.minecraft.purpur_block"),
                 },
             ),
             (
@@ -46254,7 +46254,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purpur_pillar",
+                    name: Cow::Borrowed("block.minecraft.purpur_pillar"),
                 },
             ),
             (
@@ -46292,7 +46292,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purpur_slab",
+                    name: Cow::Borrowed("block.minecraft.purpur_slab"),
                 },
             ),
             (
@@ -46330,7 +46330,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.purpur_stairs",
+                    name: Cow::Borrowed("block.minecraft.purpur_stairs"),
                 },
             ),
             (
@@ -46368,7 +46368,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.quartz",
+                    name: Cow::Borrowed("item.minecraft.quartz"),
                 },
             ),
             (
@@ -46407,7 +46407,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.quartz_block",
+                    name: Cow::Borrowed("block.minecraft.quartz_block"),
                 },
             ),
             (
@@ -46445,7 +46445,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.quartz_bricks",
+                    name: Cow::Borrowed("block.minecraft.quartz_bricks"),
                 },
             ),
             (
@@ -46483,7 +46483,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.quartz_pillar",
+                    name: Cow::Borrowed("block.minecraft.quartz_pillar"),
                 },
             ),
             (
@@ -46521,7 +46521,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.quartz_slab",
+                    name: Cow::Borrowed("block.minecraft.quartz_slab"),
                 },
             ),
             (
@@ -46559,7 +46559,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.quartz_stairs",
+                    name: Cow::Borrowed("block.minecraft.quartz_stairs"),
                 },
             ),
             (
@@ -46597,7 +46597,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.rabbit",
+                    name: Cow::Borrowed("item.minecraft.rabbit"),
                 },
             ),
             (
@@ -46653,7 +46653,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.rabbit_foot",
+                    name: Cow::Borrowed("item.minecraft.rabbit_foot"),
                 },
             ),
             (
@@ -46691,7 +46691,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.rabbit_hide",
+                    name: Cow::Borrowed("item.minecraft.rabbit_hide"),
                 },
             ),
             (
@@ -46729,7 +46729,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.rabbit_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.rabbit_spawn_egg"),
                 },
             ),
             (
@@ -46768,7 +46768,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.rabbit_stew",
+                    name: Cow::Borrowed("item.minecraft.rabbit_stew"),
                 },
             ),
             (
@@ -46825,7 +46825,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.rail",
+                    name: Cow::Borrowed("block.minecraft.rail"),
                 },
             ),
             (
@@ -46863,7 +46863,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.raiser_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.raiser_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -46901,7 +46901,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ravager_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.ravager_spawn_egg"),
                 },
             ),
             (
@@ -46940,7 +46940,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.raw_copper",
+                    name: Cow::Borrowed("item.minecraft.raw_copper"),
                 },
             ),
             (
@@ -46978,7 +46978,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.raw_copper_block",
+                    name: Cow::Borrowed("block.minecraft.raw_copper_block"),
                 },
             ),
             (
@@ -47016,7 +47016,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.raw_gold",
+                    name: Cow::Borrowed("item.minecraft.raw_gold"),
                 },
             ),
             (
@@ -47054,7 +47054,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.raw_gold_block",
+                    name: Cow::Borrowed("block.minecraft.raw_gold_block"),
                 },
             ),
             (
@@ -47092,7 +47092,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.raw_iron",
+                    name: Cow::Borrowed("item.minecraft.raw_iron"),
                 },
             ),
             (
@@ -47130,7 +47130,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.raw_iron_block",
+                    name: Cow::Borrowed("block.minecraft.raw_iron_block"),
                 },
             ),
             (
@@ -47168,7 +47168,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.recovery_compass",
+                    name: Cow::Borrowed("item.minecraft.recovery_compass"),
                 },
             ),
             (
@@ -47206,7 +47206,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_banner",
+                    name: Cow::Borrowed("block.minecraft.red_banner"),
                 },
             ),
             (
@@ -47245,7 +47245,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_bed",
+                    name: Cow::Borrowed("block.minecraft.red_bed"),
                 },
             ),
             (
@@ -47283,7 +47283,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.red_bundle",
+                    name: Cow::Borrowed("item.minecraft.red_bundle"),
                 },
             ),
             (
@@ -47322,7 +47322,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_candle",
+                    name: Cow::Borrowed("block.minecraft.red_candle"),
                 },
             ),
             (
@@ -47360,7 +47360,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_carpet",
+                    name: Cow::Borrowed("block.minecraft.red_carpet"),
                 },
             ),
             (
@@ -47417,7 +47417,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_concrete",
+                    name: Cow::Borrowed("block.minecraft.red_concrete"),
                 },
             ),
             (
@@ -47455,7 +47455,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.red_concrete_powder"),
                 },
             ),
             (
@@ -47493,7 +47493,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.red_dye",
+                    name: Cow::Borrowed("item.minecraft.red_dye"),
                 },
             ),
             (
@@ -47532,7 +47532,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.red_glazed_terracotta"),
                 },
             ),
             (
@@ -47570,7 +47570,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.red_harness",
+                    name: Cow::Borrowed("item.minecraft.red_harness"),
                 },
             ),
             (
@@ -47624,7 +47624,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_mushroom",
+                    name: Cow::Borrowed("block.minecraft.red_mushroom"),
                 },
             ),
             (
@@ -47662,7 +47662,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_mushroom_block",
+                    name: Cow::Borrowed("block.minecraft.red_mushroom_block"),
                 },
             ),
             (
@@ -47700,7 +47700,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_nether_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.red_nether_brick_slab"),
                 },
             ),
             (
@@ -47738,7 +47738,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_nether_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.red_nether_brick_stairs"),
                 },
             ),
             (
@@ -47776,7 +47776,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_nether_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.red_nether_brick_wall"),
                 },
             ),
             (
@@ -47814,7 +47814,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_nether_bricks",
+                    name: Cow::Borrowed("block.minecraft.red_nether_bricks"),
                 },
             ),
             (
@@ -47852,7 +47852,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_sand",
+                    name: Cow::Borrowed("block.minecraft.red_sand"),
                 },
             ),
             (
@@ -47890,7 +47890,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_sandstone",
+                    name: Cow::Borrowed("block.minecraft.red_sandstone"),
                 },
             ),
             (
@@ -47928,7 +47928,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_sandstone_slab",
+                    name: Cow::Borrowed("block.minecraft.red_sandstone_slab"),
                 },
             ),
             (
@@ -47966,7 +47966,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_sandstone_stairs",
+                    name: Cow::Borrowed("block.minecraft.red_sandstone_stairs"),
                 },
             ),
             (
@@ -48004,7 +48004,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_sandstone_wall",
+                    name: Cow::Borrowed("block.minecraft.red_sandstone_wall"),
                 },
             ),
             (
@@ -48042,7 +48042,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.red_shulker_box"),
                 },
             ),
             (
@@ -48081,7 +48081,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.red_stained_glass"),
                 },
             ),
             (
@@ -48119,7 +48119,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.red_stained_glass_pane"),
                 },
             ),
             (
@@ -48157,7 +48157,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_terracotta",
+                    name: Cow::Borrowed("block.minecraft.red_terracotta"),
                 },
             ),
             (
@@ -48195,7 +48195,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_tulip",
+                    name: Cow::Borrowed("block.minecraft.red_tulip"),
                 },
             ),
             (
@@ -48233,7 +48233,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.red_wool",
+                    name: Cow::Borrowed("block.minecraft.red_wool"),
                 },
             ),
             (
@@ -48271,7 +48271,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.redstone",
+                    name: Cow::Borrowed("item.minecraft.redstone"),
                 },
             ),
             (
@@ -48310,7 +48310,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.redstone_block",
+                    name: Cow::Borrowed("block.minecraft.redstone_block"),
                 },
             ),
             (
@@ -48348,7 +48348,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.redstone_lamp",
+                    name: Cow::Borrowed("block.minecraft.redstone_lamp"),
                 },
             ),
             (
@@ -48386,7 +48386,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.redstone_ore",
+                    name: Cow::Borrowed("block.minecraft.redstone_ore"),
                 },
             ),
             (
@@ -48424,7 +48424,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.redstone_torch",
+                    name: Cow::Borrowed("block.minecraft.redstone_torch"),
                 },
             ),
             (
@@ -48462,7 +48462,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.reinforced_deepslate",
+                    name: Cow::Borrowed("block.minecraft.reinforced_deepslate"),
                 },
             ),
             (
@@ -48500,7 +48500,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.repeater",
+                    name: Cow::Borrowed("block.minecraft.repeater"),
                 },
             ),
             (
@@ -48538,7 +48538,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.repeating_command_block",
+                    name: Cow::Borrowed("block.minecraft.repeating_command_block"),
                 },
             ),
             (
@@ -48576,7 +48576,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.resin_block",
+                    name: Cow::Borrowed("block.minecraft.resin_block"),
                 },
             ),
             (
@@ -48614,7 +48614,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.resin_brick",
+                    name: Cow::Borrowed("item.minecraft.resin_brick"),
                 },
             ),
             (
@@ -48653,7 +48653,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.resin_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.resin_brick_slab"),
                 },
             ),
             (
@@ -48691,7 +48691,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.resin_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.resin_brick_stairs"),
                 },
             ),
             (
@@ -48729,7 +48729,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.resin_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.resin_brick_wall"),
                 },
             ),
             (
@@ -48767,7 +48767,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.resin_bricks",
+                    name: Cow::Borrowed("block.minecraft.resin_bricks"),
                 },
             ),
             (
@@ -48805,7 +48805,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.resin_clump",
+                    name: Cow::Borrowed("item.minecraft.resin_clump"),
                 },
             ),
             (
@@ -48843,7 +48843,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.respawn_anchor",
+                    name: Cow::Borrowed("block.minecraft.respawn_anchor"),
                 },
             ),
             (
@@ -48881,7 +48881,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.rib_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.rib_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -48919,7 +48919,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.rooted_dirt",
+                    name: Cow::Borrowed("block.minecraft.rooted_dirt"),
                 },
             ),
             (
@@ -48957,7 +48957,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.rose_bush",
+                    name: Cow::Borrowed("block.minecraft.rose_bush"),
                 },
             ),
             (
@@ -48995,7 +48995,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.rotten_flesh",
+                    name: Cow::Borrowed("item.minecraft.rotten_flesh"),
                 },
             ),
             (
@@ -49061,7 +49061,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.saddle",
+                    name: Cow::Borrowed("item.minecraft.saddle"),
                 },
             ),
             (
@@ -49115,7 +49115,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.salmon",
+                    name: Cow::Borrowed("item.minecraft.salmon"),
                 },
             ),
             (
@@ -49171,7 +49171,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.salmon_bucket",
+                    name: Cow::Borrowed("item.minecraft.salmon_bucket"),
                 },
             ),
             (
@@ -49218,7 +49218,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.salmon_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.salmon_spawn_egg"),
                 },
             ),
             (
@@ -49257,7 +49257,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sand",
+                    name: Cow::Borrowed("block.minecraft.sand"),
                 },
             ),
             (
@@ -49295,7 +49295,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sandstone",
+                    name: Cow::Borrowed("block.minecraft.sandstone"),
                 },
             ),
             (
@@ -49333,7 +49333,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sandstone_slab",
+                    name: Cow::Borrowed("block.minecraft.sandstone_slab"),
                 },
             ),
             (
@@ -49371,7 +49371,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sandstone_stairs",
+                    name: Cow::Borrowed("block.minecraft.sandstone_stairs"),
                 },
             ),
             (
@@ -49409,7 +49409,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sandstone_wall",
+                    name: Cow::Borrowed("block.minecraft.sandstone_wall"),
                 },
             ),
             (
@@ -49447,7 +49447,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.scaffolding",
+                    name: Cow::Borrowed("block.minecraft.scaffolding"),
                 },
             ),
             (
@@ -49485,7 +49485,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.scrape_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.scrape_pottery_sherd"),
                 },
             ),
             (
@@ -49523,7 +49523,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sculk",
+                    name: Cow::Borrowed("block.minecraft.sculk"),
                 },
             ),
             (
@@ -49561,7 +49561,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sculk_catalyst",
+                    name: Cow::Borrowed("block.minecraft.sculk_catalyst"),
                 },
             ),
             (
@@ -49599,7 +49599,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sculk_sensor",
+                    name: Cow::Borrowed("block.minecraft.sculk_sensor"),
                 },
             ),
             (
@@ -49637,7 +49637,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sculk_shrieker",
+                    name: Cow::Borrowed("block.minecraft.sculk_shrieker"),
                 },
             ),
             (
@@ -49675,7 +49675,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sculk_vein",
+                    name: Cow::Borrowed("block.minecraft.sculk_vein"),
                 },
             ),
             (
@@ -49713,7 +49713,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sea_lantern",
+                    name: Cow::Borrowed("block.minecraft.sea_lantern"),
                 },
             ),
             (
@@ -49751,7 +49751,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sea_pickle",
+                    name: Cow::Borrowed("block.minecraft.sea_pickle"),
                 },
             ),
             (
@@ -49789,7 +49789,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.seagrass",
+                    name: Cow::Borrowed("block.minecraft.seagrass"),
                 },
             ),
             (
@@ -49827,7 +49827,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.sentry_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.sentry_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -49865,7 +49865,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.shaper_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.shaper_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -49903,7 +49903,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.sheaf_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.sheaf_pottery_sherd"),
                 },
             ),
             (
@@ -49941,7 +49941,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.shears",
+                    name: Cow::Borrowed("item.minecraft.shears"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -50011,7 +50011,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.sheep_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.sheep_spawn_egg"),
                 },
             ),
             (
@@ -50050,7 +50050,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.shelter_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.shelter_pottery_sherd"),
                 },
             ),
             (
@@ -50088,7 +50088,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.shield",
+                    name: Cow::Borrowed("item.minecraft.shield"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -50147,7 +50147,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.short_dry_grass",
+                    name: Cow::Borrowed("block.minecraft.short_dry_grass"),
                 },
             ),
             (
@@ -50185,7 +50185,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.short_grass",
+                    name: Cow::Borrowed("block.minecraft.short_grass"),
                 },
             ),
             (
@@ -50223,7 +50223,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.shroomlight",
+                    name: Cow::Borrowed("block.minecraft.shroomlight"),
                 },
             ),
             (
@@ -50261,7 +50261,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.shulker_box",
+                    name: Cow::Borrowed("block.minecraft.shulker_box"),
                 },
             ),
             (
@@ -50300,7 +50300,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.shulker_shell",
+                    name: Cow::Borrowed("item.minecraft.shulker_shell"),
                 },
             ),
             (
@@ -50338,7 +50338,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.shulker_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.shulker_spawn_egg"),
                 },
             ),
             (
@@ -50377,7 +50377,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.silence_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.silence_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -50415,7 +50415,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.silverfish_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.silverfish_spawn_egg"),
                 },
             ),
             (
@@ -50454,7 +50454,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.skeleton_horse_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.skeleton_horse_spawn_egg"),
                 },
             ),
             (
@@ -50493,7 +50493,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.skeleton_skull",
+                    name: Cow::Borrowed("block.minecraft.skeleton_skull"),
                 },
             ),
             (
@@ -50553,7 +50553,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.skeleton_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.skeleton_spawn_egg"),
                 },
             ),
             (
@@ -50592,7 +50592,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.skull_banner_pattern",
+                    name: Cow::Borrowed("item.minecraft.skull_banner_pattern"),
                 },
             ),
             (
@@ -50631,7 +50631,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.skull_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.skull_pottery_sherd"),
                 },
             ),
             (
@@ -50669,7 +50669,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.slime_ball",
+                    name: Cow::Borrowed("item.minecraft.slime_ball"),
                 },
             ),
             (
@@ -50707,7 +50707,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.slime_block",
+                    name: Cow::Borrowed("block.minecraft.slime_block"),
                 },
             ),
             (
@@ -50745,7 +50745,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.slime_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.slime_spawn_egg"),
                 },
             ),
             (
@@ -50784,7 +50784,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.small_amethyst_bud",
+                    name: Cow::Borrowed("block.minecraft.small_amethyst_bud"),
                 },
             ),
             (
@@ -50822,7 +50822,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.small_dripleaf",
+                    name: Cow::Borrowed("block.minecraft.small_dripleaf"),
                 },
             ),
             (
@@ -50860,7 +50860,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smithing_table",
+                    name: Cow::Borrowed("block.minecraft.smithing_table"),
                 },
             ),
             (
@@ -50898,7 +50898,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smoker",
+                    name: Cow::Borrowed("block.minecraft.smoker"),
                 },
             ),
             (
@@ -50937,7 +50937,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_basalt",
+                    name: Cow::Borrowed("block.minecraft.smooth_basalt"),
                 },
             ),
             (
@@ -50975,7 +50975,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_quartz",
+                    name: Cow::Borrowed("block.minecraft.smooth_quartz"),
                 },
             ),
             (
@@ -51013,7 +51013,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_quartz_slab",
+                    name: Cow::Borrowed("block.minecraft.smooth_quartz_slab"),
                 },
             ),
             (
@@ -51051,7 +51051,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_quartz_stairs",
+                    name: Cow::Borrowed("block.minecraft.smooth_quartz_stairs"),
                 },
             ),
             (
@@ -51089,7 +51089,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_red_sandstone",
+                    name: Cow::Borrowed("block.minecraft.smooth_red_sandstone"),
                 },
             ),
             (
@@ -51127,7 +51127,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_red_sandstone_slab",
+                    name: Cow::Borrowed("block.minecraft.smooth_red_sandstone_slab"),
                 },
             ),
             (
@@ -51165,7 +51165,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_red_sandstone_stairs",
+                    name: Cow::Borrowed("block.minecraft.smooth_red_sandstone_stairs"),
                 },
             ),
             (
@@ -51203,7 +51203,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_sandstone",
+                    name: Cow::Borrowed("block.minecraft.smooth_sandstone"),
                 },
             ),
             (
@@ -51241,7 +51241,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_sandstone_slab",
+                    name: Cow::Borrowed("block.minecraft.smooth_sandstone_slab"),
                 },
             ),
             (
@@ -51279,7 +51279,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_sandstone_stairs",
+                    name: Cow::Borrowed("block.minecraft.smooth_sandstone_stairs"),
                 },
             ),
             (
@@ -51317,7 +51317,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_stone",
+                    name: Cow::Borrowed("block.minecraft.smooth_stone"),
                 },
             ),
             (
@@ -51355,7 +51355,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.smooth_stone_slab",
+                    name: Cow::Borrowed("block.minecraft.smooth_stone_slab"),
                 },
             ),
             (
@@ -51393,7 +51393,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sniffer_egg",
+                    name: Cow::Borrowed("block.minecraft.sniffer_egg"),
                 },
             ),
             (
@@ -51431,7 +51431,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.sniffer_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.sniffer_spawn_egg"),
                 },
             ),
             (
@@ -51470,7 +51470,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.snort_pottery_sherd",
+                    name: Cow::Borrowed("item.minecraft.snort_pottery_sherd"),
                 },
             ),
             (
@@ -51508,7 +51508,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.snout_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.snout_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -51546,7 +51546,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.snow",
+                    name: Cow::Borrowed("block.minecraft.snow"),
                 },
             ),
             (
@@ -51584,7 +51584,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.snow_block",
+                    name: Cow::Borrowed("block.minecraft.snow_block"),
                 },
             ),
             (
@@ -51622,7 +51622,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.snow_golem_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.snow_golem_spawn_egg"),
                 },
             ),
             (
@@ -51661,7 +51661,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.snowball",
+                    name: Cow::Borrowed("item.minecraft.snowball"),
                 },
             ),
             (
@@ -51699,7 +51699,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.soul_campfire",
+                    name: Cow::Borrowed("block.minecraft.soul_campfire"),
                 },
             ),
             (
@@ -51738,7 +51738,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.soul_lantern",
+                    name: Cow::Borrowed("block.minecraft.soul_lantern"),
                 },
             ),
             (
@@ -51776,7 +51776,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.soul_sand",
+                    name: Cow::Borrowed("block.minecraft.soul_sand"),
                 },
             ),
             (
@@ -51814,7 +51814,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.soul_soil",
+                    name: Cow::Borrowed("block.minecraft.soul_soil"),
                 },
             ),
             (
@@ -51852,7 +51852,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.soul_torch",
+                    name: Cow::Borrowed("block.minecraft.soul_torch"),
                 },
             ),
             (
@@ -51890,7 +51890,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spawner",
+                    name: Cow::Borrowed("block.minecraft.spawner"),
                 },
             ),
             (
@@ -51928,7 +51928,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.spectral_arrow",
+                    name: Cow::Borrowed("item.minecraft.spectral_arrow"),
                 },
             ),
             (
@@ -51966,7 +51966,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.spider_eye",
+                    name: Cow::Borrowed("item.minecraft.spider_eye"),
                 },
             ),
             (
@@ -52032,7 +52032,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.spider_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.spider_spawn_egg"),
                 },
             ),
             (
@@ -52071,7 +52071,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.spire_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.spire_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -52109,7 +52109,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.splash_potion",
+                    name: Cow::Borrowed("item.minecraft.splash_potion"),
                 },
             ),
             (
@@ -52156,7 +52156,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sponge",
+                    name: Cow::Borrowed("block.minecraft.sponge"),
                 },
             ),
             (
@@ -52194,7 +52194,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spore_blossom",
+                    name: Cow::Borrowed("block.minecraft.spore_blossom"),
                 },
             ),
             (
@@ -52232,7 +52232,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.spruce_boat",
+                    name: Cow::Borrowed("item.minecraft.spruce_boat"),
                 },
             ),
             (
@@ -52270,7 +52270,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_button",
+                    name: Cow::Borrowed("block.minecraft.spruce_button"),
                 },
             ),
             (
@@ -52308,7 +52308,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.spruce_chest_boat",
+                    name: Cow::Borrowed("item.minecraft.spruce_chest_boat"),
                 },
             ),
             (
@@ -52346,7 +52346,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_door",
+                    name: Cow::Borrowed("block.minecraft.spruce_door"),
                 },
             ),
             (
@@ -52384,7 +52384,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_fence",
+                    name: Cow::Borrowed("block.minecraft.spruce_fence"),
                 },
             ),
             (
@@ -52422,7 +52422,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.spruce_fence_gate"),
                 },
             ),
             (
@@ -52460,7 +52460,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.spruce_hanging_sign"),
                 },
             ),
             (
@@ -52498,7 +52498,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_leaves",
+                    name: Cow::Borrowed("block.minecraft.spruce_leaves"),
                 },
             ),
             (
@@ -52536,7 +52536,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_log",
+                    name: Cow::Borrowed("block.minecraft.spruce_log"),
                 },
             ),
             (
@@ -52574,7 +52574,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_planks",
+                    name: Cow::Borrowed("block.minecraft.spruce_planks"),
                 },
             ),
             (
@@ -52612,7 +52612,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.spruce_pressure_plate"),
                 },
             ),
             (
@@ -52650,7 +52650,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_sapling",
+                    name: Cow::Borrowed("block.minecraft.spruce_sapling"),
                 },
             ),
             (
@@ -52688,7 +52688,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_shelf",
+                    name: Cow::Borrowed("block.minecraft.spruce_shelf"),
                 },
             ),
             (
@@ -52727,7 +52727,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_sign",
+                    name: Cow::Borrowed("block.minecraft.spruce_sign"),
                 },
             ),
             (
@@ -52765,7 +52765,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_slab",
+                    name: Cow::Borrowed("block.minecraft.spruce_slab"),
                 },
             ),
             (
@@ -52803,7 +52803,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_stairs",
+                    name: Cow::Borrowed("block.minecraft.spruce_stairs"),
                 },
             ),
             (
@@ -52841,7 +52841,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.spruce_trapdoor"),
                 },
             ),
             (
@@ -52879,7 +52879,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.spruce_wood",
+                    name: Cow::Borrowed("block.minecraft.spruce_wood"),
                 },
             ),
             (
@@ -52917,7 +52917,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.spyglass",
+                    name: Cow::Borrowed("item.minecraft.spyglass"),
                 },
             ),
             (
@@ -52955,7 +52955,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.squid_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.squid_spawn_egg"),
                 },
             ),
             (
@@ -52994,7 +52994,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.stick",
+                    name: Cow::Borrowed("item.minecraft.stick"),
                 },
             ),
             (
@@ -53032,7 +53032,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sticky_piston",
+                    name: Cow::Borrowed("block.minecraft.sticky_piston"),
                 },
             ),
             (
@@ -53070,7 +53070,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stone",
+                    name: Cow::Borrowed("block.minecraft.stone"),
                 },
             ),
             (
@@ -53108,7 +53108,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.stone_axe",
+                    name: Cow::Borrowed("item.minecraft.stone_axe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -53191,7 +53191,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stone_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.stone_brick_slab"),
                 },
             ),
             (
@@ -53229,7 +53229,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stone_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.stone_brick_stairs"),
                 },
             ),
             (
@@ -53267,7 +53267,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stone_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.stone_brick_wall"),
                 },
             ),
             (
@@ -53305,7 +53305,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stone_bricks",
+                    name: Cow::Borrowed("block.minecraft.stone_bricks"),
                 },
             ),
             (
@@ -53343,7 +53343,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stone_button",
+                    name: Cow::Borrowed("block.minecraft.stone_button"),
                 },
             ),
             (
@@ -53381,7 +53381,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.stone_hoe",
+                    name: Cow::Borrowed("item.minecraft.stone_hoe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -53464,7 +53464,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.stone_pickaxe",
+                    name: Cow::Borrowed("item.minecraft.stone_pickaxe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -53547,7 +53547,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stone_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.stone_pressure_plate"),
                 },
             ),
             (
@@ -53585,7 +53585,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.stone_shovel",
+                    name: Cow::Borrowed("item.minecraft.stone_shovel"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -53668,7 +53668,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stone_slab",
+                    name: Cow::Borrowed("block.minecraft.stone_slab"),
                 },
             ),
             (
@@ -53706,7 +53706,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.stone_spear",
+                    name: Cow::Borrowed("item.minecraft.stone_spear"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -53774,7 +53774,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stone_stairs",
+                    name: Cow::Borrowed("block.minecraft.stone_stairs"),
                 },
             ),
             (
@@ -53812,7 +53812,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.stone_sword",
+                    name: Cow::Borrowed("item.minecraft.stone_sword"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -53900,7 +53900,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stonecutter",
+                    name: Cow::Borrowed("block.minecraft.stonecutter"),
                 },
             ),
             (
@@ -53938,7 +53938,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.stray_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.stray_spawn_egg"),
                 },
             ),
             (
@@ -53977,7 +53977,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.strider_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.strider_spawn_egg"),
                 },
             ),
             (
@@ -54016,7 +54016,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.string",
+                    name: Cow::Borrowed("item.minecraft.string"),
                 },
             ),
             (
@@ -54054,7 +54054,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_acacia_log",
+                    name: Cow::Borrowed("block.minecraft.stripped_acacia_log"),
                 },
             ),
             (
@@ -54092,7 +54092,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_acacia_wood",
+                    name: Cow::Borrowed("block.minecraft.stripped_acacia_wood"),
                 },
             ),
             (
@@ -54130,7 +54130,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_bamboo_block",
+                    name: Cow::Borrowed("block.minecraft.stripped_bamboo_block"),
                 },
             ),
             (
@@ -54168,7 +54168,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_birch_log",
+                    name: Cow::Borrowed("block.minecraft.stripped_birch_log"),
                 },
             ),
             (
@@ -54206,7 +54206,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_birch_wood",
+                    name: Cow::Borrowed("block.minecraft.stripped_birch_wood"),
                 },
             ),
             (
@@ -54244,7 +54244,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_cherry_log",
+                    name: Cow::Borrowed("block.minecraft.stripped_cherry_log"),
                 },
             ),
             (
@@ -54282,7 +54282,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_cherry_wood",
+                    name: Cow::Borrowed("block.minecraft.stripped_cherry_wood"),
                 },
             ),
             (
@@ -54320,7 +54320,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_crimson_hyphae",
+                    name: Cow::Borrowed("block.minecraft.stripped_crimson_hyphae"),
                 },
             ),
             (
@@ -54358,7 +54358,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_crimson_stem",
+                    name: Cow::Borrowed("block.minecraft.stripped_crimson_stem"),
                 },
             ),
             (
@@ -54396,7 +54396,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_dark_oak_log",
+                    name: Cow::Borrowed("block.minecraft.stripped_dark_oak_log"),
                 },
             ),
             (
@@ -54434,7 +54434,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_dark_oak_wood",
+                    name: Cow::Borrowed("block.minecraft.stripped_dark_oak_wood"),
                 },
             ),
             (
@@ -54472,7 +54472,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_jungle_log",
+                    name: Cow::Borrowed("block.minecraft.stripped_jungle_log"),
                 },
             ),
             (
@@ -54510,7 +54510,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_jungle_wood",
+                    name: Cow::Borrowed("block.minecraft.stripped_jungle_wood"),
                 },
             ),
             (
@@ -54548,7 +54548,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_mangrove_log",
+                    name: Cow::Borrowed("block.minecraft.stripped_mangrove_log"),
                 },
             ),
             (
@@ -54586,7 +54586,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_mangrove_wood",
+                    name: Cow::Borrowed("block.minecraft.stripped_mangrove_wood"),
                 },
             ),
             (
@@ -54624,7 +54624,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_oak_log",
+                    name: Cow::Borrowed("block.minecraft.stripped_oak_log"),
                 },
             ),
             (
@@ -54662,7 +54662,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_oak_wood",
+                    name: Cow::Borrowed("block.minecraft.stripped_oak_wood"),
                 },
             ),
             (
@@ -54700,7 +54700,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_pale_oak_log",
+                    name: Cow::Borrowed("block.minecraft.stripped_pale_oak_log"),
                 },
             ),
             (
@@ -54738,7 +54738,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_pale_oak_wood",
+                    name: Cow::Borrowed("block.minecraft.stripped_pale_oak_wood"),
                 },
             ),
             (
@@ -54776,7 +54776,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_spruce_log",
+                    name: Cow::Borrowed("block.minecraft.stripped_spruce_log"),
                 },
             ),
             (
@@ -54814,7 +54814,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_spruce_wood",
+                    name: Cow::Borrowed("block.minecraft.stripped_spruce_wood"),
                 },
             ),
             (
@@ -54852,7 +54852,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_warped_hyphae",
+                    name: Cow::Borrowed("block.minecraft.stripped_warped_hyphae"),
                 },
             ),
             (
@@ -54890,7 +54890,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.stripped_warped_stem",
+                    name: Cow::Borrowed("block.minecraft.stripped_warped_stem"),
                 },
             ),
             (
@@ -54928,7 +54928,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.structure_block",
+                    name: Cow::Borrowed("block.minecraft.structure_block"),
                 },
             ),
             (
@@ -54966,7 +54966,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.structure_void",
+                    name: Cow::Borrowed("block.minecraft.structure_void"),
                 },
             ),
             (
@@ -55004,7 +55004,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.sugar",
+                    name: Cow::Borrowed("item.minecraft.sugar"),
                 },
             ),
             (
@@ -55042,7 +55042,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sugar_cane",
+                    name: Cow::Borrowed("block.minecraft.sugar_cane"),
                 },
             ),
             (
@@ -55080,7 +55080,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sulfur",
+                    name: Cow::Borrowed("block.minecraft.sulfur"),
                 },
             ),
             (
@@ -55118,7 +55118,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sulfur_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.sulfur_brick_slab"),
                 },
             ),
             (
@@ -55156,7 +55156,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sulfur_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.sulfur_brick_stairs"),
                 },
             ),
             (
@@ -55194,7 +55194,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sulfur_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.sulfur_brick_wall"),
                 },
             ),
             (
@@ -55232,7 +55232,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sulfur_bricks",
+                    name: Cow::Borrowed("block.minecraft.sulfur_bricks"),
                 },
             ),
             (
@@ -55270,7 +55270,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.sulfur_cube_bucket",
+                    name: Cow::Borrowed("item.minecraft.sulfur_cube_bucket"),
                 },
             ),
             (
@@ -55309,7 +55309,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.sulfur_cube_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.sulfur_cube_spawn_egg"),
                 },
             ),
             (
@@ -55348,7 +55348,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sulfur_slab",
+                    name: Cow::Borrowed("block.minecraft.sulfur_slab"),
                 },
             ),
             (
@@ -55386,7 +55386,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sulfur_spike",
+                    name: Cow::Borrowed("block.minecraft.sulfur_spike"),
                 },
             ),
             (
@@ -55424,7 +55424,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sulfur_stairs",
+                    name: Cow::Borrowed("block.minecraft.sulfur_stairs"),
                 },
             ),
             (
@@ -55462,7 +55462,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sulfur_wall",
+                    name: Cow::Borrowed("block.minecraft.sulfur_wall"),
                 },
             ),
             (
@@ -55500,7 +55500,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.sunflower",
+                    name: Cow::Borrowed("block.minecraft.sunflower"),
                 },
             ),
             (
@@ -55538,7 +55538,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.suspicious_gravel",
+                    name: Cow::Borrowed("block.minecraft.suspicious_gravel"),
                 },
             ),
             (
@@ -55576,7 +55576,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.suspicious_sand",
+                    name: Cow::Borrowed("block.minecraft.suspicious_sand"),
                 },
             ),
             (
@@ -55614,7 +55614,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.suspicious_stew",
+                    name: Cow::Borrowed("item.minecraft.suspicious_stew"),
                 },
             ),
             (
@@ -55657,7 +55657,7 @@ impl Item {
             (Lore, &LoreImpl),
             (Rarity, &RarityImpl),
             (RepairCost, &RepairCostImpl),
-            (SuspiciousStewEffects, &SuspiciousStewEffectsImpl),
+            (SuspiciousStewEffects, &SuspiciousStewEffectsImpl::EMPTY),
             (SwingAnimation, &SwingAnimationImpl),
             (TooltipDisplay, &TooltipDisplayImpl),
             (UseEffects, &UseEffectsImpl),
@@ -55672,7 +55672,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.sweet_berries",
+                    name: Cow::Borrowed("item.minecraft.sweet_berries"),
                 },
             ),
             (
@@ -55728,7 +55728,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.tadpole_bucket",
+                    name: Cow::Borrowed("item.minecraft.tadpole_bucket"),
                 },
             ),
             (
@@ -55767,7 +55767,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.tadpole_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.tadpole_spawn_egg"),
                 },
             ),
             (
@@ -55806,7 +55806,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tall_dry_grass",
+                    name: Cow::Borrowed("block.minecraft.tall_dry_grass"),
                 },
             ),
             (
@@ -55844,7 +55844,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tall_grass",
+                    name: Cow::Borrowed("block.minecraft.tall_grass"),
                 },
             ),
             (
@@ -55882,7 +55882,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.target",
+                    name: Cow::Borrowed("block.minecraft.target"),
                 },
             ),
             (
@@ -55920,7 +55920,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.terracotta",
+                    name: Cow::Borrowed("block.minecraft.terracotta"),
                 },
             ),
             (
@@ -55958,7 +55958,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.test_block",
+                    name: Cow::Borrowed("block.minecraft.test_block"),
                 },
             ),
             (
@@ -56002,7 +56002,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.test_instance_block",
+                    name: Cow::Borrowed("block.minecraft.test_instance_block"),
                 },
             ),
             (
@@ -56040,7 +56040,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.tide_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.tide_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -56078,7 +56078,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tinted_glass",
+                    name: Cow::Borrowed("block.minecraft.tinted_glass"),
                 },
             ),
             (
@@ -56116,7 +56116,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.tipped_arrow",
+                    name: Cow::Borrowed("item.minecraft.tipped_arrow"),
                 },
             ),
             (
@@ -56167,7 +56167,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tnt",
+                    name: Cow::Borrowed("block.minecraft.tnt"),
                 },
             ),
             (
@@ -56205,7 +56205,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.tnt_minecart",
+                    name: Cow::Borrowed("item.minecraft.tnt_minecart"),
                 },
             ),
             (
@@ -56243,7 +56243,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.torch",
+                    name: Cow::Borrowed("block.minecraft.torch"),
                 },
             ),
             (
@@ -56281,7 +56281,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.torchflower",
+                    name: Cow::Borrowed("block.minecraft.torchflower"),
                 },
             ),
             (
@@ -56319,7 +56319,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.torchflower_seeds",
+                    name: Cow::Borrowed("item.minecraft.torchflower_seeds"),
                 },
             ),
             (
@@ -56357,7 +56357,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.totem_of_undying",
+                    name: Cow::Borrowed("item.minecraft.totem_of_undying"),
                 },
             ),
             (
@@ -56396,7 +56396,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.trader_llama_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.trader_llama_spawn_egg"),
                 },
             ),
             (
@@ -56435,7 +56435,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.trapped_chest",
+                    name: Cow::Borrowed("block.minecraft.trapped_chest"),
                 },
             ),
             (
@@ -56474,7 +56474,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.trial_key",
+                    name: Cow::Borrowed("item.minecraft.trial_key"),
                 },
             ),
             (
@@ -56512,7 +56512,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.trial_spawner",
+                    name: Cow::Borrowed("block.minecraft.trial_spawner"),
                 },
             ),
             (
@@ -56550,7 +56550,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.trident",
+                    name: Cow::Borrowed("item.minecraft.trident"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -56621,7 +56621,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tripwire_hook",
+                    name: Cow::Borrowed("block.minecraft.tripwire_hook"),
                 },
             ),
             (
@@ -56659,7 +56659,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.tropical_fish",
+                    name: Cow::Borrowed("item.minecraft.tropical_fish"),
                 },
             ),
             (
@@ -56715,7 +56715,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.tropical_fish_bucket",
+                    name: Cow::Borrowed("item.minecraft.tropical_fish_bucket"),
                 },
             ),
             (
@@ -56762,7 +56762,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.tropical_fish_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.tropical_fish_spawn_egg"),
                 },
             ),
             (
@@ -56801,7 +56801,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tube_coral",
+                    name: Cow::Borrowed("block.minecraft.tube_coral"),
                 },
             ),
             (
@@ -56839,7 +56839,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tube_coral_block",
+                    name: Cow::Borrowed("block.minecraft.tube_coral_block"),
                 },
             ),
             (
@@ -56877,7 +56877,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tube_coral_fan",
+                    name: Cow::Borrowed("block.minecraft.tube_coral_fan"),
                 },
             ),
             (
@@ -56915,7 +56915,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tuff",
+                    name: Cow::Borrowed("block.minecraft.tuff"),
                 },
             ),
             (
@@ -56953,7 +56953,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tuff_brick_slab",
+                    name: Cow::Borrowed("block.minecraft.tuff_brick_slab"),
                 },
             ),
             (
@@ -56991,7 +56991,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tuff_brick_stairs",
+                    name: Cow::Borrowed("block.minecraft.tuff_brick_stairs"),
                 },
             ),
             (
@@ -57029,7 +57029,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tuff_brick_wall",
+                    name: Cow::Borrowed("block.minecraft.tuff_brick_wall"),
                 },
             ),
             (
@@ -57067,7 +57067,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tuff_bricks",
+                    name: Cow::Borrowed("block.minecraft.tuff_bricks"),
                 },
             ),
             (
@@ -57105,7 +57105,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tuff_slab",
+                    name: Cow::Borrowed("block.minecraft.tuff_slab"),
                 },
             ),
             (
@@ -57143,7 +57143,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tuff_stairs",
+                    name: Cow::Borrowed("block.minecraft.tuff_stairs"),
                 },
             ),
             (
@@ -57181,7 +57181,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.tuff_wall",
+                    name: Cow::Borrowed("block.minecraft.tuff_wall"),
                 },
             ),
             (
@@ -57219,7 +57219,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.turtle_egg",
+                    name: Cow::Borrowed("block.minecraft.turtle_egg"),
                 },
             ),
             (
@@ -57257,7 +57257,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.turtle_helmet",
+                    name: Cow::Borrowed("item.minecraft.turtle_helmet"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -57330,7 +57330,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.turtle_scute",
+                    name: Cow::Borrowed("item.minecraft.turtle_scute"),
                 },
             ),
             (
@@ -57368,7 +57368,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.turtle_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.turtle_spawn_egg"),
                 },
             ),
             (
@@ -57407,7 +57407,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.twisting_vines",
+                    name: Cow::Borrowed("block.minecraft.twisting_vines"),
                 },
             ),
             (
@@ -57445,7 +57445,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.vault",
+                    name: Cow::Borrowed("block.minecraft.vault"),
                 },
             ),
             (
@@ -57483,7 +57483,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.verdant_froglight",
+                    name: Cow::Borrowed("block.minecraft.verdant_froglight"),
                 },
             ),
             (
@@ -57521,7 +57521,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.vex_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.vex_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -57559,7 +57559,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.vex_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.vex_spawn_egg"),
                 },
             ),
             (
@@ -57598,7 +57598,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.villager_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.villager_spawn_egg"),
                 },
             ),
             (
@@ -57637,7 +57637,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.vindicator_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.vindicator_spawn_egg"),
                 },
             ),
             (
@@ -57676,7 +57676,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.vine",
+                    name: Cow::Borrowed("block.minecraft.vine"),
                 },
             ),
             (
@@ -57714,7 +57714,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wandering_trader_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.wandering_trader_spawn_egg"),
                 },
             ),
             (
@@ -57753,7 +57753,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.ward_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.ward_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -57791,7 +57791,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.warden_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.warden_spawn_egg"),
                 },
             ),
             (
@@ -57830,7 +57830,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_button",
+                    name: Cow::Borrowed("block.minecraft.warped_button"),
                 },
             ),
             (
@@ -57868,7 +57868,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_door",
+                    name: Cow::Borrowed("block.minecraft.warped_door"),
                 },
             ),
             (
@@ -57906,7 +57906,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_fence",
+                    name: Cow::Borrowed("block.minecraft.warped_fence"),
                 },
             ),
             (
@@ -57944,7 +57944,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_fence_gate",
+                    name: Cow::Borrowed("block.minecraft.warped_fence_gate"),
                 },
             ),
             (
@@ -57982,7 +57982,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_fungus",
+                    name: Cow::Borrowed("block.minecraft.warped_fungus"),
                 },
             ),
             (
@@ -58020,7 +58020,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.warped_fungus_on_a_stick",
+                    name: Cow::Borrowed("item.minecraft.warped_fungus_on_a_stick"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -58060,7 +58060,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_hanging_sign",
+                    name: Cow::Borrowed("block.minecraft.warped_hanging_sign"),
                 },
             ),
             (
@@ -58098,7 +58098,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_hyphae",
+                    name: Cow::Borrowed("block.minecraft.warped_hyphae"),
                 },
             ),
             (
@@ -58136,7 +58136,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_nylium",
+                    name: Cow::Borrowed("block.minecraft.warped_nylium"),
                 },
             ),
             (
@@ -58174,7 +58174,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_planks",
+                    name: Cow::Borrowed("block.minecraft.warped_planks"),
                 },
             ),
             (
@@ -58212,7 +58212,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_pressure_plate",
+                    name: Cow::Borrowed("block.minecraft.warped_pressure_plate"),
                 },
             ),
             (
@@ -58250,7 +58250,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_roots",
+                    name: Cow::Borrowed("block.minecraft.warped_roots"),
                 },
             ),
             (
@@ -58288,7 +58288,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_shelf",
+                    name: Cow::Borrowed("block.minecraft.warped_shelf"),
                 },
             ),
             (
@@ -58327,7 +58327,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_sign",
+                    name: Cow::Borrowed("block.minecraft.warped_sign"),
                 },
             ),
             (
@@ -58365,7 +58365,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_slab",
+                    name: Cow::Borrowed("block.minecraft.warped_slab"),
                 },
             ),
             (
@@ -58403,7 +58403,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_stairs",
+                    name: Cow::Borrowed("block.minecraft.warped_stairs"),
                 },
             ),
             (
@@ -58441,7 +58441,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_stem",
+                    name: Cow::Borrowed("block.minecraft.warped_stem"),
                 },
             ),
             (
@@ -58479,7 +58479,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.warped_trapdoor"),
                 },
             ),
             (
@@ -58517,7 +58517,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.warped_wart_block",
+                    name: Cow::Borrowed("block.minecraft.warped_wart_block"),
                 },
             ),
             (
@@ -58555,7 +58555,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.water_bucket",
+                    name: Cow::Borrowed("item.minecraft.water_bucket"),
                 },
             ),
             (
@@ -58593,7 +58593,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_chiseled_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_chiseled_copper"),
                 },
             ),
             (
@@ -58631,7 +58631,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_copper_bars",
+                    name: Cow::Borrowed("block.minecraft.waxed_copper_bars"),
                 },
             ),
             (
@@ -58669,7 +58669,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_copper_block",
+                    name: Cow::Borrowed("block.minecraft.waxed_copper_block"),
                 },
             ),
             (
@@ -58707,7 +58707,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_copper_bulb",
+                    name: Cow::Borrowed("block.minecraft.waxed_copper_bulb"),
                 },
             ),
             (
@@ -58745,7 +58745,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_copper_chain",
+                    name: Cow::Borrowed("block.minecraft.waxed_copper_chain"),
                 },
             ),
             (
@@ -58783,7 +58783,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_copper_chest",
+                    name: Cow::Borrowed("block.minecraft.waxed_copper_chest"),
                 },
             ),
             (
@@ -58821,7 +58821,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_copper_door",
+                    name: Cow::Borrowed("block.minecraft.waxed_copper_door"),
                 },
             ),
             (
@@ -58859,7 +58859,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_copper_golem_statue",
+                    name: Cow::Borrowed("block.minecraft.waxed_copper_golem_statue"),
                 },
             ),
             (
@@ -58906,7 +58906,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_copper_grate",
+                    name: Cow::Borrowed("block.minecraft.waxed_copper_grate"),
                 },
             ),
             (
@@ -58944,7 +58944,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_copper_lantern",
+                    name: Cow::Borrowed("block.minecraft.waxed_copper_lantern"),
                 },
             ),
             (
@@ -58982,7 +58982,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_copper_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.waxed_copper_trapdoor"),
                 },
             ),
             (
@@ -59020,7 +59020,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_cut_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_cut_copper"),
                 },
             ),
             (
@@ -59058,7 +59058,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_cut_copper_slab",
+                    name: Cow::Borrowed("block.minecraft.waxed_cut_copper_slab"),
                 },
             ),
             (
@@ -59096,7 +59096,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_cut_copper_stairs",
+                    name: Cow::Borrowed("block.minecraft.waxed_cut_copper_stairs"),
                 },
             ),
             (
@@ -59134,7 +59134,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_chiseled_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_chiseled_copper"),
                 },
             ),
             (
@@ -59172,7 +59172,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_copper"),
                 },
             ),
             (
@@ -59210,7 +59210,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_copper_bars",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_copper_bars"),
                 },
             ),
             (
@@ -59248,7 +59248,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_copper_bulb",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_copper_bulb"),
                 },
             ),
             (
@@ -59286,7 +59286,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_copper_chain",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_copper_chain"),
                 },
             ),
             (
@@ -59324,7 +59324,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_copper_chest",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_copper_chest"),
                 },
             ),
             (
@@ -59362,7 +59362,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_copper_door",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_copper_door"),
                 },
             ),
             (
@@ -59400,7 +59400,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_copper_golem_statue",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_copper_golem_statue"),
                 },
             ),
             (
@@ -59447,7 +59447,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_copper_grate",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_copper_grate"),
                 },
             ),
             (
@@ -59485,7 +59485,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_copper_lantern",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_copper_lantern"),
                 },
             ),
             (
@@ -59523,7 +59523,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_copper_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_copper_trapdoor"),
                 },
             ),
             (
@@ -59561,7 +59561,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_cut_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_cut_copper"),
                 },
             ),
             (
@@ -59599,7 +59599,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_cut_copper_slab",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_cut_copper_slab"),
                 },
             ),
             (
@@ -59637,7 +59637,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_cut_copper_stairs",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_cut_copper_stairs"),
                 },
             ),
             (
@@ -59675,7 +59675,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_exposed_lightning_rod",
+                    name: Cow::Borrowed("block.minecraft.waxed_exposed_lightning_rod"),
                 },
             ),
             (
@@ -59713,7 +59713,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_lightning_rod",
+                    name: Cow::Borrowed("block.minecraft.waxed_lightning_rod"),
                 },
             ),
             (
@@ -59751,7 +59751,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_chiseled_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_chiseled_copper"),
                 },
             ),
             (
@@ -59789,7 +59789,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_copper"),
                 },
             ),
             (
@@ -59827,7 +59827,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_copper_bars",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_copper_bars"),
                 },
             ),
             (
@@ -59865,7 +59865,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_copper_bulb",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_copper_bulb"),
                 },
             ),
             (
@@ -59903,7 +59903,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_copper_chain",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_copper_chain"),
                 },
             ),
             (
@@ -59941,7 +59941,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_copper_chest",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_copper_chest"),
                 },
             ),
             (
@@ -59979,7 +59979,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_copper_door",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_copper_door"),
                 },
             ),
             (
@@ -60017,7 +60017,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_copper_golem_statue",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_copper_golem_statue"),
                 },
             ),
             (
@@ -60064,7 +60064,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_copper_grate",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_copper_grate"),
                 },
             ),
             (
@@ -60102,7 +60102,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_copper_lantern",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_copper_lantern"),
                 },
             ),
             (
@@ -60140,7 +60140,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_copper_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_copper_trapdoor"),
                 },
             ),
             (
@@ -60178,7 +60178,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_cut_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_cut_copper"),
                 },
             ),
             (
@@ -60216,7 +60216,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_cut_copper_slab",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_cut_copper_slab"),
                 },
             ),
             (
@@ -60254,7 +60254,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_cut_copper_stairs",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_cut_copper_stairs"),
                 },
             ),
             (
@@ -60292,7 +60292,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_oxidized_lightning_rod",
+                    name: Cow::Borrowed("block.minecraft.waxed_oxidized_lightning_rod"),
                 },
             ),
             (
@@ -60330,7 +60330,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_chiseled_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_chiseled_copper"),
                 },
             ),
             (
@@ -60368,7 +60368,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_copper"),
                 },
             ),
             (
@@ -60406,7 +60406,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_copper_bars",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_copper_bars"),
                 },
             ),
             (
@@ -60444,7 +60444,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_copper_bulb",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_copper_bulb"),
                 },
             ),
             (
@@ -60482,7 +60482,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_copper_chain",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_copper_chain"),
                 },
             ),
             (
@@ -60520,7 +60520,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_copper_chest",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_copper_chest"),
                 },
             ),
             (
@@ -60558,7 +60558,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_copper_door",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_copper_door"),
                 },
             ),
             (
@@ -60596,7 +60596,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_copper_golem_statue",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_copper_golem_statue"),
                 },
             ),
             (
@@ -60643,7 +60643,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_copper_grate",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_copper_grate"),
                 },
             ),
             (
@@ -60681,7 +60681,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_copper_lantern",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_copper_lantern"),
                 },
             ),
             (
@@ -60719,7 +60719,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_copper_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_copper_trapdoor"),
                 },
             ),
             (
@@ -60757,7 +60757,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_cut_copper",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_cut_copper"),
                 },
             ),
             (
@@ -60795,7 +60795,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_cut_copper_slab",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_cut_copper_slab"),
                 },
             ),
             (
@@ -60833,7 +60833,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_cut_copper_stairs",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_cut_copper_stairs"),
                 },
             ),
             (
@@ -60871,7 +60871,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.waxed_weathered_lightning_rod",
+                    name: Cow::Borrowed("block.minecraft.waxed_weathered_lightning_rod"),
                 },
             ),
             (
@@ -60909,7 +60909,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wayfinder_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.wayfinder_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -60947,7 +60947,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_chiseled_copper",
+                    name: Cow::Borrowed("block.minecraft.weathered_chiseled_copper"),
                 },
             ),
             (
@@ -60985,7 +60985,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_copper",
+                    name: Cow::Borrowed("block.minecraft.weathered_copper"),
                 },
             ),
             (
@@ -61023,7 +61023,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_copper_bars",
+                    name: Cow::Borrowed("block.minecraft.weathered_copper_bars"),
                 },
             ),
             (
@@ -61061,7 +61061,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_copper_bulb",
+                    name: Cow::Borrowed("block.minecraft.weathered_copper_bulb"),
                 },
             ),
             (
@@ -61099,7 +61099,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_copper_chain",
+                    name: Cow::Borrowed("block.minecraft.weathered_copper_chain"),
                 },
             ),
             (
@@ -61137,7 +61137,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_copper_chest",
+                    name: Cow::Borrowed("block.minecraft.weathered_copper_chest"),
                 },
             ),
             (
@@ -61175,7 +61175,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_copper_door",
+                    name: Cow::Borrowed("block.minecraft.weathered_copper_door"),
                 },
             ),
             (
@@ -61213,7 +61213,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_copper_golem_statue",
+                    name: Cow::Borrowed("block.minecraft.weathered_copper_golem_statue"),
                 },
             ),
             (
@@ -61260,7 +61260,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_copper_grate",
+                    name: Cow::Borrowed("block.minecraft.weathered_copper_grate"),
                 },
             ),
             (
@@ -61298,7 +61298,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_copper_lantern",
+                    name: Cow::Borrowed("block.minecraft.weathered_copper_lantern"),
                 },
             ),
             (
@@ -61336,7 +61336,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_copper_trapdoor",
+                    name: Cow::Borrowed("block.minecraft.weathered_copper_trapdoor"),
                 },
             ),
             (
@@ -61374,7 +61374,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_cut_copper",
+                    name: Cow::Borrowed("block.minecraft.weathered_cut_copper"),
                 },
             ),
             (
@@ -61412,7 +61412,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_cut_copper_slab",
+                    name: Cow::Borrowed("block.minecraft.weathered_cut_copper_slab"),
                 },
             ),
             (
@@ -61450,7 +61450,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_cut_copper_stairs",
+                    name: Cow::Borrowed("block.minecraft.weathered_cut_copper_stairs"),
                 },
             ),
             (
@@ -61488,7 +61488,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weathered_lightning_rod",
+                    name: Cow::Borrowed("block.minecraft.weathered_lightning_rod"),
                 },
             ),
             (
@@ -61526,7 +61526,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.weeping_vines",
+                    name: Cow::Borrowed("block.minecraft.weeping_vines"),
                 },
             ),
             (
@@ -61564,7 +61564,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.wet_sponge",
+                    name: Cow::Borrowed("block.minecraft.wet_sponge"),
                 },
             ),
             (
@@ -61602,7 +61602,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wheat",
+                    name: Cow::Borrowed("item.minecraft.wheat"),
                 },
             ),
             (
@@ -61640,7 +61640,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wheat_seeds",
+                    name: Cow::Borrowed("item.minecraft.wheat_seeds"),
                 },
             ),
             (
@@ -61678,7 +61678,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_banner",
+                    name: Cow::Borrowed("block.minecraft.white_banner"),
                 },
             ),
             (
@@ -61717,7 +61717,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_bed",
+                    name: Cow::Borrowed("block.minecraft.white_bed"),
                 },
             ),
             (
@@ -61755,7 +61755,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.white_bundle",
+                    name: Cow::Borrowed("item.minecraft.white_bundle"),
                 },
             ),
             (
@@ -61794,7 +61794,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_candle",
+                    name: Cow::Borrowed("block.minecraft.white_candle"),
                 },
             ),
             (
@@ -61832,7 +61832,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_carpet",
+                    name: Cow::Borrowed("block.minecraft.white_carpet"),
                 },
             ),
             (
@@ -61889,7 +61889,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_concrete",
+                    name: Cow::Borrowed("block.minecraft.white_concrete"),
                 },
             ),
             (
@@ -61927,7 +61927,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.white_concrete_powder"),
                 },
             ),
             (
@@ -61965,7 +61965,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.white_dye",
+                    name: Cow::Borrowed("item.minecraft.white_dye"),
                 },
             ),
             (
@@ -62004,7 +62004,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.white_glazed_terracotta"),
                 },
             ),
             (
@@ -62042,7 +62042,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.white_harness",
+                    name: Cow::Borrowed("item.minecraft.white_harness"),
                 },
             ),
             (
@@ -62096,7 +62096,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.white_shulker_box"),
                 },
             ),
             (
@@ -62135,7 +62135,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.white_stained_glass"),
                 },
             ),
             (
@@ -62173,7 +62173,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.white_stained_glass_pane"),
                 },
             ),
             (
@@ -62211,7 +62211,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_terracotta",
+                    name: Cow::Borrowed("block.minecraft.white_terracotta"),
                 },
             ),
             (
@@ -62249,7 +62249,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_tulip",
+                    name: Cow::Borrowed("block.minecraft.white_tulip"),
                 },
             ),
             (
@@ -62287,7 +62287,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.white_wool",
+                    name: Cow::Borrowed("block.minecraft.white_wool"),
                 },
             ),
             (
@@ -62325,7 +62325,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wild_armor_trim_smithing_template",
+                    name: Cow::Borrowed("item.minecraft.wild_armor_trim_smithing_template"),
                 },
             ),
             (
@@ -62363,7 +62363,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.wildflowers",
+                    name: Cow::Borrowed("block.minecraft.wildflowers"),
                 },
             ),
             (
@@ -62408,7 +62408,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wind_charge",
+                    name: Cow::Borrowed("item.minecraft.wind_charge"),
                 },
             ),
             (
@@ -62446,7 +62446,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.witch_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.witch_spawn_egg"),
                 },
             ),
             (
@@ -62485,7 +62485,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.wither_rose",
+                    name: Cow::Borrowed("block.minecraft.wither_rose"),
                 },
             ),
             (
@@ -62523,7 +62523,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.wither_skeleton_skull",
+                    name: Cow::Borrowed("block.minecraft.wither_skeleton_skull"),
                 },
             ),
             (
@@ -62583,7 +62583,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wither_skeleton_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.wither_skeleton_spawn_egg"),
                 },
             ),
             (
@@ -62622,7 +62622,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wither_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.wither_spawn_egg"),
                 },
             ),
             (
@@ -62661,7 +62661,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wolf_armor",
+                    name: Cow::Borrowed("item.minecraft.wolf_armor"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -62735,7 +62735,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wolf_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.wolf_spawn_egg"),
                 },
             ),
             (
@@ -62774,7 +62774,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wooden_axe",
+                    name: Cow::Borrowed("item.minecraft.wooden_axe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -62857,7 +62857,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wooden_hoe",
+                    name: Cow::Borrowed("item.minecraft.wooden_hoe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -62940,7 +62940,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wooden_pickaxe",
+                    name: Cow::Borrowed("item.minecraft.wooden_pickaxe"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -63023,7 +63023,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wooden_shovel",
+                    name: Cow::Borrowed("item.minecraft.wooden_shovel"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -63106,7 +63106,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wooden_spear",
+                    name: Cow::Borrowed("item.minecraft.wooden_spear"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -63174,7 +63174,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.wooden_sword",
+                    name: Cow::Borrowed("item.minecraft.wooden_sword"),
                 },
             ),
             (Damage, &DamageImpl { damage: 0 }),
@@ -63262,7 +63262,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.writable_book",
+                    name: Cow::Borrowed("item.minecraft.writable_book"),
                 },
             ),
             (
@@ -63304,7 +63304,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.written_book",
+                    name: Cow::Borrowed("item.minecraft.written_book"),
                 },
             ),
             (
@@ -63343,7 +63343,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_banner",
+                    name: Cow::Borrowed("block.minecraft.yellow_banner"),
                 },
             ),
             (
@@ -63382,7 +63382,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_bed",
+                    name: Cow::Borrowed("block.minecraft.yellow_bed"),
                 },
             ),
             (
@@ -63420,7 +63420,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.yellow_bundle",
+                    name: Cow::Borrowed("item.minecraft.yellow_bundle"),
                 },
             ),
             (
@@ -63459,7 +63459,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_candle",
+                    name: Cow::Borrowed("block.minecraft.yellow_candle"),
                 },
             ),
             (
@@ -63497,7 +63497,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_carpet",
+                    name: Cow::Borrowed("block.minecraft.yellow_carpet"),
                 },
             ),
             (
@@ -63554,7 +63554,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_concrete",
+                    name: Cow::Borrowed("block.minecraft.yellow_concrete"),
                 },
             ),
             (
@@ -63592,7 +63592,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_concrete_powder",
+                    name: Cow::Borrowed("block.minecraft.yellow_concrete_powder"),
                 },
             ),
             (
@@ -63630,7 +63630,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.yellow_dye",
+                    name: Cow::Borrowed("item.minecraft.yellow_dye"),
                 },
             ),
             (
@@ -63669,7 +63669,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_glazed_terracotta",
+                    name: Cow::Borrowed("block.minecraft.yellow_glazed_terracotta"),
                 },
             ),
             (
@@ -63707,7 +63707,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.yellow_harness",
+                    name: Cow::Borrowed("item.minecraft.yellow_harness"),
                 },
             ),
             (
@@ -63761,7 +63761,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_shulker_box",
+                    name: Cow::Borrowed("block.minecraft.yellow_shulker_box"),
                 },
             ),
             (
@@ -63800,7 +63800,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_stained_glass",
+                    name: Cow::Borrowed("block.minecraft.yellow_stained_glass"),
                 },
             ),
             (
@@ -63838,7 +63838,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_stained_glass_pane",
+                    name: Cow::Borrowed("block.minecraft.yellow_stained_glass_pane"),
                 },
             ),
             (
@@ -63876,7 +63876,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_terracotta",
+                    name: Cow::Borrowed("block.minecraft.yellow_terracotta"),
                 },
             ),
             (
@@ -63914,7 +63914,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.yellow_wool",
+                    name: Cow::Borrowed("block.minecraft.yellow_wool"),
                 },
             ),
             (
@@ -63952,7 +63952,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.zoglin_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.zoglin_spawn_egg"),
                 },
             ),
             (
@@ -63991,7 +63991,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "block.minecraft.zombie_head",
+                    name: Cow::Borrowed("block.minecraft.zombie_head"),
                 },
             ),
             (
@@ -64051,7 +64051,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.zombie_horse_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.zombie_horse_spawn_egg"),
                 },
             ),
             (
@@ -64090,7 +64090,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.zombie_nautilus_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.zombie_nautilus_spawn_egg"),
                 },
             ),
             (
@@ -64129,7 +64129,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.zombie_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.zombie_spawn_egg"),
                 },
             ),
             (
@@ -64168,7 +64168,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.zombie_villager_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.zombie_villager_spawn_egg"),
                 },
             ),
             (
@@ -64207,7 +64207,7 @@ impl Item {
             (
                 ItemName,
                 &ItemNameImpl {
-                    name: "item.minecraft.zombified_piglin_spawn_egg",
+                    name: Cow::Borrowed("item.minecraft.zombified_piglin_spawn_egg"),
                 },
             ),
             (
@@ -64246,7 +64246,9 @@ impl Item {
             .iter()
             .find_map(|(id, data)| {
                 if id == &ItemName {
-                    data.as_any().downcast_ref::<ItemNameImpl>().map(|n| n.name)
+                    data.as_any()
+                        .downcast_ref::<ItemNameImpl>()
+                        .map(|n| n.name.as_ref())
                 } else {
                     None
                 }

--- a/crates/pumpkin-data/src/generated/villager.rs
+++ b/crates/pumpkin-data/src/generated/villager.rs
@@ -13,6 +13,19 @@ pub struct VillagerTrade {
     pub max_uses: i32,
     pub xp: i32,
     pub price_multiplier: f32,
+    pub modifier: VillagerTradeModifier,
+    pub allowed_types: &'static [VillagerType],
+}
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum VillagerTradeModifier {
+    None,
+    EnchantRandomly,
+    EnchantWithLevels { min: i32, max: i32 },
+    ExplorationMap { destination: &'static str },
+    RandomDyes,
+    RandomPotion,
+    SuspiciousStew,
+    Potion(&'static str),
 }
 #[derive(Clone, Copy, PartialEq)]
 pub struct VillagerTradeSet {
@@ -32,7 +45,9 @@ pub const TRADES_ARMORER_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -46,7 +61,9 @@ pub const TRADES_ARMORER_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -60,7 +77,9 @@ pub const TRADES_ARMORER_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -74,7 +93,25 @@ pub const TRADES_ARMORER_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
+    },
+    VillagerTrade {
+        wants: VillagerTradeItem {
+            item: &crate::item::Item::COAL,
+            count: 15i32,
+        },
+        wants_b: None,
+        gives: VillagerTradeItem {
+            item: &crate::item::Item::EMERALD,
+            count: 1i32,
+        },
+        max_uses: 16i32,
+        xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_ARMORER_LEVEL_2: &[VillagerTrade] = &[
@@ -90,7 +127,9 @@ pub const TRADES_ARMORER_LEVEL_2: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -104,7 +143,41 @@ pub const TRADES_ARMORER_LEVEL_2: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 5i32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
+    },
+    VillagerTrade {
+        wants: VillagerTradeItem {
+            item: &crate::item::Item::EMERALD,
+            count: 36i32,
+        },
+        wants_b: None,
+        gives: VillagerTradeItem {
+            item: &crate::item::Item::BELL,
+            count: 1i32,
+        },
+        max_uses: 12i32,
+        xp: 5i32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
+    },
+    VillagerTrade {
+        wants: VillagerTradeItem {
+            item: &crate::item::Item::IRON_INGOT,
+            count: 4i32,
+        },
+        wants_b: None,
+        gives: VillagerTradeItem {
+            item: &crate::item::Item::EMERALD,
+            count: 1i32,
+        },
+        max_uses: 12i32,
+        xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_ARMORER_LEVEL_3: &[VillagerTrade] = &[
@@ -121,6 +194,8 @@ pub const TRADES_ARMORER_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -134,7 +209,9 @@ pub const TRADES_ARMORER_LEVEL_3: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -148,7 +225,9 @@ pub const TRADES_ARMORER_LEVEL_3: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -162,7 +241,9 @@ pub const TRADES_ARMORER_LEVEL_3: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -177,6 +258,8 @@ pub const TRADES_ARMORER_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_ARMORER_LEVEL_4: &[VillagerTrade] = &[
@@ -192,7 +275,12 @@ pub const TRADES_ARMORER_LEVEL_4: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 15i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -206,7 +294,12 @@ pub const TRADES_ARMORER_LEVEL_4: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 15i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
 ];
 pub const TRADES_ARMORER_LEVEL_5: &[VillagerTrade] = &[
@@ -222,7 +315,12 @@ pub const TRADES_ARMORER_LEVEL_5: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 30i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -236,7 +334,12 @@ pub const TRADES_ARMORER_LEVEL_5: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 30i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
 ];
 pub const TRADES_BUTCHER_LEVEL_1: &[VillagerTrade] = &[
@@ -253,6 +356,8 @@ pub const TRADES_BUTCHER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -267,6 +372,8 @@ pub const TRADES_BUTCHER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -281,6 +388,8 @@ pub const TRADES_BUTCHER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -295,6 +404,8 @@ pub const TRADES_BUTCHER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_BUTCHER_LEVEL_2: &[VillagerTrade] = &[
@@ -311,6 +422,8 @@ pub const TRADES_BUTCHER_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -325,6 +438,8 @@ pub const TRADES_BUTCHER_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -339,6 +454,8 @@ pub const TRADES_BUTCHER_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_BUTCHER_LEVEL_3: &[VillagerTrade] = &[
@@ -355,6 +472,8 @@ pub const TRADES_BUTCHER_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -369,6 +488,8 @@ pub const TRADES_BUTCHER_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_BUTCHER_LEVEL_4: &[VillagerTrade] = &[VillagerTrade {
@@ -384,6 +505,8 @@ pub const TRADES_BUTCHER_LEVEL_4: &[VillagerTrade] = &[VillagerTrade {
     max_uses: 12i32,
     xp: 30i32,
     price_multiplier: 0.05f32,
+    modifier: VillagerTradeModifier::None,
+    allowed_types: &[],
 }];
 pub const TRADES_BUTCHER_LEVEL_5: &[VillagerTrade] = &[VillagerTrade {
     wants: VillagerTradeItem {
@@ -398,6 +521,8 @@ pub const TRADES_BUTCHER_LEVEL_5: &[VillagerTrade] = &[VillagerTrade {
     max_uses: 12i32,
     xp: 30i32,
     price_multiplier: 0.05f32,
+    modifier: VillagerTradeModifier::None,
+    allowed_types: &[],
 }];
 pub const TRADES_CARTOGRAPHER_LEVEL_1: &[VillagerTrade] = &[
     VillagerTrade {
@@ -413,6 +538,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -427,6 +554,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_CARTOGRAPHER_LEVEL_2: &[VillagerTrade] = &[
@@ -435,98 +564,168 @@ pub const TRADES_CARTOGRAPHER_LEVEL_2: &[VillagerTrade] = &[
             item: &crate::item::Item::EMERALD,
             count: 8i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::COMPASS,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::MAP,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::ExplorationMap {
+            destination: "minecraft:on_jungle_explorer_maps",
+        },
+        allowed_types: &[
+            VillagerType::Swamp,
+            VillagerType::Savanna,
+            VillagerType::Desert,
+        ],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 8i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::COMPASS,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::MAP,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::ExplorationMap {
+            destination: "minecraft:on_swamp_explorer_maps",
+        },
+        allowed_types: &[
+            VillagerType::Taiga,
+            VillagerType::Snow,
+            VillagerType::Jungle,
+        ],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 8i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::COMPASS,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::MAP,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::ExplorationMap {
+            destination: "minecraft:on_desert_village_maps",
+        },
+        allowed_types: &[VillagerType::Savanna, VillagerType::Jungle],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 8i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::COMPASS,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::MAP,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::ExplorationMap {
+            destination: "minecraft:on_plains_village_maps",
+        },
+        allowed_types: &[
+            VillagerType::Taiga,
+            VillagerType::Snow,
+            VillagerType::Savanna,
+            VillagerType::Desert,
+        ],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 8i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::COMPASS,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::MAP,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::ExplorationMap {
+            destination: "minecraft:on_savanna_village_maps",
+        },
+        allowed_types: &[
+            VillagerType::Plains,
+            VillagerType::Jungle,
+            VillagerType::Desert,
+        ],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 8i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::COMPASS,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::MAP,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::ExplorationMap {
+            destination: "minecraft:on_snowy_village_maps",
+        },
+        allowed_types: &[VillagerType::Taiga, VillagerType::Swamp],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 8i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::COMPASS,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::MAP,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::ExplorationMap {
+            destination: "minecraft:on_taiga_village_maps",
+        },
+        allowed_types: &[
+            VillagerType::Swamp,
+            VillagerType::Snow,
+            VillagerType::Plains,
+        ],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -541,6 +740,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_CARTOGRAPHER_LEVEL_3: &[VillagerTrade] = &[
@@ -557,34 +758,50 @@ pub const TRADES_CARTOGRAPHER_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 13i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::COMPASS,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::MAP,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::ExplorationMap {
+            destination: "minecraft:on_ocean_explorer_maps",
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 12i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::COMPASS,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::MAP,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::ExplorationMap {
+            destination: "minecraft:on_trial_chambers_maps",
+        },
+        allowed_types: &[],
     },
 ];
 pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
@@ -601,6 +818,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Swamp],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -615,6 +834,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Snow, VillagerType::Taiga],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -629,6 +850,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Plains, VillagerType::Jungle],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -643,6 +866,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Desert, VillagerType::Snow],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -657,6 +882,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Desert],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -671,6 +898,12 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[
+            VillagerType::Desert,
+            VillagerType::Savanna,
+            VillagerType::Jungle,
+        ],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -685,6 +918,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -699,6 +934,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Snow, VillagerType::Swamp],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -713,6 +950,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Desert, VillagerType::Taiga],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -727,6 +966,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Savanna],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -741,6 +982,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Savanna, VillagerType::Desert],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -755,6 +998,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Taiga, VillagerType::Plains],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -769,6 +1014,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Taiga, VillagerType::Swamp],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -783,6 +1030,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Snow, VillagerType::Savanna],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -797,6 +1046,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Snow, VillagerType::Plains],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -811,6 +1062,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Plains, VillagerType::Jungle],
     },
 ];
 pub const TRADES_CARTOGRAPHER_LEVEL_5: &[VillagerTrade] = &[
@@ -819,14 +1072,21 @@ pub const TRADES_CARTOGRAPHER_LEVEL_5: &[VillagerTrade] = &[
             item: &crate::item::Item::EMERALD,
             count: 14i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::COMPASS,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::MAP,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 30i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::ExplorationMap {
+            destination: "minecraft:on_woodland_explorer_maps",
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -841,6 +1101,8 @@ pub const TRADES_CARTOGRAPHER_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_CLERIC_LEVEL_1: &[VillagerTrade] = &[
@@ -857,6 +1119,8 @@ pub const TRADES_CLERIC_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -871,6 +1135,8 @@ pub const TRADES_CLERIC_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_CLERIC_LEVEL_2: &[VillagerTrade] = &[
@@ -887,6 +1153,8 @@ pub const TRADES_CLERIC_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -901,6 +1169,8 @@ pub const TRADES_CLERIC_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_CLERIC_LEVEL_3: &[VillagerTrade] = &[
@@ -917,6 +1187,8 @@ pub const TRADES_CLERIC_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -931,6 +1203,8 @@ pub const TRADES_CLERIC_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_CLERIC_LEVEL_4: &[VillagerTrade] = &[
@@ -947,6 +1221,8 @@ pub const TRADES_CLERIC_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -961,6 +1237,8 @@ pub const TRADES_CLERIC_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -975,6 +1253,8 @@ pub const TRADES_CLERIC_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_CLERIC_LEVEL_5: &[VillagerTrade] = &[
@@ -991,6 +1271,8 @@ pub const TRADES_CLERIC_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1005,6 +1287,8 @@ pub const TRADES_CLERIC_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FARMER_LEVEL_1: &[VillagerTrade] = &[
@@ -1021,6 +1305,8 @@ pub const TRADES_FARMER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1035,6 +1321,8 @@ pub const TRADES_FARMER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1049,6 +1337,8 @@ pub const TRADES_FARMER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1063,6 +1353,8 @@ pub const TRADES_FARMER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1077,6 +1369,8 @@ pub const TRADES_FARMER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FARMER_LEVEL_2: &[VillagerTrade] = &[
@@ -1093,6 +1387,8 @@ pub const TRADES_FARMER_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1107,6 +1403,8 @@ pub const TRADES_FARMER_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1121,6 +1419,8 @@ pub const TRADES_FARMER_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FARMER_LEVEL_3: &[VillagerTrade] = &[
@@ -1137,6 +1437,8 @@ pub const TRADES_FARMER_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1151,6 +1453,8 @@ pub const TRADES_FARMER_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FARMER_LEVEL_4: &[VillagerTrade] = &[
@@ -1167,6 +1471,8 @@ pub const TRADES_FARMER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1181,6 +1487,8 @@ pub const TRADES_FARMER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::SuspiciousStew,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FARMER_LEVEL_5: &[VillagerTrade] = &[
@@ -1197,6 +1505,8 @@ pub const TRADES_FARMER_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1211,6 +1521,8 @@ pub const TRADES_FARMER_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FISHERMAN_LEVEL_1: &[VillagerTrade] = &[
@@ -1227,6 +1539,8 @@ pub const TRADES_FISHERMAN_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1241,13 +1555,18 @@ pub const TRADES_FISHERMAN_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::COD,
             count: 6i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::EMERALD,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::COOKED_COD,
             count: 6i32,
@@ -1255,6 +1574,8 @@ pub const TRADES_FISHERMAN_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1269,6 +1590,8 @@ pub const TRADES_FISHERMAN_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FISHERMAN_LEVEL_2: &[VillagerTrade] = &[
@@ -1285,6 +1608,8 @@ pub const TRADES_FISHERMAN_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1299,13 +1624,18 @@ pub const TRADES_FISHERMAN_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::SALMON,
             count: 6i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::EMERALD,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::COOKED_SALMON,
             count: 6i32,
@@ -1313,6 +1643,8 @@ pub const TRADES_FISHERMAN_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FISHERMAN_LEVEL_3: &[VillagerTrade] = &[
@@ -1328,7 +1660,12 @@ pub const TRADES_FISHERMAN_LEVEL_3: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1343,6 +1680,8 @@ pub const TRADES_FISHERMAN_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FISHERMAN_LEVEL_4: &[VillagerTrade] = &[VillagerTrade {
@@ -1358,6 +1697,8 @@ pub const TRADES_FISHERMAN_LEVEL_4: &[VillagerTrade] = &[VillagerTrade {
     max_uses: 12i32,
     xp: 30i32,
     price_multiplier: 0.05f32,
+    modifier: VillagerTradeModifier::None,
+    allowed_types: &[],
 }];
 pub const TRADES_FISHERMAN_LEVEL_5: &[VillagerTrade] = &[
     VillagerTrade {
@@ -1373,6 +1714,8 @@ pub const TRADES_FISHERMAN_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Savanna],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1387,6 +1730,8 @@ pub const TRADES_FISHERMAN_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Swamp],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1401,6 +1746,8 @@ pub const TRADES_FISHERMAN_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Desert, VillagerType::Jungle],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1415,6 +1762,8 @@ pub const TRADES_FISHERMAN_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Plains],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1429,6 +1778,8 @@ pub const TRADES_FISHERMAN_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1443,6 +1794,8 @@ pub const TRADES_FISHERMAN_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[VillagerType::Taiga, VillagerType::Snow],
     },
 ];
 pub const TRADES_FLETCHER_LEVEL_1: &[VillagerTrade] = &[
@@ -1459,13 +1812,18 @@ pub const TRADES_FLETCHER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::GRAVEL,
             count: 10i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::EMERALD,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::FLINT,
             count: 10i32,
@@ -1473,6 +1831,8 @@ pub const TRADES_FLETCHER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1487,6 +1847,8 @@ pub const TRADES_FLETCHER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FLETCHER_LEVEL_2: &[VillagerTrade] = &[
@@ -1503,6 +1865,8 @@ pub const TRADES_FLETCHER_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1517,6 +1881,8 @@ pub const TRADES_FLETCHER_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FLETCHER_LEVEL_3: &[VillagerTrade] = &[
@@ -1533,6 +1899,8 @@ pub const TRADES_FLETCHER_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1547,6 +1915,8 @@ pub const TRADES_FLETCHER_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FLETCHER_LEVEL_4: &[VillagerTrade] = &[
@@ -1563,6 +1933,11 @@ pub const TRADES_FLETCHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 3i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1577,6 +1952,8 @@ pub const TRADES_FLETCHER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_FLETCHER_LEVEL_5: &[VillagerTrade] = &[
@@ -1585,7 +1962,10 @@ pub const TRADES_FLETCHER_LEVEL_5: &[VillagerTrade] = &[
             item: &crate::item::Item::EMERALD,
             count: 2i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::ARROW,
+            count: 5i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::TIPPED_ARROW,
             count: 5i32,
@@ -1593,6 +1973,8 @@ pub const TRADES_FLETCHER_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::RandomPotion,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1607,6 +1989,11 @@ pub const TRADES_FLETCHER_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 3i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1621,6 +2008,8 @@ pub const TRADES_FLETCHER_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_LEATHERWORKER_LEVEL_1: &[VillagerTrade] = &[
@@ -1636,7 +2025,9 @@ pub const TRADES_LEATHERWORKER_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::RandomDyes,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1650,7 +2041,9 @@ pub const TRADES_LEATHERWORKER_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::RandomDyes,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1665,6 +2058,8 @@ pub const TRADES_LEATHERWORKER_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_LEATHERWORKER_LEVEL_2: &[VillagerTrade] = &[
@@ -1680,7 +2075,9 @@ pub const TRADES_LEATHERWORKER_LEVEL_2: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::RandomDyes,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1694,7 +2091,9 @@ pub const TRADES_LEATHERWORKER_LEVEL_2: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::RandomDyes,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1709,6 +2108,8 @@ pub const TRADES_LEATHERWORKER_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_LEATHERWORKER_LEVEL_3: &[VillagerTrade] = &[
@@ -1724,7 +2125,9 @@ pub const TRADES_LEATHERWORKER_LEVEL_3: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::RandomDyes,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1739,6 +2142,8 @@ pub const TRADES_LEATHERWORKER_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_LEATHERWORKER_LEVEL_4: &[VillagerTrade] = &[
@@ -1754,7 +2159,9 @@ pub const TRADES_LEATHERWORKER_LEVEL_4: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 15i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::RandomDyes,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1769,6 +2176,8 @@ pub const TRADES_LEATHERWORKER_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_LEATHERWORKER_LEVEL_5: &[VillagerTrade] = &[
@@ -1784,7 +2193,9 @@ pub const TRADES_LEATHERWORKER_LEVEL_5: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::RandomDyes,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1798,7 +2209,9 @@ pub const TRADES_LEATHERWORKER_LEVEL_5: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 30i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_LIBRARIAN_LEVEL_1: &[VillagerTrade] = &[
@@ -1807,14 +2220,19 @@ pub const TRADES_LIBRARIAN_LEVEL_1: &[VillagerTrade] = &[
             item: &crate::item::Item::EMERALD,
             count: 0i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::BOOK,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::ENCHANTED_BOOK,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantRandomly,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1829,6 +2247,8 @@ pub const TRADES_LIBRARIAN_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1843,6 +2263,8 @@ pub const TRADES_LIBRARIAN_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_LIBRARIAN_LEVEL_2: &[VillagerTrade] = &[
@@ -1859,20 +2281,27 @@ pub const TRADES_LIBRARIAN_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 0i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::BOOK,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::ENCHANTED_BOOK,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantRandomly,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1887,6 +2316,8 @@ pub const TRADES_LIBRARIAN_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_LIBRARIAN_LEVEL_3: &[VillagerTrade] = &[
@@ -1895,14 +2326,19 @@ pub const TRADES_LIBRARIAN_LEVEL_3: &[VillagerTrade] = &[
             item: &crate::item::Item::EMERALD,
             count: 0i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::BOOK,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::ENCHANTED_BOOK,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantRandomly,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1917,6 +2353,8 @@ pub const TRADES_LIBRARIAN_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1931,6 +2369,8 @@ pub const TRADES_LIBRARIAN_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_LIBRARIAN_LEVEL_4: &[VillagerTrade] = &[
@@ -1939,14 +2379,19 @@ pub const TRADES_LIBRARIAN_LEVEL_4: &[VillagerTrade] = &[
             item: &crate::item::Item::EMERALD,
             count: 0i32,
         },
-        wants_b: None,
+        wants_b: Some(VillagerTradeItem {
+            item: &crate::item::Item::BOOK,
+            count: 1i32,
+        }),
         gives: VillagerTradeItem {
             item: &crate::item::Item::ENCHANTED_BOOK,
             count: 1i32,
         },
         max_uses: 12i32,
         xp: 15i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantRandomly,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1961,6 +2406,8 @@ pub const TRADES_LIBRARIAN_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1975,6 +2422,8 @@ pub const TRADES_LIBRARIAN_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -1989,6 +2438,8 @@ pub const TRADES_LIBRARIAN_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_LIBRARIAN_LEVEL_5: &[VillagerTrade] = &[
@@ -2005,6 +2456,8 @@ pub const TRADES_LIBRARIAN_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2019,6 +2472,8 @@ pub const TRADES_LIBRARIAN_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_MASON_LEVEL_1: &[VillagerTrade] = &[
@@ -2035,6 +2490,8 @@ pub const TRADES_MASON_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2049,6 +2506,8 @@ pub const TRADES_MASON_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_MASON_LEVEL_2: &[VillagerTrade] = &[
@@ -2065,6 +2524,8 @@ pub const TRADES_MASON_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2079,6 +2540,8 @@ pub const TRADES_MASON_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_MASON_LEVEL_3: &[VillagerTrade] = &[
@@ -2095,6 +2558,8 @@ pub const TRADES_MASON_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2109,6 +2574,8 @@ pub const TRADES_MASON_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2123,6 +2590,8 @@ pub const TRADES_MASON_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2137,6 +2606,8 @@ pub const TRADES_MASON_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2151,6 +2622,8 @@ pub const TRADES_MASON_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2165,6 +2638,8 @@ pub const TRADES_MASON_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2179,6 +2654,8 @@ pub const TRADES_MASON_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
@@ -2195,6 +2672,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2209,6 +2688,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2223,6 +2704,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2237,6 +2720,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2251,6 +2736,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2265,6 +2752,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2279,6 +2768,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2293,6 +2784,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2307,6 +2800,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2321,6 +2816,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2335,6 +2832,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2349,6 +2848,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2363,6 +2864,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2377,6 +2880,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2391,6 +2896,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2405,6 +2912,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2419,6 +2928,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2433,6 +2944,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2447,6 +2960,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2461,6 +2976,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2475,6 +2992,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2489,6 +3008,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2503,6 +3024,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2517,6 +3040,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2531,6 +3056,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2545,6 +3072,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2559,6 +3088,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2573,6 +3104,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2587,6 +3120,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2601,6 +3136,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2615,6 +3152,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2629,6 +3168,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2643,6 +3184,8 @@ pub const TRADES_MASON_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_MASON_LEVEL_5: &[VillagerTrade] = &[
@@ -2659,6 +3202,8 @@ pub const TRADES_MASON_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2673,6 +3218,8 @@ pub const TRADES_MASON_LEVEL_5: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_SHEPHERD_LEVEL_1: &[VillagerTrade] = &[
@@ -2689,6 +3236,8 @@ pub const TRADES_SHEPHERD_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2703,6 +3252,8 @@ pub const TRADES_SHEPHERD_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2717,6 +3268,8 @@ pub const TRADES_SHEPHERD_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2731,6 +3284,8 @@ pub const TRADES_SHEPHERD_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2745,6 +3300,8 @@ pub const TRADES_SHEPHERD_LEVEL_1: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
@@ -2761,6 +3318,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2775,6 +3334,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2789,6 +3350,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2803,6 +3366,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2817,6 +3382,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2831,6 +3398,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2845,6 +3414,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2859,6 +3430,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2873,6 +3446,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2887,6 +3462,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2901,6 +3478,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2915,6 +3494,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2929,6 +3510,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2943,6 +3526,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2957,6 +3542,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2971,6 +3558,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2985,6 +3574,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -2999,6 +3590,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3013,6 +3606,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3027,6 +3622,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3041,6 +3638,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3055,6 +3654,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3069,6 +3670,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3083,6 +3686,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3097,6 +3702,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3111,6 +3718,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3125,6 +3734,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3139,6 +3750,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3153,6 +3766,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3167,6 +3782,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3181,6 +3798,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3195,6 +3814,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3209,6 +3830,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 5i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3223,6 +3846,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3237,6 +3862,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3251,6 +3878,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3265,6 +3894,8 @@ pub const TRADES_SHEPHERD_LEVEL_2: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
@@ -3281,6 +3912,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3295,6 +3928,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3309,6 +3944,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3323,6 +3960,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3337,6 +3976,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3351,6 +3992,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3365,6 +4008,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3379,6 +4024,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3393,6 +4040,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3407,6 +4056,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3421,6 +4072,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3435,6 +4088,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3449,6 +4104,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3463,6 +4120,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3477,6 +4136,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3491,6 +4152,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 10i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3505,6 +4168,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3519,6 +4184,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3533,6 +4200,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3547,6 +4216,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3561,6 +4232,8 @@ pub const TRADES_SHEPHERD_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
@@ -3577,6 +4250,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3591,6 +4266,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3605,6 +4282,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3619,6 +4298,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3633,6 +4314,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3647,6 +4330,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3661,6 +4346,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3675,6 +4362,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3689,6 +4378,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3703,6 +4394,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3717,6 +4410,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3731,6 +4426,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3745,6 +4442,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3759,6 +4458,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3773,6 +4474,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3787,6 +4490,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3801,6 +4506,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3815,6 +4522,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3829,6 +4538,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 15i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3843,6 +4554,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3857,6 +4570,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3871,6 +4586,8 @@ pub const TRADES_SHEPHERD_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 16i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_SHEPHERD_LEVEL_5: &[VillagerTrade] = &[VillagerTrade {
@@ -3886,6 +4603,8 @@ pub const TRADES_SHEPHERD_LEVEL_5: &[VillagerTrade] = &[VillagerTrade {
     max_uses: 12i32,
     xp: 30i32,
     price_multiplier: 0.05f32,
+    modifier: VillagerTradeModifier::None,
+    allowed_types: &[],
 }];
 pub const TRADES_TOOLSMITH_LEVEL_1: &[VillagerTrade] = &[
     VillagerTrade {
@@ -3900,7 +4619,9 @@ pub const TRADES_TOOLSMITH_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3914,7 +4635,9 @@ pub const TRADES_TOOLSMITH_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3928,7 +4651,9 @@ pub const TRADES_TOOLSMITH_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -3942,37 +4667,25 @@ pub const TRADES_TOOLSMITH_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
-    },
-];
-pub const TRADES_TOOLSMITH_LEVEL_2: &[VillagerTrade] = &[
-    VillagerTrade {
-        wants: VillagerTradeItem {
-            item: &crate::item::Item::EMERALD,
-            count: 36i32,
-        },
-        wants_b: None,
-        gives: VillagerTradeItem {
-            item: &crate::item::Item::BELL,
-            count: 1i32,
-        },
-        max_uses: 12i32,
-        xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
-            item: &crate::item::Item::IRON_INGOT,
-            count: 4i32,
+            item: &crate::item::Item::COAL,
+            count: 15i32,
         },
         wants_b: None,
         gives: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 1i32,
         },
-        max_uses: 12i32,
-        xp: 10i32,
+        max_uses: 16i32,
+        xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_TOOLSMITH_LEVEL_3: &[VillagerTrade] = &[
@@ -3988,7 +4701,9 @@ pub const TRADES_TOOLSMITH_LEVEL_3: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -4002,7 +4717,12 @@ pub const TRADES_TOOLSMITH_LEVEL_3: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -4016,7 +4736,12 @@ pub const TRADES_TOOLSMITH_LEVEL_3: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -4030,7 +4755,12 @@ pub const TRADES_TOOLSMITH_LEVEL_3: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 10i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -4045,6 +4775,8 @@ pub const TRADES_TOOLSMITH_LEVEL_3: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 20i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_TOOLSMITH_LEVEL_4: &[VillagerTrade] = &[
@@ -4061,6 +4793,8 @@ pub const TRADES_TOOLSMITH_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -4074,7 +4808,12 @@ pub const TRADES_TOOLSMITH_LEVEL_4: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 15i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -4088,7 +4827,12 @@ pub const TRADES_TOOLSMITH_LEVEL_4: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 15i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
 ];
 pub const TRADES_TOOLSMITH_LEVEL_5: &[VillagerTrade] = &[VillagerTrade {
@@ -4103,7 +4847,12 @@ pub const TRADES_TOOLSMITH_LEVEL_5: &[VillagerTrade] = &[VillagerTrade {
     },
     max_uses: 3i32,
     xp: 30i32,
-    price_multiplier: 0.05f32,
+    price_multiplier: 0.2f32,
+    modifier: VillagerTradeModifier::EnchantWithLevels {
+        min: 5i32,
+        max: 19i32,
+    },
+    allowed_types: &[],
 }];
 pub const TRADES_WEAPONSMITH_LEVEL_1: &[VillagerTrade] = &[
     VillagerTrade {
@@ -4118,7 +4867,12 @@ pub const TRADES_WEAPONSMITH_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -4132,37 +4886,25 @@ pub const TRADES_WEAPONSMITH_LEVEL_1: &[VillagerTrade] = &[
         },
         max_uses: 12i32,
         xp: 2i32,
-        price_multiplier: 0.05f32,
-    },
-];
-pub const TRADES_WEAPONSMITH_LEVEL_2: &[VillagerTrade] = &[
-    VillagerTrade {
-        wants: VillagerTradeItem {
-            item: &crate::item::Item::EMERALD,
-            count: 36i32,
-        },
-        wants_b: None,
-        gives: VillagerTradeItem {
-            item: &crate::item::Item::BELL,
-            count: 1i32,
-        },
-        max_uses: 12i32,
-        xp: 5i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
-            item: &crate::item::Item::IRON_INGOT,
-            count: 4i32,
+            item: &crate::item::Item::COAL,
+            count: 15i32,
         },
         wants_b: None,
         gives: VillagerTradeItem {
             item: &crate::item::Item::EMERALD,
             count: 1i32,
         },
-        max_uses: 12i32,
-        xp: 10i32,
+        max_uses: 16i32,
+        xp: 2i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
 ];
 pub const TRADES_WEAPONSMITH_LEVEL_3: &[VillagerTrade] = &[VillagerTrade {
@@ -4178,6 +4920,8 @@ pub const TRADES_WEAPONSMITH_LEVEL_3: &[VillagerTrade] = &[VillagerTrade {
     max_uses: 12i32,
     xp: 20i32,
     price_multiplier: 0.05f32,
+    modifier: VillagerTradeModifier::None,
+    allowed_types: &[],
 }];
 pub const TRADES_WEAPONSMITH_LEVEL_4: &[VillagerTrade] = &[
     VillagerTrade {
@@ -4193,6 +4937,8 @@ pub const TRADES_WEAPONSMITH_LEVEL_4: &[VillagerTrade] = &[
         max_uses: 12i32,
         xp: 30i32,
         price_multiplier: 0.05f32,
+        modifier: VillagerTradeModifier::None,
+        allowed_types: &[],
     },
     VillagerTrade {
         wants: VillagerTradeItem {
@@ -4206,7 +4952,12 @@ pub const TRADES_WEAPONSMITH_LEVEL_4: &[VillagerTrade] = &[
         },
         max_uses: 3i32,
         xp: 15i32,
-        price_multiplier: 0.05f32,
+        price_multiplier: 0.2f32,
+        modifier: VillagerTradeModifier::EnchantWithLevels {
+            min: 5i32,
+            max: 19i32,
+        },
+        allowed_types: &[],
     },
 ];
 pub const TRADES_WEAPONSMITH_LEVEL_5: &[VillagerTrade] = &[VillagerTrade {
@@ -4221,7 +4972,12 @@ pub const TRADES_WEAPONSMITH_LEVEL_5: &[VillagerTrade] = &[VillagerTrade {
     },
     max_uses: 3i32,
     xp: 30i32,
-    price_multiplier: 0.05f32,
+    price_multiplier: 0.2f32,
+    modifier: VillagerTradeModifier::EnchantWithLevels {
+        min: 5i32,
+        max: 19i32,
+    },
+    allowed_types: &[],
 }];
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[repr(i32)]
@@ -4595,10 +5351,6 @@ impl VillagerProfession {
                     trades: TRADES_TOOLSMITH_LEVEL_1,
                     amount: 2i32,
                 }),
-                2i32 => Some(VillagerTradeSet {
-                    trades: TRADES_TOOLSMITH_LEVEL_2,
-                    amount: 2i32,
-                }),
                 3i32 => Some(VillagerTradeSet {
                     trades: TRADES_TOOLSMITH_LEVEL_3,
                     amount: 2i32,
@@ -4616,10 +5368,6 @@ impl VillagerProfession {
             Self::Weaponsmith => match level {
                 1i32 => Some(VillagerTradeSet {
                     trades: TRADES_WEAPONSMITH_LEVEL_1,
-                    amount: 2i32,
-                }),
-                2i32 => Some(VillagerTradeSet {
-                    trades: TRADES_WEAPONSMITH_LEVEL_2,
                     amount: 2i32,
                 }),
                 3i32 => Some(VillagerTradeSet {

--- a/crates/pumpkin-data/src/item_stack/mod.rs
+++ b/crates/pumpkin-data/src/item_stack/mod.rs
@@ -744,7 +744,8 @@ mod tests {
     use super::*;
     use crate::data_component::DataComponent;
     use crate::data_component_impl::{
-        CustomDataImpl, CustomNameImpl, DataComponentImpl, EnchantmentsImpl, UnbreakableImpl,
+        CustomDataImpl, CustomNameImpl, DataComponentImpl, EnchantmentsImpl, ItemNameImpl,
+        UnbreakableImpl,
     };
 
     /// Helper: creates a fresh Iron Sword (max_damage 250, damage 0).
@@ -927,6 +928,32 @@ mod tests {
             Some(NbtTag::String("pos1".into()))
         );
         assert!(decoded.get_data_component::<UnbreakableImpl>().is_some());
+    }
+
+    #[test]
+    fn translated_item_name_survives_item_stack_nbt_roundtrip() {
+        let mut stack = ItemStack::new(1, &Item::FILLED_MAP);
+        stack.patch.push((
+            DataComponent::ItemName,
+            Some(
+                ItemNameImpl {
+                    name: Cow::Borrowed("filled_map.mansion"),
+                }
+                .to_dyn(),
+            ),
+        ));
+
+        let mut compound = NbtCompound::new();
+        stack.write_item_stack(&mut compound);
+        let decoded = ItemStack::read_item_stack(&compound).expect("stack should decode");
+
+        assert_eq!(
+            decoded
+                .get_data_component::<ItemNameImpl>()
+                .expect("item name should decode")
+                .name,
+            "filled_map.mansion"
+        );
     }
 
     // ── damage_item ───────────────────────────────────────────────

--- a/crates/pumpkin-inventory/src/merchant/merchant_screen_handler.rs
+++ b/crates/pumpkin-inventory/src/merchant/merchant_screen_handler.rs
@@ -1,7 +1,16 @@
-use std::any::Any;
-use std::sync::Arc;
+use std::{
+    any::Any,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU8, Ordering},
+    },
+};
 
-use pumpkin_data::{item_stack::ItemStack, screen::WindowType};
+use pumpkin_data::{
+    item_stack::ItemStack,
+    screen::WindowType,
+    statistic::{CustomStatistic, StatisticCategory},
+};
 use pumpkin_world::inventory::Inventory;
 
 use crate::{
@@ -10,15 +19,22 @@ use crate::{
         InventoryPlayer, ItemStackFuture, ScreenHandler, ScreenHandlerBehaviour,
         ScreenHandlerFuture, offer_or_drop_stack,
     },
-    slot::NormalSlot,
+    slot::{BoxFuture, NormalSlot, Slot},
 };
+
+type MerchantValidityCheck = Box<dyn Fn(&dyn InventoryPlayer) -> bool + Send + Sync>;
 
 pub struct MerchantScreenHandler {
     pub inventory: Arc<dyn Inventory>,
     behaviour: ScreenHandlerBehaviour,
     selected_offer: usize,
+    active_offer: Option<usize>,
     pub offers: Vec<pumpkin_protocol::java::client::play::MerchantOffer>,
-    pub on_trade: Option<Box<dyn Fn(usize) + Send + Sync>>,
+    pub on_trade: Option<Box<dyn Fn(usize) -> ScreenHandlerFuture<'static, ()> + Send + Sync>>,
+    pub on_trade_updated: Option<Box<dyn Fn(bool) + Send + Sync>>,
+    pub on_close: Option<Box<dyn Fn() -> ScreenHandlerFuture<'static, ()> + Send + Sync>>,
+    pub validity_check: Option<MerchantValidityCheck>,
+    result_taken: Arc<AtomicBool>,
 }
 
 impl MerchantScreenHandler {
@@ -28,20 +44,32 @@ impl MerchantScreenHandler {
         inventory: Arc<dyn Inventory>,
         offers: Vec<pumpkin_protocol::java::client::play::MerchantOffer>,
     ) -> Self {
+        let result_taken = Arc::new(AtomicBool::new(false));
+        let mut behaviour = ScreenHandlerBehaviour::new(sync_id, Some(WindowType::Merchant));
+        behaviour.container_slots = 3;
         let mut handler = Self {
             inventory: inventory.clone(),
-            behaviour: ScreenHandlerBehaviour::new(sync_id, Some(WindowType::Merchant)),
+            behaviour,
             selected_offer: 0,
+            active_offer: None,
             offers,
             on_trade: None,
+            on_trade_updated: None,
+            on_close: None,
+            validity_check: None,
+            result_taken: result_taken.clone(),
         };
 
         inventory.on_open().await;
 
-        // Merchant specific slots: 2 input, 1 output
-        for i in 0..3 {
+        for i in 0..2 {
             handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), i)));
         }
+        handler.add_slot(Arc::new(MerchantResultSlot::new(
+            inventory.clone(),
+            2,
+            result_taken,
+        )));
 
         let player_inventory: Arc<dyn Inventory> = player_inventory.clone();
         handler.add_player_slots(&player_inventory);
@@ -51,35 +79,253 @@ impl MerchantScreenHandler {
 
     pub async fn set_selected_offer(&mut self, index: usize) {
         self.selected_offer = index;
+        self.try_move_items(index).await;
         self.update_result_slot().await;
+        self.notify_trade_updated().await;
         self.send_content_updates().await;
     }
 
-    pub async fn update_result_slot(&mut self) {
-        if self.selected_offer >= self.offers.len() {
-            self.inventory.set_stack(2, ItemStack::EMPTY.clone()).await;
+    async fn try_move_items(&mut self, index: usize) {
+        let Some(offer) = self.offers.get(index) else {
+            return;
+        };
+        let cost_a = offer.base_cost_a.0.as_ref().clone();
+        let cost_b = offer.cost_b.as_ref().map(|cost| cost.0.as_ref().clone());
+        let player_slots_end = self.get_behaviour().slots.len() as i32;
+
+        for index in 0..2 {
+            let mut stack = self.inventory.get_stack(index).await;
+            if !stack.is_empty()
+                && !self
+                    .insert_item(&mut stack, 3, player_slots_end, true)
+                    .await
+            {
+                return;
+            }
+            self.inventory.set_stack(index, stack).await;
+        }
+
+        if !self.inventory.get_stack(0).await.is_empty()
+            || !self.inventory.get_stack(1).await.is_empty()
+        {
             return;
         }
 
-        let offer = &self.offers[self.selected_offer];
+        self.move_from_inventory_to_payment_slot(0, &cost_a).await;
+        if let Some(cost_b) = cost_b {
+            self.move_from_inventory_to_payment_slot(1, &cost_b).await;
+        }
+    }
+
+    fn adjusted_cost_a(offer: &pumpkin_protocol::java::client::play::MerchantOffer) -> ItemStack {
+        let mut cost = offer.base_cost_a.0.as_ref().clone();
+        let demand = i32::from(cost.item_count).saturating_mul(offer.demand) as f32;
+        let demand_bonus = (demand * offer.price_multiplier).floor().max(0.0) as i32;
+        let count = i32::from(cost.item_count)
+            .saturating_add(demand_bonus)
+            .saturating_add(offer.special_price)
+            .clamp(1, i32::from(cost.get_max_stack_size()));
+        cost.set_count(count as u8);
+        cost
+    }
+
+    fn matches_cost(cost: &ItemStack, input: &ItemStack) -> bool {
+        !input.is_empty()
+            && cost.are_items_and_components_equal(input)
+            && input.item_count >= cost.item_count
+    }
+
+    fn satisfies(
+        offer: &pumpkin_protocol::java::client::play::MerchantOffer,
+        input_a: &ItemStack,
+        input_b: &ItemStack,
+    ) -> bool {
+        Self::matches_cost(&Self::adjusted_cost_a(offer), input_a)
+            && offer.cost_b.as_ref().map_or_else(
+                || input_b.is_empty(),
+                |cost_b| Self::matches_cost(&cost_b.0, input_b),
+            )
+    }
+
+    fn input_order(
+        offer: &pumpkin_protocol::java::client::play::MerchantOffer,
+        input_a: &ItemStack,
+        input_b: &ItemStack,
+    ) -> Option<bool> {
+        if Self::satisfies(offer, input_a, input_b) {
+            Some(false)
+        } else if Self::satisfies(offer, input_b, input_a) {
+            Some(true)
+        } else {
+            None
+        }
+    }
+
+    fn matching_offer(&self, input_a: &ItemStack, input_b: &ItemStack) -> Option<usize> {
+        if self.selected_offer > 0 && self.selected_offer < self.offers.len() {
+            return Self::satisfies(&self.offers[self.selected_offer], input_a, input_b)
+                .then_some(self.selected_offer);
+        }
+
+        self.offers
+            .iter()
+            .position(|offer| Self::satisfies(offer, input_a, input_b))
+    }
+
+    fn find_active_offer(&self, input_a: &ItemStack, input_b: &ItemStack) -> Option<usize> {
+        self.matching_offer(input_a, input_b)
+            .filter(|&index| !self.offers[index].is_out_of_stock())
+            .or_else(|| {
+                self.matching_offer(input_b, input_a)
+                    .filter(|&index| !self.offers[index].is_out_of_stock())
+            })
+    }
+
+    async fn consume_payment(&self, slot: usize, count: u8) {
+        let mut stack = self.inventory.get_stack(slot).await;
+        stack.decrement(count);
+        if stack.is_empty() {
+            stack = ItemStack::EMPTY.clone();
+        }
+        self.inventory.set_stack(slot, stack).await;
+        self.get_behaviour().slots[slot].mark_dirty().await;
+    }
+
+    async fn complete_trade(&mut self, player: &dyn InventoryPlayer) -> bool {
+        let Some(offer_index) = self.active_offer else {
+            return false;
+        };
+        let Some(offer) = self.offers.get(offer_index) else {
+            return false;
+        };
+        if offer.is_out_of_stock() {
+            return false;
+        }
+
         let input_a = self.inventory.get_stack(0).await;
         let input_b = self.inventory.get_stack(1).await;
+        let Some(swapped) = Self::input_order(offer, &input_a, &input_b) else {
+            return false;
+        };
+        let cost_a = Self::adjusted_cost_a(offer).item_count;
+        let cost_b = offer.cost_b.as_ref().map(|cost| cost.0.item_count);
 
-        let match_a = input_a.are_items_and_components_equal(&offer.base_cost_a.0)
-            && input_a.item_count >= offer.base_cost_a.0.item_count;
+        self.consume_payment(usize::from(swapped), cost_a).await;
+        if let Some(cost_b) = cost_b {
+            self.consume_payment(usize::from(!swapped), cost_b).await;
+        }
+        self.offers[offer_index].uses += 1;
 
-        let match_b = offer.cost_b.as_ref().map_or_else(
-            || input_b.is_empty(),
-            |cost_b| {
-                input_b.are_items_and_components_equal(&cost_b.0)
-                    && input_b.item_count >= cost_b.0.item_count
-            },
-        );
+        if let Some(on_trade) = &self.on_trade {
+            on_trade(offer_index).await;
+        }
+        player
+            .increment_stat(
+                StatisticCategory::Custom,
+                CustomStatistic::TradedWithVillager as i32,
+                1,
+            )
+            .await;
+        true
+    }
 
-        if match_a && match_b {
-            self.inventory.set_stack(2, (*offer.output.0).clone()).await;
+    /// Completes a trade selected through Bedrock's item-stack request protocol.
+    ///
+    /// Bedrock moves the result directly between named containers instead of
+    /// sending Java's slot-click action, so the caller has already validated
+    /// that the result can be inserted into its destination.
+    pub async fn complete_bedrock_trade(&mut self, player: &dyn InventoryPlayer) -> bool {
+        if !self.complete_trade(player).await {
+            return false;
+        }
+        self.update_result_slot().await;
+        self.notify_trade_updated().await;
+        self.send_content_updates().await;
+        true
+    }
+
+    async fn can_fully_insert(&self, stack: &ItemStack, start: usize, end: usize) -> bool {
+        let mut remaining = stack.item_count;
+        for slot in &self.get_behaviour().slots[start..end] {
+            if !slot.can_insert(stack).await {
+                continue;
+            }
+            let existing = slot.get_cloned_stack().await;
+            let capacity = if existing.is_empty() {
+                slot.get_max_item_count_for_stack(stack).await
+            } else if existing.are_items_and_components_equal(stack)
+                && stack.are_items_and_components_equal(&existing)
+            {
+                slot.get_max_item_count_for_stack(&existing)
+                    .await
+                    .saturating_sub(existing.item_count)
+            } else {
+                0
+            };
+            remaining = remaining.saturating_sub(capacity);
+            if remaining == 0 {
+                return true;
+            }
+        }
+        false
+    }
+
+    async fn move_from_inventory_to_payment_slot(&self, payment_slot: usize, cost: &ItemStack) {
+        let mut payment = self.inventory.get_stack(payment_slot).await;
+
+        for slot in &self.get_behaviour().slots[3..] {
+            let mut source = slot.get_stack().await;
+            if source.is_empty()
+                || source.item.id != cost.item.id
+                || !cost.are_items_and_components_equal(&source)
+                || (!payment.is_empty()
+                    && (!source.are_items_and_components_equal(&payment)
+                        || !payment.are_items_and_components_equal(&source)))
+            {
+                continue;
+            }
+
+            if payment.is_empty() {
+                payment = source.copy_with_count(0);
+            }
+            let moved = source
+                .item_count
+                .min(source.get_max_stack_size() - payment.item_count);
+            payment.increment(moved);
+            source.decrement(moved);
+            if source.is_empty() {
+                source = ItemStack::EMPTY.clone();
+            }
+            slot.set_stack(source).await;
+            if payment.item_count == payment.get_max_stack_size() {
+                break;
+            }
+        }
+        self.inventory.set_stack(payment_slot, payment).await;
+    }
+
+    pub async fn update_result_slot(&mut self) {
+        let input_a = self.inventory.get_stack(0).await;
+        let input_b = self.inventory.get_stack(1).await;
+        self.active_offer = self.find_active_offer(&input_a, &input_b);
+
+        if let Some(index) = self.active_offer {
+            self.inventory
+                .set_stack(2, (*self.offers[index].output.0).clone())
+                .await;
         } else {
             self.inventory.set_stack(2, ItemStack::EMPTY.clone()).await;
+        }
+    }
+
+    async fn notify_trade_updated(&self) {
+        if self.inventory.get_stack(0).await.is_empty()
+            && self.inventory.get_stack(1).await.is_empty()
+        {
+            return;
+        }
+        if let Some(on_trade_updated) = &self.on_trade_updated {
+            on_trade_updated(self.active_offer.is_some());
         }
     }
 }
@@ -93,6 +339,12 @@ impl ScreenHandler for MerchantScreenHandler {
         self
     }
 
+    fn can_use(&self, player: &dyn InventoryPlayer) -> bool {
+        self.validity_check
+            .as_ref()
+            .is_none_or(|check| check(player))
+    }
+
     fn get_behaviour(&self) -> &ScreenHandlerBehaviour {
         &self.behaviour
     }
@@ -103,6 +355,9 @@ impl ScreenHandler for MerchantScreenHandler {
 
     fn on_closed<'a>(&'a mut self, player: &'a dyn InventoryPlayer) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
+            if let Some(on_close) = &self.on_close {
+                on_close().await;
+            }
             self.default_on_closed(player).await;
             self.inventory.on_close().await;
             // Vanilla drops items from merchant container on close
@@ -120,45 +375,83 @@ impl ScreenHandler for MerchantScreenHandler {
 
     fn quick_move<'a>(
         &'a mut self,
-        _player: &'a dyn InventoryPlayer,
+        player: &'a dyn InventoryPlayer,
         slot_index: i32,
     ) -> ItemStackFuture<'a> {
         Box::pin(async move {
-            let mut stack_left = ItemStack::EMPTY.clone();
+            const PLAYER_INVENTORY_START: i32 = 3;
+            const PLAYER_HOTBAR_START: i32 = 30;
+
             let slot = self.get_behaviour().slots[slot_index as usize].clone();
+            let mut stack = slot.get_cloned_stack().await;
+            if stack.is_empty() {
+                return ItemStack::EMPTY.clone();
+            }
+            let original = stack.clone();
+            let player_slots_end = self.get_behaviour().slots.len() as i32;
 
-            if slot.has_stack().await {
-                let mut slot_stack = slot.get_stack().await;
-                stack_left = slot_stack.clone();
-
-                if slot_index < 3 {
-                    // From merchant slots to player inventory
-                    if !self
-                        .insert_item(
-                            &mut slot_stack,
-                            3,
-                            self.get_behaviour().slots.len() as i32,
-                            true,
-                        )
+            if slot_index == 2 {
+                if !self
+                    .can_fully_insert(
+                        &stack,
+                        PLAYER_INVENTORY_START as usize,
+                        player_slots_end as usize,
+                    )
+                    .await
+                    || !self
+                        .insert_item(&mut stack, PLAYER_INVENTORY_START, player_slots_end, true)
                         .await
-                    {
-                        return ItemStack::EMPTY.clone();
-                    }
-                } else {
-                    // From player inventory to merchant
-                    if !self.insert_item(&mut slot_stack, 0, 2, false).await {
-                        return ItemStack::EMPTY.clone();
-                    }
+                {
+                    return ItemStack::EMPTY.clone();
                 }
-
-                if slot_stack.is_empty() {
-                    slot.set_stack(ItemStack::EMPTY.clone()).await;
-                } else {
-                    slot.set_stack(slot_stack).await;
+            } else if slot_index < PLAYER_INVENTORY_START {
+                if !self
+                    .insert_item(&mut stack, PLAYER_INVENTORY_START, player_slots_end, false)
+                    .await
+                {
+                    return ItemStack::EMPTY.clone();
                 }
+            } else if slot_index < PLAYER_HOTBAR_START {
+                if !self
+                    .insert_item(&mut stack, PLAYER_HOTBAR_START, player_slots_end, false)
+                    .await
+                {
+                    return ItemStack::EMPTY.clone();
+                }
+            } else if !self
+                .insert_item(
+                    &mut stack,
+                    PLAYER_INVENTORY_START,
+                    PLAYER_HOTBAR_START,
+                    false,
+                )
+                .await
+            {
+                return ItemStack::EMPTY.clone();
             }
 
-            stack_left
+            if stack.item_count == original.item_count {
+                return ItemStack::EMPTY.clone();
+            }
+            if stack.is_empty() {
+                slot.set_stack(ItemStack::EMPTY.clone()).await;
+            } else {
+                slot.set_stack(stack.clone()).await;
+            }
+
+            let mut taken = original.clone();
+            taken.set_count(original.item_count - stack.item_count);
+            slot.on_take_item(player, &taken).await;
+            if slot_index == 2 {
+                slot.on_quick_move_crafted(stack, original.clone()).await;
+                self.result_taken.store(false, Ordering::Relaxed);
+                if !self.complete_trade(player).await {
+                    return ItemStack::EMPTY.clone();
+                }
+                self.update_result_slot().await;
+            }
+
+            original
         })
     }
 
@@ -171,51 +464,538 @@ impl ScreenHandler for MerchantScreenHandler {
     ) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
             if slot_index == 2 {
-                // Special handling for taking from output slot
-                let result_slot = self.get_behaviour().slots[2].clone();
-                if result_slot.has_stack().await {
-                    let result_stack = result_slot.get_cloned_stack().await;
-                    if !result_stack.is_empty() {
-                        // Consume inputs
-                        let (count_a, count_b, offer_xp) = {
-                            let offer = &mut self.offers[self.selected_offer];
-                            offer.uses += 1;
-                            let count_b = offer.cost_b.as_ref().map(|c| c.0.item_count);
-                            (offer.base_cost_a.0.item_count, count_b, offer.xp)
-                        };
-
-                        let mut input_a = self.inventory.get_stack(0).await;
-                        input_a.decrement(count_a);
-                        if input_a.is_empty() {
-                            input_a = ItemStack::EMPTY.clone();
-                        }
-                        self.inventory.set_stack(0, input_a).await;
-
-                        if let Some(count_b) = count_b {
-                            let mut input_b = self.inventory.get_stack(1).await;
-                            input_b.decrement(count_b);
-                            if input_b.is_empty() {
-                                input_b = ItemStack::EMPTY.clone();
-                            }
-                            self.inventory.set_stack(1, input_b).await;
-                        }
-
-                        // Award XP
-                        player.award_experience(offer_xp).await;
-
-                        if let Some(on_trade) = &self.on_trade {
-                            on_trade(self.selected_offer);
-                        }
-                    }
-                }
+                self.update_result_slot().await;
             }
-
+            self.result_taken.store(false, Ordering::Relaxed);
             self.internal_on_slot_click(slot_index, button, action_type, player)
                 .await;
-            if slot_index == 0 || slot_index == 1 || slot_index == 2 {
-                self.update_result_slot().await;
-                self.send_content_updates().await;
+            if self.result_taken.swap(false, Ordering::Relaxed) {
+                self.complete_trade(player).await;
             }
+            self.update_result_slot().await;
+            self.notify_trade_updated().await;
+            self.send_content_updates().await;
         })
+    }
+}
+
+struct MerchantResultSlot {
+    inventory: Arc<dyn Inventory>,
+    index: usize,
+    id: AtomicU8,
+    result_taken: Arc<AtomicBool>,
+}
+
+impl MerchantResultSlot {
+    fn new(inventory: Arc<dyn Inventory>, index: usize, result_taken: Arc<AtomicBool>) -> Self {
+        Self {
+            inventory,
+            index,
+            id: AtomicU8::new(0),
+            result_taken,
+        }
+    }
+}
+
+impl Slot for MerchantResultSlot {
+    fn get_inventory(&self) -> Arc<dyn Inventory> {
+        self.inventory.clone()
+    }
+
+    fn get_index(&self) -> usize {
+        self.index
+    }
+
+    fn set_id(&self, id: usize) {
+        self.id.store(id as u8, Ordering::Relaxed);
+    }
+
+    fn take_stack(&self, _amount: u8) -> BoxFuture<'_, ItemStack> {
+        Box::pin(async move { self.inventory.remove_stack(self.index).await })
+    }
+
+    fn on_take_item<'a>(
+        &'a self,
+        _player: &'a dyn InventoryPlayer,
+        _stack: &'a ItemStack,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            self.result_taken.store(true, Ordering::Relaxed);
+            self.mark_dirty().await;
+        })
+    }
+
+    fn can_insert(&self, _stack: &ItemStack) -> BoxFuture<'_, bool> {
+        Box::pin(async { false })
+    }
+
+    fn mark_dirty(&self) -> BoxFuture<'_, ()> {
+        Box::pin(async move {
+            self.inventory.mark_dirty();
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        borrow::Cow,
+        collections::HashMap,
+        sync::atomic::{AtomicI32, AtomicUsize, Ordering},
+    };
+
+    use pumpkin_data::{data_component_impl::EquipmentSlot, item::Item};
+    use pumpkin_protocol::{
+        codec::item_stack_seralizer::ItemStackSerializer,
+        java::{
+            client::play::{
+                CSetContainerContent, CSetContainerProperty, CSetContainerSlot, CSetCursorItem,
+                CSetPlayerInventory, CSetSelectedSlot,
+            },
+            server::play::SlotActionType,
+        },
+    };
+    use pumpkin_world::inventory::SimpleInventory;
+    use tokio::sync::Mutex;
+
+    use crate::{
+        entity_equipment::EntityEquipment,
+        screen_handler::{InventoryPlayer, PlayerFuture},
+    };
+
+    use super::*;
+
+    fn single_cost_offer(
+        cost: &'static Item,
+        cost_count: u8,
+        output: &'static Item,
+        max_uses: i32,
+    ) -> pumpkin_protocol::java::client::play::MerchantOffer {
+        pumpkin_protocol::java::client::play::MerchantOffer {
+            base_cost_a: ItemStackSerializer(Cow::Owned(ItemStack::new(cost_count, cost))),
+            output: ItemStackSerializer(Cow::Owned(ItemStack::new(1, output))),
+            cost_b: None,
+            reward_exp: true,
+            uses: 0,
+            max_uses,
+            xp: 2,
+            special_price: 0,
+            price_multiplier: 0.05,
+            demand: 0,
+        }
+    }
+
+    fn bookshelf_offer() -> pumpkin_protocol::java::client::play::MerchantOffer {
+        single_cost_offer(&Item::EMERALD, 9, &Item::BOOKSHELF, 12)
+    }
+
+    struct TestPlayer {
+        inventory: Arc<PlayerInventory>,
+        experience: AtomicI32,
+        traded: AtomicI32,
+    }
+
+    impl TestPlayer {
+        fn new(inventory: Arc<PlayerInventory>) -> Self {
+            Self {
+                inventory,
+                experience: AtomicI32::new(0),
+                traded: AtomicI32::new(0),
+            }
+        }
+    }
+
+    impl InventoryPlayer for TestPlayer {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn drop_item(&self, _item: ItemStack, _retain_ownership: bool) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+
+        fn get_inventory(&self) -> Arc<PlayerInventory> {
+            self.inventory.clone()
+        }
+
+        fn has_infinite_materials(&self) -> bool {
+            false
+        }
+
+        fn is_creative(&self) -> bool {
+            false
+        }
+
+        fn experience_level(&self) -> i32 {
+            0
+        }
+
+        fn add_experience_levels(&self, _levels: i32) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+
+        fn enchantment_seed(&self) -> i32 {
+            0
+        }
+
+        fn set_enchantment_seed(&self, _seed: i32) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_inventory_packet<'a>(
+            &'a self,
+            _packet: &'a CSetContainerContent,
+            _window_type: Option<WindowType>,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_slot_packet<'a>(
+            &'a self,
+            _packet: &'a CSetContainerSlot,
+            _window_type: Option<WindowType>,
+            _total_slots: usize,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_cursor_packet<'a>(
+            &'a self,
+            _packet: &'a CSetCursorItem,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_property_packet<'a>(
+            &'a self,
+            _packet: &'a CSetContainerProperty,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_slot_set_packet<'a>(
+            &'a self,
+            _packet: &'a CSetPlayerInventory,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_set_held_item_packet<'a>(
+            &'a self,
+            _packet: &'a CSetSelectedSlot,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_equipment_change<'a>(
+            &'a self,
+            _slot: &'a EquipmentSlot,
+            _stack: &'a ItemStack,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn award_experience(&self, amount: i32) -> PlayerFuture<'_, ()> {
+            Box::pin(async move {
+                self.experience.fetch_add(amount, Ordering::Relaxed);
+            })
+        }
+
+        fn increment_stat(
+            &self,
+            category: StatisticCategory,
+            stat_id: i32,
+            amount: i32,
+        ) -> PlayerFuture<'_, ()> {
+            Box::pin(async move {
+                if category == StatisticCategory::Custom
+                    && stat_id == CustomStatistic::TradedWithVillager as i32
+                {
+                    self.traded.fetch_add(amount, Ordering::Relaxed);
+                }
+            })
+        }
+    }
+
+    fn inventories() -> (Arc<PlayerInventory>, Arc<SimpleInventory>) {
+        (
+            Arc::new(PlayerInventory::new(
+                Arc::new(Mutex::new(EntityEquipment::new())),
+                Arc::new(HashMap::new()),
+            )),
+            Arc::new(SimpleInventory::new(3)),
+        )
+    }
+
+    #[tokio::test]
+    async fn selecting_bookshelf_trade_moves_payment_and_creates_result() {
+        let (player_inventory, merchant_inventory) = inventories();
+        player_inventory
+            .set_stack(0, ItemStack::new(12, &Item::EMERALD))
+            .await;
+        let mut handler = MerchantScreenHandler::new(
+            1,
+            &player_inventory,
+            merchant_inventory.clone(),
+            vec![bookshelf_offer()],
+        )
+        .await;
+
+        handler.set_selected_offer(0).await;
+
+        let payment = merchant_inventory.get_stack(0).await;
+        assert_eq!(payment.item_count, 12);
+        let result = merchant_inventory.get_stack(2).await;
+        assert_eq!(result.item.id, Item::BOOKSHELF.id);
+        assert!(player_inventory.get_stack(0).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn taking_result_commits_payment_after_delivery() {
+        let (player_inventory, merchant_inventory) = inventories();
+        merchant_inventory
+            .set_stack(0, ItemStack::new(12, &Item::EMERALD))
+            .await;
+        let player = TestPlayer::new(player_inventory.clone());
+        let mut handler = MerchantScreenHandler::new(
+            1,
+            &player_inventory,
+            merchant_inventory.clone(),
+            vec![bookshelf_offer()],
+        )
+        .await;
+        let trade_count = Arc::new(AtomicUsize::new(0));
+        handler.on_trade = Some(Box::new({
+            let trade_count = trade_count.clone();
+            move |_| {
+                let trade_count = trade_count.clone();
+                Box::pin(async move {
+                    trade_count.fetch_add(1, Ordering::Relaxed);
+                })
+            }
+        }));
+        handler.update_result_slot().await;
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Pickup, &player)
+            .await;
+
+        assert_eq!(handler.offers[0].uses, 1);
+        assert_eq!(merchant_inventory.get_stack(0).await.item_count, 3);
+        assert_eq!(
+            handler.get_behaviour().cursor_stack.lock().await.item.id,
+            Item::BOOKSHELF.id
+        );
+        assert_eq!(player.traded.load(Ordering::Relaxed), 1);
+        assert_eq!(trade_count.load(Ordering::Relaxed), 1);
+        assert_eq!(player.experience.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn bedrock_result_request_commits_the_trade() {
+        let (player_inventory, merchant_inventory) = inventories();
+        merchant_inventory
+            .set_stack(0, ItemStack::new(12, &Item::EMERALD))
+            .await;
+        let player = TestPlayer::new(player_inventory.clone());
+        let mut handler = MerchantScreenHandler::new(
+            1,
+            &player_inventory,
+            merchant_inventory.clone(),
+            vec![bookshelf_offer()],
+        )
+        .await;
+        let trade_count = Arc::new(AtomicUsize::new(0));
+        handler.on_trade = Some(Box::new({
+            let trade_count = trade_count.clone();
+            move |_| {
+                let trade_count = trade_count.clone();
+                Box::pin(async move {
+                    trade_count.fetch_add(1, Ordering::Relaxed);
+                })
+            }
+        }));
+        handler.update_result_slot().await;
+
+        assert!(handler.complete_bedrock_trade(&player).await);
+
+        assert_eq!(handler.offers[0].uses, 1);
+        assert_eq!(merchant_inventory.get_stack(0).await.item_count, 3);
+        assert_eq!(player.traded.load(Ordering::Relaxed), 1);
+        assert_eq!(trade_count.load(Ordering::Relaxed), 1);
+        assert!(merchant_inventory.get_stack(2).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn selection_hint_zero_resolves_matching_offer() {
+        let (player_inventory, merchant_inventory) = inventories();
+        merchant_inventory
+            .set_stack(0, ItemStack::new(64, &Item::PAPER))
+            .await;
+        let player = TestPlayer::new(player_inventory.clone());
+        let mut handler = MerchantScreenHandler::new(
+            1,
+            &player_inventory,
+            merchant_inventory.clone(),
+            vec![
+                bookshelf_offer(),
+                single_cost_offer(&Item::PAPER, 24, &Item::EMERALD, 16),
+            ],
+        )
+        .await;
+        let traded_offer = Arc::new(AtomicUsize::new(usize::MAX));
+        handler.on_trade = Some(Box::new({
+            let traded_offer = traded_offer.clone();
+            move |offer_index| {
+                let traded_offer = traded_offer.clone();
+                Box::pin(async move {
+                    traded_offer.store(offer_index, Ordering::Relaxed);
+                })
+            }
+        }));
+        handler.update_result_slot().await;
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Pickup, &player)
+            .await;
+
+        assert_eq!(handler.offers[0].uses, 0);
+        assert_eq!(handler.offers[1].uses, 1);
+        assert_eq!(traded_offer.load(Ordering::Relaxed), 1);
+        assert_eq!(merchant_inventory.get_stack(0).await.item_count, 40);
+        assert_eq!(
+            handler.get_behaviour().cursor_stack.lock().await.item.id,
+            Item::EMERALD.id
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_payment_does_not_notify_the_merchant() {
+        let (player_inventory, merchant_inventory) = inventories();
+        merchant_inventory
+            .set_stack(0, ItemStack::new(8, &Item::EMERALD))
+            .await;
+        let player = TestPlayer::new(player_inventory.clone());
+        let mut handler = MerchantScreenHandler::new(
+            1,
+            &player_inventory,
+            merchant_inventory.clone(),
+            vec![bookshelf_offer()],
+        )
+        .await;
+        let trade_count = Arc::new(AtomicUsize::new(0));
+        handler.on_trade = Some(Box::new({
+            let trade_count = trade_count.clone();
+            move |_| {
+                let trade_count = trade_count.clone();
+                Box::pin(async move {
+                    trade_count.fetch_add(1, Ordering::Relaxed);
+                })
+            }
+        }));
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Pickup, &player)
+            .await;
+
+        assert_eq!(handler.offers[0].uses, 0);
+        assert_eq!(trade_count.load(Ordering::Relaxed), 0);
+        assert_eq!(player.traded.load(Ordering::Relaxed), 0);
+        assert_eq!(merchant_inventory.get_stack(0).await.item_count, 8);
+        assert!(handler.get_behaviour().cursor_stack.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn full_inventory_does_not_commit_quick_moved_trade() {
+        let (player_inventory, merchant_inventory) = inventories();
+        player_inventory
+            .main_inventory
+            .write()
+            .await
+            .fill_with(|| ItemStack::new(64, &Item::COBBLESTONE));
+        merchant_inventory
+            .set_stack(0, ItemStack::new(9, &Item::EMERALD))
+            .await;
+        let player = TestPlayer::new(player_inventory.clone());
+        let mut handler = MerchantScreenHandler::new(
+            1,
+            &player_inventory,
+            merchant_inventory.clone(),
+            vec![bookshelf_offer()],
+        )
+        .await;
+        handler.update_result_slot().await;
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::QuickMove, &player)
+            .await;
+
+        assert_eq!(handler.offers[0].uses, 0);
+        assert_eq!(merchant_inventory.get_stack(0).await.item_count, 9);
+        assert_eq!(
+            merchant_inventory.get_stack(2).await.item.id,
+            Item::BOOKSHELF.id
+        );
+        assert_eq!(player.traded.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn quick_move_repeats_while_payment_and_stock_remain() {
+        let (player_inventory, merchant_inventory) = inventories();
+        merchant_inventory
+            .set_stack(0, ItemStack::new(64, &Item::EMERALD))
+            .await;
+        let player = TestPlayer::new(player_inventory.clone());
+        let mut handler = MerchantScreenHandler::new(
+            1,
+            &player_inventory,
+            merchant_inventory.clone(),
+            vec![bookshelf_offer()],
+        )
+        .await;
+        handler.update_result_slot().await;
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::QuickMove, &player)
+            .await;
+
+        assert_eq!(handler.offers[0].uses, 7);
+        assert_eq!(player.traded.load(Ordering::Relaxed), 7);
+        assert_eq!(merchant_inventory.get_stack(0).await.item_count, 1);
+        assert_eq!(player_inventory.get_stack(8).await.item_count, 7);
+    }
+
+    #[tokio::test]
+    async fn swapped_payment_slots_are_accepted_and_consumed() {
+        let (player_inventory, merchant_inventory) = inventories();
+        let mut offer = bookshelf_offer();
+        offer.base_cost_a = ItemStackSerializer(Cow::Owned(ItemStack::new(5, &Item::EMERALD)));
+        offer.cost_b = Some(ItemStackSerializer(Cow::Owned(ItemStack::new(
+            1,
+            &Item::BOOK,
+        ))));
+        merchant_inventory
+            .set_stack(0, ItemStack::new(1, &Item::BOOK))
+            .await;
+        merchant_inventory
+            .set_stack(1, ItemStack::new(5, &Item::EMERALD))
+            .await;
+        let player = TestPlayer::new(player_inventory.clone());
+        let mut handler = MerchantScreenHandler::new(
+            1,
+            &player_inventory,
+            merchant_inventory.clone(),
+            vec![offer],
+        )
+        .await;
+        handler.update_result_slot().await;
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Pickup, &player)
+            .await;
+
+        assert_eq!(handler.offers[0].uses, 1);
+        assert!(merchant_inventory.get_stack(0).await.is_empty());
+        assert!(merchant_inventory.get_stack(1).await.is_empty());
     }
 }

--- a/crates/pumpkin-protocol/src/bedrock/client/mod.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/mod.rs
@@ -55,6 +55,7 @@ pub mod transfer;
 pub mod update_abilities;
 pub mod update_attributes;
 pub mod update_block;
+pub mod update_trade;
 
 pub use add_actor::*;
 pub use add_item_actor::*;
@@ -113,3 +114,4 @@ pub use transfer::*;
 pub use update_abilities::*;
 pub use update_attributes::*;
 pub use update_block::*;
+pub use update_trade::*;

--- a/crates/pumpkin-protocol/src/bedrock/client/update_trade.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/update_trade.rs
@@ -1,0 +1,53 @@
+use pumpkin_macros::packet;
+use pumpkin_nbt::compound::NbtCompound;
+
+use crate::{
+    codec::{var_int::VarInt, var_long::VarLong},
+    serial::PacketWrite,
+};
+
+/// Opens or refreshes a Bedrock merchant screen with its complete offer list.
+#[derive(PacketWrite)]
+#[packet(80)]
+pub struct CUpdateTrade {
+    pub container_id: u8,
+    pub r#type: u8,
+    pub size: VarInt,
+    pub trader_tier: VarInt,
+    pub entity_unique_id: VarLong,
+    pub last_trading_player: VarLong,
+    pub display_name: String,
+    pub use_new_trade_screen: bool,
+    pub using_economy_trade: bool,
+    pub data: NbtCompound,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Packet, serial::PacketWrite};
+
+    #[test]
+    fn update_trade_uses_current_packet_id_and_network_nbt() {
+        assert_eq!(<CUpdateTrade as Packet>::PACKET_ID, 80);
+
+        let mut offers = NbtCompound::new();
+        offers.put_list("Recipes", Vec::new());
+        let packet = CUpdateTrade {
+            container_id: 1,
+            r#type: 15,
+            size: VarInt(0),
+            trader_tier: VarInt(0),
+            entity_unique_id: VarLong(2),
+            last_trading_player: VarLong(3),
+            display_name: "Villager".to_string(),
+            use_new_trade_screen: true,
+            using_economy_trade: true,
+            data: offers,
+        };
+
+        let mut encoded = Vec::new();
+        packet.write(&mut encoded).unwrap();
+        assert!(encoded.ends_with(&[0]));
+    }
+}

--- a/crates/pumpkin-protocol/src/codec/data_component.rs
+++ b/crates/pumpkin-protocol/src/codec/data_component.rs
@@ -8,15 +8,16 @@ use pumpkin_data::data_component_impl::{
     AxolotlVariantImpl, BundleContentsImpl, CatCollarImpl, CatSoundVariantImpl, CatVariantImpl,
     ChickenSoundVariantImpl, ChickenVariantImpl, ConsumableImpl, ConsumeAnimation, ConsumeEffect,
     CowSoundVariantImpl, CowVariantImpl, CustomDataImpl, CustomNameImpl, DamageImpl,
-    DataComponentImpl, EnchantmentsImpl, EquipmentSlot, EquippableImpl, FireworkExplosionImpl,
-    FireworkExplosionShape, FireworksImpl, FoxVariantImpl, FrogVariantImpl, HorseVariantImpl,
-    IDSet, IDSetContent, IdOr, ItemModelImpl, LlamaVariantImpl, MapIdImpl, MaxStackSizeImpl,
-    MooshroomVariantImpl, PaintingVariantImpl, ParrotVariantImpl, PigSoundVariantImpl,
-    PigVariantImpl, PotionContentsImpl, RabbitVariantImpl, SalmonSizeImpl, SheepColorImpl,
-    ShulkerColorImpl, SoundEvent, StatusEffectInstance, StoredEnchantmentsImpl,
-    TropicalFishBaseColorImpl, TropicalFishPatternColorImpl, TropicalFishPatternImpl,
-    UnbreakableImpl, UseCooldownImpl, VillagerVariantImpl, WolfCollarImpl, WolfSoundVariantImpl,
-    WolfVariantImpl, ZombieNautilusVariantImpl, get,
+    DataComponentImpl, DyedColorImpl, EnchantmentsImpl, EquipmentSlot, EquippableImpl,
+    FireworkExplosionImpl, FireworkExplosionShape, FireworksImpl, FoxVariantImpl, FrogVariantImpl,
+    HorseVariantImpl, IDSet, IDSetContent, IdOr, ItemModelImpl, ItemNameImpl, LlamaVariantImpl,
+    MapIdImpl, MaxStackSizeImpl, MooshroomVariantImpl, PaintingVariantImpl, ParrotVariantImpl,
+    PigSoundVariantImpl, PigVariantImpl, PotionContentsImpl, RabbitVariantImpl, SalmonSizeImpl,
+    SheepColorImpl, ShulkerColorImpl, SoundEvent, StatusEffectInstance, StoredEnchantmentsImpl,
+    SuspiciousStewEffect, SuspiciousStewEffectsImpl, TropicalFishBaseColorImpl,
+    TropicalFishPatternColorImpl, TropicalFishPatternImpl, UnbreakableImpl, UseCooldownImpl,
+    VillagerVariantImpl, WolfCollarImpl, WolfSoundVariantImpl, WolfVariantImpl,
+    ZombieNautilusVariantImpl, get,
 };
 use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::entity::EntityType;
@@ -330,6 +331,83 @@ impl DataComponentCodec<Self> for CustomNameImpl {
         let name = seq.get_str()?;
         Ok(Self {
             name: pumpkin_util::text::TextComponent::text(String::from(name)),
+        })
+    }
+}
+
+impl DataComponentCodec<Self> for ItemNameImpl {
+    fn serialize(&self, seq: &mut impl NetworkWriteExt) -> Result<(), WritingError> {
+        let mut name = pumpkin_nbt::compound::NbtCompound::new();
+        name.put_string("translate", self.name.to_string());
+        let mut bytes = Vec::new();
+        NbtTag::Compound(name)
+            .serialize(&mut NbtWriteHelperJava::new(&mut bytes))
+            .map_err(|error| WritingError::Message(error.to_string()))?;
+        seq.write_slice(&bytes)
+    }
+
+    fn deserialize(seq: &mut impl NetworkReadExt) -> Result<Self, ReadingError> {
+        let name = seq.get_str()?;
+        Ok(Self {
+            name: Cow::Owned(name.into()),
+        })
+    }
+}
+
+impl DataComponentCodec<Self> for DyedColorImpl {
+    fn serialize(&self, seq: &mut impl NetworkWriteExt) -> Result<(), WritingError> {
+        seq.write_i32(self.rgb)
+    }
+
+    fn deserialize(seq: &mut impl NetworkReadExt) -> Result<Self, ReadingError> {
+        Ok(Self {
+            rgb: seq.get_i32()?,
+        })
+    }
+}
+
+impl DataComponentCodec<Self> for SuspiciousStewEffectsImpl {
+    fn serialize(&self, seq: &mut impl NetworkWriteExt) -> Result<(), WritingError> {
+        let effect_count = i32::try_from(self.effects.len())
+            .map_err(|_| WritingError::Message("Too many suspicious stew effects".into()))?;
+        seq.write_var_int(&VarInt(effect_count))?;
+        for effect in self.effects.iter() {
+            let id = StatusEffect::from_minecraft_name(&effect.effect)
+                .ok_or_else(|| WritingError::Message("Unknown suspicious stew effect".into()))?
+                .id;
+            seq.write_var_int(&VarInt(i32::from(id)))?;
+            seq.write_var_int(&VarInt(effect.duration))?;
+        }
+        Ok(())
+    }
+
+    fn deserialize(seq: &mut impl NetworkReadExt) -> Result<Self, ReadingError> {
+        const MAX_EFFECTS: i32 = 128;
+
+        let count = seq.get_var_int()?.0;
+        if !(0..=MAX_EFFECTS).contains(&count) {
+            return Err(ReadingError::Message(
+                "Invalid suspicious stew effect count".into(),
+            ));
+        }
+
+        let mut effects =
+            Vec::with_capacity(usize::try_from(count).map_err(|_| {
+                ReadingError::Message("Invalid suspicious stew effect count".into())
+            })?);
+        for _ in 0..count {
+            let id = u16::try_from(seq.get_var_int()?.0)
+                .map_err(|_| ReadingError::Message("Invalid suspicious stew effect id".into()))?;
+            let effect = StatusEffect::from_id(id)
+                .ok_or_else(|| ReadingError::Message("Unknown suspicious stew effect id".into()))?;
+            let duration = seq.get_var_int()?.0;
+            effects.push(SuspiciousStewEffect {
+                effect: Cow::Borrowed(effect.minecraft_name),
+                duration,
+            });
+        }
+        Ok(Self {
+            effects: Cow::Owned(effects),
         })
     }
 }
@@ -777,9 +855,14 @@ pub fn deserialize(
         DataComponent::Damage => Ok(DamageImpl::deserialize(seq)?.to_dyn()),
         DataComponent::Unbreakable => Ok(UnbreakableImpl::deserialize(seq)?.to_dyn()),
         DataComponent::PotionContents => Ok(PotionContentsImpl::deserialize(seq)?.to_dyn()),
+        DataComponent::DyedColor => Ok(DyedColorImpl::deserialize(seq)?.to_dyn()),
+        DataComponent::SuspiciousStewEffects => {
+            Ok(SuspiciousStewEffectsImpl::deserialize(seq)?.to_dyn())
+        }
         DataComponent::FireworkExplosion => Ok(FireworkExplosionImpl::deserialize(seq)?.to_dyn()),
         DataComponent::Fireworks => Ok(FireworksImpl::deserialize(seq)?.to_dyn()),
         DataComponent::ItemModel => Ok(ItemModelImpl::deserialize(seq)?.to_dyn()),
+        DataComponent::ItemName => Ok(ItemNameImpl::deserialize(seq)?.to_dyn()),
         DataComponent::CustomName => Ok(CustomNameImpl::deserialize(seq)?.to_dyn()),
         DataComponent::Consumable => Ok(ConsumableImpl::deserialize(seq)?.to_dyn()),
         DataComponent::Equippable => Ok(EquippableImpl::deserialize(seq)?.to_dyn()),
@@ -802,9 +885,14 @@ pub fn serialize(
         DataComponent::Damage => get::<DamageImpl>(value).serialize(seq),
         DataComponent::Unbreakable => get::<UnbreakableImpl>(value).serialize(seq),
         DataComponent::PotionContents => get::<PotionContentsImpl>(value).serialize(seq),
+        DataComponent::DyedColor => get::<DyedColorImpl>(value).serialize(seq),
+        DataComponent::SuspiciousStewEffects => {
+            get::<SuspiciousStewEffectsImpl>(value).serialize(seq)
+        }
         DataComponent::FireworkExplosion => get::<FireworkExplosionImpl>(value).serialize(seq),
         DataComponent::Fireworks => get::<FireworksImpl>(value).serialize(seq),
         DataComponent::ItemModel => get::<ItemModelImpl>(value).serialize(seq),
+        DataComponent::ItemName => get::<ItemNameImpl>(value).serialize(seq),
         DataComponent::CustomName => get::<CustomNameImpl>(value).serialize(seq),
         DataComponent::Consumable => get::<ConsumableImpl>(value).serialize(seq),
         DataComponent::Equippable => get::<EquippableImpl>(value).serialize(seq),

--- a/crates/pumpkin-protocol/src/codec/item_stack_seralizer.rs
+++ b/crates/pumpkin-protocol/src/codec/item_stack_seralizer.rs
@@ -2,7 +2,7 @@ use crate::VarInt;
 use crate::codec::data_component::{deserialize, serialize};
 use crate::ser::{NetworkReadExt, NetworkWriteExt, ReadingError, WritingError};
 use pumpkin_data::data_component::DataComponent;
-use pumpkin_data::data_component_impl::{CustomNameImpl, DataComponentImpl};
+use pumpkin_data::data_component_impl::{CustomNameImpl, DataComponentImpl, ItemNameImpl};
 use pumpkin_data::item::Item;
 use pumpkin_data::item_id_remap::{remap_item_id_for_version, remap_item_id_from_version};
 use pumpkin_data::item_stack::ItemStack;
@@ -75,6 +75,31 @@ fn serialize_item_stack_with_id(
     serialize_any_item_stack_with_id(stack, item_id, false, write)
 }
 
+fn serialize_item_cost_with_id(
+    stack: &ItemStack,
+    item_id: u16,
+    write: &mut impl NetworkWriteExt,
+) -> Result<(), WritingError> {
+    let component_count = stack
+        .patch
+        .iter()
+        .filter(|(_, data)| data.is_some())
+        .count();
+    let component_count = i32::try_from(component_count)
+        .map_err(|_| WritingError::Message("Too many item cost components".into()))?;
+
+    write.put_var_int(&VarInt::from(item_id))?;
+    write.put_var_int(&VarInt::from(stack.item_count))?;
+    write.put_var_int(&VarInt(component_count))?;
+    for (id, data) in &stack.patch {
+        if let Some(data) = data {
+            write.put_var_int(&VarInt::from(id.to_id()))?;
+            serialize(*id, data.as_ref(), write)?;
+        }
+    }
+    Ok(())
+}
+
 fn read_component_id(read: &mut impl NetworkReadExt) -> Result<DataComponent, ReadingError> {
     let id_val = read.get_var_int()?.0;
     let id_u8 = id_val
@@ -101,6 +126,40 @@ fn decode_custom_name(component_data: &[u8]) -> Result<Box<dyn DataComponentImpl
     Ok(CustomNameImpl { name }.to_dyn())
 }
 
+fn decode_item_name(component_data: &[u8]) -> Result<Box<dyn DataComponentImpl>, ReadingError> {
+    let mut cursor = Cursor::new(component_data);
+    let mut nbt_reader = pumpkin_nbt::deserializer::NbtReadHelperJava::new(&mut cursor);
+    let tag = NbtTag::deserialize(&mut nbt_reader)
+        .map_err(|err| ReadingError::Message(format!("Failed to decode ItemName NBT: {err}")))?;
+    let name = match tag {
+        NbtTag::String(name) => name.to_string(),
+        NbtTag::Compound(compound) => compound
+            .get_string("translate")
+            .or_else(|| compound.get_string("text"))
+            .unwrap_or_default()
+            .to_owned(),
+        _ => String::new(),
+    };
+    Ok(ItemNameImpl {
+        name: Cow::Owned(name),
+    }
+    .to_dyn())
+}
+
+fn decode_component(
+    id: DataComponent,
+    component_data: &[u8],
+) -> Result<Box<dyn DataComponentImpl>, ReadingError> {
+    match id {
+        DataComponent::CustomName => decode_custom_name(component_data),
+        DataComponent::ItemName => decode_item_name(component_data),
+        _ => {
+            let mut cursor = Cursor::new(component_data);
+            deserialize(id, &mut cursor)
+        }
+    }
+}
+
 fn read_length_prefixed_component(
     read: &mut impl NetworkReadExt,
 ) -> Result<(DataComponent, Box<dyn DataComponentImpl>), ReadingError> {
@@ -117,22 +176,11 @@ fn read_length_prefixed_component(
         let mut stack_buf = [0u8; 256];
         let slice = &mut stack_buf[..byte_len];
         read.read_bytes_to_buf(slice)?;
-
-        if id == DataComponent::CustomName {
-            decode_custom_name(slice)?
-        } else {
-            let mut cursor = Cursor::new(slice);
-            deserialize(id, &mut cursor)?
-        }
+        decode_component(id, slice)?
     } else {
         let mut component_data = vec![0u8; byte_len];
         read.read_bytes_to_buf(&mut component_data)?;
-        if id == DataComponent::CustomName {
-            decode_custom_name(component_data.as_ref())?
-        } else {
-            let mut cursor = Cursor::new(component_data);
-            deserialize(id, &mut cursor)?
-        }
+        decode_component(id, &component_data)?
     };
 
     Ok((id, component_impl))
@@ -269,6 +317,15 @@ impl ItemStackSerializer<'_> {
     ) -> Result<(), WritingError> {
         let remapped_item_id = remap_item_id_for_version(self.0.item.id, *version);
         serialize_item_stack_with_id(self.0.as_ref(), remapped_item_id, write)
+    }
+
+    pub fn write_item_cost_with_version(
+        &self,
+        write: &mut impl NetworkWriteExt,
+        version: &JavaMinecraftVersion,
+    ) -> Result<(), WritingError> {
+        let remapped_item_id = remap_item_id_for_version(self.0.item.id, *version);
+        serialize_item_cost_with_id(self.0.as_ref(), remapped_item_id, write)
     }
 
     #[must_use]

--- a/crates/pumpkin-protocol/src/java/client/play/merchant_offers.rs
+++ b/crates/pumpkin-protocol/src/java/client/play/merchant_offers.rs
@@ -9,10 +9,10 @@ use pumpkin_util::version::JavaMinecraftVersion;
 
 #[derive(Clone)]
 pub struct MerchantOffer {
-    pub base_cost_a: ItemStackSerializer<'static>, // TODO: item cost
+    pub base_cost_a: ItemStackSerializer<'static>,
     pub output: ItemStackSerializer<'static>,
-    pub cost_b: Option<ItemStackSerializer<'static>>, // TODO: item cost
-    pub is_disabled: bool,
+    pub cost_b: Option<ItemStackSerializer<'static>>,
+    pub reward_exp: bool,
     pub uses: i32,
     pub max_uses: i32,
     pub xp: i32,
@@ -22,17 +22,36 @@ pub struct MerchantOffer {
 }
 
 impl MerchantOffer {
+    #[must_use]
+    pub const fn is_out_of_stock(&self) -> bool {
+        self.uses >= self.max_uses
+    }
+
+    #[must_use]
+    pub const fn needs_restock(&self) -> bool {
+        self.uses > 0
+    }
+
+    pub const fn update_demand(&mut self) {
+        self.demand += self.uses - (self.max_uses - self.uses);
+    }
+
+    pub const fn reset_uses(&mut self) {
+        self.uses = 0;
+    }
+
     fn write(
         &self,
         mut write: impl std::io::Write,
         version: JavaMinecraftVersion,
     ) -> Result<(), crate::ser::WritingError> {
-        self.base_cost_a.write_with_version(&mut write, &version)?;
+        self.base_cost_a
+            .write_item_cost_with_version(&mut write, &version)?;
         self.output.write_with_version(&mut write, &version)?;
         write.write_option(&self.cost_b, |w, cost_b| {
-            cost_b.write_with_version(w, &version)
+            cost_b.write_item_cost_with_version(w, &version)
         })?;
-        write.write_bool(self.is_disabled)?;
+        write.write_bool(self.is_out_of_stock())?;
         write.write_i32_be(self.uses)?;
         write.write_i32_be(self.max_uses)?;
         write.write_i32_be(self.xp)?;
@@ -90,5 +109,133 @@ impl ClientPacket for CMerchantOffers {
         write.write_bool(self.is_regular_villager)?;
         write.write_bool(self.can_restock)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{borrow::Cow, io::Cursor};
+
+    use pumpkin_data::{
+        data_component::DataComponent,
+        data_component_impl::{
+            DataComponentImpl, DyedColorImpl, ItemNameImpl, MapIdImpl, SuspiciousStewEffect,
+            SuspiciousStewEffectsImpl,
+        },
+        item::Item,
+        item_id_remap::remap_item_id_for_version,
+        item_stack::ItemStack,
+    };
+    use pumpkin_util::version::JavaMinecraftVersion;
+
+    use crate::ser::NetworkReadExt;
+
+    use super::*;
+
+    fn offer() -> MerchantOffer {
+        MerchantOffer {
+            base_cost_a: ItemStackSerializer(Cow::Owned(ItemStack::new(12, &Item::EMERALD))),
+            output: ItemStackSerializer(Cow::Owned(ItemStack::new(1, &Item::BOOK))),
+            cost_b: None,
+            reward_exp: true,
+            uses: 0,
+            max_uses: 12,
+            xp: 1,
+            special_price: 0,
+            price_multiplier: 0.05,
+            demand: 0,
+        }
+    }
+
+    #[test]
+    fn merchant_inputs_use_item_cost_encoding() {
+        let version = JavaMinecraftVersion::V_26_2;
+        let packet =
+            CMerchantOffers::new(VarInt(1), vec![offer()], VarInt(1), VarInt(0), true, true);
+        let mut bytes = Vec::new();
+        packet.write_packet_data(&mut bytes, &version).unwrap();
+        let mut cursor = Cursor::new(&bytes);
+
+        assert_eq!(cursor.get_var_int().unwrap(), VarInt(1));
+        assert_eq!(cursor.get_var_int().unwrap(), VarInt(1));
+        assert_eq!(
+            cursor.get_var_int().unwrap(),
+            VarInt::from(remap_item_id_for_version(Item::EMERALD.id, version))
+        );
+        assert_eq!(cursor.get_var_int().unwrap(), VarInt(12));
+        assert_eq!(cursor.get_var_int().unwrap(), VarInt(0));
+    }
+
+    #[test]
+    fn merchant_offer_is_out_of_stock_at_max_uses() {
+        let mut offer = offer();
+        offer.uses = offer.max_uses - 1;
+        assert!(!offer.is_out_of_stock());
+        offer.uses += 1;
+        assert!(offer.is_out_of_stock());
+    }
+
+    #[test]
+    fn restock_updates_demand_before_resetting_uses() {
+        let mut offer = offer();
+        offer.uses = 8;
+
+        assert!(offer.needs_restock());
+        offer.update_demand();
+        offer.reset_uses();
+
+        assert_eq!(offer.demand, 4);
+        assert_eq!(offer.uses, 0);
+        assert!(!offer.needs_restock());
+    }
+
+    #[test]
+    fn dynamic_villager_results_have_network_codecs() {
+        let mut dyed = ItemStack::new(1, &Item::LEATHER_CHESTPLATE);
+        dyed.patch.push((
+            DataComponent::DyedColor,
+            Some(DyedColorImpl { rgb: 0x12_34_56 }.to_dyn()),
+        ));
+        let mut stew = ItemStack::new(1, &Item::SUSPICIOUS_STEW);
+        stew.patch.push((
+            DataComponent::SuspiciousStewEffects,
+            Some(
+                SuspiciousStewEffectsImpl {
+                    effects: Cow::Owned(vec![SuspiciousStewEffect {
+                        effect: Cow::Borrowed("minecraft:night_vision"),
+                        duration: 100,
+                    }]),
+                }
+                .to_dyn(),
+            ),
+        ));
+        let mut map = ItemStack::new(1, &Item::FILLED_MAP);
+        map.patch
+            .push((DataComponent::MapId, Some(MapIdImpl { id: 1 }.to_dyn())));
+        map.patch.push((
+            DataComponent::ItemName,
+            Some(
+                ItemNameImpl {
+                    name: Cow::Borrowed("filled_map.mansion"),
+                }
+                .to_dyn(),
+            ),
+        ));
+
+        for output in [dyed, stew, map] {
+            let mut dynamic_offer = offer();
+            dynamic_offer.output = ItemStackSerializer(Cow::Owned(output));
+            let packet = CMerchantOffers::new(
+                VarInt(1),
+                vec![dynamic_offer],
+                VarInt(1),
+                VarInt(0),
+                true,
+                true,
+            );
+            packet
+                .write_packet_data(&mut Vec::new(), &JavaMinecraftVersion::V_26_2)
+                .unwrap();
+        }
     }
 }

--- a/crates/pumpkin-world/src/generation/generator/structure_finder.rs
+++ b/crates/pumpkin-world/src/generation/generator/structure_finder.rs
@@ -1,12 +1,14 @@
 use pumpkin_data::structures::{
     ConcentricRingsStructurePlacement, RandomSpreadStructurePlacement, StructurePlacement,
-    StructurePlacementType,
+    StructurePlacementType, StructureSet,
 };
 use pumpkin_util::math::{floor_div, position::BlockPos};
 
 use crate::generation::structure::placement::{
     GlobalStructureCache, get_structure_chunk_in_region,
 };
+
+use super::WorldGenerator;
 
 /// Block-level position of a found structure plus squared distance from the
 /// search origin, used internally to track the running nearest candidate.
@@ -92,6 +94,150 @@ pub fn find_nearest_structure(
     }
 
     nearest.map(|f| f.pos)
+}
+
+/// Finds the nearest candidate that actually produces one of `target_structures`.
+/// Explorer maps use this instead of pointing at a placement-only candidate whose
+/// biome may reject the requested structure.
+#[must_use]
+#[expect(clippy::too_many_lines)]
+pub fn find_nearest_structure_start(
+    origin: BlockPos,
+    structure_set: &StructureSet,
+    target_structures: &[pumpkin_data::structures::StructureKeys],
+    max_search_radius: i32,
+    generator: &WorldGenerator,
+) -> Option<BlockPos> {
+    use crate::{
+        ProtoChunk,
+        biome::{BiomeSupplier, MultiNoiseBiomeSupplier},
+        generation::{
+            biome_coords,
+            noise::router::{
+                multi_noise_sampler::{MultiNoiseSampler, MultiNoiseSamplerBuilderOptions},
+                surface_height_sampler::{
+                    SurfaceHeightEstimateSampler, SurfaceHeightSamplerBuilderOptions,
+                },
+            },
+            positions::chunk_pos::{start_block_x, start_block_z},
+            structure::{
+                lazily_generate_structure,
+                placement::should_generate_structure,
+                structures::{StructureGeneratorContext, create_chunk_random},
+            },
+        },
+    };
+    use pumpkin_data::structures::Structure;
+
+    let WorldGenerator::Noise(noise_generator) = generator else {
+        return None;
+    };
+    let StructurePlacementType::RandomSpread(placement) = &structure_set.placement.placement_type
+    else {
+        return None;
+    };
+
+    let chunk_origin_x = origin.0.x >> 4;
+    let chunk_origin_z = origin.0.z >> 4;
+    let region_origin_x = floor_div(chunk_origin_x, placement.spacing);
+    let region_origin_z = floor_div(chunk_origin_z, placement.spacing);
+    let world_seed = noise_generator.random_config.seed as i64;
+    let global_cache = &noise_generator.global_structure_cache;
+
+    for radius in 0..=max_search_radius {
+        let mut nearest: Option<FoundStructure> = None;
+        for region_x_offset in -radius..=radius {
+            for region_z_offset in -radius..=radius {
+                if region_x_offset.abs() != radius && region_z_offset.abs() != radius {
+                    continue;
+                }
+                let (chunk_x, chunk_z) = get_structure_chunk_in_region(
+                    placement,
+                    world_seed,
+                    region_origin_x + region_x_offset,
+                    region_origin_z + region_z_offset,
+                    structure_set.placement.salt,
+                );
+                let placement_chunk = ProtoChunk::new(chunk_x, chunk_z, generator);
+                if !should_generate_structure(
+                    &structure_set.placement,
+                    &noise_generator.structure_calculator,
+                    chunk_x,
+                    chunk_z,
+                    global_cache,
+                    &placement_chunk,
+                    &[],
+                ) {
+                    continue;
+                }
+
+                for &key in target_structures {
+                    let start =
+                        global_cache.get_or_compute_structure_start(key, chunk_x, chunk_z, || {
+                            let start_x = start_block_x(chunk_x);
+                            let start_z = start_block_z(chunk_z);
+                            let settings = noise_generator.settings;
+                            let mut height_sampler = SurfaceHeightEstimateSampler::generate(
+                                &noise_generator.base_router.surface_estimator,
+                                &SurfaceHeightSamplerBuilderOptions::new(
+                                    biome_coords::from_block(start_x),
+                                    biome_coords::from_block(start_z),
+                                    4,
+                                    settings.shape.min_y as i32,
+                                    settings.shape.height as i32,
+                                    (settings.shape.height
+                                        / settings.shape.vertical_cell_block_count() as u16)
+                                        as usize,
+                                ),
+                            );
+                            let mut biome_sampler = MultiNoiseSampler::generate(
+                                &noise_generator.base_router.multi_noise,
+                                &MultiNoiseSamplerBuilderOptions::new(0, 0, 0),
+                            );
+                            let biome_supplier: &dyn BiomeSupplier =
+                                &MultiNoiseBiomeSupplier::OVERWORLD;
+                            let context = StructureGeneratorContext {
+                                seed: world_seed,
+                                chunk_x,
+                                chunk_z,
+                                random: create_chunk_random(world_seed, chunk_x, chunk_z),
+                                sea_level: settings.sea_level,
+                                min_y: noise_generator.dimension.min_y,
+                                height_sampler: Some(&mut height_sampler),
+                                structure_key: Some(key),
+                            };
+                            lazily_generate_structure(
+                                &key,
+                                Structure::get(&key),
+                                context,
+                                biome_supplier,
+                                &mut biome_sampler,
+                            )
+                        });
+                    let Some(start) = start else {
+                        continue;
+                    };
+                    let position = start.start_pos;
+                    let dx = f64::from(position.0.x - origin.0.x);
+                    let dz = f64::from(position.0.z - origin.0.z);
+                    let found = FoundStructure {
+                        pos: position,
+                        distance_sq: dx * dx + dz * dz,
+                    };
+                    if nearest
+                        .as_ref()
+                        .is_none_or(|current| found.distance_sq < current.distance_sq)
+                    {
+                        nearest = Some(found);
+                    }
+                }
+            }
+        }
+        if let Some(found) = nearest {
+            return Some(found.pos);
+        }
+    }
+    None
 }
 
 fn find_nearest_concentric(

--- a/crates/pumpkin-world/src/poi/mod.rs
+++ b/crates/pumpkin-world/src/poi/mod.rs
@@ -464,6 +464,10 @@ impl PoiStorage {
     }
 
     pub fn add(&mut self, pos: BlockPos, poi_type: &str) {
+        self.add_with_free_tickets(pos, poi_type, 0);
+    }
+
+    pub fn add_with_free_tickets(&mut self, pos: BlockPos, poi_type: &str, free_tickets: i32) {
         let (rx, rz) = Self::region_coords(&pos);
         let region = self.get_or_load_region(rx, rz);
         region.add(PoiEntry {
@@ -471,7 +475,7 @@ impl PoiStorage {
             y: pos.0.y,
             z: pos.0.z,
             poi_type: poi_type.to_string(),
-            free_tickets: 0,
+            free_tickets,
         });
     }
 

--- a/crates/pumpkin/src/entity/ai/goal/mod.rs
+++ b/crates/pumpkin/src/entity/ai/goal/mod.rs
@@ -30,7 +30,9 @@ pub mod swim;
 pub mod teleport_towards_player;
 pub mod tempt;
 pub(crate) mod track_target;
+pub mod trade_with_player;
 pub mod wander_around;
+pub mod work_at_job_site;
 pub mod zombie_attack;
 
 #[must_use]

--- a/crates/pumpkin/src/entity/ai/goal/trade_with_player.rs
+++ b/crates/pumpkin/src/entity/ai/goal/trade_with_player.rs
@@ -1,0 +1,131 @@
+use std::sync::Arc;
+
+use pumpkin_util::math::vector3::Vector3;
+
+use super::{Controls, Goal, GoalFuture, to_goal_ticks};
+use crate::entity::{EntityBase, ai::pathfinder::NavigatorGoal, mob::Mob, player::Player};
+
+pub struct TradeWithPlayerGoal {
+    speed: f64,
+    player: Option<Arc<Player>>,
+    update_countdown: i32,
+}
+
+impl TradeWithPlayerGoal {
+    #[must_use]
+    pub const fn new(speed: f64) -> Self {
+        Self {
+            speed,
+            player: None,
+            update_countdown: 0,
+        }
+    }
+
+    fn trading_player_in_range(mob: &dyn Mob) -> Option<Arc<Player>> {
+        let player = mob.get_trading_player()?;
+        let entity = &mob.get_mob_entity().living_entity.entity;
+        (entity.is_alive()
+            && player.get_entity().is_alive()
+            && !entity
+                .touching_water
+                .load(std::sync::atomic::Ordering::Relaxed)
+            && entity
+                .pos
+                .load()
+                .squared_distance_to_vec(&player.get_entity().pos.load())
+                <= 16.0)
+            .then_some(player)
+    }
+
+    fn follow_player(&mut self, mob: &dyn Mob) {
+        let Some(player) = &self.player else {
+            return;
+        };
+        let mob_entity = mob.get_mob_entity();
+        let player_entity = player.get_entity();
+        let player_position = player_entity.pos.load();
+        mob_entity
+            .look_control
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .look_at(
+                mob,
+                player_position.x,
+                player_entity.get_eye_y(),
+                player_position.z,
+            );
+
+        let mob_position = mob_entity.living_entity.entity.pos.load();
+        if mob_position.squared_distance_to_vec(&player_position) <= 4.0 {
+            mob_entity
+                .navigator
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .stop();
+        } else if self.update_countdown <= 0 {
+            mob_entity
+                .navigator
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .set_progress(NavigatorGoal::new(
+                    mob_position,
+                    Vector3::new(player_position.x, player_position.y, player_position.z),
+                    self.speed,
+                ));
+            self.update_countdown = to_goal_ticks(10);
+        }
+    }
+}
+
+impl Goal for TradeWithPlayerGoal {
+    fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
+        Box::pin(async move {
+            self.player = Self::trading_player_in_range(mob);
+            self.player.is_some()
+        })
+    }
+
+    fn should_continue<'a>(&'a self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
+        Box::pin(async move {
+            let Some(current) = Self::trading_player_in_range(mob) else {
+                return false;
+            };
+            self.player.as_ref().is_some_and(|player| {
+                player.get_entity().entity_uuid == current.get_entity().entity_uuid
+            })
+        })
+    }
+
+    fn start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async move {
+            self.update_countdown = 0;
+            self.follow_player(mob);
+        })
+    }
+
+    fn stop<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async move {
+            self.player = None;
+            mob.get_mob_entity()
+                .navigator
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .stop();
+        })
+    }
+
+    fn tick<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async move {
+            self.update_countdown -= 1;
+            self.follow_player(mob);
+        })
+    }
+
+    fn should_run_every_tick(&self) -> bool {
+        true
+    }
+
+    fn controls(&self) -> Controls {
+        Controls::MOVE | Controls::LOOK
+    }
+}

--- a/crates/pumpkin/src/entity/ai/goal/work_at_job_site.rs
+++ b/crates/pumpkin/src/entity/ai/goal/work_at_job_site.rs
@@ -1,0 +1,109 @@
+use pumpkin_util::math::position::BlockPos;
+
+use super::{Controls, Goal, GoalFuture};
+use crate::entity::{ai::pathfinder::NavigatorGoal, mob::Mob};
+
+pub struct WorkAtJobSiteGoal {
+    speed: f64,
+    target: Option<BlockPos>,
+}
+
+impl WorkAtJobSiteGoal {
+    #[must_use]
+    pub const fn new(speed: f64) -> Self {
+        Self {
+            speed,
+            target: None,
+        }
+    }
+
+    async fn should_move_to_job_site(mob: &dyn Mob) -> bool {
+        if mob.is_job_site_pending().await {
+            return true;
+        }
+        let world = mob.get_mob_entity().living_entity.entity.world.load();
+        (2_000..9_000).contains(&world.level_time.lock().await.query_daytime())
+    }
+}
+
+impl Goal for WorkAtJobSiteGoal {
+    fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
+        Box::pin(async move {
+            let Some(target) = mob.get_job_site() else {
+                return false;
+            };
+            if !Self::should_move_to_job_site(mob).await {
+                return false;
+            }
+            let position = mob.get_mob_entity().living_entity.entity.pos.load();
+            if target.to_centered_f64().squared_distance_to_vec(&position) < 1.73f64.powi(2) {
+                return false;
+            }
+            self.target = Some(target);
+            true
+        })
+    }
+
+    fn should_continue<'a>(&'a self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
+        Box::pin(async move {
+            let Some(target) = self.target else {
+                return false;
+            };
+            if mob.get_job_site() != Some(target) || !Self::should_move_to_job_site(mob).await {
+                return false;
+            }
+            let entity = &mob.get_mob_entity().living_entity.entity;
+            target
+                .to_centered_f64()
+                .squared_distance_to_vec(&entity.pos.load())
+                >= 1.73f64.powi(2)
+                && !mob
+                    .get_mob_entity()
+                    .navigator
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .is_idle()
+        })
+    }
+
+    fn start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async move {
+            if let Some(target) = self.target {
+                let entity = &mob.get_mob_entity().living_entity.entity;
+                mob.get_mob_entity()
+                    .navigator
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .set_progress(NavigatorGoal::new(
+                        entity.pos.load(),
+                        target.to_centered_f64(),
+                        self.speed,
+                    ));
+            }
+        })
+    }
+
+    fn stop<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
+        Box::pin(async move {
+            if let Some(target) = self.target
+                && target
+                    .to_centered_f64()
+                    .squared_distance_to_vec(&mob.get_mob_entity().living_entity.entity.pos.load())
+                    >= 2.0f64.powi(2)
+                && mob.is_job_site_pending().await
+            {
+                mob.release_pending_job_site(target).await;
+            }
+            self.target = None;
+            mob.get_mob_entity()
+                .navigator
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .stop();
+        })
+    }
+
+    fn controls(&self) -> Controls {
+        Controls::MOVE
+    }
+}

--- a/crates/pumpkin/src/entity/ai/pathfinder/mod.rs
+++ b/crates/pumpkin/src/entity/ai/pathfinder/mod.rs
@@ -136,6 +136,17 @@ impl Navigator {
         self.mob_height = height;
     }
 
+    pub async fn can_reach_within(
+        &mut self,
+        entity: &LivingEntity,
+        destination: Vector3<f64>,
+        distance: f32,
+    ) -> bool {
+        self.compute_path(entity, destination)
+            .await
+            .is_some_and(|path| path.can_reach() || path.get_dist_to_target() <= distance)
+    }
+
     #[allow(clippy::too_many_lines)]
     async fn compute_path(
         &mut self,

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1,4 +1,5 @@
 use pumpkin_data::item::Item;
+use pumpkin_data::particle::Particle;
 use pumpkin_data::potion::Effect;
 use pumpkin_data::tag::{self, Taggable};
 use pumpkin_data::tracked_data;
@@ -57,7 +58,8 @@ use pumpkin_protocol::java::client::play::{
 };
 use pumpkin_protocol::{
     codec::item_stack_seralizer::ItemStackSerializer,
-    java::client::play::{CDamageEvent, CSetEquipment, Metadata},
+    java::client::play::{CDamageEvent, CSetEquipment, Metadata, MetadataSerializer},
+    ser::{NetworkWriteExt, WritingError},
 };
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::text::TextComponent;
@@ -118,6 +120,36 @@ pub struct LivingEntity {
 
     /// The attributes of the entity
     pub attributes: RwLock<HashMap<u8, AttributeInstance>>,
+}
+
+struct EffectParticle {
+    particle_id: VarInt,
+    color: i32,
+}
+
+struct EffectParticles(Vec<EffectParticle>);
+
+impl MetadataSerializer for EffectParticles {
+    fn write_metadata(&self, writer: &mut impl std::io::Write) -> Result<(), WritingError> {
+        let count = i32::try_from(self.0.len())
+            .map_err(|_| WritingError::Message("Too many effect particles".into()))?;
+        writer.write_var_int(&VarInt(count))?;
+        for particle in &self.0 {
+            writer.write_var_int(&particle.particle_id)?;
+            writer.write_i32(particle.color)?;
+        }
+        Ok(())
+    }
+}
+
+impl EffectParticle {
+    const fn from_effect(effect: &Effect) -> Self {
+        Self {
+            particle_id: VarInt(Particle::EntityEffect as i32),
+            color: (((if effect.ambient { 38 } else { 255 }) as u32) << 24
+                | effect.effect_type.color as u32) as i32,
+        }
+    }
 }
 
 impl LivingEntity {
@@ -690,6 +722,41 @@ impl LivingEntity {
             .world
             .load()
             .broadcast_to_chunk_editioned_sync(chunk_pos, &je_packet, &be_packet);
+        self.sync_effect_particles().await;
+    }
+
+    async fn sync_effect_particles(&self) {
+        let effects = self.active_effects.lock().await;
+        let has_effects = !effects.is_empty();
+        let particles = EffectParticles(
+            effects
+                .values()
+                .filter(|effect| effect.show_particles)
+                .map(EffectParticle::from_effect)
+                .collect(),
+        );
+        let ambient = effects
+            .values()
+            .filter(|effect| effect.show_particles)
+            .all(|effect| effect.ambient);
+        drop(effects);
+
+        self.entity.send_meta_data(
+            &[Metadata::new(
+                tracked_data::living_entity::EFFECT_PARTICLES,
+                particles,
+            )],
+            None,
+        );
+        if has_effects {
+            self.entity.send_meta_data(
+                &[Metadata::new(
+                    tracked_data::living_entity::EFFECT_AMBIENCE_ID,
+                    ambient,
+                )],
+                None,
+            );
+        }
     }
 
     pub async fn remove_effect(&self, effect_type: &'static StatusEffect) -> bool {
@@ -757,6 +824,10 @@ impl LivingEntity {
         // If glowing effect removed, disable glowing
         if effect_type == &StatusEffect::GLOWING {
             self.entity.set_glowing(false).await;
+        }
+
+        if succeeded {
+            self.sync_effect_particles().await;
         }
 
         succeeded
@@ -3222,5 +3293,32 @@ mod tests {
             LivingEntity::hurt_sound_for_entity(&EntityType::CREEPER),
             Sound::EntityGenericHurt
         );
+    }
+
+    #[test]
+    fn regeneration_particle_metadata_uses_vanilla_argb_color() {
+        let effect = Effect {
+            effect_type: &StatusEffect::REGENERATION,
+            duration: 200,
+            amplifier: 0,
+            ambient: false,
+            show_particles: true,
+            show_icon: true,
+            blend: false,
+        };
+        let metadata = Metadata::new(
+            tracked_data::living_entity::EFFECT_PARTICLES,
+            EffectParticles(vec![EffectParticle::from_effect(&effect)]),
+        );
+        let mut bytes = Vec::new();
+
+        metadata
+            .write(
+                &mut bytes,
+                &pumpkin_util::version::JavaMinecraftVersion::V_26_2,
+            )
+            .unwrap();
+
+        assert_eq!(bytes, [10, 17, 1, 28, 0xff, 0xcd, 0x5c, 0xab]);
     }
 }

--- a/crates/pumpkin/src/entity/mob/mod.rs
+++ b/crates/pumpkin/src/entity/mob/mod.rs
@@ -21,6 +21,7 @@ use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::random::xoroshiro128::Xoroshiro;
 use pumpkin_util::random::{RandomGenerator, get_seed};
+use pumpkin_util::version::JavaMinecraftVersion;
 use rand::RngExt;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -491,7 +492,41 @@ pub trait Mob: EntityBase + Send + Sync {
 
     fn get_mob_entity(&self) -> &MobEntity;
 
+    fn mob_bedrock_identifier(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// Metadata which must accompany this mob whenever it is spawned for a Java client.
+    fn mob_java_spawn_metadata(
+        &self,
+        _version: JavaMinecraftVersion,
+    ) -> EntityBaseFuture<'_, Option<Box<[u8]>>> {
+        Box::pin(async { None })
+    }
+
+    /// Metadata which must accompany this mob whenever it is spawned for a Bedrock client.
+    fn mob_bedrock_spawn_metadata(
+        &self,
+    ) -> EntityBaseFuture<
+        '_,
+        Option<pumpkin_protocol::bedrock::client::set_actor_data::EntityMetadata>,
+    > {
+        Box::pin(async { None })
+    }
+
     fn get_job_site(&self) -> Option<BlockPos> {
+        None
+    }
+
+    fn is_job_site_pending(&self) -> EntityBaseFuture<'_, bool> {
+        Box::pin(async { false })
+    }
+
+    fn release_pending_job_site(&self, _position: BlockPos) -> EntityBaseFuture<'_, ()> {
+        Box::pin(async {})
+    }
+
+    fn get_trading_player(&self) -> Option<Arc<Player>> {
         None
     }
 

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -304,10 +304,20 @@ pub trait EntityBase: Send + Sync + NBTStorage + std::any::Any {
         Box::pin(async move {
             let entity = self.get_entity();
             let runtime_id = entity.entity_id as u64;
+            let identifier = self
+                .get_mob()
+                .and_then(mob::Mob::mob_bedrock_identifier)
+                .unwrap_or(entity.entity_type.resource_name);
+            let mut metadata = entity.bedrock_metadata();
+            if let Some(mob) = self.get_mob()
+                && let Some(mob_metadata) = mob.mob_bedrock_spawn_metadata().await
+            {
+                metadata.0.extend(mob_metadata.0);
+            }
             let packet = CAddActor::new(
                 VarLong(runtime_id as i64),
                 VarULong(runtime_id),
-                self.get_entity().entity_type.resource_name.to_string(),
+                identifier.to_string(),
                 entity.pos.load().to_f32_lossy(),
                 entity.velocity.load().to_f32_lossy(),
                 entity.pitch.load(),
@@ -315,7 +325,7 @@ pub trait EntityBase: Send + Sync + NBTStorage + std::any::Any {
                 entity.head_yaw.load(),
                 entity.body_yaw.load(),
                 Vec::new(),
-                entity.bedrock_metadata(),
+                metadata,
                 PropertySyncData {
                     int_properties: std::collections::HashMap::new(),
                     float_properties: std::collections::HashMap::new(),
@@ -331,6 +341,16 @@ pub trait EntityBase: Send + Sync + NBTStorage + std::any::Any {
             client
                 .enqueue_packet(&self.get_entity().create_spawn_packet())
                 .await;
+            if let Some(mob) = self.get_mob()
+                && let Some(metadata) = mob.mob_java_spawn_metadata(client.version.load()).await
+            {
+                client
+                    .enqueue_packet(&CSetEntityMetadata::new(
+                        self.get_entity().entity_id.into(),
+                        metadata,
+                    ))
+                    .await;
+            }
         })
     }
 

--- a/crates/pumpkin/src/entity/passive/villager/data.rs
+++ b/crates/pumpkin/src/entity/passive/villager/data.rs
@@ -21,9 +21,102 @@ pub const fn get_food_points(item: &Item) -> i32 {
 pub enum GossipType {
     MajorNegative = 0,
     MinorNegative = 1,
-    MajorPositive = 2,
-    MinorPositive = 3,
+    MinorPositive = 2,
+    MajorPositive = 3,
     Trading = 4,
+}
+
+impl GossipType {
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::MajorNegative => "major_negative",
+            Self::MinorNegative => "minor_negative",
+            Self::MinorPositive => "minor_positive",
+            Self::MajorPositive => "major_positive",
+            Self::Trading => "trading",
+        }
+    }
+
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "major_negative" => Some(Self::MajorNegative),
+            "minor_negative" => Some(Self::MinorNegative),
+            "major_positive" => Some(Self::MajorPositive),
+            "minor_positive" => Some(Self::MinorPositive),
+            "trading" => Some(Self::Trading),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub const fn from_legacy_id(id: i32) -> Option<Self> {
+        match id {
+            0 => Some(Self::MajorNegative),
+            1 => Some(Self::MinorNegative),
+            2 => Some(Self::MinorPositive),
+            3 => Some(Self::MajorPositive),
+            4 => Some(Self::Trading),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub const fn weight(self) -> i32 {
+        match self {
+            Self::MajorNegative => -5,
+            Self::MinorNegative => -1,
+            Self::MajorPositive => 5,
+            Self::MinorPositive | Self::Trading => 1,
+        }
+    }
+
+    #[must_use]
+    pub const fn max_value(self) -> i32 {
+        match self {
+            Self::MajorNegative => 100,
+            Self::MinorNegative => 200,
+            Self::MajorPositive => 20,
+            Self::MinorPositive | Self::Trading => 25,
+        }
+    }
+
+    #[must_use]
+    pub const fn daily_decay(self) -> i32 {
+        match self {
+            Self::MajorNegative => 10,
+            Self::MinorNegative => 20,
+            Self::MajorPositive => 0,
+            Self::MinorPositive => 1,
+            Self::Trading => 2,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GossipType;
+
+    #[test]
+    fn gossip_types_use_vanilla_names_and_values() {
+        let types = [
+            (GossipType::MajorNegative, "major_negative", -5, 100, 10),
+            (GossipType::MinorNegative, "minor_negative", -1, 200, 20),
+            (GossipType::MinorPositive, "minor_positive", 1, 25, 1),
+            (GossipType::MajorPositive, "major_positive", 5, 20, 0),
+            (GossipType::Trading, "trading", 1, 25, 2),
+        ];
+
+        for (index, (gossip_type, name, weight, max, decay)) in types.into_iter().enumerate() {
+            assert_eq!(gossip_type.name(), name);
+            assert_eq!(GossipType::from_name(name), Some(gossip_type));
+            assert_eq!(GossipType::from_legacy_id(index as i32), Some(gossip_type));
+            assert_eq!(gossip_type.weight(), weight);
+            assert_eq!(gossip_type.max_value(), max);
+            assert_eq!(gossip_type.daily_decay(), decay);
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/pumpkin/src/entity/passive/villager/mod.rs
+++ b/crates/pumpkin/src/entity/passive/villager/mod.rs
@@ -1,38 +1,55 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicI32, AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, Ordering};
 use std::sync::{Arc, Weak};
 use uuid::Uuid;
 
 use crate::block::blocks::bed::BedBlock;
-use pumpkin_data::Block;
+use pumpkin_data::Enchantment;
+use pumpkin_data::attributes::Attributes;
 use pumpkin_data::block_properties::{
     BedPart, BlockProperties, WhiteBedLikeProperties as BedProperties,
 };
+use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::entity::{EntityPose, EntityType};
+use pumpkin_data::item::{Item, JavaToBedrockItemMapping};
 use pumpkin_data::item_stack::ItemStack;
-use pumpkin_data::tag::Taggable;
+use pumpkin_data::potion::Effect;
+use pumpkin_data::tag::{Enchantment as EnchantmentTag, Taggable};
+use pumpkin_data::tracked_data;
 use pumpkin_inventory::merchant::merchant_screen_handler::MerchantScreenHandler;
 use pumpkin_inventory::screen_handler::{
     BoxFuture, InventoryPlayer, ScreenHandlerFactory, SharedScreenHandler,
 };
 use pumpkin_nbt::compound::NbtCompound;
-use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::{
+    client::set_actor_data::{EntityMetadata, MetadataValue, entity_data_key},
+    server::actor_event::ActorEventType,
+};
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::java::client::play::{CMerchantOffers, Metadata};
 use pumpkin_util::math::{boundingbox::BoundingBox, position::BlockPos, vector3::Vector3};
 use pumpkin_util::text::TextComponent;
+use pumpkin_util::version::JavaMinecraftVersion;
 use pumpkin_world::inventory::SimpleInventory;
 use tokio::sync::Mutex;
 
 use crate::entity::player::Player;
 use crate::entity::{
     Entity, EntityBase, NBTStorage,
-    ai::goal::{
-        avoid_entity::AvoidEntityGoal, look_around::RandomLookAroundGoal,
-        look_at_entity::LookAtEntityGoal, swim::SwimGoal, wander_around::WanderAroundGoal,
+    ai::{
+        goal::{
+            avoid_entity::AvoidEntityGoal, look_around::RandomLookAroundGoal,
+            look_at_entity::LookAtEntityGoal, swim::SwimGoal,
+            trade_with_player::TradeWithPlayerGoal, wander_around::WanderAroundGoal,
+            work_at_job_site::WorkAtJobSiteGoal,
+        },
+        pathfinder::Navigator,
     },
+    experience_orb::ExperienceOrbEntity,
     mob::{Mob, MobEntity},
 };
+use crate::world::World;
+use crate::world::villager_poi::profession_for_block;
 
 pub mod data;
 pub use data::{
@@ -40,23 +57,266 @@ pub use data::{
     get_food_points,
 };
 
+async fn trigger_trade_advancement(player: &Player) {
+    player
+        .trigger_advancement(
+            crate::entity::player::advancement::trigger::AdvancementTrigger::TradedWithVillager,
+        )
+        .await;
+}
+
+fn enchanted_book_offer_items(
+    rng: &mut impl rand::Rng,
+) -> Option<(ItemStack, ItemStack, Option<ItemStack>)> {
+    use pumpkin_data::data_component::DataComponent;
+    use pumpkin_data::data_component_impl::StoredEnchantmentsImpl;
+    use rand::{RngExt, seq::IndexedRandom};
+    use std::borrow::Cow;
+
+    let enchantment_id = *EnchantmentTag::MINECRAFT_TRADEABLE.1.choose(rng)? as u8;
+    let enchantment = Enchantment::from_id(enchantment_id)?;
+    let level = rng.random_range(1..=enchantment.max_level);
+    let mut emeralds = 2 + rng.random_range(0..5 + level * 10) + 3 * level;
+    if enchantment.has_tag(&EnchantmentTag::MINECRAFT_DOUBLE_TRADE_PRICE) {
+        emeralds *= 2;
+    }
+
+    let output = ItemStack::new_with_component(
+        1,
+        &Item::ENCHANTED_BOOK,
+        vec![(
+            DataComponent::StoredEnchantments,
+            Some(Box::new(StoredEnchantmentsImpl {
+                enchantment: Cow::Owned(vec![(enchantment, level)]),
+            })),
+        )],
+    );
+
+    Some((
+        ItemStack::new(emeralds.min(64) as u8, &Item::EMERALD),
+        output,
+        Some(ItemStack::new(1, &Item::BOOK)),
+    ))
+}
+
+fn enchant_trade_item(
+    rng: &mut impl rand::Rng,
+    item: &'static Item,
+    min_level: i32,
+    max_level: i32,
+) -> Option<(ItemStack, i32)> {
+    use pumpkin_data::data_component_impl::EnchantableImpl;
+    use rand::RngExt;
+
+    let mut stack = ItemStack::new(1, item);
+    let enchantability = stack
+        .get_data_component::<EnchantableImpl>()
+        .map_or(1, |value| value.value);
+    let additional_cost = rng.random_range(min_level..=max_level);
+    let mut level = additional_cost
+        + 1
+        + rng.random_range(0..=enchantability / 4)
+        + rng.random_range(0..=enchantability / 4);
+    let bonus = (rng.random::<f32>() + rng.random::<f32>() - 1.0) * 0.15;
+    level = ((level as f32 + level as f32 * bonus).round() as i32).max(1);
+
+    let mut available = EnchantmentTag::MINECRAFT_ON_TRADED_EQUIPMENT
+        .1
+        .iter()
+        .filter_map(|id| Enchantment::from_id(*id as u8))
+        .filter(|enchantment| enchantment.can_enchant(item))
+        .filter_map(|enchantment| {
+            (1..=enchantment.max_level)
+                .rev()
+                .find(|candidate_level| {
+                    (enchantment.min_cost.calculate(*candidate_level)
+                        ..=enchantment.max_cost.calculate(*candidate_level))
+                        .contains(&level)
+                })
+                .map(|candidate_level| (enchantment, candidate_level))
+        })
+        .collect::<Vec<_>>();
+
+    if available.is_empty() {
+        return None;
+    }
+
+    while !available.is_empty() {
+        let total_weight: i32 = available
+            .iter()
+            .map(|(enchantment, _)| enchantment.weight)
+            .sum();
+        let mut choice = rng.random_range(0..total_weight);
+        let chosen_index = available
+            .iter()
+            .position(|(enchantment, _)| {
+                choice -= enchantment.weight;
+                choice < 0
+            })
+            .unwrap_or(0);
+        let (enchantment, enchantment_level) = available[chosen_index];
+        stack.enchant(enchantment, enchantment_level);
+
+        if rng.random_range(0..50) > level {
+            break;
+        }
+        available.retain(|(candidate, _)| candidate.are_compatible(enchantment));
+        level /= 2;
+    }
+    Some((stack, additional_cost))
+}
+
+fn apply_random_dye(rng: &mut impl rand::Rng, stack: &mut ItemStack) {
+    use pumpkin_data::data_component::DataComponent;
+    use pumpkin_data::data_component_impl::{DataComponentImpl, DyedColorImpl};
+    use rand::RngExt;
+
+    const COLORS: [i32; 16] = [
+        0xF9FFFE, 0xF9801D, 0xC74EBD, 0x3AB3DA, 0xFED83D, 0x80C71F, 0xF38BAA, 0x474F52, 0x9D9D97,
+        0x169C9C, 0x8932B8, 0x3C44AA, 0x835432, 0x5E7C16, 0xB02E26, 0x1D1D21,
+    ];
+    let dye_count = 1 + i32::from(rng.random_bool(0.75)) + i32::from(rng.random_bool(0.75));
+    let mut channels = [0; 3];
+    let mut brightness = 0;
+    for _ in 0..dye_count {
+        let color = COLORS[rng.random_range(0..COLORS.len())];
+        let rgb = [(color >> 16) & 255, (color >> 8) & 255, color & 255];
+        brightness += rgb[0].max(rgb[1]).max(rgb[2]);
+        for (total, value) in channels.iter_mut().zip(rgb) {
+            *total += value;
+        }
+    }
+    let mut rgb = channels.map(|channel| channel / dye_count);
+    let average_brightness = brightness / dye_count;
+    let max_channel = rgb[0].max(rgb[1]).max(rgb[2]);
+    for channel in &mut rgb {
+        *channel = average_brightness * *channel / max_channel;
+    }
+    let color = (rgb[0] << 16) | (rgb[1] << 8) | rgb[2];
+    stack.patch.push((
+        DataComponent::DyedColor,
+        Some(DyedColorImpl { rgb: color }.to_dyn()),
+    ));
+}
+
+fn apply_random_stew_effect(rng: &mut impl rand::Rng, stack: &mut ItemStack) {
+    use pumpkin_data::data_component::DataComponent;
+    use pumpkin_data::data_component_impl::{
+        DataComponentImpl, SuspiciousStewEffect, SuspiciousStewEffectsImpl,
+    };
+    use rand::RngExt;
+    use std::borrow::Cow;
+
+    const EFFECTS: [(&str, i32); 6] = [
+        ("minecraft:night_vision", 100),
+        ("minecraft:jump_boost", 160),
+        ("minecraft:weakness", 140),
+        ("minecraft:blindness", 120),
+        ("minecraft:poison", 280),
+        ("minecraft:saturation", 7),
+    ];
+    let (effect, duration) = EFFECTS[rng.random_range(0..EFFECTS.len())];
+    stack.patch.push((
+        DataComponent::SuspiciousStewEffects,
+        Some(
+            SuspiciousStewEffectsImpl {
+                effects: Cow::Owned(vec![SuspiciousStewEffect {
+                    effect: Cow::Owned(effect.to_owned()),
+                    duration,
+                }]),
+            }
+            .to_dyn(),
+        ),
+    ));
+}
+
+fn apply_potion(stack: &mut ItemStack, potion_name: &str) {
+    use pumpkin_data::data_component::DataComponent;
+    use pumpkin_data::data_component_impl::{DataComponentImpl, PotionContentsImpl};
+
+    let Some(potion) = pumpkin_data::potion::Potion::from_name(
+        potion_name
+            .strip_prefix("minecraft:")
+            .unwrap_or(potion_name),
+    ) else {
+        return;
+    };
+    stack.patch.push((
+        DataComponent::PotionContents,
+        Some(
+            PotionContentsImpl {
+                potion_id: Some(i32::from(potion.id)),
+                custom_color: None,
+                custom_effects: Vec::new(),
+                custom_name: None,
+            }
+            .to_dyn(),
+        ),
+    ));
+}
+
 pub struct VillagerEntity {
     pub mob_entity: MobEntity,
     pub villager_data: Mutex<VillagerData>,
     pub food_level: AtomicI32,
     pub xp: AtomicI32,
     pub last_restock_time: AtomicI64,
+    pub last_restock_check_day: AtomicI64,
+    pub last_worked_at_poi: AtomicI64,
     pub restocks_today: AtomicI32,
+    pub last_gossip_decay_time: AtomicI64,
     pub gossips: Mutex<HashMap<Uuid, HashMap<GossipType, i32>>>,
     pub inventory: Arc<Mutex<Vec<Arc<Mutex<ItemStack>>>>>,
     pub merchant_inventory: Arc<SimpleInventory>,
     pub offers: Mutex<Vec<pumpkin_protocol::java::client::play::MerchantOffer>>,
+    pub merchant_update_timer: AtomicI32,
+    pub unhappy_counter: AtomicI32,
+    pub trade_sound_cooldown: AtomicI32,
+    pub increase_profession_level_on_update: AtomicBool,
+    pub last_traded_player: Mutex<Option<Uuid>>,
+    pub trading_player: std::sync::Mutex<Option<(Uuid, u8)>>,
+    pub is_trading: AtomicBool,
     pub job_site: std::sync::Mutex<Option<BlockPos>>,
+    pub job_site_pending: AtomicBool,
     pub home_pos: std::sync::Mutex<Option<BlockPos>>,
     pub self_weak: std::sync::Mutex<Option<Weak<Self>>>,
 }
 
 impl VillagerEntity {
+    fn bedrock_metadata(data: VillagerData, xp: i32) -> EntityMetadata {
+        const PROFESSIONS: [i32; 15] = [0, 8, 11, 6, 7, 1, 2, 4, 12, 5, 13, 14, 3, 10, 9];
+        const REGIONS: [i32; 7] = [1, 2, 0, 3, 4, 5, 6];
+
+        let mut metadata = EntityMetadata::new();
+        metadata.set(
+            entity_data_key::VARIANT,
+            MetadataValue::Int(
+                usize::try_from(data.profession.0)
+                    .ok()
+                    .and_then(|id| PROFESSIONS.get(id))
+                    .copied()
+                    .unwrap_or_default(),
+            ),
+        );
+        metadata.set(
+            entity_data_key::MARK_VARIANT,
+            MetadataValue::Int(
+                usize::try_from(data.r#type.0)
+                    .ok()
+                    .and_then(|id| REGIONS.get(id))
+                    .copied()
+                    .unwrap_or_default(),
+            ),
+        );
+        metadata.set(
+            entity_data_key::TRADE_TIER,
+            MetadataValue::Int(data.level.0.saturating_sub(1)),
+        );
+        metadata.set(entity_data_key::MAX_TRADE_TIER, MetadataValue::Int(4));
+        metadata.set(entity_data_key::TRADE_EXPERIENCE, MetadataValue::Int(xp));
+        metadata
+    }
+
     #[allow(clippy::too_many_lines)]
     pub fn new(entity: Entity) -> Arc<Self> {
         let mob_entity = MobEntity::new(entity);
@@ -73,12 +333,23 @@ impl VillagerEntity {
             food_level: AtomicI32::new(0),
             xp: AtomicI32::new(0),
             last_restock_time: AtomicI64::new(0),
+            last_restock_check_day: AtomicI64::new(0),
+            last_worked_at_poi: AtomicI64::new(0),
             restocks_today: AtomicI32::new(0),
+            last_gossip_decay_time: AtomicI64::new(0),
             gossips: Mutex::new(HashMap::new()),
             inventory,
             merchant_inventory: Arc::new(SimpleInventory::new(3)),
             offers: Mutex::new(Vec::new()),
+            merchant_update_timer: AtomicI32::new(0),
+            unhappy_counter: AtomicI32::new(0),
+            trade_sound_cooldown: AtomicI32::new(0),
+            increase_profession_level_on_update: AtomicBool::new(false),
+            last_traded_player: Mutex::new(None),
+            trading_player: std::sync::Mutex::new(None),
+            is_trading: AtomicBool::new(false),
             job_site: std::sync::Mutex::new(None),
+            job_site_pending: AtomicBool::new(false),
             home_pos: std::sync::Mutex::new(None),
             self_weak: std::sync::Mutex::new(None),
         };
@@ -148,26 +419,29 @@ impl VillagerEntity {
                 Box::new(AvoidEntityGoal::new(&EntityType::VEX, 12.0, 0.5, 0.5)),
             );
 
+            goal_selector.add_goal(2, Box::new(TradeWithPlayerGoal::new(0.5)));
             // Basic movement and looking (Vanilla uses 0.5 speed)
-            goal_selector.add_goal(2, Box::new(WanderAroundGoal::new(0.5)));
+            goal_selector.add_goal(3, Box::new(WorkAtJobSiteGoal::new(0.5)));
+            goal_selector.add_goal(4, Box::new(WanderAroundGoal::new(0.5)));
             goal_selector.add_goal(
-                3,
+                5,
                 LookAtEntityGoal::with_default(mob_weak.clone(), &EntityType::PLAYER, 8.0),
             );
             goal_selector.add_goal(
-                4,
+                6,
                 LookAtEntityGoal::with_default(mob_weak, &EntityType::VILLAGER, 8.0),
             );
-            goal_selector.add_goal(5, Box::new(RandomLookAroundGoal::default()));
+            goal_selector.add_goal(7, Box::new(RandomLookAroundGoal::default()));
         };
 
         // Send initial metadata
+        let bedrock_metadata = Self::bedrock_metadata(villager_data, 0);
         mob_arc.get_entity().send_meta_data(
             &[Metadata::new(
-                pumpkin_data::tracked_data::villager::VILLAGER_DATA,
+                tracked_data::villager::VILLAGER_DATA,
                 villager_data,
             )],
-            None,
+            Some(&bedrock_metadata),
         );
 
         mob_arc
@@ -183,6 +457,16 @@ impl VillagerEntity {
             }
         }
         total
+    }
+
+    fn poi_owner(&self) -> Option<Weak<dyn EntityBase>> {
+        let owner = self
+            .self_weak
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()?;
+        let owner: Weak<dyn EntityBase> = owner;
+        Some(owner)
     }
 
     pub async fn eat_until_full(&self) {
@@ -219,48 +503,206 @@ impl VillagerEntity {
             *villager_data = data;
             old_profession
         };
+        let bedrock_metadata = Self::bedrock_metadata(data, self.xp.load(Ordering::Relaxed));
         self.get_entity().send_meta_data(
-            &[Metadata::new(
-                pumpkin_data::tracked_data::villager::VILLAGER_DATA,
-                data,
-            )],
-            None,
+            &[Metadata::new(tracked_data::villager::VILLAGER_DATA, data)],
+            Some(&bedrock_metadata),
         );
 
         if old_profession != data.profession {
-            self.generate_trades(data.profession_enum(), data.level.0)
-                .await;
-            if let Some(sound) = data.profession_enum().work_sound() {
-                self.get_entity().play_sound(sound);
-            }
+            self.offers.lock().await.clear();
         }
     }
 
+    #[expect(clippy::too_many_lines)]
+    async fn create_explorer_map(&self, destination: &str) -> Option<ItemStack> {
+        use pumpkin_data::data_component::DataComponent;
+        use pumpkin_data::data_component_impl::{DataComponentImpl, ItemNameImpl, MapIdImpl};
+        use pumpkin_data::structures::{StructureKeys, StructureSet};
+        use pumpkin_world::generation::generator::structure_finder::find_nearest_structure_start;
+
+        let (structure_set, structure, name, icon_type) = match destination {
+            "minecraft:on_jungle_explorer_maps" => (
+                "jungle_temples",
+                StructureKeys::JunglePyramid,
+                "filled_map.explorer_jungle",
+                32,
+            ),
+            "minecraft:on_swamp_explorer_maps" => (
+                "swamp_huts",
+                StructureKeys::SwampHut,
+                "filled_map.explorer_swamp",
+                33,
+            ),
+            "minecraft:on_desert_village_maps" => (
+                "villages",
+                StructureKeys::VillageDesert,
+                "filled_map.village_desert",
+                27,
+            ),
+            "minecraft:on_plains_village_maps" => (
+                "villages",
+                StructureKeys::VillagePlains,
+                "filled_map.village_plains",
+                28,
+            ),
+            "minecraft:on_savanna_village_maps" => (
+                "villages",
+                StructureKeys::VillageSavanna,
+                "filled_map.village_savanna",
+                29,
+            ),
+            "minecraft:on_snowy_village_maps" => (
+                "villages",
+                StructureKeys::VillageSnowy,
+                "filled_map.village_snowy",
+                30,
+            ),
+            "minecraft:on_taiga_village_maps" => (
+                "villages",
+                StructureKeys::VillageTaiga,
+                "filled_map.village_taiga",
+                31,
+            ),
+            "minecraft:on_ocean_explorer_maps" => (
+                "ocean_monuments",
+                StructureKeys::Monument,
+                "filled_map.monument",
+                9,
+            ),
+            "minecraft:on_trial_chambers_maps" => (
+                "trial_chambers",
+                StructureKeys::TrialChambers,
+                "filled_map.trial_chambers",
+                34,
+            ),
+            "minecraft:on_woodland_explorer_maps" => (
+                "woodland_mansions",
+                StructureKeys::Mansion,
+                "filled_map.mansion",
+                8,
+            ),
+            _ => return None,
+        };
+
+        let world = self.get_entity().world.load().clone();
+        let generator = world.level.world_gen();
+        let target = find_nearest_structure_start(
+            self.get_entity().block_pos.load(),
+            StructureSet::get(structure_set)?,
+            &[structure],
+            100,
+            &generator,
+        )?;
+        let server = world.server.upgrade()?;
+        let map_id = server.next_map_id();
+        let map = server.map_manager.create_map(
+            map_id,
+            world.dimension.clone(),
+            target.0.x,
+            target.0.z,
+            2,
+        );
+        map.lock()
+            .await
+            .decorations
+            .push(crate::world::map::MapDecoration {
+                icon_type,
+                x: 0,
+                z: 0,
+                direction: 8,
+                display_name: None,
+            });
+
+        let mut stack = ItemStack::new(1, &Item::FILLED_MAP);
+        stack.patch.push((
+            DataComponent::MapId,
+            Some(MapIdImpl { id: map_id }.to_dyn()),
+        ));
+        stack.patch.push((
+            DataComponent::ItemName,
+            Some(ItemNameImpl { name: name.into() }.to_dyn()),
+        ));
+        Some(stack)
+    }
+
     pub async fn add_trades(&self, profession: VillagerProfession, level: i32) {
+        use pumpkin_data::villager::VillagerTradeModifier;
         use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
         use rand::seq::IndexedRandom;
+        use rand::{RngExt, SeedableRng, rngs::StdRng};
         use std::borrow::Cow;
 
+        let villager_type = self.villager_data.lock().await.type_enum();
         let mut offers = self.offers.lock().await;
 
         if let Some(trade_set) = profession.trade_set(level) {
-            let mut rng = rand::rng();
-            let chosen_trades = trade_set.trades.sample(&mut rng, trade_set.amount as usize);
+            let mut rng = StdRng::from_rng(&mut rand::rng());
+            let mut remaining_trades = trade_set.trades.iter().collect::<Vec<_>>();
+            let mut added = 0;
+            while added < trade_set.amount && !remaining_trades.is_empty() {
+                let index = rng.random_range(0..remaining_trades.len());
+                let trade = remaining_trades.remove(index);
+                if !trade.allowed_types.is_empty() && !trade.allowed_types.contains(&villager_type)
+                {
+                    continue;
+                }
+                let mut base_cost_a = ItemStack::new(trade.wants.count as u8, trade.wants.item);
+                let mut output = ItemStack::new(trade.gives.count as u8, trade.gives.item);
+                let mut cost_b = trade
+                    .wants_b
+                    .as_ref()
+                    .map(|b| ItemStack::new(b.count as u8, b.item));
 
-            for trade in chosen_trades {
+                match trade.modifier {
+                    VillagerTradeModifier::None => {}
+                    VillagerTradeModifier::EnchantRandomly => {
+                        let Some(items) = enchanted_book_offer_items(&mut rng) else {
+                            continue;
+                        };
+                        (base_cost_a, output, cost_b) = items;
+                    }
+                    VillagerTradeModifier::EnchantWithLevels { min, max } => {
+                        let Some((enchanted, additional_cost)) =
+                            enchant_trade_item(&mut rng, trade.gives.item, min, max)
+                        else {
+                            continue;
+                        };
+                        output = enchanted;
+                        let count = i32::from(base_cost_a.item_count)
+                            .saturating_add(additional_cost)
+                            .clamp(0, i32::from(base_cost_a.get_max_stack_size()));
+                        if count == 0 {
+                            continue;
+                        }
+                        base_cost_a.set_count(count as u8);
+                    }
+                    VillagerTradeModifier::ExplorationMap { destination } => {
+                        let Some(map) = self.create_explorer_map(destination).await else {
+                            continue;
+                        };
+                        output = map;
+                    }
+                    VillagerTradeModifier::RandomDyes => apply_random_dye(&mut rng, &mut output),
+                    VillagerTradeModifier::RandomPotion => {
+                        let Some(potion_name) = pumpkin_data::tag::Potion::MINECRAFT_TRADEABLE
+                            .0
+                            .choose(&mut rng)
+                        else {
+                            continue;
+                        };
+                        apply_potion(&mut output, potion_name);
+                    }
+                    VillagerTradeModifier::SuspiciousStew => {
+                        apply_random_stew_effect(&mut rng, &mut output);
+                    }
+                    VillagerTradeModifier::Potion(potion) => apply_potion(&mut output, potion),
+                }
                 offers.push(pumpkin_protocol::java::client::play::MerchantOffer {
-                    base_cost_a: ItemStackSerializer(Cow::Owned(ItemStack::new(
-                        trade.wants.count as u8,
-                        trade.wants.item,
-                    ))),
-                    output: ItemStackSerializer(Cow::Owned(ItemStack::new(
-                        trade.gives.count as u8,
-                        trade.gives.item,
-                    ))),
-                    cost_b: trade.wants_b.as_ref().map(|b| {
-                        ItemStackSerializer(Cow::Owned(ItemStack::new(b.count as u8, b.item)))
-                    }),
-                    is_disabled: false,
+                    base_cost_a: ItemStackSerializer(Cow::Owned(base_cost_a)),
+                    output: ItemStackSerializer(Cow::Owned(output)),
+                    cost_b: cost_b.map(|stack| ItemStackSerializer(Cow::Owned(stack))),
+                    reward_exp: true,
                     uses: 0,
                     max_uses: trade.max_uses,
                     xp: trade.xp,
@@ -268,6 +710,7 @@ impl VillagerEntity {
                     price_multiplier: trade.price_multiplier,
                     demand: 0,
                 });
+                added += 1;
             }
         }
     }
@@ -277,8 +720,438 @@ impl VillagerEntity {
         self.add_trades(profession, level).await;
     }
 
+    async fn update_special_prices(&self, player: &Player) {
+        let player_uuid = player.get_entity().entity_uuid;
+        let reputation = self
+            .gossips
+            .lock()
+            .await
+            .get(&player_uuid)
+            .map_or(0, |gossips| {
+                gossips
+                    .iter()
+                    .map(|(kind, value)| kind.weight() * value)
+                    .sum()
+            });
+        let hero_amplifier = player
+            .living_entity
+            .get_effect(&StatusEffect::HERO_OF_THE_VILLAGE)
+            .await
+            .map(|effect| i32::from(effect.amplifier));
+
+        let mut offers = self.offers.lock().await;
+        for offer in offers.iter_mut() {
+            offer.special_price = -((reputation as f32 * offer.price_multiplier).floor() as i32);
+            if let Some(amplifier) = hero_amplifier {
+                let discount = ((0.3 + 0.0625 * f64::from(amplifier))
+                    * f64::from(offer.base_cost_a.0.item_count))
+                .floor() as i32;
+                offer.special_price -= discount.max(1);
+            }
+        }
+    }
+
+    async fn reset_special_prices(&self) {
+        for offer in self.offers.lock().await.iter_mut() {
+            offer.special_price = 0;
+        }
+    }
+
+    fn can_continue_trading(
+        &self,
+        inventory_player: &dyn InventoryPlayer,
+        player_uuid: Uuid,
+        sync_id: u8,
+    ) -> bool {
+        let Some(player) = inventory_player.as_any().downcast_ref::<Player>() else {
+            return false;
+        };
+        let entity = self.get_entity();
+        let range = player
+            .living_entity
+            .get_attribute_value(&Attributes::ENTITY_INTERACTION_RANGE)
+            + 4.0;
+        entity.is_alive()
+            && self.mob_entity.living_entity.health.load() > 0.0
+            && self
+                .trading_player
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .as_ref()
+                .is_some_and(|(uuid, id)| *uuid == player_uuid && *id == sync_id)
+            && entity
+                .bounding_box
+                .load()
+                .squared_magnitude(player.eye_position())
+                < range * range
+    }
+
+    async fn complete_trade(&self, offer_index: usize, world: &Arc<World>, player_uuid: Uuid) {
+        let (xp_gain, reward_exp) = {
+            let mut offers = self.offers.lock().await;
+            let Some(offer) = offers.get_mut(offer_index) else {
+                return;
+            };
+            offer.uses += 1;
+            (offer.xp, offer.reward_exp)
+        };
+
+        let current_xp = self.xp.fetch_add(xp_gain, Ordering::Relaxed) + xp_gain;
+        let villager_data = *self.villager_data.lock().await;
+        let bedrock_metadata = Self::bedrock_metadata(villager_data, current_xp);
+        self.get_entity().send_meta_data(
+            &[Metadata::new(
+                tracked_data::villager::VILLAGER_DATA,
+                villager_data,
+            )],
+            Some(&bedrock_metadata),
+        );
+        let mut reward_xp = {
+            use rand::RngExt;
+            rand::rng().random_range(3..=6)
+        };
+
+        let current_level = villager_data.level.0;
+        if current_level < 5 {
+            let max_xp = match current_level {
+                1 => 10,
+                2 => 70,
+                3 => 150,
+                4 => 250,
+                _ => 0,
+            };
+            if current_xp >= max_xp {
+                self.merchant_update_timer.store(40, Ordering::Relaxed);
+                self.increase_profession_level_on_update
+                    .store(true, Ordering::Relaxed);
+                reward_xp += 5;
+            }
+        }
+        self.get_entity()
+            .play_sound(pumpkin_data::sound::Sound::EntityVillagerYes);
+        self.trade_sound_cooldown.store(20, Ordering::Relaxed);
+        *self.last_traded_player.lock().await = Some(player_uuid);
+        if reward_exp {
+            let position = self.get_entity().pos.load().add_raw(0.0, 0.5, 0.0);
+            ExperienceOrbEntity::spawn(world, position, reward_xp).await;
+        }
+
+        if let Some(player) = world.get_player_by_uuid(player_uuid) {
+            trigger_trade_advancement(&player).await;
+        }
+    }
+
+    async fn resend_offers_to_trading_player(&self) {
+        let trading_player = *self
+            .trading_player
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some((player_uuid, sync_id)) = trading_player else {
+            return;
+        };
+        let world = self.get_entity().world.load();
+        let Some(player) = world.get_player_by_uuid(player_uuid) else {
+            return;
+        };
+        let offers = self.offers.lock().await.clone();
+        let villager_data = *self.villager_data.lock().await;
+
+        let screen = player.current_screen_handler.lock().await.clone();
+        let mut screen = screen.lock().await;
+        if screen.sync_id() != sync_id {
+            return;
+        }
+        if let Some(handler) = screen.as_any_mut().downcast_mut::<MerchantScreenHandler>() {
+            handler.offers.clone_from(&offers);
+            handler.update_result_slot().await;
+        } else {
+            return;
+        }
+        drop(screen);
+        self.send_trade_offers(&player, sync_id, offers, villager_data)
+            .await;
+    }
+
+    async fn decay_gossips(&self, game_time: i64) {
+        let last_decay = self.last_gossip_decay_time.load(Ordering::Relaxed);
+        if last_decay == 0 {
+            self.last_gossip_decay_time
+                .store(game_time, Ordering::Relaxed);
+            return;
+        }
+        if game_time < last_decay + 24_000 {
+            return;
+        }
+
+        let mut gossips = self.gossips.lock().await;
+        for values in gossips.values_mut() {
+            values.retain(|kind, value| {
+                *value -= kind.daily_decay();
+                *value > 0
+            });
+        }
+        gossips.retain(|_, values| !values.is_empty());
+        self.last_gossip_decay_time
+            .store(game_time, Ordering::Relaxed);
+    }
+
+    async fn work_at_job_site(&self, game_time: i64, day_time: i64, day: i64) {
+        use rand::RngExt;
+
+        if !(2_000..9_000).contains(&day_time)
+            || game_time - self.last_worked_at_poi.load(Ordering::Relaxed) < 300
+            || !rand::rng().random_bool(0.5)
+        {
+            return;
+        }
+        self.last_worked_at_poi.store(game_time, Ordering::Relaxed);
+
+        let Some(job_site) = self.get_job_site() else {
+            return;
+        };
+        if job_site
+            .to_centered_f64()
+            .squared_distance_to_vec(&self.get_entity().pos.load())
+            >= 1.73f64.powi(2)
+        {
+            return;
+        }
+
+        let profession = self.villager_data.lock().await.profession_enum();
+        if let Some(sound) = profession.work_sound() {
+            self.get_entity().play_sound(sound);
+        }
+
+        let last_restock = self.last_restock_time.load(Ordering::Relaxed);
+        let last_check_day = self.last_restock_check_day.swap(day, Ordering::Relaxed);
+        if game_time > last_restock + 12_000 || (last_check_day > 0 && day > last_check_day) {
+            let missed_restock_count = (2 - self.restocks_today.load(Ordering::Relaxed)).max(0);
+            let mut offers = self.offers.lock().await;
+            if missed_restock_count > 0 {
+                for offer in offers.iter_mut() {
+                    offer.reset_uses();
+                }
+            }
+            for _ in 0..missed_restock_count {
+                for offer in offers.iter_mut() {
+                    offer.update_demand();
+                }
+            }
+            drop(offers);
+            self.last_restock_time.store(game_time, Ordering::Relaxed);
+            self.restocks_today.store(0, Ordering::Relaxed);
+            self.resend_offers_to_trading_player().await;
+        }
+
+        let restocks_today = self.restocks_today.load(Ordering::Relaxed);
+        let allowed = restocks_today == 0
+            || (restocks_today < 2
+                && game_time > self.last_restock_time.load(Ordering::Relaxed) + 2_400);
+        if !allowed {
+            return;
+        }
+
+        let mut offers = self.offers.lock().await;
+        if !offers
+            .iter()
+            .any(pumpkin_protocol::java::client::play::MerchantOffer::needs_restock)
+        {
+            return;
+        }
+        for offer in offers.iter_mut() {
+            offer.update_demand();
+            offer.reset_uses();
+        }
+        self.last_restock_time.store(game_time, Ordering::Relaxed);
+        self.restocks_today.fetch_add(1, Ordering::Relaxed);
+        drop(offers);
+        self.resend_offers_to_trading_player().await;
+    }
+
+    #[expect(clippy::too_many_lines)]
+    async fn update_job_site(&self, world: &crate::world::World) {
+        let data = *self.villager_data.lock().await;
+        let profession = data.profession_enum();
+        let is_adult = self.get_entity().age.load(Ordering::Relaxed) >= 0;
+
+        if profession == VillagerProfession::Nitwit || !is_adult {
+            if let Some(site) = self.get_job_site() {
+                world
+                    .villager_poi
+                    .lock()
+                    .await
+                    .release(site, self.get_entity().entity_uuid);
+                *self
+                    .job_site
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                self.job_site_pending.store(false, Ordering::Relaxed);
+            }
+            return;
+        }
+
+        let Some(owner) = self.poi_owner() else {
+            return;
+        };
+
+        if let Some(current_site) = self.get_job_site()
+            && current_site
+                .to_centered_f64()
+                .squared_distance_to_vec(&self.get_entity().pos.load())
+                < 16.0f64.powi(2)
+        {
+            let (block, _state) = world.get_block_and_state(&current_site);
+            let expected = (profession != VillagerProfession::None).then_some(profession);
+            let valid = world
+                .villager_poi
+                .lock()
+                .await
+                .claim(current_site, block, owner.clone(), expected)
+                .is_some();
+
+            if !valid {
+                *self
+                    .job_site
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                self.job_site_pending.store(false, Ordering::Relaxed);
+                if self.xp.load(Ordering::Relaxed) == 0
+                    && data.level.0 <= 1
+                    && profession != VillagerProfession::None
+                {
+                    let r#type = self.villager_data.lock().await.type_enum();
+                    self.set_villager_data(VillagerData::new(r#type, VillagerProfession::None, 1))
+                        .await;
+                }
+            }
+        }
+
+        if self.get_job_site().is_none() {
+            let profession = self.villager_data.lock().await.profession_enum();
+            let expected = (profession != VillagerProfession::None).then_some(profession);
+            let pos = self.get_entity().block_pos.load();
+            let start = BlockPos::new(pos.0.x - 10, pos.0.y - 4, pos.0.z - 10);
+            let end = BlockPos::new(pos.0.x + 10, pos.0.y + 4, pos.0.z + 10);
+            let mut candidates = Vec::new();
+
+            let indexed_sites = world
+                .villager_poi
+                .lock()
+                .await
+                .available_job_sites(pos, 48, expected);
+            let saved_sites = world.portal_poi.lock().await.get_in_square(pos, 48, None);
+            for position in indexed_sites.into_iter().chain(saved_sites) {
+                let delta = position.0 - pos.0;
+                if i64::from(delta.x).pow(2) + i64::from(delta.y).pow(2) + i64::from(delta.z).pow(2)
+                    > 48i64.pow(2)
+                    || candidates
+                        .iter()
+                        .any(|(_, candidate, _, _)| *candidate == position)
+                {
+                    continue;
+                }
+                let (block, _state) = world.get_block_and_state(&position);
+                if let Some(site_profession) = profession_for_block(block)
+                    && expected.is_none_or(|profession| profession == site_profession)
+                {
+                    let distance = position
+                        .to_centered_f64()
+                        .squared_distance_to_vec(&self.get_entity().pos.load());
+                    candidates.push((distance, position, block, site_profession));
+                }
+            }
+
+            for position in BlockPos::iterate(start, end) {
+                let (block, _state) = world.get_block_and_state(&position);
+                let Some(site_profession) = profession_for_block(block) else {
+                    continue;
+                };
+                if expected.is_some_and(|profession| profession != site_profession)
+                    || candidates
+                        .iter()
+                        .any(|(_, candidate, _, _)| *candidate == position)
+                {
+                    continue;
+                }
+                let distance = position
+                    .to_centered_f64()
+                    .squared_distance_to_vec(&self.get_entity().pos.load());
+                candidates.push((distance, position, block, site_profession));
+            }
+            candidates.sort_by(|left, right| left.0.total_cmp(&right.0));
+
+            let mut navigator = Navigator::default();
+            let mut claimed = None;
+            for (_, position, block, _) in candidates.into_iter().take(5) {
+                if !navigator
+                    .can_reach_within(
+                        &self.mob_entity.living_entity,
+                        position.to_centered_f64(),
+                        1.73,
+                    )
+                    .await
+                {
+                    continue;
+                }
+                if world
+                    .villager_poi
+                    .lock()
+                    .await
+                    .claim(position, block, owner.clone(), expected)
+                    .is_some()
+                {
+                    claimed = Some(position);
+                    break;
+                }
+            }
+
+            if let Some(site) = claimed {
+                *self
+                    .job_site
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(site);
+                self.job_site_pending.store(true, Ordering::Relaxed);
+            }
+        }
+
+        if self.job_site_pending.load(Ordering::Relaxed)
+            && let Some(site) = self.get_job_site()
+            && site
+                .to_centered_f64()
+                .squared_distance_to_vec(&self.get_entity().pos.load())
+                < 2.0f64.powi(2)
+        {
+            let (block, _state) = world.get_block_and_state(&site);
+            if let Some(claimed_profession) = profession_for_block(block) {
+                let profession = self.villager_data.lock().await.profession_enum();
+                if profession != VillagerProfession::None && profession != claimed_profession {
+                    return;
+                }
+                world.send_entity_status(
+                    self.get_entity(),
+                    pumpkin_data::entity::EntityStatus::VillagerHappy,
+                    Some(ActorEventType::VillagerHappy),
+                );
+                self.job_site_pending.store(false, Ordering::Relaxed);
+                if profession == VillagerProfession::None {
+                    let r#type = self.villager_data.lock().await.type_enum();
+                    self.set_villager_data(VillagerData::new(r#type, claimed_profession, 1))
+                        .await;
+                }
+            }
+        }
+    }
+
     pub fn set_unhappy(&self) {
         let entity = self.get_entity();
+        self.unhappy_counter.store(40, Ordering::Relaxed);
+        entity.send_meta_data(
+            &[Metadata::new(
+                tracked_data::villager::UNHAPPY_COUNTER,
+                VarInt(40),
+            )],
+            None,
+        );
         entity.world.load().send_entity_status(
             entity,
             pumpkin_data::entity::EntityStatus::VillagerAngry,
@@ -288,26 +1161,154 @@ impl VillagerEntity {
     }
 
     pub async fn open_trading_screen(&self, player: &Arc<Player>) {
-        use pumpkin_protocol::codec::var_int::VarInt;
-        use pumpkin_protocol::java::client::play::CMerchantOffers;
-
         // Open the merchant screen and then send the current offers packet
         if let Some(sync_id) = player.open_handled_screen(self, None).await {
             let offers = self.offers.lock().await.clone();
-            let villager_data = self.villager_data.lock().await;
-
-            player
-                .client
-                .enqueue_packet(&CMerchantOffers::new(
-                    VarInt(sync_id as i32),
-                    offers,
-                    villager_data.level,
-                    VarInt(self.xp.load(Ordering::Relaxed)),
-                    true,
-                    true,
-                ))
+            let villager_data = *self.villager_data.lock().await;
+            self.send_trade_offers(player, sync_id, offers, villager_data)
                 .await;
         }
+    }
+
+    fn bedrock_trade_item(stack: &ItemStack, count: u8) -> NbtCompound {
+        let mut item = NbtCompound::new();
+        if stack.is_empty() {
+            return item;
+        }
+        let Some(mapping) = JavaToBedrockItemMapping::from_java_item_id(stack.item.id) else {
+            return item;
+        };
+        item.put_byte("Count", count as i8);
+        item.put_short("Damage", mapping.bedrock_data as i16);
+        item.put_string("Name", mapping.bedrock_item.registry_key.to_owned());
+        item
+    }
+
+    fn bedrock_trade_data(
+        offers: &[pumpkin_protocol::java::client::play::MerchantOffer],
+        level: i32,
+    ) -> NbtCompound {
+        use pumpkin_nbt::tag::NbtTag;
+
+        let tier = level.saturating_sub(1).max(0);
+        let mut recipes = Vec::with_capacity(offers.len() + usize::from(level < 5));
+        for (index, offer) in offers.iter().enumerate() {
+            let base_cost = &offer.base_cost_a.0;
+            let demand_bonus = (i32::from(base_cost.item_count).saturating_mul(offer.demand) as f32
+                * offer.price_multiplier)
+                .floor()
+                .max(0.0) as i32;
+            let adjusted_count = i32::from(base_cost.item_count)
+                .saturating_add(demand_bonus)
+                .saturating_add(offer.special_price)
+                .clamp(1, i32::from(base_cost.get_max_stack_size()))
+                as u8;
+
+            let mut recipe = NbtCompound::new();
+            recipe.put_int("netId", index as i32 + 1);
+            recipe.put_int(
+                "maxUses",
+                if offer.is_out_of_stock() {
+                    0
+                } else {
+                    offer.max_uses
+                },
+            );
+            recipe.put_int("traderExp", offer.xp);
+            recipe.put_float("priceMultiplierA", offer.price_multiplier);
+            recipe.put_float("priceMultiplierB", 0.0);
+            recipe.put_compound(
+                "sell",
+                Self::bedrock_trade_item(&offer.output.0, offer.output.0.item_count),
+            );
+            recipe.put_int("buyCountA", i32::from(base_cost.item_count));
+            recipe.put_int(
+                "buyCountB",
+                offer
+                    .cost_b
+                    .as_ref()
+                    .map_or(0, |cost| i32::from(cost.0.item_count)),
+            );
+            recipe.put_int("demand", offer.demand);
+            recipe.put_int("tier", (index as i32 / 2).min(tier));
+            recipe.put_compound("buyA", Self::bedrock_trade_item(base_cost, adjusted_count));
+            recipe.put_compound(
+                "buyB",
+                offer.cost_b.as_ref().map_or_else(NbtCompound::new, |cost| {
+                    Self::bedrock_trade_item(&cost.0, cost.0.item_count)
+                }),
+            );
+            recipe.put_int("uses", offer.uses);
+            recipe.put_byte("rewardExp", i8::from(offer.reward_exp));
+            recipes.push(NbtTag::Compound(recipe));
+        }
+
+        // Bedrock uses this hidden next-tier entry to render the villager XP bar.
+        if level < 5 {
+            let mut recipe = NbtCompound::new();
+            recipe.put_int("maxUses", 0);
+            recipe.put_int("traderExp", 0);
+            recipe.put_float("priceMultiplierA", 0.0);
+            recipe.put_float("priceMultiplierB", 0.0);
+            recipe.put_int("buyCountA", 0);
+            recipe.put_int("buyCountB", 0);
+            recipe.put_int("demand", 0);
+            recipe.put_int("tier", 5);
+            recipe.put_int("uses", 0);
+            recipe.put_byte("rewardExp", 0);
+            recipes.push(NbtTag::Compound(recipe));
+        }
+
+        let mut data = NbtCompound::new();
+        data.put_list("Recipes", recipes);
+        data.put_list(
+            "TierExpRequirements",
+            [0, 10, 70, 150, 250]
+                .into_iter()
+                .enumerate()
+                .map(|(tier, xp)| {
+                    let mut requirement = NbtCompound::new();
+                    requirement.put_int(&tier.to_string(), xp);
+                    NbtTag::Compound(requirement)
+                })
+                .collect(),
+        );
+        data
+    }
+
+    async fn send_trade_offers(
+        &self,
+        player: &Player,
+        sync_id: u8,
+        offers: Vec<pumpkin_protocol::java::client::play::MerchantOffer>,
+        villager_data: VillagerData,
+    ) {
+        use pumpkin_protocol::{bedrock::client::CUpdateTrade, codec::var_long::VarLong};
+
+        let java = CMerchantOffers::new(
+            VarInt(i32::from(sync_id)),
+            offers.clone(),
+            villager_data.level,
+            VarInt(self.xp.load(Ordering::Relaxed)),
+            true,
+            true,
+        );
+        let bedrock = CUpdateTrade {
+            container_id: sync_id,
+            r#type: 15,
+            size: VarInt(0),
+            trader_tier: VarInt(villager_data.level.0.saturating_sub(1)),
+            entity_unique_id: VarLong(i64::from(self.get_entity().entity_id)),
+            last_trading_player: VarLong(i64::from(player.entity_id())),
+            display_name: ScreenHandlerFactory::get_display_name(self).to_pretty_console(),
+            use_new_trade_screen: true,
+            using_economy_trade: true,
+            data: Self::bedrock_trade_data(&offers, villager_data.level.0),
+        };
+        player
+            .client
+            .enqueue_packet_editioned(&java, &bedrock)
+            .await;
     }
 }
 
@@ -319,16 +1320,18 @@ impl ScreenHandlerFactory for VillagerEntity {
         player: &'a dyn InventoryPlayer,
     ) -> BoxFuture<'a, Option<SharedScreenHandler>> {
         Box::pin(async move {
-            let offers = self.offers.lock().await;
             let self_weak = self
                 .self_weak
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone()?;
-            let player_uuid = player
-                .as_any()
-                .downcast_ref::<crate::entity::player::Player>()
-                .map_or_else(uuid::Uuid::nil, |p| p.get_entity().entity_uuid);
+            let server_player = player.as_any().downcast_ref::<Player>();
+            let player_uuid =
+                server_player.map_or_else(uuid::Uuid::nil, |p| p.get_entity().entity_uuid);
+            if let Some(player) = server_player {
+                self.update_special_prices(player).await;
+            }
+            let offers = self.offers.lock().await;
             let world = self.get_entity().world.load().clone();
 
             let mut handler = MerchantScreenHandler::new(
@@ -339,72 +1342,59 @@ impl ScreenHandlerFactory for VillagerEntity {
             )
             .await;
 
-            handler.on_trade = Some(Box::new(move |offer_index| {
-                if let Some(villager) = self_weak.upgrade() {
-                    let world = world.clone();
-                    tokio::spawn(async move {
-                        if let Some(player) = world.get_player_by_uuid(player_uuid) {
-                            let mut offers = villager.offers.lock().await;
-                            if offer_index < offers.len() {
-                                let offer = &mut offers[offer_index];
-                                offer.uses += 1;
-
-                                let xp_gain = offer.xp;
-                                let current_xp =
-                                    villager.xp.fetch_add(xp_gain, Ordering::Relaxed) + xp_gain;
-
-                                let mut data = villager.villager_data.lock().await;
-                                let current_level = data.level.0;
-                                if current_level < 5 {
-                                    let max_xp = match current_level {
-                                        1 => 10,
-                                        2 => 70,
-                                        3 => 150,
-                                        4 => 250,
-                                        _ => 0,
-                                    };
-                                    if current_xp >= max_xp {
-                                        data.level.0 += 1;
-                                        let new_level = data.level.0;
-                                        let prof = data.profession_enum();
-                                        drop(data);
-
-                                        // Level up! Add new trades for the new level
-                                        villager.add_trades(prof, new_level).await;
-
-                                        // Play sound & particles for level up!
-                                        let entity = villager.get_entity();
-                                        entity.world.load().send_entity_status(
-                                            entity,
-                                            pumpkin_data::entity::EntityStatus::VillagerHappy,
-                                            Some(ActorEventType::VillagerHappy),
-                                        );
-                                        entity.play_sound(
-                                            pumpkin_data::sound::Sound::EntityVillagerCelebrate,
-                                        );
-                                    } else {
-                                        drop(data);
-                                    }
-                                } else {
-                                    drop(data);
-                                }
-
-                                let current_level = villager.villager_data.lock().await.level;
-                                player
-                                    .client
-                                    .enqueue_packet(&CMerchantOffers::new(
-                                        VarInt(sync_id as i32),
-                                        offers.clone(),
-                                        current_level,
-                                        VarInt(current_xp),
-                                        true,
-                                        true,
-                                    ))
-                                    .await;
-                            }
-                        }
+            self.is_trading.store(true, Ordering::Relaxed);
+            *self
+                .trading_player
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some((player_uuid, sync_id));
+            let validity_weak = self_weak.clone();
+            handler.validity_check = Some(Box::new(move |inventory_player| {
+                validity_weak.upgrade().is_some_and(|villager| {
+                    villager.can_continue_trading(inventory_player, player_uuid, sync_id)
+                })
+            }));
+            let update_weak = self_weak.clone();
+            handler.on_trade_updated = Some(Box::new(move |has_result| {
+                let Some(villager) = update_weak.upgrade() else {
+                    return;
+                };
+                if villager
+                    .trade_sound_cooldown
+                    .compare_exchange(0, 20, Ordering::Relaxed, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    villager.get_entity().play_sound(if has_result {
+                        pumpkin_data::sound::Sound::EntityVillagerYes
+                    } else {
+                        pumpkin_data::sound::Sound::EntityVillagerNo
                     });
                 }
+            }));
+            let close_weak = self_weak.clone();
+            handler.on_close = Some(Box::new(move || {
+                let close_weak = close_weak.clone();
+                Box::pin(async move {
+                    if let Some(villager) = close_weak.upgrade() {
+                        villager.is_trading.store(false, Ordering::Relaxed);
+                        *villager
+                            .trading_player
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                        villager.reset_special_prices().await;
+                    }
+                })
+            }));
+
+            handler.on_trade = Some(Box::new(move |offer_index| {
+                let self_weak = self_weak.clone();
+                let world = world.clone();
+                Box::pin(async move {
+                    if let Some(villager) = self_weak.upgrade() {
+                        villager
+                            .complete_trade(offer_index, &world, player_uuid)
+                            .await;
+                    }
+                })
             }));
 
             Some(Arc::new(Mutex::new(handler)) as SharedScreenHandler)
@@ -412,16 +1402,16 @@ impl ScreenHandlerFactory for VillagerEntity {
     }
 
     fn get_display_name(&self) -> TextComponent {
-        // TODO: Localized name based on profession
-        TextComponent::translate_cross(
-            pumpkin_data::translation::java::ENTITY_MINECRAFT_VILLAGER,
-            pumpkin_data::translation::bedrock::ENTITY_VILLAGER_NAME,
-            [],
-        )
+        let profession = self
+            .villager_data
+            .try_lock()
+            .map_or(VillagerProfession::None, |data| data.profession_enum());
+        TextComponent::translate(profession.translation_key(), [])
     }
 }
 
 impl NBTStorage for VillagerEntity {
+    #[expect(clippy::too_many_lines)]
     fn write_nbt<'a>(&'a self, nbt: &'a mut NbtCompound) -> crate::entity::NbtFuture<'a, ()> {
         Box::pin(async move {
             self.mob_entity.living_entity.entity.write_nbt(nbt).await;
@@ -439,6 +1429,10 @@ impl NBTStorage for VillagerEntity {
                 self.last_restock_time.load(Ordering::Relaxed),
             );
             nbt.put_int("RestocksToday", self.restocks_today.load(Ordering::Relaxed));
+            nbt.put_long(
+                "LastGossipDecay",
+                self.last_gossip_decay_time.load(Ordering::Relaxed),
+            );
 
             let job_site_pos = *self
                 .job_site
@@ -448,6 +1442,10 @@ impl NBTStorage for VillagerEntity {
                 nbt.put_int("JobSiteX", pos.0.x);
                 nbt.put_int("JobSiteY", pos.0.y);
                 nbt.put_int("JobSiteZ", pos.0.z);
+                nbt.put_bool(
+                    "JobSitePending",
+                    self.job_site_pending.load(Ordering::Relaxed),
+                );
             }
 
             let home_pos = *self
@@ -485,7 +1483,7 @@ impl NBTStorage for VillagerEntity {
 
                     recipe.put_int("uses", offer.uses);
                     recipe.put_int("maxUses", offer.max_uses);
-                    recipe.put_bool("rewardExp", !offer.is_disabled);
+                    recipe.put_bool("rewardExp", offer.reward_exp);
                     recipe.put_int("xp", offer.xp);
                     recipe.put_float("priceMultiplier", offer.price_multiplier);
                     recipe.put_int("specialPrice", offer.special_price);
@@ -527,7 +1525,7 @@ impl NBTStorage for VillagerEntity {
                             (uuid_val & 0xFFFF_FFFF) as i32,
                         ]),
                     );
-                    gossip_nbt.put_int("Type", *gtype as i32);
+                    gossip_nbt.put_string("Type", gtype.name().to_owned());
                     gossip_nbt.put_int("Value", *value);
                     gossip_list.push(pumpkin_nbt::tag::NbtTag::Compound(gossip_nbt));
                 }
@@ -569,6 +1567,10 @@ impl NBTStorage for VillagerEntity {
             if let Some(today) = nbt.get_int("RestocksToday") {
                 self.restocks_today.store(today, Ordering::Relaxed);
             }
+            if let Some(last_decay) = nbt.get_long("LastGossipDecay") {
+                self.last_gossip_decay_time
+                    .store(last_decay, Ordering::Relaxed);
+            }
 
             if let (Some(x), Some(y), Some(z)) = (
                 nbt.get_int("JobSiteX"),
@@ -580,11 +1582,16 @@ impl NBTStorage for VillagerEntity {
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner) =
                     Some(BlockPos::new(x, y, z));
+                self.job_site_pending.store(
+                    nbt.get_bool("JobSitePending").unwrap_or(false),
+                    Ordering::Relaxed,
+                );
             } else {
                 *self
                     .job_site
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                self.job_site_pending.store(false, Ordering::Relaxed);
             }
 
             if let (Some(x), Some(y), Some(z)) = (
@@ -621,7 +1628,11 @@ impl NBTStorage for VillagerEntity {
                             .get_compound("sell")
                             .and_then(ItemStack::read_item_stack);
 
-                        if let (Some(buy), Some(sell_item)) = (buy, sell_item) {
+                        if let (Some(buy), Some(sell_item)) = (buy, sell_item)
+                            && !buy.is_empty()
+                            && !sell_item.is_empty()
+                            && buy_b.as_ref().is_none_or(|stack| !stack.is_empty())
+                        {
                             let uses = recipe.get_int("uses").unwrap_or(0);
                             let max_uses = recipe.get_int("maxUses").unwrap_or(12);
                             let reward_exp = recipe.get_bool("rewardExp").unwrap_or(true);
@@ -635,7 +1646,7 @@ impl NBTStorage for VillagerEntity {
                                 base_cost_a: buy.into(),
                                 output: sell_item.into(),
                                 cost_b: buy_b.map(Into::into),
-                                is_disabled: !reward_exp,
+                                reward_exp,
                                 uses,
                                 max_uses,
                                 xp,
@@ -675,19 +1686,17 @@ impl NBTStorage for VillagerEntity {
                                     | (uuid_array[3] as u128),
                             )
                         });
-                        if let (Some(uuid), Some(gtype), Some(val)) = (
-                            uuid,
-                            gossip_nbt.get_int("Type"),
-                            gossip_nbt.get_int("Value"),
-                        ) {
-                            let gossip_type = match gtype {
-                                0 => GossipType::MajorNegative,
-                                1 => GossipType::MinorNegative,
-                                2 => GossipType::MajorPositive,
-                                3 => GossipType::MinorPositive,
-                                4 => GossipType::Trading,
-                                _ => continue,
-                            };
+                        let gossip_type = gossip_nbt
+                            .get_string("Type")
+                            .and_then(GossipType::from_name)
+                            .or_else(|| {
+                                gossip_nbt
+                                    .get_int("Type")
+                                    .and_then(GossipType::from_legacy_id)
+                            });
+                        if let (Some(uuid), Some(gossip_type), Some(val)) =
+                            (uuid, gossip_type, gossip_nbt.get_int("Value"))
+                        {
                             gossips.entry(uuid).or_default().insert(gossip_type, val);
                         }
                     }
@@ -697,69 +1706,41 @@ impl NBTStorage for VillagerEntity {
     }
 }
 
-fn block_to_profession(block: &Block) -> Option<VillagerProfession> {
-    if block == &Block::COMPOSTER {
-        Some(VillagerProfession::Farmer)
-    } else if block == &Block::LECTERN {
-        Some(VillagerProfession::Librarian)
-    } else if block == &Block::BLAST_FURNACE {
-        Some(VillagerProfession::Armorer)
-    } else if block == &Block::SMOKER {
-        Some(VillagerProfession::Butcher)
-    } else if block == &Block::CARTOGRAPHY_TABLE {
-        Some(VillagerProfession::Cartographer)
-    } else if block == &Block::BREWING_STAND {
-        Some(VillagerProfession::Cleric)
-    } else if block == &Block::BARREL {
-        Some(VillagerProfession::Fisherman)
-    } else if block == &Block::FLETCHING_TABLE {
-        Some(VillagerProfession::Fletcher)
-    } else if block == &Block::CAULDRON
-        || block == &Block::WATER_CAULDRON
-        || block == &Block::LAVA_CAULDRON
-        || block == &Block::POWDER_SNOW_CAULDRON
-    {
-        Some(VillagerProfession::Leatherworker)
-    } else if block == &Block::STONECUTTER {
-        Some(VillagerProfession::Mason)
-    } else if block == &Block::LOOM {
-        Some(VillagerProfession::Shepherd)
-    } else if block == &Block::SMITHING_TABLE {
-        Some(VillagerProfession::Toolsmith)
-    } else if block == &Block::GRINDSTONE {
-        Some(VillagerProfession::Weaponsmith)
-    } else {
-        None
-    }
-}
-
-fn profession_matches_block(profession: VillagerProfession, block: &Block) -> bool {
-    match profession {
-        VillagerProfession::Farmer => block == &Block::COMPOSTER,
-        VillagerProfession::Librarian => block == &Block::LECTERN,
-        VillagerProfession::Armorer => block == &Block::BLAST_FURNACE,
-        VillagerProfession::Butcher => block == &Block::SMOKER,
-        VillagerProfession::Cartographer => block == &Block::CARTOGRAPHY_TABLE,
-        VillagerProfession::Cleric => block == &Block::BREWING_STAND,
-        VillagerProfession::Fisherman => block == &Block::BARREL,
-        VillagerProfession::Fletcher => block == &Block::FLETCHING_TABLE,
-        VillagerProfession::Leatherworker => {
-            block == &Block::CAULDRON
-                || block == &Block::WATER_CAULDRON
-                || block == &Block::LAVA_CAULDRON
-                || block == &Block::POWDER_SNOW_CAULDRON
-        }
-        VillagerProfession::Mason => block == &Block::STONECUTTER,
-        VillagerProfession::Shepherd => block == &Block::LOOM,
-        VillagerProfession::Toolsmith => block == &Block::SMITHING_TABLE,
-        VillagerProfession::Weaponsmith => block == &Block::GRINDSTONE,
-        _ => false,
-    }
-}
-
 impl Mob for VillagerEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
+    }
+
+    fn mob_bedrock_identifier(&self) -> Option<&'static str> {
+        Some("minecraft:villager_v2")
+    }
+
+    fn mob_java_spawn_metadata(
+        &self,
+        version: JavaMinecraftVersion,
+    ) -> crate::entity::EntityBaseFuture<'_, Option<Box<[u8]>>> {
+        Box::pin(async move {
+            let mut metadata = Vec::new();
+            Metadata::new(
+                tracked_data::villager::VILLAGER_DATA,
+                *self.villager_data.lock().await,
+            )
+            .write(&mut metadata, &version)
+            .ok()?;
+            metadata.push(255);
+            Some(metadata.into_boxed_slice())
+        })
+    }
+
+    fn mob_bedrock_spawn_metadata(
+        &self,
+    ) -> crate::entity::EntityBaseFuture<'_, Option<EntityMetadata>> {
+        Box::pin(async move {
+            Some(Self::bedrock_metadata(
+                *self.villager_data.lock().await,
+                self.xp.load(Ordering::Relaxed),
+            ))
+        })
     }
 
     fn get_job_site(&self) -> Option<BlockPos> {
@@ -769,11 +1750,99 @@ impl Mob for VillagerEntity {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
+    fn is_job_site_pending(&self) -> crate::entity::EntityBaseFuture<'_, bool> {
+        Box::pin(async move { self.job_site_pending.load(Ordering::Relaxed) })
+    }
+
+    fn release_pending_job_site(
+        &self,
+        position: BlockPos,
+    ) -> crate::entity::EntityBaseFuture<'_, ()> {
+        Box::pin(async move {
+            if self.get_job_site() != Some(position)
+                || !self.job_site_pending.load(Ordering::Relaxed)
+            {
+                return;
+            }
+            self.get_entity()
+                .world
+                .load()
+                .villager_poi
+                .lock()
+                .await
+                .release(position, self.get_entity().entity_uuid);
+            if self.get_job_site() == Some(position) {
+                *self
+                    .job_site
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                self.job_site_pending.store(false, Ordering::Relaxed);
+            }
+        })
+    }
+
+    fn get_trading_player(&self) -> Option<Arc<Player>> {
+        let trading_player = *self
+            .trading_player
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (player_uuid, _) = trading_player?;
+        self.get_entity()
+            .world
+            .load()
+            .get_player_by_uuid(player_uuid)
+    }
+
     fn get_home(&self) -> Option<BlockPos> {
         *self
             .home_pos
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn mob_init_data_tracker(&self) -> crate::entity::EntityBaseFuture<'_, ()> {
+        Box::pin(async move {
+            let entity = self.get_entity();
+            let data = *self.villager_data.lock().await;
+            let bedrock_metadata = Self::bedrock_metadata(data, self.xp.load(Ordering::Relaxed));
+            entity.send_meta_data(
+                &[Metadata::new(tracked_data::villager::VILLAGER_DATA, data)],
+                Some(&bedrock_metadata),
+            );
+            if entity.age.load(Ordering::Relaxed) < 0 {
+                entity.send_meta_data(
+                    &[Metadata::new(tracked_data::villager::BABY_ID, true)],
+                    None,
+                );
+            }
+        })
+    }
+
+    fn on_damage<'a>(
+        &'a self,
+        _damage_type: pumpkin_data::damage::DamageType,
+        source: Option<&'a dyn EntityBase>,
+    ) -> crate::entity::EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            let Some(source) = source.filter(|source| {
+                source.get_entity().entity_type == &pumpkin_data::entity::EntityType::PLAYER
+            }) else {
+                return;
+            };
+            let mut gossips = self.gossips.lock().await;
+            let value = gossips
+                .entry(source.get_entity().entity_uuid)
+                .or_default()
+                .entry(GossipType::MinorNegative)
+                .or_default();
+            *value = (*value + 25).min(GossipType::MinorNegative.max_value());
+            drop(gossips);
+            self.get_entity().world.load().send_entity_status(
+                self.get_entity(),
+                pumpkin_data::entity::EntityStatus::VillagerAngry,
+                Some(ActorEventType::VillagerAngry),
+            );
+        })
     }
 
     #[expect(clippy::too_many_lines)]
@@ -782,12 +1851,83 @@ impl Mob for VillagerEntity {
         _caller: &'a Arc<dyn EntityBase>,
     ) -> crate::entity::EntityBaseFuture<'a, ()> {
         Box::pin(async move {
+            let world = self.get_entity().world.load();
+
+            let unhappy_counter = self.unhappy_counter.load(Ordering::Relaxed);
+            if unhappy_counter > 0 {
+                let unhappy_counter = unhappy_counter - 1;
+                self.unhappy_counter
+                    .store(unhappy_counter, Ordering::Relaxed);
+                self.get_entity().send_meta_data(
+                    &[Metadata::new(
+                        tracked_data::villager::UNHAPPY_COUNTER,
+                        VarInt(unhappy_counter),
+                    )],
+                    None,
+                );
+            }
+            self.trade_sound_cooldown
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cooldown| {
+                    (cooldown > 0).then_some(cooldown - 1)
+                })
+                .ok();
+
+            let last_traded_player = self.last_traded_player.lock().await.take();
+            if let Some(player_uuid) = last_traded_player {
+                let mut gossips = self.gossips.lock().await;
+                let value = gossips
+                    .entry(player_uuid)
+                    .or_default()
+                    .entry(GossipType::Trading)
+                    .or_default();
+                *value = (*value + 2).min(GossipType::Trading.max_value());
+                drop(gossips);
+                world.send_entity_status(
+                    self.get_entity(),
+                    pumpkin_data::entity::EntityStatus::VillagerHappy,
+                    Some(ActorEventType::VillagerHappy),
+                );
+            }
+
+            if !self.is_trading.load(Ordering::Relaxed)
+                && self.merchant_update_timer.load(Ordering::Relaxed) > 0
+                && self.merchant_update_timer.fetch_sub(1, Ordering::Relaxed) == 1
+            {
+                if self
+                    .increase_profession_level_on_update
+                    .swap(false, Ordering::Relaxed)
+                {
+                    let mut data = *self.villager_data.lock().await;
+                    data.level.0 += 1;
+                    self.set_villager_data(data).await;
+                    self.add_trades(data.profession_enum(), data.level.0).await;
+                }
+                self.mob_entity
+                    .living_entity
+                    .add_effect(Effect {
+                        effect_type: &StatusEffect::REGENERATION,
+                        duration: 200,
+                        amplifier: 0,
+                        ambient: false,
+                        show_particles: true,
+                        show_icon: true,
+                        blend: false,
+                    })
+                    .await;
+            }
+
+            let (game_time, day_time, day) = {
+                let time = world.level_time.lock().await;
+                (time.world_age, time.query_daytime(), time.query_day())
+            };
+            self.decay_gossips(game_time).await;
+            self.work_at_job_site(game_time, day_time, day).await;
+
             let age = self.get_entity().age.load(Ordering::Relaxed);
             if age % 20 != 0 {
                 return;
             }
-
-            let world = self.get_entity().world.load();
+            self.update_job_site(&world).await;
 
             // 1. Bed / Sleeping logic (for all villagers: babies, nitwits, adults)
             let is_sleeping = self.get_entity().pose.load() == EntityPose::Sleeping;
@@ -943,134 +2083,23 @@ impl Mob for VillagerEntity {
                     );
                 }
             }
-
-            // 2. Job / Profession logic (skip for Nitwits and babies)
-            let data = self.villager_data.lock().await;
-            let is_adult = self.get_entity().age.load(Ordering::Relaxed) >= 0;
-            let xp = self.xp.load(Ordering::Relaxed);
-            let profession = data.profession_enum();
-            drop(data);
-
-            if profession == VillagerProfession::Nitwit || !is_adult {
-                return;
-            }
-
-            if let Some(current_site) = self.get_job_site() {
-                let (block, _state) = world.get_block_and_state(&current_site);
-                let valid = if profession == VillagerProfession::None {
-                    block_to_profession(block).is_some()
-                } else {
-                    profession_matches_block(profession, block)
-                };
-
-                if !valid {
-                    *self
-                        .job_site
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
-                    if xp == 0 && profession != VillagerProfession::None {
-                        let r#type = self.villager_data.lock().await.type_enum();
-                        self.set_villager_data(VillagerData::new(
-                            r#type,
-                            VillagerProfession::None,
-                            1,
-                        ))
-                        .await;
-                        self.offers.lock().await.clear();
-                    }
-                }
-            }
-
-            if self.get_job_site().is_none() {
-                let pos = self.get_entity().block_pos.load();
-                let start = BlockPos::new(pos.0.x - 10, pos.0.y - 4, pos.0.z - 10);
-                let end = BlockPos::new(pos.0.x + 10, pos.0.y + 4, pos.0.z + 10);
-
-                let aabb = BoundingBox::new(
-                    Vector3::new(
-                        pos.0.x as f64 - 32.0,
-                        pos.0.y as f64 - 16.0,
-                        pos.0.z as f64 - 32.0,
-                    ),
-                    Vector3::new(
-                        pos.0.x as f64 + 32.0,
-                        pos.0.y as f64 + 16.0,
-                        pos.0.z as f64 + 32.0,
-                    ),
-                );
-                let nearby_entities = world.get_all_at_box(&aabb);
-
-                let mut claimed_sites = Vec::new();
-                for entity in nearby_entities {
-                    if entity.get_entity().entity_id != self.get_entity().entity_id
-                        && entity.get_entity().entity_type
-                            == &pumpkin_data::entity::EntityType::VILLAGER
-                        && let Some(site) = entity.get_job_site_pos()
-                    {
-                        claimed_sites.push(site);
-                    }
-                }
-
-                let mut best_site = None;
-                let mut best_dist = f64::MAX;
-                let mut best_profession = VillagerProfession::None;
-
-                for p in BlockPos::iterate(start, end) {
-                    if claimed_sites.contains(&p) {
-                        continue;
-                    }
-
-                    let (block, _state) = world.get_block_and_state(&p);
-                    if let Some(prof) = block_to_profession(block) {
-                        if profession != VillagerProfession::None && prof != profession {
-                            continue;
-                        }
-
-                        let dist = p
-                            .to_f64()
-                            .squared_distance_to_vec(&self.get_entity().pos.load());
-                        if dist < best_dist {
-                            best_dist = dist;
-                            best_site = Some(p);
-                            best_profession = prof;
-                        }
-                    }
-                }
-
-                if let Some(site) = best_site {
-                    *self
-                        .job_site
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(site);
-                    if profession == VillagerProfession::None {
-                        let r#type = self.villager_data.lock().await.type_enum();
-                        self.set_villager_data(VillagerData::new(r#type, best_profession, 1))
-                            .await;
-                    }
-                }
-            } else {
-                let current_prof = self.villager_data.lock().await.profession_enum();
-                if current_prof == VillagerProfession::None
-                    && let Some(site) = self.get_job_site()
-                {
-                    let (block, _state) = world.get_block_and_state(&site);
-                    if let Some(prof) = block_to_profession(block) {
-                        let r#type = self.villager_data.lock().await.type_enum();
-                        self.set_villager_data(VillagerData::new(r#type, prof, 1))
-                            .await;
-                    }
-                }
-            }
         })
     }
 
     fn mob_interact<'a>(
         &'a self,
         player: &'a Arc<Player>,
-        _item_stack: &'a mut pumpkin_data::item_stack::ItemStack,
+        item_stack: &'a mut pumpkin_data::item_stack::ItemStack,
     ) -> crate::entity::EntityBaseFuture<'a, bool> {
         let player = player.clone();
         Box::pin(async move {
+            if item_stack.item == &Item::VILLAGER_SPAWN_EGG
+                || self.mob_entity.living_entity.health.load() <= 0.0
+                || self.is_trading.load(Ordering::Relaxed)
+                || self.get_entity().pose.load() == EntityPose::Sleeping
+            {
+                return false;
+            }
             if self.get_entity().age.load(Ordering::Relaxed) < 0 {
                 self.set_unhappy();
                 return true;
@@ -1111,5 +2140,155 @@ impl Mob for VillagerEntity {
 
             true
         })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use pumpkin_data::data_component_impl::{EnchantmentsImpl, StoredEnchantmentsImpl};
+    use pumpkin_data::villager::VillagerTradeModifier;
+    use pumpkin_util::version::JavaMinecraftVersion;
+
+    use super::*;
+
+    #[test]
+    fn villager_data_metadata_uses_the_villager_tracker_slot() {
+        let data = VillagerData::new(VillagerType::Plains, VillagerProfession::Librarian, 1);
+        let metadata = Metadata::new(tracked_data::villager::VILLAGER_DATA, data);
+        let mut bytes = Vec::new();
+
+        metadata
+            .write(&mut bytes, &JavaMinecraftVersion::V_26_2)
+            .unwrap();
+
+        assert_eq!(bytes, [19, 18, 2, 9, 1]);
+    }
+
+    #[test]
+    fn villager_data_maps_to_bedrock_appearance_metadata() {
+        let metadata = VillagerEntity::bedrock_metadata(
+            VillagerData::new(VillagerType::Plains, VillagerProfession::Librarian, 3),
+            75,
+        );
+
+        assert!(matches!(
+            metadata.0.get(&entity_data_key::VARIANT),
+            Some(MetadataValue::Int(5))
+        ));
+        assert!(matches!(
+            metadata.0.get(&entity_data_key::MARK_VARIANT),
+            Some(MetadataValue::Int(0))
+        ));
+        assert!(matches!(
+            metadata.0.get(&entity_data_key::TRADE_TIER),
+            Some(MetadataValue::Int(2))
+        ));
+        assert!(matches!(
+            metadata.0.get(&entity_data_key::MAX_TRADE_TIER),
+            Some(MetadataValue::Int(4))
+        ));
+        assert!(matches!(
+            metadata.0.get(&entity_data_key::TRADE_EXPERIENCE),
+            Some(MetadataValue::Int(75))
+        ));
+    }
+
+    #[test]
+    fn unhappy_counter_metadata_uses_the_abstract_villager_tracker_slot() {
+        let metadata = Metadata::new(tracked_data::villager::UNHAPPY_COUNTER, VarInt(40));
+        let mut bytes = Vec::new();
+
+        metadata
+            .write(&mut bytes, &JavaMinecraftVersion::V_26_2)
+            .unwrap();
+
+        assert_eq!(bytes, [18, 1, 40]);
+    }
+
+    #[test]
+    fn enchanted_book_offer_has_vanilla_items_and_a_nonzero_price() {
+        let (emeralds, enchanted_book, book) = enchanted_book_offer_items(&mut rand::rng())
+            .expect("the generated tradeable-enchantment tag is populated");
+        let stored = enchanted_book
+            .get_data_component::<StoredEnchantmentsImpl>()
+            .unwrap();
+
+        assert_eq!(emeralds.item.id, Item::EMERALD.id);
+        assert!((5..=64).contains(&emeralds.item_count));
+        assert_eq!(book.unwrap().item.id, Item::BOOK.id);
+        assert_eq!(enchanted_book.item.id, Item::ENCHANTED_BOOK.id);
+        assert_eq!(stored.enchantment.len(), 1);
+        assert!(
+            stored.enchantment[0]
+                .0
+                .has_tag(&EnchantmentTag::MINECRAFT_TRADEABLE)
+        );
+        assert!((1..=stored.enchantment[0].0.max_level).contains(&stored.enchantment[0].1));
+    }
+
+    #[test]
+    fn generated_trades_keep_dynamic_modifiers_and_secondary_costs() {
+        let librarian = VillagerProfession::Librarian.trade_set(1).unwrap();
+        let enchanted_book = librarian
+            .trades
+            .iter()
+            .find(|trade| trade.modifier == VillagerTradeModifier::EnchantRandomly)
+            .unwrap();
+        assert!(enchanted_book.wants.item == &Item::EMERALD);
+        assert!(enchanted_book.wants_b.unwrap().item == &Item::BOOK);
+        assert_eq!(enchanted_book.price_multiplier, 0.2);
+
+        let cartographer = VillagerProfession::Cartographer.trade_set(2).unwrap();
+        assert!(cartographer.trades.iter().any(|trade| {
+            matches!(trade.modifier, VillagerTradeModifier::ExplorationMap { .. })
+                && !trade.allowed_types.is_empty()
+                && trade
+                    .wants_b
+                    .is_some_and(|cost| cost.item == &Item::COMPASS)
+        }));
+
+        let fletcher = VillagerProfession::Fletcher.trade_set(5).unwrap();
+        assert!(fletcher.trades.iter().any(|trade| {
+            trade.modifier == VillagerTradeModifier::RandomPotion
+                && trade.wants_b.is_some_and(|cost| cost.item == &Item::ARROW)
+        }));
+    }
+
+    #[test]
+    fn smith_trade_sets_include_the_shared_vanilla_trades() {
+        let armorer_novice = VillagerProfession::Armorer.trade_set(1).unwrap();
+        assert!(armorer_novice.trades.iter().any(|trade| {
+            trade.wants.item == &Item::COAL && trade.gives.item == &Item::EMERALD
+        }));
+
+        let armorer_apprentice = VillagerProfession::Armorer.trade_set(2).unwrap();
+        assert!(armorer_apprentice.trades.iter().any(|trade| {
+            trade.wants.item == &Item::EMERALD && trade.gives.item == &Item::BELL
+        }));
+        assert!(armorer_apprentice.trades.iter().any(|trade| {
+            trade.wants.item == &Item::IRON_INGOT && trade.gives.item == &Item::EMERALD
+        }));
+
+        for profession in [
+            VillagerProfession::Toolsmith,
+            VillagerProfession::Weaponsmith,
+        ] {
+            assert!(profession.trade_set(1).unwrap().trades.iter().any(|trade| {
+                trade.wants.item == &Item::COAL && trade.gives.item == &Item::EMERALD
+            }));
+        }
+    }
+
+    #[test]
+    fn traded_equipment_is_enchanted_and_reports_its_additional_price() {
+        for _ in 0..32 {
+            let (stack, additional_price) =
+                enchant_trade_item(&mut rand::rng(), &Item::DIAMOND_SWORD, 5, 19).unwrap();
+            let enchantments = stack.get_data_component::<EnchantmentsImpl>().unwrap();
+
+            assert!((5..=19).contains(&additional_price));
+            assert!(!enchantments.enchantment.is_empty());
+        }
     }
 }

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -17,6 +17,7 @@ use arc_swap::ArcSwap;
 use crossbeam::atomic::AtomicCell;
 use crossbeam::channel::Receiver;
 use pumpkin_data::dimension::Dimension;
+use pumpkin_inventory::merchant::merchant_screen_handler::MerchantScreenHandler;
 use pumpkin_inventory::player::ender_chest_inventory::EnderChestInventory;
 use pumpkin_protocol::bedrock::client::play_status::CPlayStatus;
 use pumpkin_protocol::bedrock::client::set_time::CSetTime;
@@ -2354,13 +2355,21 @@ impl Player {
             }
         }
 
-        self.current_screen_handler
-            .lock()
-            .await
-            .lock()
-            .await
-            .send_content_updates()
-            .await;
+        let current_screen_handler = self.current_screen_handler.lock().await.clone();
+        let invalid_merchant = {
+            let screen_handler = current_screen_handler.lock().await;
+            screen_handler.as_any().is::<MerchantScreenHandler>()
+                && !screen_handler.can_use(self.as_ref())
+        };
+        if invalid_merchant {
+            self.close_handled_screen().await;
+        } else {
+            current_screen_handler
+                .lock()
+                .await
+                .send_content_updates()
+                .await;
+        }
 
         // if self.client.closed.load(Ordering::Relaxed) {
         //     return;
@@ -4364,13 +4373,20 @@ impl Player {
                             &pumpkin_data::map_decoration::MapDecorationType::PLAYER
                         };
 
-                        let icons = [MapIcon {
+                        let mut icons = vec![MapIcon {
                             icon_type: VarInt(decoration_type.id as i32),
                             x: icon_x,
                             z: icon_z,
                             direction: icon_direction,
                             display_name: None,
                         }];
+                        icons.extend(map_data.decorations.iter().map(|decoration| MapIcon {
+                            icon_type: VarInt(decoration.icon_type),
+                            x: decoration.x,
+                            z: decoration.z,
+                            direction: decoration.direction,
+                            display_name: decoration.display_name.clone(),
+                        }));
 
                         let data = map_data.dirty.then(|| MapPatch {
                             columns: 128,
@@ -4830,6 +4846,7 @@ impl Player {
                 WindowType::Anvil => 5,
                 WindowType::Hopper => 8,
                 WindowType::Beacon => 13,
+                WindowType::Merchant => 15,
                 WindowType::BlastFurnace => 27,
                 WindowType::Smoker => 28,
                 WindowType::Stonecutter => 29,

--- a/crates/pumpkin/src/entity/player/advancement/trigger.rs
+++ b/crates/pumpkin/src/entity/player/advancement/trigger.rs
@@ -21,6 +21,7 @@ pub enum AdvancementTrigger {
     Arbalistic,
     Bullseye,
     CuredZombieVillager,
+    TradedWithVillager,
 }
 
 impl Player {
@@ -734,6 +735,23 @@ impl Player {
                     self.trigger_advancement_criterion(
                         Advancement::STORY_CURE_ZOMBIE_VILLAGER,
                         "cured_zombie",
+                    )
+                    .await;
+                }
+            }
+            AdvancementTrigger::TradedWithVillager => {
+                if !self.has_advancement(Advancement::ADVENTURE_TRADE).await {
+                    self.trigger_advancement_criterion(Advancement::ADVENTURE_TRADE, "traded")
+                        .await;
+                }
+                if self.living_entity.entity.pos.load().y >= 319.0
+                    && !self
+                        .has_advancement(Advancement::ADVENTURE_TRADE_AT_WORLD_HEIGHT)
+                        .await
+                {
+                    self.trigger_advancement_criterion(
+                        Advancement::ADVENTURE_TRADE_AT_WORLD_HEIGHT,
+                        "trade_at_world_height",
                     )
                     .await;
                 }

--- a/crates/pumpkin/src/net/bedrock/mod.rs
+++ b/crates/pumpkin/src/net/bedrock/mod.rs
@@ -708,7 +708,7 @@ impl BedrockClient {
                 self.handle_item_stack_request(player, pumpkin_protocol::bedrock::server::item_stack_request::SItemStackRequest::read(reader)?).await;
             }
             SInteraction::PACKET_ID => {
-                self.handle_interaction(player, SInteraction::read(reader)?)
+                self.handle_interaction(player, SInteraction::read(reader)?, server)
                     .await;
             }
             SContainerClose::PACKET_ID => {

--- a/crates/pumpkin/src/net/bedrock/play/interaction.rs
+++ b/crates/pumpkin/src/net/bedrock/play/interaction.rs
@@ -2,8 +2,29 @@
 use super::*;
 
 impl BedrockClient {
-    pub async fn handle_interaction(&self, player: &Arc<Player>, packet: SInteraction) {
+    pub async fn handle_interaction(
+        &self,
+        player: &Arc<Player>,
+        packet: SInteraction,
+        server: &Arc<Server>,
+    ) {
         match packet.action {
+            Action::Interact => {
+                player.update_last_action_time();
+                let target_id = packet.target_runtime_id.0 as i32;
+                let Some(target) = player.world().get_entity_by_id(target_id) else {
+                    return;
+                };
+
+                let mut stack = player.inventory().held_item().await;
+                if !target.interact(player, &mut stack).await {
+                    server
+                        .item_registry
+                        .use_on_entity(&mut stack, player, target)
+                        .await;
+                }
+                player.inventory().set_held_item(stack).await;
+            }
             Action::OpenInventory => {
                 if self.inventory_opened.load(Ordering::Relaxed) {
                     return;

--- a/crates/pumpkin/src/net/bedrock/play/item_stack_request.rs
+++ b/crates/pumpkin/src/net/bedrock/play/item_stack_request.rs
@@ -103,6 +103,71 @@ impl BedrockClient {
                                 break;
                             }
 
+                            let merchant_result = screen_handler.window_type()
+                                == Some(pumpkin_data::screen::WindowType::Merchant)
+                                && matches!(
+                                    source.container_name.container_name,
+                                    ContainerName::CreatedOutput
+                                        | ContainerName::TradeResultPreview
+                                        | ContainerName::Trade2ResultPreview
+                                );
+                            if merchant_result {
+                                if count != source_stack.item_count {
+                                    result = 1;
+                                    break;
+                                }
+                                let Some(handler) = screen_handler
+                                    .as_any_mut()
+                                    .downcast_mut::<pumpkin_inventory::merchant::merchant_screen_handler::MerchantScreenHandler>()
+                                else {
+                                    result = 1;
+                                    break;
+                                };
+                                if !handler.complete_bedrock_trade(player.as_ref()).await {
+                                    result = 1;
+                                    break;
+                                }
+
+                                update_slot_stack(
+                                    player,
+                                    handler,
+                                    &destination,
+                                    dest_stack.clone(),
+                                )
+                                .await;
+                                for (container_name, slot_id, screen_slot) in [
+                                    (ContainerName::Trade2Ingredient1, 4, 0),
+                                    (ContainerName::Trade2Ingredient2, 5, 1),
+                                    (ContainerName::Trade2ResultPreview, 50, 2),
+                                ] {
+                                    let stack = handler.get_behaviour().slots[screen_slot]
+                                        .get_cloned_stack()
+                                        .await;
+                                    record_update(
+                                        &mut updates,
+                                        FullContainerName {
+                                            container_name,
+                                            dynamic_id: None,
+                                        },
+                                        slot_id,
+                                        &stack,
+                                    );
+                                }
+                                record_update(
+                                    &mut updates,
+                                    source.container_name.clone(),
+                                    source.slot_id,
+                                    ItemStack::EMPTY,
+                                );
+                                record_update(
+                                    &mut updates,
+                                    destination.container_name.clone(),
+                                    destination.slot_id,
+                                    &dest_stack,
+                                );
+                                continue;
+                            }
+
                             source_stack.decrement(count);
                             if source.container_name.container_name == ContainerName::CreatedOutput
                                 && let Some(ref mut stack) = created_item
@@ -212,6 +277,20 @@ impl BedrockClient {
                     }
                     ItemStackRequestAction::Destroy { count, source }
                     | ItemStackRequestAction::Consume { count, source } => {
+                        if screen_handler.window_type()
+                            == Some(pumpkin_data::screen::WindowType::Merchant)
+                            && matches!(
+                                source.container_name.container_name,
+                                ContainerName::TradeIngredient1
+                                    | ContainerName::TradeIngredient2
+                                    | ContainerName::Trade2Ingredient1
+                                    | ContainerName::Trade2Ingredient2
+                            )
+                        {
+                            // MerchantScreenHandler consumes both payment slots atomically when
+                            // Bedrock subsequently takes the CreatedOutput result.
+                            continue;
+                        }
                         if crafting_inputs_consumed
                             && source.container_name.container_name == ContainerName::CraftingInput
                         {
@@ -259,14 +338,50 @@ impl BedrockClient {
                         }
                     }
                     ItemStackRequestAction::CraftRecipe {
-                        recipe_id: _,
+                        recipe_id,
                         repetitions,
                     }
                     | ItemStackRequestAction::CraftRecipeAuto {
-                        recipe_id: _,
+                        recipe_id,
                         repetitions,
-                        ..
                     } => {
+                        if screen_handler.window_type()
+                            == Some(pumpkin_data::screen::WindowType::Merchant)
+                        {
+                            let Some(handler) = screen_handler
+                                .as_any_mut()
+                                .downcast_mut::<pumpkin_inventory::merchant::merchant_screen_handler::MerchantScreenHandler>()
+                            else {
+                                result = 1;
+                                break;
+                            };
+                            let trade = recipe_id.0.saturating_sub(1) as usize;
+                            if trade >= handler.offers.len() {
+                                result = 1;
+                                break;
+                            }
+                            handler.set_selected_offer(trade).await;
+                            for (container_name, slot_id, screen_slot) in [
+                                (ContainerName::Trade2Ingredient1, 4, 0),
+                                (ContainerName::Trade2Ingredient2, 5, 1),
+                                (ContainerName::Trade2ResultPreview, 50, 2),
+                            ] {
+                                let stack = handler.get_behaviour().slots[screen_slot]
+                                    .get_cloned_stack()
+                                    .await;
+                                record_update(
+                                    &mut updates,
+                                    FullContainerName {
+                                        container_name,
+                                        dynamic_id: None,
+                                    },
+                                    slot_id,
+                                    &stack,
+                                );
+                            }
+                            continue;
+                        }
+
                         if repetitions > 0 {
                             screen_handler.update_to_client().await;
 

--- a/crates/pumpkin/src/net/java/play/select_trade.rs
+++ b/crates/pumpkin/src/net/java/play/select_trade.rs
@@ -16,6 +16,9 @@ impl JavaClient {
 
         let screen_handler = player.current_screen_handler.lock().await;
         let mut screen_handler = screen_handler.lock().await;
+        if !screen_handler.can_use(player.as_ref()) {
+            return;
+        }
         if let Some(merchant) = screen_handler
             .as_any_mut()
             .downcast_mut::<MerchantScreenHandler>()

--- a/crates/pumpkin/src/world/map.rs
+++ b/crates/pumpkin/src/world/map.rs
@@ -50,6 +50,7 @@ pub struct MapData {
     pub center_x: i32,
     pub center_z: i32,
     pub colors: Box<[u8; 128 * 128]>,
+    pub decorations: Vec<MapDecoration>,
     pub dirty: bool,
     pub fully_updated: bool,
 }
@@ -64,6 +65,7 @@ impl MapData {
             center_x: x,
             center_z: z,
             colors: Box::new([0; 128 * 128]),
+            decorations: Vec::new(),
             dirty: true,
             fully_updated: false,
         }
@@ -129,4 +131,12 @@ impl MapData {
             }
         }
     }
+}
+
+pub struct MapDecoration {
+    pub icon_type: i32,
+    pub x: i8,
+    pub z: i8,
+    pub direction: i8,
+    pub display_name: Option<String>,
 }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -25,6 +25,7 @@ pub mod loot;
 pub mod map;
 pub mod portal;
 pub mod time;
+pub mod villager_poi;
 
 use crate::block::RandomTickArgs;
 use crate::world::chunker::is_within_view_distance;
@@ -263,8 +264,10 @@ pub struct World {
     synced_block_event_queue: Mutex<Vec<BlockEvent>>,
     /// A map of unsent block changes, keyed by block position.
     unsent_block_changes: Mutex<HashMap<BlockPos, BlockStateId>>,
-    /// POI storage for fast portal lookups
+    /// Persisted vanilla POI storage for portal and villager lookups.
     pub portal_poi: Mutex<portal::PortalPoiStorage>,
+    /// Villager job sites and their current owners.
+    pub villager_poi: Mutex<villager_poi::VillagerPoiStorage>,
     /// End Dragon fight manager (only present in `THE_END` dimension).
     pub dragon_fight: Option<Mutex<dragon_fight::DragonFight>>,
     pub spawn_state: ArcSwap<SpawnState>,
@@ -383,6 +386,7 @@ impl World {
             synced_block_event_queue: Mutex::new(Vec::new()),
             unsent_block_changes: Mutex::new(HashMap::new()),
             portal_poi: Mutex::new(portal_poi),
+            villager_poi: Mutex::new(villager_poi::VillagerPoiStorage::default()),
             dragon_fight,
             spawn_state: ArcSwap::new(Arc::new(SpawnState::empty())),
             active_chunks: ArcSwap::new(Arc::new(FxHashSet::default())),
@@ -4732,9 +4736,24 @@ impl World {
         let old_block = Block::from_state_id(replaced_block_state_id);
         let new_block = Block::from_state_id(block_state_id);
 
+        self.villager_poi
+            .lock()
+            .await
+            .update_block(*position, new_block);
+
         let block_moved = flags.contains(BlockFlags::MOVED);
 
         let is_new_block = old_block != new_block;
+
+        if is_new_block {
+            let mut poi = self.portal_poi.lock().await;
+            if villager_poi::profession_for_block(old_block).is_some() {
+                poi.remove(position);
+            }
+            if let Some(poi_type) = villager_poi::poi_type_for_block(new_block) {
+                poi.add_with_free_tickets(*position, poi_type, 1);
+            }
+        }
 
         // WorldChunk.java line 305-314
         if is_new_block

--- a/crates/pumpkin/src/world/villager_poi.rs
+++ b/crates/pumpkin/src/world/villager_poi.rs
@@ -1,0 +1,214 @@
+use std::{collections::HashMap, sync::Weak};
+
+use pumpkin_data::{Block, villager::VillagerProfession};
+use pumpkin_util::math::position::BlockPos;
+
+use crate::entity::EntityBase;
+
+struct JobSite {
+    profession: VillagerProfession,
+    owner: Option<Weak<dyn EntityBase>>,
+}
+
+#[derive(Default)]
+pub struct VillagerPoiStorage {
+    job_sites: HashMap<BlockPos, JobSite>,
+}
+
+impl VillagerPoiStorage {
+    fn live_owner(owner: &Weak<dyn EntityBase>) -> Option<std::sync::Arc<dyn EntityBase>> {
+        owner.upgrade().filter(|entity| {
+            entity
+                .get_living_entity()
+                .is_none_or(|living| living.health.load() > 0.0)
+        })
+    }
+
+    pub fn update_block(&mut self, position: BlockPos, block: &Block) {
+        let Some(profession) = profession_for_block(block) else {
+            self.job_sites.remove(&position);
+            return;
+        };
+        let site = self.job_sites.entry(position).or_insert(JobSite {
+            profession,
+            owner: None,
+        });
+        if site.profession != profession {
+            *site = JobSite {
+                profession,
+                owner: None,
+            };
+        }
+    }
+
+    pub fn claim(
+        &mut self,
+        position: BlockPos,
+        block: &Block,
+        owner: Weak<dyn EntityBase>,
+        expected_profession: Option<VillagerProfession>,
+    ) -> Option<VillagerProfession> {
+        self.update_block(position, block);
+        let site = self.job_sites.get_mut(&position)?;
+        if expected_profession.is_some_and(|profession| profession != site.profession) {
+            return None;
+        }
+        if let Some(current_owner) = site.owner.as_ref().and_then(Self::live_owner)
+            && current_owner.get_entity().entity_uuid != owner.upgrade()?.get_entity().entity_uuid
+        {
+            return None;
+        }
+        site.owner = Some(owner);
+        Some(site.profession)
+    }
+
+    pub fn release(&mut self, position: BlockPos, owner: uuid::Uuid) {
+        let Some(site) = self.job_sites.get_mut(&position) else {
+            return;
+        };
+        if site
+            .owner
+            .as_ref()
+            .and_then(Weak::upgrade)
+            .is_none_or(|current| current.get_entity().entity_uuid == owner)
+        {
+            site.owner = None;
+        }
+    }
+
+    #[must_use]
+    pub fn available_job_sites(
+        &self,
+        origin: BlockPos,
+        radius: i32,
+        expected_profession: Option<VillagerProfession>,
+    ) -> Vec<BlockPos> {
+        let radius_squared = i64::from(radius).pow(2);
+        let mut sites = self
+            .job_sites
+            .iter()
+            .filter(|(_, site)| {
+                expected_profession.is_none_or(|profession| profession == site.profession)
+                    && site.owner.as_ref().and_then(Self::live_owner).is_none()
+            })
+            .filter_map(|(position, _)| {
+                let delta = position.0 - origin.0;
+                let distance_squared = i64::from(delta.x).pow(2)
+                    + i64::from(delta.y).pow(2)
+                    + i64::from(delta.z).pow(2);
+                (distance_squared <= radius_squared).then_some((distance_squared, *position))
+            })
+            .collect::<Vec<_>>();
+        sites.sort_unstable_by_key(|(distance, _)| *distance);
+        sites.into_iter().map(|(_, position)| position).collect()
+    }
+}
+
+#[must_use]
+pub fn profession_for_block(block: &Block) -> Option<VillagerProfession> {
+    match block {
+        block if block == &Block::COMPOSTER => Some(VillagerProfession::Farmer),
+        block if block == &Block::LECTERN => Some(VillagerProfession::Librarian),
+        block if block == &Block::BLAST_FURNACE => Some(VillagerProfession::Armorer),
+        block if block == &Block::SMOKER => Some(VillagerProfession::Butcher),
+        block if block == &Block::CARTOGRAPHY_TABLE => Some(VillagerProfession::Cartographer),
+        block if block == &Block::BREWING_STAND => Some(VillagerProfession::Cleric),
+        block if block == &Block::BARREL => Some(VillagerProfession::Fisherman),
+        block if block == &Block::FLETCHING_TABLE => Some(VillagerProfession::Fletcher),
+        block
+            if [
+                &Block::CAULDRON,
+                &Block::WATER_CAULDRON,
+                &Block::LAVA_CAULDRON,
+                &Block::POWDER_SNOW_CAULDRON,
+            ]
+            .contains(&block) =>
+        {
+            Some(VillagerProfession::Leatherworker)
+        }
+        block if block == &Block::STONECUTTER => Some(VillagerProfession::Mason),
+        block if block == &Block::LOOM => Some(VillagerProfession::Shepherd),
+        block if block == &Block::SMITHING_TABLE => Some(VillagerProfession::Toolsmith),
+        block if block == &Block::GRINDSTONE => Some(VillagerProfession::Weaponsmith),
+        _ => None,
+    }
+}
+
+#[must_use]
+pub fn poi_type_for_block(block: &Block) -> Option<&'static str> {
+    Some(match profession_for_block(block)? {
+        VillagerProfession::Armorer => "minecraft:armorer",
+        VillagerProfession::Butcher => "minecraft:butcher",
+        VillagerProfession::Cartographer => "minecraft:cartographer",
+        VillagerProfession::Cleric => "minecraft:cleric",
+        VillagerProfession::Farmer => "minecraft:farmer",
+        VillagerProfession::Fisherman => "minecraft:fisherman",
+        VillagerProfession::Fletcher => "minecraft:fletcher",
+        VillagerProfession::Leatherworker => "minecraft:leatherworker",
+        VillagerProfession::Librarian => "minecraft:librarian",
+        VillagerProfession::Mason => "minecraft:mason",
+        VillagerProfession::Shepherd => "minecraft:shepherd",
+        VillagerProfession::Toolsmith => "minecraft:toolsmith",
+        VillagerProfession::Weaponsmith => "minecraft:weaponsmith",
+        VillagerProfession::None | VillagerProfession::Nitwit => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_villager_workstation_maps_to_its_profession() {
+        let workstations = [
+            (&Block::COMPOSTER, VillagerProfession::Farmer),
+            (&Block::LECTERN, VillagerProfession::Librarian),
+            (&Block::BLAST_FURNACE, VillagerProfession::Armorer),
+            (&Block::SMOKER, VillagerProfession::Butcher),
+            (&Block::CARTOGRAPHY_TABLE, VillagerProfession::Cartographer),
+            (&Block::BREWING_STAND, VillagerProfession::Cleric),
+            (&Block::BARREL, VillagerProfession::Fisherman),
+            (&Block::FLETCHING_TABLE, VillagerProfession::Fletcher),
+            (&Block::CAULDRON, VillagerProfession::Leatherworker),
+            (&Block::STONECUTTER, VillagerProfession::Mason),
+            (&Block::LOOM, VillagerProfession::Shepherd),
+            (&Block::SMITHING_TABLE, VillagerProfession::Toolsmith),
+            (&Block::GRINDSTONE, VillagerProfession::Weaponsmith),
+        ];
+
+        for (block, profession) in workstations {
+            assert_eq!(profession_for_block(block), Some(profession));
+            assert_eq!(
+                poi_type_for_block(block).unwrap(),
+                format!(
+                    "minecraft:{}",
+                    profession.translation_key().rsplit('.').next().unwrap()
+                )
+            );
+        }
+        assert_eq!(profession_for_block(&Block::DIRT), None);
+        assert_eq!(poi_type_for_block(&Block::DIRT), None);
+    }
+
+    #[test]
+    fn available_job_sites_respect_profession_and_vanilla_search_radius() {
+        let origin = BlockPos::new(0, 64, 0);
+        let lectern = BlockPos::new(48, 64, 0);
+        let too_far = BlockPos::new(49, 64, 0);
+        let composter = BlockPos::new(1, 64, 0);
+        let mut storage = VillagerPoiStorage::default();
+
+        storage.update_block(lectern, &Block::LECTERN);
+        storage.update_block(too_far, &Block::LECTERN);
+        storage.update_block(composter, &Block::COMPOSTER);
+
+        assert_eq!(
+            storage.available_job_sites(origin, 48, Some(VillagerProfession::Librarian)),
+            vec![lectern]
+        );
+        assert_eq!(
+            storage.available_job_sites(origin, 48, Some(VillagerProfession::Farmer)),
+            vec![composter]
+        );
+    }
+}

--- a/tools/pumpkin-codegen/src/item.rs
+++ b/tools/pumpkin-codegen/src/item.rs
@@ -213,7 +213,7 @@ impl ToTokens for ItemComponents {
         let item_name = LitStr::new(&text, Span::call_site());
         tokens.extend(quote! {
             (ItemName, &ItemNameImpl {
-                name: #item_name,
+                name: Cow::Borrowed(#item_name),
             }),
         });
 
@@ -861,7 +861,7 @@ impl ToTokens for ItemComponents {
             tokens.extend(quote! { (StoredEnchantments, &StoredEnchantmentsImpl { enchantment: Cow::Borrowed(&[]) }), });
         }
         if self.suspicious_stew_effects.is_some() {
-            tokens.extend(quote! { (SuspiciousStewEffects, &SuspiciousStewEffectsImpl), });
+            tokens.extend(quote! { (SuspiciousStewEffects, &SuspiciousStewEffectsImpl::EMPTY), });
         }
         if self.swing_animation.is_some() {
             tokens.extend(quote! { (SwingAnimation, &SwingAnimationImpl), });
@@ -1621,7 +1621,9 @@ pub fn build() -> TokenStream {
                     .iter()
                     .find_map(|(id, data)| {
                         if id == &ItemName {
-                            data.as_any().downcast_ref::<ItemNameImpl>().map(|n| n.name)
+                            data.as_any()
+                                .downcast_ref::<ItemNameImpl>()
+                                .map(|name| name.name.as_ref())
                         } else {
                             None
                         }

--- a/tools/pumpkin-codegen/src/villager.rs
+++ b/tools/pumpkin-codegen/src/villager.rs
@@ -3,6 +3,7 @@ use indexmap::IndexMap;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use serde::Deserialize;
+use serde_json::Value;
 use std::fs;
 
 #[derive(Deserialize)]
@@ -35,11 +36,16 @@ struct TradeSetJson {
 #[derive(Deserialize)]
 struct TradeJson {
     wants: TradeItemJson,
-    wants_b: Option<TradeItemJson>,
+    #[serde(alias = "wants_b")]
+    additional_wants: Option<TradeItemJson>,
     gives: TradeItemJson,
     max_uses: Option<f32>,
     xp: Option<f32>,
-    price_multiplier: Option<f32>,
+    #[serde(alias = "price_multiplier")]
+    reputation_discount: Option<f32>,
+    #[serde(default)]
+    given_item_modifiers: Vec<Value>,
+    merchant_predicate: Option<Value>,
 }
 
 #[derive(Deserialize)]
@@ -80,7 +86,7 @@ pub fn build() -> TokenStream {
         let wants_count = trade.wants.count.unwrap_or(1.0) as i32;
         let wants = quote! { VillagerTradeItem { item: &crate::item::Item::#wants_item, count: #wants_count } };
 
-        let wants_b = if let Some(b) = &trade.wants_b {
+        let wants_b = if let Some(b) = &trade.additional_wants {
             let item = format_ident!(
                 "{}",
                 b.id.strip_prefix("minecraft:")
@@ -107,7 +113,63 @@ pub fn build() -> TokenStream {
 
         let max_uses = trade.max_uses.unwrap_or(16.0) as i32;
         let xp = trade.xp.unwrap_or(2.0) as i32;
-        let price_multiplier = trade.price_multiplier.unwrap_or(0.05);
+        let price_multiplier = trade.reputation_discount.unwrap_or(0.05);
+
+        let modifier = trade
+            .given_item_modifiers
+            .iter()
+            .find_map(|modifier| {
+                let function = modifier.get("function")?.as_str()?;
+                Some(match function {
+                    "minecraft:enchant_randomly" => quote! { VillagerTradeModifier::EnchantRandomly },
+                    "minecraft:enchant_with_levels" => {
+                        let levels = modifier.get("levels")?;
+                        let min = levels.get("min")?.as_f64()? as i32;
+                        let max = levels.get("max")?.as_f64()? as i32;
+                        quote! { VillagerTradeModifier::EnchantWithLevels { min: #min, max: #max } }
+                    }
+                    "minecraft:exploration_map" => {
+                        let destination = modifier.get("destination")?.as_str()?;
+                        quote! { VillagerTradeModifier::ExplorationMap { destination: #destination } }
+                    }
+                    "minecraft:set_random_dyes" => quote! { VillagerTradeModifier::RandomDyes },
+                    "minecraft:set_random_potion" => quote! { VillagerTradeModifier::RandomPotion },
+                    "minecraft:set_stew_effect" => quote! { VillagerTradeModifier::SuspiciousStew },
+                    "minecraft:set_potion" => {
+                        let potion = modifier.get("id")?.as_str()?;
+                        quote! { VillagerTradeModifier::Potion(#potion) }
+                    }
+                    _ => return None,
+                })
+            })
+            .unwrap_or_else(|| quote! { VillagerTradeModifier::None });
+
+        let allowed_types = trade
+            .merchant_predicate
+            .as_ref()
+            .and_then(|predicate| {
+                predicate.pointer("/predicate/minecraft:predicates/minecraft:villager~1variant")
+            })
+            .map(|variants| {
+                let variants: Vec<_> = variants
+                    .as_array()
+                    .map_or_else(|| vec![variants], |variants| variants.iter().collect())
+                    .into_iter()
+                    .filter_map(Value::as_str)
+                    .map(|variant| {
+                        let ident = format_ident!(
+                            "{}",
+                            variant
+                                .strip_prefix("minecraft:")
+                                .unwrap_or(variant)
+                                .to_pascal_case()
+                        );
+                        quote! { VillagerType::#ident }
+                    })
+                    .collect();
+                quote! { &[#(#variants),*] }
+            })
+            .unwrap_or_else(|| quote! { &[] });
 
         quote! {
             VillagerTrade {
@@ -117,6 +179,8 @@ pub fn build() -> TokenStream {
                 max_uses: #max_uses,
                 xp: #xp,
                 price_multiplier: #price_multiplier,
+                modifier: #modifier,
+                allowed_types: #allowed_types,
             }
         }
     };
@@ -143,10 +207,12 @@ pub fn build() -> TokenStream {
             }
         }
 
-        // Fallback for smiths
-        if matching_trades.is_empty()
-            && (prof == "armorer" || prof == "toolsmith" || prof == "weaponsmith")
-        {
+        // The vanilla tags share a small number of smith trades between professions.
+        let includes_common_smith = matches!(
+            (prof, level_str),
+            ("armorer", "1" | "2") | ("toolsmith" | "weaponsmith", "1")
+        );
+        if includes_common_smith {
             let smith_prefix = format!("smith/{level_str}/");
             for (key, trade) in &data.villager_trades {
                 if key.starts_with(&smith_prefix) {
@@ -261,6 +327,20 @@ pub fn build() -> TokenStream {
             pub max_uses: i32,
             pub xp: i32,
             pub price_multiplier: f32,
+            pub modifier: VillagerTradeModifier,
+            pub allowed_types: &'static [VillagerType],
+        }
+
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        pub enum VillagerTradeModifier {
+            None,
+            EnchantRandomly,
+            EnchantWithLevels { min: i32, max: i32 },
+            ExplorationMap { destination: &'static str },
+            RandomDyes,
+            RandomPotion,
+            SuspiciousStew,
+            Potion(&'static str),
         }
 
         #[derive(Clone, Copy, PartialEq)]


### PR DESCRIPTION
## Description
Implements villager workstation detection, profession assignment, and the normal villager trading lifecycle.

## What
- Adult unemployed villagers locate and claim Vanilla workstation blocks within the 48-block POI search radius.
- Villagers path to potential job sites, acquire the corresponding profession on arrival, and release unreachable or invalid sites.
- Claimed workstations are persisted through Pumpkin’s existing POI region storage.
- Merchant interactions consume payment, deliver results, increment offer uses, lock exhausted offers, award villager/player XP, and support normal and shift-click trading.
- Villagers level up after Vanilla’s 40-tick delay, unlock the next trade tier, update their visible badge metadata, receive regeneration, and display the associated particles.
- Villagers restock at their workstation during working hours, including Vanilla’s demand updates, two-restocks-per-day limit, and delay between restocks.
- Trading includes reputation and Hero of the Village price adjustments.
- Villagers provide Vanilla-style interaction feedback: trade sounds, throttled valid/invalid input sounds, unhappy head movement, job-site particles, and trade particles.
- Villagers face and follow their current customer instead of continuing to wander while a merchant screen is open.

Supported workstations include lecterns, composters, blast furnaces, smokers, cartography tables, brewing stands, barrels, fletching tables, cauldrons, stonecutters, looms, smithing tables, and grindstones.

## How
- Ports the relevant behavior from vanilla, including merchant offer matching, adjusted prices, offer usage, XP thresholds, delayed level-up, restocking, job-site validation, and merchant feedback.
- Adds a compact POI ownership layer on top of Pumpkin’s existing persisted POI storage. Job-site acquisition checks the five nearest candidates for path reachability before claiming one.
- Separates potential job sites from established job sites. Villagers only change profession and emit happy particles after reaching the workstation.
- Resets a profession after losing its workstation only for an untraded novice, matching Vanilla’s XP and level restrictions.
- Uses Vanilla’s generated trade-set data for every profession and level, including secondary costs and dynamic modifiers:
  - Tradeable enchanted books with Vanilla’s level and price formula.
  - Enchanted equipment with additional price components.
  - Explorer maps with actual structure-start lookup and translated item names.
  - Random dyes, potions, and suspicious stew effects.
- Adds the required item-component network and NBT codecs so dynamic trade results survive packet encoding and world saves.
- Synchronizes villager data and active-effect particle metadata so profession badges and level-up particles update without reconnecting.

## Testing
- `cargo test -p pumpkin-data translated_item_name_survives_item_stack_nbt_roundtrip`
- `cargo test -p pumpkin-protocol merchant`
- `cargo test -p pumpkin-inventory merchant_screen_handler`
- `cargo test -p pumpkin villager`
- `cargo fmt --all -- --check`
- `cargo clippy -p pumpkin -p pumpkin-inventory -p pumpkin-protocol -p pumpkin-data --all-targets -- -D warnings`