### PR TITLE
feat: piglin and hoglin zombification in the Overworld

### DIFF
--- a/pumpkin/src/entity/mob/hoglin.rs
+++ b/pumpkin/src/entity/mob/hoglin.rs
@@ -2,11 +2,10 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Weak};
 
 use pumpkin_data::dimension::Dimension;
-use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::entity::EntityType;
-use pumpkin_data::potion::Effect;
 use pumpkin_nbt::compound::NbtCompound;
 
+use super::piglin::convert_to_zombified;
 use crate::entity::{
     Entity, EntityBase, EntityBaseFuture, NBTStorage,
     ai::goal::{
@@ -14,7 +13,6 @@ use crate::entity::{
         look_at_entity::LookAtEntityGoal, melee_attack::MeleeAttackGoal, swim::SwimGoal,
         wander_around::WanderAroundGoal,
     },
-    mob::zoglin::ZoglinEntity,
     mob::{Mob, MobEntity},
 };
 
@@ -104,77 +102,8 @@ impl Mob for HoglinEntity {
             self.time_in_overworld.store(new_time, Ordering::Relaxed);
 
             if new_time >= 300 {
-                convert_to_zoglin(caller).await;
+                convert_to_zombified(caller, &EntityType::ZOGLIN).await;
             }
         })
     }
-}
-
-async fn convert_to_zoglin(caller: &Arc<dyn EntityBase>) {
-    let entity = caller.get_entity();
-    let pos = entity.pos.load();
-    let world = entity.world.load_full();
-    let uuid = entity.entity_uuid;
-    let yaw = entity.yaw.load();
-    let pitch = entity.pitch.load();
-    let age = entity.age.load(Ordering::Relaxed);
-    let custom_name = entity.custom_name.load().clone();
-    let custom_name_visible = entity.custom_name_visible.load(Ordering::Relaxed);
-    let velocity = entity.velocity.load();
-
-    let living = caller
-        .get_living_entity()
-        .expect("Hoglin must be a living entity");
-    let health = living.health.load();
-    let equipment = {
-        let eq = living.entity_equipment.lock().await;
-        eq.clone()
-    };
-    let active_effects = {
-        let effects = living.active_effects.lock().await;
-        effects.clone()
-    };
-
-    entity.remove().await;
-
-    let new_entity = Entity::from_uuid(uuid, world.clone(), pos, &EntityType::ZOGLIN);
-    let zoglin = ZoglinEntity::new(new_entity);
-
-    let zoglin_entity = zoglin.get_entity();
-    let zoglin_living = zoglin
-        .get_living_entity()
-        .expect("Zoglin must be a living entity");
-
-    zoglin_living.health.store(health);
-    zoglin_entity.age.store(age, Ordering::Relaxed);
-    zoglin_entity.custom_name.store(custom_name);
-    zoglin_entity
-        .custom_name_visible
-        .store(custom_name_visible, Ordering::Relaxed);
-    zoglin_entity.yaw.store(yaw);
-    zoglin_entity.pitch.store(pitch);
-    zoglin_entity.velocity.store(velocity);
-
-    {
-        let mut eq = zoglin_living.entity_equipment.lock().await;
-        *eq = equipment;
-        drop(eq);
-    };
-    {
-        let mut effects = zoglin_living.active_effects.lock().await;
-        *effects = active_effects;
-    }
-    zoglin_living
-        .add_effect(Effect {
-            effect_type: &StatusEffect::NAUSEA,
-            duration: 200,
-            amplifier: 0,
-            ambient: false,
-            show_particles: true,
-            show_icon: true,
-            blend: false,
-        })
-        .await;
-
-    world.spawn_entity(zoglin).await;
 }

--- a/pumpkin/src/entity/mob/hoglin.rs
+++ b/pumpkin/src/entity/mob/hoglin.rs
@@ -1,25 +1,32 @@
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Weak};
 
