### PR TITLE
fix(net): don't kick players for attacking a removed entity

### DIFF
--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -797,7 +797,7 @@ pub trait EntityBase: Send + Sync + std::any::Any {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RemovalReason {
     Killed,
     Discarded,

--- a/crates/pumpkin/src/net/java/play/attack.rs
+++ b/crates/pumpkin/src/net/java/play/attack.rs
@@ -32,12 +32,14 @@ impl JavaClient {
             .map(|p| Arc::clone(p) as Arc<dyn EntityBase>)
             .or_else(|| world.get_entity_by_id(entity_id.0));
         let Some(target) = target else {
-            self.kick(TextComponent::translate_cross(
-                translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED,
-                translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED,
-                [],
-            ))
-            .await;
+            // The target was removed between the client sending the packet and us
+            // handling it (e.g. it died or despawned). Vanilla ignores this rather
+            // than kicking the player.
+            debug!(
+                "Player id {} attacked entity id {}, which was not found.",
+                player.entity_id(),
+                entity_id.0
+            );
             return;
         };
         if let Some(player_victim) = &player_target {

--- a/crates/pumpkin/src/net/java/play/attack.rs
+++ b/crates/pumpkin/src/net/java/play/attack.rs
@@ -36,9 +36,10 @@ impl JavaClient {
             // handling it (e.g. it died or despawned). Vanilla ignores this rather
             // than kicking the player.
             debug!(
-                "Player id {} attacked entity id {}, which was not found.",
+                "Player id {} attacked entity id {}, which was not found. {}",
                 player.entity_id(),
-                entity_id.0
+                entity_id.0,
+                describe_missing_entity(&world, entity_id.0)
             );
             return;
         };

--- a/crates/pumpkin/src/net/java/play/interact.rs
+++ b/crates/pumpkin/src/net/java/play/interact.rs
@@ -131,9 +131,10 @@ impl JavaClient {
                         // and us handling it (e.g. it died or despawned). Vanilla ignores
                         // this rather than kicking the player.
                         debug!(
-                            "Player id {} attacked entity id {}, which was not found.",
+                            "Player id {} attacked entity id {}, which was not found. {}",
                             player.entity_id(),
-                            event.entity_id
+                            event.entity_id,
+                            describe_missing_entity(&world, event.entity_id)
                         );
                     }
                 }

--- a/crates/pumpkin/src/net/java/play/interact.rs
+++ b/crates/pumpkin/src/net/java/play/interact.rs
@@ -127,13 +127,14 @@ impl JavaClient {
 
                 'after: {
                     if event.action == ActionType::Attack {
-                        error!(
-                            "Player id {} interacted with entity id {}, which was not found.",
+                        // The target was removed between the client sending the packet
+                        // and us handling it (e.g. it died or despawned). Vanilla ignores
+                        // this rather than kicking the player.
+                        debug!(
+                            "Player id {} attacked entity id {}, which was not found.",
                             player.entity_id(),
                             event.entity_id
                         );
-                        self.kick(TextComponent::translate_cross(translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED, translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED, [],))
-                        .await;
                     }
                 }
             }}

--- a/crates/pumpkin/src/net/java/play/mod.rs
+++ b/crates/pumpkin/src/net/java/play/mod.rs
@@ -217,6 +217,23 @@ impl PumpkinError for ChatError {
     }
 }
 
+/// Describes what the server still knows about an entity id it can no longer
+/// resolve. An attack packet naming a missing entity is normally a packet that
+/// lost the race against the entity's removal; this tells that case apart from
+/// an id the server has no removal record for at all.
+fn describe_missing_entity(world: &World, entity_id: i32) -> String {
+    world.recent_removal(entity_id).map_or_else(
+        || "No removal was recorded for it.".to_string(),
+        |removal| {
+            format!(
+                "It was removed ({:?}) {}ms earlier.",
+                removal.reason,
+                removal.at.elapsed().as_millis()
+            )
+        },
+    )
+}
+
 pub mod attack;
 pub mod bundle_item_selected;
 pub mod change_difficulty;

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -14,8 +14,9 @@ use pumpkin_world::generation::proto_chunk::GenerationCache;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::{Arc, Weak};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, VecDeque},
     sync::atomic::Ordering,
+    time::Instant,
 };
 use tracing::{debug, error, info, trace, warn};
 
@@ -286,6 +287,19 @@ pub struct World {
     pub custom_data: std::sync::Mutex<NbtCompound>,
     /// Persistent custom data for block entities at specific positions
     pub custom_block_entity_data: DashMap<BlockPos, NbtCompound>,
+    /// The last [`RECENT_REMOVAL_HISTORY`] entity removals, oldest first.
+    recent_removals: std::sync::Mutex<VecDeque<(i32, EntityRemoval)>>,
+}
+
+/// How many entity removals are kept around for diagnostics.
+const RECENT_REMOVAL_HISTORY: usize = 256;
+
+/// Why and when an entity id stopped existing server side.
+#[derive(Clone, Copy)]
+pub struct EntityRemoval {
+    pub reason: RemovalReason,
+    /// When the world dropped it.
+    pub at: Instant,
 }
 
 #[derive(Clone, Copy)]
