### PR TITLE
fix: stone-capped chunks when generation resumes from a saved proto chunk

### DIFF
--- a/pumpkin-world/src/generation/proto_chunk.rs
+++ b/pumpkin-world/src/generation/proto_chunk.rs
@@ -292,7 +292,7 @@ impl ProtoChunk {
 
         for z in 0..16 {
             for x in 0..16 {
-                let index = ((z << 4) + x) as usize;
+                let index = Self::local_position_to_height_map_index(x, z);
 
                 proto_chunk.flat_motion_blocking_height_map[index] = heightmap_data.get(
                     ChunkHeightmapType::MotionBlocking,

--- a/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -5,6 +5,93 @@ mod test {
     use pumpkin_data::dimension::Dimension;
     use pumpkin_util::world_seed::Seed;
 
+    // Regression test for transposed heightmaps during Noise-stage chunk resume.
+    // Flat terrain cannot expose this bug, so use a sloped chunk.
+    #[test]
+    fn heightmap_roundtrip_through_chunk_data_resume() {
+        use crate::chunk_system::chunk_state::Chunk;
+        use pumpkin_config::lighting::LightingEngineConfig;
+        use pumpkin_util::math::vector3::Vector3;
+
+        let seed = Seed(1779920288596261407);
+        let (cx, cz) = (67i32, 63i32);
+        let world_gen = get_world_gen(seed, Dimension::OVERWORLD, false, Vec::new(), String::new());
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+
+        let mut proto = ProtoChunk::new(cx, cz, &world_gen);
+        proto.step_to_biomes(generator);
+        proto.set_structure_starts(generator);
+        proto.set_structure_references(generator);
+        proto.step_to_noise(generator);
+
+        let mut expected_heights = [[0i32; 16]; 16];
+        for z in 0..16i32 {
+            for x in 0..16i32 {
+                expected_heights[z as usize][x as usize] = proto.top_block_height_exclusive(x, z);
+            }
+        }
+
+        let mut staged = Chunk::Proto(Box::new(proto));
+        staged.upgrade_to_level_chunk(&Dimension::OVERWORLD, &LightingEngineConfig::Default);
+        let Chunk::Level(chunk_data) = staged else {
+            unreachable!()
+        };
+        assert_eq!(chunk_data.status, pumpkin_data::chunk::ChunkStatus::Noise);
+
+        let mut resumed = ProtoChunk::from_chunk_data(&chunk_data, &world_gen);
+        assert_eq!(resumed.stage, StagedChunkEnum::Noise);
+
+        let mut height_mismatches = 0;
+        for z in 0..16i32 {
+            for x in 0..16i32 {
+                let expected = expected_heights[z as usize][x as usize];
+                let got = resumed.top_block_height_exclusive(x, z);
+                if got != expected {
+                    height_mismatches += 1;
+                }
+            }
+        }
+        assert_eq!(
+            height_mismatches, 0,
+            "heightmap corrupted by save/load roundtrip (transposed or lost)"
+        );
+
+        resumed.step_to_surface(generator);
+
+        let mut fresh = ProtoChunk::new(cx, cz, &world_gen);
+        fresh.step_to_biomes(generator);
+        fresh.set_structure_starts(generator);
+        fresh.set_structure_references(generator);
+        fresh.step_to_noise(generator);
+        fresh.step_to_surface(generator);
+
+        let bottom = fresh.bottom_y() as i32;
+        let top = bottom + fresh.height() as i32;
+        let mut surface_mismatches = 0;
+        for lz in 0..16i32 {
+            for lx in 0..16i32 {
+                let (wx, wz) = (cx * 16 + lx, cz * 16 + lz);
+                for y in (bottom..top).rev() {
+                    let f = fresh.get_block_state(&Vector3::new(wx, y, wz)).to_state();
+                    if f.is_air() || f.is_liquid() {
+                        continue;
+                    }
+                    let r = resumed.get_block_state(&Vector3::new(wx, y, wz)).to_state();
+                    if f.id != r.id {
+                        surface_mismatches += 1;
+                    }
+                    break;
+                }
+            }
+        }
+        assert_eq!(
+            surface_mismatches, 0,
+            "resumed chunk surface differs from uninterrupted generation (stone-trail bug)"
+        );
+    }
+
     #[test]
     fn no_blend_no_beard_0_0() {
         let seed = Seed(0);


### PR DESCRIPTION
## Description

Image of the Bug (taken from Issue #2226)
<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/dbecb9d6-f36c-4b1f-b853-5dc935780fb7" />


ProtoChunk::from_chunk_data restored the flat heightmaps using index z * 16 + x, while every reader of those maps (local_position_to_height_map_index) uses x * 16 + z. Any chunk saved to disk mid-generation and later reloaded resumed with transposed heightmaps. 

### Why
This is the cause of the stone trail bug mentioned in #2226.

1. Chunks at the generation frontier are (correctly) saved at an intermediate stage, e.g. Noise, when they get flushed (autosave/unload/shutdown)
2. When the player later moves toward them, theyre reloaded via from_chunk_data and generation resumes, now with transposed heightmaps
3. The surface stage iterates each column down from top_block_height_exclusive. On sloped terrain the transposed height lies below the real column top for part of the chunk, so the real top blocks are never touched by the surface rules and stay default stone
4. The chunk completes to Full and is saved, so the damage is permanent

Because the trigger is which chunks happened to be mid-generation at save time, the artifact looked non-deterministic and couldn't be reproduced from the seed (recreating the world with the same seed gives different results each time). The transpose is also invisible on flat terrain, which is why it only showed on slopes and "stopped" at rivers.

Reproduced deterministically by loading a status=Noise chunk from a real world save and resuming it in-process: 104/256 columns came out stone-capped vs. 0 for uninterrupted generation, and the heightmap error grid was antisymmetric across the chunk diagonal, the transpose signature.

### Impact
- Chunks resumed from disk now generate identical surfaces to uninterrupted generation (verified: resumed vs. fresh = 0 diffs on the repro chunk)
- Also fixes the motion_blocking / motion_blocking_no_leaves maps being transposed on resumed chunks, which affected feature placement
- Existing worlds: frontier chunks not yet finalized will now resume correctly; chunks already finalized with a stone surface are baked in and won't be repaired

### Limitations
While investigating I noticed from_chunk_data also doesn't restore flat_ocean_floor_height_map or structure starts/references. Neither is implicated in this bug, so they're left untouched here.

## Testing

- New regression test heightmap_roundtrip_through_chunk_data_resume: generates a sloped chunk to the Noise stage, round-trips it through ChunkData (the actual save/load path), and asserts heightmaps and the resumed surface match uninterrupted generation. Fails on master (208/256 columns transposed), passes with the fix
- cargo test -p pumpkin-world: 91 passed, 0 failed
- In-game: flew ~3000 blocks over fresh terrain crossing old generation frontiers, no stone caps

> [!NOTE]
> I did use AI for the debugging process because this shit needed sifting through the whole world gen code only to find out it was completly unrelated to that. All the code changes were applied by me, and I tested it myself.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