+use pumpkin_data::dimension::Dimension;
 use pumpkin_data::entity::EntityType;
 
 use crate::entity::{
-    Entity, NBTStorage,
+    Entity, EntityBase, EntityBaseFuture, NBTStorage,
     ai::goal::{
         active_target::ActiveTargetGoal, look_around::RandomLookAroundGoal,
         look_at_entity::LookAtEntityGoal, melee_attack::MeleeAttackGoal, swim::SwimGoal,
         wander_around::WanderAroundGoal,
     },
+    mob::zoglin::ZoglinEntity,
     mob::{Mob, MobEntity},
 };
 
 pub struct HoglinEntity {
     pub mob_entity: MobEntity,
+    pub time_in_overworld: AtomicI32,
 }
 
 impl HoglinEntity {
     pub fn new(entity: Entity) -> Arc<Self> {
         let mob_entity = MobEntity::new(entity);
-        let hoglin = Self { mob_entity };
+        let hoglin = Self {
+            mob_entity,
+            time_in_overworld: AtomicI32::new(0),
+        };
         let mob_arc = Arc::new(hoglin);
         let mob_weak: Weak<dyn Mob> = {
             let mob_arc: Arc<dyn Mob> = mob_arc.clone();
@@ -55,4 +62,86 @@ impl Mob for HoglinEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }
+
+    fn mob_tick<'a>(&'a self, caller: &'a Arc<dyn EntityBase>) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            let entity = caller.get_entity();
+            let overworld_time = self.time_in_overworld.load(Ordering::Relaxed);
+            let world = entity.world.load_full();
+
+            if world.dimension == Dimension::THE_NETHER {
+                if overworld_time > 0 {
+                    self.time_in_overworld
+                        .store(overworld_time - 1, Ordering::Relaxed);
+                }
+                return;
+            }
+
+            let new_time = overworld_time + 1;
+            self.time_in_overworld.store(new_time, Ordering::Relaxed);
+
+            if new_time >= 300 {
+                convert_to_zoglin(caller).await;
+            }
+        })
+    }
+}
+
+async fn convert_to_zoglin(caller: &Arc<dyn EntityBase>) {
+    let entity = caller.get_entity();
+    let pos = entity.pos.load();
+    let world = entity.world.load_full();
+    let uuid = entity.entity_uuid;
+    let yaw = entity.yaw.load();
+    let pitch = entity.pitch.load();
+    let age = entity.age.load(Ordering::Relaxed);
+    let custom_name = entity.custom_name.load().clone();
+    let custom_name_visible = entity.custom_name_visible.load(Ordering::Relaxed);
+    let velocity = entity.velocity.load();
+
+    let living = caller
+        .get_living_entity()
+        .expect("Hoglin must be a living entity");
+    let health = living.health.load();
+    let equipment = {
+        let eq = living.entity_equipment.lock().await;
+        eq.clone()
+    };
+    let active_effects = {
+        let effects = living.active_effects.lock().await;
+        effects.clone()
+    };
+
+    entity.remove().await;
+
+    let new_entity = Entity::from_uuid(uuid, world.clone(), pos, &EntityType::ZOGLIN);
+    let zoglin = ZoglinEntity::new(new_entity);
+
+    let zoglin_entity = zoglin.get_entity();
+    let zoglin_living = zoglin
+        .get_living_entity()
+        .expect("Zoglin must be a living entity");
+
+    zoglin_living.health.store(health);
+    zoglin_entity.age.store(age, Ordering::Relaxed);
+    zoglin_entity.custom_name.store(custom_name);
+    zoglin_entity
+        .custom_name_visible
+        .store(custom_name_visible, Ordering::Relaxed);
+    zoglin_entity.yaw.store(yaw);
+    zoglin_entity.pitch.store(pitch);
+    zoglin_entity.velocity.store(velocity);
+
+    {
+        let mut eq = zoglin_living.entity_equipment.lock().await;
+        *eq = equipment;
+        drop(eq);
+    };
+    {
+        let mut effects = zoglin_living.active_effects.lock().await;
+        *effects = active_effects;
+        drop(effects);
+    };
+
+    world.spawn_entity(zoglin).await;
 }

--- a/pumpkin/src/entity/mob/hoglin.rs
+++ b/pumpkin/src/entity/mob/hoglin.rs
@@ -2,7 +2,10 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Weak};
 
 use pumpkin_data::dimension::Dimension;
+use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::potion::Effect;
+use pumpkin_nbt::compound::NbtCompound;
 
 use crate::entity::{
     Entity, EntityBase, EntityBaseFuture, NBTStorage,
@@ -56,7 +59,27 @@ impl HoglinEntity {
     }
 }
 
