### PR TITLE
fix(entity): keep adding XP levels past the i32 total experience limit

### DIFF
--- a/pumpkin-util/src/math/experience.rs
+++ b/pumpkin-util/src/math/experience.rs
@@ -89,3 +89,96 @@ pub fn progress_in_level(points: i32, level: i32) -> f32 {
 
     progress.clamp(0.0, 1.0)
 }
+
+/// The highest level for which `points_in_level` still fits in an `i32`
+/// (`9 * level - 158 <= i32::MAX`).
+pub const MAX_LEVEL: i32 = i32::MAX / 9;
+
+/// Applies a point delta to a `(level, points_into_level)` pair, carrying
+/// across level boundaries like vanilla's `giveExperiencePoints`.
+///
+/// Unlike converting through total accumulated points, this never saturates
+/// once the total exceeds `i32::MAX`, so levels keep increasing.
+///
+/// # Returns
+/// The new `(level, points_into_level)` pair, with
+/// `0 <= points_into_level < points_in_level(level)`.
+#[must_use]
+pub fn add_points_to_level(level: i32, points: i32, added: i32) -> (i32, i32) {
+    let mut level = level.max(0);
+    let mut points = i64::from(points.max(0)) + i64::from(added);
+
+    while points < 0 {
+        if level == 0 {
+            return (0, 0);
+        }
+        level -= 1;
+        points += i64::from(points_in_level(level));
+    }
+
+    loop {
+        let needed = i64::from(points_in_level(level));
+        if points < needed {
+            break;
+        }
+        if level >= MAX_LEVEL {
+            // Saturate below the next level instead of overflowing the level math.
+            points = needed - 1;
+            break;
+        }
+        points -= needed;
+        level += 1;
+    }
+
+    (level, points as i32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_points_within_level() {
+        assert_eq!(add_points_to_level(0, 0, 5), (0, 5));
+        assert_eq!(add_points_to_level(3, 2, 4), (3, 6));
+    }
+
+    #[test]
+    fn add_points_carries_levels_up() {
+        // Level 0 needs 7 points.
+        assert_eq!(add_points_to_level(0, 0, 7), (1, 0));
+        assert_eq!(add_points_to_level(0, 0, 8), (1, 1));
+        // 7 + 9 = 16 points reaches exactly level 2.
+        assert_eq!(add_points_to_level(0, 0, 16), (2, 0));
+        assert_eq!(points_to_level(2), 16);
+    }
+
+    #[test]
+    fn add_points_carries_levels_down() {
+        // Removing one point from the start of level 1 lands at 6/7 of level 0.
+        assert_eq!(add_points_to_level(1, 0, -1), (0, 6));
+        // Removing more points than the player has clamps at zero.
+        assert_eq!(add_points_to_level(0, 3, -10), (0, 0));
+        assert_eq!(add_points_to_level(2, 0, -1000), (0, 0));
+    }
+
+    #[test]
+    fn add_points_keeps_totals_consistent() {
+        let (level, points) = add_points_to_level(0, 0, i32::MAX);
+        assert_eq!(
+            i64::from(points_to_level(level)) + i64::from(points),
+            i64::from(i32::MAX)
+        );
+        assert!(points >= 0 && points < points_in_level(level));
+    }
+
+    #[test]
+    fn add_points_exceeds_i32_total() {
+        // Issue #2094: levels must keep increasing after the accumulated
+        // total passes `i32::MAX`.
+        let (level_a, points_a) = add_points_to_level(0, 0, i32::MAX);
+        let (level_b, points_b) = add_points_to_level(level_a, points_a, i32::MAX);
+        assert!(level_b > level_a);
+        assert!(points_b >= 0 && points_b < points_in_level(level_b));
+    }
+}

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -3433,6 +3433,10 @@ impl Player {
     }
 
     /// Add experience points to the player.
+    ///
+    /// Levels are advanced incrementally like vanilla's `giveExperiencePoints`,
+    /// so the player keeps earning levels even after the accumulated total
+    /// passes `i32::MAX`.
     pub async fn add_experience_points(self: &Arc<Self>, mut added_points: i32) {
         if let Some(server) = self.world().server.upgrade() {
             let event = PlayerExpChangeEvent::new(self.clone(), added_points);
@@ -3440,14 +3444,15 @@ impl Player {
             added_points = event.amount;
         }
 
+        if added_points == 0 {
+            return;
+        }
+
         let current_level = self.experience_level.load(Ordering::Relaxed);
         let current_points = self.experience_points.load(Ordering::Relaxed);
 
-        let total_exp = experience::points_to_level(current_level) as i64 + current_points as i64;
-        let new_total_exp = total_exp + added_points as i64;
-        let safe_new_total = new_total_exp.clamp(0, i32::MAX as i64) as i32;
-
-        let (new_level, new_points) = experience::total_to_level_and_points(safe_new_total);
+        let (new_level, new_points) =
+            experience::add_points_to_level(current_level, current_points, added_points);
         let progress = experience::progress_in_level(new_points, new_level);
 
         self.set_experience(new_level, progress, new_points).await;


### PR DESCRIPTION
## Description

Adding experience points previously converted the player's level and points into a single accumulated total clamped to `i32::MAX`, so once a player reached that total, further `/xp add` commands (and any other XP gain) silently did nothing.

This PR carries points across level boundaries incrementally instead, mirroring vanilla's `giveExperiencePoints`, so levels keep increasing past the 32-bit total. The carry logic lives in `pumpkin-util` as a pure function (`experience::add_points_to_level`) with unit tests, including a regression test for adding `i32::MAX` points twice.

Fixes #2094

## Testing

- `cargo test -p pumpkin-util` — 5 new unit tests covering in-level adds, upward/downward carries, total consistency, and totals beyond `i32::MAX`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)