### PR TITLE
feat(command): add /reload command

### DIFF
--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -48,6 +48,7 @@ mod plugins;
 mod pumpkin;
 mod random;
 mod recipe;
+mod reload;
 mod ride;
 mod rotate;
 mod saveall;
@@ -178,6 +179,7 @@ pub async fn default_dispatcher(
     forceload::register(&mut dispatcher, registry);
     ride::register(&mut dispatcher, registry);
     recipe::register(&mut dispatcher, registry);
+    reload::register(&mut dispatcher, registry);
     help::register(&mut dispatcher, registry);
     kill::register(&mut dispatcher, registry);
     op::register(&mut dispatcher, registry);

--- a/pumpkin/src/command/commands/reload.rs
+++ b/pumpkin/src/command/commands/reload.rs
@@ -1,0 +1,47 @@
+use pumpkin_data::translation;
+use pumpkin_util::PermissionLvl;
+use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
+use pumpkin_util::text::TextComponent;
+
+use crate::command::argument_builder::{ArgumentBuilder, command};
+use crate::command::context::command_context::CommandContext;
+use crate::command::node::dispatcher::CommandDispatcher;
+use crate::command::node::{CommandExecutor, CommandExecutorResult};
+
+const DESCRIPTION: &str = "Reloads data packs.";
+const PERMISSION: &str = "minecraft:command.reload";
+
+struct ReloadCommandExecutor;
+
+impl CommandExecutor for ReloadCommandExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_RELOAD_SUCCESS,
+                        translation::bedrock::COMMANDS_RELOAD_SUCCESS,
+                        [],
+                    ),
+                    true,
+                )
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION,
+        DESCRIPTION,
+        PermissionDefault::Op(PermissionLvl::Two),
+    ));
+
+    dispatcher.register(
+        command("reload", DESCRIPTION)
+            .requires(PERMISSION)
+            .executes(ReloadCommandExecutor),
+    );
+}


### PR DESCRIPTION
## Description

Implements the `/reload` command, which reloads data packs. In
vanilla Minecraft this triggers the `PreparableReloadListener`
pipeline (advancements, recipes, loot tables, tags, functions).
Since Pumpkin does not yet have a data pack system, the command
currently sends the standard "Reloading!" success message and is
wired up so it can be extended when the data pack system arrives.

- Adds `pumpkin/src/command/commands/reload.rs`
- Registers command with `minecraft:command.reload` permission (OP level 2)
- Uses the `CommandContext`-based pattern
- Sends translated feedback for both Java and Bedrock clients

## Testing

- `cargo fmt --all --check` clean.
- `cargo check -p pumpkin` clean.
- `cargo clippy --all-targets` / `cargo test` pending CI.