### PR TITLE
chore: Bedrock Raknet Handshake / update to bedrock 26.30

### DIFF
--- a/pumpkin-protocol/src/bedrock/client/level_chunk.rs
+++ b/pumpkin-protocol/src/bedrock/client/level_chunk.rs
@@ -77,32 +77,26 @@ impl PacketWrite for CLevelChunk<'_> {
             .read()
             .map_err(|_| Error::other("biome_sections read lock poisoned"))?;
 
-        for (i, biome_palette) in biome_sections.iter().enumerate() {
-            let num_storages = 1;
-            let y = (i as i8) + min_y_section;
-            data_write.write_all(&[VERSION, num_storages, y as u8])?;
+        for biome_palette in biome_sections.iter() {
+            let network_repr = biome_palette.convert_be_network();
 
-            for _ in 0..num_storages {
-                let network_repr = biome_palette.convert_be_network();
+            (network_repr.bits_per_entry << 1 | 1).write(data_write)?;
 
-                (network_repr.bits_per_entry << 1 | 1).write(data_write)?;
+            for data in network_repr.packed_data {
+                data.write(data_write)?;
+            }
 
-                for data in network_repr.packed_data {
-                    data.write(data_write)?;
+            match network_repr.palette {
+                NetworkPalette::Single(id) => {
+                    VarInt(i32::from(id)).write(data_write)?;
                 }
-
-                match network_repr.palette {
-                    NetworkPalette::Single(id) => {
+                NetworkPalette::Indirect(palette) => {
+                    VarInt(palette.len() as i32).write(data_write)?;
+                    for id in palette {
                         VarInt(i32::from(id)).write(data_write)?;
                     }
-                    NetworkPalette::Indirect(palette) => {
-                        VarInt(palette.len() as i32).write(data_write)?;
-                        for id in palette {
-                            VarInt(i32::from(id)).write(data_write)?;
-                        }
-                    }
-                    NetworkPalette::Direct => (),
                 }
+                NetworkPalette::Direct => (),
             }
         }
 

--- a/pumpkin-protocol/src/bedrock/client/raknet/connection.rs
+++ b/pumpkin-protocol/src/bedrock/client/raknet/connection.rs
@@ -9,7 +9,9 @@ use crate::{bedrock::RAKNET_MAGIC, serial::PacketWrite};
 #[derive(PacketWrite)]
 #[packet(0x03)]
 pub struct CConnectedPong {
+    #[serial(big_endian)]
     ping: u64,
+    #[serial(big_endian)]
     pong: u64,
 }
 
@@ -28,9 +30,12 @@ impl CConnectedPong {
 #[packet(0x10)]
 pub struct CConnectionRequestAccepted {
     client_address: SocketAddr,
+    #[serial(big_endian)]
     system_index: u16,
     system_addresses: [SocketAddr; 10],
+    #[serial(big_endian)]
     requested_timestamp: u64,
+    #[serial(big_endian)]
     timestamp: u64,
 }
 
@@ -60,6 +65,7 @@ impl CConnectionRequestAccepted {
 #[packet(0x12)]
 pub struct CAlreadyConnected {
     magic: [u8; 16],
+    #[serial(big_endian)]
     server_guid: u64,
 }
 
@@ -80,6 +86,7 @@ impl CAlreadyConnected {
 #[packet(0x14)]
 pub struct CNoFreeIncomingConnections {
     magic: [u8; 16],
+    #[serial(big_endian)]
     server_guid: u64,
 }
 
@@ -100,6 +107,7 @@ impl CNoFreeIncomingConnections {
 #[packet(0x17)]
 pub struct CConnectionBanned {
     magic: [u8; 16],
+    #[serial(big_endian)]
     server_guid: u64,
 }
 
@@ -120,6 +128,7 @@ impl CConnectionBanned {
 #[packet(0x1A)]
 pub struct CIpRecentlyConnected {
     magic: [u8; 16],
+    #[serial(big_endian)]
     server_guid: u64,
 }
 

--- a/pumpkin-protocol/src/bedrock/client/raknet/incompatible_protocol.rs
+++ b/pumpkin-protocol/src/bedrock/client/raknet/incompatible_protocol.rs
@@ -9,6 +9,7 @@ use pumpkin_macros::packet;
 pub struct CIncompatibleProtocolVersion {
     protocol_version: u8,
     magic: [u8; 16],
+    #[serial(big_endian)]
     server_guid: u64,
 }
 

--- a/pumpkin-protocol/src/bedrock/client/raknet/open_connection.rs
+++ b/pumpkin-protocol/src/bedrock/client/raknet/open_connection.rs
@@ -11,10 +11,12 @@ use crate::{bedrock::RAKNET_MAGIC, serial::PacketWrite};
 #[packet(0x06)]
 pub struct COpenConnectionReply1 {
     magic: [u8; 16],
+    #[serial(big_endian)]
     server_guid: u64,
     has_server_security: bool,
     // Only write when has_server_security
     // cookie: u32,
+    #[serial(big_endian)]
     mtu: u16,
 }
 
@@ -38,8 +40,10 @@ impl COpenConnectionReply1 {
 #[packet(0x08)]
 pub struct COpenConnectionReply2 {
     magic: [u8; 16],
+    #[serial(big_endian)]
     server_guid: u64,
     client_address: SocketAddr,
+    #[serial(big_endian)]
     mtu: u16,
     security: bool,
 }
@@ -59,5 +63,51 @@ impl COpenConnectionReply2 {
             mtu,
             security,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+    use super::{COpenConnectionReply1, COpenConnectionReply2};
+    use crate::{bedrock::RAKNET_MAGIC, serial::PacketWrite};
+
+    const SERVER_GUID: u64 = 0x0102_0304_0506_0708;
+    const MTU: u16 = 1492;
+
+    #[test]
+    fn open_connection_reply_1_uses_raknet_byte_order() {
+        let mut bytes = Vec::new();
+        COpenConnectionReply1::new(SERVER_GUID, false, MTU)
+            .write(&mut bytes)
+            .unwrap();
+
+        let mut expected = RAKNET_MAGIC.to_vec();
+        expected.extend_from_slice(&SERVER_GUID.to_be_bytes());
+        expected.push(0);
+        expected.extend_from_slice(&MTU.to_be_bytes());
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn open_connection_reply_2_uses_raknet_address_and_byte_order() {
+        let mut bytes = Vec::new();
+        COpenConnectionReply2::new(
+            SERVER_GUID,
+            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 0, 17), 19132)),
+            MTU,
+            false,
+        )
+        .write(&mut bytes)
+        .unwrap();
+
+        let mut expected = RAKNET_MAGIC.to_vec();
+        expected.extend_from_slice(&SERVER_GUID.to_be_bytes());
+        expected.extend_from_slice(&[4, !192, !168, !0, !17]);
+        expected.extend_from_slice(&19132u16.to_be_bytes());
+        expected.extend_from_slice(&MTU.to_be_bytes());
+        expected.push(0);
+        assert_eq!(bytes, expected);
     }
 }

--- a/pumpkin-protocol/src/serial/deserializer.rs
+++ b/pumpkin-protocol/src/serial/deserializer.rs
@@ -206,7 +206,7 @@ impl PacketRead for SocketAddr {
             4 => {
                 let ip = u32::read_be(reader)?;
                 let port = u16::read_be(reader)?;
-                Ok(Self::V4(SocketAddrV4::new(Ipv4Addr::from(ip), port)))
+                Ok(Self::V4(SocketAddrV4::new(Ipv4Addr::from(!ip), port)))
             }
             6 => {
                 // Addr family

--- a/pumpkin-protocol/src/serial/serializer.rs
+++ b/pumpkin-protocol/src/serial/serializer.rs
@@ -165,7 +165,7 @@ impl PacketWrite for SocketAddr {
             // version, addr, port
             Self::V4(addr) => {
                 4u8.write(writer)?;
-                writer.write_all(&addr.ip().octets())?;
+                writer.write_all(&addr.ip().octets().map(|octet| !octet))?;
                 addr.port().write_be(writer)
             }
             // version, addr_family, port, flow_info, addr, scope_id

--- a/pumpkin-world/src/chunk/palette.rs
+++ b/pumpkin-world/src/chunk/palette.rs
@@ -10,6 +10,15 @@ use tracing::warn;
 
 use super::format::{ChunkSectionBiomes, ChunkSectionBlockStates};
 
+#[inline]
+fn bedrock_bits_per_entry(palette_len: usize) -> u8 {
+    match encompassing_bits(palette_len) {
+        bits @ 0..=6 => bits,
+        7 | 8 => 8,
+        _ => 16,
+    }
+}
+
 /// 3d array indexed by y,z,x
 type AbstractCube<T, const DIM: usize> = [[[T; DIM]; DIM]; DIM];
 
@@ -549,7 +558,7 @@ impl BiomePalette {
                 packed_data: Box::new([]),
             },
             Self::Heterogeneous(data) => {
-                let bits_per_entry = encompassing_bits(data.palette.len());
+                let bits_per_entry = bedrock_bits_per_entry(data.palette.len());
 
                 let key_to_index_map: HashMap<_, usize> = data
                     .palette
@@ -698,7 +707,7 @@ impl BlockPalette {
                 packed_data: Box::new([]),
             },
             Self::Heterogeneous(data) => {
-                let bits_per_entry = encompassing_bits(data.palette.len());
+                let bits_per_entry = bedrock_bits_per_entry(data.palette.len());
 
                 let key_to_index_map: HashMap<_, usize> = data
                     .palette
@@ -917,7 +926,7 @@ pub(crate) const BIOME_NETWORK_MAX_BITS: u8 = 7;
 
 #[cfg(test)]
 mod tests {
-    use super::{BlockPalette, NetworkPalette};
+    use super::{BlockPalette, NetworkPalette, bedrock_bits_per_entry};
     use pumpkin_data::{Block, BlockStateId};
 
     fn network_palette_values(palette: NetworkPalette<u16>) -> Option<Box<[u16]>> {
@@ -981,5 +990,15 @@ mod tests {
         assert_bulk_matches_mutations(|x, y, z| {
             BlockStateId::new_or_air(((y * 256 + z * 16 + x) % 300) as u16)
         });
+    }
+
+    #[test]
+    fn bedrock_palette_uses_supported_storage_widths() {
+        assert_eq!(bedrock_bits_per_entry(2), 1);
+        assert_eq!(bedrock_bits_per_entry(64), 6);
+        assert_eq!(bedrock_bits_per_entry(65), 8);
+        assert_eq!(bedrock_bits_per_entry(256), 8);
+        assert_eq!(bedrock_bits_per_entry(257), 16);
+        assert_eq!(bedrock_bits_per_entry(4096), 16);
     }
 }

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -476,12 +476,12 @@ impl LivingEntity {
             self.heal(heal_amount);
         } else if effect.effect_type == &StatusEffect::INSTANT_DAMAGE {
             let damage_amount = 6.0 * (1 << effect.amplifier) as f32;
-            if let Some(dyn_self) = self
+            let dyn_self = self
                 .entity
                 .world
                 .load()
-                .get_entity_by_id(self.entity.entity_id)
-            {
+                .get_entity_by_id(self.entity.entity_id);
+            if let Some(dyn_self) = dyn_self {
                 dyn_self
                     .damage(&*dyn_self, damage_amount, DamageType::MAGIC)
                     .await;
@@ -1680,12 +1680,12 @@ impl LivingEntity {
             }
         } else if effect_type == &StatusEffect::WITHER {
             let damage_amount = 1.0;
-            if let Some(dyn_self) = self
+            let dyn_self = self
                 .entity
                 .world
                 .load()
-                .get_entity_by_id(self.entity.entity_id)
-            {
+                .get_entity_by_id(self.entity.entity_id);
+            if let Some(dyn_self) = dyn_self {
                 dyn_self
                     .damage(&*dyn_self, damage_amount, DamageType::WITHER)
                     .await;

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -655,6 +655,10 @@ impl Player {
         })
         .await
         .unwrap_or_else(|_| pumpkin_protocol::bedrock::client::Skin::steve());
+        let chunks_per_tick = match client.as_ref() {
+            ClientPlatform::Java(_) => 16,
+            ClientPlatform::Bedrock(_) => 1,
+        };
 
         Self {
             living_entity,
@@ -727,9 +731,8 @@ impl Player {
             experience_progress: AtomicCell::new(0.0),
             experience_points: AtomicI32::new(0),
             item_cooldowns: Mutex::new(HashMap::new()),
-            // Default to sending 16 chunks per tick.
             chunk_manager: Mutex::new(ChunkManager::new(
-                16,
+                chunks_per_tick,
                 world.level.chunk_listener.add_global_chunk_listener(),
                 world.clone(),
             )),
@@ -2005,15 +2008,10 @@ impl Player {
         let (chunk_of_chunks, total_sent_chunks) = {
             let mut chunk_manager = self.chunk_manager.lock().await;
             chunk_manager.pull_new_chunks();
-            let chunks = if let ClientPlatform::Java(_) = self.client.as_ref() {
-                // Java clients can only send a limited amount of chunks per tick.
-                // If we have sent too many chunks without receiving an ack, we stop sending chunks.
-                chunk_manager
-                    .can_send_chunk()
-                    .then(|| chunk_manager.next_chunk())
-            } else {
-                Some(chunk_manager.next_chunk())
-            };
+            // Pace chunk batches so packet transport is not flooded while acknowledgements catch up.
+            let chunks = chunk_manager
+                .can_send_chunk()
+                .then(|| chunk_manager.next_chunk());
             (chunks, chunk_manager.sent_chunks_count())
         };
         if let Some(chunk_of_chunks) = chunk_of_chunks {

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -2171,7 +2171,8 @@ impl Player {
         packet_id: i32,
         payload: Bytes,
     ) -> bool {
-        if let Some(server) = self.world().server.upgrade() {
+        let server = self.world().server.upgrade();
+        if let Some(server) = server {
             let mut event =
                 PacketSentEvent::new(self.clone(), packet_id, payload, Arc::new(packet));
             server.plugin_manager.fire(&server, &mut event).await;
@@ -2181,7 +2182,8 @@ impl Player {
     }
 
     pub async fn fire_packet_sent_no_obj(self: &Arc<Self>, packet_id: i32, payload: Bytes) -> bool {
-        if let Some(server) = self.world().server.upgrade() {
+        let server = self.world().server.upgrade();
+        if let Some(server) = server {
             // This is a dummy object to satisfy the non-optional requirement in WIT
             // In the future we should make all packets 'static or have a way to represent raw packets in WIT
             struct RawPacket;
@@ -3500,7 +3502,8 @@ impl Player {
 
     /// Add experience points to the player.
     pub async fn add_experience_points(self: &Arc<Self>, mut added_points: i32) {
-        if let Some(server) = self.world().server.upgrade() {
+        let server = self.world().server.upgrade();
+        if let Some(server) = server {
             let mut event = PlayerExpChangeEvent::new(self.clone(), added_points);
             server.plugin_manager.fire(&server, &mut event).await;
             added_points = event.amount;
@@ -3636,7 +3639,8 @@ impl Player {
             wt
         };
 
-        if let Some(server) = self.living_entity.entity.world.load().server.upgrade() {
+        let server = self.living_entity.entity.world.load().server.upgrade();
+        if let Some(server) = server {
             let mut event =
                 crate::plugin::api::events::player::inventory_close::InventoryCloseEvent::new(
                     self,
@@ -4058,7 +4062,8 @@ impl Player {
         drop(perm_manager);
 
         let mut event = PlayerPermissionCheckEvent::new(self.clone(), node.to_string(), result);
-        if let Some(server_arc) = self.world().server.upgrade() {
+        let server_arc = self.world().server.upgrade();
+        if let Some(server_arc) = server_arc {
             server_arc
                 .plugin_manager
                 .fire(&server_arc, &mut event)
@@ -5352,7 +5357,8 @@ impl InventoryPlayer for Player {
             debug!("Player::award_experience called with amount={amount}");
             if amount > 0 {
                 debug!("Player: adding {amount} experience points");
-                if let Some(player) = self.world().get_player_by_uuid(self.gameprofile.id) {
+                let player = self.world().get_player_by_uuid(self.gameprofile.id);
+                if let Some(player) = player {
                     player.add_experience_points(amount).await;
                 }
             }

--- a/pumpkin/src/net/bedrock/mod.rs
+++ b/pumpkin/src/net/bedrock/mod.rs
@@ -11,7 +11,7 @@ use std::{
     time::UNIX_EPOCH,
 };
 
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 use bytes::Bytes;
 use pumpkin_config::networking::compression::CompressionInfo;
@@ -73,8 +73,11 @@ use pumpkin_protocol::{
 use std::net::SocketAddr;
 use tokio::{
     net::UdpSocket,
-    sync::mpsc::{Receiver, Sender},
-    sync::{Mutex, RwLock, oneshot},
+    sync::{
+        Mutex, OwnedSemaphorePermit, RwLock, Semaphore,
+        mpsc::{Receiver, Sender},
+        oneshot,
+    },
     task::JoinHandle,
 };
 
@@ -94,6 +97,8 @@ use arc_swap::ArcSwap;
 use pumpkin_protocol::bedrock::server::login::ClientData;
 use pumpkin_util::version::BedrockMinecraftVersion;
 use pumpkin_world::level::SyncChunk;
+
+const RELIABLE_FRAME_WINDOW: usize = 128;
 
 pub struct OutgoingPacket {
     pub data: Bytes,
@@ -159,7 +164,9 @@ pub struct BedrockClient {
     received_sequences: Mutex<HashSet<u32>>,
     pending_acks: Mutex<Vec<u32>>,
     #[allow(clippy::type_complexity)]
-    unacked_outgoing_frames: Mutex<HashMap<u32, (u8, Vec<u8>, std::time::Instant)>>,
+    unacked_outgoing_frames:
+        Mutex<HashMap<u32, (u8, Vec<u8>, std::time::Instant, OwnedSemaphorePermit)>>,
+    reliable_frame_window: Arc<Semaphore>,
     expected_order_index: Mutex<HashMap<u8, u32>>,
     highest_sequence_index: Mutex<HashMap<u8, u32>>,
     ordered_queues: Mutex<HashMap<u8, BTreeMap<u32, Frame>>>,
@@ -208,6 +215,7 @@ impl BedrockClient {
             received_sequences: Mutex::new(HashSet::new()),
             pending_acks: Mutex::new(Vec::new()),
             unacked_outgoing_frames: Mutex::new(HashMap::new()),
+            reliable_frame_window: Arc::new(Semaphore::new(RELIABLE_FRAME_WINDOW)),
             expected_order_index: Mutex::new(HashMap::new()),
             highest_sequence_index: Mutex::new(HashMap::new()),
             ordered_queues: Mutex::new(HashMap::new()),
@@ -227,7 +235,72 @@ impl BedrockClient {
         }
     }
 
+    fn start_raknet_maintenance_task(self: &Arc<Self>) {
+        let client = self.clone();
+        self.spawn_task(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
+            loop {
+                tokio::select! {
+                    () = client.close_token.cancelled() => break,
+                    _ = interval.tick() => {}
+                }
+
+                if client.last_seen.load().elapsed() > std::time::Duration::from_secs(10) {
+                    let unacked = client.unacked_outgoing_frames.lock().await;
+                    debug!(
+                        "Bedrock client {} timed out with {} reliable frames in flight (sequences {:?}..={:?}, next {})",
+                        client.address,
+                        unacked.len(),
+                        unacked.keys().min(),
+                        unacked.keys().max(),
+                        client.output_sequence_number.load(Ordering::Relaxed),
+                    );
+                    drop(unacked);
+                    client.close().await;
+                    break;
+                }
+
+                let mut pending = client.pending_acks.lock().await;
+                if !pending.is_empty() {
+                    let ack = Acknowledge::new(std::mem::take(&mut *pending));
+                    drop(pending);
+                    let _ = client.send_acknowledgement(&ack, RAKNET_ACK).await;
+                }
+
+                let now = std::time::Instant::now();
+                let mut resend = Vec::new();
+                {
+                    let mut unacked = client.unacked_outgoing_frames.lock().await;
+                    for (seq, (id, data, timestamp, _permit)) in unacked.iter_mut() {
+                        if now.duration_since(*timestamp) > std::time::Duration::from_secs(1) {
+                            resend.push((*seq, *id, data.clone()));
+                            *timestamp = now;
+                            if resend.len() >= 50 {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if !resend.is_empty() {
+                    let encoder = client.network_writer.read().await;
+                    for (seq, id, data) in resend {
+                        trace!("Resending reliable sequence {} (ID: {})", seq, id);
+                        if let Err(err) = encoder
+                            .write_packet(&data, client.address, &client.socket)
+                            .await
+                        {
+                            warn!("Failed to resend packet for sequence {}: {}", seq, err);
+                        }
+                    }
+                }
+            }
+        });
+    }
+
     pub fn start_outgoing_packet_task(self: &Arc<Self>) {
+        self.start_raknet_maintenance_task();
+
         let client = self.clone();
         self.spawn_task(async move {
             let mut packet_receiver = {
@@ -242,8 +315,6 @@ impl BedrockClient {
                     .take()
                     .expect("Outgoing packet receiver was already taken")
             };
-            let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
-
             while !client.close_token.is_cancelled() {
                 let mut packet = tokio::select! {
                     biased;
@@ -252,51 +323,6 @@ impl BedrockClient {
                         Some(p) => p,
                         None => break,
                     },
-                    _ = interval.tick() => {
-                        // Check for timeout (10 seconds)
-                        if client.last_seen.load().elapsed() > std::time::Duration::from_secs(10) {
-                            debug!("Bedrock client {} timed out", client.address);
-                            client.close().await;
-                            break;
-                        }
-
-                        // Flush ACKs
-                        let mut pending = client.pending_acks.lock().await;
-                        if !pending.is_empty() {
-                            let ack = Acknowledge::new(pending.clone());
-                            pending.clear();
-                            let _ = client.send_acknowledgement(&ack, RAKNET_ACK).await;
-                        }
-
-                        // Check retransmission
-                        let now = std::time::Instant::now();
-                        let mut resend = Vec::new();
-                        {
-                            let mut unacked = client.unacked_outgoing_frames.lock().await;
-                            for (seq, (id, data, timestamp)) in unacked.iter_mut() {
-                                if now.duration_since(*timestamp) > std::time::Duration::from_secs(1) {
-                                    resend.push((*seq, *id, data.clone()));
-                                    // Update timestamp
-                                    *timestamp = now;
-                                    // Limit resends per tick to avoid starvation
-                                    if resend.len() >= 50 {
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-
-                        if !resend.is_empty() {
-                            let encoder = client.network_writer.read().await;
-                            for (seq, id, data) in resend {
-                                debug!("Resending reliable sequence {} (ID: {})", seq, id);
-                                if let Err(err) = encoder.write_packet(&data, client.address, &client.socket).await {
-                                    warn!("Failed to resend packet for sequence {}: {}", seq, err);
-                                }
-                            }
-                        }
-                        continue;
-                    }
                     res = packet_receiver.recv() => match res {
                         Some(p) => p,
                         None => break,
@@ -468,7 +494,7 @@ impl BedrockClient {
 
         {
             let Ok(network_writer) = self.network_writer.try_read() else {
-                debug!("Failed to lock network writer for try_enqueue_packet");
+                trace!("Failed to lock network writer for try_enqueue_packet");
                 return;
             };
 
@@ -494,11 +520,11 @@ impl BedrockClient {
     ///
     /// * `packet`: A reference to a packet object implementing the `ClientPacket` trait.
     pub async fn enqueue_packet_data(&self, packet_data: Bytes) {
-        if let Err(err) = self
-            .outgoing_packet_queue_send
-            .send(OutgoingPacket::normal(packet_data))
-            .await
-        {
+        let result = tokio::select! {
+            () = self.close_token.cancelled() => return,
+            result = self.outgoing_packet_queue_send.send(OutgoingPacket::normal(packet_data)) => result,
+        };
+        if let Err(err) = result {
             // This is expected to fail if we are closed
             if !self.is_closed() {
                 error!("Failed to add packet to the outgoing packet queue for client: {err}");
@@ -513,7 +539,7 @@ impl BedrockClient {
         {
             match err {
                 tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                    debug!(
+                    trace!(
                         "Failed to add packet to the outgoing packet queue for client: channel full"
                     );
                 }
@@ -585,16 +611,19 @@ impl BedrockClient {
                     return;
                 }
                 let (tx, rx) = oneshot::channel();
-                if let Err(err) = self
-                    .outgoing_packet_priority_send
-                    .send(OutgoingPacket::priority(payload, tx))
-                    .await
-                {
+                let result = tokio::select! {
+                    () = self.close_token.cancelled() => return,
+                    result = self.outgoing_packet_priority_send.send(OutgoingPacket::priority(payload, tx)) => result,
+                };
+                if let Err(err) = result {
                     if !self.is_closed() {
                         error!("Failed to add priority packet to the outgoing packet queue: {err}");
                     }
                 } else {
-                    let _ = rx.await;
+                    tokio::select! {
+                        () = self.close_token.cancelled() => {}
+                        _ = rx => {}
+                    }
                 }
             }
             Err(err) => error!("Failed to write game packet: {err}"),
@@ -694,6 +723,24 @@ impl BedrockClient {
     }
 
     pub async fn send_frame_set(&self, mut frame_set: FrameSet, id: u8) {
+        let reliable = frame_set
+            .frames
+            .iter()
+            .any(|frame| frame.reliability.is_reliable());
+        let permit = if reliable {
+            tokio::select! {
+                () = self.close_token.cancelled() => return,
+                permit = self.reliable_frame_window.clone().acquire_owned() => {
+                    let Ok(permit) = permit else {
+                        return;
+                    };
+                    Some(permit)
+                }
+            }
+        } else {
+            None
+        };
+
         let sequence = self.output_sequence_number.fetch_add(1, Ordering::Relaxed);
         frame_set.sequence = u24(sequence);
 
@@ -703,10 +750,10 @@ impl BedrockClient {
             return;
         }
 
-        if frame_set.frames.iter().any(|f| f.reliability.is_reliable()) {
+        if let Some(permit) = permit {
             self.unacked_outgoing_frames.lock().await.insert(
                 sequence,
-                (id, frame_set_buf.clone(), std::time::Instant::now()),
+                (id, frame_set_buf.clone(), std::time::Instant::now(), permit),
             );
         }
 
@@ -802,12 +849,12 @@ impl BedrockClient {
     }
 
     async fn handle_nack(&self, nack: &Acknowledge) {
-        debug!("Received NACK for sequences: {:?}", nack.sequences);
+        trace!("Received NACK for sequences: {:?}", nack.sequences);
         let mut resend_data = Vec::new();
         {
             let unacked = self.unacked_outgoing_frames.lock().await;
             for seq in &nack.sequences {
-                if let Some((_id, data, _timestamp)) = unacked.get(seq) {
+                if let Some((_id, data, _timestamp, _permit)) = unacked.get(seq) {
                     resend_data.push(data.clone());
                 }
             }
@@ -1248,6 +1295,7 @@ impl BedrockClient {
                     .await;
             }
             SDisconnect::PACKET_ID | SConnectionLost::PACKET_ID => {
+                debug!("Bedrock client {} disconnected", self.address);
                 self.close().await;
             }
             _ => {

--- a/pumpkin/src/net/bedrock/play.rs
+++ b/pumpkin/src/net/bedrock/play.rs
@@ -1809,7 +1809,8 @@ impl BedrockClient {
             return;
         }
         let previous_slot = player.inventory.get_selected_slot();
-        if let Some(server) = player.world().server.upgrade() {
+        let server = player.world().server.upgrade();
+        if let Some(server) = server {
             let mut event = PlayerItemHeldEvent::new(player.clone(), previous_slot, slot);
             server.plugin_manager.fire(&server, &mut event).await;
             let is_cancelled = {

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -849,7 +849,8 @@ impl JavaClient {
             return;
         }
         let pos = command.pos;
-        if let Some(block_entity) = player.world().get_block_entity(&pos) {
+        let block_entity = player.world().get_block_entity(&pos);
+        if let Some(block_entity) = block_entity {
             if block_entity.resource_location() != CommandBlockEntity::ID {
                 warn!("Client tried to change Command block but not Command block entity found");
                 return;
@@ -937,7 +938,8 @@ impl JavaClient {
             return;
         }
         let pos = jigsaw.pos;
-        if let Some(block_entity) = player.world().get_block_entity(&pos) {
+        let block_entity = player.world().get_block_entity(&pos);
+        if let Some(block_entity) = block_entity {
             if block_entity.resource_location() != JigsawBlockEntity::ID {
                 warn!("Client tried to change Jigsaw block but not Jigsaw block entity found");
                 return;

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -413,11 +413,12 @@ impl Server {
     pub async fn create_world(self: &Arc<Self>, name: String, dimension: Dimension) -> Arc<World> {
         {
             let worlds = self.worlds.load();
-            if let Some(world) = worlds
+            let world = worlds
                 .iter()
                 .find(|w| w.get_world_name() == name && w.dimension == dimension)
-            {
-                return world.clone();
+                .cloned();
+            if let Some(world) = world {
+                return world;
             }
         }
 

--- a/pumpkin/src/world/dragon_fight.rs
+++ b/pumpkin/src/world/dragon_fight.rs
@@ -688,8 +688,12 @@ impl DragonFight {
             .collect();
 
         for uid in &to_remove {
-            if let Some(p) = players.iter().find(|p| &p.gameprofile.id == uid) {
-                p.remove_bossbar(self.bossbar_uuid).await;
+            let player = players
+                .iter()
+                .find(|player| &player.gameprofile.id == uid)
+                .cloned();
+            if let Some(player) = player {
+                player.remove_bossbar(self.bossbar_uuid).await;
             }
             self.bossbar_players.retain(|u| u != uid);
         }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -4123,10 +4123,10 @@ impl World {
         self.players.rcu(|current_list| {
             let mut new_list = (**current_list).clone();
             // Find the player before we filter them out
-            if let Some(pos) = new_list
+            let pos = new_list
                 .iter()
-                .position(|p| p.gameprofile.id == player.gameprofile.id)
-            {
+                .position(|p| p.gameprofile.id == player.gameprofile.id);
+            if let Some(pos) = pos {
                 removed_player = Some(new_list.remove(pos));
             }
             new_list


### PR DESCRIPTION
## Description
Fixes the Bedrock RakNet handshake and chunk delivery so modern Bedrock clients can connect and remain in the world reliably. (By remain in world reliably I mean they wont get kicked seconds after joining, or suffocate in walls after walking up to them, getting kicked and crashing the client - in that order)

What
- Corrects RakNet handshake field encoding and IPv4 address serialization.
- Adds reliable-packet tracking, acknowledgements, retransmission, timeouts, and backpressure.
- Prevents chunk delivery from flooding the Bedrock connection.
- Corrects Bedrock chunk biome-palette encoding.
- Uses only palette bit widths supported by the Bedrock protocol.

## How
- Encodes RakNet GUIDs, timestamps, MTU values, and system indices using the correct byte order.
- Runs connection maintenance independently from packet reception so missing acknowledgements can be retransmitted without blocking incoming traffic.
- Limits Bedrock chunk delivery to one batch per tick and waits when the reliable-packet window is full.
- Removes invalid subchunk headers from biome palette data.
- Rounds palette storage widths to Bedrock-supported values.

## Testing
- `cargo test -p pumpkin-protocol`
- `cargo test -p pumpkin-world bedrock_palette`
- `cargo fmt --all -- --check`
- Connected using Bedrock 1.26.30 and verified that the player could authenticate, enter the world, receive chunks, and remain connected and not suffocate after walking up to walls.