### PR TITLE
docs: add Nix/NixOS installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,29 @@ See our [Quick Start](https://docs.pumpkinmc.org/#quick-start) guide to get Pump
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md)
 
+### NixOS / Nix
+
+Pumpkin is available in [nixpkgs](https://github.com/NixOS/nixpkgs) as `pumpkin-mc`, with a NixOS module for running it as a systemd service.
+
+Try it without installing:
+
+```bash
+nix run nixpkgs#pumpkin-mc
+```
+
+Or enable the service in `configuration.nix`:
+
+```nix
+services.pumpkin-mc = {
+  enable = true;
+  openFirewall = true;
+};
+```
+
+The module runs Pumpkin under a hardened systemd service and exposes typed options for most of `pumpkin.toml` - Java/Bedrock/RCON/query/proxy networking, whitelist, world storage, logging, PvP, and more — plus a `settings` freeform option for anything not yet covered. RCON passwords and Velocity forwarding secrets are read from files at service start rather than stored in the Nix store, so they work with `sops-nix`/`agenix`.
+
+See the [module source](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/games/pumpkin-mc.nix) for the full list of options.
+
 ## Docs
 
 Pumpkin's documentation can be found at <https://pumpkinmc.org/>


### PR DESCRIPTION
## What
Adds a "NixOS / Nix" subsection under "How to run", documenting the \`pumpkin-mc\` package and \`services.pumpkin-mc\` NixOS module.

## Why
Pumpkin is packaged in nixpkgs (see NixOS/nixpkgs#545183), including a full NixOS module for running it as a systemd service with typed options covering networking, whitelist, world storage, RCON/Velocity secrets (via sops-nix/agenix-compatible file paths), and more. This wasn't discoverable from the README.

## Impact
Documentation-only change; no code paths affected.

## Related
- [NixOS/nixpkgs#545183](https://github.com/NixOS/nixpkgs/pull/545183) (package + module)