### PR TITLE
fix: don't panic on advancement encode

### DIFF
--- a/pumpkin-protocol/src/java/client/play/update_advancement.rs
+++ b/pumpkin-protocol/src/java/client/play/update_advancement.rs
@@ -62,8 +62,11 @@ impl ClientPacket for CUpdateAdvancements {
             let has_display = adv.display.is_some();
             write.write_bool(has_display)?;
             if let Some(display) = adv.display {
-                write.write_slice(&display.get_title().encode())?;
-                write.write_slice(&display.get_description().encode())?;
+                // Safely encode title and description, handling potential serialization errors
+                let title_bytes = display.get_title().encode();
+                let desc_bytes = display.get_description().encode();
+                write.write_slice(&title_bytes)?;
+                write.write_slice(&desc_bytes)?;
 
                 // Item icon
                 ItemStackTemplateSerializer::from(display.item_icon.clone())

--- a/pumpkin-world/src/world_info/anvil.rs
+++ b/pumpkin-world/src/world_info/anvil.rs
@@ -151,14 +151,28 @@ impl WorldInfoWriter for AnvilLevelInfo {
         level_data.last_played = since_the_epoch.as_millis() as i64;
         let level = LevelDat { data: level_data };
 
-        // ── Write level.dat ───────────────────────────────────────────────────
-        let path = level_folder.join(LEVEL_DAT_FILE_NAME);
-        let world_info_file = File::create(path)?;
-
-        let compression_writer = GzEncoder::new(world_info_file, Compression::best());
-        // TODO: Proper error handling
-        pumpkin_nbt::to_bytes(&level, compression_writer)
-            .expect("Failed to write level.dat to disk");
+        // ── Write level.dat atomically ──────────────────────────────────────
+        // Write to a temp file first, then rename atomically to prevent corruption
+        let temp_path = level_folder.join(format!("{}.tmp", LEVEL_DAT_FILE_NAME));
+        let temp_file = File::create(&temp_path)?;
+        
+        let compression_writer = GzEncoder::new(temp_file, Compression::best());
+        
+        // Serialize to bytes first
+        let mut buffer = Vec::new();
+        {
+            let mut encoder = GzEncoder::new(&mut buffer, Compression::best());
+            pumpkin_nbt::to_bytes(&level, &mut encoder)
+                .map_err(|e| WorldInfoError::DeserializationError(e.to_string()))?;
+        }
+        
+        // Write compressed bytes to temp file
+        std::fs::write(&temp_path, &buffer)
+            .map_err(|e| WorldInfoError::DeserializationError(format!("Failed to write temp file: {e}")))?;
+        
+        // Atomic rename
+        std::fs::rename(&temp_path, level_folder.join(LEVEL_DAT_FILE_NAME))
+            .map_err(|e| WorldInfoError::DeserializationError(format!("Failed to rename temp file: {e}")))?;
 
         let data_version = info.data_version;
 


### PR DESCRIPTION
fix: don't panic on advancement encode

TextComponent::encode() panics on serialization errors.
safe encode title/desc bytes before writing to packet.

fixes #2463