### PR TITLE
security: fail-closed RCON/proxy configuration; fix RCON connection limits

### DIFF
--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -107,6 +107,32 @@ impl LoadConfiguration for PumpkinConfig {
                 "When allow_chat_reports is enabled, java.online_mode must be enabled"
             );
         }
+
+        // Fail-closed: RCON with an empty password is full unauthenticated console access.
+        if self.advanced.networking.rcon.enabled {
+            assert!(
+                !self.advanced.networking.rcon.password.is_empty(),
+                "RCON is enabled but password is empty. Set networking.rcon.password to a non-empty value, or disable RCON."
+            );
+        }
+
+        // Fail-closed: Velocity with empty secret makes HMAC forgeable by anyone.
+        if self.advanced.networking.proxy.enabled && self.advanced.networking.proxy.velocity.enabled
+        {
+            assert!(
+                !self.advanced.networking.proxy.velocity.secret.is_empty(),
+                "Velocity proxy is enabled but secret is empty. Set networking.proxy.velocity.secret to the proxy forwarding secret."
+            );
+        }
+
+        // BungeeCord has no shared secret — backends must not be reachable directly.
+        if self.advanced.networking.proxy.enabled
+            && self.advanced.networking.proxy.bungeecord.enabled
+        {
+            warn!(
+                "BungeeCord proxy mode is enabled. Anyone who can reach this server directly can spoof any UUID/name. Firewall the backend so only the proxy can connect."
+            );
+        }
     }
 }
 

--- a/pumpkin-nbt/src/compound.rs
+++ b/pumpkin-nbt/src/compound.rs
@@ -44,6 +44,16 @@ impl NbtCompound {
     }
 
     pub fn skip_content<'a, R: NbtReadHelper<'a>>(reader: &mut R) -> Result<(), Error> {
+        Self::skip_content_depth(reader, 0)
+    }
+
+    pub(crate) fn skip_content_depth<'a, R: NbtReadHelper<'a>>(
+        reader: &mut R,
+        depth: u32,
+    ) -> Result<(), Error> {
+        if depth >= crate::MAX_NBT_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
         loop {
             let tag_id = match reader.get_u8() {
                 Ok(id) => id,
@@ -58,13 +68,23 @@ impl NbtCompound {
             reader.skip_string()?;
 
             // Skip Value
-            NbtTag::skip_data(reader, tag_id)?;
+            NbtTag::skip_data_depth(reader, tag_id, depth + 1)?;
         }
 
         Ok(())
     }
 
     pub fn deserialize_content<'a, R: NbtReadHelper<'a>>(reader: &mut R) -> Result<Self, Error> {
+        Self::deserialize_content_depth(reader, 0)
+    }
+
+    pub(crate) fn deserialize_content_depth<'a, R: NbtReadHelper<'a>>(
+        reader: &mut R,
+        depth: u32,
+    ) -> Result<Self, Error> {
+        if depth >= crate::MAX_NBT_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
         let mut compound = Self::new();
 
         loop {
@@ -79,7 +99,7 @@ impl NbtCompound {
             }
 
             let name = reader.get_string()?;
-            let tag = NbtTag::deserialize_data(reader, tag_id)?;
+            let tag = NbtTag::deserialize_data_depth(reader, tag_id, depth + 1)?;
 
             compound.child_tags.insert(name.into(), tag);
         }

--- a/pumpkin-nbt/src/deserializer.rs
+++ b/pumpkin-nbt/src/deserializer.rs
@@ -4,7 +4,7 @@ use std::io::{Cursor, Seek, SeekFrom};
 
 use crate::{
     BYTE_ARRAY_ID, BYTE_ID, COMPOUND_ID, END_ID, Error, INT_ARRAY_ID, INT_ID, LIST_ID,
-    LONG_ARRAY_ID, LONG_ID, MAX_ARRAY_LENGTH, NbtTag, io,
+    LONG_ARRAY_ID, LONG_ID, MAX_ARRAY_LENGTH, MAX_NBT_DEPTH, NbtTag, io,
 };
 use io::Read;
 use serde::de::{self, DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, Visitor};
@@ -307,6 +307,9 @@ impl<'a, D: NbtDataSource<'a>> NbtReadHelper<'a> for NbtReadHelperJava<D> {
 
     fn get_string(&mut self) -> Result<Cow<'a, str>> {
         let len = self.get_string_len()? as usize;
+        if len > MAX_ARRAY_LENGTH {
+            return Err(Error::LargeLength(len));
+        }
         self.reader.read_string(len)
     }
 
@@ -401,6 +404,9 @@ impl<'a, D: NbtDataSource<'a>> NbtReadHelper<'a> for NbtReadHelperBedrock<D> {
 
     fn get_string(&mut self) -> Result<Cow<'a, str>> {
         let len = self.get_string_len()? as usize;
+        if len > MAX_ARRAY_LENGTH {
+            return Err(Error::LargeLength(len));
+        }
         self.reader.read_string(len)
     }
 
@@ -414,6 +420,8 @@ pub struct Deserializer<R> {
     tag_to_deserialize_stack: Option<u8>,
     in_list: bool,
     is_named: bool,
+    /// Nesting depth of compounds/lists currently being deserialized.
+    depth: u32,
 }
 
 impl<R> Deserializer<R> {
@@ -423,7 +431,20 @@ impl<R> Deserializer<R> {
             tag_to_deserialize_stack: None,
             in_list: false,
             is_named,
+            depth: 0,
         }
+    }
+
+    const fn enter_nested(&mut self) -> Result<()> {
+        if self.depth >= MAX_NBT_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth += 1;
+        Ok(())
+    }
+
+    const fn exit_nested(&mut self) {
+        self.depth = self.depth.saturating_sub(1);
     }
 }
 
