### PR TITLE
feat: persist item components that were only set at runtime

### DIFF
--- a/pumpkin-data/src/data_component_impl/basic.rs
+++ b/pumpkin-data/src/data_component_impl/basic.rs
@@ -247,63 +247,61 @@ impl DataComponentImpl for EnchantmentGlintOverrideImpl {
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TooltipStyleImpl {
-    pub id: Cow<'static, str>,
+    pub id: String,
 }
 impl TooltipStyleImpl {
     pub fn read_data(data: &NbtTag) -> Option<Self> {
-        data.extract_string().map(|id| Self {
-            id: Cow::Owned(id.to_string()),
-        })
+        data.extract_string().map(|id| Self { id: id.to_string() })
     }
 }
 impl DataComponentImpl for TooltipStyleImpl {
     fn write_data(&self) -> NbtTag {
-        NbtTag::String(self.id.clone().into_owned().into())
+        NbtTag::String(self.id.clone().into())
     }
     fn get_hash(&self) -> i32 {
-        get_str_hash(self.id.as_ref()) as i32
+        get_str_hash(&self.id) as i32
     }
     default_impl!(TooltipStyle);
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct NoteBlockSoundImpl {
-    pub sound: Cow<'static, str>,
+    pub sound: String,
 }
 impl NoteBlockSoundImpl {
     pub fn read_data(data: &NbtTag) -> Option<Self> {
         data.extract_string().map(|sound| Self {
-            sound: Cow::Owned(sound.to_string()),
+            sound: sound.to_string(),
         })
     }
 }
 impl DataComponentImpl for NoteBlockSoundImpl {
     fn write_data(&self) -> NbtTag {
-        NbtTag::String(self.sound.clone().into_owned().into())
+        NbtTag::String(self.sound.clone().into())
     }
     fn get_hash(&self) -> i32 {
-        get_str_hash(self.sound.as_ref()) as i32
+        get_str_hash(&self.sound) as i32
     }
     default_impl!(NoteBlockSound);
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct BaseColorImpl {
-    pub color: Cow<'static, str>,
+    pub color: String,
 }
 impl BaseColorImpl {
     pub fn read_data(data: &NbtTag) -> Option<Self> {
         data.extract_string().map(|color| Self {
-            color: Cow::Owned(color.to_string()),
+            color: color.to_string(),
         })
     }
 }
 impl DataComponentImpl for BaseColorImpl {
     fn write_data(&self) -> NbtTag {
-        NbtTag::String(self.color.clone().into_owned().into())
+        NbtTag::String(self.color.clone().into())
     }
     fn get_hash(&self) -> i32 {
-        get_str_hash(self.color.as_ref()) as i32
+        get_str_hash(&self.color) as i32
     }
     default_impl!(BaseColor);
 }

--- a/pumpkin-data/src/data_component_impl/basic.rs
+++ b/pumpkin-data/src/data_component_impl/basic.rs
@@ -158,9 +158,72 @@ impl DataComponentImpl for RarityImpl {
     default_impl!(Rarity);
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct CustomModelDataImpl;
+#[derive(Clone, Debug, PartialEq)]
+pub struct CustomModelDataImpl {
+    pub floats: Vec<f32>,
+    pub flags: Vec<bool>,
+    pub strings: Vec<String>,
+    pub colors: Vec<i32>,
+}
+impl CustomModelDataImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        let compound = data.extract_compound()?;
+        let floats = compound
+            .get_list("floats")
+            .map(|l| l.iter().filter_map(NbtTag::extract_float).collect())
+            .unwrap_or_default();
+        let flags = compound
+            .get_list("flags")
+            .map(|l| l.iter().filter_map(NbtTag::extract_bool).collect())
+            .unwrap_or_default();
+        let strings = compound
+            .get_list("strings")
+            .map(|l| {
+                l.iter()
+                    .filter_map(|t| t.extract_string().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+        // Vanilla encodes the color list as ints, but tolerate a packed int array too.
+        let colors = if let Some(arr) = compound.get_int_array("colors") {
+            arr.to_vec()
+        } else if let Some(l) = compound.get_list("colors") {
+            l.iter().filter_map(NbtTag::extract_int).collect()
+        } else {
+            Vec::new()
+        };
+        Some(Self {
+            floats,
+            flags,
+            strings,
+            colors,
+        })
+    }
+}
 impl DataComponentImpl for CustomModelDataImpl {
+    fn write_data(&self) -> NbtTag {
+        let mut compound = NbtCompound::new();
+        compound.put_list(
+            "floats",
+            self.floats.iter().map(|f| NbtTag::Float(*f)).collect(),
+        );
+        compound.put_list(
+            "flags",
+            self.flags.iter().map(|b| NbtTag::Byte(*b as i8)).collect(),
+        );
+        compound.put_list(
+            "strings",
+            self.strings
+                .iter()
+                .map(|s| NbtTag::String(s.clone().into()))
+                .collect(),
+        );
+        compound.put_list(
+            "colors",
+            self.colors.iter().map(|c| NbtTag::Int(*c)).collect(),
+        );
+        NbtTag::Compound(compound)
+    }
     default_impl!(CustomModelData);
 }
 
@@ -183,20 +246,65 @@ impl DataComponentImpl for EnchantmentGlintOverrideImpl {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct TooltipStyleImpl;
+pub struct TooltipStyleImpl {
+    pub id: Cow<'static, str>,
+}
+impl TooltipStyleImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        data.extract_string().map(|id| Self {
+            id: Cow::Owned(id.to_string()),
+        })
+    }
+}
 impl DataComponentImpl for TooltipStyleImpl {
+    fn write_data(&self) -> NbtTag {
+        NbtTag::String(self.id.clone().into_owned().into())
+    }
+    fn get_hash(&self) -> i32 {
+        get_str_hash(self.id.as_ref()) as i32
+    }
     default_impl!(TooltipStyle);
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct NoteBlockSoundImpl;
+pub struct NoteBlockSoundImpl {
+    pub sound: Cow<'static, str>,
+}
+impl NoteBlockSoundImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        data.extract_string().map(|sound| Self {
+            sound: Cow::Owned(sound.to_string()),
+        })
+    }
+}
 impl DataComponentImpl for NoteBlockSoundImpl {
+    fn write_data(&self) -> NbtTag {
+        NbtTag::String(self.sound.clone().into_owned().into())
+    }
+    fn get_hash(&self) -> i32 {
+        get_str_hash(self.sound.as_ref()) as i32
+    }
     default_impl!(NoteBlockSound);
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct BaseColorImpl;
+pub struct BaseColorImpl {
+    pub color: Cow<'static, str>,
+}
+impl BaseColorImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        data.extract_string().map(|color| Self {
+            color: Cow::Owned(color.to_string()),
+        })
+    }
+}
 impl DataComponentImpl for BaseColorImpl {
+    fn write_data(&self) -> NbtTag {
+        NbtTag::String(self.color.clone().into_owned().into())
+    }
+    fn get_hash(&self) -> i32 {
+        get_str_hash(self.color.as_ref()) as i32
+    }
     default_impl!(BaseColor);
 }
 
@@ -230,9 +338,24 @@ impl DataComponentImpl for PotDecorationsImpl {
     default_impl!(PotDecorations);
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct LockImpl;
+/// The lock's item predicate, kept as its raw NBT compound since Pumpkin does
+/// not yet model item predicates.
+// TODO: replace `predicate` with a typed item predicate once item predicates are modelled.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LockImpl {
+    pub predicate: NbtCompound,
+}
+impl LockImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        data.extract_compound().map(|predicate| Self {
+            predicate: predicate.clone(),
+        })
+    }
+}
 impl DataComponentImpl for LockImpl {
+    fn write_data(&self) -> NbtTag {
+        NbtTag::Compound(self.predicate.clone())
+    }
     default_impl!(Lock);
 }
 

