### PR TITLE
feat(plugin-api): Add `clear_permissions` player method in api

### DIFF
--- a/pumpkin-util/src/permission.rs
+++ b/pumpkin-util/src/permission.rs
@@ -173,6 +173,11 @@ impl PermissionAttachment {
         self.permissions.remove(node);
     }
 
+    /// Clears all explicitly set permissions from this attachment.
+    pub fn clear_permissions(&mut self) {
+        self.permissions.clear();
+    }
+
     /// Checks if a permission is explicitly set.
     ///
     /// # Parameters

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -803,6 +803,19 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         Ok(())
     }
 
+    async fn clear_permissions(&mut self, player: Resource<Player>) -> wasmtime::Result<()> {
+        let player = player_from_resource(self, &player)?;
+        let server = self.server.as_ref().expect("server not available");
+
+        let mut perm_manager = server.permission_manager.write().await;
+        let attachment = perm_manager.get_attachment(player.gameprofile.id);
+        drop(perm_manager);
+
+        attachment.write().await.clear_permissions();
+
+        Ok(())
+    }
+
     async fn has_permission_set(
         &mut self,
         player: Resource<Player>,


### PR DESCRIPTION
## Description
Adds a `clear_permissions` method to both `PermissionAttachment` and `Player` in the plugin API which removes all explicitly set permissions from the player.

## Testing
`cargo test` ✅
`cargo clippy --all-targets` ✅