### PR TITLE
fix: do not panic on unknown or unprefixed items in loot table entries

### DIFF
--- a/pumpkin/src/world/loot.rs
+++ b/pumpkin/src/world/loot.rs
@@ -385,8 +385,17 @@ impl LootPoolEntryTypesExt for LootPoolEntryTypes {
                     })
             }
             Self::Item(item_entry) => {
-                let key = &item_entry.name.strip_prefix("minecraft:").unwrap();
-                vec![ItemStack::new(1, Item::from_registry_key(key).unwrap())]
+                let key = item_entry
+                    .name
+                    .strip_prefix("minecraft:")
+                    .unwrap_or(item_entry.name);
+                Item::from_registry_key(key).map_or_else(
+                    || {
+                        tracing::warn!("Unknown item {:?} in loot table entry", item_entry.name);
+                        Vec::new()
+                    },
+                    |item| vec![ItemStack::new(1, item)],
+                )
             }
             Self::Tag(tag) => {
                 let key = tag.name.strip_prefix("minecraft:").unwrap_or(tag.name);

--- a/pumpkin/src/world/loot.rs
+++ b/pumpkin/src/world/loot.rs
@@ -384,19 +384,15 @@ impl LootPoolEntryTypesExt for LootPoolEntryTypes {
                         generate_chest_loot(chest_table, seed)
                     })
             }
-            Self::Item(item_entry) => {
-                let key = item_entry
-                    .name
-                    .strip_prefix("minecraft:")
-                    .unwrap_or(item_entry.name);
-                Item::from_registry_key(key).map_or_else(
-                    || {
-                        tracing::warn!("Unknown item {:?} in loot table entry", item_entry.name);
-                        Vec::new()
-                    },
-                    |item| vec![ItemStack::new(1, item)],
-                )
-            }
+            // `from_registry_key` strips the `minecraft:` prefix itself, so
+            // prefixed and unprefixed names both resolve here.
+            Self::Item(item_entry) => Item::from_registry_key(item_entry.name).map_or_else(
+                || {
+                    tracing::warn!("Unknown item {:?} in loot table entry", item_entry.name);
+                    Vec::new()
+                },
+                |item| vec![ItemStack::new(1, item)],
+            ),
             Self::Tag(tag) => {
                 let key = tag.name.strip_prefix("minecraft:").unwrap_or(tag.name);
 


### PR DESCRIPTION
## Description

The `Item` entry arm of `LootPoolEntryTypes::get_stacks` unwraps both the `minecraft:` prefix strip and the item registry lookup:

```rust
let key = &item_entry.name.strip_prefix("minecraft:").unwrap();
vec![ItemStack::new(1, Item::from_registry_key(key).unwrap())]
```

A loot table entry naming an item without the `minecraft:` prefix, or one that is missing from the item registry, panics the server in the middle of loot generation (for example on a mob kill). The neighboring `LootTable` and `Tag` arms already handle both cases defensively with `unwrap_or` and `filter_map`, so this arm was the odd one out.

This PR makes the `Item` arm match: the prefix is treated as optional, and an unknown item logs a warning and drops the entry instead of panicking, the same way the `Tag` arm skips unknown items.

I looked at this while investigating #2453; that crash turned out to be the already-fixed advancement panic (#2424), so this PR does not claim to fix it, but the panic path here is real and reachable from data.

## Testing

- `cargo clippy -p pumpkin --all-targets` passes with the workspace deny-level lints
- `cargo fmt --check` passes
- Behavior for well-formed entries is unchanged: prefixed names resolve to the same registry key as before