--- a/pumpkin-data/src/data_component_impl/block_entity.rs
+++ b/pumpkin-data/src/data_component_impl/block_entity.rs
@@ -138,8 +138,25 @@ impl DataComponentImpl for BeesImpl {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct ContainerLootImpl;
+pub struct ContainerLootImpl {
+    pub loot_table: String,
+    pub seed: i64,
+}
+impl ContainerLootImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        let compound = data.extract_compound()?;
+        let loot_table = compound.get_string("loot_table")?.to_string();
+        let seed = compound.get_long("seed").unwrap_or(0);
+        Some(Self { loot_table, seed })
+    }
+}
 impl DataComponentImpl for ContainerLootImpl {
+    fn write_data(&self) -> NbtTag {
+        let mut compound = NbtCompound::new();
+        compound.put_string("loot_table", self.loot_table.clone());
+        compound.put_long("seed", self.seed);
+        NbtTag::Compound(compound)
+    }
     default_impl!(ContainerLoot);
 }
 

--- a/pumpkin-data/src/data_component_impl/combat.rs
+++ b/pumpkin-data/src/data_component_impl/combat.rs
@@ -85,15 +85,45 @@ impl DataComponentImpl for EnchantmentsImpl {
     default_impl!(Enchantments);
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct CanPlaceOnImpl;
+/// An adventure-mode block predicate, kept as its raw NBT (a compound or list)
+/// since Pumpkin does not yet model block predicates.
+// TODO: replace `predicate` with a typed block predicate once block predicates are modelled.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CanPlaceOnImpl {
+    pub predicate: NbtTag,
+}
+impl CanPlaceOnImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        Some(Self {
+            predicate: data.clone(),
+        })
+    }
+}
 impl DataComponentImpl for CanPlaceOnImpl {
+    fn write_data(&self) -> NbtTag {
+        self.predicate.clone()
+    }
     default_impl!(CanPlaceOn);
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct CanBreakImpl;
+/// An adventure-mode block predicate, kept as its raw NBT (a compound or list)
+/// since Pumpkin does not yet model block predicates.
+// TODO: replace `predicate` with a typed block predicate once block predicates are modelled.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CanBreakImpl {
+    pub predicate: NbtTag,
+}
+impl CanBreakImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        Some(Self {
+            predicate: data.clone(),
+        })
+    }
+}
 impl DataComponentImpl for CanBreakImpl {
+    fn write_data(&self) -> NbtTag {
+        self.predicate.clone()
+    }
     default_impl!(CanBreak);
 }
 
