### PR TITLE
fix: make /setblock trigger neighbor shape updates like vanilla

### DIFF
--- a/pumpkin/src/command/commands/setblock.rs
+++ b/pumpkin/src/command/commands/setblock.rs
@@ -64,21 +64,13 @@ impl CommandExecutor for Executor {
                         .break_block(&pos, None, BlockFlags::SKIP_DROPS | BlockFlags::FORCE_STATE)
                         .await;
                     world
-                        .set_block_state(
-                            &pos,
-                            block_state_id,
-                            BlockFlags::FORCE_STATE | BlockFlags::NOTIFY_NEIGHBORS,
-                        )
+                        .set_block_state(&pos, block_state_id, BlockFlags::NOTIFY_ALL)
                         .await;
                     true
                 }
                 Mode::Replace => {
                     world
-                        .set_block_state(
-                            &pos,
-                            block_state_id,
-                            BlockFlags::FORCE_STATE | BlockFlags::NOTIFY_NEIGHBORS,
-                        )
+                        .set_block_state(&pos, block_state_id, BlockFlags::NOTIFY_ALL)
                         .await;
                     true
                 }
@@ -86,11 +78,7 @@ impl CommandExecutor for Executor {
                     let old_state = world.get_block_state(&pos);
                     if old_state.is_air() {
                         world
-                            .set_block_state(
-                                &pos,
-                                block_state_id,
-                                BlockFlags::FORCE_STATE | BlockFlags::NOTIFY_NEIGHBORS,
-                            )
+                            .set_block_state(&pos, block_state_id, BlockFlags::NOTIFY_ALL)
                             .await;
                         true
                     } else {


### PR DESCRIPTION
## Description

The setblock command passed `FORCE_STATE` on every mode. In `World::set_block_state`, `FORCE_STATE` (correctly, matching vanilla) skips the neighbor shape-update pass, so `get_state_for_neighbor_update` never runs for the six adjacent blocks after a command-driven change. Vanilla's `/setblock` does not set that flag.

Most visible consequence: removing the support under sand/gravel with `/setblock ... air` leaves the sand floating forever, because the falling-block behaviour relies on the shape-update hook to schedule its fall.

This PR switches the destroy/replace/keep modes to `NOTIFY_ALL`. Strict mode is left untouched. The fill command has the same problem in a worse form (bare `FORCE_STATE`, no notifications at all) and could get the same treatment as a follow-up; happy to do that one too if maintainers agree with the approach here.

## Testing

Verified live on a server built from this branch (headless client keeping chunks ticking + RCON probes):

- before: stone at Y, stone at Y+1, sand at Y+2; `setblock <X> <Y+1> <Z> air`; sand stayed floating at Y+2 indefinitely (probed via `setblock ... keep` responses)
- after: same rig; within 2 s the sand fell and settled at Y+1 (start position AIR, landing position occupied)
- sanity: sand placed directly over an air gap still falls and lands as before (that path was already working)
- `cargo clippy -p pumpkin --all-targets` and `cargo fmt --check` pass with workspace deny-level lints