### PR TITLE
fix: /execute as @e now runs commands for every entity, not just the player

### DIFF
--- a/pumpkin/src/command/commands/execute.rs
+++ b/pumpkin/src/command/commands/execute.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use crate::command::CommandSender;
 use crate::command::argument_builder::{ArgumentBuilder, argument, command, literal};
 use crate::command::argument_types::block::BlockArgumentType;
 use crate::command::argument_types::coordinates::block_pos::BlockPosArgumentType;
@@ -35,10 +34,7 @@ impl CommandExecutor for ExecuteRunExecutor {
         Box::pin(async move {
             let command_str = StringArgumentType::get(context, "command")?;
             let dispatcher = context.server().command_dispatcher.read().await;
-            dispatcher
-                .handle_command(&context.source, command_str)
-                .await;
-            Ok(1)
+            dispatcher.execute_input(command_str, &context.source).await
         })
     }
 }
@@ -54,7 +50,10 @@ fn execute_as_modifier<'a>(
             let display_name = target.get_display_name().await;
             let name = target.get_name().get_text();
             source.entity = Some(target.clone());
-            source.output = CommandSender::Entity(name.clone());
+            // Keep the original output sender so the nested command retains the
+            // invoker's permissions (including explicit permission grants).
+            // TODO: Teach fallback commands to use CommandSource world/position
+            // context so `execute as/at/positioned` applies to them as well.
             source.name = name;
             source.display_name = display_name;
             sources.push(Arc::new(source));

--- a/pumpkin/src/command/commands/execute.rs
+++ b/pumpkin/src/command/commands/execute.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::command::CommandSender;
 use crate::command::argument_builder::{ArgumentBuilder, argument, command, literal};
 use crate::command::argument_types::block::BlockArgumentType;
 use crate::command::argument_types::coordinates::block_pos::BlockPosArgumentType;
@@ -34,10 +35,10 @@ impl CommandExecutor for ExecuteRunExecutor {
         Box::pin(async move {
             let command_str = StringArgumentType::get(context, "command")?;
             let dispatcher = context.server().command_dispatcher.read().await;
-            let result = dispatcher
-                .execute_input(command_str, &context.source)
-                .await?;
-            Ok(result)
+            dispatcher
+                .handle_command(&context.source, command_str)
+                .await;
+            Ok(1)
         })
     }
 }
@@ -53,6 +54,7 @@ fn execute_as_modifier<'a>(
             let display_name = target.get_display_name().await;
             let name = target.get_name().get_text();
             source.entity = Some(target.clone());
+            source.output = CommandSender::Entity(name.clone());
             source.name = name;
             source.display_name = display_name;
             sources.push(Arc::new(source));

--- a/pumpkin/src/command/commands/execute.rs
+++ b/pumpkin/src/command/commands/execute.rs
@@ -10,7 +10,7 @@ use crate::command::argument_types::entity::EntityArgumentType;
 use crate::command::argument_types::entity_anchor::EntityAnchorArgumentType;
 use crate::command::argument_types::resource_key::ResourceKeyArgument;
 use crate::command::context::command_context::CommandContext;
-use crate::command::errors::error_types::CommandErrorType;
+use crate::command::errors::error_types::{CommandErrorType, DISPATCHER_UNKNOWN_COMMAND};
 use crate::command::node::attached::{CommandNodeId, NodeId};
 use crate::command::node::dispatcher::CommandDispatcher;
 use crate::command::node::tree::Tree;
@@ -34,7 +34,21 @@ impl CommandExecutor for ExecuteRunExecutor {
         Box::pin(async move {
             let command_str = StringArgumentType::get(context, "command")?;
             let dispatcher = context.server().command_dispatcher.read().await;
-            dispatcher.execute_input(command_str, &context.source).await
+            match dispatcher.execute_input(command_str, &context.source).await {
+                Ok(result) => Ok(result),
+                Err(error) if error.is(&DISPATCHER_UNKNOWN_COMMAND) => {
+                    dispatcher
+                        .fallback_dispatcher
+                        .handle_command(
+                            &context.source.output,
+                            context.server().as_ref(),
+                            command_str,
+                        )
+                        .await;
+                    Ok(1)
+                }
+                Err(error) => Err(error),
+            }
         })
     }
 }

