### PR TITLE
fix: do not drop block experience when silk touching

### DIFF
--- a/pumpkin/src/block/mod.rs
+++ b/pumpkin/src/block/mod.rs
@@ -444,16 +444,29 @@ pub async fn drop_loot(
     experience: bool,
     params: LootContextParameters,
 ) {
+    // In 1.21 a tool's `block_experience` enchantment effects are folded over
+    // the sampled amount, and Silk Touch is the only enchantment that defines
+    // one: it sets the result to zero. Special-casing it is equivalent for
+    // now, but a general effect pass would be the faithful implementation.
+    // Read before `params` is moved into the loot table below.
+    let silk_touched = experience
+        && block.experience.is_some()
+        && params.tool.as_ref().is_some_and(|tool| {
+            tool.get_enchantment_level(&pumpkin_data::Enchantment::SILK_TOUCH) > 0
+        });
+
     if let Some(loot_table) = &block.loot_table {
         for stack in loot_table.get_loot(params) {
             world.drop_stack(pos, stack).await;
         }
     }
 
-    if experience && let Some(experience) = &block.experience {
+    if experience
+        && !silk_touched
+        && let Some(experience) = &block.experience
+    {
         let mut random = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(get_seed()));
         let amount = experience.experience.get(&mut random);
-        // TODO: Silk touch gives no exp
         if amount > 0 {
             ExperienceOrbEntity::spawn(world, pos.to_f64(), amount as u32).await;
         }


### PR DESCRIPTION
## Description

**What vanilla does (1.21):** Silk Touch declares a `minecraft:block_experience` enchantment effect of `{"type": "minecraft:set", "value": 0.0}`. `Block#dropExperienceWhenMined` folds the tool's `block_experience` effects over the sampled amount via `EnchantmentHelper.getBlockExperience`, so a silk touched block drops no experience. (In 1.20 and earlier this was an explicit `getItemEnchantmentLevel(SILK_TOUCH) == 0` check; 1.21 made it data driven.)

**What Pumpkin did:** `drop_loot` spawned the experience orb whenever the block had an `experience` field, ignoring the tool entirely, even though `LootContextParameters::tool` already carries the breaking player's held stack. Silk touching diamond ore gave you the ore block *and* the full experience.

**Change:** read the tool's Silk Touch level before `params` is moved into the loot table, and skip the orb spawn when it is present. Only Silk Touch defines such an effect today, so special casing it is equivalent for now; a general effect pass would be the faithful implementation and the comment says so.

**Impact:** affects the 11 blocks in Pumpkin's data that carry a non-zero `experience` value: coal, lapis, diamond and emerald ore (stone and deepslate variants), nether quartz ore, nether gold ore, and sculk.

**Known limitations, deliberately not addressed here:**

- The monster spawner drops experience in vanilla *even when silk touched*, because it bypasses the gated helper. Pumpkin has no spawner experience yet, so there is nothing to special case; if that lands later it must not go through this path.
- `redstone_ore`, the sculk sensors and the spawner are missing an `experience` field in `assets/blocks.json` entirely (vanilla hardcodes redstone ore's in `RedstoneOreBlock` rather than `Blocks.java`), so they drop no experience today with or without this change. That is a data extraction gap, not something this PR can fix.

## Testing

- `cargo clippy -p pumpkin --all-targets` and `cargo fmt --check` pass with the workspace deny-level lints, and with `RUSTFLAGS="-D warnings"`.
- Behaviour is unchanged when the tool is absent: the explosion path passes `experience: false`, and the piston path passes no tool, which matches vanilla's `ItemStack.EMPTY` overloads that do drop experience.

I have not exercised this one on a live server: driving a bot to break a block with an enchanted tool needs an attack/dig packet path that my headless harness cannot currently reach on this build. The change is small and the tool plumbing was already in place, but flagging it rather than claiming verification I did not do.