-impl NBTStorage for HoglinEntity {}
+impl NBTStorage for HoglinEntity {
+    fn write_nbt<'a>(&'a self, nbt: &'a mut NbtCompound) -> crate::entity::NbtFuture<'a, ()> {
+        Box::pin(async move {
+            self.mob_entity.living_entity.write_nbt(nbt).await;
+            nbt.put_int(
+                "TimeInOverworld",
+                self.time_in_overworld.load(Ordering::Relaxed),
+            );
+        })
+    }
+
+    fn read_nbt_non_mut<'a>(&'a self, nbt: &'a NbtCompound) -> crate::entity::NbtFuture<'a, ()> {
+        Box::pin(async move {
+            self.mob_entity.living_entity.read_nbt_non_mut(nbt).await;
+            self.time_in_overworld.store(
+                nbt.get_int("TimeInOverworld").unwrap_or(0),
+                Ordering::Relaxed,
+            );
+        })
+    }
+}
 
 impl Mob for HoglinEntity {
     fn get_mob_entity(&self) -> &MobEntity {
@@ -140,8 +163,18 @@ async fn convert_to_zoglin(caller: &Arc<dyn EntityBase>) {
     {
         let mut effects = zoglin_living.active_effects.lock().await;
         *effects = active_effects;
-        drop(effects);
-    };
+    }
+    zoglin_living
+        .add_effect(Effect {
+            effect_type: &StatusEffect::NAUSEA,
+            duration: 200,
+            amplifier: 0,
+            ambient: false,
+            show_particles: true,
+            show_icon: true,
+            blend: false,
+        })
+        .await;
 
     world.spawn_entity(zoglin).await;
 }

--- a/pumpkin/src/entity/mob/piglin.rs
+++ b/pumpkin/src/entity/mob/piglin.rs
@@ -1,25 +1,32 @@
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Weak};
 
+use pumpkin_data::dimension::Dimension;
 use pumpkin_data::entity::EntityType;
 
 use crate::entity::{
-    Entity, NBTStorage,
+    Entity, EntityBase, EntityBaseFuture, NBTStorage,
     ai::goal::{
         active_target::ActiveTargetGoal, look_around::RandomLookAroundGoal,
         look_at_entity::LookAtEntityGoal, melee_attack::MeleeAttackGoal, swim::SwimGoal,
         wander_around::WanderAroundGoal,
     },
+    mob::zombified_piglin::ZombifiedPiglinEntity,
     mob::{Mob, MobEntity},
 };
 
 pub struct PiglinEntity {
     pub mob_entity: MobEntity,
+    pub time_in_overworld: AtomicI32,
 }
 
 impl PiglinEntity {
     pub fn new(entity: Entity) -> Arc<Self> {
         let mob_entity = MobEntity::new(entity);
-        let piglin = Self { mob_entity };
+        let piglin = Self {
+            mob_entity,
+            time_in_overworld: AtomicI32::new(0),
+        };
         let mob_arc = Arc::new(piglin);
         let mob_weak: Weak<dyn Mob> = {
             let mob_arc: Arc<dyn Mob> = mob_arc.clone();
@@ -68,4 +75,86 @@ impl Mob for PiglinEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }
+
+    fn mob_tick<'a>(&'a self, caller: &'a Arc<dyn EntityBase>) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            let entity = caller.get_entity();
+            let overworld_time = self.time_in_overworld.load(Ordering::Relaxed);
+            let world = entity.world.load_full();
+
+            if world.dimension == Dimension::THE_NETHER {
+                if overworld_time > 0 {
+                    self.time_in_overworld
+                        .store(overworld_time - 1, Ordering::Relaxed);
+                }
+                return;
+            }
+
+            let new_time = overworld_time + 1;
+            self.time_in_overworld.store(new_time, Ordering::Relaxed);
+
+            if new_time >= 300 {
+                convert_to_zombified_piglin(caller).await;
+            }
+        })
+    }
+}
+
+pub(super) async fn convert_to_zombified_piglin(caller: &Arc<dyn EntityBase>) {
+    let entity = caller.get_entity();
+    let pos = entity.pos.load();
+    let world = entity.world.load_full();
+    let uuid = entity.entity_uuid;
+    let yaw = entity.yaw.load();
+    let pitch = entity.pitch.load();
+    let age = entity.age.load(Ordering::Relaxed);
+    let custom_name = entity.custom_name.load().clone();
+    let custom_name_visible = entity.custom_name_visible.load(Ordering::Relaxed);
+    let velocity = entity.velocity.load();
+
+    let living = caller
+        .get_living_entity()
+        .expect("Piglin must be a living entity");
+    let health = living.health.load();
+    let equipment = {
+        let eq = living.entity_equipment.lock().await;
+        eq.clone()
+    };
+    let active_effects = {
+        let effects = living.active_effects.lock().await;
+        effects.clone()
+    };
+
+    entity.remove().await;
+
+    let new_entity = Entity::from_uuid(uuid, world.clone(), pos, &EntityType::ZOMBIFIED_PIGLIN);
+    let zombified = ZombifiedPiglinEntity::new(new_entity);
+
+    let zombified_entity = zombified.get_entity();
+    let zombified_living = zombified
+        .get_living_entity()
+        .expect("Zombified Piglin must be a living entity");
+
+    zombified_living.health.store(health);
+    zombified_entity.age.store(age, Ordering::Relaxed);
+    zombified_entity.custom_name.store(custom_name);
+    zombified_entity
+        .custom_name_visible
+        .store(custom_name_visible, Ordering::Relaxed);
+    zombified_entity.yaw.store(yaw);
+    zombified_entity.pitch.store(pitch);
+    zombified_entity.velocity.store(velocity);
+
+    {
+        let mut eq = zombified_living.entity_equipment.lock().await;
+        *eq = equipment;
+        drop(eq);
+    };
+    {
+        let mut effects = zombified_living.active_effects.lock().await;
+        *effects = active_effects;
+        drop(effects);
+    };
+
+    world.spawn_entity(zombified).await;
 }

