### PR TITLE
perf(world): preserve tick headroom during generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,7 +2602,6 @@ dependencies = [
  "pumpkin-util",
  "pumpkin-world",
  "rand",
- "rayon",
  "rsa",
  "rustc-hash",
  "rustc_version_runtime",

--- a/pumpkin-config/src/world.rs
+++ b/pumpkin-config/src/world.rs
@@ -1,6 +1,38 @@
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroUsize;
 
 use crate::{chunk::ChunkConfig, lighting::LightingEngineConfig};
+
+/// Controls the CPU workers used for background chunk generation.
+#[derive(Deserialize, Serialize, Default, Clone)]
+#[serde(default)]
+pub struct GenerationConfig {
+    /// Maximum number of Rayon workers used for chunk generation.
+    ///
+    /// When omitted, Pumpkin chooses a conservative value from the logical CPU count.
+    pub max_threads: Option<NonZeroUsize>,
+}
+
+impl GenerationConfig {
+    /// Resolves the configured worker count for a host reporting `available_cpus`.
+    #[must_use]
+    pub fn resolve_threads(&self, available_cpus: usize) -> usize {
+        self.max_threads.map_or_else(
+            || default_generation_threads(available_cpus),
+            NonZeroUsize::get,
+        )
+    }
+}
+
+/// Chooses a low-core-aware default while leaving some scheduling headroom.
+#[must_use]
+pub const fn default_generation_threads(available_cpus: usize) -> usize {
+    match available_cpus {
+        0 | 1 => 1,
+        2..=4 => available_cpus - 1,
+        _ => available_cpus - 2,
+    }
+}
 
 /// Configuration for world and level-specific settings.
 ///
@@ -11,6 +43,9 @@ pub struct LevelConfig {
     pub chunk: ChunkConfig,
     #[serde(default)]
     pub lighting: LightingEngineConfig,
+    /// Background chunk-generation worker configuration.
+    #[serde(default)]
+    pub generation: GenerationConfig,
     /// Number of ticks between autosave checks. If 0, autosave is disabled.
     #[serde(default = "default_autosave_ticks")]
     pub autosave_ticks: u64,
@@ -19,4 +54,41 @@ pub struct LevelConfig {
 
 const fn default_autosave_ticks() -> u64 {
     6000 // Default to 5 minutes at 20 TPS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GenerationConfig, default_generation_threads};
+    use std::num::NonZeroUsize;
+
+    #[test]
+    fn automatic_generation_threads_preserve_low_core_capacity() {
+        for (cpus, expected) in [(0, 1), (1, 1), (2, 1), (3, 2), (4, 3), (8, 6), (16, 14)] {
+            assert_eq!(default_generation_threads(cpus), expected);
+        }
+    }
+
+    #[test]
+    fn explicit_generation_threads_override_automatic_default() {
+        let config = GenerationConfig {
+            max_threads: NonZeroUsize::new(7),
+        };
+        assert_eq!(config.resolve_threads(2), 7);
+    }
+
+    #[test]
+    fn generation_config_toml_supports_automatic_and_explicit_modes() {
+        let automatic: GenerationConfig = toml::from_str("").unwrap();
+        assert!(automatic.max_threads.is_none());
+
+        let explicit: GenerationConfig = toml::from_str("max_threads = 7").unwrap();
+        assert_eq!(explicit.max_threads.unwrap().get(), 7);
+        let serialized = toml::to_string(&explicit).unwrap();
+        assert!(serialized.contains("max_threads = 7"));
+    }
+
+    #[test]
+    fn generation_config_rejects_zero_threads() {
+        assert!(toml::from_str::<GenerationConfig>("max_threads = 0").is_err());
+    }
 }

--- a/pumpkin-world/src/chunk_system/admission.rs
+++ b/pumpkin-world/src/chunk_system/admission.rs
@@ -1,0 +1,126 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+const GENERATION_QUEUE_SLACK: usize = 2;
+
+/// Shared Rayon pool and admission budget used by every level on a server.
+pub struct GenerationRuntime {
+    pool: Arc<rayon::ThreadPool>,
+    admission: Arc<GenerationAdmission>,
+}
+
+impl GenerationRuntime {
+    /// Builds a runtime with a small amount of queued work beyond the worker count.
+    pub fn new(worker_count: usize) -> Result<Arc<Self>, rayon::ThreadPoolBuildError> {
+        let worker_count = worker_count.max(1);
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(worker_count)
+                .thread_name(|i| format!("Gen-Pool-{i}"))
+                .build()?,
+        );
+        let limit = worker_count.saturating_add(GENERATION_QUEUE_SLACK);
+        Ok(Arc::new(Self {
+            pool,
+            admission: Arc::new(GenerationAdmission::new(limit)),
+        }))
+    }
+
+    #[must_use]
+    pub const fn pool(&self) -> &Arc<rayon::ThreadPool> {
+        &self.pool
+    }
+
+    #[must_use]
+    pub const fn admission(&self) -> &Arc<GenerationAdmission> {
+        &self.admission
+    }
+
+    #[must_use]
+    pub fn worker_count(&self) -> usize {
+        self.pool.current_num_threads()
+    }
+
+    #[must_use]
+    pub fn admission_limit(&self) -> usize {
+        self.admission.limit
+    }
+}
+
+/// A process-wide cap on chunk-generation jobs submitted to Rayon.
+pub struct GenerationAdmission {
+    limit: usize,
+    admitted: AtomicUsize,
+}
+
+impl GenerationAdmission {
+    #[must_use]
+    pub const fn new(limit: usize) -> Self {
+        Self {
+            limit: if limit == 0 { 1 } else { limit },
+            admitted: AtomicUsize::new(0),
+        }
+    }
+
+    #[must_use]
+    pub fn try_acquire(self: &Arc<Self>) -> Option<GenerationPermit> {
+        self.admitted
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < self.limit).then_some(current + 1)
+            })
+            .ok()
+            .map(|_| GenerationPermit {
+                admission: self.clone(),
+            })
+    }
+
+    #[must_use]
+    pub fn admitted(&self) -> usize {
+        self.admitted.load(Ordering::Acquire)
+    }
+
+    #[must_use]
+    pub const fn limit(&self) -> usize {
+        self.limit
+    }
+}
+
+/// Releases one shared admission slot when the generation result is consumed or dropped.
+pub struct GenerationPermit {
+    admission: Arc<GenerationAdmission>,
+}
+
+impl Drop for GenerationPermit {
+    fn drop(&mut self) {
+        let released =
+            self.admission
+                .admitted
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                    current.checked_sub(1)
+                });
+        debug_assert!(released.is_ok(), "generation admission permit underflow");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GenerationAdmission;
+    use std::sync::Arc;
+
+    #[test]
+    fn permits_are_bounded_and_released_on_drop() {
+        let admission = Arc::new(GenerationAdmission::new(2));
+        let first = admission.try_acquire().unwrap();
+        let second = admission.try_acquire().unwrap();
+        assert!(admission.try_acquire().is_none());
+        assert_eq!(admission.admitted(), 2);
+
+        drop(first);
+        let replacement = admission.try_acquire().unwrap();
+        assert_eq!(admission.admitted(), 2);
+        drop((second, replacement));
+        assert_eq!(admission.admitted(), 0);
+    }
+}