@@ -105,7 +135,15 @@ impl DataComponentImpl for RepairCostImpl {
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct IntangibleProjectileImpl;
+impl IntangibleProjectileImpl {
+    pub const fn read_data(_data: &NbtTag) -> Option<Self> {
+        Some(Self)
+    }
+}
 impl DataComponentImpl for IntangibleProjectileImpl {
+    fn write_data(&self) -> NbtTag {
+        NbtTag::Compound(NbtCompound::new())
+    }
     default_impl!(IntangibleProjectile);
 }
 
@@ -505,7 +543,15 @@ impl DataComponentImpl for RepairableImpl {
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GliderImpl;
+impl GliderImpl {
+    pub const fn read_data(_data: &NbtTag) -> Option<Self> {
+        Some(Self)
+    }
+}
 impl DataComponentImpl for GliderImpl {
+    fn write_data(&self) -> NbtTag {
+        NbtTag::Compound(NbtCompound::new())
+    }
     default_impl!(Glider);
 }
 
@@ -601,9 +647,30 @@ impl DataComponentImpl for OminousBottleAmplifierImpl {
     default_impl!(OminousBottleAmplifier);
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct TrimImpl;
+/// An armor trim's material and pattern, kept as their raw NBT (each a registry
+/// id or an inline definition) since Pumpkin does not yet model trim registries.
+// TODO: replace `material`/`pattern` with typed trim material/pattern once those registries are modelled.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrimImpl {
+    pub material: NbtTag,
+    pub pattern: NbtTag,
+}
+impl TrimImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        let compound = data.extract_compound()?;
+        Some(Self {
+            material: compound.get("material")?.clone(),
+            pattern: compound.get("pattern")?.clone(),
+        })
+    }
+}
 impl DataComponentImpl for TrimImpl {
+    fn write_data(&self) -> NbtTag {
+        let mut compound = NbtCompound::new();
+        compound.put("material", self.material.clone());
+        compound.put("pattern", self.pattern.clone());
+        NbtTag::Compound(compound)
+    }
     default_impl!(Trim);
 }
 