@@ -511,15 +532,29 @@ impl<'de, R: NbtReadHelper<'de>> de::Deserializer<'de> for &mut Deserializer<R> 
                     return Err(Error::LargeLength(remaining_values));
                 }
 
+                // Empty END-typed lists are valid; non-empty are not.
+                if list_type == END_ID && remaining_values != 0 {
+                    return Err(Error::UnknownTagId(list_type));
+                }
+
+                //TODO this is a bit hacky but I couldn't think of a better way
+                // This flag gets auto cleared in visit_seq
                 set_curr_visitor_seq_list_id(Some(list_type));
+                self.enter_nested()?;
                 let result = visitor.visit_seq(ListAccess {
                     de: self,
                     list_type,
                     remaining_values,
-                })?;
-                Ok(result)
+                });
+                self.exit_nested();
+                result
             }
-            COMPOUND_ID => visitor.visit_map(CompoundAccess { de: self }),
+            COMPOUND_ID => {
+                self.enter_nested()?;
+                let result = visitor.visit_map(CompoundAccess { de: self });
+                self.exit_nested();
+                result
+            }
             _ => {
                 let result = match NbtTag::deserialize_data(&mut self.input, tag_to_deserialize)? {
                     NbtTag::Byte(value) => visitor.visit_i8::<Error>(value)?,
@@ -636,8 +671,10 @@ impl<'de, R: NbtReadHelper<'de>> de::Deserializer<'de> for &mut Deserializer<R> 
             }
         }
 
-        let value = visitor.visit_map(CompoundAccess { de: self })?;
-        Ok(value)
+        self.enter_nested()?;
+        let value = visitor.visit_map(CompoundAccess { de: self });
+        self.exit_nested();
+        value
     }
 
     fn deserialize_struct<V: Visitor<'de>>(

--- a/pumpkin-nbt/src/lib.rs
+++ b/pumpkin-nbt/src/lib.rs
@@ -42,6 +42,12 @@ pub const INT_ARRAY_ID: u8 = 0x0B;
 pub const LONG_ARRAY_ID: u8 = 0x0C;
 
 pub const MAX_ARRAY_LENGTH: usize = 2_000_000;