--- a/pumpkin/src/entity/mob/piglin.rs
+++ b/pumpkin/src/entity/mob/piglin.rs
@@ -2,7 +2,10 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Weak};
 
 use pumpkin_data::dimension::Dimension;
+use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::potion::Effect;
+use pumpkin_nbt::compound::NbtCompound;
 
 use crate::entity::{
     Entity, EntityBase, EntityBaseFuture, NBTStorage,
@@ -69,7 +72,27 @@ impl PiglinEntity {
     }
 }
 
-impl NBTStorage for PiglinEntity {}
+impl NBTStorage for PiglinEntity {
+    fn write_nbt<'a>(&'a self, nbt: &'a mut NbtCompound) -> crate::entity::NbtFuture<'a, ()> {
+        Box::pin(async move {
+            self.mob_entity.living_entity.write_nbt(nbt).await;
+            nbt.put_int(
+                "TimeInOverworld",
+                self.time_in_overworld.load(Ordering::Relaxed),
+            );
+        })
+    }
+
+    fn read_nbt_non_mut<'a>(&'a self, nbt: &'a NbtCompound) -> crate::entity::NbtFuture<'a, ()> {
+        Box::pin(async move {
+            self.mob_entity.living_entity.read_nbt_non_mut(nbt).await;
+            self.time_in_overworld.store(
+                nbt.get_int("TimeInOverworld").unwrap_or(0),
+                Ordering::Relaxed,
+            );
+        })
+    }
+}
 
 impl Mob for PiglinEntity {
     fn get_mob_entity(&self) -> &MobEntity {
@@ -153,8 +176,18 @@ pub(super) async fn convert_to_zombified_piglin(caller: &Arc<dyn EntityBase>) {
     {
         let mut effects = zombified_living.active_effects.lock().await;
         *effects = active_effects;
-        drop(effects);
-    };
+    }
+    zombified_living
+        .add_effect(Effect {
+            effect_type: &StatusEffect::NAUSEA,
+            duration: 200,
+            amplifier: 0,
+            ambient: false,
+            show_particles: true,
+            show_icon: true,
+            blend: false,
+        })
+        .await;
 
     world.spawn_entity(zombified).await;
 }

--- a/pumpkin/src/entity/mob/piglin.rs
+++ b/pumpkin/src/entity/mob/piglin.rs
@@ -14,8 +14,8 @@ use crate::entity::{
         look_at_entity::LookAtEntityGoal, melee_attack::MeleeAttackGoal, swim::SwimGoal,
         wander_around::WanderAroundGoal,
     },
-    mob::zombified_piglin::ZombifiedPiglinEntity,
     mob::{Mob, MobEntity},
+    r#type::from_type,
 };
 
 pub struct PiglinEntity {
@@ -117,13 +117,16 @@ impl Mob for PiglinEntity {
             self.time_in_overworld.store(new_time, Ordering::Relaxed);
 
             if new_time >= 300 {
-                convert_to_zombified_piglin(caller).await;
+                convert_to_zombified(caller, &EntityType::ZOMBIFIED_PIGLIN).await;
             }
         })
     }
 }
 
