### PR TITLE
fix: reject native plugins with implausible metadata instead of aborting

### DIFF
--- a/pumpkin/src/plugin/loader/mod.rs
+++ b/pumpkin/src/plugin/loader/mod.rs
@@ -42,6 +42,11 @@ pub enum LoaderError {
     #[error("Missing plugin metadata")]
     MetadataMissing,
 
+    #[error(
+        "Plugin metadata appears corrupt (implausible field sizes). The plugin was likely built with a different Rust toolchain or Pumpkin version; please rebuild it against this Pumpkin build."
+    )]
+    MetadataCorrupt,
+
     #[error("Missing plugin entrypoint")]
     EntrypointMissing,
 

--- a/pumpkin/src/plugin/loader/native.rs
+++ b/pumpkin/src/plugin/loader/native.rs
@@ -23,8 +23,20 @@ const MAX_METADATA_LIST_LEN: usize = 1024;
 /// against a different Pumpkin build, the field lengths read here can be
 /// garbage even when the API version check passes, and cloning or logging
 /// such metadata aborts the server with an enormous allocation (see issue
-/// #2434). Only lengths and capacities are inspected here; the potentially
-/// invalid data pointers are never dereferenced.
+/// #2434).
+///
+/// This is a mitigation, not a sound fix: reading a `#[repr(Rust)]` struct
+/// written by a different toolchain is already undefined behaviour, and
+/// checking the strings inside the lists follows the lists' data pointers.
+/// It does not dereference anything that the `metadata.clone()` below would
+/// not dereference anyway, and it bails out earlier: the scalar fields are
+/// checked first and short-circuit, so mismatched metadata is almost always
+/// rejected before any pointer is followed.
+///
+/// The sound fix is to give the metadata a stable representation across the
+/// boundary (C strings or serialized bytes) and to export a build
+/// fingerprint alongside `PUMPKIN_API_VERSION` so a toolchain mismatch is
+/// rejected deterministically.
 fn is_metadata_plausible(metadata: &PluginMetadata) -> bool {
     let text_plausible =
         |text: &String| text.len() <= MAX_METADATA_TEXT_LEN && text.len() <= text.capacity();
@@ -122,6 +134,11 @@ impl PluginLoader for NativePluginLoader {
     }
 }
 