--- a/pumpkin-world/src/chunk_system/mod.rs
+++ b/pumpkin-world/src/chunk_system/mod.rs
@@ -15,6 +15,7 @@ pub type IOLock = std::sync::Arc<(
     tokio::sync::Notify,
 )>;
 
+pub mod admission;
 pub mod channel;
 pub mod chunk_holder;
 pub mod chunk_listener;
@@ -29,6 +30,7 @@ pub mod worker_logic;
 #[cfg(test)]
 mod tests;
 
+pub use admission::GenerationRuntime;
 pub use channel::LevelChannel;
 pub use chunk_holder::ChunkHolder;
 pub use chunk_listener::ChunkListener;

--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -1,9 +1,12 @@
+use super::admission::{GenerationAdmission, GenerationPermit, GenerationRuntime};
 use super::channel::LevelChange;
 use super::chunk_holder::ChunkHolder;
 use super::chunk_state::{Chunk, StagedChunkEnum};
 use super::dag::{DAG, EdgeKey, Node, NodeKey};
 use super::generation_cache::Cache;
-use super::worker_logic::{RecvChunk, generation_work, io_read_work, io_write_work};
+use super::worker_logic::{
+    RecvChunk, finish_generation, generation_work, io_read_work, io_write_work,
+};
 use super::{
     ChunkLevel, ChunkListener, ChunkLoading, ChunkPos, HashMapType, HashSetType, IOLock,
     LevelChannel,
@@ -66,18 +69,27 @@ pub struct GenerationSchedule {
     waiting_for_chunks: HashSetType<NodeKey>,
 
     io_lock: IOLock,
-    running_task_count: u16,
-    max_in_flight: u16,
+    running_io_count: usize,
+    running_generation_count: usize,
+    max_io_in_flight: usize,
+    generation_admission: Arc<GenerationAdmission>,
     queue_dirty: bool,
     recv_chunk: crossfire::compat::MRx<(ChunkPos, RecvChunk)>,
     io_read: crossfire::compat::MTx<Vec<ChunkPos>>,
     io_write: crossfire::compat::Tx<Vec<(ChunkPos, Chunk)>>,
-    generate: crossfire::compat::MTx<(ChunkPos, Cache, StagedChunkEnum)>,
+    generate: crossfire::compat::MTx<(ChunkPos, Cache, StagedChunkEnum, GenerationPermit)>,
     send_chunk: crossfire::compat::MTx<(ChunkPos, RecvChunk)>,
-    gen_pool: Option<Arc<rayon::ThreadPool>>,
+    generation_runtime: Option<Arc<GenerationRuntime>>,
     listener: Arc<ChunkListener>,
     lighting_config: LightingEngineConfig,
     last_unload: std::time::Instant,
+    last_metrics: std::time::Instant,
+    interval_generation_admitted: u64,
+    interval_generation_completed: u64,
+    interval_generation_failed: u64,
+    interval_full_chunks: u64,
+    interval_stage_count: [u64; StagedChunkEnum::Full as usize + 1],
+    interval_stage_nanos: [u128; StagedChunkEnum::Full as usize + 1],
 }
 
 impl GenerationSchedule {
@@ -88,7 +100,7 @@ impl GenerationSchedule {
         level_channel: Arc<LevelChannel>,
         listener: Arc<ChunkListener>,
         thread_tracker: &mut Vec<thread::JoinHandle<()>>,
-        gen_pool: Option<Arc<rayon::ThreadPool>>,
+        generation_runtime: Option<Arc<GenerationRuntime>>,
     ) {
         let (send_chunk, recv_chunk) = crossfire::compat::mpmc::unbounded_blocking();
 
@@ -120,7 +132,7 @@ impl GenerationSchedule {
             io_lock.clone(),
         ));
 
-        if gen_pool.is_none() {
+        if generation_runtime.is_none() {
             for i in 0..gen_thread_count {
                 let recv_gen = recv_gen.clone();
                 let send_chunk = send_chunk.clone();
@@ -137,11 +149,11 @@ impl GenerationSchedule {
             }
         }
 
-        let max_in_flight = if gen_pool.is_some() {
-            (thread::available_parallelism().map_or(1, std::num::NonZero::get) * 4) as u16
-        } else {
-            gen_thread_count as u16
-        };
+        let generation_admission = generation_runtime.as_ref().map_or_else(
+            || Arc::new(GenerationAdmission::new(gen_thread_count)),
+            |runtime| runtime.admission().clone(),
+        );
+        let max_io_in_flight = io_read_thread_count.saturating_mul(16).max(1);
 
         let level_sched = level;
         let lighting_config = level_sched.lighting_config;
@@ -158,19 +170,28 @@ impl GenerationSchedule {
                     unload_chunks: HashSetType::default(),
                     waiting_for_chunks: HashSetType::default(),
                     io_lock,
-                    running_task_count: 0,
-                    max_in_flight,
+                    running_io_count: 0,
+                    running_generation_count: 0,
+                    max_io_in_flight,
+                    generation_admission,
                     queue_dirty: false,
                     recv_chunk,
                     io_read: send_read_io,
                     io_write: send_write_io,
                     generate: send_gen,
                     send_chunk,
-                    gen_pool,
+                    generation_runtime,
                     listener,
                     chunk_map: HashMap::default(),
                     lighting_config,
                     last_unload: std::time::Instant::now(),
+                    last_metrics: std::time::Instant::now(),
+                    interval_generation_admitted: 0,
+                    interval_generation_completed: 0,
+                    interval_generation_failed: 0,
+                    interval_full_chunks: 0,
+                    interval_stage_count: [0; StagedChunkEnum::Full as usize + 1],
+                    interval_stage_nanos: [0; StagedChunkEnum::Full as usize + 1],
                 };
                 scheduler.work(&level_sched);
             })
@@ -203,6 +224,96 @@ impl GenerationSchedule {
             }
             LightingEngineConfig::Default => {}
         }
+    }
+
+    const fn record_generation_result(
+        &mut self,
+        stage: StagedChunkEnum,
+        elapsed: Duration,
+        succeeded: bool,
+    ) {
+        if succeeded {
+            self.interval_generation_completed += 1;
+        } else {
+            self.interval_generation_failed += 1;
+        }
+        self.interval_stage_count[stage as usize] += 1;
+        self.interval_stage_nanos[stage as usize] += elapsed.as_nanos();
+    }
+
+    fn flush_io_batch(&mut self, batch: &mut Vec<ChunkPos>) -> bool {
+        if batch.is_empty() {
+            return true;
+        }
+        let batch = std::mem::take(batch);
+        let batch_len = batch.len();
+        if self.io_read.send(batch).is_err() {
+            self.running_io_count = self.running_io_count.saturating_sub(batch_len);
+            return false;
+        }
+        true
+    }
+
+    fn emit_metrics(&mut self, level: &Level) {
+        if self.last_metrics.elapsed() < Duration::from_secs(1) {
+            return;
+        }
+
+        let mut ready_io = 0;
+        let mut ready_generation = 0;
+        for task in &self.queue {
+            if self
+                .graph
+                .nodes
+                .get(task.1)
+                .is_some_and(|node| node.stage == StagedChunkEnum::Empty)
+            {
+                ready_io += 1;
+            } else {
+                ready_generation += 1;
+            }
+        }
+
+        debug!(
+            target: "pumpkin_world::generation_metrics",
+            dimension = ?level.world_gen.dimension(),
+            ready_io,
+            ready_generation,
+            waiting_for_dependencies = self.waiting_for_chunks.len(),
+            io_in_flight = self.running_io_count,
+            generation_in_flight = self.running_generation_count,
+            generation_admitted_global = self.generation_admission.admitted(),
+            generation_admission_limit = self.generation_admission.limit(),
+            jobs_admitted = self.interval_generation_admitted,
+            jobs_completed = self.interval_generation_completed,
+            jobs_failed = self.interval_generation_failed,
+            full_chunks = self.interval_full_chunks,
+            "chunk generation interval"
+        );
+
+        for stage_index in StagedChunkEnum::Biomes as usize..=StagedChunkEnum::Full as usize {
+            let count = self.interval_stage_count[stage_index];
+            if count > 0 {
+                let average_ms =
+                    self.interval_stage_nanos[stage_index] as f64 / count as f64 / 1_000_000.0;
+                debug!(
+                    target: "pumpkin_world::generation_metrics",
+                    dimension = ?level.world_gen.dimension(),
+                    stage = ?StagedChunkEnum::from(stage_index as u8),
+                    finished = count,
+                    average_ms,
+                    "chunk generation stage interval"
+                );
+            }
+        }
+
+        self.interval_generation_admitted = 0;
+        self.interval_generation_completed = 0;
+        self.interval_generation_failed = 0;
+        self.interval_full_chunks = 0;
+        self.interval_stage_count.fill(0);
+        self.interval_stage_nanos.fill(0);
+        self.last_metrics = std::time::Instant::now();
     }
 
     fn calc_priority(
@@ -780,6 +891,7 @@ impl GenerationSchedule {
     fn receive_chunk(&mut self, pos: ChunkPos, data: RecvChunk) {
         match data {
             RecvChunk::IO(chunk) => {
+                self.running_io_count = self.running_io_count.saturating_sub(1);
                 let mut holder = self.chunk_map.remove(&pos).unwrap();
                 if holder.chunk.is_some() {
                     warn!(
@@ -830,7 +942,14 @@ impl GenerationSchedule {
                 // A new chunk arrived — unblock any waiting generation tasks
                 self.check_waiting_tasks();
             }
-            RecvChunk::Generation(data) => {
+            RecvChunk::Generation {
+                data,
+                stage,
+                elapsed,
+                _permit,
+            } => {
+                self.running_generation_count = self.running_generation_count.saturating_sub(1);
+                self.record_generation_result(stage, elapsed, true);
                 let mut dx = 0;
                 let mut dy = 0;
                 for chunk in data.chunks {
@@ -840,6 +959,7 @@ impl GenerationSchedule {
                             let mut holder = self.chunk_map.remove(&new_pos).unwrap();
                             let stage = StagedChunkEnum::Full;
                             if new_pos == pos {
+                                self.interval_full_chunks += 1;
                                 if holder.current_stage != StagedChunkEnum::Spawn {
                                     warn!(
                                         "receive_chunk(Level): holder at {:?} for pos {:?} expected {:?}; aligning",
@@ -963,7 +1083,11 @@ impl GenerationSchedule {
                 pos: fail_pos,
                 stage,
                 error,
+                elapsed,
+                _permit,
             } => {
+                self.running_generation_count = self.running_generation_count.saturating_sub(1);
+                self.record_generation_result(stage, elapsed, false);
                 error!(
                     "Received generation failure notification for chunk {:?} at stage {:?}: {}",
                     fail_pos, stage, error
@@ -1028,7 +1152,6 @@ impl GenerationSchedule {
                 }
             }
         }
-        self.running_task_count -= 1;
     }
 
     #[expect(clippy::too_many_lines)]
@@ -1039,6 +1162,7 @@ impl GenerationSchedule {
             thread::current().name().unwrap_or("unknown")
         );
         loop {
+            self.emit_metrics(level);
             if level.should_unload.swap(false, Relaxed) {
                 self.garbage_collect_dependencies();
                 self.process_unload_queue();
@@ -1077,18 +1201,15 @@ impl GenerationSchedule {
                 self.queue_dirty = false;
             }
 
-            // 4. Process ready tasks in the queue (up to max_in_flight)
+            // 4. Process ready tasks without letting one saturated work class block the other.
             let mut io_batch = Vec::with_capacity(16);
+            let mut deferred_tasks = Vec::new();
+            let mut admitted_work = false;
             'out2: while let Some(task) = self.queue.pop() {
                 if level.shut_down_chunk_system.load(Relaxed) {
                     self.queue.push(task);
                     info!("Shutdown detected during task processing, saving chunks...");
                     self.save_all_chunk(true);
-                    break 'out2;
-                }
-
-                if self.running_task_count >= self.max_in_flight {
-                    self.queue.push(task);
                     break 'out2;
                 }
 
@@ -1103,13 +1224,25 @@ impl GenerationSchedule {
                     }
                 }
 
-                if let Some(node) = self.graph.nodes.get_mut(task.1) {
+                if let Some(node) = self.graph.nodes.get(task.1).cloned() {
                     if node.in_degree != 0 {
-                        node.in_queue = false;
+                        self.graph.nodes.get_mut(task.1).unwrap().in_queue = false;
                         continue;
                     }
-                    node.in_flight = true;
-                    let node = node.clone();
+
+                    let generation_permit = if node.stage == StagedChunkEnum::Empty {
+                        if self.running_io_count >= self.max_io_in_flight {
+                            deferred_tasks.push(task);
+                            continue;
+                        }
+                        None
+                    } else if let Some(permit) = self.generation_admission.try_acquire() {
+                        Some(permit)
+                    } else {
+                        deferred_tasks.push(task);
+                        continue;
+                    };
+                    self.graph.nodes.get_mut(task.1).unwrap().in_flight = true;
 
                     // A chunk can be advanced as part of a neighboring task's write cache.
                     // In that case its queued node may survive even though the returned
@@ -1136,7 +1269,8 @@ impl GenerationSchedule {
                     }
 
                     if node.stage == StagedChunkEnum::Empty {
-                        self.running_task_count += 1;
+                        self.running_io_count += 1;
+                        admitted_work = true;
                         let holder = self.chunk_map.get_mut(&node.pos).unwrap();
                         debug_assert!(holder.occupied.is_null());
                         debug_assert_eq!(holder.current_stage, StagedChunkEnum::None);
@@ -1151,18 +1285,14 @@ impl GenerationSchedule {
                         holder.occupied = occupy;
 
                         io_batch.push(node.pos);
-                        if io_batch.len() >= 16
-                            && self.io_read.send(std::mem::take(&mut io_batch)).is_err()
-                        {
+                        if io_batch.len() >= 16 && !self.flush_io_batch(&mut io_batch) {
                             info!("IO read thread closed, saving remaining chunks...");
                             self.save_all_chunk(true);
                             break 'out2;
                         }
                     } else {
                         // Send any pending IO batch before starting generation
-                        if !io_batch.is_empty()
-                            && self.io_read.send(std::mem::take(&mut io_batch)).is_err()
-                        {
+                        if !self.flush_io_batch(&mut io_batch) {
                             info!("IO read thread closed, saving remaining chunks...");
                             self.save_all_chunk(true);
                             break 'out2;
@@ -1199,7 +1329,7 @@ impl GenerationSchedule {
                                 // have arrived in the recv_chunk drain that happened earlier
                                 // in this same loop iteration, before this task was parked.
                                 // If so, check_waiting_tasks() will immediately re-queue it
-                                // so it isn't stranded with running_task_count==0.
+                                // so it isn't stranded with no in-flight work.
                                 self.check_waiting_tasks();
                                 continue;
                             }
@@ -1268,8 +1398,11 @@ impl GenerationSchedule {
                             }
                         }
 
-                        self.running_task_count += 1;
-                        if let Some(pool) = &self.gen_pool {
+                        self.running_generation_count += 1;
+                        self.interval_generation_admitted += 1;
+                        admitted_work = true;
+                        let permit = generation_permit.expect("generation task acquired a permit");
+                        if let Some(runtime) = &self.generation_runtime {
                             let pos = node.pos;
                             let stage = node.stage;
                             let send_chunk = self.send_chunk.clone();
@@ -1277,14 +1410,18 @@ impl GenerationSchedule {
                             let settings =
                                 GenerationSettings::from_dimension(level.world_gen.dimension());
 
-                            pool.spawn(move || {
-                                let result = crate::chunk_system::worker_logic::run_generation(
-                                    pos, cache, stage, &level, settings,
-                                );
+                            runtime.pool().spawn(move || {
+                                let result =
+                                    finish_generation(pos, cache, stage, &level, settings, permit);
                                 let _ = send_chunk.send((pos, result));
                             });
-                        } else if self.generate.send((node.pos, cache, node.stage)).is_err() {
-                            self.running_task_count = self.running_task_count.saturating_sub(1);
+                        } else if self
+                            .generate
+                            .send((node.pos, cache, node.stage, permit))
+                            .is_err()
+                        {
+                            self.running_generation_count =
+                                self.running_generation_count.saturating_sub(1);
                             info!("Generation thread closed, saving remaining chunks...");
                             self.save_all_chunk(true);
                             break 'out2;
@@ -1292,17 +1429,22 @@ impl GenerationSchedule {
                     }
                 }
             }
+            self.queue.extend(deferred_tasks);
 
             // Flush any remaining IO batch
-            if !io_batch.is_empty() && self.io_read.send(std::mem::take(&mut io_batch)).is_err() {
+            if !self.flush_io_batch(&mut io_batch) {
                 info!("IO read thread closed, saving remaining chunks...");
                 self.save_all_chunk(true);
             }
 
             // 3. If queue is empty, wait for work or results
-            if self.queue.is_empty() {
+            if self.queue.is_empty() || !admitted_work {
                 // If we have tasks in flight, wait for them with timeout
-                if self.running_task_count > 0 || !self.waiting_for_chunks.is_empty() {
+                if self.running_io_count > 0
+                    || self.running_generation_count > 0
+                    || !self.waiting_for_chunks.is_empty()
+                    || !self.queue.is_empty()
+                {
                     match self.recv_chunk.recv_timeout(Duration::from_millis(5)) {
                         Ok((pos, data)) => {
                             self.receive_chunk(pos, data);
@@ -1329,7 +1471,8 @@ impl GenerationSchedule {
                         continue;
                     }
                     debug_assert!(self.debug_check());
-                    debug_assert_eq!(self.running_task_count, 0);
+                    debug_assert_eq!(self.running_io_count, 0);
+                    debug_assert_eq!(self.running_generation_count, 0);
                     self.resort_work(self.send_level.wait_and_get(level));
                 }
                 if self.queue_dirty {
@@ -1339,12 +1482,15 @@ impl GenerationSchedule {
             }
         }
         info!(
-            "schedule: waiting for {} generation tasks to finish",
-            self.running_task_count
+            io_in_flight = self.running_io_count,
+            generation_in_flight = self.running_generation_count,
+            "schedule: waiting for in-flight chunk work to finish"
         );
         let mut wait_iterations = 0;
         let max_wait_iterations = 100; // 5 seconds max wait
-        while self.running_task_count > 0 && wait_iterations < max_wait_iterations {
+        while (self.running_io_count > 0 || self.running_generation_count > 0)
+            && wait_iterations < max_wait_iterations
+        {
             if let Ok((pos, data)) = self.recv_chunk.try_recv() {
                 self.receive_chunk(pos, data);
                 wait_iterations = 0;
@@ -1352,19 +1498,21 @@ impl GenerationSchedule {
                 wait_iterations += 1;
                 if wait_iterations % 20 == 0 {
                     warn!(
-                        "Still waiting for {} tasks to complete (waited {}ms)",
-                        self.running_task_count,
-                        wait_iterations * 50
+                        io_in_flight = self.running_io_count,
+                        generation_in_flight = self.running_generation_count,
+                        waited_ms = wait_iterations * 50,
+                        "Still waiting for chunk work to complete"
                     );
                 }
                 thread::sleep(Duration::from_millis(50));
             }
         }
 
-        if self.running_task_count > 0 {
+        if self.running_io_count > 0 || self.running_generation_count > 0 {
             warn!(
-                "Cancelling {} in-flight generation tasks",
-                self.running_task_count
+                io_in_flight = self.running_io_count,
+                generation_in_flight = self.running_generation_count,
+                "Cancelling in-flight chunk work"
             );
             let mut nodes_to_drop = Vec::new();
 
@@ -1391,7 +1539,8 @@ impl GenerationSchedule {
                 self.drop_node(node_key);
             }
 
-            self.running_task_count = 0;
+            self.running_io_count = 0;
+            self.running_generation_count = 0;
         }
 
         drop(self.io_write);

--- a/pumpkin-world/src/chunk_system/worker_logic.rs
+++ b/pumpkin-world/src/chunk_system/worker_logic.rs
@@ -1,3 +1,4 @@
+use super::admission::GenerationPermit;
 use super::chunk_state::{Chunk, StagedChunkEnum};
 use super::generation_cache::Cache;
 use super::{ChunkPos, IOLock};
@@ -13,16 +14,29 @@ use pumpkin_data::chunk_gen_settings::GenerationSettings;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::sync::atomic::Ordering::Relaxed;
+use std::time::{Duration, Instant};
 use tracing::{debug, error, warn};
 
 pub enum RecvChunk {
     IO(Chunk),
-    Generation(Cache),
+    Generation {
+        data: Cache,
+        stage: StagedChunkEnum,
+        elapsed: Duration,
+        _permit: GenerationPermit,
+    },
     GenerationFailure {
         pos: ChunkPos,
         stage: StagedChunkEnum,
         error: String,
+        elapsed: Duration,
+        _permit: GenerationPermit,
     },
+}
+
+pub enum GenerationOutcome {
+    Success(Cache),
+    Failure(String),
 }
 
 /// Checks if a chunk needs relighting based on the current lighting configuration
@@ -227,7 +241,7 @@ pub fn run_generation(
     stage: StagedChunkEnum,
     level: &Level,
     _settings: &GenerationSettings,
-) -> RecvChunk {
+) -> GenerationOutcome {
     let portal = level.world_portal.load_full();
     let portal_ref = portal.as_deref().expect("Portal should be initialized");
     // Run generation with panic catching
@@ -237,7 +251,7 @@ pub fn run_generation(
     }));
 
     match result {
-        Ok(cache) => RecvChunk::Generation(cache),
+        Ok(cache) => GenerationOutcome::Success(cache),
         Err(payload) => {
             let msg = payload
                 .downcast_ref::<&str>()
@@ -251,29 +265,53 @@ pub fn run_generation(
 
             error!("Chunk generation FAILED at {pos:?} ({stage:?}): {msg}");
 
-            RecvChunk::GenerationFailure {
-                pos,
-                stage,
-                error: msg.to_string(),
-            }
+            GenerationOutcome::Failure(msg.to_string())
         }
     }
 }
 
+pub fn finish_generation(
+    pos: ChunkPos,
+    cache: Cache,
+    stage: StagedChunkEnum,
+    level: &Level,
+    settings: &GenerationSettings,
+    permit: GenerationPermit,
+) -> RecvChunk {
+    let start = Instant::now();
+    let outcome = run_generation(pos, cache, stage, level, settings);
+    let elapsed = start.elapsed();
+    match outcome {
+        GenerationOutcome::Success(data) => RecvChunk::Generation {
+            data,
+            stage,
+            elapsed,
+            _permit: permit,
+        },
+        GenerationOutcome::Failure(error) => RecvChunk::GenerationFailure {
+            pos,
+            stage,
+            error,
+            elapsed,
+            _permit: permit,
+        },
+    }
+}
+
 pub fn generation_work(
-    recv: &crossfire::compat::MRx<(ChunkPos, Cache, StagedChunkEnum)>,
+    recv: &crossfire::compat::MRx<(ChunkPos, Cache, StagedChunkEnum, GenerationPermit)>,
     send: &crossfire::compat::MTx<(ChunkPos, RecvChunk)>,
     level: &Arc<Level>,
 ) {
     let settings = GenerationSettings::from_dimension(level.world_gen.dimension());
 
     loop {
-        let Ok((pos, cache, stage)) = recv.recv() else {
+        let Ok((pos, cache, stage, permit)) = recv.recv() else {
             debug!("generation channel closed, exiting");
             break;
         };
 
-        let result = run_generation(pos, cache, stage, level, settings);
+        let result = finish_generation(pos, cache, stage, level, settings, permit);
         if send.send((pos, result)).is_err() {
             break;
         }

--- a/pumpkin-world/src/dimension.rs
+++ b/pumpkin-world/src/dimension.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use pumpkin_config::world::LevelConfig;
 use pumpkin_data::dimension::Dimension;
 
-use crate::level::Level;
+use crate::{chunk_system::GenerationRuntime, level::Level};
 
 #[must_use]
 pub fn into_level(
@@ -11,7 +11,7 @@ pub fn into_level(
     level_config: &LevelConfig,
     mut base_directory: PathBuf,
     seed: i64,
-    gen_pool: Option<Arc<rayon::ThreadPool>>,
+    generation_runtime: Option<Arc<GenerationRuntime>>,
 ) -> Arc<Level> {
     if dimension.minecraft_name == Dimension::OVERWORLD.minecraft_name {
     } else if dimension.minecraft_name == Dimension::THE_NETHER.minecraft_name {
@@ -19,5 +19,11 @@ pub fn into_level(
     } else if dimension.minecraft_name == Dimension::THE_END.minecraft_name {
         base_directory.push("DIM1");
     }
-    Level::from_root_folder(level_config, base_directory, seed, dimension, gen_pool)
+    Level::from_root_folder(
+        level_config,
+        base_directory,
+        seed,
+        dimension,
+        generation_runtime,
+    )
 }

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -1,6 +1,8 @@
 use crate::chunk::format::linear::LinearV2File;
 use crate::chunk::format::pump::PumpFile;
-use crate::chunk_system::{ChunkListener, ChunkLoading, GenerationSchedule, LevelChannel};
+use crate::chunk_system::{
+    ChunkListener, ChunkLoading, GenerationRuntime, GenerationSchedule, LevelChannel,
+};
 use crate::generation::generator::WorldGenerator;
 use crate::lighting::DynamicLightEngine;
 use crate::{
@@ -102,7 +104,7 @@ pub struct Level {
     pub level_channel: Arc<LevelChannel>,
     pub thread_tracker: Mutex<Vec<thread::JoinHandle<()>>>,
     pub chunk_listener: Arc<ChunkListener>,
-    pub gen_pool: Option<Arc<rayon::ThreadPool>>,
+    pub generation_runtime: Option<Arc<GenerationRuntime>>,
 }
 
 pub struct TickData {
@@ -134,7 +136,7 @@ impl Level {
         root_folder: PathBuf,
         seed: i64,
         dimension: Dimension,
-        gen_pool: Option<Arc<rayon::ThreadPool>>,
+        generation_runtime: Option<Arc<GenerationRuntime>>,
     ) -> Arc<Self> {
         let dim_folder = if dimension.minecraft_name == Dimension::OVERWORLD.minecraft_name
             || dimension.minecraft_name == Dimension::THE_NETHER.minecraft_name
@@ -271,24 +273,23 @@ impl Level {
             level_channel: level_channel.clone(),
             thread_tracker,
             chunk_listener: listener.clone(),
-            gen_pool: gen_pool.clone(),
+            generation_runtime: generation_runtime.clone(),
         });
 
-        // TODO
-        let total_cores = thread::available_parallelism()
-            .map_or(1, std::num::NonZero::get)
-            .saturating_sub(2)
-            .max(1);
-        let threads_per_dimension = (total_cores / 2).max(1);
+        let available_cpus = thread::available_parallelism().map_or(1, std::num::NonZero::get);
+        let generation_threads = generation_runtime.as_ref().map_or_else(
+            || level_config.generation.resolve_threads(available_cpus),
+            |runtime| runtime.worker_count(),
+        );
 
         GenerationSchedule::create(
             4,
-            threads_per_dimension,
+            generation_threads,
             level_ref.clone(),
             level_channel,
             listener,
             level_ref.thread_tracker.lock().unwrap().as_mut(),
-            gen_pool,
+            generation_runtime,
         );
 
         level_ref
@@ -296,8 +297,8 @@ impl Level {
 
     pub fn spawn_entity_generation(self: &Arc<Self>, pos: Vector2<i32>) {
         let level = self.clone();
-        if let Some(pool) = &self.gen_pool {
-            pool.spawn(move || {
+        if let Some(runtime) = &self.generation_runtime {
+            runtime.pool().spawn(move || {
                 let arc_chunk = Arc::new(ChunkEntityData {
                     x: pos.x,
                     z: pos.y,

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 [dependencies]
 # pumpkin
 arc-swap.workspace = true
-rayon.workspace = true
 pumpkin-util.workspace = true
 pumpkin-nbt.workspace = true
 pumpkin-config.workspace = true

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -25,6 +25,7 @@ use pumpkin_data::dimension::Dimension;
 use pumpkin_data::entity::EntityType;
 use pumpkin_util::permission::{PermissionManager, PermissionRegistry};
 use pumpkin_util::text::color::NamedColor;
+use pumpkin_world::chunk_system::GenerationRuntime;
 use pumpkin_world::dimension::into_level;
 use pumpkin_world::world::WorldPortalExt;
 use tracing::{debug, error, info, warn};
@@ -101,6 +102,8 @@ pub struct Server {
     pub item_registry: Arc<ItemRegistry>,
     /// Manages multiple worlds within the server.
     pub worlds: ArcSwap<Vec<Arc<World>>>,
+    /// Shared chunk-generation workers and global admission budget.
+    pub generation_runtime: Arc<GenerationRuntime>,
     /// All the dimensions that exist on the server.
     pub dimensions: Vec<Dimension>,
     /// Assigns unique IDs to containers.
@@ -255,6 +258,19 @@ impl Server {
                 .collect::<Vec<_>>()
         );
 
+        let available_cpus = std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
+        let generation_threads = advanced_config
+            .world
+            .generation
+            .resolve_threads(available_cpus);
+        let generation_runtime = GenerationRuntime::new(generation_threads)
+            .expect("Failed to build generation thread pool");
+        info!(
+            workers = generation_runtime.worker_count(),
+            admission_limit = generation_runtime.admission_limit(),
+            "Configured background chunk generation"
+        );
+
         let server = Self {
             basic_config,
             advanced_config,
@@ -268,6 +284,7 @@ impl Server {
             recipe_manager: Arc::new(recipe::RecipeManager::new()),
             map_id: level_info.load().map_id.into(),
             worlds: ArcSwap::from_pointee(vec![]),
+            generation_runtime,
             dimensions,
             command_dispatcher,
             block_registry: block_registry.clone(),
@@ -298,13 +315,6 @@ impl Server {
         };
         let server = Arc::new(server);
 
-        let gen_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .thread_name(|i| format!("Gen-Pool-{i}"))
-                .build()
-                .expect("Failed to build generation thread pool"),
-        );
-
         let server_clone = server.clone();
         tokio::spawn(async move {
             server_clone
@@ -319,7 +329,7 @@ impl Server {
             let l_info = server.level_info.clone(); // Access from struct
             let weak = Arc::downgrade(&server);
             let config = Arc::new(server.advanced_config.world.clone());
-            let pool = gen_pool.clone();
+            let generation_runtime = server.generation_runtime.clone();
 
             tokio::task::spawn_blocking(move || {
                 info!(
@@ -328,7 +338,7 @@ impl Server {
                         .color_named(NamedColor::DarkGreen)
                         .to_pretty_console()
                 );
-                let level = into_level(dim.clone(), &config, path, seed, Some(pool));
+                let level = into_level(dim.clone(), &config, path, seed, Some(generation_runtime));
                 let world = Arc::new(World::load(level.clone(), l_info, dim, registry, weak));
                 let portal: Arc<dyn WorldPortalExt> = Arc::new(WorldPortal(world.clone()));
                 level.world_portal.store(Arc::new(Some(portal)));
@@ -432,13 +442,12 @@ impl Server {
             let config = Arc::new(server.advanced_config.world.clone());
             let seed = server.level_info.load().world_gen_settings.seed;
 
-            // TODO: gen_pool should be reused
             let level = pumpkin_world::dimension::into_level(
                 dimension.clone(),
                 &config,
                 world_path,
                 seed,
-                None,
+                Some(server.generation_runtime.clone()),
             );
             let world: World = World::load(level.clone(), l_info, dimension, registry, weak);
             let world = Arc::new(world);

--- a/pumpkin/src/server/ticker.rs
+++ b/pumpkin/src/server/ticker.rs
@@ -17,6 +17,7 @@ impl Ticker {
     /// IMPORTANT: Run this in a new thread/tokio task.
     pub async fn run(server: &Arc<Server>) {
         let mut next_tick = Instant::now();
+        let mut last_metrics = std::time::Instant::now();
 
         'ticker: loop {
             let tick_start_time = std::time::Instant::now();
@@ -50,6 +51,37 @@ impl Ticker {
                 .await;
 
             server.update_tick_times(tick_duration_nanos).await;
+
+            if last_metrics.elapsed() >= Duration::from_secs(1) {
+                let tick_count = server.tick_count.load(Ordering::Relaxed);
+                let sample_size = (tick_count as usize).min(100);
+                if sample_size > 0 {
+                    let mut samples = server.get_tick_times_nanos_copy().await;
+                    let samples = &mut samples[..sample_size];
+                    samples.sort_unstable();
+                    let percentile = |fraction: f64| {
+                        let index = ((sample_size - 1) as f64 * fraction).round() as usize;
+                        samples[index]
+                    };
+                    let target_nanos = manager.nanoseconds_per_tick();
+                    let ticks_over_budget = samples
+                        .iter()
+                        .filter(|duration| **duration > target_nanos)
+                        .count();
+                    debug!(
+                        target: "pumpkin::tick_metrics",
+                        sample_size,
+                        p50_ms = percentile(0.50) as f64 / 1_000_000.0,
+                        p95_ms = percentile(0.95) as f64 / 1_000_000.0,
+                        p99_ms = percentile(0.99) as f64 / 1_000_000.0,
+                        max_ms = samples[sample_size - 1] as f64 / 1_000_000.0,
+                        ticks_over_budget,
+                        target_ms = target_nanos as f64 / 1_000_000.0,
+                        "server tick interval"
+                    );
+                }
+                last_metrics = std::time::Instant::now();
+            }
 
             let tick_interval = if manager.is_sprinting() {
                 Duration::ZERO


### PR DESCRIPTION
## Summary

  Bounds background chunk-generation admission so sustained exploration is less likely to starve latency-sensitive tick and network work.

  This does not reserve CPU cores. It reduces the number of simultaneously runnable generation workers and limits how much generation work can be queued ahead.

  ## Changes

  - Adds configurable generation concurrency:

  [world.generation]
  max_threads = 6

  When omitted, Pumpkin selects:

  | Logical CPUs | Generation workers|
  |---|---|
  |1|1|
  |2–4| N - 1|
  |Above 4| N - 2|

  - Uses one generation runtime shared by all dimensions and dynamically created worlds.
  - Globally bounds admitted generation work to worker_count + 2.
  - Holds admission permits until results are consumed or dropped, including failure and shutdown paths.
  - Separates generation and disk-I/O in-flight accounting.
  - Allows eligible reads to continue when generation admission is saturated.
  - Preserves scheduler priority when temporarily deferring saturated work.
  - Adds structured generation and tick-health telemetry.

  ## Motivation

  Rayon already limits actively executing CPU work to its worker count. The scheduler’s previous 4 × available_parallelism limit primarily allowed significant work to
  accumulate ahead of execution.

  That could:

  - retain more chunk-generation caches;
  - increase memory pressure;
  - delay reprioritisation;
  - commit resources to chunks that are no longer urgent;
  - increase contention with ticking and networking.

  The new global admission limit stays close to actual generation capacity while retaining two queued jobs to keep workers supplied.

  Disk reads are accounted for separately, so limiting CPU-bound generation does not unnecessarily block I/O.

  ## Instrumentation

  Generation telemetry includes:

  - ready generation and I/O work;
  - dependency-waiting tasks;
  - local and global admitted work;
  - admission limit;
  - jobs admitted, completed and failed;
  - chunks reaching Full;
  - average duration per generation stage.

  Tick telemetry includes rolling:

  - p50, p95 and p99 MSPT;
  - maximum MSPT;
  - ticks exceeding the configured tick budget.

  Enable it with:

  RUST_LOG=pumpkin_world::generation_metrics=debug,pumpkin::tick_metrics=debug

  ## Benchmark

  Tested on an Intel Core Ultra 7 155H using the existing concurrent full-generation benchmark:

  16 chunks
  4 Rayon workers
  3 alternating runs per revision
  10 samples per run

 |Revision| Median runtime| Approx. throughput|
 |---|---|---|
 |Master| 159.38 ms| 100.39 chunks/s|
 |This PR|160.83 ms| 99.48 chunks/s|

  The approximately 0.9% difference is within observed run-to-run variation, indicating no material raw-generation throughput regression.

  This benchmark bypasses the live scheduler and tick loop, so it does not measure the intended tail-latency improvement. The added telemetry enables a follow-up scripted
  exploration comparison using p99 MSPT, ticks over budget, requested-chunk latency and connection responsiveness.

  ## Validation

  - cargo test -p pumpkin-world --lib - 101 passed
  - New configuration and admission-limit tests pass
  - Clippy passes with warnings denied across pumpkin, pumpkin-world and pumpkin-config
  - Formatting and git diff --check pass

  Adaptive generation concurrency based on tick health remains suitable for a follow-up. This PR establishes the configuration, accounting, global admission control and
  instrumentation needed to implement it safely.
