### PR TITLE
fix: restore terminal state when exiting while console input is active

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2653,6 +2653,7 @@ dependencies = [
  "hyper",
  "image",
  "indexmap",
+ "libc",
  "libloading",
  "notify",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ heck = { version = "0.5", default-features = false }
 hmac = { version = "=0.13.0", default-features = false }
 indexmap = { version = "2.14", default-features = false, features = ["std"] }
 itertools = { version = "0.15.0", default-features = false, features = ["use_std"] }
+libc = { version = "0.2", default-features = false, features = ["std"] }
 libloading = { version = "0.9", default-features = false, features = ["std"] }
 lru = { version = "0.18.1", default-features = false }
 lz4-java-wrc = { version = "0.2.0", default-features = false, features = ["lz4_flex"] }

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -113,6 +113,10 @@ image = { version = "0.25.10", default-features = false, features = ["png"] }
 
 indexmap.workspace = true
 
+# Restoring the terminal state on exit (see `src/terminal.rs`)
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true
 

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -48,6 +48,7 @@ pub mod logging;
 pub mod net;
 pub mod plugin;
 pub mod server;
+pub mod terminal;
 pub mod world;
 
 pub struct LoggingConfig {
@@ -98,6 +99,10 @@ pub fn init_logger(advanced_config: &AdvancedConfiguration) {
             Box<dyn std::io::Write + Send + 'static>,
             Option<Editor<PumpkinCommandCompleter, FileHistory>>,
         ) = if advanced_config.commands.use_tty && stdin().is_terminal() {
+            // Save the terminal state before rustyline can switch it to raw
+            // mode, so it can be restored if the server exits while a
+            // `readline` call is still active (e.g. after a panic).
+            terminal::save_original_state();
             let rl_config = Config::builder()
                 .auto_add_history(true)
                 .completion_type(rustyline::CompletionType::List)

--- a/pumpkin/src/terminal.rs
+++ b/pumpkin/src/terminal.rs
@@ -63,8 +63,11 @@ mod imp {
 
 #[cfg(not(unix))]
 mod imp {
-    /// Saving and restoring terminal attributes is only needed on Unix,
-    /// where leaked raw mode outlives the process; this is a no-op here.
+    /// Not implemented on this platform. On Windows, rustyline changes the
+    /// console mode with `SetConsoleMode` and can leak it the same way on an
+    /// abnormal exit; restoring it would need `GetConsoleMode` plus an exit
+    /// hook, which is left for someone who can test it. Every report in
+    /// issue #2441 is from Unix.
     pub const fn save_original_state() {}
 }
 

--- a/pumpkin/src/terminal.rs
+++ b/pumpkin/src/terminal.rs
@@ -1,0 +1,71 @@
+//! Restores the terminal to its original state when the process exits.
+//!
+//! The console thread reads input through `rustyline`, which switches the
+//! terminal into raw mode while a `readline` call is active. `rustyline`
+//! only restores the previous terminal state when that call returns, so if
+//! the process exits while the console thread is still blocked inside
+//! `readline` (for example after a panic in another thread), the terminal
+//! is left in raw mode: typed characters stop echoing until the user runs
+//! `reset`. See <https://github.com/Pumpkin-MC/Pumpkin/issues/2441>.
+//!
+//! To avoid this, the original terminal attributes are saved before the
+//! line editor is created, and an `atexit` handler restores them on any
+//! exit path, including `std::process::exit` from the panic hook.
+
+#[cfg(unix)]
+mod imp {
+    use std::mem::MaybeUninit;
+    use std::sync::OnceLock;
+
+    static ORIGINAL_TERMIOS: OnceLock<Option<libc::termios>> = OnceLock::new();
+
+    extern "C" fn restore_terminal() {
+        if let Some(&Some(original)) = ORIGINAL_TERMIOS.get() {
+            // SAFETY: `original` was produced by a successful `tcgetattr`
+            // call on stdin, so it is a valid `termios` for this stream.
+            unsafe {
+                let _ = libc::tcsetattr(libc::STDIN_FILENO, libc::TCSAFLUSH, &raw const original);
+            }
+        }
+    }
+
+    /// Saves the current terminal attributes of stdin and registers an
+    /// `atexit` handler that restores them when the process exits.
+    ///
+    /// Only the first call has an effect; subsequent calls are no-ops.
+    /// Does nothing if stdin is not a terminal.
+    pub fn save_original_state() {
+        ORIGINAL_TERMIOS.get_or_init(|| {
+            // SAFETY: `isatty` and `tcgetattr` are called with a valid file
+            // descriptor, and the `termios` value is only read after
+            // `tcgetattr` reported success by returning 0.
+            let termios = unsafe {
+                if libc::isatty(libc::STDIN_FILENO) == 0 {
+                    return None;
+                }
+                let mut termios = MaybeUninit::<libc::termios>::uninit();
+                if libc::tcgetattr(libc::STDIN_FILENO, termios.as_mut_ptr()) != 0 {
+                    return None;
+                }
+                termios.assume_init()
+            };
+
+            // SAFETY: `restore_terminal` only performs async-signal-safe
+            // work and is safe to run during process shutdown.
+            unsafe {
+                let _ = libc::atexit(restore_terminal);
+            }
+
+            Some(termios)
+        });
+    }
+}
+
+#[cfg(not(unix))]
+mod imp {
+    /// Saving and restoring terminal attributes is only needed on Unix,
+    /// where leaked raw mode outlives the process; this is a no-op here.
+    pub const fn save_original_state() {}
+}
+
+pub use imp::save_original_state;


### PR DESCRIPTION
## Description

Fixes #2441.

`rustyline` switches the terminal into raw mode while a `readline()` call is active and only restores it when that call returns. If the process exits while the console thread is still blocked inside `readline()` — e.g. after a panic in another thread, where the panic hook ends in `std::process::exit(1)` — the terminal is left in raw mode. Typing in the shell afterwards is invisible until the user runs `reset`, which matches what everyone in #2441 reported (and why running the server again "fixes" it: rustyline saves the already-broken state and restores that).

This PR adds a small `terminal` module (unix-only, no-op on other platforms) that:

- saves the original termios of stdin in `init_logger`, right before the rustyline editor is created (only when stdin is a TTY and `use_tty` is enabled)
- registers a `libc::atexit` handler that restores those attributes on any exit path — `exit(1)` from the panic hook, `exit(code)` from `stop_or_exit_server`, and normal returns. On the graceful `$stop` path rustyline has already restored the state, so the handler is a harmless no-op there.

`libc` is added as a unix-only dependency of the `pumpkin` crate (it is already in the dependency tree transitively).

## Testing

- `cargo clippy -p pumpkin --all-targets` passes with the workspace deny-level lints
- `cargo fmt --check` passes
- The restore runs on every process exit via `atexit`, so the panic-exit path from #2441 is covered by construction; I have not reproduced the original advancement crash end-to-end, so a confirmation from someone who can trigger it would be welcome.