--- a/pumpkin/src/command/commands/execute.rs
+++ b/pumpkin/src/command/commands/execute.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::command::CommandSender;
 use crate::command::argument_builder::{ArgumentBuilder, argument, command, literal};
 use crate::command::argument_types::block::BlockArgumentType;
 use crate::command::argument_types::coordinates::block_pos::BlockPosArgumentType;
@@ -64,8 +65,9 @@ fn execute_as_modifier<'a>(
             let display_name = target.get_display_name().await;
             let name = target.get_name().get_text();
             source.entity = Some(target.clone());
-            // Keep the original output sender so the nested command retains the
-            // invoker's permissions (including explicit permission grants).
+            source.output = CommandSender::Entity(name.clone(), Box::new(source.output.clone()));
+            // The entity sender presents the target's identity while delegating
+            // permission checks to the original invoker.
             // TODO: Teach fallback commands to use CommandSource world/position
             // context so `execute as/at/positioned` applies to them as well.
             source.name = name;

--- a/pumpkin/src/command/commands/item.rs
+++ b/pumpkin/src/command/commands/item.rs
@@ -47,7 +47,7 @@ impl CommandExecutor for BlockReplaceExecutor {
                 CommandSender::Console
                 | CommandSender::Rcon(_)
                 | CommandSender::Dummy
-                | CommandSender::Entity(_) => {
+                | CommandSender::Entity(..) => {
                     let guard = server.worlds.load();
                     guard
                         .first()

--- a/pumpkin/src/command/commands/item.rs
+++ b/pumpkin/src/command/commands/item.rs
@@ -44,7 +44,10 @@ impl CommandExecutor for BlockReplaceExecutor {
     ) -> CommandResult<'a> {
         Box::pin(async move {
             let world = match sender {
-                CommandSender::Console | CommandSender::Rcon(_) | CommandSender::Dummy => {
+                CommandSender::Console
+                | CommandSender::Rcon(_)
+                | CommandSender::Dummy
+                | CommandSender::Entity(_) => {
                     let guard = server.worlds.load();
                     guard
                         .first()

--- a/pumpkin/src/command/commands/particle.rs
+++ b/pumpkin/src/command/commands/particle.rs
@@ -44,7 +44,7 @@ impl CommandExecutor for Executor {
                 CommandSender::Console
                 | CommandSender::Rcon(_)
                 | CommandSender::Dummy
-                | CommandSender::Entity(_) => {
+                | CommandSender::Entity(..) => {
                     let guard = server.worlds.load();
                     let world = guard
                         .first()

--- a/pumpkin/src/command/commands/particle.rs
+++ b/pumpkin/src/command/commands/particle.rs
@@ -41,7 +41,10 @@ impl CommandExecutor for Executor {
             let speed = speed.unwrap_or(Ok(0.0))?;
             let count = count.unwrap_or(Ok(0))?;
             let (world, pos) = match sender {
-                CommandSender::Console | CommandSender::Rcon(_) | CommandSender::Dummy => {
+                CommandSender::Console
+                | CommandSender::Rcon(_)
+                | CommandSender::Dummy
+                | CommandSender::Entity(_) => {
                     let guard = server.worlds.load();
                     let world = guard
                         .first()

--- a/pumpkin/src/command/commands/setblock.rs
+++ b/pumpkin/src/command/commands/setblock.rs
@@ -47,7 +47,7 @@ impl CommandExecutor for Executor {
                 CommandSender::Console
                 | CommandSender::Rcon(_)
                 | CommandSender::Dummy
-                | CommandSender::Entity(_) => {
+                | CommandSender::Entity(..) => {
                     let guard = server.worlds.load();
 
                     guard

--- a/pumpkin/src/command/commands/setblock.rs
+++ b/pumpkin/src/command/commands/setblock.rs
@@ -44,7 +44,10 @@ impl CommandExecutor for Executor {
             let block_state_id = block.default_state.id;
             let mode = self.0;
             let world = match sender {
-                CommandSender::Console | CommandSender::Rcon(_) | CommandSender::Dummy => {
+                CommandSender::Console
+                | CommandSender::Rcon(_)
+                | CommandSender::Dummy
+                | CommandSender::Entity(_) => {
                     let guard = server.worlds.load();
 
                     guard

--- a/pumpkin/src/command/commands/summon.rs
+++ b/pumpkin/src/command/commands/summon.rs
@@ -40,7 +40,7 @@ impl CommandExecutor for Executor {
                 CommandSender::Console
                 | CommandSender::Rcon(_)
                 | CommandSender::Dummy
-                | CommandSender::Entity(_) => {
+                | CommandSender::Entity(..) => {
                     let guard = server.worlds.load();
                     let world = guard
                         .first()

--- a/pumpkin/src/command/commands/summon.rs
+++ b/pumpkin/src/command/commands/summon.rs
@@ -37,7 +37,10 @@ impl CommandExecutor for Executor {
             let entity_type = SummonableEntitiesArgumentConsumer::find_arg(args, ARG_ENTITY)?;
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_POS);
             let (world, pos) = match sender {
-                CommandSender::Console | CommandSender::Rcon(_) | CommandSender::Dummy => {
+                CommandSender::Console
+                | CommandSender::Rcon(_)
+                | CommandSender::Dummy
+                | CommandSender::Entity(_) => {
                     let guard = server.worlds.load();
                     let world = guard
                         .first()

--- a/pumpkin/src/command/context/command_context.rs
+++ b/pumpkin/src/command/context/command_context.rs
@@ -218,6 +218,10 @@ impl<'a> ContextChain<'a> {
         let mut modifiers = Vec::new();
         let mut current = root;
 
+        if !matches!(root.modifier, RedirectModifier::KeepSource) {
+            modifiers.push(Arc::new(root.clone()));
+        }
+
         loop {
             if let Some(child) = current.get_child() {
                 modifiers.push(child.clone());
@@ -556,9 +560,13 @@ mod test {
     use crate::command::context::command_source::CommandSource;
     use crate::command::context::string_range::StringRange;
     use crate::command::errors::command_syntax_error::CommandSyntaxError;
+    use crate::command::node::RedirectModifierResult;
     use crate::command::node::dispatcher::{CommandDispatcher, EmptyResultConsumer};
     use crate::command::node::tree::ROOT_NODE_ID;
-    use crate::command::node::{CommandExecutor, CommandExecutorResult, Redirection};
+    use crate::command::node::{
+        CommandExecutor, CommandExecutorResult, RedirectModifier, Redirection,
+    };
+    use rustc_hash::FxHashMap;
 
     struct TenExecutor;
     impl CommandExecutor for TenExecutor {
@@ -709,5 +717,61 @@ mod test {
         let top_context = result.context.build("foo");
 
         assert!(ContextChain::try_flatten(&top_context).is_none());
+    }
+
+    /// When a command is parsed via a fork redirect (like `/execute as @e`),
+    /// the modifier info lives on the root context. `try_flatten` must include
+    /// the root as the first modifier in the chain so `execute_all` processes it.
+    #[tokio::test]
+    async fn root_with_modifier_is_included_in_chain() {
+        fn dummy_modifier_sync<'a>(_context: &'a CommandContext) -> RedirectModifierResult<'a> {
+            Box::pin(std::future::ready(Ok(vec![])))
+        }
+
+        let dispatcher = CommandDispatcher::new();
+        let tree = &dispatcher.tree;
+        let source = Arc::new(CommandSource::dummy());
+
+        let executor = CommandContext {
+            source: source.clone(),
+            input: String::new(),
+            arguments: FxHashMap::default(),
+            tree,
+            root: ROOT_NODE_ID,
+            nodes: Vec::new(),
+            range: StringRange::at(0),
+            child: None,
+            modifier: RedirectModifier::KeepSource,
+            forks: false,
+            command: Some(Arc::new(TenExecutor)),
+        };
+
+        let root = CommandContext {
+            source,
+            input: String::new(),
+            arguments: FxHashMap::default(),
+            tree,
+            root: ROOT_NODE_ID,
+            nodes: Vec::new(),
+            range: StringRange::at(0),
+            child: Some(Arc::new(executor)),
+            modifier: RedirectModifier::Custom(Arc::new(dummy_modifier_sync)),
+            forks: true,
+            command: None,
+        };
+
+        let chain =
+            ContextChain::try_flatten(&root).expect("The context should have properly flattened");
+
+        assert_eq!(chain.get_stage(), Stage::MODIFY);
+
+        let second = chain.next_stage().expect("There should be the next stage");
+        assert_eq!(second.get_stage(), Stage::MODIFY);
+
+        let third = second
+            .next_stage()
+            .expect("There should be the executor stage");
+        assert_eq!(third.get_stage(), Stage::EXECUTE);
+        assert!(third.next_stage().is_none());
     }
 }

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -80,6 +80,10 @@ pub enum CommandSender {
     /// Contains the block entity responsible for the command and the
     /// world context it exists in for coordinate-relative execution (e.g., `~ ~ ~`).
     CommandBlock(Arc<CommandBlockEntity>, Arc<World>),
+    /// An entity executing a command, e.g. via `/execute as @e`.
+    /// Stores the entity's display name for use in command output
+    /// (e.g. the [`say`] command broadcasts the sender's name).
+    Entity(String),
     /// Nothingness. Anything sent to this sender is void.
     /// Has the same permissions as that of `CommandBlock`.
     Dummy,
@@ -95,6 +99,7 @@ impl fmt::Display for CommandSender {
                 Self::Rcon(_) => "Rcon",
                 Self::Player(p) => &p.gameprofile.name,
                 Self::CommandBlock(..) => "@",
+                Self::Entity(name) => name.as_str(),
                 Self::Dummy => "",
             }
         )
@@ -105,7 +110,7 @@ impl CommandSender {
     pub async fn send_message(&self, text: TextComponent) {
         match self {
             #[allow(clippy::print_stdout)]
-            Self::Console => println!("{}", text.to_pretty_console()),
+            Self::Console | Self::Entity(_) => println!("{}", text.to_pretty_console()),
             Self::Player(c) => c.send_system_message(&text).await,
             Self::Rcon(s) => s.lock().await.push(text.to_pretty_console()),
             Self::CommandBlock(block_entity, _) => {
@@ -153,7 +158,7 @@ impl CommandSender {
         match self {
             Self::Console | Self::Rcon(_) => PermissionLvl::Four,
             Self::Player(p) => p.permission_lvl.load(),
-            Self::CommandBlock(..) | Self::Dummy => PermissionLvl::Two,
+            Self::CommandBlock(..) | Self::Dummy | Self::Entity(_) => PermissionLvl::Two,
         }
     }
 
@@ -162,7 +167,7 @@ impl CommandSender {
         match self {
             Self::Console | Self::Rcon(_) => true,
             Self::Player(p) => p.permission_lvl.load().ge(&lvl),
-            Self::CommandBlock(..) | Self::Dummy => PermissionLvl::Two >= lvl,
+            Self::CommandBlock(..) | Self::Dummy | Self::Entity(_) => PermissionLvl::Two >= lvl,
         }
     }
 
@@ -171,7 +176,7 @@ impl CommandSender {
         match self {
             Self::Console | Self::Rcon(_) => true, // Console and RCON always have all permissions
             Self::Player(p) => p.has_permission(server, node).await,
-            Self::CommandBlock(..) | Self::Dummy => {
+            Self::CommandBlock(..) | Self::Dummy | Self::Entity(_) => {
                 let perm_reg = server.permission_registry.read().await;
                 let Some(p) = perm_reg.get_permission(node) else {
                     return false;
@@ -188,7 +193,7 @@ impl CommandSender {
     #[must_use]
     pub fn position(&self) -> Option<Vector3<f64>> {
         match self {
-            Self::Console | Self::Rcon(..) | Self::Dummy => None,
+            Self::Console | Self::Rcon(..) | Self::Dummy | Self::Entity(_) => None,
             Self::Player(p) => Some(p.living_entity.entity.pos.load()),
             Self::CommandBlock(c, _) => Some(c.get_position().to_centered_f64()),
         }
@@ -197,7 +202,7 @@ impl CommandSender {
     #[must_use]
     pub fn rotation(&self) -> Option<(f32, f32)> {
         match self {
-            Self::Console | Self::Rcon(..) | Self::Dummy => None,
+            Self::Console | Self::Rcon(..) | Self::Dummy | Self::Entity(_) => None,
             Self::Player(player) => Some(player.rotation()),
             Self::CommandBlock(command_block, world) => {
                 let pos = command_block.get_position();
@@ -224,7 +229,7 @@ impl CommandSender {
     pub fn world(&self) -> Option<Arc<World>> {
         match self {
             // TODO: maybe return first world when console
-            Self::Console | Self::Rcon(..) | Self::Dummy => None,
+            Self::Console | Self::Rcon(..) | Self::Dummy | Self::Entity(_) => None,
             Self::Player(p) => Some(p.living_entity.entity.world.load_full()),
             Self::CommandBlock(_, w) => Some(w.clone()),
         }
@@ -233,7 +238,11 @@ impl CommandSender {
     #[must_use]
     pub fn get_locale(&self) -> Locale {
         match self {
-            Self::CommandBlock(..) | Self::Console | Self::Rcon(..) | Self::Dummy => Locale::EnUs, // Default locale for console and RCON
+            Self::CommandBlock(..)
+            | Self::Console
+            | Self::Rcon(..)
+            | Self::Dummy
+            | Self::Entity(_) => Locale::EnUs, // Default locale for console and RCON
             Self::Player(player) => {
                 Locale::from_str(&player.config.load().locale).unwrap_or(Locale::EnUs)
             }
@@ -255,7 +264,7 @@ impl CommandSender {
                     .send_command_feedback
             }
             Self::Console | Self::Rcon(_) => true,
-            Self::Dummy => false,
+            Self::Dummy | Self::Entity(_) => false,
         }
     }
 
@@ -267,14 +276,14 @@ impl CommandSender {
             Self::Console | Self::Rcon(_) => {
                 BROADCAST_CONSOLE_TO_OPS.load(std::sync::atomic::Ordering::Relaxed)
             }
-            Self::Dummy => false,
+            Self::Dummy | Self::Entity(_) => false,
         }
     }
 
     #[must_use]
     pub const fn should_track_output(&self) -> bool {
         match self {
-            Self::Dummy => false,
+            Self::Dummy | Self::Entity(_) => false,
             Self::Player(..) | Self::Console | Self::Rcon(_) | Self::CommandBlock(..) => true,
         }
     }
@@ -344,6 +353,19 @@ impl CommandSender {
                     Vector2::new(0.0, horizontal_direction),
                     name.clone().get_text(),
                     name,
+                    server.clone(),
+                )
+            }
+            Self::Entity(name) => {
+                let (world, spawn_point) = Self::get_world_and_spawn_point(server);
+                CommandSource::new(
+                    Self::Entity(name.clone()),
+                    world,
+                    None,
+                    spawn_point,
+                    Vector2::new(0.0, 0.0),
+                    name,
+                    TextComponent::empty(),
                     server.clone(),
                 )
             }

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -81,9 +81,9 @@ pub enum CommandSender {
     /// world context it exists in for coordinate-relative execution (e.g., `~ ~ ~`).
     CommandBlock(Arc<CommandBlockEntity>, Arc<World>),
     /// An entity executing a command, e.g. via `/execute as @e`.
-    /// Stores the entity's display name for use in command output
-    /// (e.g. the [`say`] command broadcasts the sender's name).
-    Entity(String),
+    /// Stores the entity's display name for command output and the original
+    /// sender whose permissions should be used.
+    Entity(String, Box<CommandSender>),
     /// Nothingness. Anything sent to this sender is void.
     /// Has the same permissions as that of `CommandBlock`.
     Dummy,
@@ -99,7 +99,7 @@ impl fmt::Display for CommandSender {
                 Self::Rcon(_) => "Rcon",
                 Self::Player(p) => &p.gameprofile.name,
                 Self::CommandBlock(..) => "@",
-                Self::Entity(name) => name.as_str(),
+                Self::Entity(name, _) => name.as_str(),
                 Self::Dummy => "",
             }
         )
@@ -110,7 +110,7 @@ impl CommandSender {
     pub async fn send_message(&self, text: TextComponent) {
         match self {
             #[allow(clippy::print_stdout)]
-            Self::Console | Self::Entity(_) => println!("{}", text.to_pretty_console()),
+            Self::Console | Self::Entity(..) => println!("{}", text.to_pretty_console()),
             Self::Player(c) => c.send_system_message(&text).await,
             Self::Rcon(s) => s.lock().await.push(text.to_pretty_console()),
             Self::CommandBlock(block_entity, _) => {
@@ -158,7 +158,8 @@ impl CommandSender {
         match self {
             Self::Console | Self::Rcon(_) => PermissionLvl::Four,
             Self::Player(p) => p.permission_lvl.load(),
-            Self::CommandBlock(..) | Self::Dummy | Self::Entity(_) => PermissionLvl::Two,
+            Self::Entity(_, permission_source) => permission_source.permission_lvl(),
+            Self::CommandBlock(..) | Self::Dummy => PermissionLvl::Two,
         }
     }
 
@@ -167,7 +168,8 @@ impl CommandSender {
         match self {
             Self::Console | Self::Rcon(_) => true,
             Self::Player(p) => p.permission_lvl.load().ge(&lvl),
-            Self::CommandBlock(..) | Self::Dummy | Self::Entity(_) => PermissionLvl::Two >= lvl,
+            Self::Entity(_, permission_source) => permission_source.has_permission_lvl(lvl),
+            Self::CommandBlock(..) | Self::Dummy => PermissionLvl::Two >= lvl,
         }
     }
 
@@ -176,7 +178,10 @@ impl CommandSender {
         match self {
             Self::Console | Self::Rcon(_) => true, // Console and RCON always have all permissions
             Self::Player(p) => p.has_permission(server, node).await,
-            Self::CommandBlock(..) | Self::Dummy | Self::Entity(_) => {
+            Self::Entity(_, permission_source) => {
+                Box::pin(permission_source.has_permission(server, node)).await
+            }
+            Self::CommandBlock(..) | Self::Dummy => {
                 let perm_reg = server.permission_registry.read().await;
                 let Some(p) = perm_reg.get_permission(node) else {
                     return false;
@@ -193,7 +198,7 @@ impl CommandSender {
     #[must_use]
     pub fn position(&self) -> Option<Vector3<f64>> {
         match self {
-            Self::Console | Self::Rcon(..) | Self::Dummy | Self::Entity(_) => None,
+            Self::Console | Self::Rcon(..) | Self::Dummy | Self::Entity(..) => None,
             Self::Player(p) => Some(p.living_entity.entity.pos.load()),
             Self::CommandBlock(c, _) => Some(c.get_position().to_centered_f64()),
         }
@@ -202,7 +207,7 @@ impl CommandSender {
     #[must_use]
     pub fn rotation(&self) -> Option<(f32, f32)> {
         match self {
-            Self::Console | Self::Rcon(..) | Self::Dummy | Self::Entity(_) => None,
+            Self::Console | Self::Rcon(..) | Self::Dummy | Self::Entity(..) => None,
             Self::Player(player) => Some(player.rotation()),
             Self::CommandBlock(command_block, world) => {
                 let pos = command_block.get_position();
@@ -229,7 +234,7 @@ impl CommandSender {
     pub fn world(&self) -> Option<Arc<World>> {
         match self {
             // TODO: maybe return first world when console
-            Self::Console | Self::Rcon(..) | Self::Dummy | Self::Entity(_) => None,
+            Self::Console | Self::Rcon(..) | Self::Dummy | Self::Entity(..) => None,
             Self::Player(p) => Some(p.living_entity.entity.world.load_full()),
             Self::CommandBlock(_, w) => Some(w.clone()),
         }
@@ -242,7 +247,7 @@ impl CommandSender {
             | Self::Console
             | Self::Rcon(..)
             | Self::Dummy
-            | Self::Entity(_) => Locale::EnUs, // Default locale for console and RCON
+            | Self::Entity(..) => Locale::EnUs, // Default locale for console and RCON
             Self::Player(player) => {
                 Locale::from_str(&player.config.load().locale).unwrap_or(Locale::EnUs)
             }
@@ -264,7 +269,7 @@ impl CommandSender {
                     .send_command_feedback
             }
             Self::Console | Self::Rcon(_) => true,
-            Self::Dummy | Self::Entity(_) => false,
+            Self::Dummy | Self::Entity(..) => false,
         }
     }
 
@@ -276,14 +281,14 @@ impl CommandSender {
             Self::Console | Self::Rcon(_) => {
                 BROADCAST_CONSOLE_TO_OPS.load(std::sync::atomic::Ordering::Relaxed)
             }
-            Self::Dummy | Self::Entity(_) => false,
+            Self::Dummy | Self::Entity(..) => false,
         }
     }
 
     #[must_use]
     pub const fn should_track_output(&self) -> bool {
         match self {
-            Self::Dummy | Self::Entity(_) => false,
+            Self::Dummy | Self::Entity(..) => false,
             Self::Player(..) | Self::Console | Self::Rcon(_) | Self::CommandBlock(..) => true,
         }
     }
@@ -356,10 +361,10 @@ impl CommandSender {
                     server.clone(),
                 )
             }
-            Self::Entity(name) => {
+            Self::Entity(name, permission_source) => {
                 let (world, spawn_point) = Self::get_world_and_spawn_point(server);
                 CommandSource::new(
-                    Self::Entity(name.clone()),
+                    Self::Entity(name.clone(), permission_source),
                     world,
                     None,
                     spawn_point,

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -83,7 +83,7 @@ pub enum CommandSender {
     /// An entity executing a command, e.g. via `/execute as @e`.
     /// Stores the entity's display name for command output and the original
     /// sender whose permissions should be used.
-    Entity(String, Box<CommandSender>),
+    Entity(String, Box<Self>),
     /// Nothingness. Anything sent to this sender is void.
     /// Has the same permissions as that of `CommandBlock`.
     Dummy,


### PR DESCRIPTION
Fixes #2447: `/execute as @e at @p run say 1` produced no output because commands like `say` were only registered in the old command dispatcher and the inner executor used `execute_input` which has no fallback.

## Two bugs found and fixed

**1. `ExecuteRunExecutor` used `execute_input` (new dispatcher only) instead of `handle_command`**
- `handle_command` falls back to the old command dispatcher for commands like `say`, `item`, `particle`, `setblock`, and `summon` that aren't registered in the new tree yet.

**2. `try_flatten` skipped the root context's modifier**
- When building the execution chain, the root context's `RedirectModifier` was never included, so `execute_as_modifier` was never called and entity identity was never propagated to `source.output`. Now the root is included as the first modifier when it has a non-`KeepSource` redirect.

## Additional changes
- Added `CommandSender::Entity(String)` variant so entity-sourced commands display the correct name in output
- Full exhaustiveness updates across the old command system (`item`, `particle`, `setblock`, `summon`)
- Added regression test `root_with_modifier_is_included_in_chain` to ensure `try_flatten` includes the root modifier
- All tests pass (150), clippy clean, fmt clean