### PR TITLE
feat: Implement pillager outpost structures

### DIFF
--- a/pumpkin-world/src/chunk_system/generation.rs
+++ b/pumpkin-world/src/chunk_system/generation.rs
@@ -183,4 +183,99 @@ mod tests {
         );
         assert_eq!(jigsaw_blocks, 0, "jigsaw blocks were not replaced");
     }
+
+    #[test]
+    fn seed_zero_generates_the_vanilla_pillager_outpost_chunk() {
+        let dimension = Dimension::OVERWORLD;
+        let seed = Seed(0);
+        let block_registry = Arc::new(BlockRegistry);
+        let world_gen = get_world_gen(seed, dimension.clone(), false, Vec::new(), String::new());
+        let biome_mixer_seed = hash_seed(world_gen.seed());
+
+        // Vanilla 26.2 locates seed 0's nearest outpost at block 576, 1648.
+        let chunk = generate_single_chunk(
+            &dimension,
+            biome_mixer_seed,
+            &world_gen,
+            block_registry.as_ref(),
+            35,
+            103,
+            StagedChunkEnum::Features,
+        );
+        let super::Chunk::Proto(chunk) = chunk else {
+            panic!("features stage should return a proto chunk");
+        };
+        let mut outpost_blocks = 0;
+        let mut jigsaw_blocks = 0;
+        for x in 560..576 {
+            for z in 1648..1664 {
+                for y in -64..320 {
+                    let block = chunk
+                        .get_block_state(&pumpkin_util::math::vector3::Vector3::new(x, y, z))
+                        .to_block_id();
+                    if [
+                        pumpkin_data::Block::DARK_OAK_LOG.id,
+                        pumpkin_data::Block::DARK_OAK_PLANKS.id,
+                        pumpkin_data::Block::DARK_OAK_FENCE.id,
+                    ]
+                    .contains(&block)
+                    {
+                        outpost_blocks += 1;
+                    }
+                    if block == pumpkin_data::Block::JIGSAW.id {
+                        jigsaw_blocks += 1;
+                    }
+                }
+            }
+        }
+
+        assert!(
+            outpost_blocks > 0,
+            "reference chunk contains no outpost blocks"
+        );
+        assert_eq!(jigsaw_blocks, 0, "jigsaw blocks were not replaced");
+    }
+
+    #[test]
+    fn pillager_outpost_features_shape_ground_at_vanilla_height() {
+        let dimension = Dimension::OVERWORLD;
+        let seed = Seed(1_782_124_772_053_846_960);
+        let block_registry = Arc::new(BlockRegistry);
+        let world_gen = get_world_gen(seed, dimension.clone(), false, Vec::new(), String::new());
+        let biome_mixer_seed = hash_seed(world_gen.seed());
+
+        let chunk = generate_single_chunk(
+            &dimension,
+            biome_mixer_seed,
+            &world_gen,
+            block_registry.as_ref(),
+            73,
+            -82,
+            StagedChunkEnum::Features,
+        );
+        let super::Chunk::Proto(chunk) = chunk else {
+            panic!("features stage should return a proto chunk");
+        };
+
+        for (x, y, z) in [(1173, 70, -1311), (1173, 70, -1305)] {
+            let state = chunk.get_block_state(&pumpkin_util::math::vector3::Vector3::new(x, y, z));
+            assert_eq!(state.to_block_id(), pumpkin_data::Block::GRASS_BLOCK.id);
+        }
+
+        let cage_chunk = generate_single_chunk(
+            &dimension,
+            biome_mixer_seed,
+            &world_gen,
+            block_registry.as_ref(),
+            73,
+            -84,
+            StagedChunkEnum::Features,
+        );
+        let super::Chunk::Proto(cage_chunk) = cage_chunk else {
+            panic!("features stage should return a proto chunk");
+        };
+        let state =
+            cage_chunk.get_block_state(&pumpkin_util::math::vector3::Vector3::new(1183, 68, -1330));
+        assert_eq!(state.to_block_id(), pumpkin_data::Block::GRASS_BLOCK.id);
+    }
 }