--- a/pumpkin-data/src/data_component_impl/mod.rs
+++ b/pumpkin-data/src/data_component_impl/mod.rs
@@ -637,7 +637,7 @@ mod tests {
     fn base_color_round_trip() {
         assert_round_trip(
             BaseColorImpl {
-                color: Cow::Borrowed("light_blue"),
+                color: "light_blue".to_string(),
             },
             BaseColorImpl::read_data,
         );
@@ -647,7 +647,7 @@ mod tests {
     fn note_block_sound_round_trip() {
         assert_round_trip(
             NoteBlockSoundImpl {
-                sound: Cow::Borrowed("minecraft:block.note_block.pling"),
+                sound: "minecraft:block.note_block.pling".to_string(),
             },
             NoteBlockSoundImpl::read_data,
         );
@@ -657,7 +657,7 @@ mod tests {
     fn tooltip_style_round_trip() {
         assert_round_trip(
             TooltipStyleImpl {
-                id: Cow::Borrowed("minecraft:my_style"),
+                id: "minecraft:my_style".to_string(),
             },
             TooltipStyleImpl::read_data,
         );

--- a/pumpkin-data/src/data_component_impl/mod.rs
+++ b/pumpkin-data/src/data_component_impl/mod.rs
@@ -582,6 +582,21 @@ pub fn read_data(id: DataComponent, data: &NbtTag) -> Option<Box<dyn DataCompone
         DataComponent::CatCollar => Some(CatCollarImpl::read_data(data)?.to_dyn()),
         DataComponent::SheepColor => Some(SheepColorImpl::read_data(data)?.to_dyn()),
         DataComponent::ShulkerColor => Some(ShulkerColorImpl::read_data(data)?.to_dyn()),
+        DataComponent::DyedColor => Some(DyedColorImpl::read_data(data)?.to_dyn()),
+        DataComponent::BaseColor => Some(BaseColorImpl::read_data(data)?.to_dyn()),
+        DataComponent::NoteBlockSound => Some(NoteBlockSoundImpl::read_data(data)?.to_dyn()),
+        DataComponent::TooltipStyle => Some(TooltipStyleImpl::read_data(data)?.to_dyn()),
+        DataComponent::Lock => Some(LockImpl::read_data(data)?.to_dyn()),
+        DataComponent::ContainerLoot => Some(ContainerLootImpl::read_data(data)?.to_dyn()),
+        DataComponent::CustomModelData => Some(CustomModelDataImpl::read_data(data)?.to_dyn()),
+        DataComponent::LodestoneTracker => Some(LodestoneTrackerImpl::read_data(data)?.to_dyn()),
+        DataComponent::Glider => Some(GliderImpl::read_data(data)?.to_dyn()),
+        DataComponent::IntangibleProjectile => {
+            Some(IntangibleProjectileImpl::read_data(data)?.to_dyn())
+        }
+        DataComponent::Trim => Some(TrimImpl::read_data(data)?.to_dyn()),
+        DataComponent::CanPlaceOn => Some(CanPlaceOnImpl::read_data(data)?.to_dyn()),
+        DataComponent::CanBreak => Some(CanBreakImpl::read_data(data)?.to_dyn()),
         _ => None,
     }
 }
@@ -603,5 +618,125 @@ mod tests {
         );
         assert_eq!(MaxStackSizeImpl { size: 99 }.get_hash(), -1632321551i32);
         assert_eq!(MapIdImpl { id: 10 }.get_hash(), -919192125i32);
+    }
+
+    fn assert_round_trip<T: DataComponentImpl + Clone + 'static>(
+        value: T,
+        read: impl Fn(&NbtTag) -> Option<T>,
+    ) {
+        let restored = read(&value.write_data()).expect("read_data returned None");
+        assert!(value.equal(&restored));
+    }
+
+    #[test]
+    fn dyed_color_round_trip() {
+        assert_round_trip(DyedColorImpl { rgb: 0x00A0F0 }, DyedColorImpl::read_data);
+    }
+
+    #[test]
+    fn base_color_round_trip() {
+        assert_round_trip(
+            BaseColorImpl {
+                color: Cow::Borrowed("light_blue"),
+            },
+            BaseColorImpl::read_data,
+        );
+    }
+
+    #[test]
+    fn note_block_sound_round_trip() {
+        assert_round_trip(
+            NoteBlockSoundImpl {
+                sound: Cow::Borrowed("minecraft:block.note_block.pling"),
+            },
+            NoteBlockSoundImpl::read_data,
+        );
+    }
+
+    #[test]
+    fn tooltip_style_round_trip() {
+        assert_round_trip(
+            TooltipStyleImpl {
+                id: Cow::Borrowed("minecraft:my_style"),
+            },
+            TooltipStyleImpl::read_data,
+        );
+    }
+
+    #[test]
+    fn container_loot_round_trip() {
+        assert_round_trip(
+            ContainerLootImpl {
+                loot_table: "minecraft:chests/simple_dungeon".to_string(),
+                seed: 123_456_789,
+            },
+            ContainerLootImpl::read_data,
+        );
+    }
+
+    #[test]
+    fn custom_model_data_round_trip() {
+        assert_round_trip(
+            CustomModelDataImpl {
+                floats: vec![1.5, -2.0],
+                flags: vec![true, false, true],
+                strings: vec!["a".to_string(), "b".to_string()],
+                colors: vec![0xFF0000, 0x00FF00],
+            },
+            CustomModelDataImpl::read_data,
+        );
+    }
+
+    #[test]
+    fn lodestone_tracker_round_trip() {
+        assert_round_trip(
+            LodestoneTrackerImpl {
+                target: Some(LodestoneTarget {
+                    dimension: "minecraft:overworld".to_string(),
+                    x: 10,
+                    y: 64,
+                    z: -30,
+                }),
+                tracked: true,
+            },
+            LodestoneTrackerImpl::read_data,
+        );
+        assert_round_trip(
+            LodestoneTrackerImpl {
+                target: None,
+                tracked: false,
+            },
+            LodestoneTrackerImpl::read_data,
+        );
+    }
+
+    #[test]
+    fn marker_components_round_trip() {
+        assert_round_trip(GliderImpl, GliderImpl::read_data);
+        assert_round_trip(
+            IntangibleProjectileImpl,
+            IntangibleProjectileImpl::read_data,
+        );
+    }
+
+    #[test]
+    fn raw_nbt_components_round_trip() {
+        let mut material = NbtCompound::new();
+        material.put_string("material", "minecraft:diamond".to_string());
+        material.put_string("pattern", "minecraft:coast".to_string());
+        assert_round_trip(
+            TrimImpl::read_data(&NbtTag::Compound(material)).unwrap(),
+            TrimImpl::read_data,
+        );
+
+        let mut predicate = NbtCompound::new();
+        predicate.put_string("blocks", "minecraft:stone".to_string());
+        assert_round_trip(
+            CanPlaceOnImpl {
+                predicate: NbtTag::Compound(predicate.clone()),
+            },
+            CanPlaceOnImpl::read_data,
+        );
+        assert_round_trip(LockImpl { predicate }, LockImpl::read_data);
     }
 }

--- a/pumpkin-data/src/data_component_impl/utility.rs
+++ b/pumpkin-data/src/data_component_impl/utility.rs
@@ -13,8 +13,21 @@ impl DataComponentImpl for DyeImpl {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct DyedColorImpl;
+pub struct DyedColorImpl {
+    pub rgb: i32,
+}
+impl DyedColorImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        data.extract_int().map(|rgb| Self { rgb })
+    }
+}
 impl DataComponentImpl for DyedColorImpl {
+    fn write_data(&self) -> NbtTag {
+        NbtTag::Int(self.rgb)
+    }
+    fn get_hash(&self) -> i32 {
+        get_i32_hash(self.rgb) as i32
+    }
     default_impl!(DyedColor);
 }
 