@@ -401,7 +415,39 @@ impl World {
             block_entities: DashMap::new(),
             custom_data: std::sync::Mutex::new(custom_data),
             custom_block_entity_data: DashMap::new(),
+            recent_removals: std::sync::Mutex::new(VecDeque::with_capacity(RECENT_REMOVAL_HISTORY)),
         }
+    }
+
+    /// Records that `entity_id` was removed, so a later packet naming that id can be
+    /// told apart from one naming an id the server never knew.
+    fn record_removal(&self, entity_id: i32, reason: RemovalReason) {
+        let mut removals = self
+            .recent_removals
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if removals.len() == RECENT_REMOVAL_HISTORY {
+            removals.pop_front();
+        }
+        removals.push_back((
+            entity_id,
+            EntityRemoval {
+                reason,
+                at: Instant::now(),
+            },
+        ));
+    }
+
+    /// The most recent removal recorded for `entity_id`, if it is still in the history.
+    #[must_use]
+    pub fn recent_removal(&self, entity_id: i32) -> Option<EntityRemoval> {
+        self.recent_removals
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .rev()
+            .find(|(id, _)| *id == entity_id)
+            .map(|(_, removal)| *removal)
     }
 
     pub fn update_active_chunks(self: &Arc<Self>) {
@@ -4755,6 +4801,7 @@ impl World {
                 &CRemoveActor::new(VarLong(entity_id as i64)),
             )
             .await;
+            self.record_removal(entity_id, RemovalReason::UnloadedWithPlayer);
 
             if fire_event {
                 let msg_comp = TextComponent::translate_cross(
@@ -4879,6 +4926,7 @@ impl World {
             &CRemoveEntities::new(&[base_entity.entity_id.into()]),
             &CRemoveActor::new(VarLong(base_entity.entity_id as i64)),
         );
+        self.record_removal(base_entity.entity_id, RemovalReason::Discarded);
     }
 
     pub async fn remove_entities_in_chunks(
@@ -4909,6 +4957,10 @@ impl World {
         for entity in entities_to_remove {
             self.save_entity(&entity).await;
             self.spawn_state.load().remove_entity(self, entity.as_ref());
+            self.record_removal(
+                entity.get_entity().entity_id,
+                RemovalReason::UnloadedToChunk,
+            );
         }
 
         for chunk_pos in &chunks_set {

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -1755,12 +1755,14 @@ impl JavaClient {
             .map(|p| Arc::clone(p) as Arc<dyn EntityBase>)
             .or_else(|| world.get_entity_by_id(entity_id.0));
         let Some(target) = target else {
-            self.kick(TextComponent::translate_cross(
-                translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED,
-                translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED,
-                [],
-            ))
-            .await;
+            // The target was removed between the client sending the packet and us
+            // handling it (e.g. it died or despawned). Vanilla ignores this rather
+            // than kicking the player.
+            debug!(
+                "Player id {} attacked entity id {}, which was not found.",
+                player.entity_id(),
+                entity_id.0
+            );
             return;
         };
         if let Some(player_victim) = &player_target {
@@ -1892,13 +1894,14 @@ impl JavaClient {
 
                 'after: {
                     if event.action == ActionType::Attack {
-                        error!(
-                            "Player id {} interacted with entity id {}, which was not found.",
+                        // The target was removed between the client sending the packet
+                        // and us handling it (e.g. it died or despawned). Vanilla ignores
+                        // this rather than kicking the player.
+                        debug!(
+                            "Player id {} attacked entity id {}, which was not found.",
                             player.entity_id(),
                             event.entity_id
                         );
-                        self.kick(TextComponent::translate_cross(translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED, translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED, [],))
-                        .await;
                     }
                 }
             }}


### PR DESCRIPTION
## Description

When an attack/interact packet references an entity id the server can no longer find, `handle_attack` and the unknown-entity branch of `handle_interact` disconnected the player with `MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED` ("attempting to attack an invalid entity").

This is a normal race: the target can die or despawn between the client sending the packet and the server handling it. Vanillas `handleInteract` ignores a null target instead of kicking.

Both not-found branches now log at `debug` and return. The separate anti-cheat check for a client claiming to attack its own entity id is untouched and still kicks.

Fixes #1800

## Testing

`cargo test -p pumpkin`, `cargo clippy -p pumpkin` and `cargo fmt --check` pass. The change is control flow inside async packet handlers, which are not covered by the existing unit tests, so it is verified by matching vanilla behaviour rather than a new test.