### PR TITLE
fix(block): melt snow layers under high block light

### DIFF
--- a/pumpkin/src/block/blocks/snow.rs
+++ b/pumpkin/src/block/blocks/snow.rs
@@ -10,7 +10,7 @@ use pumpkin_world::{
 
 use crate::block::{
     BlockBehaviour, BlockFuture, GetStateForNeighborUpdateArgs, OnPlaceArgs, OnScheduledTickArgs,
-    UseWithItemArgs, registry::BlockActionResult,
+    RandomTickArgs, UseWithItemArgs, registry::BlockActionResult,
 };
 
 #[pumpkin_block("minecraft:snow")]
@@ -79,6 +79,23 @@ impl BlockBehaviour for LayeredSnowBlock {
     fn on_scheduled_tick<'a>(&'a self, args: OnScheduledTickArgs<'a>) -> BlockFuture<'a, ()> {
         Box::pin(async move {
             if !can_place_at(args.world.as_ref(), args.position) {
+                args.world
+                    .break_block(args.position, None, BlockFlags::empty())
+                    .await;
+            }
+        })
+    }
+
+    fn random_tick<'a>(&'a self, args: RandomTickArgs<'a>) -> BlockFuture<'a, ()> {
+        Box::pin(async move {
+            // Snow layers melt when lit by block light above level 11,
+            // e.g. from a nearby torch.
+            if args
+                .world
+                .get_block_light_level(args.position)
+                .unwrap_or(0)
+                > 11
+            {
                 args.world
                     .break_block(args.position, None, BlockFlags::empty())
                     .await;

--- a/pumpkin/src/block/blocks/snow.rs
+++ b/pumpkin/src/block/blocks/snow.rs
@@ -90,12 +90,7 @@ impl BlockBehaviour for LayeredSnowBlock {
         Box::pin(async move {
             // Snow layers melt when lit by block light above level 11,
             // e.g. from a nearby torch.
-            if args
-                .world
-                .get_block_light_level(args.position)
-                .unwrap_or(0)
-                > 11
-            {
+            if args.world.get_block_light_level(args.position).unwrap_or(0) > 11 {
                 args.world
                     .break_block(args.position, None, BlockFlags::empty())
                     .await;


### PR DESCRIPTION
## Description

Snow layers never melted because the block had no `random_tick` handler. This PR mirrors vanilla `SnowLayerBlock.randomTick`: on a random tick, the layer is removed when the block light level at its position exceeds 11 (e.g. from a nearby torch).

The snow layer's block states are already flagged as randomly ticking in the generated vanilla data, and the server-side lighting engine already exposes `World::get_block_light_level`, so this only adds the missing handler.

Fixes #2179

## Testing

- Verified via a temporary data test that `Block::SNOW` states have `has_random_ticks` set, so the new handler is actually dispatched.
- `cargo check` / `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)