@@ -152,9 +165,51 @@ impl DataComponentImpl for BundleContentsImpl {
     default_impl!(BundleContents);
 }
 
+/// The dimension and block position a lodestone compass points to.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct LodestoneTrackerImpl;
+pub struct LodestoneTarget {
+    pub dimension: String,
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+}
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct LodestoneTrackerImpl {
+    pub target: Option<LodestoneTarget>,
+    pub tracked: bool,
+}
+impl LodestoneTrackerImpl {
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        let compound = data.extract_compound()?;
+        let tracked = compound.get_bool("tracked").unwrap_or(true);
+        let target = compound.get_compound("target").and_then(|target| {
+            let dimension = target.get_string("dimension")?.to_string();
+            let pos = target.get_int_array("pos")?;
+            if pos.len() != 3 {
+                return None;
+            }
+            Some(LodestoneTarget {
+                dimension,
+                x: pos[0],
+                y: pos[1],
+                z: pos[2],
+            })
+        });
+        Some(Self { target, tracked })
+    }
+}
 impl DataComponentImpl for LodestoneTrackerImpl {
+    fn write_data(&self) -> NbtTag {
+        let mut compound = NbtCompound::new();
+        if let Some(target) = &self.target {
+            let mut target_compound = NbtCompound::new();
+            target_compound.put_string("dimension", target.dimension.clone());
+            target_compound.put("pos", NbtTag::IntArray(vec![target.x, target.y, target.z]));
+            compound.put_compound("target", target_compound);
+        }
+        compound.put_bool("tracked", self.tracked);
+        NbtTag::Compound(compound)
+    }
     default_impl!(LodestoneTracker);
 }
 


