### PR TITLE
Fix crash when serializing advancement item icons

### DIFF
--- a/pumpkin-protocol/src/java/client/play/update_advancement.rs
+++ b/pumpkin-protocol/src/java/client/play/update_advancement.rs
@@ -66,8 +66,15 @@ impl ClientPacket for CUpdateAdvancements {
                 write.write_slice(&display.get_description().encode())?;
 
                 // Item icon
-                ItemStackTemplateSerializer::from(display.item_icon.clone())
-                    .write_with_version(&mut write, version)?;
+                let icon_result = ItemStackTemplateSerializer::from(display.item_icon.clone())
+                    .write_with_version(&mut write, version);
+                if icon_result.is_err() {
+                    // Fallback
+                    write.write_var_int(&VarInt(0))?; // item_id = 0 (AIR)
+                    write.write_var_int(&VarInt(0))?; // count = 0
+                    write.write_var_int(&VarInt(0))?; // to_add = 0
+                    write.write_var_int(&VarInt(0))?; // to_remove = 0
+                }
 
                 write.write_var_int(&VarInt(display.frame_type as i32))?;
                 let flags = (display.has_background() as i32)


### PR DESCRIPTION
## Description

Fixes a server crash when sending advancement packets with item icons.

`update_advancement` did not handle item serialization failures. When serialization failed, the error propagated and caused the server to panic. This change falls back to an empty item instead of crashing the server.

## Testing

- Tested advancements triggered by Mace interaction
- Confirmed the server no longer crashes when advancements are triggered