### PR TITLE
Reject native plugins with incompatible metadata layouts

### DIFF
--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -30,9 +30,12 @@ pub use api::*;
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-/// Bump this whenever the public plugin API or any event layout changes in a way
+/// Bump this whenever the native plugin API or any event layout changes in a way
 /// that makes old binary plugins incompatible.
-pub const PLUGIN_API_VERSION: u32 = 2;
+///
+/// Native plugins exchange Rust types with the server, so changing a type's
+/// layout, such as adding a field to [`PluginMetadata`], is an API break.
+pub const PLUGIN_API_VERSION: u32 = 3;
 
 const PLUGIN_DIR: &str = "./plugins";
 


### PR DESCRIPTION
Fixes #2434

## Description

Bumps the native plugin API version to 3.

`PluginMetadata` gained fields without a corresponding native API version bump. Older native plugins could therefore pass the compatibility check despite using an incompatible Rust struct layout, which may cause invalid allocation attempts during initialization.

This change makes affected plugins fail with the existing API-version mismatch error and prompts users to rebuild them against the current Pumpkin build.

## Testing

- `cargo fmt --check`
- `git diff --check`

`cargo test -p pumpkin --lib` is currently blocked by unrelated generated WASM binding errors caused by the existing `pumpkin-plugin-wit` worktree change.
