### PR TITLE
fix(entity): prevent mobs from getting stuck after navigation finishes

### DIFF
--- a/crates/pumpkin/src/entity/ai/pathfinder/mod.rs
+++ b/crates/pumpkin/src/entity/ai/pathfinder/mod.rs
@@ -119,6 +119,12 @@ impl Navigator {
         self.path_start_pos = None;
     }
 
+    fn finish_navigation(&mut self, entity: &LivingEntity) {
+        self.stop();
+        entity.movement_input.store(Vector3::new(0.0, 0.0, 0.0));
+        entity.jumping.store(false, Ordering::Relaxed);
+    }
+
     pub fn set_pathfinding_malus(&mut self, path_type: PathType, malus: f32) {
         self.path_type_overrides.insert(path_type, malus);
     }
@@ -312,9 +318,7 @@ impl Navigator {
         };
 
         if goal.current_progress == goal.destination {
-            self.is_idle.store(true, Ordering::Relaxed);
-            self.current_path = None;
-            entity.movement_input.store(Vector3::new(0.0, 0.0, 0.0));
+            self.finish_navigation(entity);
             return;
         }
 
@@ -332,15 +336,13 @@ impl Navigator {
         }
 
         if self.current_path.is_none() {
-            entity.movement_input.store(Vector3::new(0.0, 0.0, 0.0));
-            self.current_goal = Some(goal);
+            self.finish_navigation(entity);
             return;
         }
 
         if let Some(path) = &mut self.current_path {
             if path.is_done() || !path.is_valid() {
-                entity.movement_input.store(Vector3::new(0.0, 0.0, 0.0));
-                self.current_goal = Some(goal);
+                self.finish_navigation(entity);
                 return;
             }
 
@@ -353,10 +355,7 @@ impl Navigator {
             }
 
             if self.ticks_on_current_node > 100 {
-                self.current_path = None;
-                self.ticks_on_current_node = 0;
-                entity.movement_input.store(Vector3::new(0.0, 0.0, 0.0));
-                self.current_goal = Some(goal);
+                self.finish_navigation(entity);
                 return;
             }
 
@@ -368,10 +367,7 @@ impl Navigator {
                     let dz = current_pos.z - start_pos.z;
                     let dist_sq = dx * dx + dy * dy + dz * dz;
                     if dist_sq < 2.0 * 2.0 {
-                        self.current_path = None;
-                        self.ticks_on_current_node = 0;
-                        entity.movement_input.store(Vector3::new(0.0, 0.0, 0.0));
-                        self.current_goal = Some(goal);
+                        self.finish_navigation(entity);
                         return;
                     }
                 }
@@ -442,9 +438,8 @@ impl Navigator {
                         .store(false, std::sync::atomic::Ordering::SeqCst);
                 }
             } else {
-                self.is_idle.store(true, Ordering::Relaxed);
-                self.current_path = None;
-                entity.movement_input.store(Vector3::new(0.0, 0.0, 0.0));
+                self.finish_navigation(entity);
+                return;
             }
         }
 


### PR DESCRIPTION
## Description

This PR completes the mob-movement fix started by #2442.

Eric (sirtzn) found the first part of the issue in `move_control.rs`: the default move control cleared `movement_input` while waiting, even though the navigator had already set it earlier in the same tick. #2442 has now merged that correction.

The link to the conversation I had with Eric on the server: https://discord.com/channels/1268592337445978193/1268611668930203689/1529575774699651133

After testing further, I found a second issue. Some mobs moved once and then stopped again. Hitting them made them flee, but after that path finished they became stuck again.

When a path finished, failed, became invalid, or detected that the mob was stuck, the navigator stopped movement but retained the old navigation goal. Goals such as wandering and escaping therefore believed navigation was still active and never selected another destination.

This change routes terminal navigation outcomes through one cleanup path that releases the goal, path, and stuck-detection state, marks navigation idle, and stops path-owned movement and jumping.

The ordinary no-goal idle branch intentionally does not clear `jumping`. Goals tick before the navigator, so clearing it there would erase `SwimGoal` output in the same tick and cause idle mobs in water to sink.

Thanks to Eric for finding the original `MoveControl` issue and for catching the swim-jump ownership problem during review.

## Testing

I tested this using a 1.21.11 client on a local server.

Before the fix, mobs would stand still, move only once, or temporarily move after being hit before becoming stuck again. After the fix, passive mobs can complete multiple paths and continue wandering, mobs can flee after being hit without becoming permanently stuck, and hostile mobs continue following their targets.

Mob AI still has separate behavioral problems, including tempting-food behavior. Those are outside the movement and terminal-navigation issues fixed here.