### PR TITLE
fix(entity): apply knockback resistance to living entities

### DIFF
--- a/pumpkin/src/entity/combat.rs
+++ b/pumpkin/src/entity/combat.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::Ordering;
 
 use crate::entity::EntityBase;
 use pumpkin_data::{
+    attributes::Attributes,
     particle::Particle,
     sound::{Sound, SoundCategory},
 };
@@ -61,13 +62,27 @@ impl AttackType {
     }
 }
 
-pub fn handle_knockback(attacker: &Entity, victim: &Entity, strength: f64) {
-    let yaw = attacker.yaw.load();
-    victim.knockback(
-        strength * 0.5,
-        f64::from((yaw.to_radians()).sin()),
-        f64::from(-(yaw.to_radians()).cos()),
-    );
+/// Scales a knockback `strength` by a living entity's knockback resistance,
+/// mirroring vanilla `LivingEntity.knockback`: `strength *= 1.0 - resistance`.
+/// A resistance of 1.0 (iron golem, warden, ...) cancels the knockback entirely.
+pub fn knockback_after_resistance(strength: f64, resistance: f64) -> f64 {
+    strength * (1.0 - resistance)
+}
+
+pub fn handle_knockback(attacker: &Entity, victim: &dyn EntityBase, strength: f64) {
+    let resistance = victim.get_living_entity().map_or(0.0, |living| {
+        living.get_attribute_value(&Attributes::KNOCKBACK_RESISTANCE)
+    });
+    let strength = knockback_after_resistance(strength * 0.5, resistance);
+
+    if strength > 0.0 {
+        let yaw = attacker.yaw.load();
+        victim.get_entity().knockback(
+            strength,
+            f64::from((yaw.to_radians()).sin()),
+            f64::from(-(yaw.to_radians()).cos()),
+        );
+    }
 
     let velocity = attacker.velocity.load();
     attacker.velocity.store(velocity.multiply(0.6, 1.0, 0.6));
@@ -114,5 +129,34 @@ pub async fn player_attack_sound(pos: &Vector3<f64>, world: &World, attack_type:
         AttackType::MaceSmash => {
             world.play_sound(Sound::ItemMaceSmashAir, SoundCategory::Players, pos);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::knockback_after_resistance;
+
+    #[test]
+    fn zero_resistance_keeps_full_strength() {
+        assert_eq!(knockback_after_resistance(0.4, 0.0), 0.4);
+    }
+
+    #[test]
+    fn full_resistance_cancels_knockback() {
+        // Iron golem / warden have KNOCKBACK_RESISTANCE == 1.0.
+        assert_eq!(knockback_after_resistance(0.4, 1.0), 0.0);
+    }
+
+    #[test]
+    fn partial_resistance_scales_strength() {
+        // Ravager has KNOCKBACK_RESISTANCE == 0.75.
+        assert!((knockback_after_resistance(0.4, 0.75) - 0.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn over_full_resistance_is_negative_so_callers_skip_it() {
+        // Stacked armour modifiers can push resistance above 1.0; the result is
+        // negative and callers guard on `strength > 0.0`.
+        assert!(knockback_after_resistance(0.4, 1.2) < 0.0);
     }
 }

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -29,6 +29,7 @@ use crate::block::OnLandedUponArgs;
 use crate::entity::attributes::AttributeInstance;
 use crate::entity::attributes::Modifier;
 use crate::entity::attributes::ModifierOperation;
+use crate::entity::combat::knockback_after_resistance;
 use crate::entity::mob::equipment::DEFAULT_EQUIPMENT_DROP_CHANCE;
 use crate::entity::mob::slime::SlimeEntity;
 use crate::entity::player::statistics::{CustomStatistic, StatisticCategory};
@@ -2419,7 +2420,12 @@ impl EntityBase for LivingEntity {
                     let target_pos = self.entity.pos.load();
                     let dx = source_pos.x - target_pos.x;
                     let dz = source_pos.z - target_pos.z;
-                    self.entity.apply_knockback(0.4, dx, dz);
+                    let resistance = self.get_attribute_value(&Attributes::KNOCKBACK_RESISTANCE);
+                    self.entity.apply_knockback(
+                        knockback_after_resistance(0.4, resistance),
+                        dx,
+                        dz,
+                    );
                     self.entity.send_velocity();
                 }
             }

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -1354,9 +1354,11 @@ impl Entity {
     /// `LivingEntity.takeKnockback()`
     /// This function calculates the entity's new velocity based on the specified knockback strength and direction.
     ///
-    /// `strength` is expected to already be scaled by the victim's
-    /// `KNOCKBACK_RESISTANCE` (see `combat::knockback_after_resistance`), since
-    /// that attribute lives on `LivingEntity`, not `Entity`.
+    /// Knockback resistance is not applied here, because it is a `LivingEntity`
+    /// attribute and this is an `Entity` method. Callers modelling vanilla's
+    /// `LivingEntity.knockback` scale `strength` with
+    /// `combat::knockback_after_resistance` first; callers modelling vanilla's raw
+    /// `Entity.push` (such as the ender dragon) pass `strength` unscaled.
     pub fn apply_knockback(&self, strength: f64, mut x: f64, mut z: f64) {
         if strength <= 0.0 {
             return;

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -1353,9 +1353,11 @@ impl Entity {
     /// Applies knockback to the entity, following vanilla Minecraft's mechanics.
     /// `LivingEntity.takeKnockback()`
     /// This function calculates the entity's new velocity based on the specified knockback strength and direction.
+    ///
+    /// `strength` is expected to already be scaled by the victim's
+    /// `KNOCKBACK_RESISTANCE` (see `combat::knockback_after_resistance`), since
+    /// that attribute lives on `LivingEntity`, not `Entity`.
     pub fn apply_knockback(&self, strength: f64, mut x: f64, mut z: f64) {
-        // TODO: strength *= 1 - Entity attribute knockback resistance
-
         if strength <= 0.0 {
             return;
         }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1142,7 +1142,7 @@ impl Player {
                 _ => {}
             }
             if config.knockback {
-                combat::handle_knockback(attacker_entity, victim_entity, knockback_strength);
+                combat::handle_knockback(attacker_entity, victim.as_ref(), knockback_strength);
             }
         }
 

--- a/pumpkin/src/entity/projectile/arrow.rs
+++ b/pumpkin/src/entity/projectile/arrow.rs
@@ -420,7 +420,7 @@ impl EntityBase for ArrowEntity {
                         {
                             crate::entity::combat::handle_knockback(
                                 owner_entity.get_entity(),
-                                target.get_entity(),
+                                target.as_ref(),
                                 f64::from(punch) * 0.6,
                             );
                         }


### PR DESCRIPTION
## Description

Vanilla `LivingEntity.knockback` scales the knockback strength by `1.0 - KNOCKBACK_RESISTANCE`, but Pumpkin never applied it. Mobs with high resistance (iron golem, warden and ravager all have >= 0.75) were knocked back like any other mob.

This scales both knockback paths by the victim's resistance:
- the base hit knockback in `LivingEntity`
- the sprint/enchant bonus in `combat::handle_knockback`, which now takes the victim as `&dyn EntityBase` so it can read the attribute

The resistance data already exists per entity in `pumpkin-data` (iron golem = 1.0), so no data changes are needed. A resistance of 1.0 cancels the knockback entirely.

Fixes #1761

This is also the calculation half of #1013. The per-entity base values and the armor `knockback_resistance` modifiers are already present in `pumpkin-data`, but equipment attribute modifiers are still read ad-hoc for `ARMOR`/`ARMOR_TOUGHNESS` at damage time instead of being registered on the entity's attribute instances, so armor-granted resistance won't apply until that is wired up. Leaving #1013 open for that part.

## Testing

Added unit tests for the resistance scaling (`knockback_after_resistance`): zero resistance keeps full strength, 1.0 cancels it, 0.75 scales to a quarter, and >1.0 goes negative so the `strength > 0.0` guards skip it.

`cargo test -p pumpkin`, `cargo clippy -p pumpkin` and `cargo fmt --check` pass.