--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -764,7 +764,10 @@ impl GenerationSchedule {
     }
 
     fn drop_satisfied_tasks(&mut self, holder: &mut ChunkHolder, stage: StagedChunkEnum) {
-        for task_idx in (holder.current_stage as usize + 1)..=(stage as usize) {
+        // A neighboring generation cache may already have advanced this holder past the
+        // returning task's stage. Drop every scheduled task satisfied by the returned data,
+        // including that task's stale in-flight node.
+        for task_idx in (StagedChunkEnum::None as usize + 1)..=(stage as usize) {
             if !holder.tasks[task_idx].is_null() {
                 self.waiting_for_chunks.remove(&holder.tasks[task_idx]);
                 self.drop_node(holder.tasks[task_idx]);

--- a/pumpkin-world/src/generation/noise/mod.rs
+++ b/pumpkin-world/src/generation/noise/mod.rs
@@ -163,6 +163,7 @@ pub struct ChunkNoiseGenerator<'a> {
     generation_shape: &'a GenerationShapeConfig,
     start_cell_pos_x: i32,
     start_cell_pos_z: i32,
+    horizontal_cell_count: usize,
 
     vertical_cell_count: usize,
     minimum_cell_y: i32,
@@ -255,6 +256,7 @@ impl<'a> ChunkNoiseGenerator<'a> {
             generation_shape,
             start_cell_pos_x,
             start_cell_pos_z,
+            horizontal_cell_count,
             vertical_cell_count,
             minimum_cell_y,
 
@@ -279,7 +281,7 @@ impl<'a> ChunkNoiseGenerator<'a> {
     fn sample_density(&mut self, start: bool, current_x: i32) {
         let x = current_x * self.horizontal_cell_block_count() as i32;
 
-        for cell_z in 0..=(16 / self.horizontal_cell_block_count()) {
+        for cell_z in 0..=self.horizontal_cell_count {
             let current_cell_z_pos = self.start_cell_pos_z + cell_z as i32;
             let z = current_cell_z_pos * self.horizontal_cell_block_count() as i32;
             self.cache_fill_unique_id += 1;
@@ -305,7 +307,7 @@ impl<'a> ChunkNoiseGenerator<'a> {
                 0,
             );
 
-            self.fill_interpolator_buffers(start, cell_z as usize, &mapper, &mut options);
+            self.fill_interpolator_buffers(start, cell_z, &mapper, &mut options);
             self.cache_result_unique_id = options.cache_result_unique_id;
         }
         self.cache_fill_unique_id += 1;

--- a/pumpkin-world/src/generation/proto_chunk.rs
+++ b/pumpkin-world/src/generation/proto_chunk.rs
@@ -144,6 +144,7 @@ pub struct ProtoChunk {
     pub carving_mask: crate::generation::carver::mask::CarvingMask,
     pub blending_data: Option<crate::generation::blender::blending_data::BlendingData>,
     pub pending_block_entities: Vec<NbtCompound>,
+    pending_structure_entities: Vec<NbtCompound>,
     pub fluid_ticks: Vec<ScheduledTick<&'static Fluid>>,
 }
 
@@ -229,6 +230,7 @@ impl ProtoChunk {
             ),
             blending_data: None,
             pending_block_entities: Vec::new(),
+            pending_structure_entities: Vec::new(),
             fluid_ticks: Vec::new(),
         }
     }
@@ -341,6 +343,14 @@ impl ProtoChunk {
 
     pub fn take_pending_block_entities(&mut self) -> Vec<NbtCompound> {
         std::mem::take(&mut self.pending_block_entities)
+    }
+
+    pub fn add_structure_entity(&mut self, nbt: NbtCompound) {
+        self.pending_structure_entities.push(nbt);
+    }
+
+    fn take_pending_structure_entities(&mut self) -> Vec<NbtCompound> {
+        std::mem::take(&mut self.pending_structure_entities)
     }
 
     pub fn schedule_fluid_tick(&mut self, x: i32, y: i32, z: i32, fluid: &'static Fluid) {
@@ -871,6 +881,11 @@ impl ProtoChunk {
 
         block_registry.spawn_mobs_for_chunk_generation(cache, biome, x, z);
 
+        let entities = cache
+            .get_center_chunk_mut()
+            .take_pending_structure_entities();
+        block_registry.spawn_structure_entities(entities);
+
         cache.get_center_chunk_mut().stage = StagedChunkEnum::Spawn;
     }
 
@@ -1211,17 +1226,12 @@ impl ProtoChunk {
 
         let seed = random_config.seed;
 
-        let mut height_sampler = crate::generation::noise::router::surface_height_sampler::SurfaceHeightEstimateSampler::generate(
-            &generator.base_router.surface_estimator,
-            &crate::generation::noise::router::surface_height_sampler::SurfaceHeightSamplerBuilderOptions::new(
-                crate::generation::biome_coords::from_block(crate::generation::positions::chunk_pos::start_block_x(self.x)),
-                crate::generation::biome_coords::from_block(crate::generation::positions::chunk_pos::start_block_z(self.z)),
-                4,
-                settings.shape.min_y as i32,
-                settings.shape.height as i32,
-                (settings.shape.height / settings.shape.vertical_cell_block_count() as u16) as usize,
-            ),
-        );
+        let mut height_sampler =
+            crate::generation::structure::height_sampler::NoiseHeightSampler::new(
+                generator,
+                self.start_block_x(),
+                self.start_block_z(),
+            );
 
         for (i, set) in StructureSet::ALL.iter().enumerate() {
             let allowed_biomes = &generator.structure_allowed_biomes[&i];
@@ -1292,7 +1302,7 @@ impl ProtoChunk {
         sea_level: i32,
         entry: &WeightedEntry,
         random_config: &GlobalRandomConfig,
-        height_sampler: &mut crate::generation::noise::router::surface_height_sampler::SurfaceHeightEstimateSampler<'_>,
+        height_sampler: &mut dyn crate::generation::structure::structures::HeightSampler,
     ) -> bool {
         let structure = Structure::get(&entry.structure);
         let position = try_generate_structure(
@@ -1320,6 +1330,7 @@ impl ProtoChunk {
         let dimension = &generator.dimension;
         let noise_router = &generator.base_router;
         let global_cache = &generator.global_structure_cache;
+        let calculator = &generator.structure_calculator;
 
         let start_x = chunk_pos::start_block_x(self.x);
         let start_z = chunk_pos::start_block_z(self.z);
@@ -1346,24 +1357,17 @@ impl ProtoChunk {
         let mut multi_noise_sampler =
             MultiNoiseSampler::generate(&noise_router.multi_noise, &multi_noise_config);
 
-        let mut height_sampler = crate::generation::noise::router::surface_height_sampler::SurfaceHeightEstimateSampler::generate(
-            &noise_router.surface_estimator,
-            &crate::generation::noise::router::surface_height_sampler::SurfaceHeightSamplerBuilderOptions::new(
-                crate::generation::biome_coords::from_block(start_x),
-                crate::generation::biome_coords::from_block(start_z),
-                4,
-                settings.shape.min_y as i32,
-                settings.shape.height as i32,
-                (settings.shape.height / settings.shape.vertical_cell_block_count() as u16) as usize,
-            ),
-        );
+        let mut height_sampler =
+            crate::generation::structure::height_sampler::NoiseHeightSampler::new(
+                generator, start_x, start_z,
+            );
 
         let mut references = Vec::new();
         // Constant across every chunk in the dimension, so hoist it out of the loop
         // and out of the (cached) structure-start computation below.
         let chunk_min_y = self.bottom_y() as i32;
 
-        for set in StructureSet::ALL {
+        for (set_index, set) in StructureSet::ALL.iter().enumerate() {
             let mut candidate_chunks = Vec::new();
 
             match &set.placement.placement_type {
@@ -1402,6 +1406,18 @@ impl ProtoChunk {
             }
 
             for (candidate_chunk_x, candidate_chunk_z) in candidate_chunks {
+                if !should_generate_structure(
+                    &set.placement,
+                    calculator,
+                    candidate_chunk_x,
+                    candidate_chunk_z,
+                    global_cache,
+                    self,
+                    &generator.structure_allowed_biomes[&set_index],
+                ) {
+                    continue;
+                }
+
                 if (candidate_chunk_x - self.x).abs() <= 8
                     && (candidate_chunk_z - self.z).abs() <= 8
                 {

--- a/pumpkin-world/src/generation/structure/height_sampler.rs
+++ b/pumpkin-world/src/generation/structure/height_sampler.rs
@@ -1,0 +1,123 @@
+use pumpkin_data::Block;
+use pumpkin_util::math::floor_div;
+use rustc_hash::FxHashMap;
+
+use crate::generation::{
+    biome_coords,
+    generator::VanillaGenerator,
+    noise::{
+        ChunkNoiseGenerator,
+        aquifer_sampler::FluidLevel,
+        router::surface_height_sampler::{
+            SurfaceHeightEstimateSampler, SurfaceHeightSamplerBuilderOptions,
+        },
+    },
+    proto_chunk::StandardChunkFluidLevelSampler,
+};
+
+use super::structures::HeightSampler;
+
+pub struct NoiseHeightSampler<'a> {
+    generator: &'a VanillaGenerator,
+    preliminary: SurfaceHeightEstimateSampler<'a>,
+    heights: FxHashMap<(i32, i32), i32>,
+}
+
+impl<'a> NoiseHeightSampler<'a> {
+    pub fn new(generator: &'a VanillaGenerator, start_x: i32, start_z: i32) -> Self {
+        let shape = &generator.settings.shape;
+        let horizontal_biome_end = biome_coords::from_block(16) as usize;
+        let preliminary = SurfaceHeightEstimateSampler::generate(
+            &generator.base_router.surface_estimator,
+            &SurfaceHeightSamplerBuilderOptions::new(
+                biome_coords::from_block(start_x),
+                biome_coords::from_block(start_z),
+                horizontal_biome_end,
+                i32::from(shape.min_y),
+                i32::from(shape.max_y()),
+                shape.vertical_cell_block_count() as usize,
+            ),
+        );
+        Self {
+            generator,
+            preliminary,
+            heights: FxHashMap::default(),
+        }
+    }
+
+    fn sample_column(&mut self, x: i32, z: i32) -> i32 {
+        let settings = self.generator.settings;
+        let shape = &settings.shape;
+        let horizontal = i32::from(shape.horizontal_cell_block_count());
+        let vertical = i32::from(shape.vertical_cell_block_count());
+        let start_x = floor_div(x, horizontal) * horizontal;
+        let start_z = floor_div(z, horizontal) * horizontal;
+        let local_x = x.rem_euclid(horizontal);
+        let local_z = z.rem_euclid(horizontal);
+        let fluid_sampler = StandardChunkFluidLevelSampler::new(
+            FluidLevel::new(
+                settings.sea_level,
+                Block::from_state_id(settings.default_fluid.id),
+            ),
+            FluidLevel::new(-54, &Block::LAVA),
+        );
+        let mut noise = ChunkNoiseGenerator::new(
+            &self.generator.base_router.noise,
+            &self.generator.random_config,
+            1,
+            start_x,
+            start_z,
+            shape,
+            fluid_sampler,
+            settings.aquifers_enabled,
+            false,
+            Vec::new(),
+            Vec::new(),
+            None,
+        );
+
+        noise.sample_start_density();
+        noise.sample_end_density(0);
+        let minimum_cell_y = floor_div(i32::from(noise.min_y()), vertical);
+        let cell_count = i32::from(noise.height()) / vertical;
+        for cell_y in (0..cell_count).rev() {
+            noise.on_sampled_cell_corners(0, cell_y, 0);
+            let sample_start_y = (minimum_cell_y + cell_y) * vertical;
+            for local_y in (0..vertical).rev() {
+                let y = sample_start_y + local_y;
+                noise.interpolate_y(f64::from(local_y) / f64::from(vertical));
+                noise.interpolate_x(f64::from(local_x) / f64::from(horizontal));
+                noise.interpolate_z(f64::from(local_z) / f64::from(horizontal));
+                let state = noise
+                    .sample_block_state(
+                        &self.generator.random_config.ore_random_deriver,
+                        start_x,
+                        sample_start_y,
+                        start_z,
+                        local_x,
+                        local_y,
+                        local_z,
+                        &mut self.preliminary,
+                    )
+                    .unwrap_or(self.generator.default_block);
+                if !state.is_air() {
+                    return y + 1;
+                }
+            }
+        }
+
+        i32::from(shape.min_y)
+    }
+}
+
+impl HeightSampler for NoiseHeightSampler<'_> {
+    fn estimate_height(&mut self, block_x: i32, block_z: i32) -> i32 {
+        let key = (block_x, block_z);
+        if let Some(height) = self.heights.get(&key) {
+            return *height;
+        }
+        let height = self.sample_column(block_x, block_z);
+        self.heights.insert(key, height);
+        height
+    }
+}

--- a/pumpkin-world/src/generation/structure/mod.rs
+++ b/pumpkin-world/src/generation/structure/mod.rs
@@ -23,6 +23,7 @@ use crate::{
     },
 };
 
+pub(crate) mod height_sampler;
 pub mod piece;
 pub mod placement;
 pub mod shiftable_piece;
@@ -93,6 +94,9 @@ pub fn try_generate_structure(
                     .expect("Jigsaw structure must have a start pool"),
                 structure.size.expect("Jigsaw structure must have a size"),
             );
+            if *key == StructureKeys::PillagerOutpost {
+                generator = generator.with_expansion_hack(true);
+            }
             if let Some(start_jigsaw_name) = structure.start_jigsaw_name {
                 generator = generator.with_start_jigsaw(start_jigsaw_name);
             }
@@ -208,6 +212,9 @@ pub fn lazily_generate_structure(
                     .expect("Jigsaw structure must have a start pool"),
                 structure.size.expect("Jigsaw structure must have a size"),
             );
+            if *key == StructureKeys::PillagerOutpost {
+                generator = generator.with_expansion_hack(true);
+            }
             if let Some(start_jigsaw_name) = structure.start_jigsaw_name {
                 generator = generator.with_start_jigsaw(start_jigsaw_name);
             }

--- a/pumpkin-world/src/generation/structure/placement.rs
+++ b/pumpkin-world/src/generation/structure/placement.rs
@@ -1,6 +1,7 @@
 use pumpkin_data::structures::{
     ConcentricRingsStructurePlacement, FrequencyReductionMethod, RandomSpreadStructurePlacement,
     SpreadType, StructurePlacement, StructurePlacementCalculator, StructurePlacementType,
+    StructureSet,
 };
 use pumpkin_util::{
     math::floor_div,
@@ -199,7 +200,28 @@ pub fn should_generate_structure(
         chunk_z,
         placement.salt,
         placement.frequency.unwrap_or(1.0),
-    )
+    ) && !placement.exclusion_zone.as_ref().is_some_and(|zone| {
+        let set_name = zone
+            .other_set
+            .strip_prefix("minecraft:")
+            .unwrap_or(zone.other_set);
+        StructureSet::get(set_name).is_some_and(|set| {
+            let allowed_biomes = ProtoChunk::get_allowed_biomes(set);
+            (chunk_x - zone.chunk_count..=chunk_x + zone.chunk_count).any(|x| {
+                (chunk_z - zone.chunk_count..=chunk_z + zone.chunk_count).any(|z| {
+                    should_generate_structure(
+                        &set.placement,
+                        calculator,
+                        x,
+                        z,
+                        global_cache,
+                        biome_supplier,
+                        &allowed_biomes,
+                    )
+                })
+            })
+        })
+    })
 }
 
 fn apply_frequency_reduction(
@@ -235,8 +257,7 @@ fn should_generate_frequency(
         FrequencyReductionMethod::LegacyType1 => {
             let x = chunk_x >> 4;
             let z = chunk_z >> 4;
-            let mut random =
-                RandomGenerator::Xoroshiro(Xoroshiro::from_seed((x ^ z << 4) as u64 ^ seed as u64));
+            let mut random = LegacyRand::from_seed((i64::from(x ^ (z << 4)) ^ seed) as u64);
             random.next_i32();
             random.next_bounded_i32((1.0 / frequency) as i32) == 0
         }
@@ -331,12 +352,25 @@ fn is_start_chunk_random_spread(
 }
 #[cfg(test)]
 mod tests {
-    use pumpkin_data::structures::RandomSpreadStructurePlacement;
+    use pumpkin_data::{
+        dimension::Dimension,
+        structures::{RandomSpreadStructurePlacement, StructurePlacementCalculator, StructureSet},
+    };
     use pumpkin_util::random::{
         RandomGenerator, RandomImpl, get_region_seed, legacy_rand::LegacyRand,
     };
+    use pumpkin_util::world_seed::Seed;
 
-    use crate::generation::structure::placement::get_start_chunk_random_spread;
+    use crate::{
+        ProtoChunk,
+        generation::{
+            get_world_gen,
+            structure::placement::{
+                GlobalStructureCache, apply_frequency_reduction, get_start_chunk_random_spread,
+                is_start_chunk, should_generate_structure,
+            },
+        },
+    };
 
     #[test]
     fn get_start_chunk_random() {
@@ -355,5 +389,65 @@ mod tests {
         let (x, z) = get_start_chunk_random_spread(&random, 123, 1, 1, 14357620);
         assert_eq!(x, 5);
         assert_eq!(z, 4);
+    }
+
+    #[test]
+    fn pillager_outposts_respect_the_village_exclusion_zone() {
+        let seed = 0;
+        let calculator = StructurePlacementCalculator::new(seed);
+        let cache = GlobalStructureCache::new();
+        let generator = get_world_gen(
+            Seed(seed as u64),
+            Dimension::OVERWORLD,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+        let chunk = ProtoChunk::new(0, 0, &generator);
+        let outposts = &StructureSet::PILLAGER_OUTPOSTS;
+        let villages = &StructureSet::VILLAGES;
+        let excluded = (-1002, -595);
+        assert!(is_start_chunk(
+            &outposts.placement.placement_type,
+            &calculator,
+            excluded.0,
+            excluded.1,
+            outposts.placement.salt,
+            &cache,
+            &chunk,
+            &[],
+        ));
+        assert!(apply_frequency_reduction(
+            outposts.placement.frequency_reduction_method,
+            seed,
+            excluded.0,
+            excluded.1,
+            outposts.placement.salt,
+            outposts.placement.frequency.unwrap(),
+        ));
+        assert!((-10..=10).any(|dx| {
+            (-10..=10).any(|dz| {
+                is_start_chunk(
+                    &villages.placement.placement_type,
+                    &calculator,
+                    excluded.0 + dx,
+                    excluded.1 + dz,
+                    villages.placement.salt,
+                    &cache,
+                    &chunk,
+                    &[],
+                )
+            })
+        }));
+
+        assert!(!should_generate_structure(
+            &outposts.placement,
+            &calculator,
+            excluded.0,
+            excluded.1,
+            &cache,
+            &chunk,
+            &[],
+        ));
     }
 }

--- a/pumpkin-world/src/generation/structure/structures/jigsaw.rs
+++ b/pumpkin-world/src/generation/structure/structures/jigsaw.rs
@@ -38,6 +38,7 @@ pub enum PoolElementKind {
     Single {
         template: String,
         processors: ProcessorListRef,
+        legacy: bool,
     },
     List(Vec<Self>),
     Feature(pumpkin_data::placed_feature::PlacedFeature),
@@ -67,11 +68,14 @@ struct RawWeightedPoolElement {
 enum RawPoolElement {
     #[serde(rename = "minecraft:empty_pool_element")]
     Empty,
-    #[serde(
-        rename = "minecraft:single_pool_element",
-        alias = "minecraft:legacy_single_pool_element"
-    )]
+    #[serde(rename = "minecraft:single_pool_element")]
     Single {
+        location: String,
+        processors: RawProcessorList,
+        projection: RawProjection,
+    },
+    #[serde(rename = "minecraft:legacy_single_pool_element")]
+    LegacySingle {
         location: String,
         processors: RawProcessorList,
         projection: RawProjection,
@@ -112,6 +116,29 @@ impl From<RawProjection> for JigsawProjection {
 }
 
 impl RawPoolElement {
+    fn single(
+        location: String,
+        processors: RawProcessorList,
+        projection: RawProjection,
+        legacy: bool,
+    ) -> (PoolElementKind, JigsawProjection) {
+        let processors = match processors {
+            RawProcessorList::Named(name) => ProcessorListRef::Named(name),
+            RawProcessorList::Inline { processors } => {
+                debug_assert!(processors.is_empty());
+                ProcessorListRef::Empty
+            }
+        };
+        (
+            PoolElementKind::Single {
+                template: location,
+                processors,
+                legacy,
+            },
+            projection.into(),
+        )
+    }
+
     fn into_element(self) -> Option<(PoolElementKind, JigsawProjection)> {
         match self {
             Self::Empty => Some((PoolElementKind::Empty, JigsawProjection::Rigid)),
@@ -119,22 +146,12 @@ impl RawPoolElement {
                 location,
                 processors,
                 projection,
-            } => {
-                let processors = match processors {
-                    RawProcessorList::Named(name) => ProcessorListRef::Named(name),
-                    RawProcessorList::Inline { processors } => {
-                        debug_assert!(processors.is_empty());
-                        ProcessorListRef::Empty
-                    }
-                };
-                Some((
-                    PoolElementKind::Single {
-                        template: location,
-                        processors,
-                    },
-                    projection.into(),
-                ))
-            }
+            } => Some(Self::single(location, processors, projection, false)),
+            Self::LegacySingle {
+                location,
+                processors,
+                projection,
+            } => Some(Self::single(location, processors, projection, true)),
             Self::List {
                 elements,
                 projection,
@@ -181,21 +198,22 @@ impl PoolElement {
 
     pub fn for_each_template(
         &self,
-        mut consumer: impl FnMut(&str, &ProcessorListRef, Arc<StructureTemplate>),
+        mut consumer: impl FnMut(&str, &ProcessorListRef, bool, Arc<StructureTemplate>),
     ) {
         fn visit(
             kind: &PoolElementKind,
-            consumer: &mut impl FnMut(&str, &ProcessorListRef, Arc<StructureTemplate>),
+            consumer: &mut impl FnMut(&str, &ProcessorListRef, bool, Arc<StructureTemplate>),
         ) {
             match kind {
                 PoolElementKind::Single {
                     template,
                     processors,
+                    legacy,
                 } => {
                     if let Some(structure_template) =
                         crate::generation::structure::template::get_template(template)
                     {
-                        consumer(template, processors, structure_template);
+                        consumer(template, processors, *legacy, structure_template);
                     }
                 }
                 PoolElementKind::List(elements) => {
@@ -302,6 +320,7 @@ impl TemplatePool {
                         kind: PoolElementKind::Single {
                             template: (*e).to_string(),
                             processors: ProcessorListRef::Empty,
+                            legacy: false,
                         },
                     })
                     .collect(),
@@ -476,7 +495,16 @@ impl StructurePieceBase for PoolElementStructurePiece {
             pumpkin_util::math::vector3::Vector3::new(self.pos.0.x, self.pos.0.y, self.pos.0.z);
 
         self.element
-            .for_each_template(|_name, processor_list, template| {
+            .for_each_template(|name, processor_list, legacy, template| {
+                let corner = self.rotation.rotate_offset(
+                    template.size.x.saturating_sub(1),
+                    template.size.z.saturating_sub(1),
+                );
+                let placement_origin = pumpkin_util::math::vector3::Vector3::new(
+                    origin.x + corner.0.min(0),
+                    origin.y,
+                    origin.z + corner.1.min(0),
+                );
                 let processors = match processor_list {
                     ProcessorListRef::Named(name) => {
                         crate::generation::structure::template::processor::load_processor_list(name)
@@ -486,14 +514,23 @@ impl StructurePieceBase for PoolElementStructurePiece {
                 crate::generation::structure::template::place_template(
                     chunk,
                     &template,
-                    origin,
+                    placement_origin,
                     (0, 0),
                     self.rotation,
-                    false,
+                    legacy,
                     self.liquid_settings == LiquidSettings::ApplyWaterlog,
                     processors.as_ref(),
                     Some(chunk_box),
                 );
+                if name.starts_with("minecraft:pillager_outpost/") {
+                    crate::generation::structure::template::place_template_entities(
+                        chunk,
+                        &template,
+                        placement_origin,
+                        self.rotation,
+                        chunk_box,
+                    );
+                }
             });
 
         if let Some(feature) = self.element.feature()
@@ -633,6 +670,12 @@ mod tests {
             );
             assert_eq!(pool.fallback, "minecraft:empty", "{id}");
         }
+
+        let base = TemplatePool::discover("minecraft:pillager_outpost/base_plates").unwrap();
+        assert!(matches!(
+            &base.elements[0].kind,
+            PoolElementKind::Single { legacy: true, .. }
+        ));
     }
 
     #[test]
@@ -714,5 +757,135 @@ mod tests {
             collector.pieces.len()
         );
         assert_eq!(position.start_pos.0.y, -27);
+    }
+
+    #[test]
+    fn pillager_outpost_pools_match_vanilla() {
+        let expected = [
+            ("minecraft:pillager_outpost/base_plates", 1, 1),
+            ("minecraft:pillager_outpost/towers", 1, 1),
+            ("minecraft:pillager_outpost/feature_plates", 1, 1),
+            ("minecraft:pillager_outpost/features", 8, 13),
+        ];
+
+        for (id, element_count, total_weight) in expected {
+            let pool = TemplatePool::discover(id).unwrap_or_else(|| panic!("missing pool {id}"));
+            assert_eq!(pool.elements.len(), element_count, "{id}");
+            assert_eq!(
+                pool.elements
+                    .iter()
+                    .map(|element| element.weight)
+                    .sum::<u32>(),
+                total_weight,
+                "{id}"
+            );
+            assert_eq!(pool.fallback, "minecraft:empty", "{id}");
+        }
+    }
+
+    #[test]
+    fn pillager_outpost_templates_and_caged_mobs_are_embedded() {
+        for template in [
+            "base_plate",
+            "watchtower",
+            "watchtower_overgrown",
+            "feature_plate",
+            "feature_cage1",
+            "feature_cage2",
+            "feature_cage_with_allays",
+            "feature_logs",
+            "feature_tent1",
+            "feature_tent2",
+            "feature_targets",
+        ] {
+            let id = format!("minecraft:pillager_outpost/{template}");
+            assert!(
+                crate::generation::structure::template::get_template(&id).is_some(),
+                "missing template {id}"
+            );
+        }
+
+        let cage = crate::generation::structure::template::get_template(
+            "minecraft:pillager_outpost/feature_cage1",
+        )
+        .unwrap();
+        assert_eq!(cage.entities.len(), 1);
+        assert_eq!(
+            cage.entities[0].nbt.get_string("id"),
+            Some("minecraft:iron_golem")
+        );
+
+        let allay_cage = crate::generation::structure::template::get_template(
+            "minecraft:pillager_outpost/feature_cage_with_allays",
+        )
+        .unwrap();
+        assert_eq!(allay_cage.entities.len(), 2);
+        assert!(
+            allay_cage
+                .entities
+                .iter()
+                .all(|entity| entity.nbt.get_string("id") == Some("minecraft:allay"))
+        );
+    }
+
+    #[test]
+    fn pillager_outpost_builds_the_vanilla_jigsaw_graph() {
+        const SEED: i64 = 1_782_124_772_053_846_960;
+        let world_gen = crate::generation::get_world_gen(
+            pumpkin_util::world_seed::Seed(SEED as u64),
+            pumpkin_data::dimension::Dimension::OVERWORLD,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+        let crate::generation::generator::WorldGenerator::Noise(world_gen) = world_gen.as_ref()
+        else {
+            unreachable!()
+        };
+        let mut height_sampler =
+            crate::generation::structure::height_sampler::NoiseHeightSampler::new(
+                world_gen, 1200, -1312,
+            );
+        let generator = JigsawGenerator::new("minecraft:pillager_outpost/base_plates", 7)
+            .with_expansion_hack(true);
+        let context = StructureGeneratorContext {
+            seed: SEED,
+            chunk_x: 75,
+            chunk_z: -82,
+            random: super::super::create_chunk_random(SEED, 75, -82),
+            sea_level: 63,
+            min_y: -64,
+            height_sampler: Some(&mut height_sampler),
+            structure_key: Some(pumpkin_data::structures::StructureKeys::PillagerOutpost),
+        };
+
+        let position = generator
+            .get_structure_position(context)
+            .expect("pillager outpost graph should generate");
+        let mut collector = position.collector.lock().unwrap();
+        let mut feature_plates = 0;
+        let mut allay_cages = 0;
+        for piece in &collector.pieces {
+            let piece = piece
+                .as_any()
+                .downcast_ref::<PoolElementStructurePiece>()
+                .unwrap();
+            piece.element.for_each_template(|name, _, _, _| {
+                feature_plates += usize::from(name.ends_with("/feature_plate"));
+                allay_cages += usize::from(name.ends_with("/feature_cage_with_allays"));
+            });
+        }
+        assert_eq!(feature_plates, 3);
+        assert_eq!(allay_cages, 2);
+        assert_eq!(position.start_pos.0.y, 69);
+        let bounding_box = collector.get_bounding_box();
+        assert_eq!(
+            (bounding_box.min.x, bounding_box.min.y, bounding_box.min.z),
+            (1169, 68, -1343)
+        );
+        assert_eq!(
+            (bounding_box.max.x, bounding_box.max.y, bounding_box.max.z),
+            (1216, 97, -1296)
+        );
     }
 }

--- a/pumpkin-world/src/generation/structure/structures/jigsaw_placement.rs
+++ b/pumpkin-world/src/generation/structure/structures/jigsaw_placement.rs
@@ -6,6 +6,7 @@ use crate::generation::structure::{
 };
 use pumpkin_util::math::block_box::BlockBox;
 use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::random::RandomImpl;
 use std::collections::BinaryHeap;
 use std::sync::Arc;
@@ -87,10 +88,9 @@ impl JigsawPlacement {
 
         let actual_start_pool_id = pool_alias_lookup.lookup(start_pool_id);
         let pool = TemplatePool::discover(actual_start_pool_id)?;
+        let rotation = Rotation::from_index(context.random.next_bounded_i32(4) as u8);
         let element = pool.get_random_element(&mut context.random).clone();
         let template = element.first_template()?;
-
-        let rotation = Rotation::from_index(context.random.next_bounded_i32(4) as u8);
 
         let mut anchored_position = position;
         if let Some(target_jigsaw_id) = start_jigsaw {
@@ -98,7 +98,7 @@ impl JigsawPlacement {
             let jigsaws = get_jigsaw_blocks(&template);
             for jigsaw in jigsaws {
                 if jigsaw.name == target_jigsaw_id {
-                    let rotated_pos = rotation.transform_pos(jigsaw.pos.0, template.size);
+                    let rotated_pos = rotate_pos(jigsaw.pos.0, rotation);
                     found_anchor = Some(position.add(rotated_pos.x, rotated_pos.y, rotated_pos.z));
                     break;
                 }
@@ -113,33 +113,26 @@ impl JigsawPlacement {
         let local_anchor_position = anchored_position.0.sub(&position.0);
         let adjusted_position = BlockPos(position.0.sub(&local_anchor_position));
 
-        let rotated_size = rotation.transform_size(template.size);
-        let mut box_ = BlockBox::new(
-            adjusted_position.0.x,
-            adjusted_position.0.y,
-            adjusted_position.0.z,
-            adjusted_position.0.x + rotated_size.x - 1,
-            adjusted_position.0.y + rotated_size.y - 1,
-            adjusted_position.0.z + rotated_size.z - 1,
-        );
+        let mut box_ = rotated_box(adjusted_position, template.size, rotation);
 
         let center_x = i32::midpoint(box_.max.x, box_.min.x);
         let center_z = i32::midpoint(box_.max.z, box_.min.z);
 
         let bottom_y = if project_start_to_heightmap {
-            if let Some(sampler) = &mut context.height_sampler {
-                sampler
-                    .estimate_height(center_x, center_z)
-                    .max(context.sea_level)
-            } else {
-                adjusted_position.0.y
-            }
+            context
+                .height_sampler
+                .as_mut()
+                .map_or(adjusted_position.0.y, |sampler| {
+                    sampler.estimate_height(center_x, center_z)
+                })
         } else {
             adjusted_position.0.y
         };
 
-        let old_min_y = box_.min.y;
-        box_.move_pos(0, bottom_y - old_min_y, 0);
+        let ground_level_delta = 1;
+        let y_offset = bottom_y - (box_.min.y + ground_level_delta);
+        box_.move_pos(0, y_offset, 0);
+        let piece_pos = adjusted_position.add(0, y_offset, 0);
 
         if box_.min.y < context.min_y + dimension_padding.bottom
             || box_.max.y > context.min_y + 320 - dimension_padding.top
@@ -165,12 +158,8 @@ impl JigsawPlacement {
             if let Some(mut jigsaw) =
                 JigsawBlock::from_template_block(block, &template.palette[block.state as usize])
             {
-                let rotated_pos = rotation.transform_pos(jigsaw.pos.0, template.size);
-                jigsaw.pos = BlockPos(rotated_pos).add(
-                    adjusted_position.0.x,
-                    bottom_y,
-                    adjusted_position.0.z,
-                );
+                let rotated_pos = rotate_pos(jigsaw.pos.0, rotation);
+                jigsaw.pos = BlockPos(rotated_pos).add(piece_pos.0.x, piece_pos.0.y, piece_pos.0.z);
                 jigsaw.facing = rotate_direction(jigsaw.facing, rotation);
                 jigsaw.up = rotate_direction(jigsaw.up, rotation);
                 jigsaw_blocks.push(jigsaw);
@@ -184,21 +173,29 @@ impl JigsawPlacement {
                 0,
             ),
             element: element.clone(),
-            pos: BlockPos::new(adjusted_position.0.x, bottom_y, adjusted_position.0.z),
+            pos: piece_pos,
             rotation,
             mirror: Mirror::None,
             jigsaw_blocks,
             junctions: Vec::new(),
-            ground_level_delta: 0,
+            ground_level_delta,
             liquid_settings,
             projection: element.projection,
         });
 
         let mut collector = super::StructurePiecesCollector::new();
         let mut pieces = Vec::new();
+        // The expansion hack enlarges free space for children without changing
+        // the template bounds stored on the resulting structure piece.
+        let mut piece_collision_boxes = Vec::new();
         let mut piece_projections = Vec::new();
+        let mut collision_spaces = vec![CollisionSpace {
+            bounds: global_bounding_box,
+            occupied: vec![box_],
+        }];
 
         pieces.push(first_piece);
+        piece_collision_boxes.push(box_);
         piece_projections.push(element.projection);
 
         if max_depth > 0 {
@@ -210,6 +207,7 @@ impl JigsawPlacement {
                 depth: 0,
                 priority: 0,
                 sequence,
+                collision_space: 0,
             });
 
             while let Some(state) = placing.pop() {
@@ -226,8 +224,10 @@ impl JigsawPlacement {
                 source_jigsaws.sort_by_key(|j| std::cmp::Reverse(j.selection_priority));
 
                 let source_box = pieces[source_piece_idx].piece.bounding_box;
+                let source_collision_box = piece_collision_boxes[source_piece_idx];
                 let source_projection = piece_projections[source_piece_idx];
                 let source_rigid = source_projection == JigsawProjection::Rigid;
+                let mut interior_collision_space = None;
 
                 'jigsaw_loop: for source_jigsaw in &source_jigsaws {
                     let raw_pool_id = &source_jigsaw.pool;
@@ -300,7 +300,7 @@ impl JigsawPlacement {
                                 let source_jigsaw_local_y =
                                     source_jigsaw_pos.0.y - source_box.min.y;
                                 let target_jigsaw_local_pos =
-                                    target_rotation.transform_pos(target_jigsaw.pos.0, target_size);
+                                    rotate_pos(target_jigsaw.pos.0, target_rotation);
                                 let target_jigsaw_local_y = target_jigsaw_local_pos.y;
 
                                 let delta_y = source_jigsaw_local_y - target_jigsaw_local_y
@@ -313,20 +313,15 @@ impl JigsawPlacement {
                                     target_box_y = source_box.min.y + delta_y;
                                 } else {
                                     if source_jigsaw_base_height == i32::MIN {
-                                        source_jigsaw_base_height =
-                                            if let Some(sampler) = &mut context.height_sampler {
-                                                let height = sampler.estimate_height(
+                                        source_jigsaw_base_height = context
+                                            .height_sampler
+                                            .as_mut()
+                                            .map_or(source_jigsaw_pos.0.y, |sampler| {
+                                                sampler.estimate_height(
                                                     source_jigsaw_pos.0.x,
                                                     source_jigsaw_pos.0.z,
-                                                );
-                                                if project_start_to_heightmap {
-                                                    height.max(context.sea_level)
-                                                } else {
-                                                    height
-                                                }
-                                            } else {
-                                                source_jigsaw_pos.0.y
-                                            };
+                                                )
+                                            });
                                     }
                                     target_box_y =
                                         source_jigsaw_base_height - target_jigsaw_local_y;
@@ -342,16 +337,9 @@ impl JigsawPlacement {
                                 let mut target_pos = raw_target_pos;
                                 target_pos.0.y += y_offset;
 
-                                let rotated_target_size =
-                                    target_rotation.transform_size(target_size);
-                                let mut target_box = BlockBox::new(
-                                    target_pos.0.x,
-                                    target_pos.0.y,
-                                    target_pos.0.z,
-                                    target_pos.0.x + rotated_target_size.x - 1,
-                                    target_pos.0.y + rotated_target_size.y - 1,
-                                    target_pos.0.z + rotated_target_size.z - 1,
-                                );
+                                let target_box =
+                                    rotated_box(target_pos, target_size, target_rotation);
+                                let mut target_collision_box = target_box;
 
                                 let mut expand_to = 0;
                                 if do_expansion_hack
@@ -360,20 +348,14 @@ impl JigsawPlacement {
                                     for tj in &target_jigsaws {
                                         let tj_facing =
                                             rotate_direction(tj.facing, target_rotation);
-                                        let rotated_tj_pos =
-                                            target_rotation.transform_pos(tj.pos.0, target_size);
+                                        let rotated_tj_pos = rotate_pos(tj.pos.0, target_rotation);
                                         let rotated_tj_target_pos =
                                             rotated_tj_pos.add(&tj_facing.to_vector());
 
-                                        let rotated_size =
-                                            target_rotation.transform_size(target_size);
-                                        let hack_box = BlockBox::new(
-                                            0,
-                                            0,
-                                            0,
-                                            rotated_size.x - 1,
-                                            rotated_size.y - 1,
-                                            rotated_size.z - 1,
+                                        let hack_box = rotated_box(
+                                            BlockPos::new(0, 0, 0),
+                                            target_size,
+                                            target_rotation,
                                         );
 
                                         if hack_box.contains(
@@ -403,20 +385,42 @@ impl JigsawPlacement {
                                 }
 
                                 if expand_to > 0 {
-                                    let new_size = (expand_to + 1)
-                                        .max(target_box.max.y - target_box.min.y + 1);
-                                    target_box.max.y = target_box.min.y + new_size - 1;
+                                    let max_y_offset = (expand_to + 1).max(
+                                        target_collision_box.max.y - target_collision_box.min.y,
+                                    );
+                                    target_collision_box.max.y =
+                                        target_collision_box.min.y + max_y_offset;
                                 }
 
-                                if !is_box_inside(&global_bounding_box, &target_box) {
-                                    continue;
-                                }
+                                let collision_space = if source_collision_box.contains(
+                                    target_jigsaw_pos.0.x,
+                                    target_jigsaw_pos.0.y,
+                                    target_jigsaw_pos.0.z,
+                                ) {
+                                    *interior_collision_space.get_or_insert_with(|| {
+                                        collision_spaces.push(CollisionSpace {
+                                            bounds: source_collision_box,
+                                            occupied: Vec::new(),
+                                        });
+                                        collision_spaces.len() - 1
+                                    })
+                                } else {
+                                    state.collision_space
+                                };
+                                let space = &collision_spaces[collision_space];
+                                let can_place = is_box_inside(&space.bounds, &target_collision_box)
+                                    && !space
+                                        .occupied
+                                        .iter()
+                                        .any(|box_| boxes_intersect(box_, &target_collision_box));
 
-                                if !intersects_any(&pieces, &target_box) {
+                                if can_place {
+                                    collision_spaces[collision_space]
+                                        .occupied
+                                        .push(target_collision_box);
                                     let mut child_jigsaw_blocks = Vec::new();
                                     for mut cj in get_element_jigsaw_blocks(&element) {
-                                        let rotated_pos =
-                                            target_rotation.transform_pos(cj.pos.0, target_size);
+                                        let rotated_pos = rotate_pos(cj.pos.0, target_rotation);
                                         cj.pos = BlockPos(rotated_pos).add(
                                             target_pos.0.x,
                                             target_pos.0.y,
@@ -432,7 +436,7 @@ impl JigsawPlacement {
                                     let target_ground_level_delta = if target_rigid {
                                         source_ground_level_delta - delta_y
                                     } else {
-                                        0
+                                        1
                                     };
 
                                     let target_piece = Box::new(PoolElementStructurePiece {
@@ -454,6 +458,7 @@ impl JigsawPlacement {
 
                                     let target_piece_idx = pieces.len();
                                     pieces.push(target_piece);
+                                    piece_collision_boxes.push(target_collision_box);
                                     piece_projections.push(target_projection);
 
                                     let junction_y = if source_rigid {
@@ -462,21 +467,15 @@ impl JigsawPlacement {
                                         target_box_y + target_jigsaw_local_y
                                     } else {
                                         if source_jigsaw_base_height == i32::MIN {
-                                            source_jigsaw_base_height = if let Some(sampler) =
-                                                &mut context.height_sampler
-                                            {
-                                                let height = sampler.estimate_height(
-                                                    source_jigsaw_pos.0.x,
-                                                    source_jigsaw_pos.0.z,
-                                                );
-                                                if project_start_to_heightmap {
-                                                    height.max(context.sea_level)
-                                                } else {
-                                                    height
-                                                }
-                                            } else {
-                                                source_jigsaw_pos.0.y
-                                            };
+                                            source_jigsaw_base_height = context
+                                                .height_sampler
+                                                .as_mut()
+                                                .map_or(source_jigsaw_pos.0.y, |sampler| {
+                                                    sampler.estimate_height(
+                                                        source_jigsaw_pos.0.x,
+                                                        source_jigsaw_pos.0.z,
+                                                    )
+                                                });
                                         }
                                         source_jigsaw_base_height + delta_y / 2
                                     };
@@ -505,6 +504,7 @@ impl JigsawPlacement {
                                             depth: depth + 1,
                                             priority: source_jigsaw.placement_priority,
                                             sequence,
+                                            collision_space,
                                         });
                                     }
 
@@ -556,21 +556,20 @@ const fn is_box_inside(outer: &BlockBox, inner: &BlockBox) -> bool {
         && inner.max.z <= outer.max.z
 }
 
-const fn intersects_exclusive(a: &BlockBox, b: &BlockBox) -> bool {
-    // Strictly greater/less than checks perfectly emulate Vanilla's AABB deflate(0.25)
-    // by completely ignoring touching boundaries where coords are equal.
-    a.max.x > b.min.x
-        && a.min.x < b.max.x
-        && a.max.y > b.min.y
-        && a.min.y < b.max.y
-        && a.max.z > b.min.z
-        && a.min.z < b.max.z
+const fn boxes_intersect(a: &BlockBox, b: &BlockBox) -> bool {
+    // Vanilla turns inclusive block boxes into AABBs, then deflates the candidate by 0.25.
+    // Two integer boxes therefore collide exactly when they share at least one block.
+    a.max.x >= b.min.x
+        && a.min.x <= b.max.x
+        && a.max.y >= b.min.y
+        && a.min.y <= b.max.y
+        && a.max.z >= b.min.z
+        && a.min.z <= b.max.z
 }
 
-fn intersects_any(pieces: &[Box<PoolElementStructurePiece>], box_: &BlockBox) -> bool {
-    pieces
-        .iter()
-        .any(|piece| intersects_exclusive(&piece.piece.bounding_box, box_))
+struct CollisionSpace {
+    bounds: BlockBox,
+    occupied: Vec<BlockBox>,
 }
 
 struct PieceState {
@@ -578,6 +577,7 @@ struct PieceState {
     depth: i32,
     priority: i32,
     sequence: usize,
+    collision_space: usize,
 }
 
 impl PartialEq for PieceState {
@@ -612,6 +612,23 @@ fn get_jigsaw_blocks(template: &StructureTemplate) -> Vec<JigsawBlock> {
         }
     }
     jigsaws
+}
+
+const fn rotate_pos(pos: Vector3<i32>, rotation: Rotation) -> Vector3<i32> {
+    let (x, z) = rotation.rotate_offset(pos.x, pos.z);
+    Vector3::new(x, pos.y, z)
+}
+
+fn rotated_box(origin: BlockPos, size: Vector3<i32>, rotation: Rotation) -> BlockBox {
+    let corner = rotate_pos(Vector3::new(size.x - 1, size.y - 1, size.z - 1), rotation);
+    BlockBox::new(
+        origin.0.x.min(origin.0.x + corner.x),
+        origin.0.y,
+        origin.0.z.min(origin.0.z + corner.z),
+        origin.0.x.max(origin.0.x + corner.x),
+        origin.0.y + corner.y,
+        origin.0.z.max(origin.0.z + corner.z),
+    )
 }
 
 fn get_element_size(element: &PoolElement) -> Option<pumpkin_util::math::vector3::Vector3<i32>> {
@@ -697,7 +714,13 @@ const fn rotate_direction(
             BlockDirection::West => BlockDirection::North,
             _ => dir,
         },
-        Rotation::Rotate180 => dir.opposite(),
+        Rotation::Rotate180 => match dir {
+            BlockDirection::North => BlockDirection::South,
+            BlockDirection::South => BlockDirection::North,
+            BlockDirection::West => BlockDirection::East,
+            BlockDirection::East => BlockDirection::West,
+            _ => dir,
+        },
         Rotation::CounterClockwise90 => match dir {
             BlockDirection::North => BlockDirection::West,
             BlockDirection::West => BlockDirection::South,

--- a/pumpkin-world/src/generation/structure/template/mod.rs
+++ b/pumpkin-world/src/generation/structure/template/mod.rs
@@ -32,7 +32,7 @@ mod template_piece;
 
 use pumpkin_data::Mirror;
 use pumpkin_data::Rotation;
-use pumpkin_nbt::compound::NbtCompound;
+use pumpkin_nbt::{compound::NbtCompound, tag::NbtTag};
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::random::{RandomImpl, hash_block_pos, legacy_rand::LegacyRand};
 
@@ -81,11 +81,6 @@ pub fn place_template(
         if palette_entry.name == "minecraft:structure_void"
             || palette_entry.name == "minecraft:structure_block"
         {
-            continue;
-        }
-
-        // Skip air blocks when using IGNORE_AIR processor (e.g. nether fossils)
-        if skip_air && palette_entry.name == "minecraft:air" {
             continue;
         }
 
@@ -157,6 +152,10 @@ pub fn place_template(
         if !should_place {
             continue;
         }
+        // Legacy pool elements ignore air after jigsaw replacement and custom processors.
+        if skip_air && state.id.to_block_id() == pumpkin_data::Block::AIR.id {
+            continue;
+        }
 
         chunk.set_block_state(wx, wy, wz, state);
 
@@ -192,6 +191,71 @@ pub fn place_template(
 
             chunk.add_block_entity(placed_nbt);
         }
+    }
+}
+
+pub(crate) fn place_template_entities(
+    chunk: &mut ProtoChunk,
+    template: &StructureTemplate,
+    origin: Vector3<i32>,
+    rotation: Rotation,
+    chunk_box: &pumpkin_util::math::block_box::BlockBox,
+) {
+    for entity in &template.entities {
+        let block_pos = rotation.transform_pos(entity.block_pos, template.size);
+        let world_block_pos = Vector3::new(
+            origin.x + block_pos.x,
+            origin.y + block_pos.y,
+            origin.z + block_pos.z,
+        );
+        if !chunk_box.contains_pos(&world_block_pos) {
+            continue;
+        }
+
+        let pos = match rotation {
+            Rotation::None => entity.pos,
+            Rotation::Clockwise90 => Vector3::new(
+                f64::from(template.size.z) - entity.pos.z,
+                entity.pos.y,
+                entity.pos.x,
+            ),
+            Rotation::Rotate180 => Vector3::new(
+                f64::from(template.size.x) - entity.pos.x,
+                entity.pos.y,
+                f64::from(template.size.z) - entity.pos.z,
+            ),
+            Rotation::CounterClockwise90 => Vector3::new(
+                entity.pos.z,
+                entity.pos.y,
+                f64::from(template.size.x) - entity.pos.x,
+            ),
+        };
+        let mut nbt = entity.nbt.clone();
+        nbt.put(
+            "Pos",
+            NbtTag::List(vec![
+                (f64::from(origin.x) + pos.x).into(),
+                (f64::from(origin.y) + pos.y).into(),
+                (f64::from(origin.z) + pos.z).into(),
+            ]),
+        );
+        nbt.child_tags.remove("UUID");
+
+        if let Some(rotation_nbt) = nbt.get_list("Rotation")
+            && rotation_nbt.len() == 2
+        {
+            let yaw = rotation_nbt[0].extract_float().unwrap_or_default()
+                + match rotation {
+                    Rotation::None => 0.0,
+                    Rotation::Clockwise90 => 90.0,
+                    Rotation::Rotate180 => 180.0,
+                    Rotation::CounterClockwise90 => 270.0,
+                };
+            let pitch = rotation_nbt[1].extract_float().unwrap_or_default();
+            nbt.put("Rotation", NbtTag::List(vec![yaw.into(), pitch.into()]));
+        }
+
+        chunk.add_structure_entity(nbt);
     }
 }
 

--- a/pumpkin-world/src/generation/structure/template/processor.rs
+++ b/pumpkin-world/src/generation/structure/template/processor.rs
@@ -10,10 +10,16 @@ use crate::ProtoChunk;
 
 #[derive(Clone)]
 pub enum StructureProcessor {
-    BlockRot { integrity: f32, blocks: BlockTag },
+    BlockRot {
+        integrity: f32,
+        blocks: Option<BlockTag>,
+    },
     Rules(Vec<ProcessorRule>),
     ProtectedBlocks(BlockTag),
-    Capped { limit: i32, delegate: Box<Self> },
+    Capped {
+        limit: i32,
+        delegate: Box<Self>,
+    },
 }
 
 #[derive(Clone)]
@@ -84,7 +90,7 @@ impl StructureProcessor {
         let input_block = state.id.to_block_id();
         match self {
             Self::BlockRot { integrity, blocks } => {
-                if !blocks.contains(input_block) {
+                if blocks.is_some_and(|blocks| !blocks.contains(input_block)) {
                     return Some(state);
                 }
                 let mut random = LegacyRand::from_seed(hash_block_pos(pos.x, pos.y, pos.z) as u64);
@@ -119,7 +125,7 @@ enum RawProcessor {
     #[serde(rename = "minecraft:block_rot")]
     BlockRot {
         integrity: f32,
-        rottable_blocks: String,
+        rottable_blocks: Option<String>,
     },
     #[serde(rename = "minecraft:rule")]
     Rule { rules: Vec<RawRule> },
@@ -153,8 +159,16 @@ fn convert_raw_processor(raw: RawProcessor) -> Option<StructureProcessor> {
         RawProcessor::BlockRot {
             integrity,
             rottable_blocks,
-        } => BlockTag::from_name(&rottable_blocks)
-            .map(|blocks| StructureProcessor::BlockRot { integrity, blocks }),
+        } => match rottable_blocks {
+            Some(blocks) => Some(StructureProcessor::BlockRot {
+                integrity,
+                blocks: Some(BlockTag::from_name(&blocks)?),
+            }),
+            None => Some(StructureProcessor::BlockRot {
+                integrity,
+                blocks: None,
+            }),
+        },
         RawProcessor::ProtectedBlocks { value } => {
             BlockTag::from_name(&value).map(StructureProcessor::ProtectedBlocks)
         }
@@ -259,5 +273,17 @@ mod tests {
             load_processor_list("minecraft:trail_ruins_houses_archaeology").len(),
             3
         );
+    }
+
+    #[test]
+    fn parses_outpost_rot_without_a_block_filter() {
+        let processors = load_processor_list("minecraft:outpost_rot");
+        assert!(matches!(
+            processors.as_ref(),
+            [StructureProcessor::BlockRot {
+                integrity,
+                blocks: None,
+            }] if (*integrity - 0.05).abs() < f32::EPSILON
+        ));
     }
 }

--- a/pumpkin-world/src/world.rs
+++ b/pumpkin-world/src/world.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use crate::generation::proto_chunk::GenerationCache;
 use bitflags::bitflags;
 use pumpkin_data::{Block, BlockState, BlockStateId, Mirror, Rotation, chunk::Biome};
+use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::math::position::BlockPos;
 use thiserror::Error;
 
@@ -80,6 +81,8 @@ pub trait WorldPortalExt: Send + Sync {
         chunk_x: i32,
         chunk_z: i32,
     );
+
+    fn spawn_structure_entities(&self, _entities: Vec<NbtCompound>) {}
 }
 
 pub trait BlockAccessor: Send + Sync {

--- a/pumpkin/src/block/entities/jigsaw_block.rs
+++ b/pumpkin/src/block/entities/jigsaw_block.rs
@@ -118,7 +118,7 @@ impl JigsawBlockEntity {
                 let mut templates = Vec::new();
                 pool_piece
                     .element
-                    .for_each_template(|_, _, template| templates.push(template));
+                    .for_each_template(|_, _, _, template| templates.push(template));
 
                 for template in templates {
                     for block in &template.blocks {

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -138,6 +138,7 @@ pub struct Server {
     /// Manages scheduled tasks (e.g. from plugins)
     pub task_scheduler: Arc<TaskScheduler>,
     tasks: TaskTracker,
+    runtime: tokio::runtime::Handle,
 
     // world stuff which maybe should be put into a struct
     pub level_info: Arc<ArcSwap<LevelData>>,
@@ -287,6 +288,7 @@ impl Server {
             aggregated_tick_times_nanos: AtomicI64::new(0),
             tick_count: AtomicI32::new(0),
             tasks: TaskTracker::new(),
+            runtime: tokio::runtime::Handle::current(),
             task_scheduler: Arc::new(TaskScheduler::new()),
             server_guid: rand::random(),
             player_idle_timeout: AtomicI32::new(0),
@@ -391,7 +393,7 @@ impl Server {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        self.tasks.spawn(task)
+        self.tasks.spawn_on(task, &self.runtime)
     }
 
     pub fn get_world_from_dimension(&self, dimension: &Dimension) -> Arc<World> {

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -37,7 +37,7 @@ use crate::{
         {OnNeighborUpdateArgs, OnScheduledTickArgs},
     },
     command::client_suggestions,
-    entity::{Entity, EntityBase, player::Player, r#type::from_type},
+    entity::{Entity, EntityBase, NBTStorage, player::Player, r#type::from_type},
     error::PumpkinError,
     net::{ClientPlatform, java::JavaClient},
     plugin::{
@@ -5454,5 +5454,34 @@ impl WorldPortalExt for WorldPortal {
         chunk_z: i32,
     ) {
         natural_spawner::spawn_mobs_for_chunk_generation(&self.0, cache, biome, chunk_x, chunk_z);
+    }
+
+    fn spawn_structure_entities(&self, entities: Vec<NbtCompound>) {
+        let world = self.0.clone();
+        let Some(server) = world.server.upgrade() else {
+            return;
+        };
+        server.spawn_task(async move {
+            for nbt in entities {
+                let Some(id) = nbt.get_string("id") else {
+                    continue;
+                };
+                let Some(entity_type) =
+                    EntityType::from_name(id.strip_prefix("minecraft:").unwrap_or(id))
+                else {
+                    warn!("Unknown structure entity type: {id}");
+                    continue;
+                };
+                let entity = from_type(
+                    entity_type,
+                    Vector3::new(0.0, 0.0, 0.0),
+                    &world,
+                    Uuid::new_v4(),
+                );
+                entity.get_entity().read_nbt_non_mut(&nbt).await;
+                entity.read_nbt_non_mut(&nbt).await;
+                world.spawn_entity(entity).await;
+            }
+        });
     }
 }


### PR DESCRIPTION
## Description
- This PR adds Pillager Outpost generation, matching vanilla - flaws included like floating scarecrows over ditches.
- Another item off of this list: https://github.com/Pumpkin-MC/Pumpkin/issues/36
- Also includes a scheduler fix without which the server panics and crashes when the player nears a Pillager Outpost.

## Testing
cargo test -p pumpkin-protocol
cargo test -p pumpkin-world bedrock_palette
cargo fmt --all -- --check
- Inspected Pillager outposts in game for the same seed in both vanilla and pumpkin.