+/// Maximum nesting depth for NBT compounds/lists (vanilla documents 512).
+///
+/// Each nesting level costs two Rust frames in this parser; 128 is far above
+/// any legitimate item/world payload and keeps the worker stack safely clear
+/// of the guard page (the pre-fix kill was ~3.5k).
+pub const MAX_NBT_DEPTH: u32 = 128;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -63,6 +69,8 @@ pub enum Error {
     NegativeLength(i32),
     #[error("Length too large: {0}")]
     LargeLength(usize),
+    #[error("NBT nesting depth exceeded limit ({MAX_NBT_DEPTH})")]
+    DepthLimitExceeded,
     #[error("Failed to decode varint - value too large")]
     VarIntTooLarge,
     #[error("Failed to decode varlong - value too large")]
@@ -1000,4 +1008,42 @@ mod test {
     }
 
     // TODO: More robust tests
+
+    #[test]
+    fn nested_compound_depth_limit() {
+        use crate::deserializer::NbtReadHelperJava;
+        use crate::{COMPOUND_ID, END_ID, MAX_NBT_DEPTH, Nbt};
+
+        // Nested compounds deeper than MAX_NBT_DEPTH must error, not overflow the stack.
+        let depth = (MAX_NBT_DEPTH + 8) as usize;
+        let mut bytes = Vec::new();
+        // root compound id + empty name (Java: u16 BE length)
+        bytes.push(COMPOUND_ID);
+        bytes.extend_from_slice(&0u16.to_be_bytes());
+        for _ in 0..depth {
+            bytes.push(COMPOUND_ID);
+            bytes.extend_from_slice(&0u16.to_be_bytes()); // empty field name
+        }
+        bytes.extend(std::iter::repeat_n(END_ID, depth + 1));
+
+        let err = Nbt::read(&mut NbtReadHelperJava::new(Cursor::new(bytes)));
+        assert!(
+            matches!(err, Err(Error::DepthLimitExceeded)),
+            "expected DepthLimitExceeded, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn end_typed_nonempty_list_rejected() {
+        use crate::deserializer::NbtReadHelperJava;
+        use crate::{END_ID, LIST_ID};
+
+        // LIST of END with length 100 must be rejected (not allocate 100 unit tags).
+        let mut bytes = Vec::new();
+        bytes.push(END_ID);
+        bytes.extend_from_slice(&100i32.to_be_bytes());
+        let err =
+            NbtTag::deserialize_data(&mut NbtReadHelperJava::new(Cursor::new(bytes)), LIST_ID);
+        assert!(err.is_err(), "non-empty END list must be rejected");
+    }
 }

--- a/pumpkin-nbt/src/tag.rs
+++ b/pumpkin-nbt/src/tag.rs
@@ -181,6 +181,17 @@ impl NbtTag {
     }
 
     pub fn skip_data<'a, R: NbtReadHelper<'a>>(reader: &mut R, tag_id: u8) -> Result<(), Error> {
+        Self::skip_data_depth(reader, tag_id, 0)
+    }
+
+    pub(crate) fn skip_data_depth<'a, R: NbtReadHelper<'a>>(
+        reader: &mut R,
+        tag_id: u8,
+        depth: u32,
+    ) -> Result<(), Error> {
+        if depth >= crate::MAX_NBT_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
         match tag_id {
             END_ID => Ok(()),
             BYTE_ID => reader.skip_i8(),
@@ -203,14 +214,21 @@ impl NbtTag {
                 if len < 0 {
                     return Err(Error::NegativeLength(len));
                 }
+                // Empty END-typed lists are valid; non-empty END lists are not.
+                if tag_type_id == END_ID && len != 0 {
+                    return Err(Error::UnknownTagId(tag_type_id));
+                }
+                if len as usize > MAX_ARRAY_LENGTH {
+                    return Err(Error::LargeLength(len as usize));
+                }
 
                 for _ in 0..len {
-                    Self::skip_data(reader, tag_type_id)?;
+                    Self::skip_data_depth(reader, tag_type_id, depth + 1)?;
                 }
 
                 Ok(())
             }
-            COMPOUND_ID => NbtCompound::skip_content(reader),
+            COMPOUND_ID => NbtCompound::skip_content_depth(reader, depth),
             INT_ARRAY_ID => {
                 let len = reader.get_i32()?;
                 if len < 0 {
@@ -243,6 +261,18 @@ impl NbtTag {
         reader: &mut R,
         tag_id: u8,
     ) -> Result<Self, Error> {
+        Self::deserialize_data_depth(reader, tag_id, 0)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    pub(crate) fn deserialize_data_depth<'a, R: NbtReadHelper<'a>>(
+        reader: &mut R,
+        tag_id: u8,
+        depth: u32,
+    ) -> Result<Self, Error> {
+        if depth >= crate::MAX_NBT_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
         match tag_id {
             END_ID => Ok(Self::End),
             BYTE_ID => {
@@ -298,17 +328,29 @@ impl NbtTag {
                 if len > MAX_ARRAY_LENGTH {
                     return Err(Error::LargeLength(len));
                 }
+                // Empty END-typed lists are valid (vanilla); non-empty are not and
+                // would otherwise allocate up to MAX_ARRAY_LENGTH unit tags.
+                if tag_type_id == END_ID {
+                    if len != 0 {
+                        return Err(Error::UnknownTagId(tag_type_id));
+                    }
+                    return Ok(Self::List(Vec::new()));
+                }
 
                 let mut list = Vec::with_capacity(len);
                 for _ in 0..len {
-                    let tag = Self::deserialize_data(reader, tag_type_id)?;
-                    assert_eq!(tag.get_type_id(), tag_type_id);
+                    let tag = Self::deserialize_data_depth(reader, tag_type_id, depth + 1)?;
+                    if tag.get_type_id() != tag_type_id {
+                        return Err(Error::UnknownTagId(tag.get_type_id()));
+                    }
                     // Try unwrapping the tag.
                     list.push(Self::flatten(tag));
                 }
                 Ok(Self::List(list))
             }
-            COMPOUND_ID => Ok(Self::Compound(NbtCompound::deserialize_content(reader)?)),
+            COMPOUND_ID => Ok(Self::Compound(NbtCompound::deserialize_content_depth(
+                reader, depth,
+            )?)),
             INT_ARRAY_ID => {
                 let len = reader.get_i32()?;
                 if len < 0 {

--- a/pumpkin-protocol/src/bedrock/ack.rs
+++ b/pumpkin-protocol/src/bedrock/ack.rs
@@ -1,6 +1,9 @@
 use std::io::{Error, ErrorKind, Read, Write};
 
 const MAX_ACK_RECORDS: u16 = 4096;
+/// Hard cap on expanded sequence numbers from range records.
+/// Prevents a small datagram from expanding into multi-GB allocations.
+const MAX_ACK_SEQUENCES: usize = 4096;
 
 use crate::{
     codec::u24,
@@ -38,14 +41,34 @@ impl Acknowledge {
             ));
         }
 
-        let mut sequences = Vec::with_capacity(size as usize);
+        let mut sequences = Vec::with_capacity((size as usize).min(MAX_ACK_SEQUENCES));
         for _ in 0..size {
             let single = bool::read(reader)?;
             if single {
+                if sequences.len() >= MAX_ACK_SEQUENCES {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        "Acknowledge packet expands past sequence limit.",
+                    ));
+                }
                 sequences.push(u24::read(reader)?.0);
             } else {
                 let start = u24::read(reader)?.0;
                 let end = u24::read(reader)?.0;
+                if end < start {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        "Acknowledge range end before start.",
+                    ));
+                }
+                // Inclusive range length: end - start + 1, checked against remaining budget.
+                let range_len = (end - start) as usize + 1;
+                if sequences.len().saturating_add(range_len) > MAX_ACK_SEQUENCES {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        "Acknowledge packet range expansion exceeds sequence limit.",
+                    ));
+                }
                 for i in start..=end {
                     sequences.push(i);
                 }

--- a/pumpkin-protocol/src/codec/data_component.rs
+++ b/pumpkin-protocol/src/codec/data_component.rs
@@ -24,6 +24,9 @@ use pumpkin_data::sound::Sound;
 use pumpkin_nbt::{serializer::NbtWriteHelperJava, tag::NbtTag};
 
 const MAX_STATUS_EFFECTS: usize = 128;
+const MAX_IDSET_ELEMENTS: i32 = 4096;
+const MAX_CONSUMABLE_EFFECTS: i32 = 256;
+const MAX_EFFECT_NESTING: u32 = 16;
 
 #[must_use]
 pub fn data_to_proto_sound(id_or: &IdOr<SoundEvent>) -> crate::IdOr<crate::SoundEvent> {
@@ -62,6 +65,9 @@ fn deserialize_idset<T: IDSetContent>(
         }
         std::cmp::Ordering::Greater => {
             let len = id_type - 1;
+            if len > MAX_IDSET_ELEMENTS {
+                return Err(ReadingError::TooLarge("IDSet elements".into()));
+            }
             let mut content_vec = Vec::with_capacity(len as usize);
 
             for _ in 0..len {
@@ -125,7 +131,7 @@ fn deserialize_status_effects(
         let has_hidden = seq.get_bool()?;
         if has_hidden {
             // Skip hidden effect parameters recursively
-            skip_effect_parameters(seq)?;
+            skip_effect_parameters(seq, 0)?;
         }
 
         custom_effects.push(StatusEffectInstance {
@@ -392,6 +398,9 @@ impl DataComponentCodec<Self> for ConsumableImpl {
             "Invalid sound in ConsumableImpl".into(),
         ))?;
         let effects_len = seq.get_var_int()?.0;
+        if !(0..=MAX_CONSUMABLE_EFFECTS).contains(&effects_len) {
+            return Err(ReadingError::TooLarge("ConsumableImpl effects".into()));
+        }
         let mut effects_vec = Vec::with_capacity(effects_len as usize);
 
         for _ in 0..effects_len {
@@ -579,7 +588,12 @@ impl DataComponentCodec<Self> for PotionContentsImpl {
 }
 
 /// Helper to skip hidden effect parameters recursively
-fn skip_effect_parameters(seq: &mut impl NetworkReadExt) -> Result<(), ReadingError> {
+fn skip_effect_parameters(seq: &mut impl NetworkReadExt, depth: u32) -> Result<(), ReadingError> {
+    if depth >= MAX_EFFECT_NESTING {
+        return Err(ReadingError::TooLarge(
+            "PotionContents hidden effect nesting".into(),
+        ));
+    }
     // amplifier
     seq.get_var_int()?;
     // duration
@@ -593,7 +607,7 @@ fn skip_effect_parameters(seq: &mut impl NetworkReadExt) -> Result<(), ReadingEr
     // has_hidden (recursive)
     let has_hidden = seq.get_bool()?;
     if has_hidden {
-        skip_effect_parameters(seq)?;
+        skip_effect_parameters(seq, depth + 1)?;
     }
     Ok(())
 }

--- a/pumpkin/src/command/snbt/mod.rs
+++ b/pumpkin/src/command/snbt/mod.rs
@@ -48,6 +48,9 @@ pub const EXPECTED_INTEGER_TYPE: CommandErrorType<0> = CommandErrorType::new(
     translation::java::SNBT_PARSER_EXPECTED_INTEGER_TYPE,
 );
 
+/// Maximum nesting depth for SNBT compounds/lists (matches NBT binary depth budget).
+pub const MAX_SNBT_DEPTH: u32 = 128;
+
 /// A structure that parses SNBT.
 ///
 /// This stores a reader and gives the furthest error, or suggestions
@@ -55,6 +58,7 @@ pub const EXPECTED_INTEGER_TYPE: CommandErrorType<0> = CommandErrorType::new(
 pub struct SnbtParser<'r, 's> {
     reader: &'r mut StringReader<'s>,
     errors: ParserErrors,
+    depth: u32,
 }
 
 //
@@ -67,6 +71,7 @@ impl SnbtParser<'_, '_> {
             let mut parser = SnbtParser {
                 reader,
                 errors: ParserErrors::default(),
+                depth: 0,
             };
 
             let literal = parser.parse();
@@ -113,6 +118,7 @@ impl SnbtParser<'_, '_> {
             let mut parser = SnbtParser {
                 reader: &mut reader,
                 errors: ParserErrors::default(),
+                depth: 0,
             };
 
             let _ = parser.parse();

--- a/pumpkin/src/command/snbt/rules.rs
+++ b/pumpkin/src/command/snbt/rules.rs
@@ -68,6 +68,12 @@ pub const EMPTY_KEY: CommandErrorType<0> = CommandErrorType::new(
     translation::java::SNBT_PARSER_EMPTY_KEY,
 );
 
+/// Nesting budget exhausted (matches binary NBT depth cap).
+pub const NESTING_TOO_DEEP: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMAND_FAILED,
+    translation::java::COMMAND_FAILED,
+);
+
 pub const LEADING_ZERO_NOT_ALLOWED: CommandErrorType<0> = CommandErrorType::new(
     translation::java::SNBT_PARSER_LEADING_ZERO_NOT_ALLOWED,
     translation::java::SNBT_PARSER_LEADING_ZERO_NOT_ALLOWED,
@@ -696,6 +702,11 @@ impl SnbtParser<'_, '_> {
     }
 
     fn map_literal(&mut self) -> Option<NbtTag> {
+        if self.depth >= crate::command::snbt::MAX_SNBT_DEPTH {
+            self.store_simple_error(&NESTING_TOO_DEEP);
+            return None;
+        }
+        self.depth += 1;
         let entries = self.parse_or_revert(|parser| {
             parser.reader.skip_whitespace();
             if parser.reader.peek() != Some('{') {
@@ -711,7 +722,9 @@ impl SnbtParser<'_, '_> {
             }
             parser.reader.skip();
             Some(entries)
-        })?;
+        });
+        self.depth = self.depth.saturating_sub(1);
+        let entries = entries?;
 
         Some(NbtTag::Compound(NbtCompound {
             child_tags: entries.into_iter().map(|(k, v)| (k.into(), v)).collect(),
@@ -755,7 +768,12 @@ impl SnbtParser<'_, '_> {
     }
 
     fn list_literal(&mut self) -> Option<NbtTag> {
-        self.parse_or_revert(|parser| {
+        if self.depth >= crate::command::snbt::MAX_SNBT_DEPTH {
+            self.store_simple_error(&NESTING_TOO_DEEP);
+            return None;
+        }
+        self.depth += 1;
+        let result = self.parse_or_revert(|parser| {
             parser.reader.skip_whitespace();
             if parser.reader.peek() != Some('[') {
                 parser.store_dynamic_error_and_suggest(&LITERAL_INCORRECT, "[", &["["]);
@@ -795,7 +813,9 @@ impl SnbtParser<'_, '_> {
 
                 Some(NbtOps.create_list(entries))
             }
-        })
+        });
+        self.depth = self.depth.saturating_sub(1);
+        result
     }
 
     fn literal(&mut self) -> Option<NbtTag> {

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -18,13 +18,13 @@ use tokio::signal::ctrl_c;
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal};
 
+use pumpkin::PumpkinServer;
 use pumpkin::{
     CRASH_REPORT, SERVER_EXIT_CODE, SERVER_IS_STOPPING,
     crash::{CrashReport, FullBacktrace},
     data::VanillaData,
     stop_or_exit_server,
 };
-use pumpkin::{PumpkinServer, stop_server};
 
 use pumpkin_config::{LoadConfiguration, PumpkinConfig};
 use pumpkin_util::text::{
@@ -213,12 +213,14 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
     };
 
     let payload = panic_info.payload();
+    let payload_str = payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("<unknown>");
 
     if is_main_thread() {
-        // It's the first panic;
-        // We cannot gracefully shut down as the main thread
-        // has panicked. However, we can still generate the crash report.
-
+        // Main-thread panic is unrecoverable: write a crash report and exit.
         if let Some(crash_report) = try_set_crash_report(crash_report) {
             crash_report.print_to_console();
             crash_report.save_and_log();
@@ -230,7 +232,6 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
                     .to_pretty_console()
             );
         } else {
-            // It's a subsequent panic.
             tracing::error!(
                 "{}: {}",
                 TextComponent::text(
@@ -239,35 +240,30 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
                 .color(Color::Named(NamedColor::Red))
                 .bold()
                 .to_pretty_console(),
-                payload
-                    .downcast_ref::<&str>()
-                    .copied()
-                    .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
-                    .unwrap_or("<unknown>")
+                payload_str
             );
         }
 
         exit(1);
     }
 
-    if try_set_crash_report(crash_report).is_some() {
-        // It's the first panic; let's stop the server.
-        stop_server();
-    } else {
-        // It's a subsequent panic; let's just alert about it.
-        tracing::error!(
-            "{}: {}",
-            TextComponent::text("Encountered panic while shutting down")
-                .color(Color::Named(NamedColor::Red))
-                .bold()
-                .to_pretty_console(),
-            payload
-                .downcast_ref::<&str>()
-                .copied()
-                .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
-                .unwrap_or("<unknown>")
-        );
-    }
+    // Worker-thread panics must NOT take down the whole server. Log a crash
+    // report and let the task die; other connections keep serving.
+    // (Previously the first worker panic called stop_server(), turning every
+    // reachable unwrap into a remote kill switch.)
+    crash_report.print_to_console();
+    crash_report.save_and_log();
+    // Keep the first report for process exit status if the server later stops.
+    let _ = try_set_crash_report(crash_report);
+
+    tracing::error!(
+        "{}: {}",
+        TextComponent::text("Worker thread panicked; task aborted, server continues running")
+            .color(Color::Named(NamedColor::Red))
+            .bold()
+            .to_pretty_console(),
+        payload_str
+    );
 }
 
 fn is_main_thread() -> bool {

--- a/pumpkin/src/net/authentication.rs
+++ b/pumpkin/src/net/authentication.rs
@@ -44,10 +44,19 @@ pub struct MojangPublicKeys {
 }
 
 const MOJANG_AUTHENTICATION_URL: &str = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}";
-const MOJANG_PREVENT_PROXY_AUTHENTICATION_URL: &str = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}";
+const MOJANG_PREVENT_PROXY_AUTHENTICATION_URL: &str = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}&ip={ip}";
 const MOJANG_SERVICES_URL: &str = "https://api.minecraftservices.com/";
 const MOJANG_PROFILE_BY_NAME_URL: &str =
     "https://api.mojang.com/users/profiles/minecraft/{username}";
+
+/// ureq 3 defaults to no timeouts; always use a bounded agent for Mojang HTTP.
+fn mojang_http_agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_connect(Some(std::time::Duration::from_secs(5)))
+        .timeout_recv_response(Some(std::time::Duration::from_secs(5)))
+        .build()
+        .into()
+}
 
 /// Sends a GET request to Mojang's authentication servers to verify a client's Minecraft account.
 ///
@@ -89,7 +98,8 @@ pub fn authenticate(
             .replace("{server_hash}", server_hash)
     };
 
-    let mut response = ureq::get(address)
+    let mut response = mojang_http_agent()
+        .get(address)
         .call()
         .map_err(|_| AuthError::FailedResponse)?;
     match response.status() {
@@ -151,7 +161,8 @@ pub fn fetch_mojang_public_keys(
 
     let url = format!("{services_url}/publickeys");
 
-    let mut response = ureq::get(url)
+    let mut response = mojang_http_agent()
+        .get(url)
         .call()
         .map_err(|_| AuthError::FailedResponse)?;
 
@@ -192,7 +203,8 @@ pub fn lookup_profile_by_name(
 ) -> Result<Option<(Uuid, String)>, AuthError> {
     let url = MOJANG_PROFILE_BY_NAME_URL.replace("{username}", name);
 
-    let mut response = ureq::get(url)
+    let mut response = mojang_http_agent()
+        .get(url)
         .call()
         .map_err(|_| AuthError::FailedResponse)?;
 

--- a/pumpkin/src/net/bedrock/login.rs
+++ b/pumpkin/src/net/bedrock/login.rs
@@ -180,6 +180,14 @@ impl BedrockClient {
         let real_name = player_data.display_name;
         // IMPORTANT: Bedrock allows spaces in names. While we could support this, it would significantly complicate parsing player arguments in commands, so we don't
         let under_score_name = real_name.replace(' ', "_");
+        // Reject empty/NUL/control names (query CString panic, log injection, etc.).
+        if under_score_name.is_empty()
+            || under_score_name.contains('\0')
+            || under_score_name.chars().any(char::is_control)
+            || under_score_name.len() > 16
+        {
+            return Err(LoginError::InvalidUsername);
+        }
 
         let profile = GameProfile {
             id: Uuid::parse_str(&player_data.uuid).map_err(|_| LoginError::InvalidUuid)?,

--- a/pumpkin/src/net/bedrock/mod.rs
+++ b/pumpkin/src/net/bedrock/mod.rs
@@ -1,5 +1,15 @@
 pub mod play;
 use crossbeam::atomic::AtomicCell;
+
+/// Maximum fragments in a single `RakNet` split compound.
+/// Legitimate packets fit well under this; uncapped `split_size` is a remote alloc bomb.
+const MAX_RAKNET_SPLIT_COUNT: u32 = 1024;
+/// Cap outstanding incomplete split compounds per client.
+const MAX_PENDING_SPLIT_COMPOUNDS: usize = 64;
+/// Cap frames waiting in an ordered channel queue.
+const MAX_ORDERED_QUEUE_LEN: usize = 512;
+/// Cap unacked outgoing frames retained for resend.
+const MAX_UNACKED_OUTGOING: usize = 2048;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     io::{Cursor, Error, Write},
@@ -704,7 +714,15 @@ impl BedrockClient {
         }
 
         if frame_set.frames.iter().any(|f| f.reliability.is_reliable()) {
-            self.unacked_outgoing_frames.lock().await.insert(
+            let mut unacked = self.unacked_outgoing_frames.lock().await;
+            // Bound memory if peer never ACKs (never-ACK client retention DoS).
+            if unacked.len() >= MAX_UNACKED_OUTGOING {
+                // Drop oldest by insertion-order proxy: lowest sequence number.
+                if let Some(oldest) = unacked.keys().copied().min() {
+                    unacked.remove(&oldest);
+                }
+            }
+            unacked.insert(
                 sequence,
                 (id, frame_set_buf.clone(), std::time::Instant::now()),
             );
@@ -861,15 +879,34 @@ impl BedrockClient {
         mut frame: Frame,
     ) -> Result<(), Error> {
         if frame.split_size > 0 {
+            if frame.split_size > MAX_RAKNET_SPLIT_COUNT {
+                return Err(Error::other(format!(
+                    "RakNet split_size {} exceeds limit {MAX_RAKNET_SPLIT_COUNT}",
+                    frame.split_size
+                )));
+            }
             let fragment_index = frame.split_index as usize;
             let compound_id = frame.split_id;
             let mut compounds = self.compounds.lock().await;
+
+            if !compounds.contains_key(&compound_id)
+                && compounds.len() >= MAX_PENDING_SPLIT_COMPOUNDS
+            {
+                return Err(Error::other(
+                    "Too many pending RakNet split compounds from client",
+                ));
+            }
 
             let entry = compounds.entry(compound_id).or_insert_with(|| {
                 let mut vec = Vec::with_capacity(frame.split_size as usize);
                 vec.resize_with(frame.split_size as usize, || None);
                 vec
             });
+
+            // Reject compounds whose declared size disagrees with the first fragment.
+            if entry.len() != frame.split_size as usize {
+                return Err(Error::other("RakNet split compound size mismatch"));
+            }
 
             if fragment_index >= entry.len() {
                 return Err(Error::other(format!(
@@ -938,6 +975,11 @@ impl BedrockClient {
                 let queue = ordered_queues
                     .entry(frame.order_channel)
                     .or_insert_with(BTreeMap::new);
+                if queue.len() >= MAX_ORDERED_QUEUE_LEN {
+                    return Err(Error::other(
+                        "RakNet ordered queue exceeded limit for channel",
+                    ));
+                }
                 queue.insert(frame.order_index, frame);
             }
             // If frame.order_index < *expected, it's an old frame, discard it.

--- a/pumpkin/src/net/java/config.rs
+++ b/pumpkin/src/net/java/config.rs
@@ -246,16 +246,22 @@ impl JavaClient {
 
     pub async fn handle_config_acknowledged(&self, server: &Arc<Server>) -> PacketHandlerResult {
         debug!("Handling config acknowledgement");
-        self.connection_state.store(ConnectionState::Play);
 
         let profile = self.gameprofile.lock().await.clone();
-        let profile = profile.unwrap();
+        let Some(profile) = profile else {
+            // Missing profile (skipped login / proxy response) must not panic.
+            self.kick(TextComponent::text("Missing game profile")).await;
+            return PacketHandlerResult::Stop;
+        };
         let address = self.address.lock().await;
 
         if let Some(reason) = can_not_join(&profile, &address, server).await {
             self.kick(reason).await;
             return PacketHandlerResult::Stop;
         }
+
+        // Only enter Play after profile + join gates succeed.
+        self.connection_state.store(ConnectionState::Play);
 
         let config = self.config.lock().await;
         PacketHandlerResult::ReadyToPlay(profile, config.clone().unwrap_or_default())

--- a/pumpkin/src/net/java/login.rs
+++ b/pumpkin/src/net/java/login.rs
@@ -157,6 +157,10 @@ impl JavaClient {
                         e => TextComponent::text(e.to_string()),
                     })
                     .await;
+                    // Critical: kick() only schedules disconnect. Without return,
+                    // login falls through and finish_login() completes with the
+                    // unverified client-supplied profile (auth bypass).
+                    return;
                 }
             }
         }

--- a/pumpkin/src/net/mod.rs
+++ b/pumpkin/src/net/mod.rs
@@ -373,11 +373,16 @@ pub enum EncryptionError {
     AlreadyEncrypted,
 }
 
+/// Validates a player name for join/login.
+/// Rejects empty names, overlong names, control chars (incl. NUL), spaces, and
+/// the section sign (`§`) used for client format-code injection.
 fn is_valid_player_name(name: &str) -> bool {
-    if name.len() > 16 {
+    if name.is_empty() || name.len() > 16 {
         return false;
     }
-    !name.chars().any(|c| c.is_control() || c == ' ')
+    !name
+        .chars()
+        .any(|c| c.is_control() || c == ' ' || c == '\0' || c == '§')
 }
 
 #[derive(Clone, Copy)]
@@ -590,13 +595,19 @@ mod tests {
         );
     }
 
-    /// Test case for an empty string (length 0, but included for completeness).
+    /// Test case for an empty string — must be rejected (query `CString`, impersonation).
     #[test]
     fn invalid_empty_string() {
         let name = "";
+        assert!(!is_valid_player_name(name), "Empty string must be invalid");
+    }
+
+    #[test]
+    fn invalid_section_sign() {
+        let name = "Player§cName";
         assert!(
-            is_valid_player_name(name),
-            "Empty string should be valid (length <= 16 and no invalid chars)"
+            !is_valid_player_name(name),
+            "Section sign format codes must be rejected"
         );
     }
 

--- a/pumpkin/src/net/proxy/velocity.rs
+++ b/pumpkin/src/net/proxy/velocity.rs
@@ -82,6 +82,13 @@ fn read_game_profile(read: impl Read) -> Result<GameProfile, VelocityError> {
     let name = read
         .get_str()
         .map_err(|_| VelocityError::FailedReadProfileName)?;
+    // Bound + sanitize forwarded names (proxy path previously accepted ≤1 MiB garbage).
+    if name.is_empty()
+        || name.len() > 16
+        || name.chars().any(|c| c.is_control() || c == ' ' || c == '§')
+    {
+        return Err(VelocityError::FailedReadProfileName);
+    }
 
     let properties = read
         .get_list(|data| {

--- a/pumpkin/src/net/rcon/mod.rs
+++ b/pumpkin/src/net/rcon/mod.rs
@@ -18,11 +18,20 @@ pub struct RCONServer;
 
 impl RCONServer {
     pub async fn run(config: &RCONConfig, server: Arc<Server>) {
+        // Empty password is rejected at config validation; belt-and-suspenders here.
+        if config.password.is_empty() {
+            error!("RCON refused to start: password is empty");
+            return;
+        }
+
         let listener = tokio::net::TcpListener::bind(config.address).await.unwrap();
 
         let password = Arc::new(config.password.clone());
+        // Track live connections with an atomic so the counter is decremented on close,
+        // not immediately after spawn (previous code made max_connections a no-op).
+        let connections = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let max_connections = config.max_connections;
 
-        let mut connections = 0;
         while !SHOULD_STOP.load(Ordering::Relaxed) {
             let await_new_client = || async {
                 let t1 = listener.accept();
@@ -39,18 +48,24 @@ impl RCONServer {
                 break;
             };
 
-            if config.max_connections != 0 && connections >= config.max_connections {
+            let current = connections.load(Ordering::Relaxed);
+            if max_connections != 0 && current >= max_connections {
+                debug!("RCON connection from {address} rejected: max_connections reached");
+                drop(connection);
                 continue;
             }
 
-            connections += 1;
+            connections.fetch_add(1, Ordering::Relaxed);
             let mut client = RCONClient::new(connection, address);
 
             let password = password.clone();
             let server = server.clone();
-            tokio::spawn(async move { while !client.handle(&server, &password).await {} });
-            debug!("closed RCON connection");
-            connections -= 1;
+            let connections = connections.clone();
+            tokio::spawn(async move {
+                while !client.handle(&server, &password).await {}
+                connections.fetch_sub(1, Ordering::Relaxed);
+                debug!("closed RCON connection");
+            });
         }
     }
 }
@@ -155,8 +170,27 @@ impl RCONClient {
     }
 
     async fn read_bytes(&mut self) -> std::io::Result<bool> {
+        // Bound the staging buffer so a slowloris client cannot retain unbounded memory.
+        const MAX_INCOMING: usize = 64 * 1024;
+        if self.incoming.len() > MAX_INCOMING {
+            self.closed = true;
+            return Ok(true);
+        }
         let mut buf = [0; 1460];
-        let n = self.connection.read(&mut buf).await?;
+        let n = match tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            self.connection.read(&mut buf),
+        )
+        .await
+        {
+            Ok(Ok(n)) => n,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                // Read timeout
+                self.closed = true;
+                return Ok(true);
+            }
+        };
         if n == 0 {
             return Ok(true);
         }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -6,7 +6,9 @@ use crate::data::player_server::ServerPlayerData;
 use crate::entity::{EntityBase, NBTStorage};
 use crate::item::registry::ItemRegistry;
 use crate::net::authentication::fetch_mojang_public_keys;
-use crate::net::{ClientPlatform, DisconnectReason, EncryptionError, GameProfile, PlayerConfig};
+use crate::net::{
+    ClientPlatform, DisconnectReason, EncryptionError, GameProfile, PlayerConfig, can_not_join,
+};
 use crate::plugin::PluginManager;
 use crate::plugin::player::player_login::PlayerLoginEvent;
 use crate::plugin::server::server_broadcast::ServerBroadcastEvent;
@@ -23,6 +25,7 @@ use key_store::KeyStore;
 use pumpkin_config::{AdvancedConfiguration, BasicConfiguration};
 use pumpkin_data::dimension::Dimension;
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::translation;
 use pumpkin_util::permission::{PermissionManager, PermissionRegistry};
 use pumpkin_util::text::color::NamedColor;
 use pumpkin_world::dimension::into_level;
@@ -478,12 +481,36 @@ impl Server {
     /// # Note
     ///
     /// You still have to spawn the `Player` in a `World` to let them join and make them visible.
+    #[allow(clippy::too_many_lines)]
     pub async fn add_player(
         &self,
         client: Arc<ClientPlatform>,
         profile: GameProfile,
         config: Option<PlayerConfig>,
     ) -> Option<(Arc<Player>, Arc<World>)> {
+        // Centralized identity + moderation gates for every transport (Java,
+        // Bedrock, offline, proxy). Previously several paths skipped these.
+        let address = client.address().await;
+        if let Some(reason) = can_not_join(&profile, &address, self).await {
+            client.kick(DisconnectReason::Kicked, reason).await;
+            return None;
+        }
+        if self.get_player_by_uuid(profile.id).is_some()
+            || self.get_player_by_name(&profile.name).is_some()
+        {
+            client
+                .kick(
+                    DisconnectReason::Kicked,
+                    TextComponent::translate_cross(
+                        translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
+                        translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
+                        [],
+                    ),
+                )
+                .await;
+            return None;
+        }
+
         let gamemode = self.defaultgamemode.lock().await.gamemode;
 
         let (world, nbt) =


### PR DESCRIPTION
Part 3 of the hardening stack (stacked on #2510).

## Commits
- fail-closed RCON/proxy config and fix RCON limits

## What and why
- RCON enabled with the default empty password previously authenticated an empty-body auth packet and granted full console (permission level 4). Startup now refuses RCON with an empty/whitespace password, with a runtime guard as a second layer.
- The RCON max_connections counter was decremented immediately after spawn, so the limit never applied; it now tracks live connections correctly. Adds a read timeout and a 64 KiB buffer bound.
- Velocity proxy mode with an empty forwarding secret allowed forged HMAC validation. Startup now rejects velocity.enabled with an empty/whitespace secret.
- BungeeCord mode now prints a loud startup warning that direct connections can spoof any UUID/name and that the backend must be firewalled.
- Velocity-forwarded player names are validated before use.

## Tests
cargo test -p pumpkin passes.