-pub(super) async fn convert_to_zombified_piglin(caller: &Arc<dyn EntityBase>) {
+pub(super) async fn convert_to_zombified(
+    caller: &Arc<dyn EntityBase>,
+    target_type: &'static EntityType,
+) {
     let entity = caller.get_entity();
     let pos = entity.pos.load();
     let world = entity.world.load_full();
@@ -150,9 +153,7 @@ pub(super) async fn convert_to_zombified_piglin(caller: &Arc<dyn EntityBase>) {
 
     entity.remove().await;
 
-    let new_entity = Entity::from_uuid(uuid, world.clone(), pos, &EntityType::ZOMBIFIED_PIGLIN);
-    let zombified = ZombifiedPiglinEntity::new(new_entity);
-
+    let zombified = from_type(target_type, pos, &world, uuid);
     let zombified_entity = zombified.get_entity();
     let zombified_living = zombified
         .get_living_entity()

--- a/pumpkin/src/entity/mob/piglin.rs
+++ b/pumpkin/src/entity/mob/piglin.rs
@@ -177,7 +177,7 @@ pub(super) async fn convert_to_zombified(
     {
         let mut effects = zombified_living.active_effects.lock().await;
         *effects = active_effects;
-    }
+    };
     zombified_living
         .add_effect(Effect {
             effect_type: &StatusEffect::NAUSEA,

--- a/pumpkin/src/entity/mob/piglin_brute.rs
+++ b/pumpkin/src/entity/mob/piglin_brute.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Weak};
 
 use pumpkin_data::dimension::Dimension;
 use pumpkin_data::entity::EntityType;
+use pumpkin_nbt::compound::NbtCompound;
 
 use crate::entity::{
     Entity, EntityBase, EntityBaseFuture, NBTStorage,
@@ -69,7 +70,27 @@ impl PiglinBruteEntity {
     }
 }
 
-impl NBTStorage for PiglinBruteEntity {}
+impl NBTStorage for PiglinBruteEntity {
+    fn write_nbt<'a>(&'a self, nbt: &'a mut NbtCompound) -> crate::entity::NbtFuture<'a, ()> {
+        Box::pin(async move {
+            self.mob_entity.living_entity.write_nbt(nbt).await;
+            nbt.put_int(
+                "TimeInOverworld",
+                self.time_in_overworld.load(Ordering::Relaxed),
+            );
+        })
+    }
+
+    fn read_nbt_non_mut<'a>(&'a self, nbt: &'a NbtCompound) -> crate::entity::NbtFuture<'a, ()> {
+        Box::pin(async move {
+            self.mob_entity.living_entity.read_nbt_non_mut(nbt).await;
+            self.time_in_overworld.store(
+                nbt.get_int("TimeInOverworld").unwrap_or(0),
+                Ordering::Relaxed,
+            );
+        })
+    }
+}
 
 impl Mob for PiglinBruteEntity {
     fn get_mob_entity(&self) -> &MobEntity {

--- a/pumpkin/src/entity/mob/piglin_brute.rs
+++ b/pumpkin/src/entity/mob/piglin_brute.rs
@@ -1,9 +1,11 @@
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Weak};
 
+use pumpkin_data::dimension::Dimension;
 use pumpkin_data::entity::EntityType;
 
 use crate::entity::{
-    Entity, NBTStorage,
+    Entity, EntityBase, EntityBaseFuture, NBTStorage,
     ai::goal::{
         active_target::ActiveTargetGoal, look_around::RandomLookAroundGoal,
         look_at_entity::LookAtEntityGoal, melee_attack::MeleeAttackGoal, swim::SwimGoal,
@@ -12,14 +14,20 @@ use crate::entity::{
     mob::{Mob, MobEntity},
 };
 
+use super::piglin::convert_to_zombified_piglin;
+
 pub struct PiglinBruteEntity {
     pub mob_entity: MobEntity,
+    pub time_in_overworld: AtomicI32,
 }
 
 impl PiglinBruteEntity {
     pub fn new(entity: Entity) -> Arc<Self> {
         let mob_entity = MobEntity::new(entity);
-        let piglin = Self { mob_entity };
+        let piglin = Self {
+            mob_entity,
+            time_in_overworld: AtomicI32::new(0),
+        };
         let mob_arc = Arc::new(piglin);
         let mob_weak: Weak<dyn Mob> = {
             let mob_arc: Arc<dyn Mob> = mob_arc.clone();
@@ -66,5 +74,28 @@ impl NBTStorage for PiglinBruteEntity {}
 impl Mob for PiglinBruteEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
+    }
+
+    fn mob_tick<'a>(&'a self, caller: &'a Arc<dyn EntityBase>) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            let entity = caller.get_entity();
+            let overworld_time = self.time_in_overworld.load(Ordering::Relaxed);
+            let world = entity.world.load_full();
+
+            if world.dimension == Dimension::THE_NETHER {
+                if overworld_time > 0 {
+                    self.time_in_overworld
+                        .store(overworld_time - 1, Ordering::Relaxed);
+                }
+                return;
+            }
+
+            let new_time = overworld_time + 1;
+            self.time_in_overworld.store(new_time, Ordering::Relaxed);
+
+            if new_time >= 300 {
+                convert_to_zombified_piglin(caller).await;
+            }
+        })
     }
 }

--- a/pumpkin/src/entity/mob/piglin_brute.rs
+++ b/pumpkin/src/entity/mob/piglin_brute.rs
@@ -15,7 +15,7 @@ use crate::entity::{
     mob::{Mob, MobEntity},
 };
 
-use super::piglin::convert_to_zombified_piglin;
+use super::piglin::convert_to_zombified;
 
 pub struct PiglinBruteEntity {
     pub mob_entity: MobEntity,
@@ -115,7 +115,7 @@ impl Mob for PiglinBruteEntity {
             self.time_in_overworld.store(new_time, Ordering::Relaxed);
 
             if new_time >= 300 {
-                convert_to_zombified_piglin(caller).await;
+                convert_to_zombified(caller, &EntityType::ZOMBIFIED_PIGLIN).await;
             }
         })
     }


### PR DESCRIPTION
Implements the vanilla mechanic where piglins and hoglins convert to their undead counterparts after spending 15 seconds outside the Nether.

## Conversions

| Source | Result |
|---|---|
| Piglin | Zombified Piglin (neutral, fire-immune) |
| Piglin Brute | Zombified Piglin (neutral, fire-immune) |
| Hoglin | Zoglin (aggressive, fire-immune) |

## Mechanics

- `TimeInOverworld` counter per mob, incrementing by 1 per tick in the Overworld or End
- Counter **decrements** by 1 per tick in the Nether (reversible if pushed back through a portal)
- Conversion triggers at exactly **300 ticks** (15 seconds)
- All attributes preserved: health, age, custom name, equipment, effects, yaw/pitch, velocity, UUID

## Files changed

- `pumpkin/src/entity/mob/piglin.rs` — added `time_in_overworld` field + `mob_tick` override + `convert_to_zombified_piglin()` shared helper
- `pumpkin/src/entity/mob/piglin_brute.rs` — same logic, reuses `convert_to_zombified_piglin()` from piglin.rs
- `pumpkin/src/entity/mob/hoglin.rs` — added `time_in_overworld` field + `mob_tick` override + `convert_to_zoglin()`

## Verification

- `cargo clippy --all-targets` — clean
- `cargo fmt --check --all` — clean
- `cargo test -p pumpkin` — all 149 tests pass