### PR DESCRIPTION
### Problem

A bunch of data components still used the default `write_data` (`NbtTag::End`), so their contents were quietly thrown away whenever an item stack got written to NBT (chests, inventories, chunk saves). None of these show up as item defaults in the generated item table, they only ever get set at runtime, so I could give them a real data model without having to touch any generated code.

### Change

Added `write_data` plus a matching `read_data` (and the `read_data` dispatcher entry) for:

- Scalars and simple compounds, following the vanilla shape: `dyed_color` (rgb int), `base_color`, `note_block_sound`, `tooltip_style`, `container_loot` (loot table + seed), `custom_model_data` (floats/flags/strings/colors) and `lodestone_tracker` (target dimension+pos and the tracked flag).
- Unit markers: `glider` and `intangible_projectile` now serialize to an empty compound `{}`, same as vanilla's `Unit` codec (that's what `unbreakable` already does).
- The predicate-ish ones I kept as raw NBT for now so they round-trip without losing anything: `lock`, `trim`, `can_place_on` and `can_break`. Each has a `TODO` to move to a proper typed model later.

All of these survive `write_item_stack` / `read_item_stack` now. Added round-trip tests too.

### Notes

- Network-only components (`creative_slot_lock`, `additional_trade_cost`, `map_post_processing`) are left as they are on purpose, vanilla never writes those to disk so `End` is already correct there.
- A proper block/item predicate subsystem, to replace the raw NBT on `lock`, `can_place_on` and `can_break`, is planned as its own PR.