+// These cover only the pure predicate on well-formed values. The actual
+// hazard (a struct whose layout came from another toolchain) cannot be
+// constructed in safe Rust, so the `len <= capacity` conjunct is untestable
+// here. Adding a field to `PluginMetadata` deliberately breaks `valid()`, so
+// that the new field has to be considered in `is_metadata_plausible`.
 #[cfg(test)]
 mod tests {
     use super::{MAX_METADATA_LIST_LEN, MAX_METADATA_TEXT_LEN, is_metadata_plausible};

--- a/pumpkin/src/plugin/loader/native.rs
+++ b/pumpkin/src/plugin/loader/native.rs
@@ -28,8 +28,13 @@ const MAX_METADATA_LIST_LEN: usize = 1024;
 fn is_metadata_plausible(metadata: &PluginMetadata) -> bool {
     let text_plausible =
         |text: &String| text.len() <= MAX_METADATA_TEXT_LEN && text.len() <= text.capacity();
-    let list_plausible =
-        |list: &Vec<String>| list.len() <= MAX_METADATA_LIST_LEN && list.len() <= list.capacity();
+    // The inner strings must be checked too: a list header can look sane
+    // while its elements are garbage, and those elements are cloned as well.
+    let list_plausible = |list: &Vec<String>| {
+        list.len() <= MAX_METADATA_LIST_LEN
+            && list.len() <= list.capacity()
+            && list.iter().all(text_plausible)
+    };
 
     !metadata.name.is_empty()
         && text_plausible(&metadata.name)
@@ -114,5 +119,63 @@ impl PluginLoader for NativePluginLoader {
     /// Windows specific issue: Windows locks DLLs, so we must indicate they cannot be unloaded.
     fn can_unload(&self) -> bool {
         !cfg!(target_os = "windows")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_METADATA_LIST_LEN, MAX_METADATA_TEXT_LEN, is_metadata_plausible};
+    use crate::plugin::PluginMetadata;
+
+    fn valid() -> PluginMetadata {
+        PluginMetadata {
+            name: "example".to_string(),
+            version: "1.0.0".to_string(),
+            authors: vec!["someone".to_string()],
+            description: "an example plugin".to_string(),
+            dependencies: Vec::new(),
+            permissions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn accepts_normal_metadata() {
+        assert!(is_metadata_plausible(&valid()));
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        let mut metadata = valid();
+        metadata.name = String::new();
+        assert!(!is_metadata_plausible(&metadata));
+    }
+
+    #[test]
+    fn rejects_oversized_text_field() {
+        let mut metadata = valid();
+        metadata.description = "x".repeat(MAX_METADATA_TEXT_LEN + 1);
+        assert!(!is_metadata_plausible(&metadata));
+    }
+
+    #[test]
+    fn rejects_oversized_list() {
+        let mut metadata = valid();
+        metadata.authors = vec![String::new(); MAX_METADATA_LIST_LEN + 1];
+        assert!(!is_metadata_plausible(&metadata));
+    }
+
+    #[test]
+    fn rejects_oversized_string_inside_a_list() {
+        let mut metadata = valid();
+        metadata.authors = vec!["y".repeat(MAX_METADATA_TEXT_LEN + 1)];
+        assert!(!is_metadata_plausible(&metadata));
+    }
+
+    #[test]
+    fn accepts_field_at_the_size_limit() {
+        let mut metadata = valid();
+        metadata.description = "x".repeat(MAX_METADATA_TEXT_LEN);
+        metadata.permissions = vec!["z".repeat(MAX_METADATA_TEXT_LEN); 2];
+        assert!(is_metadata_plausible(&metadata));
     }
 }

--- a/pumpkin/src/plugin/loader/native.rs
+++ b/pumpkin/src/plugin/loader/native.rs
@@ -11,6 +11,35 @@ use super::{LoaderError, Path, Plugin, PluginLoader, PluginMetadata};
 
 pub struct NativePluginLoader;
 
+/// Upper bound for plausible metadata text field lengths, in bytes.
+const MAX_METADATA_TEXT_LEN: usize = 4096;
+/// Upper bound for plausible metadata list lengths, in entries.
+const MAX_METADATA_LIST_LEN: usize = 1024;
+
+/// Best-effort check that metadata read from a plugin binary is plausible.
+///
+/// `METADATA` is plain Rust data whose layout is not stable across
+/// toolchains. If the plugin was built with a different Rust version or
+/// against a different Pumpkin build, the field lengths read here can be
+/// garbage even when the API version check passes, and cloning or logging
+/// such metadata aborts the server with an enormous allocation (see issue
+/// #2434). Only lengths and capacities are inspected here; the potentially
+/// invalid data pointers are never dereferenced.
+fn is_metadata_plausible(metadata: &PluginMetadata) -> bool {
+    let text_plausible =
+        |text: &String| text.len() <= MAX_METADATA_TEXT_LEN && text.len() <= text.capacity();
+    let list_plausible =
+        |list: &Vec<String>| list.len() <= MAX_METADATA_LIST_LEN && list.len() <= list.capacity();
+
+    !metadata.name.is_empty()
+        && text_plausible(&metadata.name)
+        && text_plausible(&metadata.version)
+        && text_plausible(&metadata.description)
+        && list_plausible(&metadata.authors)
+        && list_plausible(&metadata.dependencies)
+        && list_plausible(&metadata.permissions)
+}
+
 impl PluginLoader for NativePluginLoader {
     fn load<'a>(&'a self, path: &'a Path) -> PluginLoadFuture<'a> {
         Box::pin(async {
@@ -40,6 +69,10 @@ impl PluginLoader for NativePluginLoader {
                     .get::<*const PluginMetadata>(b"METADATA")
                     .map_err(|_| LoaderError::MetadataMissing)?
             };
+
+            if !is_metadata_plausible(metadata) {
+                return Err(LoaderError::MetadataCorrupt);
+            }
 
             // 3. Extract Plugin Factory (plugin)
             let plugin_factory = unsafe {


### PR DESCRIPTION
## Description

Fixes #2434.

The `METADATA` symbol in a native plugin is plain Rust data (`String`/`Vec` fields) whose layout is not stable across toolchains. When a plugin was built with a different Rust version or against a different Pumpkin build, the field lengths read from it can be garbage even though the `PUMPKIN_API_VERSION` check passes (the constant only captures the plugin API revision, not the toolchain). Cloning or logging such metadata then aborts the whole server with an allocation failure in the trillions of bytes, which is exactly the backtrace in #2434: the abort happens inside `format!` in `spawn_plugin_initialization`, after the "cached permission decision for plugin \"\"" line shows an empty misread name.

This PR validates the metadata before it is ever cloned or formatted:

- new `is_metadata_plausible` check in the native loader that bounds every text field to 4 KiB, every list to 1024 entries, requires a non-empty name, and requires `len <= capacity` for each field
- only lengths and capacities are inspected; the potentially invalid data pointers are never dereferenced
- implausible metadata fails the load with a new `LoaderError::MetadataCorrupt` that tells the user to rebuild the plugin against this Pumpkin build

This is deliberately a best-effort mitigation: any ABI-mismatched dylib is undefined behavior territory, and the durable fix would be passing metadata across the boundary in a stable representation (C strings or serialized bytes) plus embedding the rustc version in the exported symbols. That is an API design decision I did not want to make unilaterally, but I am happy to follow up on it if there is interest.

## Testing

- `cargo clippy -p pumpkin --all-targets` passes with the workspace deny-level lints
- `cargo fmt --check` passes
- The reported failure mode (a field length in the trillions) is caught by the length bound before the `metadata.clone()` in the loader, so the PatchBukkit case from the issue reports gets a clean "metadata appears corrupt" load error instead of an abort. I do not have a PatchBukkit binary to verify end to end.