### PR TITLE
perf(world): bulk-build generated chunk palettes

### DIFF
--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -68,9 +68,9 @@ serde_json5.workspace = true
 name = "chunk"
 harness = false
 
-#[[bench]]
-#name = "chunk_io"
-#harness = false
+[[bench]]
+name = "chunk_io"
+harness = false
 
 [[bench]]
 name = "chunk_gen"

--- a/pumpkin-world/benches/chunk_gen.rs
+++ b/pumpkin-world/benches/chunk_gen.rs
@@ -82,6 +82,7 @@ fn setup_cache(
         StagedChunkEnum::Carvers,
         StagedChunkEnum::Features,
         StagedChunkEnum::Lighting,
+        StagedChunkEnum::Spawn,
     ];
     for stage in pipeline {
         if stage as u8 >= target_stage as u8 {
@@ -322,6 +323,27 @@ fn bench_lighting_generation(c: &mut Criterion) {
     });
 }
 
+fn bench_level_chunk_conversion(c: &mut Criterion) {
+    let world_gen = make_world_gen();
+    let block_registry = Arc::new(BlockRegistry);
+
+    c.bench_function("level_chunk_conversion", |b| {
+        b.iter_batched(
+            || setup_cache(StagedChunkEnum::Full, &world_gen, block_registry.as_ref()),
+            |mut cache| {
+                cache.advance(
+                    StagedChunkEnum::Full,
+                    &world_gen,
+                    block_registry.as_ref(),
+                    &LightingEngineConfig::Default,
+                );
+                black_box(cache);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 criterion_group!(
     benches,
     bench_full_chunk_generation,
@@ -333,5 +355,6 @@ criterion_group!(
     bench_carvers_generation,
     bench_features_generation,
     bench_lighting_generation,
+    bench_level_chunk_conversion,
 );
 criterion_main!(benches);

--- a/pumpkin-world/benches/chunk_io.rs
+++ b/pumpkin-world/benches/chunk_io.rs
@@ -1,274 +1,93 @@
-// use std::{fs, path::PathBuf, sync::Arc};
-//
-//
-// use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-// use pumpkin_data::BlockDirection;
-// use pumpkin_util::math::{position::BlockPos, vector2::Vector2};
-// use pumpkin_world::{
-//     chunk::ChunkData,
-//     dimension::Dimension,
-//     global_path,
-//     level::Level,
-//     world::{BlockAccessor, BlockRegistryExt},
-// };
-// use tokio::{runtime::Runtime, sync::RwLock};
-//
-// #[ignore]
-// async fn reads(level: &Arc<Level>, positions: Vec<Vector2<i32>>) {
-//     // let level = level.clone();
-//     // let mut receiver = level.receive_chunks(positions);
-//     //
-//     // while let Some(x) = receiver.recv().await {
-//     //     // Don't compile me away!
-//     //     let _ = x;
-//     // }
-// }
-//
-// /*
-// async fn reads_parallel(level: &Arc<Level>, positions: Vec<Vector2<i32>>, threads: usize) {
-//     let mut tasks = JoinSet::new();
-//
-//     // we write non overlapping chunks to avoid conflicts or level cache
-//     // also we use `.rev()` to get the external radius first, avoiding
-//     // multiple files on the same request.
-//     for positions in positions.chunks(CHUNKS_ON_PARALLEL).rev().take(threads) {
-//         let level = level.clone();
-//         let positions = positions.to_vec();
-//         tasks.spawn(async move {
-//             test_reads(&level, positions.clone()).await;
-//         });
-//     }
-//
-//     let _ = tasks.join_all().await;
-// }
-// */
-//
-// async fn writes(level: &Arc<Level>, chunks: Vec<(Vector2<i32>, Arc<RwLock<ChunkData>>)>) {
-//     level.write_chunks(chunks).await;
-// }
-//
-// /*
-// async fn writes_parallel(
-//     level: &Arc<Level>,
-//     chunks: Vec<(Vector2<i32>, Arc<RwLock<ChunkData>>)>,
-//     threads: usize,
-// ) {
-//     let mut tasks = JoinSet::new();
-//
-//     // we write non overlapping chunks to avoid conflicts or level cache
-//     // also we use `.rev()` to get the external radius first, avoiding
-//     // multiple files on the same request.
-//     for chunks in chunks.chunks(CHUNKS_ON_PARALLEL).rev().take(threads) {
-//         let level = level.clone();
-//         let chunks = chunks.to_vec();
-//         tasks.spawn(async move {
-//             test_writes(&level, chunks).await;
-//         });
-//     }
-//
-//     let _ = tasks.join_all().await;
-// }
-// */
-//
-// // -16..16 == 32 chunks, 32*32 == 1024 chunks
-// const MIN_CHUNK: i32 = -16;
-// const MAX_CHUNK: i32 = 16;
-//
-// // How many chunks to use on parallel tests
-// //const CHUNKS_ON_PARALLEL: usize = 32;
-//
-// struct BlockRegistry;
-//
-// impl BlockRegistryExt for BlockRegistry {
-//     fn can_place_at(
-//         &self,
-//         _block: &pumpkin_data::Block,
-//         _block_accessor: &dyn BlockAccessor,
-//         _block_pos: &BlockPos,
-//         _face: BlockDirection,
-//     ) -> bool {
-//         true
-//     }
-// }
-//
-// #[ignore]
-// fn initialize_level(
-//     async_handler: &Runtime,
-//     root_dir: PathBuf,
-// ) -> Vec<(Vector2<i32>, Arc<RwLock<ChunkData>>)> {
-//     println!("Initializing data...");
-//     // Initial writes
-//     let mut chunks = Vec::new();
-//     async_handler.block_on(async {
-//         let block_registry = Arc::new(BlockRegistry);
-//
-//         // Our data dir is empty, so we're generating new chunks here
-//         let level_to_save = Arc::new(Level::from_root_folder(
-//             root_dir.clone(),
-//             block_registry,
-//             123,
-//             Dimension::Overworld,
-//         ));
-//         println!("Level Seed is: {}", level_to_save.seed.0);
-//
-//         let level_to_fetch = level_to_save.clone();
-//         let chunks_to_generate = (MIN_CHUNK..MAX_CHUNK)
-//             .flat_map(|x| (MIN_CHUNK..MAX_CHUNK).map(move |z| Vector2::new(x, z)))
-//             .collect::<Vec<_>>();
-//         // let mut receiver = level_to_fetch.receive_chunks(chunks_to_generate);
-//
-//         // while let Some((chunk, _)) = receiver.recv().await {
-//         //     let pos = chunk.read().await.position;
-//         //     chunks.push((pos, chunk));
-//         // }
-//         level_to_save.write_chunks(chunks.clone()).await;
-//     });
-//
-//     // Sort by distance from origin to ensure a fair selection
-//     // when using a subset of the total chunks for the benchmarks
-//     chunks.sort_unstable_by_key(|chunk| (chunk.0.x * chunk.0.x) + (chunk.0.y * chunk.0.y));
-//     chunks
-// }
-//
-// // Depends on config options from `./config`
-// /*
-// // This doesn't really test anything...
-// fn bench_chunk_io_parallel(c: &mut Criterion) {
-//     // System temp dirs are in-memory, so we can't use temp_dir
-//     let root_dir = global_path!("./bench_root_tmp");
-//     let _ = fs::remove_dir_all(&root_dir); // delete if it exists
-//     fs::create_dir(&root_dir).unwrap(); // create the directory
-//
-//     let async_handler = tokio::runtime::Builder::new_multi_thread().build().unwrap();
-//
-//     let chunks = initialize_level(&async_handler, root_dir.clone());
-//     let positions = chunks.iter().map(|(pos, _)| *pos).collect::<Vec<_>>();
-//
-//     let iters = [1, 2, 8, 32];
-//
-//     let mut write_group_parallel = c.benchmark_group("write_chunks");
-//     for n_requests in iters {
-//         let root_dir = root_dir.clone();
-//
-//         write_group_parallel.bench_with_input(
-//             BenchmarkId::new("Parallel", n_requests),
-//             &chunks,
-//             |b, parallel_chunks| {
-//                 let chunks = parallel_chunks.to_vec();
-//                 b.to_async(&async_handler).iter(async || {
-//                     let level = Arc::new(Level::from_root_folder(root_dir.clone()));
-//                     test_writes_parallel(&level, chunks.clone(), n_requests).await
-//                 })
-//             },
-//         );
-//     }
-//     write_group_parallel.finish();
-//
-//     let mut read_group = c.benchmark_group("read_chunks");
-//     for n_requests in iters {
-//         let root_dir = root_dir.clone();
-//
-//
-//         read_group.bench_with_input(
-//             BenchmarkId::new("Parallel", n_requests),
-//             &positions,
-//             |b, positions| {
-//                 let positions = positions.to_vec();
-//                 b.to_async(&async_handler).iter(async || {
-//                     let level = Arc::new(Level::from_root_folder(root_dir.clone()));
-//                     test_reads_parallel(&level, positions.clone(), n_requests).await
-//                 })
-//             },
-//         );
-//     }
-//     read_group.finish();
-//
-//     fs::remove_dir_all(&root_dir).unwrap(); // cleanup
-//
-// }
-// */
-//
-// // Depends on config options from `./config`
-// fn bench_chunk_io(c: &mut Criterion) {
-//     // System temp dirs are in-memory, so we can't use temp_dir
-//     let root_dir = global_path!("./bench_root_tmp");
-//     let _ = fs::remove_dir_all(&root_dir); // delete it if it exists
-//     fs::create_dir(&root_dir).unwrap(); // create the directory
-//
-//     let async_handler = tokio::runtime::Builder::new_current_thread()
-//         .build()
-//         .unwrap();
-//
-//     let chunks = initialize_level(&async_handler, root_dir.clone());
-//     let positions = chunks.iter().map(|(pos, _)| *pos).collect::<Vec<_>>();
-//
-//     let iters = [16, 64, 256, 512];
-//     // These test worst case: no caching done by `Level`
-//     // testing with 16, 64, 256 chunks
-//     let mut write_group = c.benchmark_group("write_chunks");
-//     for n_chunks in iters {
-//         let chunks = &chunks[..n_chunks];
-//         let root_dir = root_dir.clone();
-//         assert!(
-//             chunks.len() == n_chunks,
-//             "Expected {} chunks, got {}",
-//             n_chunks,
-//             chunks.len()
-//         );
-//         let block_registry = Arc::new(BlockRegistry);
-//
-//         write_group.bench_with_input(
-//             BenchmarkId::new("Single", n_chunks),
-//             &chunks,
-//             |b, chunks| {
-//                 b.to_async(&async_handler).iter(async || {
-//                     let level = Arc::new(Level::from_root_folder(
-//                         root_dir.clone(),
-//                         block_registry.clone(),
-//                         123,
-//                         Dimension::Overworld,
-//                     ));
-//                     test_writes(&level, chunks.to_vec()).await
-//                 })
-//             },
-//         );
-//     }
-//     write_group.finish();
-//
-//     // These test worst case: no caching done by `Level`
-//     // testing with 16, 64, 256 chunks
-//     let mut read_group = c.benchmark_group("read_chunks");
-//     for n_chunks in iters {
-//         let positions = &positions[..n_chunks];
-//         let root_dir = root_dir.clone();
-//         assert!(
-//             positions.len() == n_chunks,
-//             "Expected {} chunks, got {}",
-//             n_chunks,
-//             positions.len()
-//         );
-//         let block_registry = Arc::new(BlockRegistry);
-//
-//         read_group.bench_with_input(
-//             BenchmarkId::new("Single", n_chunks),
-//             &positions,
-//             |b, positions| {
-//                 b.to_async(&async_handler).iter(async || {
-//                     let level = Arc::new(Level::from_root_folder(
-//                         root_dir.clone(),
-//                         block_registry.clone(),
-//                         123,
-//                         Dimension::Overworld,
-//                     ));
-//                     test_reads(&level, positions.to_vec()).await
-//                 })
-//             },
-//         );
-//     }
-//     read_group.finish();
-//
-//     fs::remove_dir_all(&root_dir).unwrap(); // cleanup
-// }
-//
-// criterion_group!(benches, bench_chunk_io);
-// criterion_main!(benches);
+use criterion::{Criterion, criterion_group, criterion_main};
+use pumpkin_data::{BlockStateId, dimension::Dimension};
+use pumpkin_util::{math::vector2::Vector2, world_seed::Seed};
+use pumpkin_world::{
+    chunk::{ChunkData, format::anvil::SingleChunkDataSerializer},
+    chunk_system::{Chunk, StagedChunkEnum, generate_single_chunk},
+    generation::get_world_gen,
+    world::WorldPortalExt,
+};
+use std::hint::black_box;
+
+struct BlockRegistry;
+
+impl WorldPortalExt for BlockRegistry {
+    fn can_place_at(
+        &self,
+        _block: &pumpkin_data::Block,
+        _state: &pumpkin_data::BlockState,
+        _block_accessor: &dyn pumpkin_world::world::BlockAccessor,
+        _block_pos: &pumpkin_util::math::position::BlockPos,
+    ) -> bool {
+        true
+    }
+
+    fn mirror(
+        &self,
+        block: &pumpkin_data::Block,
+        state_id: BlockStateId,
+        mirror: pumpkin_data::Mirror,
+    ) -> &'static pumpkin_data::BlockState {
+        block.mirror(state_id, mirror)
+    }
+
+    fn rotate(
+        &self,
+        block: &pumpkin_data::Block,
+        state_id: BlockStateId,
+        rotation: pumpkin_data::Rotation,
+    ) -> &'static pumpkin_data::BlockState {
+        block.rotate(state_id, rotation)
+    }
+
+    fn spawn_mobs_for_chunk_generation(
+        &self,
+        _cache: &mut dyn pumpkin_world::generation::proto_chunk::GenerationCache,
+        _biome: &'static pumpkin_data::chunk::Biome,
+        _chunk_x: i32,
+        _chunk_z: i32,
+    ) {
+    }
+}
+
+fn bench_chunk_deserialization(c: &mut Criterion) {
+    let dimension = Dimension::OVERWORLD;
+    let world_gen = get_world_gen(
+        Seed(42),
+        dimension.clone(),
+        false,
+        Vec::new(),
+        String::new(),
+    );
+    let chunk = generate_single_chunk(
+        &dimension,
+        0,
+        &world_gen,
+        &BlockRegistry,
+        0,
+        0,
+        StagedChunkEnum::Full,
+    );
+    let Chunk::Level(chunk) = chunk else {
+        panic!("full generation must return a level chunk");
+    };
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("failed to create benchmark runtime");
+    let bytes = runtime
+        .block_on(chunk.to_bytes())
+        .expect("failed to serialize benchmark chunk");
+    let position = Vector2::new(chunk.x, chunk.z);
+
+    c.bench_function("chunk_nbt_deserialization", |b| {
+        b.iter(|| {
+            black_box(
+                ChunkData::from_bytes(black_box(&bytes), position)
+                    .expect("failed to deserialize benchmark chunk"),
+            );
+        });
+    });
+}
+
+criterion_group!(benches, bench_chunk_deserialization);
+criterion_main!(benches);

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -360,6 +360,31 @@ impl ChunkSections {
     }
 
     #[must_use]
+    pub(crate) fn from_palettes(
+        block_sections: Box<[BlockPalette]>,
+        biome_sections: Box<[BiomePalette]>,
+        min_y: i32,
+    ) -> Self {
+        assert_eq!(
+            block_sections.len(),
+            biome_sections.len(),
+            "block and biome section counts must match"
+        );
+        let count = block_sections.len();
+        let (random_tick_sections, randomly_ticking_mask) =
+            Self::build_random_tick_sections_cache(&block_sections);
+
+        Self {
+            count,
+            block_sections: RwLock::new(block_sections),
+            random_tick_sections: RwLock::new(random_tick_sections),
+            randomly_ticking_mask: std::sync::atomic::AtomicU32::new(randomly_ticking_mask),
+            biome_sections: RwLock::new(biome_sections),
+            min_y,
+        }
+    }
+
+    #[must_use]
     pub fn get_block_absolute_y(
         &self,
         relative_x: usize,

--- a/pumpkin-world/src/chunk/palette.rs
+++ b/pumpkin-world/src/chunk/palette.rs
@@ -182,6 +182,50 @@ impl<V: Hash + Eq + Copy + Default, const DIM: usize> PalettedContainer<V, DIM> 
         }
     }
 
+    /// Builds a complete palette without paying the bookkeeping cost of individual mutations.
+    pub(crate) fn from_fn(mut value_at: impl FnMut(usize, usize, usize) -> V) -> Self {
+        let mut cube = Box::new([[[V::default(); DIM]; DIM]; DIM]);
+        let mut indices = Box::new([[[0u8; DIM]; DIM]; DIM]);
+        let mut palette = Vec::new();
+        let mut counts = Vec::<u16>::new();
+
+        for y in 0..DIM {
+            for z in 0..DIM {
+                for x in 0..DIM {
+                    let value = value_at(x, y, z);
+                    cube[y][z][x] = value;
+                    let index =
+                        if let Some(index) = palette.iter().position(|entry| *entry == value) {
+                            counts[index] += 1;
+                            index
+                        } else {
+                            palette.push(value);
+                            counts.push(1);
+                            palette.len() - 1
+                        };
+                    if let Ok(index) = u8::try_from(index) {
+                        indices[y][z][x] = index;
+                    }
+                }
+            }
+        }
+
+        if palette.len() == 1 {
+            return Self::Homogeneous(palette[0]);
+        }
+
+        let storage = if palette.len() <= 256 && std::mem::size_of::<V>() > 1 {
+            PaletteStorage::Indexed(indices)
+        } else {
+            PaletteStorage::Dense(cube)
+        };
+        Self::Heterogeneous(Box::new(HeterogeneousPaletteData {
+            storage,
+            palette,
+            counts,
+        }))
+    }
+
     fn bits_per_entry(&self) -> u8 {
         match self {
             Self::Homogeneous(_) => 0,
@@ -870,3 +914,72 @@ const BIOME_DISK_MIN_BITS: u8 = 0;
 const BIOME_NETWORK_MIN_MAP_BITS: u8 = 1;
 const BIOME_NETWORK_MAX_MAP_BITS: u8 = 3;
 pub(crate) const BIOME_NETWORK_MAX_BITS: u8 = 7;
+
+#[cfg(test)]
+mod tests {
+    use super::{BlockPalette, NetworkPalette};
+    use pumpkin_data::{Block, BlockStateId};
+
+    fn network_palette_values(palette: NetworkPalette<u16>) -> Option<Box<[u16]>> {
+        match palette {
+            NetworkPalette::Single(value) => Some(Box::new([value])),
+            NetworkPalette::Indirect(values) => Some(values),
+            NetworkPalette::Direct => None,
+        }
+    }
+
+    fn assert_bulk_matches_mutations(value_at: impl Fn(usize, usize, usize) -> BlockStateId) {
+        let mut mutated = BlockPalette::default();
+        for y in 0..BlockPalette::SIZE {
+            for z in 0..BlockPalette::SIZE {
+                for x in 0..BlockPalette::SIZE {
+                    mutated.set(x, y, z, value_at(x, y, z));
+                }
+            }
+        }
+        let bulk = BlockPalette::from_fn(value_at);
+
+        assert_eq!(
+            mutated.iter().collect::<Vec<_>>(),
+            bulk.iter().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            mutated.random_ticking_counts(),
+            bulk.random_ticking_counts()
+        );
+        assert_eq!(mutated.non_air_block_count(), bulk.non_air_block_count());
+        assert_eq!(mutated.liquid_block_count(), bulk.liquid_block_count());
+
+        let mutated_network = mutated.convert_network();
+        let bulk_network = bulk.convert_network();
+        assert_eq!(mutated_network.bits_per_entry, bulk_network.bits_per_entry);
+        assert_eq!(mutated_network.packed_data, bulk_network.packed_data);
+        assert_eq!(
+            network_palette_values(mutated_network.palette),
+            network_palette_values(bulk_network.palette)
+        );
+    }
+
+    #[test]
+    fn bulk_palette_matches_individual_mutations() {
+        let states = [
+            Block::AIR.default_state.id,
+            Block::STONE.default_state.id,
+            Block::WATER.default_state.id,
+            Block::LAVA.default_state.id,
+        ];
+        assert_bulk_matches_mutations(|x, y, z| states[(x + y + z) % states.len()]);
+    }
+
+    #[test]
+    fn bulk_palette_handles_homogeneous_sections() {
+        assert_bulk_matches_mutations(|_, _, _| Block::STONE.default_state.id);
+    }
+
+    #[test]
+    fn bulk_palette_handles_direct_network_palettes() {
+        assert_bulk_matches_mutations(|x, y, z| {
+            BlockStateId::new_or_air(((y * 256 + z * 16 + x) % 300) as u16)
+        });
+    }
+}

--- a/pumpkin-world/src/chunk_system/chunk_state.rs
+++ b/pumpkin-world/src/chunk_system/chunk_state.rs
@@ -1,4 +1,7 @@
-use crate::chunk::{ChunkData, ChunkLight, ChunkSections};
+use crate::chunk::{
+    ChunkData, ChunkHeightmapType, ChunkHeightmaps, ChunkLight, ChunkSections,
+    palette::{BiomePalette, BlockPalette},
+};
 use crate::generation::biome_coords;
 use crate::tick::scheduler::ChunkTickScheduler;
 use pumpkin_config::lighting::LightingEngineConfig;
@@ -200,6 +203,58 @@ impl Chunk {
             Self::Proto(chunk) => chunk,
         }
     }
+
+    fn build_level_sections(proto_chunk: &ProtoChunk, dimension: &Dimension) -> ChunkSections {
+        let total_sections = dimension.height as usize / BlockPalette::SIZE;
+        let biome_min_y = biome_coords::from_block(dimension.min_y);
+        let block_sections = (0..total_sections)
+            .map(|section_index| {
+                BlockPalette::from_fn(|x, y, z| {
+                    let y = section_index * BlockPalette::SIZE + y;
+                    proto_chunk.get_block_state_raw(x as i32, y as i32, z as i32)
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let biome_sections = (0..total_sections)
+            .map(|section_index| {
+                BiomePalette::from_fn(|x, y, z| {
+                    let y = section_index * BiomePalette::SIZE + y;
+                    proto_chunk.get_biome_id(x as i32, biome_min_y + y as i32, z as i32)
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+
+        ChunkSections::from_palettes(block_sections, biome_sections, dimension.min_y)
+    }
+
+    fn build_level_heightmaps(proto_chunk: &ProtoChunk, min_y: i32) -> ChunkHeightmaps {
+        let mut heightmaps = ChunkHeightmaps::default();
+        for x in 0..16 {
+            for z in 0..16 {
+                let source_index = x * 16 + z;
+                for (heightmap_type, height) in [
+                    (
+                        ChunkHeightmapType::WorldSurface,
+                        proto_chunk.flat_surface_height_map[source_index],
+                    ),
+                    (
+                        ChunkHeightmapType::MotionBlocking,
+                        proto_chunk.flat_motion_blocking_height_map[source_index],
+                    ),
+                    (
+                        ChunkHeightmapType::MotionBlockingNoLeaves,
+                        proto_chunk.flat_motion_blocking_no_leaves_height_map[source_index],
+                    ),
+                ] {
+                    heightmaps.set(heightmap_type, x as i32, z as i32, i32::from(height), min_y);
+                }
+            }
+        }
+        heightmaps
+    }
+
     pub fn upgrade_to_level_chunk(
         &mut self,
         dimension: &Dimension,
@@ -230,54 +285,8 @@ impl Chunk {
 
         let proto_chunk = *proto_chunk_box;
 
-        let total_sections = dimension.height as usize / 16;
-        let sections = ChunkSections::new(total_sections, dimension.min_y);
-
-        let proto_biome_height = biome_coords::from_block(proto_chunk.height() as i32);
-        let biome_min_y = biome_coords::from_block(dimension.min_y);
-
-        for y_offset in 0..proto_biome_height {
-            let section_index = y_offset as usize / 4;
-            let relative_y = y_offset as usize % 4;
-
-            if let Some(section) = sections
-                .biome_sections
-                .write()
-                .unwrap()
-                .get_mut(section_index)
-            {
-                let absolute_biome_y = biome_min_y + y_offset;
-
-                for z in 0..4 {
-                    for x in 0..4 {
-                        let biome = proto_chunk.get_biome_id(x as i32, absolute_biome_y, z as i32);
-                        section.set(x, relative_y, z, biome);
-                    }
-                }
-            }
-        }
-
-        let proto_block_height = proto_chunk.height();
-
-        for y_offset in 0..proto_block_height {
-            let section_index = (y_offset as usize) / 16;
-            let relative_y = (y_offset as usize) % 16;
-
-            if let Some(section) = sections
-                .block_sections
-                .write()
-                .unwrap()
-                .get_mut(section_index)
-            {
-                for z in 0..16 {
-                    for x in 0..16 {
-                        let block =
-                            proto_chunk.get_block_state_raw(x as i32, y_offset as i32, z as i32);
-                        section.set(x, relative_y, z, block);
-                    }
-                }
-            }
-        }
+        let sections = Self::build_level_sections(&proto_chunk, dimension);
+        let heightmaps = Self::build_level_heightmaps(&proto_chunk, dimension.min_y);
 
         // Move the light data instead of cloning it
         // By taking ownership of proto_chunk, we can move the light data directly
@@ -300,11 +309,11 @@ impl Chunk {
             }
         }
 
-        let mut chunk = ChunkData {
+        let chunk = ChunkData {
             light_engine: Mutex::new(light_data),
             light_populated: AtomicBool::new(is_lit),
             section: sections,
-            heightmap: Mutex::default(),
+            heightmap: Mutex::new(heightmaps),
             x: proto_chunk.x,
             z: proto_chunk.z,
             dirty: AtomicBool::new(true),
@@ -315,7 +324,6 @@ impl Chunk {
             blending_data: proto_chunk.blending_data,
         };
 
-        chunk.heightmap = Mutex::new(chunk.calculate_heightmap());
         *self = Self::Level(Arc::new(chunk));
     }
 }

--- a/pumpkin-world/src/chunk_system/generation.rs
+++ b/pumpkin-world/src/chunk_system/generation.rs
@@ -64,6 +64,8 @@ pub fn generate_single_chunk(
 #[cfg(test)]
 mod tests {
     use crate::biome::hash_seed;
+    use crate::chunk::ChunkHeightmapType;
+    use crate::chunk_system::Chunk;
     use crate::chunk_system::{StagedChunkEnum, generate_single_chunk};
     use crate::generation::get_world_gen;
     use crate::world::WorldPortalExt;
@@ -120,7 +122,7 @@ mod tests {
         let world_gen = get_world_gen(seed, dimension.clone(), false, Vec::new(), String::new());
         let biome_mixer_seed = hash_seed(world_gen.seed());
 
-        let _ = generate_single_chunk(
+        let chunk = generate_single_chunk(
             &dimension,
             biome_mixer_seed,
             &world_gen,
@@ -129,6 +131,25 @@ mod tests {
             0,
             StagedChunkEnum::Full,
         );
+        let Chunk::Level(chunk) = chunk else {
+            panic!("full generation must return a level chunk");
+        };
+        let recalculated = chunk.calculate_heightmap();
+        let generated = chunk.heightmap.lock().unwrap();
+        for x in 0..16 {
+            for z in 0..16 {
+                for heightmap_type in [
+                    ChunkHeightmapType::WorldSurface,
+                    ChunkHeightmapType::MotionBlocking,
+                    ChunkHeightmapType::MotionBlockingNoLeaves,
+                ] {
+                    assert_eq!(
+                        generated.get(heightmap_type, x, z, chunk.section.min_y),
+                        recalculated.get(heightmap_type, x, z, chunk.section.min_y),
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -91,6 +91,11 @@ async fn main() {
             "Release"
         }
     );
+    if cfg!(debug_assertions) {
+        warn!(
+            "Pumpkin is running an unoptimized debug build. Do not use this build for performance testing; run `cargo run --release` or use a release binary."
+        );
+    }
     print_support_links_and_warning();
 
     tokio::spawn(async {


### PR DESCRIPTION
## Summary

Speed up the final conversion from a generated `ProtoChunk` into a loaded `ChunkData`.

The old path populated empty block and biome palettes through roughly 98,000 individual mutation calls for a normal Overworld chunk. Those mutations maintain bookkeeping intended for live block updates. The new path bulk-builds each palette in one pass, then constructs random-tick metadata once.

The conversion also reuses the heightmaps already calculated during generation instead of rescanning the final chunk.

## Performance

Release Criterion results on the same machine and workload:

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Final proto-to-level conversion | 667.22 us | 289.45 us | 56.6% faster |
| Full generated chunk pipeline | 43.62 ms | 41.47 ms | 4.9% faster |

The conversion itself is now much cheaper, but generation stages such as noise, features, and lighting still dominate total fresh-chunk time. The full-pipeline figure is therefore the useful expectation for exploration.

Also adds an NBT deserialisation baseline for already-generated terrain: 188.84 us median for a representative generated chunk. This is a measurement baseline only, not a claimed improvement.

## Correctness

- Bulk palettes are checked against the individual-mutation implementation for homogeneous, indirect, direct, liquid, and randomly ticking sections.
- Generated heightmaps are checked against a complete recalculation.
- Existing Anvil and other world-format round-trip tests remain in the suite.

## Passed locally

- `cargo fmt --all -- --check`
- Strict clippy for pumpkin and pumpkin-world
- `cargo test -p pumpkin-world --lib`
