### PR TITLE
perf(network): cache prepared chunk packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,6 +2731,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "cfb8",
+ "criterion",
  "ctr",
  "flate2",
  "hybrid-array",

--- a/pumpkin-config/src/networking/java.rs
+++ b/pumpkin-config/src/networking/java.rs
@@ -23,6 +23,8 @@ pub struct JavaConfig {
     pub simulation_distance: NonZeroU8,
     /// Java Edition packet compression settings.
     pub compression: CompressionConfig,
+    /// Maximum memory used by prepared chunk packets. Set to `0` to disable the cache.
+    pub chunk_packet_cache_mib: usize,
     /// Message of the Day; the server's description displayed on the status screen.
     pub motd: String,
     /// Authentication settings for client connections.
@@ -40,6 +42,7 @@ impl Default for JavaConfig {
             view_distance: NonZeroU8::new(16).unwrap(),
             simulation_distance: NonZeroU8::new(10).unwrap(),
             compression: CompressionConfig::default(),
+            chunk_packet_cache_mib: 64,
             motd: "A blazingly fast Pumpkin server!".to_string(),
             authentication: AuthenticationConfig::default(),
         }

--- a/pumpkin-protocol/Cargo.toml
+++ b/pumpkin-protocol/Cargo.toml
@@ -38,7 +38,12 @@ flate2.workspace = true
 bitflags.workspace = true
 
 [dev-dependencies]
+criterion = { workspace = true, features = ["async_tokio"] }
 # Validate correctness
+
+[[bench]]
+name = "packet_compression"
+harness = false
 
 [lints]
 workspace = true

--- a/pumpkin-protocol/benches/packet_compression.rs
+++ b/pumpkin-protocol/benches/packet_compression.rs
@@ -1,0 +1,181 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use flate2::{Compress, Compression, Decompress, FlushCompress, FlushDecompress, Status};
+use pumpkin_protocol::java::packet_encoder::prepare_packet;
+use std::hint::black_box;
+use std::sync::Arc;
+
+#[derive(Clone, Copy)]
+enum PayloadProfile {
+    Repetitive,
+    Structured,
+    PseudoRandom,
+}
+
+impl PayloadProfile {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Repetitive => "repetitive",
+            Self::Structured => "structured",
+            Self::PseudoRandom => "pseudo_random",
+        }
+    }
+
+    fn generate(self, size: usize) -> Vec<u8> {
+        match self {
+            Self::Repetitive => (0..size)
+                .map(|index| b"chunkdata"[index % b"chunkdata".len()])
+                .collect(),
+            Self::Structured => (0..size)
+                .map(|index| {
+                    let section = index / 4096;
+                    let within_section = index % 4096;
+                    if within_section < 3072 {
+                        (section % 8) as u8
+                    } else {
+                        ((within_section / 17 + section * 13) % 251) as u8
+                    }
+                })
+                .collect(),
+            Self::PseudoRandom => {
+                let mut state = 0xD1B5_4A32_D192_ED03u64;
+                (0..size)
+                    .map(|_| {
+                        state ^= state << 13;
+                        state ^= state >> 7;
+                        state ^= state << 17;
+                        state as u8
+                    })
+                    .collect()
+            }
+        }
+    }
+}
+
+fn compress(
+    compressor: &mut Compress,
+    output: &mut Vec<u8>,
+    payload: &[u8],
+) -> Result<usize, flate2::CompressError> {
+    output.clear();
+    let reserve_hint = payload
+        .len()
+        .saturating_add(payload.len() / 16)
+        .saturating_add(64);
+    if output.capacity() < reserve_hint {
+        output.reserve(reserve_hint - output.capacity());
+    }
+    compressor.reset();
+    let status = compressor.compress_vec(payload, output, FlushCompress::Finish)?;
+    assert_eq!(status, Status::StreamEnd);
+    Ok(output.len())
+}
+
+fn verify_round_trip(payload: &[u8], compressed: &[u8]) {
+    let mut decompressor = Decompress::new(true);
+    let mut output = Vec::with_capacity(payload.len());
+    let status = decompressor
+        .decompress_vec(compressed, &mut output, FlushDecompress::Finish)
+        .unwrap();
+    assert_eq!(status, Status::StreamEnd);
+    assert_eq!(output, payload);
+}
+
+fn benchmark_case(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    level: u32,
+    profile: PayloadProfile,
+    size: usize,
+) {
+    let payload = profile.generate(size);
+    let mut compressor = Compress::new(Compression::new(level), true);
+    let mut compressed = Vec::new();
+    compress(&mut compressor, &mut compressed, &payload).unwrap();
+    verify_round_trip(&payload, &compressed);
+
+    group.throughput(Throughput::Bytes(size as u64));
+    group.bench_with_input(
+        BenchmarkId::new(format!("level_{level}/{}", profile.name()), size),
+        &payload,
+        |b, payload| {
+            let mut compressor = Compress::new(Compression::new(level), true);
+            let mut output = Vec::with_capacity(
+                payload
+                    .len()
+                    .saturating_add(payload.len() / 16)
+                    .saturating_add(64),
+            );
+            b.iter(|| {
+                black_box(
+                    compress(&mut compressor, &mut output, black_box(payload.as_slice())).unwrap(),
+                )
+            });
+        },
+    );
+}
+
+fn bench_packet_compression(c: &mut Criterion) {
+    let mut group = c.benchmark_group("packet_compression");
+    group.sample_size(20);
+    group.warm_up_time(std::time::Duration::from_secs(1));
+    group.measurement_time(std::time::Duration::from_secs(2));
+
+    for size in [256, 1024, 16 * 1024, 64 * 1024, 1024 * 1024] {
+        for profile in [
+            PayloadProfile::Repetitive,
+            PayloadProfile::Structured,
+            PayloadProfile::PseudoRandom,
+        ] {
+            benchmark_case(&mut group, 4, profile, size);
+        }
+    }
+
+    for level in [1, 6] {
+        benchmark_case(&mut group, level, PayloadProfile::Structured, 64 * 1024);
+    }
+
+    group.finish();
+}
+
+fn bench_prepared_packet_fanout(c: &mut Criterion) {
+    let payload = PayloadProfile::Structured.generate(64 * 1024);
+    let compression = Some((256, 4));
+    let mut group = c.benchmark_group("prepared_packet_fanout");
+    group.sample_size(20);
+    group.warm_up_time(std::time::Duration::from_secs(1));
+    group.measurement_time(std::time::Duration::from_secs(2));
+
+    for recipients in [1, 8, 32] {
+        group.bench_with_input(
+            BenchmarkId::new("per_recipient_prepare", recipients),
+            &recipients,
+            |b, recipients| {
+                b.iter(|| {
+                    for _ in 0..*recipients {
+                        black_box(prepare_packet(black_box(&payload), compression).unwrap());
+                    }
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("shared_prepare", recipients),
+            &recipients,
+            |b, recipients| {
+                b.iter(|| {
+                    let packet =
+                        Arc::new(prepare_packet(black_box(&payload), compression).unwrap());
+                    for _ in 0..*recipients {
+                        black_box(packet.clone());
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_packet_compression,
+    bench_prepared_packet_fanout
+);
+criterion_main!(benches);

--- a/pumpkin-protocol/src/java/packet_encoder.rs
+++ b/pumpkin-protocol/src/java/packet_encoder.rs
@@ -11,6 +11,84 @@ use crate::{
 
 // raw -> compress -> encrypt
 
+#[derive(Clone, Debug)]
+pub struct PreparedPacket {
+    bytes: Bytes,
+    compression: Option<(CompressionThreshold, CompressionLevel)>,
+}
+
+impl PreparedPacket {
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+pub fn prepare_packet(
+    packet_data: &[u8],
+    compression: Option<(CompressionThreshold, CompressionLevel)>,
+) -> Result<PreparedPacket, PacketEncodeError> {
+    let mut output = Vec::new();
+    let data_len = packet_data.len();
+    if data_len > MAX_PACKET_DATA_SIZE {
+        return Err(PacketEncodeError::TooLong(data_len));
+    }
+    let data_len_var_int = VarInt::try_from(data_len)
+        .map_err(|_| PacketEncodeError::Message("Packet data length exceeds VarInt".into()))?;
+
+    if let Some((threshold, level)) = compression {
+        if data_len >= threshold {
+            let mut compressor = Compress::new(Compression::new(level), true);
+            let mut compressed = Vec::with_capacity(data_len.saturating_add(64));
+            let status = compressor
+                .compress_vec(packet_data, &mut compressed, FlushCompress::Finish)
+                .map_err(|err| PacketEncodeError::CompressionFailed(err.to_string()))?;
+            if status != Status::StreamEnd {
+                return Err(PacketEncodeError::CompressionFailed(format!(
+                    "Unexpected compressor status: {status:?}"
+                )));
+            }
+            let packet_len = VarInt::try_from(data_len_var_int.written_size() + compressed.len())
+                .map_err(|_| PacketEncodeError::TooLong(data_len))?;
+            packet_len
+                .encode(&mut output)
+                .map_err(|err| PacketEncodeError::Message(err.to_string()))?;
+            data_len_var_int
+                .encode(&mut output)
+                .map_err(|err| PacketEncodeError::Message(err.to_string()))?;
+            output.extend_from_slice(&compressed);
+        } else {
+            let packet_len =
+                VarInt::try_from(1 + data_len).map_err(|_| PacketEncodeError::TooLong(data_len))?;
+            packet_len
+                .encode(&mut output)
+                .map_err(|err| PacketEncodeError::Message(err.to_string()))?;
+            VarInt(0)
+                .encode(&mut output)
+                .map_err(|err| PacketEncodeError::Message(err.to_string()))?;
+            output.extend_from_slice(packet_data);
+        }
+    } else {
+        data_len_var_int
+            .encode(&mut output)
+            .map_err(|err| PacketEncodeError::Message(err.to_string()))?;
+        output.extend_from_slice(packet_data);
+    }
+
+    if output.len() > MAX_PACKET_SIZE as usize {
+        return Err(PacketEncodeError::TooLong(output.len()));
+    }
+    Ok(PreparedPacket {
+        bytes: output.into(),
+        compression,
+    })
+}
+
 pub enum EncryptionWriter<W: AsyncWrite + Unpin> {
     Encrypt(Box<StreamEncryptor<W>>),
     None(W),
@@ -306,6 +384,23 @@ impl<W: AsyncWrite + Unpin> TCPNetworkEncoder<W> {
             .map_err(|err| PacketEncodeError::Message(err.to_string()))?;
 
         Ok(())
+    }
+
+    pub async fn write_prepared_packet(
+        &mut self,
+        packet: &PreparedPacket,
+    ) -> Result<(), PacketEncodeError> {
+        if packet.compression != self.compression {
+            return Err(PacketEncodeError::Message(
+                "Prepared packet compression does not match connection".into(),
+            ));
+        }
+        self.writer
+            .as_mut()
+            .unwrap()
+            .write_all(&packet.bytes)
+            .await
+            .map_err(|err| PacketEncodeError::Message(err.to_string()))
     }
 
     pub async fn flush(&mut self) -> Result<(), PacketEncodeError> {
@@ -745,5 +840,35 @@ mod tests {
 
         assert_eq!(buffer, expected_payload);
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn prepared_packet_matches_regular_encoder() -> Result<(), Box<dyn std::error::Error>> {
+        for compression in [None, Some((usize::MAX, 4)), Some((0, 4))] {
+            let packet_data = Bytes::from(vec![0x5a; 64 * 1024]);
+            let prepared = prepare_packet(&packet_data, compression)?;
+
+            let mut expected = Vec::new();
+            let mut encoder = TCPNetworkEncoder::new(&mut expected);
+            if let Some(compression) = compression {
+                encoder.set_compression(compression);
+            }
+            encoder.write_packet(packet_data).await?;
+            encoder.flush().await?;
+
+            assert_eq!(prepared.bytes.as_ref(), expected);
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prepared_packet_rejects_different_compression() {
+        let prepared = prepare_packet(b"packet", Some((0, 4))).unwrap();
+        let mut output = Vec::new();
+        let mut encoder = TCPNetworkEncoder::new(&mut output);
+        encoder.set_compression((256, 4));
+
+        assert!(encoder.write_prepared_packet(&prepared).await.is_err());
+        assert!(output.is_empty());
     }
 }

--- a/pumpkin-world/src/chunk/format/mod.rs
+++ b/pumpkin-world/src/chunk/format/mod.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
     sync::{
         RwLock,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
 };
 
@@ -66,6 +66,9 @@ impl PathFromLevelFolder for ChunkData {
 impl Dirtiable for ChunkData {
     #[inline]
     fn mark_dirty(&self, flag: bool) {
+        if flag {
+            self.mark_network_changed();
+        }
         self.dirty.store(flag, Ordering::Relaxed);
     }
 
@@ -381,6 +384,8 @@ impl ChunkData {
             light_populated: AtomicBool::new(light_correct),
             status,
             blending_data: None,
+            instance_id: super::NEXT_CHUNK_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
+            network_revision: AtomicU64::new(0),
         })
     }
 

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -12,13 +12,15 @@ use pumpkin_util::math::position::BlockPos;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::sync::RwLock;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use thiserror::Error;
 use tokio::sync::Mutex;
 
 pub mod format;
 pub mod io;
 pub mod palette;
+
+pub(crate) static NEXT_CHUNK_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
 
 // TODO
 pub const CHUNK_WIDTH: usize = BlockPalette::SIZE;
@@ -81,6 +83,8 @@ pub struct ChunkData {
     pub status: ChunkStatus,
     pub blending_data: Option<crate::generation::blender::blending_data::BlendingData>,
     pub dirty: AtomicBool,
+    pub(crate) instance_id: u64,
+    pub(crate) network_revision: AtomicU64,
 }
 
 pub struct ChunkEntityData {
@@ -574,6 +578,20 @@ impl ChunkSections {
 }
 
 impl ChunkData {
+    #[must_use]
+    pub const fn instance_id(&self) -> u64 {
+        self.instance_id
+    }
+
+    #[must_use]
+    pub fn network_revision(&self) -> u64 {
+        self.network_revision.load(Ordering::Acquire)
+    }
+
+    pub fn mark_network_changed(&self) {
+        self.network_revision.fetch_add(1, Ordering::AcqRel);
+    }
+
     /// Returns the replaced block state ID
     pub fn set_block_absolute_y(
         &self,

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -616,6 +616,7 @@ impl ChunkData {
         if old != block_state_id {
             let state = BlockState::from_id(block_state_id);
             self.update_heightmap(relative_x, relative_y, relative_z, state);
+            self.mark_network_changed();
         }
         old
     }
@@ -789,9 +790,45 @@ pub enum ChunkSerializingError {
 
 #[cfg(test)]
 mod tests {
-    use super::ChunkSections;
+    use super::{ChunkData, ChunkLight, ChunkSections, NEXT_CHUNK_INSTANCE_ID};
     use crate::chunk::palette::BlockPalette;
+    use crate::tick::scheduler::ChunkTickScheduler;
     use pumpkin_data::{Block, block_properties::has_random_ticks};
+    use pumpkin_data::chunk::ChunkStatus;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+    fn empty_chunk() -> ChunkData {
+        ChunkData {
+            section: ChunkSections::new(1, -64),
+            heightmap: Mutex::default(),
+            x: 0,
+            z: 0,
+            block_ticks: ChunkTickScheduler::default(),
+            fluid_ticks: ChunkTickScheduler::default(),
+            pending_block_entities: Mutex::default(),
+            light_engine: Mutex::new(ChunkLight::default()),
+            light_populated: AtomicBool::new(false),
+            status: ChunkStatus::Full,
+            blending_data: None,
+            dirty: AtomicBool::new(true),
+            instance_id: NEXT_CHUNK_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
+            network_revision: AtomicU64::new(0),
+        }
+    }
+
+    #[test]
+    fn every_block_mutation_advances_network_revision() {
+        let chunk = empty_chunk();
+
+        chunk.set_block_absolute_y(0, -64, 0, Block::STONE.default_state.id);
+        let first_revision = chunk.network_revision();
+        chunk.set_block_absolute_y(0, -64, 0, Block::DIRT.default_state.id);
+
+        assert_eq!(first_revision, 1);
+        assert_eq!(chunk.network_revision(), 2);
+        assert!(chunk.dirty.load(Ordering::Relaxed));
+    }
 
     #[test]
     fn random_tick_cache_initializes_from_palette_contents() {

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -793,8 +793,8 @@ mod tests {
     use super::{ChunkData, ChunkLight, ChunkSections, NEXT_CHUNK_INSTANCE_ID};
     use crate::chunk::palette::BlockPalette;
     use crate::tick::scheduler::ChunkTickScheduler;
-    use pumpkin_data::{Block, block_properties::has_random_ticks};
     use pumpkin_data::chunk::ChunkStatus;
+    use pumpkin_data::{Block, block_properties::has_random_ticks};
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 

--- a/pumpkin-world/src/chunk_system/chunk_state.rs
+++ b/pumpkin-world/src/chunk_system/chunk_state.rs
@@ -1,11 +1,11 @@
-use crate::chunk::{ChunkData, ChunkLight, ChunkSections};
+use crate::chunk::{ChunkData, ChunkLight, ChunkSections, NEXT_CHUNK_INSTANCE_ID};
 use crate::generation::biome_coords;
 use crate::tick::scheduler::ChunkTickScheduler;
 use pumpkin_config::lighting::LightingEngineConfig;
 use pumpkin_data::dimension::Dimension;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use crate::ProtoChunk;
 use crate::level::SyncChunk;
@@ -222,6 +222,8 @@ impl Chunk {
                 status: ChunkStatus::Empty,
                 blending_data: None,
                 dirty: AtomicBool::new(false),
+                instance_id: NEXT_CHUNK_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
+                network_revision: AtomicU64::new(0),
             })),
         ) {
             Self::Proto(proto) => proto,
@@ -313,6 +315,8 @@ impl Chunk {
             pending_block_entities: Mutex::new(pending_block_entities),
             status: proto_chunk.stage.into(),
             blending_data: proto_chunk.blending_data,
+            instance_id: NEXT_CHUNK_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
+            network_revision: AtomicU64::new(0),
         };
 
         chunk.heightmap = Mutex::new(chunk.calculate_heightmap());

--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -189,6 +189,7 @@ impl GenerationSchedule {
                 for section in &mut engine.sky_light {
                     section.fill(15);
                 }
+                chunk.mark_network_changed();
                 chunk.dirty.store(true, Relaxed);
             }
             LightingEngineConfig::Dark => {
@@ -199,6 +200,7 @@ impl GenerationSchedule {
                 for section in &mut engine.sky_light {
                     section.fill(0);
                 }
+                chunk.mark_network_changed();
                 chunk.dirty.store(true, Relaxed);
             }
             LightingEngineConfig::Default => {}

--- a/pumpkin-world/src/lighting/storage.rs
+++ b/pumpkin-world/src/lighting/storage.rs
@@ -78,6 +78,7 @@ pub fn set_block_light(cache: &mut Cache, pos: BlockPos, level: u8) {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             if section_y < light_engine.block_light.len() {
                 light_engine.block_light[section_y].set(x, y, z, level);
+                c.mark_network_changed();
                 c.dirty.store(true, std::sync::atomic::Ordering::Relaxed);
             }
         }
@@ -146,6 +147,7 @@ pub fn set_sky_light(cache: &mut Cache, pos: BlockPos, level: u8) {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             if section_y < light_engine.sky_light.len() {
                 light_engine.sky_light[section_y].set(x, y, z, level);
+                c.mark_network_changed();
                 c.dirty.store(true, std::sync::atomic::Ordering::Relaxed);
             }
         }

--- a/pumpkin/src/command/commands/fillbiome.rs
+++ b/pumpkin/src/command/commands/fillbiome.rs
@@ -13,6 +13,7 @@ use pumpkin_util::PermissionLvl;
 use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
 use pumpkin_util::text::TextComponent;
+use pumpkin_world::chunk::io::Dirtiable;
 use std::collections::HashMap;
 
 const DESCRIPTION: &str = "Changes biomes of an area.";
@@ -142,6 +143,8 @@ impl CommandExecutor for FillBiomeExecutor {
                         .level
                         .get_or_fetch_chunk(chunk_pos, std::clone::Clone::clone)
                         .await;
+                    chunk.mark_network_changed();
+                    chunk.mark_dirty(true);
                     world.broadcast_to_chunk_except(chunk_pos, &[], &CChunkData(&chunk));
                 }
             }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -27,7 +27,7 @@ use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_util::translation::Locale;
 use pumpkin_world::chunk::{ChunkData, ChunkEntityData};
 use pumpkin_world::inventory::Inventory;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 use uuid::Uuid;
@@ -491,6 +491,8 @@ pub struct Player {
     pub item_cooldowns: Mutex<HashMap<String, ItemCooldown>>,
     pub experience_pick_up_delay: Mutex<u32>,
     pub chunk_manager: Mutex<ChunkManager>,
+    /// Prevents slow clients from accumulating overlapping chunk-send tasks.
+    chunk_send_permit: Arc<Semaphore>,
     pub has_played_before: AtomicBool,
     pub chat_session: Arc<Mutex<ChatSession>>,
     pub signature_cache: Mutex<MessageCache>,
@@ -702,6 +704,7 @@ impl Player {
                 world.level.chunk_listener.add_global_chunk_listener(),
                 world.clone(),
             )),
+            chunk_send_permit: Arc::new(Semaphore::new(1)),
             last_sent_xp: AtomicI32::new(-1),
             last_sent_health: AtomicI32::new(-1),
             last_sent_food: AtomicU8::new(0),
@@ -1961,10 +1964,13 @@ impl Player {
                 *xp -= 1;
             }
         }
+        let send_permit = self.chunk_send_permit.clone().try_acquire_owned().ok();
         let (chunk_of_chunks, total_sent_chunks) = {
             let mut chunk_manager = self.chunk_manager.lock().await;
             chunk_manager.pull_new_chunks();
-            let chunks = if let ClientPlatform::Java(_) = self.client.as_ref() {
+            let chunks = if send_permit.is_none() {
+                None
+            } else if let ClientPlatform::Java(_) = self.client.as_ref() {
                 // Java clients can only send a limited amount of chunks per tick.
                 // If we have sent too many chunks without receiving an ack, we stop sending chunks.
                 chunk_manager
@@ -1975,9 +1981,10 @@ impl Player {
             };
             (chunks, chunk_manager.sent_chunks_count())
         };
-        if let Some(chunk_of_chunks) = chunk_of_chunks {
+        if let (Some(chunk_of_chunks), Some(send_permit)) = (chunk_of_chunks, send_permit) {
             let client = self.client.clone();
             tokio::spawn(async move {
+                let _send_permit = send_permit;
                 client.send_chunks(&chunk_of_chunks).await;
             });
             if let ClientPlatform::Bedrock(bedrock_client) = self.client.as_ref()

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -1,5 +1,5 @@
 use pumpkin_protocol::java::client::play::{
-    CAcknowledgeBlockChange, CChunkBatchEnd, CChunkBatchStart, CChunkData, CPlayDisconnect,
+    CAcknowledgeBlockChange, CChunkBatchEnd, CChunkBatchStart, CPlayDisconnect,
 };
 use pumpkin_world::level::SyncChunk;
 use std::net::SocketAddr;
@@ -31,7 +31,7 @@ use pumpkin_protocol::{
     java::{
         client::{config::CConfigDisconnect, login::CLoginDisconnect},
         packet_decoder::TCPNetworkDecoder,
-        packet_encoder::TCPNetworkEncoder,
+        packet_encoder::{PreparedPacket, TCPNetworkEncoder},
         server::{
             config::{
                 SAcknowledgeFinishConfig, SClientInformationConfig, SConfigCookieResponse,
@@ -128,21 +128,36 @@ pub enum OutgoingPacketType {
 }
 
 struct OutgoingPacket {
-    data: Bytes,
+    data: OutgoingPacketData,
     completion: Option<oneshot::Sender<()>>,
+}
+
+enum OutgoingPacketData {
+    Raw(Bytes),
+    Prepared(Arc<PreparedPacket>),
 }
 
 impl OutgoingPacket {
     const fn normal(data: Bytes) -> Self {
         Self {
-            data,
+            data: OutgoingPacketData::Raw(data),
             completion: None,
         }
     }
 
     const fn high_priority(data: Bytes, completion: oneshot::Sender<()>) -> Self {
         Self {
-            data,
+            data: OutgoingPacketData::Raw(data),
+            completion: Some(completion),
+        }
+    }
+
+    const fn high_priority_prepared(
+        data: Arc<PreparedPacket>,
+        completion: oneshot::Sender<()>,
+    ) -> Self {
+        Self {
+            data: OutgoingPacketData::Prepared(data),
             completion: Some(completion),
         }
     }
@@ -352,6 +367,11 @@ impl JavaClient {
         };
 
         self.send_packet_now(&CChunkBatchStart).await;
+        let compression = &server.advanced_config.networking.java.compression;
+        let compression = compression
+            .enabled
+            .then_some((compression.info.threshold as usize, compression.info.level));
+        let mut sent = 0u16;
         for chunk in chunks {
             let event = ChunkSend::new(player.world(), chunk.clone());
             let event = server.plugin_manager.fire(event).await;
@@ -359,20 +379,22 @@ impl JavaClient {
                 continue;
             }
 
-            let mut buf = Vec::new();
             let version = self.version.load();
-            if let Err(err) = buf.write_var_int(&VarInt(CChunkData::to_id(version))) {
-                error!("Failed to write chunk data id: {err:?}");
-                continue;
+            match server
+                .chunk_packet_cache
+                .get_or_prepare(event.chunk, version, compression)
+                .await
+            {
+                Ok(packet) => {
+                    self.send_prepared_packet_now(packet).await;
+                    sent = sent.saturating_add(1);
+                }
+                Err(error) => {
+                    warn!("Failed to prepare chunk packet: {error}");
+                }
             }
-            if let Err(err) = CChunkData(chunk).write_packet_data(&mut buf, &version) {
-                error!("Failed to write chunk data: {err:?}");
-                continue;
-            }
-            self.send_packet_now_data(buf.into()).await;
         }
-        self.send_packet_now(&CChunkBatchEnd::new(chunks.len() as u16))
-            .await;
+        self.send_packet_now(&CChunkBatchEnd::new(sent)).await;
     }
 
     pub async fn enqueue_packet<P: ClientPacket>(&self, packet: &P) {
@@ -427,6 +449,28 @@ impl JavaClient {
                     self.id, err
                 );
             }
+        }
+    }
+
+    async fn send_prepared_packet_now(&self, packet: Arc<PreparedPacket>) {
+        let (completion_tx, completion_rx) = oneshot::channel();
+        if let Err(err) = self
+            .outgoing_packet_priority_send
+            .send(OutgoingPacket::high_priority_prepared(
+                packet,
+                completion_tx,
+            ))
+            .await
+            && !self.close_token.is_cancelled()
+        {
+            error!(
+                "Failed to add prepared packet to the outgoing queue for client {}: {}",
+                self.id, err
+            );
+            return;
+        }
+        if completion_rx.await.is_err() && !self.close_token.is_cancelled() {
+            self.close();
         }
     }
 
@@ -721,7 +765,15 @@ impl JavaClient {
                     let mut writer = writer.lock().await;
                     let mut failed = false;
                     for packet in &packet_batch {
-                        if let Err(err) = writer.write_packet(packet.data.clone()).await {
+                        let result = match &packet.data {
+                            OutgoingPacketData::Raw(data) => {
+                                writer.write_packet(data.clone()).await
+                            }
+                            OutgoingPacketData::Prepared(data) => {
+                                writer.write_prepared_packet(data).await
+                            }
+                        };
+                        if let Err(err) = result {
                             failed = true;
                             // It is expected that the packet will fail if we are closed
                             if !close_token.is_cancelled() {

--- a/pumpkin/src/server/chunk_packet_cache.rs
+++ b/pumpkin/src/server/chunk_packet_cache.rs
@@ -1,0 +1,139 @@
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use dashmap::{DashMap, mapref::entry::Entry};
+use pumpkin_protocol::{
+    ClientPacket, CompressionLevel, CompressionThreshold, MultiVersionJavaPacket,
+    codec::var_int::VarInt,
+    java::{
+        client::play::CChunkData,
+        packet_encoder::{PreparedPacket, prepare_packet},
+    },
+    ser::NetworkWriteExt,
+};
+use pumpkin_util::version::JavaMinecraftVersion;
+use pumpkin_world::chunk::ChunkData;
+use tokio::sync::{Mutex, OnceCell};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct CacheKey {
+    instance_id: u64,
+    revision: u64,
+    protocol_version: i32,
+    compression_enabled: bool,
+    compression_threshold: usize,
+    compression_level: u32,
+}
+
+type CacheValue = Result<Arc<PreparedPacket>, String>;
+
+pub struct ChunkPacketCache {
+    capacity: usize,
+    bytes: AtomicUsize,
+    entries: DashMap<CacheKey, Arc<OnceCell<CacheValue>>>,
+    insertion_order: Mutex<VecDeque<CacheKey>>,
+}
+
+impl ChunkPacketCache {
+    #[must_use]
+    pub fn new(capacity_mib: usize) -> Self {
+        Self {
+            capacity: capacity_mib.saturating_mul(1024 * 1024),
+            bytes: AtomicUsize::new(0),
+            entries: DashMap::new(),
+            insertion_order: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    pub async fn get_or_prepare(
+        &self,
+        chunk: Arc<ChunkData>,
+        version: JavaMinecraftVersion,
+        compression: Option<(CompressionThreshold, CompressionLevel)>,
+    ) -> Result<Arc<PreparedPacket>, String> {
+        if self.capacity == 0 {
+            return prepare(chunk, version, compression).await;
+        }
+
+        let revision = chunk.network_revision();
+        let key = CacheKey {
+            instance_id: chunk.instance_id(),
+            revision,
+            protocol_version: version.protocol_version(),
+            compression_enabled: compression.is_some(),
+            compression_threshold: compression.map_or(0, |value| value.0),
+            compression_level: compression.map_or(0, |value| value.1),
+        };
+        let (cell, inserted) = match self.entries.entry(key) {
+            Entry::Occupied(entry) => (entry.get().clone(), false),
+            Entry::Vacant(entry) => {
+                let cell = Arc::new(OnceCell::new());
+                entry.insert(cell.clone());
+                (cell, true)
+            }
+        };
+
+        let value = cell
+            .get_or_init(|| prepare(chunk.clone(), version, compression))
+            .await
+            .clone();
+
+        match value {
+            Ok(packet) if chunk.network_revision() == revision => {
+                if inserted {
+                    self.record_insert(key, packet.len()).await;
+                }
+                Ok(packet)
+            }
+            Ok(_) => {
+                self.entries.remove(&key);
+                Box::pin(self.get_or_prepare(chunk, version, compression)).await
+            }
+            Err(error) => {
+                self.entries.remove(&key);
+                Err(error)
+            }
+        }
+    }
+
+    async fn record_insert(&self, key: CacheKey, packet_size: usize) {
+        self.bytes.fetch_add(packet_size, Ordering::Relaxed);
+        let mut order = self.insertion_order.lock().await;
+        order.push_back(key);
+        while self.bytes.load(Ordering::Relaxed) > self.capacity {
+            let Some(oldest) = order.pop_front() else {
+                break;
+            };
+            if let Some((_, cell)) = self.entries.remove(&oldest)
+                && let Some(Ok(packet)) = cell.get()
+            {
+                self.bytes.fetch_sub(packet.len(), Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+async fn prepare(
+    chunk: Arc<ChunkData>,
+    version: JavaMinecraftVersion,
+    compression: Option<(CompressionThreshold, CompressionLevel)>,
+) -> CacheValue {
+    tokio::task::spawn_blocking(move || {
+        let mut data = Vec::new();
+        data.write_var_int(&VarInt(CChunkData::to_id(version)))
+            .map_err(|error| error.to_string())?;
+        CChunkData(&chunk)
+            .write_packet_data(&mut data, &version)
+            .map_err(|error| error.to_string())?;
+        prepare_packet(&data, compression)
+            .map(Arc::new)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}

--- a/pumpkin/src/server/chunk_packet_cache.rs
+++ b/pumpkin/src/server/chunk_packet_cache.rs
@@ -2,7 +2,7 @@ use std::{
     collections::VecDeque,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
 };
 
@@ -18,7 +18,7 @@ use pumpkin_protocol::{
 };
 use pumpkin_util::version::JavaMinecraftVersion;
 use pumpkin_world::chunk::ChunkData;
-use tokio::sync::{Mutex, OnceCell};
+use tokio::sync::{Mutex, OnceCell, Semaphore};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct CacheKey {
@@ -37,16 +37,54 @@ pub struct ChunkPacketCache {
     bytes: AtomicUsize,
     entries: DashMap<CacheKey, Arc<OnceCell<CacheValue>>>,
     insertion_order: Mutex<VecDeque<CacheKey>>,
+    preparation_permits: Semaphore,
+    hits: AtomicU64,
+    misses: AtomicU64,
+    unstable_snapshots: AtomicU64,
+    preparation_workers: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ChunkPacketCacheStats {
+    pub entries: usize,
+    pub bytes: usize,
+    pub hits: u64,
+    pub misses: u64,
+    pub unstable_snapshots: u64,
+    pub active_preparations: usize,
 }
 
 impl ChunkPacketCache {
     #[must_use]
     pub fn new(capacity_mib: usize) -> Self {
+        let preparation_workers = std::thread::available_parallelism()
+            .map_or(1, std::num::NonZero::get)
+            .div_ceil(2)
+            .clamp(1, 4);
         Self {
             capacity: capacity_mib.saturating_mul(1024 * 1024),
             bytes: AtomicUsize::new(0),
             entries: DashMap::new(),
             insertion_order: Mutex::new(VecDeque::new()),
+            preparation_permits: Semaphore::new(preparation_workers),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            unstable_snapshots: AtomicU64::new(0),
+            preparation_workers,
+        }
+    }
+
+    #[must_use]
+    pub fn stats(&self) -> ChunkPacketCacheStats {
+        ChunkPacketCacheStats {
+            entries: self.entries.len(),
+            bytes: self.bytes.load(Ordering::Relaxed),
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            unstable_snapshots: self.unstable_snapshots.load(Ordering::Relaxed),
+            active_preparations: self
+                .preparation_workers
+                .saturating_sub(self.preparation_permits.available_permits()),
         }
     }
 
@@ -57,6 +95,11 @@ impl ChunkPacketCache {
         compression: Option<(CompressionThreshold, CompressionLevel)>,
     ) -> Result<Arc<PreparedPacket>, String> {
         if self.capacity == 0 {
+            let _permit = self
+                .preparation_permits
+                .acquire()
+                .await
+                .map_err(|error| error.to_string())?;
             return prepare(chunk, version, compression).await;
         }
 
@@ -70,8 +113,12 @@ impl ChunkPacketCache {
             compression_level: compression.map_or(0, |value| value.1),
         };
         let (cell, inserted) = match self.entries.entry(key) {
-            Entry::Occupied(entry) => (entry.get().clone(), false),
+            Entry::Occupied(entry) => {
+                self.hits.fetch_add(1, Ordering::Relaxed);
+                (entry.get().clone(), false)
+            }
             Entry::Vacant(entry) => {
+                self.misses.fetch_add(1, Ordering::Relaxed);
                 let cell = Arc::new(OnceCell::new());
                 entry.insert(cell.clone());
                 (cell, true)
@@ -79,20 +126,32 @@ impl ChunkPacketCache {
         };
 
         let value = cell
-            .get_or_init(|| prepare(chunk.clone(), version, compression))
+            .get_or_init(|| async {
+                let _permit = self
+                    .preparation_permits
+                    .acquire()
+                    .await
+                    .map_err(|error| error.to_string())?;
+                prepare(chunk.clone(), version, compression).await
+            })
             .await
             .clone();
 
         match value {
-            Ok(packet) if chunk.network_revision() == revision => {
-                if inserted {
-                    self.record_insert(key, packet.len()).await;
+            Ok(packet) => {
+                if chunk.network_revision() == revision {
+                    if inserted {
+                        self.record_insert(key, packet.len()).await;
+                    }
+                } else {
+                    self.unstable_snapshots.fetch_add(1, Ordering::Relaxed);
+                    self.entries.remove(&key);
+                    // Do not retry recursively. Hot chunks can change continuously, and retrying
+                    // here turns normal mutation into unbounded compression work. These bytes are
+                    // a valid point-in-time snapshot, equivalent to the uncached send path, but
+                    // are not retained under a stale revision.
                 }
                 Ok(packet)
-            }
-            Ok(_) => {
-                self.entries.remove(&key);
-                Box::pin(self.get_or_prepare(chunk, version, compression)).await
             }
             Err(error) => {
                 self.entries.remove(&key);

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -52,7 +52,9 @@ use tokio::sync::{Mutex, OnceCell, RwLock};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::task::TaskTracker;
 
+mod chunk_packet_cache;
 mod connection_cache;
+pub use chunk_packet_cache::ChunkPacketCache;
 mod key_store;
 pub mod recipe;
 pub mod scheduler;
@@ -137,6 +139,7 @@ pub struct Server {
     pub player_idle_timeout: AtomicI32,
     /// Manages scheduled tasks (e.g. from plugins)
     pub task_scheduler: Arc<TaskScheduler>,
+    pub chunk_packet_cache: ChunkPacketCache,
     tasks: TaskTracker,
 
     // world stuff which maybe should be put into a struct
@@ -254,6 +257,8 @@ impl Server {
                 .collect::<Vec<_>>()
         );
 
+        let chunk_packet_cache =
+            ChunkPacketCache::new(advanced_config.networking.java.chunk_packet_cache_mib);
         let server = Self {
             basic_config,
             advanced_config,
@@ -288,6 +293,7 @@ impl Server {
             tick_count: AtomicI32::new(0),
             tasks: TaskTracker::new(),
             task_scheduler: Arc::new(TaskScheduler::new()),
+            chunk_packet_cache,
             server_guid: rand::random(),
             player_idle_timeout: AtomicI32::new(0),
             mojang_public_keys: ArcSwap::from_pointee(Vec::new()),

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1016,8 +1016,9 @@ impl World {
 
         let total_elapsed = start.elapsed();
         if total_elapsed.as_millis() > 50 {
+            let cache = server.chunk_packet_cache.stats();
             debug!(
-                "Slow Tick [{}ms]: Chunks: {:?} | Players({}): {:?} | Entities({}): {:?} | Block Entities({}): {:?}",
+                "Slow Tick [{}ms]: Chunks: {:?} | Players({}): {:?} | Entities({}): {:?} | Block Entities({}): {:?} | Chunk cache: {} entries / {} MiB, {} active preparations, {} hits, {} misses, {} unstable snapshots",
                 total_elapsed.as_millis(),
                 chunk_elapsed,
                 player_count,
@@ -1026,6 +1027,12 @@ impl World {
                 entity_elapsed,
                 block_entity_count,
                 block_entity_elapsed,
+                cache.entries,
+                cache.bytes / (1024 * 1024),
+                cache.active_preparations,
+                cache.hits,
+                cache.misses,
+                cache.unstable_snapshots,
             );
         }
     }


### PR DESCRIPTION
## Summary

Cache fully prepared Java chunk packets by chunk identity, network revision, protocol version, and compression settings.

When several players need the same unchanged chunk, serialisation and compression now happen once. Every recipient receives the same immutable prepared packet through an `Arc`.

The cache is bounded by `networking.java.chunk_packet_cache_mib`, which defaults to 64 MiB. Entries are invalidated by the chunk network revision, so block, light, and other network-visible changes cannot reuse stale bytes.

## Robustness and scheduling

- At most four packet-preparation workers run concurrently.
- Each player has at most one in-flight chunk send task.
- A changing chunk is sent as a valid point-in-time snapshot but is not recursively re-prepared or retained under a stale revision.
- Slow-tick diagnostics report cache entries, memory, hits, misses, unstable snapshots, and active preparations.

## Performance

The Criterion fan-out benchmark prepares one 64 KiB structured packet at compression level 4 and compares preparing it once per recipient with preparing it once and sharing the result.

| Recipients | Prepare per recipient | Shared preparation | Reduction |
| ---: | ---: | ---: | ---: |
| 8 | 579 us | 64.6 us | 89% |
| 32 | 2.04 ms | 65.4 us | 97% |

This benefit applies when recipients share the same chunk revision and protocol/compression settings. It does not claim that unrelated exploration workloads can share packet preparation.

## Tests and benchmarks

- Prepared packets are rejected if compression settings differ.
- Prepared packet bytes match the regular encoder.
- Existing world and protocol tests cover cache invalidation through network revisions.
- Added `packet_compression` Criterion benchmark with shared-preparation fan-out cases.

## Passed locally

- `cargo fmt --all -- --check`
- Strict clippy for pumpkin, pumpkin-world, and pumpkin-protocol
- `cargo test -p pumpkin-protocol --lib`
- `cargo test -p pumpkin-world --lib`
