### PR TITLE
fix: preserve navigator movement while move control is idle

### DIFF
--- a/pumpkin/src/entity/ai/control/move_control.rs
+++ b/pumpkin/src/entity/ai/control/move_control.rs
@@ -97,11 +97,9 @@ impl MoveControlTrait for MoveControl {
             if entity.on_ground.load(Ordering::Relaxed) {
                 self.operation = Operation::Wait;
             }
-        } else {
-            living_entity
-                .movement_input
-                .store(Vector3::new(0.0, 0.0, 0.0));
         }
+
+        // Navigator owns movement input while this controller waits.
     }
 }
 


### PR DESCRIPTION
## What changed

Prevented `MoveControl` from clearing movement input while it is in the `Wait` state.

## Why

`Navigator` runs first and writes forward movement for path-following. `MoveControl` then ran in its normal idle state and overwrote that input with zero, so mobs could find paths but could not follow them.

## Impact

Mobs can now follow existing navigator paths.

This PR does not change pathfinding, goals, strafing, or movement speed.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- Playtested, and mobs can move now. Before, they could not move.

AI disclaimer: Codex was used to help with this PR.