### PR TITLE
security: charge trade/anvil output on verified take; settle Bedrock craft takes via slot hooks; throttle registry/decompress/panic reports

### DIFF
--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -108,20 +108,28 @@ impl LoadConfiguration for PumpkinConfig {
             );
         }
 
-        // Fail-closed: RCON with an empty password is full unauthenticated console access.
+        // Fail-closed: RCON with an empty/whitespace password is full console access.
         if self.advanced.networking.rcon.enabled {
             assert!(
-                !self.advanced.networking.rcon.password.is_empty(),
+                !self.advanced.networking.rcon.password.trim().is_empty(),
                 "RCON is enabled but password is empty. Set networking.rcon.password to a non-empty value, or disable RCON."
             );
         }
 
-        // Fail-closed: Velocity with empty secret makes HMAC forgeable by anyone.
-        if self.advanced.networking.proxy.enabled && self.advanced.networking.proxy.velocity.enabled
-        {
+        // Fail-closed whenever the Velocity handler can run. The plugin-response
+        // path keys only on velocity.enabled (not proxy.enabled), so require a
+        // non-empty secret whenever velocity is enabled.
+        if self.advanced.networking.proxy.velocity.enabled {
             assert!(
-                !self.advanced.networking.proxy.velocity.secret.is_empty(),
-                "Velocity proxy is enabled but secret is empty. Set networking.proxy.velocity.secret to the proxy forwarding secret."
+                !self
+                    .advanced
+                    .networking
+                    .proxy
+                    .velocity
+                    .secret
+                    .trim()
+                    .is_empty(),
+                "Velocity is enabled but secret is empty. Set networking.proxy.velocity.secret to the proxy forwarding secret."
             );
         }
 

--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -107,6 +107,32 @@ impl LoadConfiguration for PumpkinConfig {
                 "When allow_chat_reports is enabled, java.online_mode must be enabled"
             );
         }
+
+        // Fail-closed: RCON with an empty password is full unauthenticated console access.
+        if self.advanced.networking.rcon.enabled {
+            assert!(
+                !self.advanced.networking.rcon.password.is_empty(),
+                "RCON is enabled but password is empty. Set networking.rcon.password to a non-empty value, or disable RCON."
+            );
+        }
+
+        // Fail-closed: Velocity with empty secret makes HMAC forgeable by anyone.
+        if self.advanced.networking.proxy.enabled && self.advanced.networking.proxy.velocity.enabled
+        {
+            assert!(
+                !self.advanced.networking.proxy.velocity.secret.is_empty(),
+                "Velocity proxy is enabled but secret is empty. Set networking.proxy.velocity.secret to the proxy forwarding secret."
+            );
+        }
+
+        // BungeeCord has no shared secret — backends must not be reachable directly.
+        if self.advanced.networking.proxy.enabled
+            && self.advanced.networking.proxy.bungeecord.enabled
+        {
+            warn!(
+                "BungeeCord proxy mode is enabled. Anyone who can reach this server directly can spoof any UUID/name. Firewall the backend so only the proxy can connect."
+            );
+        }
     }
 }
 

--- a/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
+++ b/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
@@ -186,6 +186,15 @@ impl ScreenHandler for AnvilScreenHandler {
         player: &'a dyn InventoryPlayer,
     ) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
+            use pumpkin_protocol::java::server::play::SlotActionType;
+
+            // PickupAll on the result slot steals the renamed output without
+            // consuming the input / charging XP (stackable rename dupe).
+            if slot_index == 2 && action_type == SlotActionType::PickupAll {
+                self.send_content_updates().await;
+                return;
+            }
+
             if slot_index == 2 {
                 // Taking from output slot
                 let result_slot = self.get_behaviour().slots[2].clone();
@@ -202,9 +211,11 @@ impl ScreenHandler for AnvilScreenHandler {
                                     .await;
                             }
 
-                            // Consume inputs
+                            // Consume both input slots (base + sacrifice).
                             self.inventory.set_stack(0, ItemStack::EMPTY.clone()).await;
                             self.get_behaviour().slots[0].mark_dirty().await;
+                            self.inventory.set_stack(1, ItemStack::EMPTY.clone()).await;
+                            self.get_behaviour().slots[1].mark_dirty().await;
                         } else {
                             // Cancel click
                             self.send_content_updates().await;

--- a/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
+++ b/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
@@ -10,7 +10,7 @@ use crate::{
         InventoryPlayer, ItemStackFuture, ScreenHandler, ScreenHandlerBehaviour,
         ScreenHandlerFuture, offer_or_drop_stack,
     },
-    slot::NormalSlot,
+    slot::{NormalSlot, TakeOnlySlot},
     window_property::{Anvil, WindowProperty},
 };
 
@@ -35,10 +35,10 @@ impl AnvilScreenHandler {
             repair_cost: 0,
         };
 
-        // Anvil specific slots: 2 input, 1 output
-        for i in 0..3 {
-            handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), i)));
-        }
+        // Anvil: 2 input slots + take-only output (PickupAll must not sweep output).
+        handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 0)));
+        handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 1)));
+        handler.add_slot(Arc::new(TakeOnlySlot::new(inventory.clone(), 2)));
 
         let player_inventory: Arc<dyn Inventory> = player_inventory.clone();
         handler.add_player_slots(&player_inventory);
@@ -186,17 +186,10 @@ impl ScreenHandler for AnvilScreenHandler {
         player: &'a dyn InventoryPlayer,
     ) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
-            use pumpkin_protocol::java::server::play::SlotActionType;
-
-            // PickupAll on the result slot steals the renamed output without
-            // consuming the input / charging XP (stackable rename dupe).
-            if slot_index == 2 && action_type == SlotActionType::PickupAll {
-                self.send_content_updates().await;
-                return;
-            }
-
+            // Charge rename/XP on take from take-only output. Combining is not
+            // implemented yet — only clear the base input so a sacrifice item
+            // is not voided on rename. PickupAll cannot sweep this slot.
             if slot_index == 2 {
-                // Taking from output slot
                 let result_slot = self.get_behaviour().slots[2].clone();
                 if result_slot.has_stack().await {
                     let result_stack = result_slot.get_cloned_stack().await;
@@ -204,20 +197,16 @@ impl ScreenHandler for AnvilScreenHandler {
                         if player.experience_level() >= self.repair_cost as i32
                             || player.is_creative()
                         {
-                            // Consume experience
                             if !player.is_creative() {
                                 player
                                     .add_experience_levels(-(self.repair_cost as i32))
                                     .await;
                             }
 
-                            // Consume both input slots (base + sacrifice).
+                            // Rename-only path consumes the base item in slot 0.
                             self.inventory.set_stack(0, ItemStack::EMPTY.clone()).await;
                             self.get_behaviour().slots[0].mark_dirty().await;
-                            self.inventory.set_stack(1, ItemStack::EMPTY.clone()).await;
-                            self.get_behaviour().slots[1].mark_dirty().await;
                         } else {
-                            // Cancel click
                             self.send_content_updates().await;
                             return;
                         }

--- a/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
+++ b/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
@@ -186,10 +186,14 @@ impl ScreenHandler for AnvilScreenHandler {
         player: &'a dyn InventoryPlayer,
     ) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
-            // Charge rename/XP on take from take-only output. Combining is not
-            // implemented yet — only clear the base input so a sacrifice item
-            // is not voided on rename. PickupAll cannot sweep this slot.
-            if slot_index == 2 {
+            use pumpkin_protocol::java::server::play::SlotActionType;
+
+            // Charge only for actions that take the result (not PickupAll no-ops).
+            let will_take = matches!(
+                action_type,
+                SlotActionType::Pickup | SlotActionType::QuickMove
+            );
+            if slot_index == 2 && will_take {
                 let result_slot = self.get_behaviour().slots[2].clone();
                 if result_slot.has_stack().await {
                     let result_stack = result_slot.get_cloned_stack().await;

--- a/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
+++ b/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI16, Ordering};
 
 use pumpkin_data::{item_stack::ItemStack, screen::WindowType};
 use pumpkin_world::inventory::Inventory;
@@ -10,7 +11,7 @@ use crate::{
         InventoryPlayer, ItemStackFuture, ScreenHandler, ScreenHandlerBehaviour,
         ScreenHandlerFuture, offer_or_drop_stack,
     },
-    slot::{NormalSlot, TakeOnlySlot},
+    slot::{BoxFuture, NormalSlot, TakeOnlySlot, TakeSlotCharge},
     window_property::{Anvil, WindowProperty},
 };
 
@@ -18,7 +19,43 @@ pub struct AnvilScreenHandler {
     pub inventory: Arc<dyn Inventory>,
     behaviour: ScreenHandlerBehaviour,
     pub rename_text: String,
-    pub repair_cost: i16,
+    /// Repair cost in XP levels, shared with the output slot's charge hook.
+    pub repair_cost: Arc<AtomicI16>,
+}
+
+/// Charges XP levels and the base item on the anvil output slot.
+///
+/// Fires from the slot's take path, so every verified take — pickup,
+/// shift-click, throw, swap — is charged exactly once; there is no
+/// per-action gate that could forget one.
+struct AnvilSlotCharge {
+    inventory: Arc<dyn Inventory>,
+    repair_cost: Arc<AtomicI16>,
+}
+
+impl TakeSlotCharge for AnvilSlotCharge {
+    fn can_take(&self, player: &dyn InventoryPlayer) -> bool {
+        player.is_creative()
+            || player.experience_level() >= i32::from(self.repair_cost.load(Ordering::Relaxed))
+    }
+
+    fn on_take<'a>(
+        &'a self,
+        player: &'a dyn InventoryPlayer,
+        _stack: &'a ItemStack,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            if !player.is_creative() {
+                player
+                    .add_experience_levels(-i32::from(self.repair_cost.load(Ordering::Relaxed)))
+                    .await;
+            }
+
+            // Rename-only path consumes the base item in slot 0.
+            self.inventory.set_stack(0, ItemStack::EMPTY.clone()).await;
+            self.inventory.mark_dirty();
+        })
+    }
 }
 
 impl AnvilScreenHandler {
@@ -28,17 +65,28 @@ impl AnvilScreenHandler {
         player_inventory: &Arc<PlayerInventory>,
         inventory: Arc<dyn Inventory>,
     ) -> Self {
+        let repair_cost = Arc::new(AtomicI16::new(0));
         let mut handler = Self {
             inventory: inventory.clone(),
             behaviour: ScreenHandlerBehaviour::new(sync_id, Some(WindowType::Anvil)),
             rename_text: String::new(),
-            repair_cost: 0,
+            repair_cost: repair_cost.clone(),
         };
 
         // Anvil: 2 input slots + take-only output (PickupAll must not sweep output).
+        // The output slot owns the charge hook so every take path charges once.
         handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 0)));
         handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 1)));
-        handler.add_slot(Arc::new(TakeOnlySlot::new(inventory.clone(), 2)));
+        handler.add_slot(Arc::new(TakeOnlySlot::with_charge(
+            inventory.clone(),
+            2,
+            Arc::new(AnvilSlotCharge {
+                inventory: inventory.clone(),
+                repair_cost,
+            }),
+        )));
+        // Container slots precede the player slots; used by Bedrock slot mapping.
+        handler.behaviour.container_slots = handler.behaviour.slots.len();
 
         let player_inventory: Arc<dyn Inventory> = player_inventory.clone();
         handler.add_player_slots(&player_inventory);
@@ -85,7 +133,7 @@ impl AnvilScreenHandler {
     }
 
     pub async fn set_repair_cost(&mut self, cost: i16) {
-        self.repair_cost = cost;
+        self.repair_cost.store(cost, Ordering::Relaxed);
         if let Some(sync_handler) = self.behaviour.sync_handler.as_ref() {
             let (property_id, property_value) =
                 WindowProperty::new(Anvil::RepairCost, cost).into_tuple();
@@ -130,20 +178,16 @@ impl ScreenHandler for AnvilScreenHandler {
 
     fn quick_move<'a>(
         &'a mut self,
-        _player: &'a dyn InventoryPlayer,
+        player: &'a dyn InventoryPlayer,
         slot_index: i32,
     ) -> ItemStackFuture<'a> {
         Box::pin(async move {
-            let mut stack_left = ItemStack::EMPTY.clone();
             let slot = self.get_behaviour().slots[slot_index as usize].clone();
 
             if slot.has_stack().await {
                 let slot_stack_lock = slot.get_stack().await;
-                let slot_stack_guard = slot_stack_lock.lock().await;
-                stack_left = slot_stack_guard.clone();
-                drop(slot_stack_guard);
-
                 let mut slot_stack_mut = slot_stack_lock.lock().await;
+                let stack_prev = slot_stack_mut.clone();
 
                 if slot_index < 3 {
                     // From anvil to player
@@ -165,16 +209,27 @@ impl ScreenHandler for AnvilScreenHandler {
                     }
                 }
 
-                if slot_stack_mut.is_empty() {
-                    drop(slot_stack_mut);
+                let stack = slot_stack_mut.clone();
+                drop(slot_stack_mut);
+                if stack.is_empty() {
                     slot.set_stack(ItemStack::EMPTY.clone()).await;
                 } else {
-                    drop(slot_stack_mut);
                     slot.mark_dirty().await;
                 }
+                if stack.item_count == stack_prev.item_count {
+                    return ItemStack::EMPTY.clone();
+                }
+
+                // Charge only what was actually moved; a failed delivery above
+                // returns before this point and charges nothing.
+                let mut taken_stack = stack_prev.clone();
+                taken_stack.set_count(stack_prev.item_count - stack.item_count);
+                slot.on_take_item(player, &taken_stack).await;
+
+                return stack_prev;
             }
 
-            stack_left
+            ItemStack::EMPTY.clone()
         })
     }
 
@@ -186,38 +241,6 @@ impl ScreenHandler for AnvilScreenHandler {
         player: &'a dyn InventoryPlayer,
     ) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
-            use pumpkin_protocol::java::server::play::SlotActionType;
-
-            // Charge only for actions that take the result (not PickupAll no-ops).
-            let will_take = matches!(
-                action_type,
-                SlotActionType::Pickup | SlotActionType::QuickMove
-            );
-            if slot_index == 2 && will_take {
-                let result_slot = self.get_behaviour().slots[2].clone();
-                if result_slot.has_stack().await {
-                    let result_stack = result_slot.get_cloned_stack().await;
-                    if !result_stack.is_empty() {
-                        if player.experience_level() >= self.repair_cost as i32
-                            || player.is_creative()
-                        {
-                            if !player.is_creative() {
-                                player
-                                    .add_experience_levels(-(self.repair_cost as i32))
-                                    .await;
-                            }
-
-                            // Rename-only path consumes the base item in slot 0.
-                            self.inventory.set_stack(0, ItemStack::EMPTY.clone()).await;
-                            self.get_behaviour().slots[0].mark_dirty().await;
-                        } else {
-                            self.send_content_updates().await;
-                            return;
-                        }
-                    }
-                }
-            }
-
             self.internal_on_slot_click(slot_index, button, action_type, player)
                 .await;
             if slot_index == 0 || slot_index == 1 || slot_index == 2 {
@@ -225,5 +248,165 @@ impl ScreenHandler for AnvilScreenHandler {
                 self.send_content_updates().await;
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pumpkin_data::item::Item;
+    use pumpkin_protocol::java::server::play::SlotActionType;
+    use pumpkin_world::inventory::SimpleInventory;
+
+    use crate::screen_handler::ScreenHandler;
+    use crate::test_util::MockPlayer;
+
+    async fn setup() -> (AnvilScreenHandler, Arc<MockPlayer>) {
+        let player = Arc::new(MockPlayer::new());
+        player.xp_levels.store(5, Ordering::Relaxed);
+        let inventory: Arc<dyn Inventory> = Arc::new(SimpleInventory::new(3));
+        inventory
+            .set_stack(0, ItemStack::new(1, &Item::IRON_SWORD))
+            .await;
+        let mut handler = AnvilScreenHandler::new(1, &player.player_inventory, inventory);
+        handler.update_item_name("Pointy".to_string()).await;
+        assert_eq!(handler.get_behaviour().container_slots, 3);
+        assert_eq!(handler.repair_cost.load(Ordering::Relaxed), 1);
+        (handler, player)
+    }
+
+    async fn inv_stack(inventory: &Arc<dyn Inventory>, index: usize) -> ItemStack {
+        inventory.get_stack(index).await.lock().await.clone()
+    }
+
+    fn xp_levels(player: &MockPlayer) -> i32 {
+        player.xp_levels.load(Ordering::Relaxed)
+    }
+
+    #[tokio::test]
+    async fn throw_on_output_charges_exactly_once() {
+        let (mut handler, player) = setup().await;
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 1);
+
+        // Q on the result slot: one take, one charge. A double-fired take
+        // hook would show up as two levels charged for one delivered item.
+        handler
+            .on_slot_click(2, 0, SlotActionType::Throw, player.as_ref())
+            .await;
+        assert_eq!(xp_levels(&player), 4);
+        assert!(inv_stack(&handler.inventory, 0).await.is_empty());
+        let dropped = player.dropped.lock().await;
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(dropped[0].item.id, Item::IRON_SWORD.id);
+        drop(dropped);
+        // Input consumed -> result cleared, nothing more to take.
+        assert!(inv_stack(&handler.inventory, 2).await.is_empty());
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Throw, player.as_ref())
+            .await;
+        assert_eq!(xp_levels(&player), 4, "no result, no second charge");
+        assert_eq!(player.dropped.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn swap_on_output_charges_once() {
+        let (mut handler, player) = setup().await;
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Swap, player.as_ref())
+            .await;
+        assert_eq!(xp_levels(&player), 4);
+        assert!(inv_stack(&handler.inventory, 0).await.is_empty());
+        let hotbar = player.player_inventory.get_stack(0).await;
+        let hotbar = hotbar.lock().await;
+        assert_eq!(hotbar.item.id, Item::IRON_SWORD.id);
+    }
+
+    #[tokio::test]
+    async fn pickup_all_on_output_is_noop() {
+        let (mut handler, player) = setup().await;
+        let output = inv_stack(&handler.inventory, 2).await;
+        *handler.get_behaviour_mut().cursor_stack.lock().await = output;
+
+        // Double-click sweep must skip the take-only output slot entirely.
+        handler
+            .on_slot_click(2, 0, SlotActionType::PickupAll, player.as_ref())
+            .await;
+        assert_eq!(xp_levels(&player), 5, "PickupAll must not charge");
+        assert!(!inv_stack(&handler.inventory, 0).await.is_empty());
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 1);
+        assert_eq!(
+            handler.get_behaviour().cursor_stack.lock().await.item_count,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn quick_move_into_full_inventory_charges_nothing() {
+        let (mut handler, player) = setup().await;
+        for i in 0..36 {
+            player
+                .player_inventory
+                .set_stack(i, ItemStack::new(64, &Item::COBBLESTONE))
+                .await;
+        }
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::QuickMove, player.as_ref())
+            .await;
+        assert_eq!(xp_levels(&player), 5, "failed delivery must not charge");
+        assert!(!inv_stack(&handler.inventory, 0).await.is_empty());
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 1);
+    }
+
+    #[tokio::test]
+    async fn insufficient_xp_blocks_take() {
+        let (mut handler, player) = setup().await;
+        player.xp_levels.store(0, Ordering::Relaxed);
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Pickup, player.as_ref())
+            .await;
+        assert_eq!(xp_levels(&player), 0);
+        assert!(!inv_stack(&handler.inventory, 0).await.is_empty());
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 1);
+        assert!(handler.get_behaviour().cursor_stack.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn pickup_on_output_charges_once() {
+        let (mut handler, player) = setup().await;
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Pickup, player.as_ref())
+            .await;
+        assert_eq!(xp_levels(&player), 4);
+        assert!(inv_stack(&handler.inventory, 0).await.is_empty());
+        let cursor = handler.get_behaviour().cursor_stack.lock().await;
+        assert_eq!(cursor.item.id, Item::IRON_SWORD.id);
+        drop(cursor);
+        assert!(inv_stack(&handler.inventory, 2).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn quick_move_on_output_charges_once() {
+        let (mut handler, player) = setup().await;
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::QuickMove, player.as_ref())
+            .await;
+        assert_eq!(xp_levels(&player), 4);
+        assert!(inv_stack(&handler.inventory, 0).await.is_empty());
+        let mut moved = 0;
+        for i in 0..36 {
+            let stack = player.player_inventory.get_stack(i).await;
+            let stack = stack.lock().await;
+            if stack.item.id == Item::IRON_SWORD.id {
+                moved += stack.item_count;
+            }
+        }
+        assert_eq!(moved, 1, "the result must reach the player");
     }
 }

--- a/pumpkin-inventory/src/beacon_screen_handler.rs
+++ b/pumpkin-inventory/src/beacon_screen_handler.rs
@@ -47,6 +47,8 @@ impl BeaconScreenHandler {
 
         // Add the single payment slot for the beacon (slot 0)
         handler.add_slot(Arc::new(NormalSlot::new(handler.inventory.clone(), 0)));
+        // Container slots precede the player slots; used by Bedrock slot mapping.
+        handler.behaviour.container_slots = handler.behaviour.slots.len();
 
         // Add the player's inventory slots (27 slots + 9 hotbar)
         let player_inventory_arc: Arc<dyn Inventory> = player_inventory.clone();

--- a/pumpkin-inventory/src/brewing/brewing_screen_handler.rs
+++ b/pumpkin-inventory/src/brewing/brewing_screen_handler.rs
@@ -89,6 +89,8 @@ impl BrewingScreenHandler {
                 i,
             )));
         }
+        // Container slots precede the player slots; used by Bedrock slot mapping.
+        handler.behaviour.container_slots = handler.behaviour.slots.len();
 
         // Add player slots
         let pi: Arc<dyn Inventory> = player_inventory.clone();

--- a/pumpkin-inventory/src/crafting/crafting_screen_handler.rs
+++ b/pumpkin-inventory/src/crafting/crafting_screen_handler.rs
@@ -585,6 +585,9 @@ impl CraftingTableScreenHandler {
         crafting_table_handler
             .add_recipe_slots(crafting_inventory, provider)
             .await;
+        // Container slots (result + grid) precede the player slots.
+        crafting_table_handler.behaviour.container_slots =
+            crafting_table_handler.behaviour.slots.len();
         let player_inventory: Arc<dyn Inventory> = player_inventory.clone();
         crafting_table_handler.add_player_slots(&player_inventory);
         crafting_table_handler
@@ -676,3 +679,29 @@ impl ScreenHandler for CraftingTableScreenHandler {
 }
 
 impl CraftingScreenHandler<CraftingInventory> for CraftingTableScreenHandler {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generic_container_screen_handler::create_generic_9x3;
+    use crate::test_util::MockPlayer;
+    use pumpkin_world::inventory::SimpleInventory;
+
+    #[tokio::test]
+    async fn crafting_table_sets_container_slots() {
+        let player = MockPlayer::new();
+        let handler = CraftingTableScreenHandler::new(1, &player.player_inventory, None).await;
+        // 1 result + 9 grid slots precede the player slots.
+        assert_eq!(handler.get_behaviour().container_slots, 10);
+        assert_eq!(handler.get_behaviour().slots.len(), 46);
+    }
+
+    #[tokio::test]
+    async fn generic_container_sets_container_slots() {
+        let player = MockPlayer::new();
+        let inventory: Arc<dyn Inventory> = Arc::new(SimpleInventory::new(27));
+        let handler = create_generic_9x3(1, &player.player_inventory, inventory).await;
+        assert_eq!(handler.get_behaviour().container_slots, 27);
+        assert_eq!(handler.get_behaviour().slots.len(), 63);
+    }
+}

--- a/pumpkin-inventory/src/crafting/crafting_screen_handler.rs
+++ b/pumpkin-inventory/src/crafting/crafting_screen_handler.rs
@@ -451,12 +451,20 @@ impl Slot for ResultSlot {
                 .await;
             for i in 0..self.inventory.size() {
                 let slot = self.inventory.get_stack(i).await;
-                let mut stack = slot.lock().await;
-                if !stack.is_empty() {
-                    stack.item_count -= 1;
+                let mut grid_stack = slot.lock().await;
+                if !grid_stack.is_empty() {
+                    // Saturating so empty/underflowed grid cannot wrap.
+                    grid_stack.item_count = grid_stack.item_count.saturating_sub(1);
+                    if grid_stack.item_count == 0 {
+                        *grid_stack = ItemStack::EMPTY.clone();
+                    }
                 }
             }
             self.mark_dirty().await;
+            // Re-derive the craft result from remaining ingredients. Without
+            // this, Bedrock craft-repetition loops keep reading a stale result
+            // and mint free stacks after the grid is empty (F-GAME-16).
+            self.refill_output().await;
         })
     }
     fn can_insert(&self, _stack: &ItemStack) -> BoxFuture<'_, bool> {

--- a/pumpkin-inventory/src/enchanting/enchanting_screen_handler.rs
+++ b/pumpkin-inventory/src/enchanting/enchanting_screen_handler.rs
@@ -52,6 +52,8 @@ impl EnchantingTableScreenHandler {
         // Enchanting slots: 0 is item, 1 is lapis
         handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 0)));
         handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 1)));
+        // Container slots precede the player slots; used by Bedrock slot mapping.
+        handler.behaviour.container_slots = handler.behaviour.slots.len();
 
         let player_inventory: Arc<dyn Inventory> = player_inventory.clone();
         handler.add_player_slots(&player_inventory);

--- a/pumpkin-inventory/src/furnace_like/furnace_like_screen_handler.rs
+++ b/pumpkin-inventory/src/furnace_like/furnace_like_screen_handler.rs
@@ -103,6 +103,8 @@ impl FurnaceLikeScreenHandler {
             .add_listener(Arc::new(FurnaceLikeScreenListener))
             .await;
         handler.add_inventory_slots();
+        // Container slots precede the player slots; used by Bedrock slot mapping.
+        handler.behaviour.container_slots = handler.behaviour.slots.len();
         let player_inventory: Arc<dyn Inventory> = player_inventory.clone();
         handler.add_player_slots(&player_inventory);
 

--- a/pumpkin-inventory/src/generic_container_screen_handler.rs
+++ b/pumpkin-inventory/src/generic_container_screen_handler.rs
@@ -160,6 +160,8 @@ impl GenericContainerScreenHandler {
         inventory.on_open().await;
 
         handler.add_inventory_slots();
+        // Container slots precede the player slots; used by Bedrock slot mapping.
+        handler.behaviour.container_slots = handler.behaviour.slots.len();
         let player_inventory: Arc<dyn Inventory> = player_inventory.clone();
         handler.add_player_slots(&player_inventory);
 

--- a/pumpkin-inventory/src/lib.rs
+++ b/pumpkin-inventory/src/lib.rs
@@ -49,6 +49,8 @@ pub mod screen_handler;
 pub mod slot;
 pub mod stonecutter_screen_handler;
 pub mod sync_handler;
+#[cfg(test)]
+pub(crate) mod test_util;
 pub mod window_property;
 
 use std::collections::HashMap;

--- a/pumpkin-inventory/src/merchant/merchant_screen_handler.rs
+++ b/pumpkin-inventory/src/merchant/merchant_screen_handler.rs
@@ -1,7 +1,8 @@
 use std::any::Any;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use pumpkin_data::{item_stack::ItemStack, screen::WindowType};
+use pumpkin_protocol::java::client::play::MerchantOffer;
 use pumpkin_world::inventory::Inventory;
 
 use crate::{
@@ -10,15 +11,91 @@ use crate::{
         InventoryPlayer, ItemStackFuture, ScreenHandler, ScreenHandlerBehaviour,
         ScreenHandlerFuture, offer_or_drop_stack,
     },
-    slot::{NormalSlot, TakeOnlySlot},
+    slot::{BoxFuture, NormalSlot, TakeOnlySlot, TakeSlotCharge},
 };
 
 pub struct MerchantScreenHandler {
     pub inventory: Arc<dyn Inventory>,
     behaviour: ScreenHandlerBehaviour,
-    selected_offer: usize,
-    pub offers: Vec<pumpkin_protocol::java::client::play::MerchantOffer>,
+    /// Trade state shared with the output slot's charge hook.
+    trade: Arc<Mutex<MerchantTrade>>,
     pub on_trade: Option<Box<dyn Fn(usize) + Send + Sync>>,
+}
+
+/// Trade state shared between the screen handler and its output slot.
+struct MerchantTrade {
+    selected_offer: usize,
+    offers: Vec<MerchantOffer>,
+    /// Offers charged by the take hook, not yet forwarded to `on_trade`.
+    charged: Vec<usize>,
+}
+
+/// Charges one trade on the merchant output slot.
+///
+/// Fires from the slot's take path, so every verified take — pickup,
+/// shift-click, throw, swap — consumes the offer's inputs and counts
+/// exactly one use; there is no per-action gate that could forget one.
+struct MerchantSlotCharge {
+    inventory: Arc<dyn Inventory>,
+    trade: Arc<Mutex<MerchantTrade>>,
+}
+
+impl TakeSlotCharge for MerchantSlotCharge {
+    fn can_take(&self, _player: &dyn InventoryPlayer) -> bool {
+        let trade = self.trade.lock().unwrap();
+        trade
+            .offers
+            .get(trade.selected_offer)
+            .is_some_and(|offer| !offer.is_disabled && offer.uses < offer.max_uses)
+    }
+
+    fn on_take<'a>(
+        &'a self,
+        player: &'a dyn InventoryPlayer,
+        _stack: &'a ItemStack,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            let (count_a, count_b, offer_xp) = {
+                let mut trade = self.trade.lock().unwrap();
+                let selected = trade.selected_offer;
+                let Some(offer) = trade.offers.get_mut(selected) else {
+                    return;
+                };
+                if offer.is_disabled || offer.uses >= offer.max_uses {
+                    return;
+                }
+                offer.uses += 1;
+                let data = (
+                    offer.base_cost_a.0.item_count,
+                    offer.cost_b.as_ref().map(|c| c.0.item_count),
+                    offer.xp,
+                );
+                trade.charged.push(selected);
+                data
+            };
+
+            let input_a = self.inventory.get_stack(0).await;
+            let mut input_a = input_a.lock().await;
+            input_a.decrement(count_a);
+            if input_a.is_empty() {
+                *input_a = ItemStack::EMPTY.clone();
+            }
+            drop(input_a);
+
+            if let Some(count_b) = count_b {
+                let input_b = self.inventory.get_stack(1).await;
+                let mut input_b = input_b.lock().await;
+                input_b.decrement(count_b);
+                if input_b.is_empty() {
+                    *input_b = ItemStack::EMPTY.clone();
+                }
+                drop(input_b);
+            }
+            self.inventory.mark_dirty();
+
+            player.award_experience(offer_xp).await;
+        })
+    }
 }
 
 impl MerchantScreenHandler {
@@ -26,22 +103,34 @@ impl MerchantScreenHandler {
         sync_id: u8,
         player_inventory: &Arc<PlayerInventory>,
         inventory: Arc<dyn Inventory>,
-        offers: Vec<pumpkin_protocol::java::client::play::MerchantOffer>,
+        offers: Vec<MerchantOffer>,
     ) -> Self {
+        let trade = Arc::new(Mutex::new(MerchantTrade {
+            selected_offer: 0,
+            offers,
+            charged: Vec::new(),
+        }));
         let mut handler = Self {
             inventory: inventory.clone(),
             behaviour: ScreenHandlerBehaviour::new(sync_id, Some(WindowType::Merchant)),
-            selected_offer: 0,
-            offers,
+            trade: trade.clone(),
             on_trade: None,
         };
-
         inventory.on_open().await;
 
         // Merchant: 2 input slots + take-only output (PickupAll must not sweep output).
+        // The output slot owns the charge hook so every take path charges once.
         handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 0)));
         handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 1)));
-        handler.add_slot(Arc::new(TakeOnlySlot::new(inventory.clone(), 2)));
+        handler.add_slot(Arc::new(TakeOnlySlot::with_charge(
+            inventory.clone(),
+            2,
+            Arc::new(MerchantSlotCharge {
+                inventory: inventory.clone(),
+                trade,
+            }),
+        )));
+        handler.behaviour.container_slots = handler.behaviour.slots.len();
 
         let player_inventory: Arc<dyn Inventory> = player_inventory.clone();
         handler.add_player_slots(&player_inventory);
@@ -50,38 +139,61 @@ impl MerchantScreenHandler {
     }
 
     pub async fn set_selected_offer(&mut self, index: usize) {
-        self.selected_offer = index;
+        self.trade.lock().unwrap().selected_offer = index;
         self.update_result_slot().await;
         self.send_content_updates().await;
     }
 
     pub async fn update_result_slot(&mut self) {
-        if self.selected_offer >= self.offers.len() {
+        let offer_data = {
+            let trade = self.trade.lock().unwrap();
+            trade.offers.get(trade.selected_offer).map(|offer| {
+                (
+                    (*offer.base_cost_a.0).clone(),
+                    offer.cost_b.as_ref().map(|c| (*c.0).clone()),
+                    (*offer.output.0).clone(),
+                )
+            })
+        };
+
+        let Some((cost_a, cost_b, output)) = offer_data else {
             self.inventory.set_stack(2, ItemStack::EMPTY.clone()).await;
             return;
-        }
+        };
 
-        let offer = &self.offers[self.selected_offer];
         let input_a = self.inventory.get_stack(0).await;
         let input_a = input_a.lock().await;
         let input_b = self.inventory.get_stack(1).await;
         let input_b = input_b.lock().await;
 
-        let match_a = input_a.are_items_and_components_equal(&offer.base_cost_a.0)
-            && input_a.item_count >= offer.base_cost_a.0.item_count;
+        let match_a = input_a.are_items_and_components_equal(&cost_a)
+            && input_a.item_count >= cost_a.item_count;
 
-        let match_b = offer.cost_b.as_ref().map_or_else(
+        let match_b = cost_b.map_or_else(
             || input_b.is_empty(),
             |cost_b| {
-                input_b.are_items_and_components_equal(&cost_b.0)
-                    && input_b.item_count >= cost_b.0.item_count
+                input_b.are_items_and_components_equal(&cost_b)
+                    && input_b.item_count >= cost_b.item_count
             },
         );
 
         if match_a && match_b {
-            self.inventory.set_stack(2, (*offer.output.0).clone()).await;
+            self.inventory.set_stack(2, output).await;
         } else {
             self.inventory.set_stack(2, ItemStack::EMPTY.clone()).await;
+        }
+    }
+
+    /// Forwards trades charged by the output slot's take hook to `on_trade`.
+    fn forward_charged_trades(&self) {
+        let charged = {
+            let mut trade = self.trade.lock().unwrap();
+            std::mem::take(&mut trade.charged)
+        };
+        if let Some(on_trade) = &self.on_trade {
+            for offer_index in charged {
+                on_trade(offer_index);
+            }
         }
     }
 }
@@ -105,6 +217,9 @@ impl ScreenHandler for MerchantScreenHandler {
 
     fn on_closed<'a>(&'a mut self, player: &'a dyn InventoryPlayer) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
+            // Forward any trades taken through non-click paths (e.g. direct
+            // slot takes) before the screen state is torn down.
+            self.forward_charged_trades();
             self.default_on_closed(player).await;
             self.inventory.on_close().await;
             // Vanilla drops items from merchant container on close
@@ -122,20 +237,16 @@ impl ScreenHandler for MerchantScreenHandler {
 
     fn quick_move<'a>(
         &'a mut self,
-        _player: &'a dyn InventoryPlayer,
+        player: &'a dyn InventoryPlayer,
         slot_index: i32,
     ) -> ItemStackFuture<'a> {
         Box::pin(async move {
-            let mut stack_left = ItemStack::EMPTY.clone();
             let slot = self.get_behaviour().slots[slot_index as usize].clone();
 
             if slot.has_stack().await {
                 let slot_stack_lock = slot.get_stack().await;
-                let slot_stack_guard = slot_stack_lock.lock().await;
-                stack_left = slot_stack_guard.clone();
-                drop(slot_stack_guard);
-
                 let mut slot_stack_mut = slot_stack_lock.lock().await;
+                let stack_prev = slot_stack_mut.clone();
 
                 if slot_index < 3 {
                     // From merchant slots to player inventory
@@ -157,16 +268,27 @@ impl ScreenHandler for MerchantScreenHandler {
                     }
                 }
 
-                if slot_stack_mut.is_empty() {
-                    drop(slot_stack_mut);
+                let stack = slot_stack_mut.clone();
+                drop(slot_stack_mut);
+                if stack.is_empty() {
                     slot.set_stack(ItemStack::EMPTY.clone()).await;
                 } else {
-                    drop(slot_stack_mut);
                     slot.mark_dirty().await;
                 }
+                if stack.item_count == stack_prev.item_count {
+                    return ItemStack::EMPTY.clone();
+                }
+
+                // Charge only what was actually moved; a failed delivery above
+                // returns before this point and charges nothing.
+                let mut taken_stack = stack_prev.clone();
+                taken_stack.set_count(stack_prev.item_count - stack.item_count);
+                slot.on_take_item(player, &taken_stack).await;
+
+                return stack_prev;
             }
 
-            stack_left
+            ItemStack::EMPTY.clone()
         })
     }
 
@@ -178,74 +300,291 @@ impl ScreenHandler for MerchantScreenHandler {
         player: &'a dyn InventoryPlayer,
     ) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
-            use pumpkin_protocol::java::server::play::SlotActionType;
-
-            // Charge only when the click will actually take from the output.
-            // PickupAll on this slot is a no-op (take-only); charging would
-            // consume inputs without delivering items.
-            let will_take = matches!(
-                action_type,
-                SlotActionType::Pickup | SlotActionType::QuickMove
-            );
-            if slot_index == 2 && will_take {
-                let result_slot = self.get_behaviour().slots[2].clone();
-                if result_slot.has_stack().await {
-                    let result_stack = result_slot.get_cloned_stack().await;
-                    if !result_stack.is_empty() {
-                        if self.selected_offer >= self.offers.len() {
-                            self.send_content_updates().await;
-                            return;
-                        }
-                        {
-                            let offer = &self.offers[self.selected_offer];
-                            if offer.is_disabled || offer.uses >= offer.max_uses {
-                                self.send_content_updates().await;
-                                return;
-                            }
-                        }
-
-                        let (count_a, count_b, offer_xp) = {
-                            let offer = &mut self.offers[self.selected_offer];
-                            offer.uses += 1;
-                            let count_b = offer.cost_b.as_ref().map(|c| c.0.item_count);
-                            (offer.base_cost_a.0.item_count, count_b, offer.xp)
-                        };
-
-                        let input_a = self.inventory.get_stack(0).await;
-                        let mut input_a = input_a.lock().await;
-                        input_a.decrement(count_a);
-                        if input_a.is_empty() {
-                            *input_a = ItemStack::EMPTY.clone();
-                        }
-                        drop(input_a);
-                        self.get_behaviour().slots[0].mark_dirty().await;
-
-                        if let Some(count_b) = count_b {
-                            let input_b = self.inventory.get_stack(1).await;
-                            let mut input_b = input_b.lock().await;
-                            input_b.decrement(count_b);
-                            if input_b.is_empty() {
-                                *input_b = ItemStack::EMPTY.clone();
-                            }
-                            drop(input_b);
-                            self.get_behaviour().slots[1].mark_dirty().await;
-                        }
-
-                        player.award_experience(offer_xp).await;
-
-                        if let Some(on_trade) = &self.on_trade {
-                            on_trade(self.selected_offer);
-                        }
-                    }
-                }
-            }
-
             self.internal_on_slot_click(slot_index, button, action_type, player)
                 .await;
+            self.forward_charged_trades();
             if slot_index == 0 || slot_index == 1 || slot_index == 2 {
                 self.update_result_slot().await;
                 self.send_content_updates().await;
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use pumpkin_data::item::Item;
+    use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
+    use pumpkin_protocol::java::server::play::SlotActionType;
+    use pumpkin_world::inventory::SimpleInventory;
+
+    use crate::screen_handler::ScreenHandler;
+    use crate::test_util::MockPlayer;
+
+    fn test_offer() -> MerchantOffer {
+        MerchantOffer {
+            base_cost_a: ItemStackSerializer(Cow::Owned(ItemStack::new(5, &Item::EMERALD))),
+            output: ItemStackSerializer(Cow::Owned(ItemStack::new(2, &Item::DIAMOND))),
+            cost_b: Some(ItemStackSerializer(Cow::Owned(ItemStack::new(
+                3,
+                &Item::COAL,
+            )))),
+            is_disabled: false,
+            uses: 0,
+            max_uses: 12,
+            xp: 7,
+            special_price: 0,
+            price_multiplier: 0.0,
+            demand: 0,
+        }
+    }
+
+    async fn setup() -> (MerchantScreenHandler, Arc<MockPlayer>) {
+        let player = Arc::new(MockPlayer::new());
+        let inventory: Arc<dyn Inventory> = Arc::new(SimpleInventory::new(3));
+        inventory
+            .set_stack(0, ItemStack::new(10, &Item::EMERALD))
+            .await;
+        inventory.set_stack(1, ItemStack::new(6, &Item::COAL)).await;
+        let mut handler =
+            MerchantScreenHandler::new(1, &player.player_inventory, inventory, vec![test_offer()])
+                .await;
+        handler.update_result_slot().await;
+        assert_eq!(handler.get_behaviour().container_slots, 3);
+        (handler, player)
+    }
+
+    async fn inv_stack(inventory: &Arc<dyn Inventory>, index: usize) -> ItemStack {
+        inventory.get_stack(index).await.lock().await.clone()
+    }
+
+    fn uses(handler: &MerchantScreenHandler) -> i32 {
+        handler.trade.lock().unwrap().offers[0].uses
+    }
+
+    fn xp_awarded(player: &MockPlayer) -> i32 {
+        player.xp_awarded.load(Ordering::Relaxed)
+    }
+
+    async fn dropped_count(player: &MockPlayer) -> usize {
+        player.dropped.lock().await.len()
+    }
+
+    fn assert_charged_once(handler: &MerchantScreenHandler, player: &MockPlayer) {
+        assert_eq!(uses(handler), 1, "exactly one trade use must be counted");
+        assert_eq!(xp_awarded(player), 7, "trade XP must be awarded once");
+    }
+
+    #[tokio::test]
+    async fn throw_on_output_charges_exactly_once() {
+        let (mut handler, player) = setup().await;
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 2);
+
+        // Q on the result slot: takes one item, pays the full trade once.
+        handler
+            .on_slot_click(2, 0, SlotActionType::Throw, player.as_ref())
+            .await;
+        assert_charged_once(&handler, &player);
+        assert_eq!(dropped_count(&player).await, 1);
+        assert_eq!(inv_stack(&handler.inventory, 0).await.item_count, 5);
+        assert_eq!(inv_stack(&handler.inventory, 1).await.item_count, 3);
+        // Inputs still cover a trade, so the result refills.
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 2);
+
+        // Second take consumes the remaining inputs; the cycle then dies.
+        handler
+            .on_slot_click(2, 0, SlotActionType::Throw, player.as_ref())
+            .await;
+        assert_eq!(uses(&handler), 2);
+        assert_eq!(dropped_count(&player).await, 2);
+        assert!(inv_stack(&handler.inventory, 0).await.is_empty());
+        assert!(inv_stack(&handler.inventory, 1).await.is_empty());
+        assert!(inv_stack(&handler.inventory, 2).await.is_empty());
+
+        // No inputs -> no result -> further throws take and charge nothing.
+        handler
+            .on_slot_click(2, 0, SlotActionType::Throw, player.as_ref())
+            .await;
+        assert_eq!(uses(&handler), 2);
+        assert_eq!(dropped_count(&player).await, 2);
+        assert_eq!(xp_awarded(&player), 14);
+    }
+
+    #[tokio::test]
+    async fn throw_all_on_output_charges_once() {
+        let (mut handler, player) = setup().await;
+
+        // Ctrl-Q on the result slot: the whole stack drops, charged once.
+        handler
+            .on_slot_click(2, 1, SlotActionType::Throw, player.as_ref())
+            .await;
+        assert_charged_once(&handler, &player);
+        let dropped = player.dropped.lock().await;
+        assert_eq!(dropped.len(), 1);
+        assert_eq!(dropped[0].item_count, 2);
+        drop(dropped);
+        assert_eq!(inv_stack(&handler.inventory, 0).await.item_count, 5);
+        assert_eq!(inv_stack(&handler.inventory, 1).await.item_count, 3);
+    }
+
+    #[tokio::test]
+    async fn swap_on_output_charges_once() {
+        let (mut handler, player) = setup().await;
+
+        // Number-key swap onto an empty hotbar slot takes the result.
+        handler
+            .on_slot_click(2, 0, SlotActionType::Swap, player.as_ref())
+            .await;
+        assert_charged_once(&handler, &player);
+        let hotbar = player.player_inventory.get_stack(0).await;
+        let hotbar = hotbar.lock().await;
+        assert_eq!(hotbar.item.id, Item::DIAMOND.id);
+        assert_eq!(hotbar.item_count, 2);
+        drop(hotbar);
+        assert_eq!(inv_stack(&handler.inventory, 0).await.item_count, 5);
+        assert_eq!(inv_stack(&handler.inventory, 1).await.item_count, 3);
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 2);
+    }
+
+    #[tokio::test]
+    async fn pickup_all_on_output_is_noop() {
+        let (mut handler, player) = setup().await;
+        *handler.get_behaviour_mut().cursor_stack.lock().await = ItemStack::new(1, &Item::DIAMOND);
+
+        // Double-click sweep must skip the take-only output slot entirely.
+        handler
+            .on_slot_click(2, 0, SlotActionType::PickupAll, player.as_ref())
+            .await;
+        assert_eq!(uses(&handler), 0);
+        assert_eq!(xp_awarded(&player), 0);
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 2);
+        let cursor = handler.get_behaviour().cursor_stack.lock().await;
+        assert_eq!(cursor.item_count, 1);
+    }
+
+    #[tokio::test]
+    async fn quick_move_into_full_inventory_charges_nothing() {
+        let (mut handler, player) = setup().await;
+        for i in 0..36 {
+            player
+                .player_inventory
+                .set_stack(i, ItemStack::new(64, &Item::COBBLESTONE))
+                .await;
+        }
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::QuickMove, player.as_ref())
+            .await;
+        assert_eq!(uses(&handler), 0, "failed delivery must not charge");
+        assert_eq!(xp_awarded(&player), 0);
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 2);
+        assert_eq!(inv_stack(&handler.inventory, 0).await.item_count, 10);
+        assert_eq!(inv_stack(&handler.inventory, 1).await.item_count, 6);
+    }
+
+    #[tokio::test]
+    async fn quick_move_on_output_charges_once() {
+        let (mut handler, player) = setup().await;
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::QuickMove, player.as_ref())
+            .await;
+        assert_charged_once(&handler, &player);
+        let mut moved = 0;
+        for i in 0..36 {
+            let stack = player.player_inventory.get_stack(i).await;
+            let stack = stack.lock().await;
+            if stack.item.id == Item::DIAMOND.id {
+                moved += stack.item_count;
+            }
+        }
+        assert_eq!(moved, 2, "the result stack must reach the player");
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 2);
+    }
+
+    #[tokio::test]
+    async fn pickup_with_incompatible_cursor_charges_nothing() {
+        let (mut handler, player) = setup().await;
+        *handler.get_behaviour_mut().cursor_stack.lock().await = ItemStack::new(1, &Item::DIRT);
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Pickup, player.as_ref())
+            .await;
+        assert_eq!(uses(&handler), 0, "no delivery happened, so no charge");
+        assert_eq!(xp_awarded(&player), 0);
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 2);
+        let cursor = handler.get_behaviour().cursor_stack.lock().await;
+        assert_eq!(cursor.item.id, Item::DIRT.id);
+    }
+
+    #[tokio::test]
+    async fn pickup_on_output_charges_once() {
+        let (mut handler, player) = setup().await;
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Pickup, player.as_ref())
+            .await;
+        assert_charged_once(&handler, &player);
+        let cursor = handler.get_behaviour().cursor_stack.lock().await;
+        assert_eq!(cursor.item.id, Item::DIAMOND.id);
+        assert_eq!(cursor.item_count, 2);
+        drop(cursor);
+        assert_eq!(inv_stack(&handler.inventory, 0).await.item_count, 5);
+        assert_eq!(inv_stack(&handler.inventory, 1).await.item_count, 3);
+        assert_eq!(inv_stack(&handler.inventory, 2).await.item_count, 2);
+    }
+
+    #[tokio::test]
+    async fn depleted_offer_blocks_every_take_path() {
+        let (mut handler, player) = setup().await;
+        handler.trade.lock().unwrap().offers[0].uses = 12;
+
+        for action in [SlotActionType::Pickup, SlotActionType::Throw] {
+            handler.on_slot_click(2, 0, action, player.as_ref()).await;
+        }
+        handler
+            .on_slot_click(2, 0, SlotActionType::Swap, player.as_ref())
+            .await;
+        handler
+            .on_slot_click(2, 0, SlotActionType::QuickMove, player.as_ref())
+            .await;
+
+        assert_eq!(uses(&handler), 12);
+        assert_eq!(xp_awarded(&player), 0);
+        assert_eq!(dropped_count(&player).await, 0);
+        assert_eq!(inv_stack(&handler.inventory, 0).await.item_count, 10);
+        assert!(
+            player
+                .player_inventory
+                .get_stack(0)
+                .await
+                .lock()
+                .await
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn on_trade_callback_fires_exactly_once_per_take() {
+        let (mut handler, player) = setup().await;
+        let trade_count = Arc::new(AtomicUsize::new(0));
+        let counter = trade_count.clone();
+        handler.on_trade = Some(Box::new(move |_offer_index| {
+            counter.fetch_add(1, Ordering::Relaxed);
+        }));
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Throw, player.as_ref())
+            .await;
+        assert_eq!(trade_count.load(Ordering::Relaxed), 1);
+
+        handler
+            .on_slot_click(2, 0, SlotActionType::Pickup, player.as_ref())
+            .await;
+        assert_eq!(trade_count.load(Ordering::Relaxed), 2);
     }
 }

--- a/pumpkin-inventory/src/merchant/merchant_screen_handler.rs
+++ b/pumpkin-inventory/src/merchant/merchant_screen_handler.rs
@@ -178,12 +178,34 @@ impl ScreenHandler for MerchantScreenHandler {
         player: &'a dyn InventoryPlayer,
     ) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
+            use pumpkin_protocol::java::server::play::SlotActionType;
+
+            // PickupAll on the result slot is a free-item dupe: it sweeps the
+            // output without going through the consume/uses path cleanly.
+            if slot_index == 2 && action_type == SlotActionType::PickupAll {
+                self.send_content_updates().await;
+                return;
+            }
+
             if slot_index == 2 {
                 // Special handling for taking from output slot
                 let result_slot = self.get_behaviour().slots[2].clone();
                 if result_slot.has_stack().await {
                     let result_stack = result_slot.get_cloned_stack().await;
                     if !result_stack.is_empty() {
+                        // Enforce trade limits before consuming.
+                        if self.selected_offer >= self.offers.len() {
+                            self.send_content_updates().await;
+                            return;
+                        }
+                        {
+                            let offer = &self.offers[self.selected_offer];
+                            if offer.is_disabled || offer.uses >= offer.max_uses {
+                                self.send_content_updates().await;
+                                return;
+                            }
+                        }
+
                         // Consume inputs
                         let (count_a, count_b, offer_xp) = {
                             let offer = &mut self.offers[self.selected_offer];

--- a/pumpkin-inventory/src/merchant/merchant_screen_handler.rs
+++ b/pumpkin-inventory/src/merchant/merchant_screen_handler.rs
@@ -10,7 +10,7 @@ use crate::{
         InventoryPlayer, ItemStackFuture, ScreenHandler, ScreenHandlerBehaviour,
         ScreenHandlerFuture, offer_or_drop_stack,
     },
-    slot::NormalSlot,
+    slot::{NormalSlot, TakeOnlySlot},
 };
 
 pub struct MerchantScreenHandler {
@@ -38,10 +38,10 @@ impl MerchantScreenHandler {
 
         inventory.on_open().await;
 
-        // Merchant specific slots: 2 input, 1 output
-        for i in 0..3 {
-            handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), i)));
-        }
+        // Merchant: 2 input slots + take-only output (PickupAll must not sweep output).
+        handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 0)));
+        handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 1)));
+        handler.add_slot(Arc::new(TakeOnlySlot::new(inventory.clone(), 2)));
 
         let player_inventory: Arc<dyn Inventory> = player_inventory.clone();
         handler.add_player_slots(&player_inventory);
@@ -178,22 +178,14 @@ impl ScreenHandler for MerchantScreenHandler {
         player: &'a dyn InventoryPlayer,
     ) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
-            use pumpkin_protocol::java::server::play::SlotActionType;
-
-            // PickupAll on the result slot is a free-item dupe: it sweeps the
-            // output without going through the consume/uses path cleanly.
-            if slot_index == 2 && action_type == SlotActionType::PickupAll {
-                self.send_content_updates().await;
-                return;
-            }
-
+            // Taking from the take-only output: charge the trade before the
+            // generic click path removes the stack. PickupAll never reaches
+            // here for the output (can_insert=false skips it in the sweep).
             if slot_index == 2 {
-                // Special handling for taking from output slot
                 let result_slot = self.get_behaviour().slots[2].clone();
                 if result_slot.has_stack().await {
                     let result_stack = result_slot.get_cloned_stack().await;
                     if !result_stack.is_empty() {
-                        // Enforce trade limits before consuming.
                         if self.selected_offer >= self.offers.len() {
                             self.send_content_updates().await;
                             return;
@@ -206,7 +198,6 @@ impl ScreenHandler for MerchantScreenHandler {
                             }
                         }
 
-                        // Consume inputs
                         let (count_a, count_b, offer_xp) = {
                             let offer = &mut self.offers[self.selected_offer];
                             offer.uses += 1;
@@ -234,7 +225,6 @@ impl ScreenHandler for MerchantScreenHandler {
                             self.get_behaviour().slots[1].mark_dirty().await;
                         }
 
-                        // Award XP
                         player.award_experience(offer_xp).await;
 
                         if let Some(on_trade) = &self.on_trade {

--- a/pumpkin-inventory/src/merchant/merchant_screen_handler.rs
+++ b/pumpkin-inventory/src/merchant/merchant_screen_handler.rs
@@ -178,10 +178,16 @@ impl ScreenHandler for MerchantScreenHandler {
         player: &'a dyn InventoryPlayer,
     ) -> ScreenHandlerFuture<'a, ()> {
         Box::pin(async move {
-            // Taking from the take-only output: charge the trade before the
-            // generic click path removes the stack. PickupAll never reaches
-            // here for the output (can_insert=false skips it in the sweep).
-            if slot_index == 2 {
+            use pumpkin_protocol::java::server::play::SlotActionType;
+
+            // Charge only when the click will actually take from the output.
+            // PickupAll on this slot is a no-op (take-only); charging would
+            // consume inputs without delivering items.
+            let will_take = matches!(
+                action_type,
+                SlotActionType::Pickup | SlotActionType::QuickMove
+            );
+            if slot_index == 2 && will_take {
                 let result_slot = self.get_behaviour().slots[2].clone();
                 if result_slot.has_stack().await {
                     let result_stack = result_slot.get_cloned_stack().await;

--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -916,6 +916,17 @@ pub trait ScreenHandler: Send + Sync {
 
                     let mut cursor_stack = behaviour.cursor_stack.lock().await;
                     let initial_count = cursor_stack.item_count;
+                    let drag_slot_count = behaviour.drag_slots.len();
+                    // Guard against empty or oversized drag sets. Casting len to u8
+                    // previously wrapped at 256 → division by zero → panic → shutdown.
+                    if drag_slot_count == 0 || drag_slot_count > 256 {
+                        behaviour.drag_slots.clear();
+                        return;
+                    }
+                    if !matches!(drag_button, 0..=2) {
+                        behaviour.drag_slots.clear();
+                        return;
+                    }
                     for slot_index in &behaviour.drag_slots {
                         let slot = behaviour.slots[*slot_index as usize].clone();
                         let stack_lock = slot.get_stack().await;
@@ -925,14 +936,13 @@ pub trait ScreenHandler: Send + Sync {
                             && slot.can_insert(&cursor_stack).await
                         {
                             let mut inserting_count = if drag_button == 0 {
-                                initial_count / behaviour.drag_slots.len() as u8
+                                (u32::from(initial_count) / drag_slot_count as u32) as u8
                             } else if drag_button == 1 {
                                 1
-                            } else if drag_button == 2 {
+                            } else {
+                                // drag_button == 2 (creative full-stack drag)
                                 cursor_stack.item_count = cursor_stack.get_max_stack_size();
                                 cursor_stack.item_count
-                            } else {
-                                panic!("Invalid drag button: {drag_button}");
                             };
                             inserting_count = inserting_count
                                 .min(max(
@@ -1220,8 +1230,8 @@ pub trait ScreenHandler: Send + Sync {
 
                     slot.mark_dirty().await;
                 }
-            } else if action_type == SlotActionType::Swap && (0..9).contains(&button)
-                || button == 40
+            } else if action_type == SlotActionType::Swap
+                && ((0..9).contains(&button) || button == 40)
             {
                 if slot_index < 0 {
                     return;

--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -993,9 +993,11 @@ pub trait ScreenHandler: Send + Sync {
                                 // player.handleCreativeModeItemDrop(itemStack);
                             }
                         } else {
+                            // safe_take already fires on_take_item once per
+                            // taken stack; calling it again here would charge
+                            // result slots twice for a single take.
                             let drop_stack = slot.safe_take(1, u8::MAX, player).await;
                             if !drop_stack.is_empty() {
-                                slot.on_take_item(player, &drop_stack).await;
                                 player.drop_item(drop_stack, true).await;
                             }
                         }

--- a/pumpkin-inventory/src/slot.rs
+++ b/pumpkin-inventory/src/slot.rs
@@ -6,6 +6,7 @@
 //! # Slot Types
 //!
 //! - [`NormalSlot`] - A basic inventory slot with no restrictions
+//! - [`TakeOnlySlot`] - Output/result slot: take allowed, insert and `PickupAll` sweep blocked
 //! - [`ArmorSlot`] - An armor slot that only accepts appropriate item types
 //!   (helmets in head slot, chestplates in chest slot, etc.)
 //!
@@ -371,6 +372,52 @@ impl Slot for NormalSlot {
     }
 }
 
+/// Result/output slot: items may be taken, but never inserted by the player.
+///
+/// `allow_modification` is `can_insert && can_take`, so with `can_insert = false`
+/// `PickupAll` skips this slot when sweeping matching stacks. That is the correct
+/// defense for merchant/anvil output steal (F-INV-03/04); a `slot_index == 2`
+/// guard cannot work because `PickupAll` is invoked on a *different* slot.
+pub struct TakeOnlySlot {
+    pub inventory: Arc<dyn Inventory>,
+    pub index: usize,
+    pub id: AtomicU8,
+}
+
+impl TakeOnlySlot {
+    pub fn new(inventory: Arc<dyn Inventory>, index: usize) -> Self {
+        Self {
+            inventory,
+            index,
+            id: AtomicU8::new(0),
+        }
+    }
+}
+
+impl Slot for TakeOnlySlot {
+    fn get_inventory(&self) -> Arc<dyn Inventory> {
+        self.inventory.clone()
+    }
+
+    fn get_index(&self) -> usize {
+        self.index
+    }
+
+    fn set_id(&self, id: usize) {
+        self.id.store(id as u8, Ordering::Relaxed);
+    }
+
+    fn can_insert(&self, _stack: &ItemStack) -> BoxFuture<'_, bool> {
+        Box::pin(async move { false })
+    }
+
+    fn mark_dirty(&self) -> BoxFuture<'_, ()> {
+        Box::pin(async move {
+            self.inventory.mark_dirty();
+        })
+    }
+}
+
 /// An armor equipment slot.
 ///
 /// Restricts which items can be placed based on the equipment slot type:
@@ -459,5 +506,33 @@ impl Slot for ArmorSlot {
             // TODO: Check enchantments
             true
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pumpkin_world::inventory::SimpleInventory;
+
+    #[tokio::test]
+    async fn take_only_slot_rejects_insert() {
+        let inv = Arc::new(SimpleInventory::new(1));
+        let stack = ItemStack::new(16, &Item::EMERALD);
+        inv.set_stack(0, stack.clone()).await;
+        let slot = TakeOnlySlot::new(inv, 0);
+        assert!(
+            !slot.can_insert(&stack).await,
+            "result/output slots must not accept inserts (blocks PickupAll sweep)"
+        );
+        assert!(slot.has_stack().await);
+        assert_eq!(slot.get_cloned_stack().await.item.id, Item::EMERALD.id);
+    }
+
+    #[tokio::test]
+    async fn normal_slot_accepts_insert() {
+        let inv = Arc::new(SimpleInventory::new(1));
+        let stack = ItemStack::new(16, &Item::EMERALD);
+        let slot = NormalSlot::new(inv, 0);
+        assert!(slot.can_insert(&stack).await);
     }
 }

--- a/pumpkin-inventory/src/slot.rs
+++ b/pumpkin-inventory/src/slot.rs
@@ -372,6 +372,26 @@ impl Slot for NormalSlot {
     }
 }
 
+/// Charge logic attached to a [`TakeOnlySlot`] output (merchant/anvil result).
+///
+/// Every take path that actually removes items from a slot ends in
+/// [`Slot::on_take_item`], and every path checks [`Slot::can_take_items`]
+/// first. Putting the charge here (rather than in per-action click gates)
+/// guarantees that inputs/XP are consumed exactly once per verified take,
+/// no matter which action (pickup, shift-click, throw, swap) performed it.
+pub trait TakeSlotCharge: Send + Sync {
+    /// Whether the player may currently take from the output slot
+    /// (e.g. trade not depleted, enough XP levels).
+    fn can_take(&self, player: &dyn InventoryPlayer) -> bool;
+
+    /// Charges one taken output stack (consumes inputs, counts uses, XP).
+    fn on_take<'a>(
+        &'a self,
+        player: &'a dyn InventoryPlayer,
+        stack: &'a ItemStack,
+    ) -> BoxFuture<'a, ()>;
+}
+
 /// Result/output slot: items may be taken, but never inserted by the player.
 ///
 /// `allow_modification` is `can_insert && can_take`, so with `can_insert = false`
@@ -382,6 +402,8 @@ pub struct TakeOnlySlot {
     pub inventory: Arc<dyn Inventory>,
     pub index: usize,
     pub id: AtomicU8,
+    /// Optional charge logic fired on take (merchant/anvil output).
+    charge: Option<Arc<dyn TakeSlotCharge>>,
 }
 
 impl TakeOnlySlot {
@@ -390,6 +412,21 @@ impl TakeOnlySlot {
             inventory,
             index,
             id: AtomicU8::new(0),
+            charge: None,
+        }
+    }
+
+    /// Creates a take-only slot that charges via `charge` on every take.
+    pub fn with_charge(
+        inventory: Arc<dyn Inventory>,
+        index: usize,
+        charge: Arc<dyn TakeSlotCharge>,
+    ) -> Self {
+        Self {
+            inventory,
+            index,
+            id: AtomicU8::new(0),
+            charge: Some(charge),
         }
     }
 }
@@ -409,6 +446,27 @@ impl Slot for TakeOnlySlot {
 
     fn can_insert(&self, _stack: &ItemStack) -> BoxFuture<'_, bool> {
         Box::pin(async move { false })
+    }
+
+    fn can_take_items(&self, player: &dyn InventoryPlayer) -> BoxFuture<'_, bool> {
+        let allowed = self
+            .charge
+            .as_ref()
+            .is_none_or(|charge| charge.can_take(player));
+        Box::pin(async move { allowed })
+    }
+
+    fn on_take_item<'a>(
+        &'a self,
+        player: &'a dyn InventoryPlayer,
+        stack: &'a ItemStack,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            if let Some(charge) = &self.charge {
+                charge.on_take(player, stack).await;
+            }
+            self.mark_dirty().await;
+        })
     }
 
     fn mark_dirty(&self) -> BoxFuture<'_, ()> {

--- a/pumpkin-inventory/src/stonecutter_screen_handler.rs
+++ b/pumpkin-inventory/src/stonecutter_screen_handler.rs
@@ -47,6 +47,8 @@ impl StonecutterScreenHandler {
             input_inventory as Arc<dyn Inventory>,
             0,
         )));
+        // Container slots precede the player slots; used by Bedrock slot mapping.
+        handler.behaviour.container_slots = handler.behaviour.slots.len();
 
         let player_inventory: Arc<dyn Inventory> = player_inventory.clone();
 

--- a/pumpkin-inventory/src/test_util.rs
+++ b/pumpkin-inventory/src/test_util.rs
@@ -1,0 +1,150 @@
+//! Test utilities: a minimal [`InventoryPlayer`] implementation for
+//! screen-handler tests. Tracks XP and dropped stacks in memory instead of
+//! talking to a world or network connection.
+
+use std::any::Any;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use pumpkin_data::data_component_impl::EquipmentSlot;
+use pumpkin_data::item_stack::ItemStack;
+use pumpkin_data::statistic::StatisticCategory;
+use pumpkin_protocol::java::client::play::{
+    CSetContainerContent, CSetContainerProperty, CSetContainerSlot, CSetCursorItem,
+    CSetPlayerInventory, CSetSelectedSlot,
+};
+use tokio::sync::Mutex;
+
+use crate::entity_equipment::EntityEquipment;
+use crate::player::player_inventory::PlayerInventory;
+use crate::screen_handler::{InventoryPlayer, PlayerFuture};
+
+pub struct MockPlayer {
+    pub(crate) player_inventory: Arc<PlayerInventory>,
+    pub(crate) xp_levels: AtomicI32,
+    pub(crate) xp_awarded: AtomicI32,
+    pub(crate) dropped: Mutex<Vec<ItemStack>>,
+    creative: bool,
+}
+
+impl MockPlayer {
+    pub(crate) fn new() -> Self {
+        Self {
+            player_inventory: Arc::new(PlayerInventory::new(
+                Arc::new(Mutex::new(EntityEquipment::new())),
+                Arc::new(crate::build_equipment_slots()),
+            )),
+            xp_levels: AtomicI32::new(0),
+            xp_awarded: AtomicI32::new(0),
+            dropped: Mutex::new(Vec::new()),
+            creative: false,
+        }
+    }
+}
+
+impl Default for MockPlayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InventoryPlayer for MockPlayer {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn drop_item(&self, item: ItemStack, _retain_ownership: bool) -> PlayerFuture<'_, ()> {
+        Box::pin(async move {
+            self.dropped.lock().await.push(item);
+        })
+    }
+
+    fn get_inventory(&self) -> Arc<PlayerInventory> {
+        self.player_inventory.clone()
+    }
+
+    fn has_infinite_materials(&self) -> bool {
+        self.creative
+    }
+
+    fn is_creative(&self) -> bool {
+        self.creative
+    }
+
+    fn experience_level(&self) -> i32 {
+        self.xp_levels.load(Ordering::Relaxed)
+    }
+
+    fn add_experience_levels(&self, levels: i32) -> PlayerFuture<'_, ()> {
+        Box::pin(async move {
+            self.xp_levels.fetch_add(levels, Ordering::Relaxed);
+        })
+    }
+
+    fn enchantment_seed(&self) -> i32 {
+        0
+    }
+
+    fn set_enchantment_seed(&self, _seed: i32) -> PlayerFuture<'_, ()> {
+        Box::pin(async {})
+    }
+
+    fn enqueue_inventory_packet<'a>(
+        &'a self,
+        _packet: &'a CSetContainerContent,
+    ) -> PlayerFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn enqueue_slot_packet<'a>(&'a self, _packet: &'a CSetContainerSlot) -> PlayerFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn enqueue_cursor_packet<'a>(&'a self, _packet: &'a CSetCursorItem) -> PlayerFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn enqueue_property_packet<'a>(
+        &'a self,
+        _packet: &'a CSetContainerProperty,
+    ) -> PlayerFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn enqueue_slot_set_packet<'a>(
+        &'a self,
+        _packet: &'a CSetPlayerInventory,
+    ) -> PlayerFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn enqueue_set_held_item_packet<'a>(
+        &'a self,
+        _packet: &'a CSetSelectedSlot,
+    ) -> PlayerFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn enqueue_equipment_change<'a>(
+        &'a self,
+        _slot: &'a EquipmentSlot,
+        _stack: &'a ItemStack,
+    ) -> PlayerFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn award_experience(&self, amount: i32) -> PlayerFuture<'_, ()> {
+        Box::pin(async move {
+            self.xp_awarded.fetch_add(amount, Ordering::Relaxed);
+        })
+    }
+
+    fn increment_stat(
+        &self,
+        _category: StatisticCategory,
+        _stat_id: i32,
+        _amount: i32,
+    ) -> PlayerFuture<'_, ()> {
+        Box::pin(async {})
+    }
+}

--- a/pumpkin-nbt/src/compound.rs
+++ b/pumpkin-nbt/src/compound.rs
@@ -44,6 +44,16 @@ impl NbtCompound {
     }
 
     pub fn skip_content<'a, R: NbtReadHelper<'a>>(reader: &mut R) -> Result<(), Error> {
+        Self::skip_content_depth(reader, 0)
+    }
+
+    pub(crate) fn skip_content_depth<'a, R: NbtReadHelper<'a>>(
+        reader: &mut R,
+        depth: u32,
+    ) -> Result<(), Error> {
+        if depth >= crate::MAX_NBT_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
         loop {
             let tag_id = match reader.get_u8() {
                 Ok(id) => id,
@@ -58,13 +68,23 @@ impl NbtCompound {
             reader.skip_string()?;
 
             // Skip Value
-            NbtTag::skip_data(reader, tag_id)?;
+            NbtTag::skip_data_depth(reader, tag_id, depth + 1)?;
         }
 
         Ok(())
     }
 
     pub fn deserialize_content<'a, R: NbtReadHelper<'a>>(reader: &mut R) -> Result<Self, Error> {
+        Self::deserialize_content_depth(reader, 0)
+    }
+
+    pub(crate) fn deserialize_content_depth<'a, R: NbtReadHelper<'a>>(
+        reader: &mut R,
+        depth: u32,
+    ) -> Result<Self, Error> {
+        if depth >= crate::MAX_NBT_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
         let mut compound = Self::new();
 
         loop {
@@ -79,7 +99,7 @@ impl NbtCompound {
             }
 
             let name = reader.get_string()?;
-            let tag = NbtTag::deserialize_data(reader, tag_id)?;
+            let tag = NbtTag::deserialize_data_depth(reader, tag_id, depth + 1)?;
 
             compound.child_tags.insert(name.into(), tag);
         }

--- a/pumpkin-nbt/src/deserializer.rs
+++ b/pumpkin-nbt/src/deserializer.rs
@@ -4,7 +4,7 @@ use std::io::{Cursor, Seek, SeekFrom};
 
 use crate::{
     BYTE_ARRAY_ID, BYTE_ID, COMPOUND_ID, END_ID, Error, INT_ARRAY_ID, INT_ID, LIST_ID,
-    LONG_ARRAY_ID, LONG_ID, MAX_ARRAY_LENGTH, NbtTag, io,
+    LONG_ARRAY_ID, LONG_ID, MAX_ARRAY_LENGTH, MAX_NBT_DEPTH, NbtTag, io,
 };
 use io::Read;
 use serde::de::{self, DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, Visitor};
@@ -307,6 +307,9 @@ impl<'a, D: NbtDataSource<'a>> NbtReadHelper<'a> for NbtReadHelperJava<D> {
 
     fn get_string(&mut self) -> Result<Cow<'a, str>> {
         let len = self.get_string_len()? as usize;
+        if len > MAX_ARRAY_LENGTH {
+            return Err(Error::LargeLength(len));
+        }
         self.reader.read_string(len)
     }
 
@@ -401,6 +404,9 @@ impl<'a, D: NbtDataSource<'a>> NbtReadHelper<'a> for NbtReadHelperBedrock<D> {
 
     fn get_string(&mut self) -> Result<Cow<'a, str>> {
         let len = self.get_string_len()? as usize;
+        if len > MAX_ARRAY_LENGTH {
+            return Err(Error::LargeLength(len));
+        }
         self.reader.read_string(len)
     }
 
@@ -414,6 +420,8 @@ pub struct Deserializer<R> {
     tag_to_deserialize_stack: Option<u8>,
     in_list: bool,
     is_named: bool,
+    /// Nesting depth of compounds/lists currently being deserialized.
+    depth: u32,
 }
 
 impl<R> Deserializer<R> {
@@ -423,7 +431,20 @@ impl<R> Deserializer<R> {
             tag_to_deserialize_stack: None,
             in_list: false,
             is_named,
+            depth: 0,
         }
+    }
+
+    const fn enter_nested(&mut self) -> Result<()> {
+        if self.depth >= MAX_NBT_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
+        self.depth += 1;
+        Ok(())
+    }
+
+    const fn exit_nested(&mut self) {
+        self.depth = self.depth.saturating_sub(1);
     }
 }
 
@@ -511,15 +532,29 @@ impl<'de, R: NbtReadHelper<'de>> de::Deserializer<'de> for &mut Deserializer<R> 
                     return Err(Error::LargeLength(remaining_values));
                 }
 
+                // Empty END-typed lists are valid; non-empty are not.
+                if list_type == END_ID && remaining_values != 0 {
+                    return Err(Error::UnknownTagId(list_type));
+                }
+
+                //TODO this is a bit hacky but I couldn't think of a better way
+                // This flag gets auto cleared in visit_seq
                 set_curr_visitor_seq_list_id(Some(list_type));
+                self.enter_nested()?;
                 let result = visitor.visit_seq(ListAccess {
                     de: self,
                     list_type,
                     remaining_values,
-                })?;
-                Ok(result)
+                });
+                self.exit_nested();
+                result
             }
-            COMPOUND_ID => visitor.visit_map(CompoundAccess { de: self }),
+            COMPOUND_ID => {
+                self.enter_nested()?;
+                let result = visitor.visit_map(CompoundAccess { de: self });
+                self.exit_nested();
+                result
+            }
             _ => {
                 let result = match NbtTag::deserialize_data(&mut self.input, tag_to_deserialize)? {
                     NbtTag::Byte(value) => visitor.visit_i8::<Error>(value)?,
@@ -636,8 +671,10 @@ impl<'de, R: NbtReadHelper<'de>> de::Deserializer<'de> for &mut Deserializer<R> 
             }
         }
 
-        let value = visitor.visit_map(CompoundAccess { de: self })?;
-        Ok(value)
+        self.enter_nested()?;
+        let value = visitor.visit_map(CompoundAccess { de: self });
+        self.exit_nested();
+        value
     }
 
     fn deserialize_struct<V: Visitor<'de>>(

--- a/pumpkin-nbt/src/lib.rs
+++ b/pumpkin-nbt/src/lib.rs
@@ -42,6 +42,12 @@ pub const INT_ARRAY_ID: u8 = 0x0B;
 pub const LONG_ARRAY_ID: u8 = 0x0C;
 
 pub const MAX_ARRAY_LENGTH: usize = 2_000_000;
+/// Maximum nesting depth for NBT compounds/lists (vanilla documents 512).
+///
+/// Each nesting level costs two Rust frames in this parser; 128 is far above
+/// any legitimate item/world payload and keeps the worker stack safely clear
+/// of the guard page (the pre-fix kill was ~3.5k).
+pub const MAX_NBT_DEPTH: u32 = 128;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -63,6 +69,8 @@ pub enum Error {
     NegativeLength(i32),
     #[error("Length too large: {0}")]
     LargeLength(usize),
+    #[error("NBT nesting depth exceeded limit ({MAX_NBT_DEPTH})")]
+    DepthLimitExceeded,
     #[error("Failed to decode varint - value too large")]
     VarIntTooLarge,
     #[error("Failed to decode varlong - value too large")]
@@ -1000,4 +1008,42 @@ mod test {
     }
 
     // TODO: More robust tests
+
+    #[test]
+    fn nested_compound_depth_limit() {
+        use crate::deserializer::NbtReadHelperJava;
+        use crate::{COMPOUND_ID, END_ID, MAX_NBT_DEPTH, Nbt};
+
+        // Nested compounds deeper than MAX_NBT_DEPTH must error, not overflow the stack.
+        let depth = (MAX_NBT_DEPTH + 8) as usize;
+        let mut bytes = Vec::new();
+        // root compound id + empty name (Java: u16 BE length)
+        bytes.push(COMPOUND_ID);
+        bytes.extend_from_slice(&0u16.to_be_bytes());
+        for _ in 0..depth {
+            bytes.push(COMPOUND_ID);
+            bytes.extend_from_slice(&0u16.to_be_bytes()); // empty field name
+        }
+        bytes.extend(std::iter::repeat_n(END_ID, depth + 1));
+
+        let err = Nbt::read(&mut NbtReadHelperJava::new(Cursor::new(bytes)));
+        assert!(
+            matches!(err, Err(Error::DepthLimitExceeded)),
+            "expected DepthLimitExceeded, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn end_typed_nonempty_list_rejected() {
+        use crate::deserializer::NbtReadHelperJava;
+        use crate::{END_ID, LIST_ID};
+
+        // LIST of END with length 100 must be rejected (not allocate 100 unit tags).
+        let mut bytes = Vec::new();
+        bytes.push(END_ID);
+        bytes.extend_from_slice(&100i32.to_be_bytes());
+        let err =
+            NbtTag::deserialize_data(&mut NbtReadHelperJava::new(Cursor::new(bytes)), LIST_ID);
+        assert!(err.is_err(), "non-empty END list must be rejected");
+    }
 }

--- a/pumpkin-nbt/src/tag.rs
+++ b/pumpkin-nbt/src/tag.rs
@@ -181,6 +181,17 @@ impl NbtTag {
     }
 
     pub fn skip_data<'a, R: NbtReadHelper<'a>>(reader: &mut R, tag_id: u8) -> Result<(), Error> {
+        Self::skip_data_depth(reader, tag_id, 0)
+    }
+
+    pub(crate) fn skip_data_depth<'a, R: NbtReadHelper<'a>>(
+        reader: &mut R,
+        tag_id: u8,
+        depth: u32,
+    ) -> Result<(), Error> {
+        if depth >= crate::MAX_NBT_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
         match tag_id {
             END_ID => Ok(()),
             BYTE_ID => reader.skip_i8(),
@@ -203,14 +214,21 @@ impl NbtTag {
                 if len < 0 {
                     return Err(Error::NegativeLength(len));
                 }
+                // Empty END-typed lists are valid; non-empty END lists are not.
+                if tag_type_id == END_ID && len != 0 {
+                    return Err(Error::UnknownTagId(tag_type_id));
+                }
+                if len as usize > MAX_ARRAY_LENGTH {
+                    return Err(Error::LargeLength(len as usize));
+                }
 
                 for _ in 0..len {
-                    Self::skip_data(reader, tag_type_id)?;
+                    Self::skip_data_depth(reader, tag_type_id, depth + 1)?;
                 }
 
                 Ok(())
             }
-            COMPOUND_ID => NbtCompound::skip_content(reader),
+            COMPOUND_ID => NbtCompound::skip_content_depth(reader, depth),
             INT_ARRAY_ID => {
                 let len = reader.get_i32()?;
                 if len < 0 {
@@ -243,6 +261,18 @@ impl NbtTag {
         reader: &mut R,
         tag_id: u8,
     ) -> Result<Self, Error> {
+        Self::deserialize_data_depth(reader, tag_id, 0)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    pub(crate) fn deserialize_data_depth<'a, R: NbtReadHelper<'a>>(
+        reader: &mut R,
+        tag_id: u8,
+        depth: u32,
+    ) -> Result<Self, Error> {
+        if depth >= crate::MAX_NBT_DEPTH {
+            return Err(Error::DepthLimitExceeded);
+        }
         match tag_id {
             END_ID => Ok(Self::End),
             BYTE_ID => {
@@ -298,17 +328,29 @@ impl NbtTag {
                 if len > MAX_ARRAY_LENGTH {
                     return Err(Error::LargeLength(len));
                 }
+                // Empty END-typed lists are valid (vanilla); non-empty are not and
+                // would otherwise allocate up to MAX_ARRAY_LENGTH unit tags.
+                if tag_type_id == END_ID {
+                    if len != 0 {
+                        return Err(Error::UnknownTagId(tag_type_id));
+                    }
+                    return Ok(Self::List(Vec::new()));
+                }
 
                 let mut list = Vec::with_capacity(len);
                 for _ in 0..len {
-                    let tag = Self::deserialize_data(reader, tag_type_id)?;
-                    assert_eq!(tag.get_type_id(), tag_type_id);
+                    let tag = Self::deserialize_data_depth(reader, tag_type_id, depth + 1)?;
+                    if tag.get_type_id() != tag_type_id {
+                        return Err(Error::UnknownTagId(tag.get_type_id()));
+                    }
                     // Try unwrapping the tag.
                     list.push(Self::flatten(tag));
                 }
                 Ok(Self::List(list))
             }
-            COMPOUND_ID => Ok(Self::Compound(NbtCompound::deserialize_content(reader)?)),
+            COMPOUND_ID => Ok(Self::Compound(NbtCompound::deserialize_content_depth(
+                reader, depth,
+            )?)),
             INT_ARRAY_ID => {
                 let len = reader.get_i32()?;
                 if len < 0 {

--- a/pumpkin-protocol/src/bedrock/ack.rs
+++ b/pumpkin-protocol/src/bedrock/ack.rs
@@ -1,6 +1,9 @@
 use std::io::{Error, ErrorKind, Read, Write};
 
 const MAX_ACK_RECORDS: u16 = 4096;
+/// Hard cap on expanded sequence numbers from range records.
+/// Prevents a small datagram from expanding into multi-GB allocations.
+const MAX_ACK_SEQUENCES: usize = 4096;
 
 use crate::{
     codec::u24,
@@ -38,14 +41,34 @@ impl Acknowledge {
             ));
         }
 
-        let mut sequences = Vec::with_capacity(size as usize);
+        let mut sequences = Vec::with_capacity((size as usize).min(MAX_ACK_SEQUENCES));
         for _ in 0..size {
             let single = bool::read(reader)?;
             if single {
+                if sequences.len() >= MAX_ACK_SEQUENCES {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        "Acknowledge packet expands past sequence limit.",
+                    ));
+                }
                 sequences.push(u24::read(reader)?.0);
             } else {
                 let start = u24::read(reader)?.0;
                 let end = u24::read(reader)?.0;
+                if end < start {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        "Acknowledge range end before start.",
+                    ));
+                }
+                // Inclusive range length: end - start + 1, checked against remaining budget.
+                let range_len = (end - start) as usize + 1;
+                if sequences.len().saturating_add(range_len) > MAX_ACK_SEQUENCES {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        "Acknowledge packet range expansion exceeds sequence limit.",
+                    ));
+                }
                 for i in start..=end {
                     sequences.push(i);
                 }

--- a/pumpkin-protocol/src/bedrock/network_item.rs
+++ b/pumpkin-protocol/src/bedrock/network_item.rs
@@ -10,6 +10,22 @@ use crate::{
     serial::{PacketRead, PacketWrite},
 };
 
+/// Cap for Bedrock item user-data / extra-data wire buffers.
+/// Unbounded `VarUInt` lengths allocate multi-GiB vectors from a few packet bytes.
+const MAX_ITEM_USER_DATA_LEN: u32 = 256 * 1024;
+
+fn read_capped_bytes<R: Read>(buf: &mut R, len: u32) -> Result<Vec<u8>, Error> {
+    if len > MAX_ITEM_USER_DATA_LEN {
+        return Err(Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Item data length {len} exceeds limit {MAX_ITEM_USER_DATA_LEN}"),
+        ));
+    }
+    let mut data = vec![0u8; len as usize];
+    buf.read_exact(&mut data)?;
+    Ok(data)
+}
+
 #[derive(Default, Clone, Debug)]
 pub struct NetworkItemDescriptor {
     // I hate mojang
@@ -51,8 +67,7 @@ impl PacketRead for NetworkItemDescriptor {
         let block_runtime_id = VarInt::read(buf)?;
 
         let user_data_len = VarUInt::read(buf)?.0;
-        let mut user_data = vec![0u8; user_data_len as usize];
-        buf.read_exact(&mut user_data)?;
+        let user_data = read_capped_bytes(buf, user_data_len)?;
 
         let mut nbt_data = Nbt::default();
         let mut place_on_blocks = Vec::new();
@@ -247,8 +262,7 @@ impl PacketRead for ItemStackWrapper {
         let block_runtime_id = VarInt::read(buf)?;
 
         let user_data_len = VarUInt::read(buf)?.0;
-        let mut user_data = vec![0u8; user_data_len as usize];
-        buf.read_exact(&mut user_data)?;
+        let user_data = read_capped_bytes(buf, user_data_len)?;
 
         let mut nbt_data = Nbt::default();
         let mut place_on_blocks = Vec::new();
@@ -370,8 +384,7 @@ impl PacketRead for NetworkItemStackDescriptor {
         let block_runtime_id = VarUInt::read(buf)?;
 
         let extra_data_len = VarUInt::read(buf)?.0;
-        let mut extra_data = vec![0u8; extra_data_len as usize];
-        buf.read_exact(&mut extra_data)?;
+        let extra_data = read_capped_bytes(buf, extra_data_len)?;
 
         Ok(Self {
             id,
@@ -608,8 +621,7 @@ impl PacketRead for NetworkItemStack {
         let block_runtime_id = VarInt::read(buf)?;
 
         let extra_data_len = VarUInt::read(buf)?.0;
-        let mut extra_data = vec![0u8; extra_data_len as usize];
-        buf.read_exact(&mut extra_data)?;
+        let extra_data = read_capped_bytes(buf, extra_data_len)?;
 
         Ok(Self {
             id,
@@ -618,5 +630,27 @@ impl PacketRead for NetworkItemStack {
             block_runtime_id,
             extra_data,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn capped_bytes_accepts_small_payload() {
+        let data = [1u8, 2, 3];
+        let mut cur = Cursor::new(data.as_slice());
+        let out = read_capped_bytes(&mut cur, 3).expect("small payload ok");
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn capped_bytes_rejects_oversize_length() {
+        let mut cur = Cursor::new([0u8; 0].as_slice());
+        let err = read_capped_bytes(&mut cur, MAX_ITEM_USER_DATA_LEN + 1)
+            .expect_err("oversize must fail before allocate");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 }

--- a/pumpkin-protocol/src/bedrock/server/emote_list.rs
+++ b/pumpkin-protocol/src/bedrock/server/emote_list.rs
@@ -1,4 +1,4 @@
-use std::io::{Error, Read, Write};
+use std::io::{Error, ErrorKind, Read, Write};
 use uuid::Uuid;
 
 use crate::{
@@ -6,6 +6,10 @@ use crate::{
     serial::{PacketRead, PacketWrite},
 };
 use pumpkin_macros::packet;
+
+/// Bound for the emote piece list. Currently unreachable (dispatch is commented out),
+/// but the unbounded `VarUInt` length would pre-allocate attacker-sized memory if re-enabled.
+const MAX_EMOTE_PIECES: usize = 64;
 
 #[derive(Debug)]
 #[packet(152)]
@@ -18,6 +22,12 @@ impl PacketRead for SEmoteList {
     fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
         let runtime_entity_id = VarULong::read(reader)?;
         let len = VarUInt::read(reader)?.0 as usize;
+        if len > MAX_EMOTE_PIECES {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("emote piece count {len} exceeds limit {MAX_EMOTE_PIECES}"),
+            ));
+        }
         let mut emote_pieces = Vec::with_capacity(len);
         for _ in 0..len {
             emote_pieces.push(Uuid::read(reader)?);
@@ -60,5 +70,31 @@ mod tests {
 
         assert_eq!(packet.runtime_entity_id.0, decoded.runtime_entity_id.0);
         assert_eq!(packet.emote_pieces, decoded.emote_pieces);
+    }
+
+    #[test]
+    fn accepts_emote_count_at_cap() {
+        let packet = SEmoteList {
+            runtime_entity_id: VarULong(123),
+            emote_pieces: vec![Uuid::nil(); MAX_EMOTE_PIECES],
+        };
+
+        let mut buf = Vec::new();
+        packet.write(&mut buf).unwrap();
+
+        let decoded = SEmoteList::read(&mut Cursor::new(buf)).unwrap();
+        assert_eq!(decoded.emote_pieces.len(), MAX_EMOTE_PIECES);
+    }
+
+    #[test]
+    fn rejects_emote_count_over_cap() {
+        let mut buf = Vec::new();
+        VarULong(123).write(&mut buf).unwrap();
+        VarUInt((MAX_EMOTE_PIECES + 1) as u32)
+            .write(&mut buf)
+            .unwrap();
+
+        let err = SEmoteList::read(&mut Cursor::new(buf)).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
     }
 }

--- a/pumpkin-protocol/src/bedrock/server/inventory_transaction.rs
+++ b/pumpkin-protocol/src/bedrock/server/inventory_transaction.rs
@@ -49,6 +49,11 @@ pub enum TransactionData {
 /// unbounded `VarUInt`; without a cap a small packet claims a multi-GiB allocation.
 const MAX_LEGACY_SLOT_BYTES: u32 = 1024;
 
+/// Bound for the legacy set-item slot entry count and the action count of a
+/// transaction. Vanilla sends a handful; an unbounded `VarUInt` count drives an
+/// attacker-sized parse loop.
+const MAX_TRANSACTION_ENTRIES: u32 = 256;
+
 #[derive(Debug)]
 pub struct LegacySetItemSlot {
     pub container_id: u8,
@@ -217,6 +222,14 @@ impl PacketRead for SInventoryTransaction {
         let mut legacy_set_item_slots = Vec::new();
         if has_legacy_slots {
             let len = VarUInt::read(buf)?.0;
+            if len > MAX_TRANSACTION_ENTRIES {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "legacy slot entry count {len} exceeds limit {MAX_TRANSACTION_ENTRIES}"
+                    ),
+                ));
+            }
             for _ in 0..len {
                 legacy_set_item_slots.push(LegacySetItemSlot::read(buf)?);
             }
@@ -231,6 +244,14 @@ impl PacketRead for SInventoryTransaction {
         let mut actions = Vec::new();
         if has_value {
             let actions_len = VarUInt::read(buf)?.0;
+            if actions_len > MAX_TRANSACTION_ENTRIES {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "inventory action count {actions_len} exceeds limit {MAX_TRANSACTION_ENTRIES}"
+                    ),
+                ));
+            }
             for _ in 0..actions_len {
                 actions.push(InventoryAction::read(buf)?);
             }
@@ -301,5 +322,58 @@ mod alloc_cap_tests {
 
         let err = SInventoryTransaction::read(&mut Cursor::new(buf)).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn transaction_rejects_legacy_entry_count_over_cap() {
+        let mut buf = Vec::new();
+        VarInt(0).write(&mut buf).unwrap(); // legacy_request_id
+        true.write(&mut buf).unwrap(); // has_legacy_slots
+        VarUInt(MAX_TRANSACTION_ENTRIES + 1)
+            .write(&mut buf)
+            .unwrap();
+
+        let err = SInventoryTransaction::read(&mut Cursor::new(buf)).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn transaction_rejects_actions_len_over_cap() {
+        let mut buf = Vec::new();
+        VarInt(0).write(&mut buf).unwrap(); // legacy_request_id
+        false.write(&mut buf).unwrap(); // has_legacy_slots
+        false.write(&mut buf).unwrap(); // has_transaction_type
+        VarUInt(0).write(&mut buf).unwrap(); // transaction_type: Normal
+        false.write(&mut buf).unwrap(); // has_tr_data
+        true.write(&mut buf).unwrap(); // has_value
+        VarUInt(MAX_TRANSACTION_ENTRIES + 1)
+            .write(&mut buf)
+            .unwrap();
+
+        let err = SInventoryTransaction::read(&mut Cursor::new(buf)).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn transaction_accepts_actions_len_at_cap() {
+        let mut buf = Vec::new();
+        VarInt(0).write(&mut buf).unwrap(); // legacy_request_id
+        false.write(&mut buf).unwrap(); // has_legacy_slots
+        false.write(&mut buf).unwrap(); // has_transaction_type
+        VarUInt(0).write(&mut buf).unwrap(); // transaction_type: Normal
+        false.write(&mut buf).unwrap(); // has_tr_data
+        true.write(&mut buf).unwrap(); // has_value
+        VarUInt(MAX_TRANSACTION_ENTRIES).write(&mut buf).unwrap();
+        for _ in 0..MAX_TRANSACTION_ENTRIES {
+            // source_type Container, window_id 0, slot 0, empty old/new items
+            VarULong(0).write(&mut buf).unwrap();
+            VarInt(0).write(&mut buf).unwrap();
+            VarULong(0).write(&mut buf).unwrap();
+            NetworkItemDescriptor::default().write(&mut buf).unwrap();
+            NetworkItemDescriptor::default().write(&mut buf).unwrap();
+        }
+
+        let parsed = SInventoryTransaction::read(&mut Cursor::new(buf)).unwrap();
+        assert_eq!(parsed.actions.len(), MAX_TRANSACTION_ENTRIES as usize);
     }
 }

--- a/pumpkin-protocol/src/bedrock/server/inventory_transaction.rs
+++ b/pumpkin-protocol/src/bedrock/server/inventory_transaction.rs
@@ -45,10 +45,33 @@ pub enum TransactionData {
     ReleaseItem(ReleaseItemTransactionData),
 }
 
-#[derive(Debug, PacketRead)]
+/// Bound for the byte list of a legacy set-item slot entry. The wire length is an
+/// unbounded `VarUInt`; without a cap a small packet claims a multi-GiB allocation.
+const MAX_LEGACY_SLOT_BYTES: u32 = 1024;
+
+#[derive(Debug)]
 pub struct LegacySetItemSlot {
     pub container_id: u8,
     pub slots: Vec<u8>,
+}
+
+impl PacketRead for LegacySetItemSlot {
+    fn read<R: Read>(buf: &mut R) -> Result<Self, Error> {
+        let container_id = u8::read(buf)?;
+        let slots_len = VarUInt::read(buf)?.0;
+        if slots_len > MAX_LEGACY_SLOT_BYTES {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("legacy slot byte count {slots_len} exceeds limit {MAX_LEGACY_SLOT_BYTES}"),
+            ));
+        }
+        let mut slots = vec![0u8; slots_len as usize];
+        buf.read_exact(&mut slots)?;
+        Ok(Self {
+            container_id,
+            slots,
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -235,5 +258,48 @@ impl PacketRead for SInventoryTransaction {
             transaction_type,
             transaction_data,
         })
+    }
+}
+
+#[cfg(test)]
+mod alloc_cap_tests {
+    use super::*;
+    use crate::serial::PacketWrite;
+    use std::io::Cursor;
+
+    #[test]
+    fn legacy_slot_rejects_oversize_slots_len() {
+        let mut buf = Vec::new();
+        0u8.write(&mut buf).unwrap(); // container_id
+        VarUInt(MAX_LEGACY_SLOT_BYTES + 1).write(&mut buf).unwrap();
+
+        let err = LegacySetItemSlot::read(&mut Cursor::new(buf)).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn legacy_slot_accepts_slots_len_at_cap() {
+        let mut buf = Vec::new();
+        7u8.write(&mut buf).unwrap(); // container_id
+        VarUInt(MAX_LEGACY_SLOT_BYTES).write(&mut buf).unwrap();
+        buf.extend_from_slice(&vec![3u8; MAX_LEGACY_SLOT_BYTES as usize]);
+
+        let parsed = LegacySetItemSlot::read(&mut Cursor::new(buf)).unwrap();
+        assert_eq!(parsed.container_id, 7);
+        assert_eq!(parsed.slots.len(), MAX_LEGACY_SLOT_BYTES as usize);
+    }
+
+    #[test]
+    fn transaction_legacy_path_rejects_oversize_slots_len() {
+        // SInventoryTransaction with one legacy entry whose inner byte length is over the cap.
+        let mut buf = Vec::new();
+        VarInt(0).write(&mut buf).unwrap(); // legacy_request_id
+        true.write(&mut buf).unwrap(); // has_legacy_slots
+        VarUInt(1).write(&mut buf).unwrap(); // one legacy entry
+        0u8.write(&mut buf).unwrap(); // container_id
+        VarUInt(MAX_LEGACY_SLOT_BYTES + 1).write(&mut buf).unwrap();
+
+        let err = SInventoryTransaction::read(&mut Cursor::new(buf)).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
     }
 }

--- a/pumpkin-protocol/src/bedrock/server/item_stack_request.rs
+++ b/pumpkin-protocol/src/bedrock/server/item_stack_request.rs
@@ -36,6 +36,12 @@ impl PacketWrite for ItemStackRequestSlotInfo {
     }
 }
 
+/// Bounds for `ItemStackRequest` wire arrays (alloc bombs from huge `VarUInt`).
+const MAX_ITEM_STACK_ACTIONS: usize = 256;
+const MAX_ITEM_STACK_REQUESTS: usize = 64;
+const MAX_RESULT_ITEMS: usize = 64;
+const MAX_FILTER_STRINGS: usize = 64;
+
 #[derive(Debug)]
 pub enum ItemStackRequestAction {
     Take {
@@ -217,8 +223,14 @@ impl PacketRead for ItemStackRequestAction {
             }),
             18 => Ok(Self::CraftNonImplemented),
             19 => {
-                let result_items_len = VarUInt::read(buf)?.0;
-                let mut result_items = Vec::with_capacity(result_items_len as usize);
+                let result_items_len = VarUInt::read(buf)?.0 as usize;
+                if result_items_len > MAX_RESULT_ITEMS {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        format!("result_items_len {result_items_len} exceeds {MAX_RESULT_ITEMS}"),
+                    ));
+                }
+                let mut result_items = Vec::with_capacity(result_items_len);
                 for _ in 0..result_items_len {
                     result_items.push(crate::bedrock::network_item::NetworkItemStack::read(buf)?);
                 }
@@ -247,13 +259,25 @@ pub struct ItemStackRequest {
 impl PacketRead for ItemStackRequest {
     fn read<R: Read>(buf: &mut R) -> Result<Self, Error> {
         let request_id = VarInt::read(buf)?;
-        let actions_len = VarUInt::read(buf)?.0;
-        let mut actions = Vec::with_capacity(actions_len as usize);
+        let actions_len = VarUInt::read(buf)?.0 as usize;
+        if actions_len > MAX_ITEM_STACK_ACTIONS {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("actions_len {actions_len} exceeds {MAX_ITEM_STACK_ACTIONS}"),
+            ));
+        }
+        let mut actions = Vec::with_capacity(actions_len);
         for _ in 0..actions_len {
             actions.push(ItemStackRequestAction::read(buf)?);
         }
-        let filter_strings_len = VarUInt::read(buf)?.0;
-        let mut filter_strings = Vec::with_capacity(filter_strings_len as usize);
+        let filter_strings_len = VarUInt::read(buf)?.0 as usize;
+        if filter_strings_len > MAX_FILTER_STRINGS {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("filter_strings_len {filter_strings_len} exceeds {MAX_FILTER_STRINGS}"),
+            ));
+        }
+        let mut filter_strings = Vec::with_capacity(filter_strings_len);
         for _ in 0..filter_strings_len {
             filter_strings.push(String::read(buf)?);
         }
@@ -275,11 +299,49 @@ pub struct SItemStackRequest {
 
 impl PacketRead for SItemStackRequest {
     fn read<R: Read>(buf: &mut R) -> Result<Self, Error> {
-        let requests_len = VarUInt::read(buf)?.0;
-        let mut requests = Vec::with_capacity(requests_len as usize);
+        let requests_len = VarUInt::read(buf)?.0 as usize;
+        if requests_len > MAX_ITEM_STACK_REQUESTS {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("requests_len {requests_len} exceeds {MAX_ITEM_STACK_REQUESTS}"),
+            ));
+        }
+        let mut requests = Vec::with_capacity(requests_len);
         for _ in 0..requests_len {
             requests.push(ItemStackRequest::read(buf)?);
         }
         Ok(Self { requests })
+    }
+}
+
+#[cfg(test)]
+mod alloc_cap_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn rejects_oversize_actions_len() {
+        // request_id VarInt(0) + actions_len VarUInt huge
+        let mut buf = Vec::new();
+        // request_id = 0
+        buf.push(0);
+        // VarUInt 10000 encoded - write a large value via many continuation bits is hard;
+        // encode 300 as varuint: 300 = 0b1_00101100 with continuation
+        // Simple: write VarUInt manually for MAX+1
+        let over = (MAX_ITEM_STACK_ACTIONS + 1) as u32;
+        let mut v = over;
+        loop {
+            let mut b = (v & 0x7F) as u8;
+            v >>= 7;
+            if v != 0 {
+                b |= 0x80;
+            }
+            buf.push(b);
+            if v == 0 {
+                break;
+            }
+        }
+        let err = ItemStackRequest::read(&mut Cursor::new(buf)).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
     }
 }

--- a/pumpkin-protocol/src/bedrock/server/player_auth_input.rs
+++ b/pumpkin-protocol/src/bedrock/server/player_auth_input.rs
@@ -140,6 +140,10 @@ pub struct PlayerInventoryAction {
     pub transaction: crate::bedrock::server::inventory_transaction::UseItemTransactionData,
 }
 
+/// Bound for the action list in an inventory transaction carried by auth input.
+/// Vanilla sends a handful; an unbounded `VarUInt` length pre-allocates attacker-sized memory.
+const MAX_INVENTORY_ACTIONS: usize = 64;
+
 impl PacketRead for PlayerInventoryAction {
     fn read<R: Read>(buf: &mut R) -> Result<Self, Error> {
         let legacy_request_id = VarInt::read(buf)?;
@@ -152,8 +156,16 @@ impl PacketRead for PlayerInventoryAction {
                 );
             }
         }
-        let actions_len = VarUInt::read(buf)?.0;
-        let mut actions = Vec::with_capacity(actions_len as usize);
+        let actions_len = VarUInt::read(buf)?.0 as usize;
+        if actions_len > MAX_INVENTORY_ACTIONS {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "inventory action count {actions_len} exceeds limit {MAX_INVENTORY_ACTIONS}"
+                ),
+            ));
+        }
+        let mut actions = Vec::with_capacity(actions_len);
         for _ in 0..actions_len {
             actions
                 .push(crate::bedrock::server::inventory_transaction::InventoryAction::read(buf)?);
@@ -270,4 +282,66 @@ pub enum InputData {
     SneakReleasedRaw = 62,
     SneakPressedRaw = 63,
     SneakCurrentRaw = 64,
+}
+
+#[cfg(test)]
+mod alloc_cap_tests {
+    use super::*;
+    use crate::bedrock::network_item::NetworkItemDescriptor;
+    use crate::serial::PacketWrite;
+    use std::io::Cursor;
+
+    fn encode_inventory_action(buf: &mut Vec<u8>) {
+        // source_type Container, window_id 0, slot 0, empty old/new items
+        VarULong(0).write(buf).unwrap();
+        VarInt(0).write(buf).unwrap();
+        VarULong(0).write(buf).unwrap();
+        NetworkItemDescriptor::default().write(buf).unwrap();
+        NetworkItemDescriptor::default().write(buf).unwrap();
+    }
+
+    fn encode_use_item_transaction(buf: &mut Vec<u8>) {
+        VarUInt(0).write(buf).unwrap(); // action_type
+        0u8.write(buf).unwrap(); // trigger_type
+        VarInt(0).write(buf).unwrap(); // block_pos x
+        VarInt(0).write(buf).unwrap(); // block_pos y
+        VarInt(0).write(buf).unwrap(); // block_pos z
+        0u8.write(buf).unwrap(); // block_face
+        VarInt(0).write(buf).unwrap(); // hot_bar_slot
+        NetworkItemDescriptor::default().write(buf).unwrap(); // item_in_hand
+        for _ in 0..6 {
+            0.0f32.write(buf).unwrap(); // player_position + click_position
+        }
+        VarUInt(0).write(buf).unwrap(); // block_runtime_id
+        0u8.write(buf).unwrap(); // client_prediction
+        0u8.write(buf).unwrap(); // client_cooldown_state
+    }
+
+    #[test]
+    fn accepts_actions_len_at_cap() {
+        let mut buf = Vec::new();
+        VarInt(0).write(&mut buf).unwrap(); // legacy_request_id: no legacy slots
+        VarUInt(MAX_INVENTORY_ACTIONS as u32)
+            .write(&mut buf)
+            .unwrap();
+        for _ in 0..MAX_INVENTORY_ACTIONS {
+            encode_inventory_action(&mut buf);
+        }
+        encode_use_item_transaction(&mut buf);
+
+        let parsed = PlayerInventoryAction::read(&mut Cursor::new(buf)).unwrap();
+        assert_eq!(parsed.actions.len(), MAX_INVENTORY_ACTIONS);
+    }
+
+    #[test]
+    fn rejects_actions_len_over_cap() {
+        let mut buf = Vec::new();
+        VarInt(0).write(&mut buf).unwrap(); // legacy_request_id: no legacy slots
+        VarUInt((MAX_INVENTORY_ACTIONS + 1) as u32)
+            .write(&mut buf)
+            .unwrap();
+
+        let err = PlayerInventoryAction::read(&mut Cursor::new(buf)).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
 }

--- a/pumpkin-protocol/src/bedrock/server/player_auth_input.rs
+++ b/pumpkin-protocol/src/bedrock/server/player_auth_input.rs
@@ -69,7 +69,21 @@ impl PacketRead for SPlayerAuthInput {
 
         // 3. Block Actions
         let block_actions = if input_data.get(InputData::PerformBlockActions as usize) {
-            let count = VarInt::read(reader)?.0 as usize;
+            const MAX_BLOCK_ACTIONS: usize = 64;
+            let count_i = VarInt::read(reader)?.0;
+            if count_i < 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "negative block action count",
+                ));
+            }
+            let count = count_i as usize;
+            if count > MAX_BLOCK_ACTIONS {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("block action count {count_i} exceeds limit {MAX_BLOCK_ACTIONS}"),
+                ));
+            }
             let mut actions = Vec::with_capacity(count);
             for _ in 0..count {
                 actions.push(PlayerBlockAction::read(reader)?);

--- a/pumpkin-protocol/src/bedrock/server/player_auth_input.rs
+++ b/pumpkin-protocol/src/bedrock/server/player_auth_input.rs
@@ -144,12 +144,22 @@ pub struct PlayerInventoryAction {
 /// Vanilla sends a handful; an unbounded `VarUInt` length pre-allocates attacker-sized memory.
 const MAX_INVENTORY_ACTIONS: usize = 64;
 
+/// Bound for the legacy set-item slot entry count carried by auth input.
+/// Vanilla sends a handful; an unbounded `VarUInt` count drives an attacker-sized parse loop.
+const MAX_LEGACY_SLOTS: u32 = 256;
+
 impl PacketRead for PlayerInventoryAction {
     fn read<R: Read>(buf: &mut R) -> Result<Self, Error> {
         let legacy_request_id = VarInt::read(buf)?;
         let mut legacy_slots = Vec::new();
         if legacy_request_id.0 < -1 && (legacy_request_id.0 & 1) == 0 {
             let slots_len = VarUInt::read(buf)?.0;
+            if slots_len > MAX_LEGACY_SLOTS {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("legacy slot count {slots_len} exceeds limit {MAX_LEGACY_SLOTS}"),
+                ));
+            }
             for _ in 0..slots_len {
                 legacy_slots.push(
                     crate::bedrock::server::inventory_transaction::LegacySetItemSlot::read(buf)?,
@@ -340,6 +350,16 @@ mod alloc_cap_tests {
         VarUInt((MAX_INVENTORY_ACTIONS + 1) as u32)
             .write(&mut buf)
             .unwrap();
+
+        let err = PlayerInventoryAction::read(&mut Cursor::new(buf)).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn rejects_legacy_slots_len_over_cap() {
+        let mut buf = Vec::new();
+        VarInt(-2).write(&mut buf).unwrap(); // legacy_request_id: legacy slots follow
+        VarUInt(MAX_LEGACY_SLOTS + 1).write(&mut buf).unwrap();
 
         let err = PlayerInventoryAction::read(&mut Cursor::new(buf)).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);

--- a/pumpkin-protocol/src/codec/bit_set.rs
+++ b/pumpkin-protocol/src/codec/bit_set.rs
@@ -22,13 +22,59 @@ impl BitSet {
     }
 
     pub fn decode(read: &mut impl Read) -> Result<Self, ReadingError> {
+        /// Bound for a decoded bit set's long count. Vanilla bit sets (chunk, light,
+        /// chat acknowledgement) are far smaller; an uncapped `VarInt` length
+        /// pre-allocates attacker-sized memory.
+        const MAX_BITSET_LONGS: i32 = 4096;
+
         // Read length
         let length = read.get_var_int()?;
+        if length.0 < 0 || length.0 > MAX_BITSET_LONGS {
+            return Err(ReadingError::TooLarge(format!(
+                "BitSet length {} exceeds limit {MAX_BITSET_LONGS}",
+                length.0
+            )));
+        }
         let mut array: Vec<i64> = Vec::with_capacity(length.0 as usize);
         for _ in 0..length.0 {
             let long = read.get_i64_be()?;
             array.push(long);
         }
         Ok(Self(array.into_boxed_slice()))
+    }
+}
+
+#[cfg(test)]
+mod alloc_cap_tests {
+    use super::*;
+    use crate::codec::var_int::VarInt;
+    use std::io::Cursor;
+
+    #[test]
+    fn rejects_oversize_length() {
+        let mut buf = Vec::new();
+        VarInt(4097).encode(&mut buf).unwrap();
+
+        let result = BitSet::decode(&mut Cursor::new(buf));
+        assert!(matches!(result, Err(ReadingError::TooLarge(_))));
+    }
+
+    #[test]
+    fn rejects_negative_length() {
+        let mut buf = Vec::new();
+        VarInt(-1).encode(&mut buf).unwrap();
+
+        let result = BitSet::decode(&mut Cursor::new(buf));
+        assert!(matches!(result, Err(ReadingError::TooLarge(_))));
+    }
+
+    #[test]
+    fn round_trips_small_bit_set() {
+        let bit_set = BitSet(Box::new([i64::MIN, 0, i64::MAX]));
+        let mut buf = Vec::new();
+        bit_set.encode(&mut buf).unwrap();
+
+        let decoded = BitSet::decode(&mut Cursor::new(buf)).unwrap();
+        assert_eq!(decoded.0, bit_set.0);
     }
 }

--- a/pumpkin-protocol/src/codec/data_component.rs
+++ b/pumpkin-protocol/src/codec/data_component.rs
@@ -24,6 +24,9 @@ use pumpkin_data::sound::Sound;
 use pumpkin_nbt::{serializer::NbtWriteHelperJava, tag::NbtTag};
 
 const MAX_STATUS_EFFECTS: usize = 128;
+const MAX_IDSET_ELEMENTS: i32 = 4096;
+const MAX_CONSUMABLE_EFFECTS: i32 = 256;
+const MAX_EFFECT_NESTING: u32 = 16;
 
 #[must_use]
 pub fn data_to_proto_sound(id_or: &IdOr<SoundEvent>) -> crate::IdOr<crate::SoundEvent> {
@@ -62,6 +65,9 @@ fn deserialize_idset<T: IDSetContent>(
         }
         std::cmp::Ordering::Greater => {
             let len = id_type - 1;
+            if len > MAX_IDSET_ELEMENTS {
+                return Err(ReadingError::TooLarge("IDSet elements".into()));
+            }
             let mut content_vec = Vec::with_capacity(len as usize);
 
             for _ in 0..len {
@@ -125,7 +131,7 @@ fn deserialize_status_effects(
         let has_hidden = seq.get_bool()?;
         if has_hidden {
             // Skip hidden effect parameters recursively
-            skip_effect_parameters(seq)?;
+            skip_effect_parameters(seq, 0)?;
         }
 
         custom_effects.push(StatusEffectInstance {
@@ -392,6 +398,9 @@ impl DataComponentCodec<Self> for ConsumableImpl {
             "Invalid sound in ConsumableImpl".into(),
         ))?;
         let effects_len = seq.get_var_int()?.0;
+        if !(0..=MAX_CONSUMABLE_EFFECTS).contains(&effects_len) {
+            return Err(ReadingError::TooLarge("ConsumableImpl effects".into()));
+        }
         let mut effects_vec = Vec::with_capacity(effects_len as usize);
 
         for _ in 0..effects_len {
@@ -579,7 +588,12 @@ impl DataComponentCodec<Self> for PotionContentsImpl {
 }
 
 /// Helper to skip hidden effect parameters recursively
-fn skip_effect_parameters(seq: &mut impl NetworkReadExt) -> Result<(), ReadingError> {
+fn skip_effect_parameters(seq: &mut impl NetworkReadExt, depth: u32) -> Result<(), ReadingError> {
+    if depth >= MAX_EFFECT_NESTING {
+        return Err(ReadingError::TooLarge(
+            "PotionContents hidden effect nesting".into(),
+        ));
+    }
     // amplifier
     seq.get_var_int()?;
     // duration
@@ -593,7 +607,7 @@ fn skip_effect_parameters(seq: &mut impl NetworkReadExt) -> Result<(), ReadingEr
     // has_hidden (recursive)
     let has_hidden = seq.get_bool()?;
     if has_hidden {
-        skip_effect_parameters(seq)?;
+        skip_effect_parameters(seq, depth + 1)?;
     }
     Ok(())
 }

--- a/pumpkin-protocol/src/codec/var_int.rs
+++ b/pumpkin-protocol/src/codec/var_int.rs
@@ -83,7 +83,8 @@ impl VarInt {
         &self,
         write: &mut (impl AsyncWrite + Unpin),
     ) -> Result<(), WritingError> {
-        let mut val = self.0;
+        // Cast to u32 so negative values terminate (matches `encode`).
+        let mut val = self.0 as u32;
         for _ in 0..Self::MAX_SIZE.get() {
             let b: u8 = val as u8 & 0b0111_1111;
             val >>= 7;
@@ -164,14 +165,65 @@ impl PacketWrite for VarInt {
 
 impl PacketRead for VarInt {
     fn read<W: Read>(read: &mut W) -> Result<Self, Error> {
-        let mut val = 0;
+        let mut val: u32 = 0;
         for i in 0..Self::MAX_SIZE.get() {
             let byte = u8::read(read)?;
-            val |= (i32::from(byte) & 0x7F) << (i * 7);
+            val |= (u32::from(byte) & 0x7F) << (i * 7);
             if byte & 0x80 == 0 {
-                return Ok(Self((val >> 1) ^ (val << 31)));
+                // Bedrock VarInts are ZigZag-encoded: (val >> 1) ^ -(val & 1).
+                // The shift must be logical (u32), not arithmetic.
+                return Ok(Self(((val >> 1) as i32) ^ -((val & 1) as i32)));
             }
         }
-        Err(Error::new(ErrorKind::InvalidData, ""))
+        Err(Error::new(ErrorKind::InvalidData, "VarInt is too big"))
+    }
+}
+
+#[cfg(test)]
+mod zigzag_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn round_trip_zigzag_values() {
+        for value in [i32::MIN, -100, -2, -1, 0, 1, 2, 63, 64, 100, i32::MAX] {
+            let mut buf = Vec::new();
+            VarInt(value).write(&mut buf).unwrap();
+            let decoded = VarInt::read(&mut Cursor::new(buf)).unwrap();
+            assert_eq!(decoded.0, value, "round trip failed for {value}");
+        }
+    }
+
+    #[test]
+    fn decodes_zigzag_wire_vectors() {
+        // Single-byte ZigZag wire values.
+        for (wire, expected) in [(0x00u8, 0i32), (0x01, -1), (0x02, 1), (0x03, -2)] {
+            let decoded = VarInt::read(&mut Cursor::new(vec![wire])).unwrap();
+            assert_eq!(decoded.0, expected, "wire {wire:#04x}");
+        }
+        // Five-byte encoding of i32::MIN (ZigZag 0xFFFF_FFFF).
+        let decoded = VarInt::read(&mut Cursor::new(vec![0xFF, 0xFF, 0xFF, 0xFF, 0x0F])).unwrap();
+        assert_eq!(decoded.0, i32::MIN);
+    }
+
+    #[test]
+    fn encodes_zigzag_wire_vectors() {
+        for (value, wire) in [
+            (0i32, vec![0x00u8]),
+            (-1, vec![0x01]),
+            (1, vec![0x02]),
+            (-2, vec![0x03]),
+            (i32::MIN, vec![0xFF, 0xFF, 0xFF, 0xFF, 0x0F]),
+        ] {
+            let mut buf = Vec::new();
+            VarInt(value).write(&mut buf).unwrap();
+            assert_eq!(buf, wire, "encode {value}");
+        }
+    }
+
+    #[test]
+    fn rejects_too_many_bytes() {
+        let err = VarInt::read(&mut Cursor::new(vec![0x80u8; 6])).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
     }
 }

--- a/pumpkin-protocol/src/codec/var_long.rs
+++ b/pumpkin-protocol/src/codec/var_long.rs
@@ -128,3 +128,27 @@ impl PacketWrite for VarLong {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod zigzag_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn round_trip_zigzag_values() {
+        for value in [i64::MIN, -100, -2, -1, 0, 1, 2, 63, 64, 100, i64::MAX] {
+            let mut buf = Vec::new();
+            VarLong(value).write(&mut buf).unwrap();
+            let decoded = VarLong::read(&mut Cursor::new(buf)).unwrap();
+            assert_eq!(decoded.0, value, "round trip failed for {value}");
+        }
+    }
+
+    #[test]
+    fn decodes_zigzag_wire_vectors() {
+        for (wire, expected) in [(0x00u8, 0i64), (0x01, -1), (0x02, 1), (0x03, -2)] {
+            let decoded = VarLong::read(&mut Cursor::new(vec![wire])).unwrap();
+            assert_eq!(decoded.0, expected, "wire {wire:#04x}");
+        }
+    }
+}

--- a/pumpkin-protocol/src/java/packet_decoder.rs
+++ b/pumpkin-protocol/src/java/packet_decoder.rs
@@ -10,6 +10,15 @@ use crate::{
 
 // decrypt -> decompress -> raw
 
+/// Read chunk used to grow the payload buffer incrementally.
+///
+/// Applies while decoding (including inflating) a packet. The client-declared
+/// decompressed length may be as large as `MAX_PACKET_DATA_SIZE`, so it must
+/// not be reserved up front; growing in chunks bounds the allocation a lying
+/// declaration can force (F-PROT-06). The total is still hard-capped by the
+/// declared-length checks.
+const PAYLOAD_READ_CHUNK: usize = 64 * 1024;
+
 pub enum DecompressionReader<R: AsyncRead + Unpin> {
     Decompress(ZlibDecoder<BufReader<R>>),
     None(R),
@@ -168,10 +177,13 @@ impl<R: AsyncRead + Unpin> TCPNetworkDecoder<R> {
 
         let payload_len_hint = expected_packet_data_len.saturating_sub(packet_id_len);
         self.payload_scratch.clear();
-        self.payload_scratch.reserve(payload_len_hint);
 
-        let mut total_read = 0;
-        while total_read < payload_len_hint {
+        // Grow the scratch incrementally as bytes actually arrive instead of
+        // reserving the client-declared length up front; `payload_len_hint` is
+        // already capped at `MAX_PACKET_DATA_SIZE`, which bounds the loop.
+        while self.payload_scratch.len() < payload_len_hint {
+            let to_read = (payload_len_hint - self.payload_scratch.len()).min(PAYLOAD_READ_CHUNK);
+            self.payload_scratch.reserve(to_read);
             let bytes_read = reader
                 .read_buf(&mut self.payload_scratch)
                 .await
@@ -179,7 +191,6 @@ impl<R: AsyncRead + Unpin> TCPNetworkDecoder<R> {
             if bytes_read == 0 {
                 break;
             }
-            total_read += bytes_read;
         }
 
         if let Some(expected_uncompressed_packet_data_len) = expected_uncompressed_packet_data_len {
@@ -493,6 +504,55 @@ mod tests {
             cap_after_p2, cap_after_p1,
             "Buffer capacity should be retained and reused without new heap allocations"
         );
+        Ok(())
+    }
+
+    /// A valid compressed packet larger than one read chunk must decode
+    /// correctly while the scratch buffer grows incrementally.
+    #[tokio::test]
+    async fn decode_large_compressed_packet_incremental_growth()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let packet_id = 9;
+        let payload = vec![0x55u8; 3 * PAYLOAD_READ_CHUNK + 17];
+
+        let packet = build_packet(packet_id, &payload, true, None, None)?;
+
+        let mut decoder = TCPNetworkDecoder::new(packet.as_slice());
+        decoder.set_compression(1000);
+
+        let raw_packet = decoder.get_raw_packet().await.map_err(|e| e.to_string())?;
+        assert_eq!(raw_packet.id, packet_id);
+        assert_eq!(raw_packet.payload.as_ref(), payload);
+        Ok(())
+    }
+
+    /// A declared decompressed length larger than what the stream actually
+    /// inflates to must fail the equality check after an early EOF.
+    #[tokio::test]
+    async fn decode_with_larger_declared_decompressed_length()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let packet_id = 10;
+        let payload = b"small";
+
+        let mut data_to_compress = Vec::new();
+        data_to_compress.write_var_int(&VarInt(packet_id))?;
+        data_to_compress.write_slice(payload)?;
+        let compressed = compress_zlib(&data_to_compress)?;
+
+        let mut buffer = Vec::new();
+        // Lie about the decompressed length.
+        buffer.write_var_int(&VarInt((data_to_compress.len() + 1_000_000) as i32))?;
+        buffer.write_slice(&compressed)?;
+
+        let mut packet = Vec::new();
+        packet.write_var_int(&VarInt(buffer.len() as i32))?;
+        packet.extend_from_slice(&buffer);
+
+        let mut decoder = TCPNetworkDecoder::new(packet.as_slice());
+        decoder.set_compression(1000);
+
+        let result = decoder.get_raw_packet().await;
+        assert!(result.is_err(), "declared-length mismatch must error");
         Ok(())
     }
 }

--- a/pumpkin-protocol/src/serial/deserializer.rs
+++ b/pumpkin-protocol/src/serial/deserializer.rs
@@ -7,6 +7,7 @@ use pumpkin_util::math::{position::BlockPos, vector2::Vector2, vector3::Vector3}
 use uuid::Uuid;
 
 use crate::{
+    MAX_PACKET_DATA_SIZE,
     codec::{var_int::VarInt, var_uint::VarUInt},
     serial::PacketRead,
 };
@@ -160,7 +161,15 @@ impl PacketRead for Vec<u8> {
     fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
         #[expect(clippy::uninit_vec)]
         {
-            let len = VarUInt::read(reader)?.0 as _;
+            let len = VarUInt::read(reader)?.0 as usize;
+            // Landmine cap: no current caller reads a byte list from the wire, but
+            // an unbounded `VarUInt` length here would pre-allocate attacker-sized memory.
+            if len > MAX_PACKET_DATA_SIZE {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("byte array length {len} exceeds limit {MAX_PACKET_DATA_SIZE}"),
+                ));
+            }
             let mut buf = Self::with_capacity(len);
             unsafe {
                 buf.set_len(len);
@@ -397,5 +406,33 @@ impl<'a> crate::serial::PacketReadSlice<'a> for crate::codec::var_uint::VarUInt 
 impl<'a> crate::serial::PacketReadSlice<'a> for crate::codec::var_ulong::VarULong {
     fn read_slice(buf: &mut &'a [u8]) -> Result<Self, Error> {
         Self::read(buf)
+    }
+}
+
+#[cfg(test)]
+mod alloc_cap_tests {
+    use super::*;
+    use crate::serial::PacketWrite;
+    use std::io::Cursor;
+
+    #[test]
+    fn vec_u8_rejects_len_over_cap() {
+        let mut buf = Vec::new();
+        VarUInt((MAX_PACKET_DATA_SIZE + 1) as u32)
+            .write(&mut buf)
+            .unwrap();
+
+        let err = Vec::<u8>::read(&mut Cursor::new(buf)).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn vec_u8_reads_small_payload() {
+        let mut buf = Vec::new();
+        VarUInt(3).write(&mut buf).unwrap();
+        buf.extend_from_slice(&[1, 2, 3]);
+
+        let parsed = Vec::<u8>::read(&mut Cursor::new(buf)).unwrap();
+        assert_eq!(parsed, vec![1, 2, 3]);
     }
 }

--- a/pumpkin/src/command/snbt/mod.rs
+++ b/pumpkin/src/command/snbt/mod.rs
@@ -48,6 +48,9 @@ pub const EXPECTED_INTEGER_TYPE: CommandErrorType<0> = CommandErrorType::new(
     translation::java::SNBT_PARSER_EXPECTED_INTEGER_TYPE,
 );
 
+/// Maximum nesting depth for SNBT compounds/lists (matches NBT binary depth budget).
+pub const MAX_SNBT_DEPTH: u32 = 128;
+
 /// A structure that parses SNBT.
 ///
 /// This stores a reader and gives the furthest error, or suggestions
@@ -55,6 +58,7 @@ pub const EXPECTED_INTEGER_TYPE: CommandErrorType<0> = CommandErrorType::new(
 pub struct SnbtParser<'r, 's> {
     reader: &'r mut StringReader<'s>,
     errors: ParserErrors,
+    depth: u32,
 }
 
 //
@@ -67,6 +71,7 @@ impl SnbtParser<'_, '_> {
             let mut parser = SnbtParser {
                 reader,
                 errors: ParserErrors::default(),
+                depth: 0,
             };
 
             let literal = parser.parse();
@@ -113,6 +118,7 @@ impl SnbtParser<'_, '_> {
             let mut parser = SnbtParser {
                 reader: &mut reader,
                 errors: ParserErrors::default(),
+                depth: 0,
             };
 
             let _ = parser.parse();

--- a/pumpkin/src/command/snbt/rules.rs
+++ b/pumpkin/src/command/snbt/rules.rs
@@ -68,6 +68,12 @@ pub const EMPTY_KEY: CommandErrorType<0> = CommandErrorType::new(
     translation::java::SNBT_PARSER_EMPTY_KEY,
 );
 
+/// Nesting budget exhausted (matches binary NBT depth cap).
+pub const NESTING_TOO_DEEP: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMAND_FAILED,
+    translation::java::COMMAND_FAILED,
+);
+
 pub const LEADING_ZERO_NOT_ALLOWED: CommandErrorType<0> = CommandErrorType::new(
     translation::java::SNBT_PARSER_LEADING_ZERO_NOT_ALLOWED,
     translation::java::SNBT_PARSER_LEADING_ZERO_NOT_ALLOWED,
@@ -696,6 +702,11 @@ impl SnbtParser<'_, '_> {
     }
 
     fn map_literal(&mut self) -> Option<NbtTag> {
+        if self.depth >= crate::command::snbt::MAX_SNBT_DEPTH {
+            self.store_simple_error(&NESTING_TOO_DEEP);
+            return None;
+        }
+        self.depth += 1;
         let entries = self.parse_or_revert(|parser| {
             parser.reader.skip_whitespace();
             if parser.reader.peek() != Some('{') {
@@ -711,7 +722,9 @@ impl SnbtParser<'_, '_> {
             }
             parser.reader.skip();
             Some(entries)
-        })?;
+        });
+        self.depth = self.depth.saturating_sub(1);
+        let entries = entries?;
 
         Some(NbtTag::Compound(NbtCompound {
             child_tags: entries.into_iter().map(|(k, v)| (k.into(), v)).collect(),
@@ -755,7 +768,12 @@ impl SnbtParser<'_, '_> {
     }
 
     fn list_literal(&mut self) -> Option<NbtTag> {
-        self.parse_or_revert(|parser| {
+        if self.depth >= crate::command::snbt::MAX_SNBT_DEPTH {
+            self.store_simple_error(&NESTING_TOO_DEEP);
+            return None;
+        }
+        self.depth += 1;
+        let result = self.parse_or_revert(|parser| {
             parser.reader.skip_whitespace();
             if parser.reader.peek() != Some('[') {
                 parser.store_dynamic_error_and_suggest(&LITERAL_INCORRECT, "[", &["["]);
@@ -795,7 +813,9 @@ impl SnbtParser<'_, '_> {
 
                 Some(NbtOps.create_list(entries))
             }
-        })
+        });
+        self.depth = self.depth.saturating_sub(1);
+        result
     }
 
     fn literal(&mut self) -> Option<NbtTag> {

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -285,7 +285,11 @@ impl LivingEntity {
     }
 
     pub fn heal(&self, additional_health: f32) {
-        assert!(additional_health > 0.0);
+        // Guard against overflowed potion amplifiers producing non-positive/NaN amounts
+        // (previously assert! → panic hook → full server shutdown).
+        if !additional_health.is_finite() || additional_health <= 0.0 {
+            return;
+        }
         self.set_health(self.health.load() + additional_health);
     }
 
@@ -470,10 +474,13 @@ impl LivingEntity {
     pub async fn add_effect(&self, effect: Effect) {
         // Apply instant effects immediately before storing
         if effect.effect_type == &StatusEffect::INSTANT_HEALTH {
-            let heal_amount = 4.0 * (1 << effect.amplifier) as f32;
+            // amplifier is u8; shift beyond 31 is UB in debug / wraps in release → NaN/negative.
+            let shift = u32::from(effect.amplifier).min(30);
+            let heal_amount = 4.0 * ((1u32 << shift) as f32);
             self.heal(heal_amount);
         } else if effect.effect_type == &StatusEffect::INSTANT_DAMAGE {
-            let damage_amount = 6.0 * (1 << effect.amplifier) as f32;
+            let shift = u32::from(effect.amplifier).min(30);
+            let damage_amount = 6.0 * ((1u32 << shift) as f32);
             if let Some(dyn_self) = self
                 .entity
                 .world

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -476,6 +476,9 @@ pub struct Player {
     /// Whether the client has reported that it has loaded.
     pub client_loaded: AtomicBool,
     pub bedrock_spawned: AtomicBool,
+    /// Set on first `remove()` so duplicate-login kick + connection-task cleanup
+    /// cannot double-unwatch chunks or double-count leave stats.
+    pub has_left: AtomicBool,
     /// The amount of time (in ticks) the client has to report having finished loading before being timed out.
     pub client_loaded_timeout: AtomicU32,
     /// Item usage tracking for bows, crossbows, etc.
@@ -673,6 +676,7 @@ impl Player {
             last_attacked_ticks: AtomicU32::new(0),
             client_loaded: AtomicBool::new(false),
             bedrock_spawned: AtomicBool::new(false),
+            has_left: AtomicBool::new(false),
             client_loaded_timeout: AtomicU32::new(60),
             // Item usage tracking
             using_item: AtomicBool::new(false),
@@ -859,7 +863,16 @@ impl Player {
     }
 
     /// Removes the [`Player`] out of the current [`World`].
+    ///
+    /// Idempotent: safe when both a duplicate-login kick and the connection
+    /// task try to clean up the same session.
     pub async fn remove(self: &Arc<Self>) {
+        if self
+            .has_left
+            .swap(true, std::sync::atomic::Ordering::AcqRel)
+        {
+            return;
+        }
         self.stats
             .lock()
             .await

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -473,7 +473,13 @@ impl PumpkinServer {
                                      java_client.close();
                                      java_client.await_tasks().await;
                                 },
-                                PacketHandlerResult::ReadyToPlay(profile,config) => {
+                                PacketHandlerResult::ReadyToPlay(profile, config) => {
+                                    // Drop if kick already closed the socket during login races.
+                                    if java_client.is_closed() {
+                                        java_client.close();
+                                        java_client.await_tasks().await;
+                                        return;
+                                    }
                                      if let Some((player, world)) = server_clone
                                      .add_player(Arc::new(ClientPlatform::Java(java_client)), profile, Some(config))
                                           .await
@@ -486,12 +492,33 @@ impl PumpkinServer {
                                     world
                                         .spawn_java_player(&server_clone.basic_config, &player, &server_clone)
                                         .await;
+                                    // Run the play loop in a child task so a panic still
+                                    // returns here for player cleanup (ghost-player fix).
                                     if let ClientPlatform::Java(client) = player.client.as_ref() {
-                                        client.progress_player_packets(&player, &server_clone).await;
+                                        let player_play = player.clone();
+                                        let server_play = server_clone.clone();
+                                        let client_id = client.id;
+                                        let play_join = tokio::spawn(async move {
+                                            // Re-resolve client from player for the play loop.
+                                            if let ClientPlatform::Java(c) = player_play.client.as_ref() {
+                                                c.progress_player_packets(&player_play, &server_play).await;
+                                            } else {
+                                                tracing::error!(
+                                                    "Java play task lost Java client for id {client_id}"
+                                                );
+                                            }
+                                        });
+                                        if let Err(e) = play_join.await {
+                                            error!(
+                                                "Java play task for player {} ended with panic/cancel: {e}",
+                                                player.gameprofile.name
+                                            );
+                                        }
 
-                                        // Close when done
-                                        client.close();
-                                        client.await_tasks().await;
+                                        if let ClientPlatform::Java(client) = player.client.as_ref() {
+                                            client.close();
+                                            client.await_tasks().await;
+                                        }
                                     }
                                     player.remove().await;
                                     server_clone.remove_player(&player).await;
@@ -568,13 +595,35 @@ impl PumpkinServer {
                                                 client_clone.await_tasks().await;
                                             }
                                             PacketHandlerResult::ReadyToPlay(profile, config) => {
+                                                if client_clone.is_closed() {
+                                                    client_clone.close().await;
+                                                    client_clone.await_tasks().await;
+                                                    return;
+                                                }
                                                 if let Some((player, _world)) = server_clone
                                                     .add_player(Arc::new(ClientPlatform::Bedrock(client_clone.clone())), profile, Some(config))
                                                     .await
                                                 {
                                                     *client_clone.player.lock().await = Some(player.clone());
 
-                                                    client_clone.progress_player_packets(&player, &server_clone).await;
+                                                    // Child task so panic during play still cleans up.
+                                                    let player_play = player.clone();
+                                                    let server_play = server_clone.clone();
+                                                    let client_play = client_clone.clone();
+                                                    let play_join = tokio::spawn(async move {
+                                                        client_play
+                                                            .progress_player_packets(
+                                                                &player_play,
+                                                                &server_play,
+                                                            )
+                                                            .await;
+                                                    });
+                                                    if let Err(e) = play_join.await {
+                                                        error!(
+                                                            "Bedrock play task for player {} ended with panic/cancel: {e}",
+                                                            player.gameprofile.name
+                                                        );
+                                                    }
 
                                                     client_clone.close().await;
                                                     client_clone.await_tasks().await;

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -373,19 +373,19 @@ impl PumpkinServer {
 
         SERVER_IS_STOPPING.store(true, Ordering::Release);
 
-        if let Some(crash_report) = CRASH_REPORT.get() {
-            crash_report.print_to_console();
-            crash_report.save_and_log();
-
-            info!(
-                "{}",
-                TextComponent::text("Gracefully shutting down...")
-                    .color(Color::Named(NamedColor::Green))
-                    .to_pretty_console()
-            );
-
-            SERVER_EXIT_CODE.store(1, Ordering::Release);
+        // Contained worker panics already saved a crash report; do not flip the
+        // process exit code to 1 on a later manual stop (systemd would treat a
+        // clean Ctrl-C as a crash).
+        if CRASH_REPORT.get().is_some() {
+            info!("A prior worker panic was recorded (crash report on disk); exiting cleanly");
         }
+
+        info!(
+            "{}",
+            TextComponent::text("Gracefully shutting down...")
+                .color(Color::Named(NamedColor::Green))
+                .to_pretty_console()
+        );
 
         info!("Stopped accepting incoming connections");
 
@@ -489,36 +489,36 @@ impl PumpkinServer {
                                     if let ClientPlatform::Java(client) = player.client.as_ref() {
                                         *client.player.lock().await = Some(player.clone());
                                     }
-                                    world
-                                        .spawn_java_player(&server_clone.basic_config, &player, &server_clone)
-                                        .await;
-                                    // Run the play loop in a child task so a panic still
-                                    // returns here for player cleanup (ghost-player fix).
-                                    if let ClientPlatform::Java(client) = player.client.as_ref() {
-                                        let player_play = player.clone();
-                                        let server_play = server_clone.clone();
-                                        let client_id = client.id;
-                                        let play_join = tokio::spawn(async move {
-                                            // Re-resolve client from player for the play loop.
-                                            if let ClientPlatform::Java(c) = player_play.client.as_ref() {
-                                                c.progress_player_packets(&player_play, &server_play).await;
-                                            } else {
-                                                tracing::error!(
-                                                    "Java play task lost Java client for id {client_id}"
-                                                );
-                                            }
-                                        });
-                                        if let Err(e) = play_join.await {
-                                            error!(
-                                                "Java play task for player {} ended with panic/cancel: {e}",
-                                                player.gameprofile.name
-                                            );
+                                    // Spawn + play loop both run in a child task so a panic
+                                    // during spawn_java_player still hits cleanup below.
+                                    let player_play = player.clone();
+                                    let server_play = server_clone.clone();
+                                    let world_play = world.clone();
+                                    let play_join = tokio::spawn(async move {
+                                        world_play
+                                            .spawn_java_player(
+                                                &server_play.basic_config,
+                                                &player_play,
+                                                &server_play,
+                                            )
+                                            .await;
+                                        if let ClientPlatform::Java(c) =
+                                            player_play.client.as_ref()
+                                        {
+                                            c.progress_player_packets(&player_play, &server_play)
+                                                .await;
                                         }
+                                    });
+                                    if let Err(e) = play_join.await {
+                                        error!(
+                                            "Java play task for player {} ended with panic/cancel: {e}",
+                                            player.gameprofile.name
+                                        );
+                                    }
 
-                                        if let ClientPlatform::Java(client) = player.client.as_ref() {
-                                            client.close();
-                                            client.await_tasks().await;
-                                        }
+                                    if let ClientPlatform::Java(client) = player.client.as_ref() {
+                                        client.close();
+                                        client.await_tasks().await;
                                     }
                                     player.remove().await;
                                     server_clone.remove_player(&player).await;

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -18,13 +18,13 @@ use tokio::signal::ctrl_c;
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal};
 
+use pumpkin::PumpkinServer;
 use pumpkin::{
     CRASH_REPORT, SERVER_EXIT_CODE, SERVER_IS_STOPPING,
     crash::{CrashReport, FullBacktrace},
     data::VanillaData,
     stop_or_exit_server,
 };
-use pumpkin::{PumpkinServer, stop_server};
 
 use pumpkin_config::{LoadConfiguration, PumpkinConfig};
 use pumpkin_util::text::{
@@ -213,12 +213,14 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
     };
 
     let payload = panic_info.payload();
+    let payload_str = payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("<unknown>");
 
     if is_main_thread() {
-        // It's the first panic;
-        // We cannot gracefully shut down as the main thread
-        // has panicked. However, we can still generate the crash report.
-
+        // Main-thread panic is unrecoverable: write a crash report and exit.
         if let Some(crash_report) = try_set_crash_report(crash_report) {
             crash_report.print_to_console();
             crash_report.save_and_log();
@@ -230,7 +232,6 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
                     .to_pretty_console()
             );
         } else {
-            // It's a subsequent panic.
             tracing::error!(
                 "{}: {}",
                 TextComponent::text(
@@ -239,35 +240,30 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
                 .color(Color::Named(NamedColor::Red))
                 .bold()
                 .to_pretty_console(),
-                payload
-                    .downcast_ref::<&str>()
-                    .copied()
-                    .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
-                    .unwrap_or("<unknown>")
+                payload_str
             );
         }
 
         exit(1);
     }
 
-    if try_set_crash_report(crash_report).is_some() {
-        // It's the first panic; let's stop the server.
-        stop_server();
-    } else {
-        // It's a subsequent panic; let's just alert about it.
-        tracing::error!(
-            "{}: {}",
-            TextComponent::text("Encountered panic while shutting down")
-                .color(Color::Named(NamedColor::Red))
-                .bold()
-                .to_pretty_console(),
-            payload
-                .downcast_ref::<&str>()
-                .copied()
-                .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
-                .unwrap_or("<unknown>")
-        );
-    }
+    // Worker-thread panics must NOT take down the whole server. Log a crash
+    // report and let the task die; other connections keep serving.
+    // (Previously the first worker panic called stop_server(), turning every
+    // reachable unwrap into a remote kill switch.)
+    crash_report.print_to_console();
+    crash_report.save_and_log();
+    // Keep the first report for process exit status if the server later stops.
+    let _ = try_set_crash_report(crash_report);
+
+    tracing::error!(
+        "{}: {}",
+        TextComponent::text("Worker thread panicked; task aborted, server continues running")
+            .color(Color::Named(NamedColor::Red))
+            .bold()
+            .to_pretty_console(),
+        payload_str
+    );
 }
 
 fn is_main_thread() -> bool {

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -247,14 +247,17 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
         exit(1);
     }
 
-    // Worker-thread panics must NOT take down the whole server. Log a crash
-    // report and let the task die; other connections keep serving.
+    // Worker-thread panics must NOT take down the whole server. Log and let the
+    // task die; other connections keep serving.
     // (Previously the first worker panic called stop_server(), turning every
     // reachable unwrap into a remote kill switch.)
-    crash_report.print_to_console();
-    crash_report.save_and_log();
-    // Keep the first report for process exit status if the server later stops.
-    let _ = try_set_crash_report(crash_report);
+    //
+    // Only the first worker panic saves a full crash report to disk — a
+    // repeatable panic primitive must not fill the disk with reports.
+    if let Some(report) = try_set_crash_report(crash_report) {
+        report.print_to_console();
+        report.save_and_log();
+    }
 
     tracing::error!(
         "{}: {}",

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -197,21 +197,6 @@ fn handle_interrupt() {
 }
 
 fn handle_panic(panic_info: &PanicHookInfo<'_>) {
-    // Generate a crash report.
-    let crash_report = {
-        // We capture the backtraces here, and not in the
-        // crash report, so that the backtrace doesn't show
-        // the CrashReport's `new` function.
-        let captured_backtrace = Backtrace::capture();
-        let full_backtrace = if captured_backtrace.status() == BacktraceStatus::Captured {
-            FullBacktrace::Captured
-        } else {
-            FullBacktrace::ForceCaptured(Backtrace::force_capture())
-        };
-
-        CrashReport::new(panic_info, captured_backtrace, full_backtrace)
-    };
-
     let payload = panic_info.payload();
     let payload_str = payload
         .downcast_ref::<&str>()
@@ -219,9 +204,18 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
         .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
         .unwrap_or("<unknown>");
 
+    // Building a crash report captures a backtrace, which is expensive. Only
+    // build one when it can actually be stored (the first panic overall);
+    // `try_set_crash_report` remains the authoritative gate, so a race between
+    // concurrent first panics merely builds one report too many.
+    let report_storable =
+        !SERVER_IS_STOPPING.load(Ordering::Acquire) && CRASH_REPORT.get().is_none();
+
     if is_main_thread() {
         // Main-thread panic is unrecoverable: write a crash report and exit.
-        if let Some(crash_report) = try_set_crash_report(crash_report) {
+        if report_storable
+            && let Some(crash_report) = try_set_crash_report(build_crash_report(panic_info))
+        {
             crash_report.print_to_console();
             crash_report.save_and_log();
 
@@ -253,8 +247,10 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
     // reachable unwrap into a remote kill switch.)
     //
     // Only the first worker panic saves a full crash report to disk — a
-    // repeatable panic primitive must not fill the disk with reports.
-    if let Some(report) = try_set_crash_report(crash_report) {
+    // repeatable panic primitive must not fill the disk with reports, nor burn
+    // CPU capturing a backtrace per panic; subsequent panics only get the log
+    // line below.
+    if report_storable && let Some(report) = try_set_crash_report(build_crash_report(panic_info)) {
         report.print_to_console();
         report.save_and_log();
     }
@@ -267,6 +263,20 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
             .to_pretty_console(),
         payload_str
     );
+}
+
+fn build_crash_report(panic_info: &PanicHookInfo<'_>) -> CrashReport {
+    // We capture the backtraces here, and not in the
+    // crash report, so that the backtrace doesn't show
+    // the CrashReport's `new` function.
+    let captured_backtrace = Backtrace::capture();
+    let full_backtrace = if captured_backtrace.status() == BacktraceStatus::Captured {
+        FullBacktrace::Captured
+    } else {
+        FullBacktrace::ForceCaptured(Backtrace::force_capture())
+    };
+
+    CrashReport::new(panic_info, captured_backtrace, full_backtrace)
 }
 
 fn is_main_thread() -> bool {

--- a/pumpkin/src/net/authentication.rs
+++ b/pumpkin/src/net/authentication.rs
@@ -44,10 +44,19 @@ pub struct MojangPublicKeys {
 }
 
 const MOJANG_AUTHENTICATION_URL: &str = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}";
-const MOJANG_PREVENT_PROXY_AUTHENTICATION_URL: &str = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}";
+const MOJANG_PREVENT_PROXY_AUTHENTICATION_URL: &str = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}&ip={ip}";
 const MOJANG_SERVICES_URL: &str = "https://api.minecraftservices.com/";
 const MOJANG_PROFILE_BY_NAME_URL: &str =
     "https://api.mojang.com/users/profiles/minecraft/{username}";
+
+/// ureq 3 defaults to no timeouts; always use a bounded agent for Mojang HTTP.
+fn mojang_http_agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_connect(Some(std::time::Duration::from_secs(5)))
+        .timeout_recv_response(Some(std::time::Duration::from_secs(5)))
+        .build()
+        .into()
+}
 
 /// Sends a GET request to Mojang's authentication servers to verify a client's Minecraft account.
 ///
@@ -89,7 +98,8 @@ pub fn authenticate(
             .replace("{server_hash}", server_hash)
     };
 
-    let mut response = ureq::get(address)
+    let mut response = mojang_http_agent()
+        .get(address)
         .call()
         .map_err(|_| AuthError::FailedResponse)?;
     match response.status() {
@@ -151,7 +161,8 @@ pub fn fetch_mojang_public_keys(
 
     let url = format!("{services_url}/publickeys");
 
-    let mut response = ureq::get(url)
+    let mut response = mojang_http_agent()
+        .get(url)
         .call()
         .map_err(|_| AuthError::FailedResponse)?;
 
@@ -192,7 +203,8 @@ pub fn lookup_profile_by_name(
 ) -> Result<Option<(Uuid, String)>, AuthError> {
     let url = MOJANG_PROFILE_BY_NAME_URL.replace("{username}", name);
 
-    let mut response = ureq::get(url)
+    let mut response = mojang_http_agent()
+        .get(url)
         .call()
         .map_err(|_| AuthError::FailedResponse)?;
 

--- a/pumpkin/src/net/bedrock/login.rs
+++ b/pumpkin/src/net/bedrock/login.rs
@@ -180,6 +180,14 @@ impl BedrockClient {
         let real_name = player_data.display_name;
         // IMPORTANT: Bedrock allows spaces in names. While we could support this, it would significantly complicate parsing player arguments in commands, so we don't
         let under_score_name = real_name.replace(' ', "_");
+        // Reject empty/NUL/control names (query CString panic, log injection, etc.).
+        if under_score_name.is_empty()
+            || under_score_name.contains('\0')
+            || under_score_name.chars().any(char::is_control)
+            || under_score_name.len() > 16
+        {
+            return Err(LoginError::InvalidUsername);
+        }
 
         let profile = GameProfile {
             id: Uuid::parse_str(&player_data.uuid).map_err(|_| LoginError::InvalidUuid)?,

--- a/pumpkin/src/net/bedrock/login.rs
+++ b/pumpkin/src/net/bedrock/login.rs
@@ -180,9 +180,10 @@ impl BedrockClient {
         let real_name = player_data.display_name;
         // IMPORTANT: Bedrock allows spaces in names. While we could support this, it would significantly complicate parsing player arguments in commands, so we don't
         let under_score_name = real_name.replace(' ', "_");
-        // Reject empty/NUL/control names (query CString panic, log injection, etc.).
+        // Reject empty/NUL/control/§ names (query CString panic, log/format injection).
         if under_score_name.is_empty()
             || under_score_name.contains('\0')
+            || under_score_name.contains('§')
             || under_score_name.chars().any(char::is_control)
             || under_score_name.len() > 16
         {

--- a/pumpkin/src/net/bedrock/mod.rs
+++ b/pumpkin/src/net/bedrock/mod.rs
@@ -1,5 +1,15 @@
 pub mod play;
 use crossbeam::atomic::AtomicCell;
+
+/// Maximum fragments in a single `RakNet` split compound.
+/// Legitimate packets fit well under this; uncapped `split_size` is a remote alloc bomb.
+const MAX_RAKNET_SPLIT_COUNT: u32 = 1024;
+/// Cap outstanding incomplete split compounds per client.
+const MAX_PENDING_SPLIT_COMPOUNDS: usize = 64;
+/// Cap frames waiting in an ordered channel queue.
+const MAX_ORDERED_QUEUE_LEN: usize = 512;
+/// Cap unacked outgoing frames retained for resend.
+const MAX_UNACKED_OUTGOING: usize = 2048;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     io::{Cursor, Error, Write},
@@ -704,7 +714,15 @@ impl BedrockClient {
         }
 
         if frame_set.frames.iter().any(|f| f.reliability.is_reliable()) {
-            self.unacked_outgoing_frames.lock().await.insert(
+            let mut unacked = self.unacked_outgoing_frames.lock().await;
+            // Bound memory if peer never ACKs (never-ACK client retention DoS).
+            if unacked.len() >= MAX_UNACKED_OUTGOING {
+                // Drop oldest by insertion-order proxy: lowest sequence number.
+                if let Some(oldest) = unacked.keys().copied().min() {
+                    unacked.remove(&oldest);
+                }
+            }
+            unacked.insert(
                 sequence,
                 (id, frame_set_buf.clone(), std::time::Instant::now()),
             );
@@ -861,15 +879,34 @@ impl BedrockClient {
         mut frame: Frame,
     ) -> Result<(), Error> {
         if frame.split_size > 0 {
+            if frame.split_size > MAX_RAKNET_SPLIT_COUNT {
+                return Err(Error::other(format!(
+                    "RakNet split_size {} exceeds limit {MAX_RAKNET_SPLIT_COUNT}",
+                    frame.split_size
+                )));
+            }
             let fragment_index = frame.split_index as usize;
             let compound_id = frame.split_id;
             let mut compounds = self.compounds.lock().await;
+
+            if !compounds.contains_key(&compound_id)
+                && compounds.len() >= MAX_PENDING_SPLIT_COMPOUNDS
+            {
+                return Err(Error::other(
+                    "Too many pending RakNet split compounds from client",
+                ));
+            }
 
             let entry = compounds.entry(compound_id).or_insert_with(|| {
                 let mut vec = Vec::with_capacity(frame.split_size as usize);
                 vec.resize_with(frame.split_size as usize, || None);
                 vec
             });
+
+            // Reject compounds whose declared size disagrees with the first fragment.
+            if entry.len() != frame.split_size as usize {
+                return Err(Error::other("RakNet split compound size mismatch"));
+            }
 
             if fragment_index >= entry.len() {
                 return Err(Error::other(format!(
@@ -938,6 +975,11 @@ impl BedrockClient {
                 let queue = ordered_queues
                     .entry(frame.order_channel)
                     .or_insert_with(BTreeMap::new);
+                if queue.len() >= MAX_ORDERED_QUEUE_LEN {
+                    return Err(Error::other(
+                        "RakNet ordered queue exceeded limit for channel",
+                    ));
+                }
                 queue.insert(frame.order_index, frame);
             }
             // If frame.order_index < *expected, it's an old frame, discard it.

--- a/pumpkin/src/net/bedrock/play.rs
+++ b/pumpkin/src/net/bedrock/play.rs
@@ -1354,11 +1354,6 @@ impl BedrockClient {
                         source,
                         destination,
                     } => {
-                        if is_result_preview_container(source.container_name.container_name) {
-                            tracing::debug!("Reject Take/Place from result preview container");
-                            result = 1;
-                            break;
-                        }
                         if source.container_name.container_name == ContainerName::CreatedOutput
                             && created_item.is_none()
                         {
@@ -1366,6 +1361,11 @@ impl BedrockClient {
                             result = 1;
                             break;
                         }
+                        // A Cursor source backed by the created-item mirror spends the
+                        // mirror; its remainder must not materialize in the physical cursor.
+                        let source_uses_mirror =
+                            is_cursor_mirror(&*screen_handler, &source, created_item.as_ref())
+                                .await;
                         let mut source_stack =
                             get_slot_stack(&*screen_handler, &source, created_item.as_ref()).await;
                         if source_stack.is_empty() {
@@ -1375,12 +1375,18 @@ impl BedrockClient {
                         }
                         let count = count.min(source_stack.item_count);
                         if count > 0 {
-                            let mut dest_stack = get_slot_stack(
-                                &*screen_handler,
-                                &destination,
-                                created_item.as_ref(),
-                            )
-                            .await;
+                            // Destinations resolve to physical state only; the
+                            // created-item mirror is never a merge base.
+                            let mut dest_stack =
+                                get_destination_slot_stack(&*screen_handler, &destination).await;
+                            // Take-only slots (result/output) never accept moved-in stacks.
+                            if !destination_accepts(&*screen_handler, &destination, &source_stack)
+                                .await
+                            {
+                                tracing::debug!("Take/Place destination is take-only");
+                                result = 1;
+                                break;
+                            }
                             if dest_stack.is_empty() {
                                 dest_stack = source_stack.copy_with_count(count);
                             } else if dest_stack.are_items_and_components_equal(&source_stack) {
@@ -1393,6 +1399,23 @@ impl BedrockClient {
                                 break;
                             }
 
+                            let taken_stack = source_stack.copy_with_count(count);
+                            // A take from a take-only slot is settled through the
+                            // slot itself exactly once (grid use, trade cost, XP).
+                            // Settle before consuming anything so a refused take
+                            // leaves both the craft mirror and the grid untouched.
+                            if !charge_take_only_source(
+                                player.as_ref(),
+                                &*screen_handler,
+                                &source,
+                                &taken_stack,
+                            )
+                            .await
+                            {
+                                tracing::debug!("Take/Place source slot refuses the take");
+                                result = 1;
+                                break;
+                            }
                             source_stack.decrement(count);
                             consume_created_output_source(
                                 source.container_name.container_name,
@@ -1401,7 +1424,7 @@ impl BedrockClient {
                                 &*screen_handler,
                             )
                             .await;
-                            let source_stack = if source_stack.is_empty() {
+                            let source_stack = if source_stack.is_empty() || source_uses_mirror {
                                 ItemStack::EMPTY.clone()
                             } else {
                                 source_stack
@@ -1439,13 +1462,6 @@ impl BedrockClient {
                         }
                     }
                     ItemStackRequestAction::Swap { slot1, slot2 } => {
-                        // Preview/result containers are not free-item sources.
-                        if is_result_preview_container(slot1.container_name.container_name)
-                            || is_result_preview_container(slot2.container_name.container_name)
-                        {
-                            result = 1;
-                            break;
-                        }
                         if (slot1.container_name.container_name == ContainerName::CreatedOutput
                             || slot2.container_name.container_name == ContainerName::CreatedOutput)
                             && created_item.is_none()
@@ -1458,11 +1474,34 @@ impl BedrockClient {
                         let stack2 =
                             get_slot_stack(&*screen_handler, &slot2, created_item.as_ref()).await;
 
+                        // Take-only slots (result/output) never join a swap: the
+                        // incoming half would be a free write into the result.
+                        if !destination_accepts(&*screen_handler, &slot1, &stack2).await
+                            || !destination_accepts(&*screen_handler, &slot2, &stack1).await
+                        {
+                            result = 1;
+                            break;
+                        }
+
+                        // Mirror flags must be captured before any consumption.
+                        let slot1_uses_mirror =
+                            is_cursor_mirror(&*screen_handler, &slot1, created_item.as_ref()).await;
+                        let slot2_uses_mirror =
+                            is_cursor_mirror(&*screen_handler, &slot2, created_item.as_ref()).await;
+
                         // Moving CreatedOutput into inventory must spend the craft.
                         if slot1.container_name.container_name == ContainerName::CreatedOutput {
                             consume_created_item(&mut created_item, stack1.item_count);
                         }
                         if slot2.container_name.container_name == ContainerName::CreatedOutput {
+                            consume_created_item(&mut created_item, stack2.item_count);
+                        }
+                        // A Cursor side backed by the created-item mirror spends the
+                        // mirror exactly like a CreatedOutput source.
+                        if slot1_uses_mirror {
+                            consume_created_item(&mut created_item, stack1.item_count);
+                        }
+                        if slot2_uses_mirror {
                             consume_created_item(&mut created_item, stack2.item_count);
                         }
 
@@ -1491,16 +1530,15 @@ impl BedrockClient {
                         source,
                         randomly: _,
                     } => {
-                        if is_result_preview_container(source.container_name.container_name) {
-                            result = 1;
-                            break;
-                        }
                         if source.container_name.container_name == ContainerName::CreatedOutput
                             && created_item.is_none()
                         {
                             result = 1;
                             break;
                         }
+                        let source_uses_mirror =
+                            is_cursor_mirror(&*screen_handler, &source, created_item.as_ref())
+                                .await;
                         let mut source_stack =
                             get_slot_stack(&*screen_handler, &source, created_item.as_ref()).await;
                         if source_stack.is_empty() {
@@ -1510,6 +1548,20 @@ impl BedrockClient {
                         let count = count.min(source_stack.item_count);
                         if count > 0 {
                             let dropped_stack = source_stack.copy_with_count(count);
+                            // A take from a take-only slot is settled through the
+                            // slot itself exactly once (grid use, trade cost, XP),
+                            // and only a settled take may be dropped.
+                            if !charge_take_only_source(
+                                player.as_ref(),
+                                &*screen_handler,
+                                &source,
+                                &dropped_stack,
+                            )
+                            .await
+                            {
+                                result = 1;
+                                break;
+                            }
                             player.drop_item(dropped_stack).await;
 
                             source_stack.decrement(count);
@@ -1520,7 +1572,7 @@ impl BedrockClient {
                                 &*screen_handler,
                             )
                             .await;
-                            let source_stack = if source_stack.is_empty() {
+                            let source_stack = if source_stack.is_empty() || source_uses_mirror {
                                 ItemStack::EMPTY.clone()
                             } else {
                                 source_stack
@@ -1545,16 +1597,15 @@ impl BedrockClient {
                     }
                     ItemStackRequestAction::Destroy { count, source }
                     | ItemStackRequestAction::Consume { count, source } => {
-                        if is_result_preview_container(source.container_name.container_name) {
-                            result = 1;
-                            break;
-                        }
                         if source.container_name.container_name == ContainerName::CreatedOutput
                             && created_item.is_none()
                         {
                             result = 1;
                             break;
                         }
+                        let source_uses_mirror =
+                            is_cursor_mirror(&*screen_handler, &source, created_item.as_ref())
+                                .await;
                         let mut source_stack =
                             get_slot_stack(&*screen_handler, &source, created_item.as_ref()).await;
                         if source_stack.is_empty() {
@@ -1563,6 +1614,20 @@ impl BedrockClient {
                         }
                         let count = count.min(source_stack.item_count);
                         if count > 0 {
+                            let consumed_stack = source_stack.copy_with_count(count);
+                            // A take from a take-only slot is settled through the
+                            // slot itself exactly once (grid use, trade cost, XP).
+                            if !charge_take_only_source(
+                                player.as_ref(),
+                                &*screen_handler,
+                                &source,
+                                &consumed_stack,
+                            )
+                            .await
+                            {
+                                result = 1;
+                                break;
+                            }
                             source_stack.decrement(count);
                             consume_created_output_source(
                                 source.container_name.container_name,
@@ -1571,7 +1636,7 @@ impl BedrockClient {
                                 &*screen_handler,
                             )
                             .await;
-                            let source_stack = if source_stack.is_empty() {
+                            let source_stack = if source_stack.is_empty() || source_uses_mirror {
                                 ItemStack::EMPTY.clone()
                             } else {
                                 source_stack
@@ -1607,9 +1672,7 @@ impl BedrockClient {
                         // open window would treat slots[0] as "output" and mint
                         // free stacks from chest/etc contents.
                         let window_type = screen_handler.window_type();
-                        let is_crafting_screen = window_type.is_none()
-                            || window_type == Some(pumpkin_data::screen::WindowType::Crafting);
-                        if !is_crafting_screen {
+                        if !window_allows_craft_recipe(window_type) {
                             tracing::debug!(
                                 "Reject CraftRecipe on non-crafting window {:?}",
                                 window_type
@@ -1952,21 +2015,94 @@ impl BedrockClient {
     }
 }
 
-/// Display-only result previews must never be move *sources* — they map to the
-/// real result slot and would mint free items without consumption.
-const fn is_result_preview_container(name: ContainerName) -> bool {
+/// Only the 2×2 player craft and 3×3 crafting table may run `CraftRecipe`.
+/// Any other open window would treat slots[0] as "output" and mint free
+/// stacks from chest/etc contents.
+const fn window_allows_craft_recipe(window_type: Option<pumpkin_data::screen::WindowType>) -> bool {
     matches!(
-        name,
-        ContainerName::CraftingOutputPreview
-            | ContainerName::AnvilResultPreview
-            | ContainerName::SmithingTableResultPreview
-            | ContainerName::TradeResultPreview
-            | ContainerName::Trade2ResultPreview
-            | ContainerName::LoomResultPreview
-            | ContainerName::GrindstoneResultPreview
-            | ContainerName::StonecutterResultPreview
-            | ContainerName::CartographyResultPreview
+        window_type,
+        None | Some(pumpkin_data::screen::WindowType::Crafting)
     )
+}
+
+/// True when a `Cursor` reference is served by the created-item mirror: the
+/// physical cursor is empty while a crafted stack is still tracked. Mirror
+/// reads are spent from `created_item`, and the remainder must never be
+/// written back into the physical cursor — it lives in exactly one place.
+async fn is_cursor_mirror(
+    screen_handler: &dyn ScreenHandler,
+    slot_info: &pumpkin_protocol::bedrock::server::item_stack_request::ItemStackRequestSlotInfo,
+    created_item: Option<&ItemStack>,
+) -> bool {
+    slot_info.container_name.container_name == ContainerName::Cursor
+        && created_item.is_some()
+        && screen_handler
+            .get_behaviour()
+            .cursor_stack
+            .lock()
+            .await
+            .is_empty()
+}
+
+/// Destination resolution for moves. The created-item mirror is a virtual
+/// craft remainder, never a merge base, so destinations read physical
+/// state only.
+async fn get_destination_slot_stack(
+    screen_handler: &dyn ScreenHandler,
+    slot_info: &pumpkin_protocol::bedrock::server::item_stack_request::ItemStackRequestSlotInfo,
+) -> ItemStack {
+    get_slot_stack(screen_handler, slot_info, None).await
+}
+
+/// Whether a move destination may receive the given stack. Virtual or
+/// unmapped containers accept the write-back as a no-op; a resolved slot
+/// that refuses inserts (result/output slots) rejects the move so results
+/// can never be written into for free.
+async fn destination_accepts(
+    screen_handler: &dyn ScreenHandler,
+    slot_info: &pumpkin_protocol::bedrock::server::item_stack_request::ItemStackRequestSlotInfo,
+    stack: &ItemStack,
+) -> bool {
+    if let Some(screen_slot) = map_bedrock_container_slot(
+        screen_handler,
+        slot_info.container_name.container_name,
+        slot_info.slot_id,
+    ) {
+        return screen_handler.get_behaviour().slots[screen_slot]
+            .can_insert(stack)
+            .await;
+    }
+    true
+}
+
+/// Settles a take from a resolved slot through the slot itself, exactly once
+/// per verified take. A slot that refuses re-insertion of the stack taken
+/// from it is take-only (result/output); its `on_take_item` performs the
+/// consumption/charging (crafting grid use, trade cost, furnace XP).
+/// Ordinary inventory slots accept the stack back and need no settlement.
+/// Returns false when the slot currently refuses the take.
+async fn charge_take_only_source(
+    player: &dyn InventoryPlayer,
+    screen_handler: &dyn ScreenHandler,
+    slot_info: &pumpkin_protocol::bedrock::server::item_stack_request::ItemStackRequestSlotInfo,
+    taken_stack: &ItemStack,
+) -> bool {
+    let Some(screen_slot) = map_bedrock_container_slot(
+        screen_handler,
+        slot_info.container_name.container_name,
+        slot_info.slot_id,
+    ) else {
+        return true;
+    };
+    let slot = &screen_handler.get_behaviour().slots[screen_slot];
+    if slot.can_insert(taken_stack).await {
+        return true;
+    }
+    if !slot.can_take_items(player).await {
+        return false;
+    }
+    slot.on_take_item(player, taken_stack).await;
+    true
 }
 
 fn consume_created_item(created_item: &mut Option<ItemStack>, count: u8) {
@@ -2067,7 +2203,8 @@ fn map_bedrock_container_slot(
                 None
             }
         }
-        // Previews map for write-back/display only; get_slot_stack refuses them as free sources.
+        // Previews resolve to the real result slot; takes from them are
+        // settled through the slot's on_take_item, never served free.
         ContainerName::CraftingOutputPreview => (is_player_screen
             || screen_handler.window_type() == Some(pumpkin_data::screen::WindowType::Crafting))
         .then_some(0),
@@ -2288,10 +2425,9 @@ async fn get_slot_stack(
             .cloned()
             .unwrap_or_else(|| ItemStack::EMPTY.clone());
     }
-    // Result previews are display-only as *sources* — never copy real results free.
-    if is_result_preview_container(name) {
-        return ItemStack::EMPTY.clone();
-    }
+    // Cursor reads fall back to the created-item mirror when the physical
+    // cursor is empty. Callers spending a mirror read must consume it (see
+    // is_cursor_mirror); destination reads must use get_destination_slot_stack.
     if name == ContainerName::Cursor {
         let cursor_lock = screen_handler.get_behaviour().cursor_stack.lock().await;
         if cursor_lock.is_empty()
@@ -2301,6 +2437,8 @@ async fn get_slot_stack(
         }
         return cursor_lock.clone();
     }
+    // Result previews resolve to the real result slot; takes from such a
+    // slot are settled through charge_take_only_source, never served free.
     if let Some(screen_slot) = map_bedrock_container_slot(screen_handler, name, slot_info.slot_id) {
         screen_handler.get_behaviour().slots[screen_slot]
             .get_cloned_stack()
@@ -2365,27 +2503,244 @@ async fn update_slot_stack(
 
 #[cfg(test)]
 mod hardening_tests {
+    //! Exploit-sequence tests for Bedrock item-move authority. A full packet
+    //! round-trip needs a live `Server`/`Player`, so each test composes the
+    //! exact helpers the request arms use, in the same order; `update_slot_stack`'s
+    //! Cursor branch is a plain cursor write and is mirrored directly. Every
+    //! sequence is traced from the reviews' exploit reports.
     use super::*;
+    use pumpkin_data::item::Item;
+    use pumpkin_data::screen::WindowType;
+    use pumpkin_data::statistic::StatisticCategory;
+    use pumpkin_inventory::crafting::crafting_inventory::CraftingInventory;
+    use pumpkin_inventory::crafting::crafting_screen_handler::ResultSlot;
+    use pumpkin_inventory::crafting::recipes::RecipeInputInventory;
+    use pumpkin_inventory::entity_equipment::EntityEquipment;
+    use pumpkin_inventory::player::player_inventory::PlayerInventory;
+    use pumpkin_inventory::screen_handler::{
+        ItemStackFuture, PlayerFuture, ScreenHandlerBehaviour,
+    };
+    use pumpkin_inventory::slot::{BoxFuture, NormalSlot, TakeOnlySlot};
+    use pumpkin_protocol::bedrock::server::item_stack_request::ItemStackRequestSlotInfo;
+    use pumpkin_protocol::java::client::play::{
+        CSetContainerContent, CSetContainerProperty, CSetContainerSlot, CSetCursorItem,
+        CSetPlayerInventory,
+    };
+    use pumpkin_world::inventory::SimpleInventory;
+    use std::any::Any;
+    use std::collections::HashMap;
+    use std::sync::atomic::AtomicU8;
+    use tokio::sync::Mutex;
 
-    #[test]
-    fn result_preview_containers_are_flagged() {
-        assert!(is_result_preview_container(
-            ContainerName::CraftingOutputPreview
-        ));
-        assert!(is_result_preview_container(
-            ContainerName::AnvilResultPreview
-        ));
-        assert!(is_result_preview_container(
-            ContainerName::TradeResultPreview
-        ));
-        assert!(!is_result_preview_container(ContainerName::CreatedOutput));
-        assert!(!is_result_preview_container(ContainerName::HotBar));
-        assert!(!is_result_preview_container(ContainerName::FurnaceResult));
+    struct MockScreenHandler {
+        behaviour: ScreenHandlerBehaviour,
+    }
+
+    impl MockScreenHandler {
+        fn new(window_type: Option<WindowType>, container_slots: usize) -> Self {
+            let mut behaviour = ScreenHandlerBehaviour::new(1, window_type);
+            behaviour.container_slots = container_slots;
+            Self { behaviour }
+        }
+    }
+
+    impl ScreenHandler for MockScreenHandler {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+        fn get_behaviour(&self) -> &ScreenHandlerBehaviour {
+            &self.behaviour
+        }
+        fn get_behaviour_mut(&mut self) -> &mut ScreenHandlerBehaviour {
+            &mut self.behaviour
+        }
+        fn quick_move<'a>(
+            &'a mut self,
+            _player: &'a dyn InventoryPlayer,
+            _slot_index: i32,
+        ) -> ItemStackFuture<'a> {
+            Box::pin(async { ItemStack::EMPTY.clone() })
+        }
+    }
+
+    struct MockInventoryPlayer {
+        inventory: Arc<PlayerInventory>,
+    }
+
+    impl MockInventoryPlayer {
+        fn new() -> Self {
+            Self {
+                inventory: Arc::new(PlayerInventory::new(
+                    Arc::new(Mutex::new(EntityEquipment::new())),
+                    Arc::new(HashMap::new()),
+                )),
+            }
+        }
+    }
+
+    impl InventoryPlayer for MockInventoryPlayer {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn drop_item(&self, _item: ItemStack, _retain_ownership: bool) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+        fn get_inventory(&self) -> Arc<PlayerInventory> {
+            self.inventory.clone()
+        }
+        fn has_infinite_materials(&self) -> bool {
+            false
+        }
+        fn is_creative(&self) -> bool {
+            false
+        }
+        fn experience_level(&self) -> i32 {
+            0
+        }
+        fn add_experience_levels(&self, _levels: i32) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+        fn enchantment_seed(&self) -> i32 {
+            0
+        }
+        fn set_enchantment_seed(&self, _seed: i32) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+        fn enqueue_inventory_packet<'a>(
+            &'a self,
+            _packet: &'a CSetContainerContent,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+        fn enqueue_slot_packet<'a>(
+            &'a self,
+            _packet: &'a CSetContainerSlot,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+        fn enqueue_cursor_packet<'a>(
+            &'a self,
+            _packet: &'a CSetCursorItem,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+        fn enqueue_property_packet<'a>(
+            &'a self,
+            _packet: &'a CSetContainerProperty,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+        fn enqueue_slot_set_packet<'a>(
+            &'a self,
+            _packet: &'a CSetPlayerInventory,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+        fn enqueue_set_held_item_packet<'a>(
+            &'a self,
+            _packet: &'a CSetSelectedSlot,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+        fn enqueue_equipment_change<'a>(
+            &'a self,
+            _slot: &'a EquipmentSlot,
+            _stack: &'a ItemStack,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+        fn award_experience(&self, _amount: i32) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+        fn increment_stat(
+            &self,
+            _category: StatisticCategory,
+            _stat_id: i32,
+            _amount: i32,
+        ) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+    }
+
+    /// Slot that records every `on_take_item` call; `accepts_insert` models
+    /// normal vs take-only (result/output) slots.
+    struct RecordingSlot {
+        inventory: Arc<SimpleInventory>,
+        index: usize,
+        id: AtomicU8,
+        accepts_insert: bool,
+        can_take: bool,
+        taken: Arc<Mutex<Vec<ItemStack>>>,
+    }
+
+    impl RecordingSlot {
+        fn new(
+            inventory: Arc<SimpleInventory>,
+            index: usize,
+            accepts_insert: bool,
+            can_take: bool,
+            taken: Arc<Mutex<Vec<ItemStack>>>,
+        ) -> Self {
+            Self {
+                inventory,
+                index,
+                id: AtomicU8::new(0),
+                accepts_insert,
+                can_take,
+                taken,
+            }
+        }
+    }
+
+    impl Slot for RecordingSlot {
+        fn get_inventory(&self) -> Arc<dyn Inventory> {
+            self.inventory.clone()
+        }
+        fn get_index(&self) -> usize {
+            self.index
+        }
+        fn set_id(&self, index: usize) {
+            self.id.store(index as u8, Ordering::Relaxed);
+        }
+        fn can_insert<'a>(&'a self, _stack: &'a ItemStack) -> BoxFuture<'a, bool> {
+            let accepts = self.accepts_insert;
+            Box::pin(async move { accepts })
+        }
+        fn can_take_items(&self, _player: &dyn InventoryPlayer) -> BoxFuture<'_, bool> {
+            let can_take = self.can_take;
+            Box::pin(async move { can_take })
+        }
+        fn on_take_item<'a>(
+            &'a self,
+            _player: &'a dyn InventoryPlayer,
+            stack: &'a ItemStack,
+        ) -> BoxFuture<'a, ()> {
+            Box::pin(async move {
+                self.taken.lock().await.push(stack.clone());
+            })
+        }
+        fn mark_dirty(&self) -> BoxFuture<'_, ()> {
+            Box::pin(async {})
+        }
+    }
+
+    fn make_slot_info(name: ContainerName, slot_id: u8) -> ItemStackRequestSlotInfo {
+        ItemStackRequestSlotInfo {
+            container_name: FullContainerName {
+                container_name: name,
+                dynamic_id: None,
+            },
+            slot_id,
+            stack_id: VarInt(0),
+        }
     }
 
     #[test]
     fn consume_created_item_clears_when_empty() {
-        let mut created = Some(ItemStack::new(3, &pumpkin_data::item::Item::EMERALD));
+        let mut created = Some(ItemStack::new(3, &Item::EMERALD));
         consume_created_item(&mut created, 2);
         assert_eq!(created.as_ref().unwrap().item_count, 1);
         consume_created_item(&mut created, 1);
@@ -2393,5 +2748,304 @@ mod hardening_tests {
         // No panic when already none
         consume_created_item(&mut created, 5);
         assert!(created.is_none());
+    }
+
+    #[test]
+    fn craft_recipe_window_gate_rejects_non_crafting_windows() {
+        assert!(window_allows_craft_recipe(None));
+        assert!(window_allows_craft_recipe(Some(WindowType::Crafting)));
+        assert!(!window_allows_craft_recipe(Some(WindowType::Generic9x3)));
+        assert!(!window_allows_craft_recipe(Some(WindowType::Merchant)));
+        assert!(!window_allows_craft_recipe(Some(WindowType::Anvil)));
+    }
+
+    /// Sequence: [CraftRecipe{1}, Take{src=CreatedOutput, dst=Cursor, count=4}]
+    /// on a 4-output craft must leave cursor=4 and created=0, not cursor=8.
+    #[tokio::test]
+    async fn cursor_mirror_take_to_cursor_does_not_double() {
+        let handler = MockScreenHandler::new(None, 0);
+        let mut created = Some(ItemStack::new(4, &Item::STICK));
+        let source = make_slot_info(ContainerName::CreatedOutput, 0);
+        let destination = make_slot_info(ContainerName::Cursor, 0);
+
+        // Arm flow: source read sees the tracked craft...
+        let source_stack = get_slot_stack(&handler, &source, created.as_ref()).await;
+        assert_eq!(source_stack.item_count, 4);
+        // ...but the destination must resolve to physical state only.
+        let mut dest_stack = get_destination_slot_stack(&handler, &destination).await;
+        assert!(
+            dest_stack.is_empty(),
+            "created-item mirror must never be a destination merge base"
+        );
+        dest_stack = source_stack.copy_with_count(4);
+        consume_created_output_source(ContainerName::CreatedOutput, 4, &mut created, &handler)
+            .await;
+        // update_slot_stack's Cursor branch is a plain physical write.
+        *handler.get_behaviour().cursor_stack.lock().await = dest_stack;
+
+        assert!(created.is_none(), "craft spent exactly once");
+        let cursor = handler.get_behaviour().cursor_stack.lock().await;
+        assert_eq!(cursor.item_count, 4, "no 4->8 cursor doubling");
+        assert_eq!(cursor.item.id, Item::STICK.id);
+    }
+
+    /// Sequence: [CraftRecipe{1}, Swap{slot1=Cursor, slot2=Inventory}] — the
+    /// mirror read must spend `created_item` exactly once.
+    #[tokio::test]
+    async fn cursor_mirror_swap_spends_created_once() {
+        let inventory = Arc::new(SimpleInventory::new(36));
+        inventory
+            .set_stack(9, ItemStack::new(2, &Item::DIAMOND))
+            .await;
+        let mut handler = MockScreenHandler::new(None, 0);
+        for i in 0..10 {
+            handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), i)));
+        }
+        let mut created = Some(ItemStack::new(4, &Item::STICK));
+        let slot1 = make_slot_info(ContainerName::Cursor, 0);
+        let slot2 = make_slot_info(ContainerName::Inventory, 9);
+
+        let stack1 = get_slot_stack(&handler, &slot1, created.as_ref()).await;
+        let stack2 = get_slot_stack(&handler, &slot2, created.as_ref()).await;
+        assert_eq!(stack1.item_count, 4, "Cursor source reads the mirror");
+        assert_eq!(stack2.item_count, 2);
+        assert!(is_cursor_mirror(&handler, &slot1, created.as_ref()).await);
+        assert!(!is_cursor_mirror(&handler, &slot2, created.as_ref()).await);
+
+        // Arm flow: a mirror-backed Cursor side spends the craft.
+        consume_created_item(&mut created, stack1.item_count);
+        *handler.get_behaviour().cursor_stack.lock().await = stack2;
+        handler.get_behaviour().slots[9].set_stack(stack1).await;
+
+        assert!(created.is_none(), "mirror consumed exactly once");
+        assert_eq!(
+            handler.get_behaviour().cursor_stack.lock().await.item_count,
+            2
+        );
+        assert_eq!(
+            handler.get_behaviour().slots[9]
+                .get_cloned_stack()
+                .await
+                .item_count,
+            4
+        );
+    }
+
+    /// Sequence: [CraftRecipe{1}, Take{src=Cursor, dst=Inventory, count=2}]
+    /// with the physical cursor empty — the remainder must stay tracked in
+    /// exactly one place (`created_item`), not both mirror and cursor.
+    #[tokio::test]
+    async fn cursor_mirror_partial_take_leaves_single_remainder() {
+        let handler = MockScreenHandler::new(None, 0);
+        let mut created = Some(ItemStack::new(4, &Item::STICK));
+        let source = make_slot_info(ContainerName::Cursor, 0);
+
+        assert!(is_cursor_mirror(&handler, &source, created.as_ref()).await);
+        let source_stack = get_slot_stack(&handler, &source, created.as_ref()).await;
+        assert_eq!(source_stack.item_count, 4, "mirror read while cursor empty");
+
+        // Arm flow: take 2, spend the mirror, write nothing back to the cursor.
+        consume_created_output_source(ContainerName::Cursor, 2, &mut created, &handler).await;
+        *handler.get_behaviour().cursor_stack.lock().await = ItemStack::EMPTY.clone();
+
+        assert_eq!(
+            created.as_ref().unwrap().item_count,
+            2,
+            "remainder stays in created_item only"
+        );
+        assert!(
+            handler.get_behaviour().cursor_stack.lock().await.is_empty(),
+            "remainder must not materialize in the physical cursor"
+        );
+        // A follow-up Cursor read still resolves through the mirror.
+        let next = get_slot_stack(&handler, &source, created.as_ref()).await;
+        assert_eq!(next.item_count, 2);
+    }
+
+    /// Sequence: Take{src=CraftingOutputPreview, dst=Inventory} on a crafting
+    /// table — resolves to the real result slot, consumes the grid, and does
+    /// not refill for free.
+    #[tokio::test]
+    async fn preview_take_consumes_grid_without_free_refill() {
+        let player = MockInventoryPlayer::new();
+        let crafting_inv = Arc::new(CraftingInventory::new(3, 3));
+        // Stick recipe input: two planks in one column.
+        crafting_inv
+            .set_stack(0, ItemStack::new(1, &Item::OAK_PLANKS))
+            .await;
+        crafting_inv
+            .set_stack(3, ItemStack::new(1, &Item::OAK_PLANKS))
+            .await;
+        let recipe_inv: Arc<dyn RecipeInputInventory> = crafting_inv.clone();
+        let result = Arc::new(Mutex::new(ItemStack::new(4, &Item::STICK)));
+        let result_slot = Arc::new(ResultSlot {
+            inventory: recipe_inv,
+            id: AtomicU8::new(0),
+            result: result.clone(),
+            recipe_provider: None,
+        });
+        let mut handler = MockScreenHandler::new(Some(WindowType::Crafting), 10);
+        handler.add_slot(result_slot);
+
+        let source = make_slot_info(ContainerName::CraftingOutputPreview, 0);
+        // Previews resolve to the real result slot (previously rejected/empty).
+        let source_stack = get_slot_stack(&handler, &source, None).await;
+        assert_eq!(source_stack.item_count, 4);
+        assert_eq!(source_stack.item.id, Item::STICK.id);
+        // ...and the result slot refuses moves into it.
+        assert!(!destination_accepts(&handler, &source, &source_stack).await);
+
+        // Arm flow: the take is settled through the slot exactly once.
+        let taken = source_stack.copy_with_count(4);
+        assert!(charge_take_only_source(&player, &handler, &source, &taken).await);
+
+        for i in 0..crafting_inv.size() {
+            assert!(
+                crafting_inv.get_stack(i).await.lock().await.is_empty(),
+                "grid slot {i} must be consumed by the take"
+            );
+        }
+        assert!(
+            result.lock().await.is_empty(),
+            "result re-derives to empty instead of refilling for free"
+        );
+    }
+
+    /// Take-only sources are charged via `on_take_item` exactly once; ordinary
+    /// slots are not charged; a slot refusing the take rejects the move.
+    #[tokio::test]
+    async fn take_only_source_charged_exactly_once() {
+        let player = MockInventoryPlayer::new();
+        let inventory = Arc::new(SimpleInventory::new(3));
+        inventory
+            .set_stack(2, ItemStack::new(1, &Item::DIAMOND))
+            .await;
+        let mut handler = MockScreenHandler::new(Some(WindowType::Anvil), 3);
+        handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 0)));
+        handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 1)));
+        handler.add_slot(Arc::new(TakeOnlySlot::new(inventory.clone(), 2)));
+
+        // Previews resolve to the real take-only result slot (previously empty).
+        let source = make_slot_info(ContainerName::AnvilResultPreview, 0);
+        let stack = get_slot_stack(&handler, &source, None).await;
+        assert_eq!(
+            stack.item.id,
+            Item::DIAMOND.id,
+            "preview resolves to result"
+        );
+        assert!(!destination_accepts(&handler, &source, &stack).await);
+        assert!(charge_take_only_source(&player, &handler, &source, &stack).await);
+
+        // A take-only slot that allows the take charges exactly once.
+        let taken_log = Arc::new(Mutex::new(Vec::new()));
+        let mut handler2 = MockScreenHandler::new(Some(WindowType::Anvil), 3);
+        handler2.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 0)));
+        handler2.add_slot(Arc::new(NormalSlot::new(inventory.clone(), 1)));
+        handler2.add_slot(Arc::new(RecordingSlot::new(
+            inventory.clone(),
+            2,
+            false,
+            true,
+            taken_log.clone(),
+        )));
+        let source2 = make_slot_info(ContainerName::AnvilResultPreview, 0);
+        let stack2 = get_slot_stack(&handler2, &source2, None).await;
+        assert!(charge_take_only_source(&player, &handler2, &source2, &stack2).await);
+        assert_eq!(taken_log.lock().await.len(), 1, "exactly one charge");
+
+        // A take-only slot that refuses the take rejects the move, uncharged.
+        let refused_log = Arc::new(Mutex::new(Vec::new()));
+        let mut handler3 = MockScreenHandler::new(Some(WindowType::Anvil), 3);
+        handler3.add_slot(Arc::new(RecordingSlot::new(
+            inventory.clone(),
+            0,
+            false,
+            false,
+            refused_log.clone(),
+        )));
+        let source3 = make_slot_info(ContainerName::AnvilInput, 0);
+        let stack3 = get_slot_stack(&handler3, &source3, None).await;
+        assert!(!charge_take_only_source(&player, &handler3, &source3, &stack3).await);
+        assert!(
+            refused_log.lock().await.is_empty(),
+            "refused take never charges"
+        );
+
+        // Ordinary inventory slots are not charged through the slot at all.
+        let normal_log = Arc::new(Mutex::new(Vec::new()));
+        let mut handler4 = MockScreenHandler::new(Some(WindowType::Anvil), 3);
+        handler4.add_slot(Arc::new(RecordingSlot::new(
+            inventory.clone(),
+            0,
+            true,
+            true,
+            normal_log.clone(),
+        )));
+        assert!(
+            charge_take_only_source(&player, &handler4, &source3, &stack3).await,
+            "ordinary slot allows the take"
+        );
+        assert!(
+            normal_log.lock().await.is_empty(),
+            "ordinary slot not charged"
+        );
+    }
+
+    /// Misroute guard: with `container_slots == 0` an `Inventory` source slot 9
+    /// resolves to screen slot 0; if that slot is take-only the take must be
+    /// settled through `on_take_item` — never served free (belt-and-suspenders
+    /// while per-screen `container_slots` values are fixed in pumpkin-inventory).
+    #[tokio::test]
+    async fn misrouted_take_only_source_is_charged_not_free() {
+        let player = MockInventoryPlayer::new();
+        let inventory = Arc::new(SimpleInventory::new(46));
+        inventory
+            .set_stack(0, ItemStack::new(4, &Item::STICK))
+            .await;
+        let taken_log = Arc::new(Mutex::new(Vec::new()));
+        let mut handler = MockScreenHandler::new(Some(WindowType::Crafting), 0);
+        handler.add_slot(Arc::new(RecordingSlot::new(
+            inventory.clone(),
+            0,
+            false,
+            true,
+            taken_log.clone(),
+        )));
+        for i in 1..46 {
+            handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), i)));
+        }
+
+        let source = make_slot_info(ContainerName::Inventory, 9);
+        let stack = get_slot_stack(&handler, &source, None).await;
+        assert_eq!(stack.item_count, 4, "misroute resolves to screen slot 0");
+        assert!(!destination_accepts(&handler, &source, &stack).await);
+        assert!(charge_take_only_source(&player, &handler, &source, &stack).await);
+        assert_eq!(taken_log.lock().await.len(), 1, "settled through the slot");
+    }
+
+    /// `CreatedOutput` without a tracked craft must resolve empty (arms reject).
+    #[tokio::test]
+    async fn created_output_without_tracked_craft_is_empty() {
+        let handler = MockScreenHandler::new(None, 0);
+        let source = make_slot_info(ContainerName::CreatedOutput, 0);
+        assert!(get_slot_stack(&handler, &source, None).await.is_empty());
+    }
+
+    /// Offhand/armor names on small screens must stay in range (no panic).
+    #[tokio::test]
+    async fn offhand_and_armor_on_small_screen_stay_in_range() {
+        let inventory = Arc::new(SimpleInventory::new(5));
+        let mut handler = MockScreenHandler::new(None, 0);
+        for i in 0..5 {
+            handler.add_slot(Arc::new(NormalSlot::new(inventory.clone(), i)));
+        }
+        let offhand = make_slot_info(ContainerName::Offhand, 0);
+        assert!(get_slot_stack(&handler, &offhand, None).await.is_empty());
+        let armor = make_slot_info(ContainerName::Armor, 3);
+        assert!(get_slot_stack(&handler, &armor, None).await.is_empty());
+
+        // On non-player screens Offhand never resolves at all.
+        let anvil = MockScreenHandler::new(Some(WindowType::Anvil), 3);
+        assert!(get_slot_stack(&anvil, &offhand, None).await.is_empty());
     }
 }

--- a/pumpkin/src/net/bedrock/play.rs
+++ b/pumpkin/src/net/bedrock/play.rs
@@ -10,6 +10,7 @@ use pumpkin_data::{
     item_stack::ItemStack,
 };
 use pumpkin_inventory::screen_handler::{InventoryPlayer, ScreenHandler};
+use pumpkin_inventory::slot::Slot;
 use pumpkin_macros::send_cancellable;
 use pumpkin_protocol::bedrock::{
     client::inventory_content::CInventoryContent,
@@ -765,15 +766,19 @@ impl BedrockClient {
                         }
                     }
                 } else if data.action_type.0 == 1 {
-                    // Click air / Use item
+                    // Click air / Use item. Same rule as click-block: never adopt
+                    // client item_in_hand in survival.
                     let is_creative = player.gamemode.load() == GameMode::Creative;
-                    let client_stack = descriptor_to_stack(&data.item_in_hand, is_creative);
-
                     let held_item = player.inventory.held_item();
-                    if !client_stack.is_empty() {
-                        let mut server_stack = held_item.lock().await;
-                        if server_stack.is_empty() || server_stack.item.id != client_stack.item.id {
-                            *server_stack = client_stack.clone();
+                    if is_creative {
+                        let client_stack = descriptor_to_stack(&data.item_in_hand, true);
+                        if !client_stack.is_empty() {
+                            let mut server_stack = held_item.lock().await;
+                            if server_stack.is_empty()
+                                || server_stack.item.id != client_stack.item.id
+                            {
+                                *server_stack = client_stack;
+                            }
                         }
                     }
 
@@ -1270,6 +1275,8 @@ impl BedrockClient {
         };
         use pumpkin_protocol::bedrock::server::item_stack_request::ItemStackRequestAction;
 
+        const MAX_CRAFT_REPETITIONS: u8 = 64;
+
         let current_screen_handler = player.current_screen_handler.lock().await.clone();
         let mut screen_handler = current_screen_handler.lock().await;
 
@@ -1347,9 +1354,11 @@ impl BedrockClient {
                         source,
                         destination,
                     } => {
-                        // CreatedOutput is only valid after a craft action set
-                        // `created_item`. Mapping it to the real result slot lets
-                        // clients copy craft output without consuming the grid.
+                        if is_result_preview_container(source.container_name.container_name) {
+                            tracing::debug!("Reject Take/Place from result preview container");
+                            result = 1;
+                            break;
+                        }
                         if source.container_name.container_name == ContainerName::CreatedOutput
                             && created_item.is_none()
                         {
@@ -1359,7 +1368,7 @@ impl BedrockClient {
                         }
                         let mut source_stack =
                             get_slot_stack(&*screen_handler, &source, created_item.as_ref()).await;
-                        if source_stack.is_empty() && created_item.is_none() {
+                        if source_stack.is_empty() {
                             tracing::debug!("Source stack is empty in Take/Place");
                             result = 1;
                             break;
@@ -1385,29 +1394,13 @@ impl BedrockClient {
                             }
 
                             source_stack.decrement(count);
-                            if source.container_name.container_name == ContainerName::CreatedOutput
-                            {
-                                if let Some(ref mut stack) = created_item {
-                                    stack.decrement(count);
-                                    if stack.is_empty() {
-                                        created_item = None;
-                                    }
-                                }
-                            } else if source.container_name.container_name == ContainerName::Cursor
-                            {
-                                let cursor_is_empty = screen_handler
-                                    .get_behaviour()
-                                    .cursor_stack
-                                    .lock()
-                                    .await
-                                    .is_empty();
-                                if cursor_is_empty && let Some(ref mut stack) = created_item {
-                                    stack.decrement(count);
-                                    if stack.is_empty() {
-                                        created_item = None;
-                                    }
-                                }
-                            }
+                            consume_created_output_source(
+                                source.container_name.container_name,
+                                count,
+                                &mut created_item,
+                                &*screen_handler,
+                            )
+                            .await;
                             let source_stack = if source_stack.is_empty() {
                                 ItemStack::EMPTY.clone()
                             } else {
@@ -1446,10 +1439,32 @@ impl BedrockClient {
                         }
                     }
                     ItemStackRequestAction::Swap { slot1, slot2 } => {
+                        // Preview/result containers are not free-item sources.
+                        if is_result_preview_container(slot1.container_name.container_name)
+                            || is_result_preview_container(slot2.container_name.container_name)
+                        {
+                            result = 1;
+                            break;
+                        }
+                        if (slot1.container_name.container_name == ContainerName::CreatedOutput
+                            || slot2.container_name.container_name == ContainerName::CreatedOutput)
+                            && created_item.is_none()
+                        {
+                            result = 1;
+                            break;
+                        }
                         let stack1 =
                             get_slot_stack(&*screen_handler, &slot1, created_item.as_ref()).await;
                         let stack2 =
                             get_slot_stack(&*screen_handler, &slot2, created_item.as_ref()).await;
+
+                        // Moving CreatedOutput into inventory must spend the craft.
+                        if slot1.container_name.container_name == ContainerName::CreatedOutput {
+                            consume_created_item(&mut created_item, stack1.item_count);
+                        }
+                        if slot2.container_name.container_name == ContainerName::CreatedOutput {
+                            consume_created_item(&mut created_item, stack2.item_count);
+                        }
 
                         update_slot_stack(player, &mut *screen_handler, &slot1, stack2.clone())
                             .await;
@@ -1476,6 +1491,16 @@ impl BedrockClient {
                         source,
                         randomly: _,
                     } => {
+                        if is_result_preview_container(source.container_name.container_name) {
+                            result = 1;
+                            break;
+                        }
+                        if source.container_name.container_name == ContainerName::CreatedOutput
+                            && created_item.is_none()
+                        {
+                            result = 1;
+                            break;
+                        }
                         let mut source_stack =
                             get_slot_stack(&*screen_handler, &source, created_item.as_ref()).await;
                         if source_stack.is_empty() {
@@ -1488,6 +1513,13 @@ impl BedrockClient {
                             player.drop_item(dropped_stack).await;
 
                             source_stack.decrement(count);
+                            consume_created_output_source(
+                                source.container_name.container_name,
+                                count,
+                                &mut created_item,
+                                &*screen_handler,
+                            )
+                            .await;
                             let source_stack = if source_stack.is_empty() {
                                 ItemStack::EMPTY.clone()
                             } else {
@@ -1513,6 +1545,16 @@ impl BedrockClient {
                     }
                     ItemStackRequestAction::Destroy { count, source }
                     | ItemStackRequestAction::Consume { count, source } => {
+                        if is_result_preview_container(source.container_name.container_name) {
+                            result = 1;
+                            break;
+                        }
+                        if source.container_name.container_name == ContainerName::CreatedOutput
+                            && created_item.is_none()
+                        {
+                            result = 1;
+                            break;
+                        }
                         let mut source_stack =
                             get_slot_stack(&*screen_handler, &source, created_item.as_ref()).await;
                         if source_stack.is_empty() {
@@ -1522,6 +1564,13 @@ impl BedrockClient {
                         let count = count.min(source_stack.item_count);
                         if count > 0 {
                             source_stack.decrement(count);
+                            consume_created_output_source(
+                                source.container_name.container_name,
+                                count,
+                                &mut created_item,
+                                &*screen_handler,
+                            )
+                            .await;
                             let source_stack = if source_stack.is_empty() {
                                 ItemStack::EMPTY.clone()
                             } else {
@@ -1554,38 +1603,49 @@ impl BedrockClient {
                         repetitions,
                         ..
                     } => {
-                        // Bound repetitions; each take must consume a full set of inputs.
-                        const MAX_CRAFT_REPETITIONS: u8 = 64;
+                        // Only 2×2 player craft and 3×3 crafting table. Any other
+                        // open window would treat slots[0] as "output" and mint
+                        // free stacks from chest/etc contents.
+                        let window_type = screen_handler.window_type();
+                        let is_crafting_screen = window_type.is_none()
+                            || window_type == Some(pumpkin_data::screen::WindowType::Crafting);
+                        if !is_crafting_screen {
+                            tracing::debug!(
+                                "Reject CraftRecipe on non-crafting window {:?}",
+                                window_type
+                            );
+                            result = 1;
+                            break;
+                        }
+
                         if repetitions > 0 {
                             let reps = repetitions.min(MAX_CRAFT_REPETITIONS);
                             screen_handler.update_to_client().await;
 
-                            let is_player = screen_handler.window_type().is_none();
+                            let is_player = window_type.is_none();
                             let grid_size = if is_player { 4 } else { 9 };
-                            for i in 0..grid_size {
-                                let grid_slot_index = 1 + i;
-                                let grid_slot =
-                                    screen_handler.get_behaviour().slots[grid_slot_index].clone();
-                                let grid_stack = grid_slot.get_cloned_stack().await;
-                                tracing::debug!(
-                                    "Crafting Grid slot {i} (slot index {grid_slot_index}): Item ID: {}, Count: {}",
-                                    grid_stack.item.id,
-                                    grid_stack.item_count
-                                );
+                            let slots = &screen_handler.get_behaviour().slots;
+                            // Output + full grid must exist.
+                            if slots.len() <= grid_size {
+                                result = 1;
+                                break;
                             }
 
-                            let output_slot = screen_handler.get_behaviour().slots[0].clone();
-                            let output_stack = output_slot.get_cloned_stack().await;
+                            let output_slot = slots[0].clone();
+                            // Refuse if slot 0 accepts inserts (not a craft output).
+                            if Slot::can_insert(output_slot.as_ref(), ItemStack::EMPTY).await {
+                                tracing::debug!("CraftRecipe output slot is not take-only");
+                                result = 1;
+                                break;
+                            }
 
+                            let output_stack = output_slot.get_cloned_stack().await;
                             if output_stack.is_empty() {
                                 tracing::warn!("Client tried to craft, but output slot is empty!");
                                 result = 1;
                                 break;
                             }
 
-                            // Take one craft at a time. ResultSlot::on_take_item
-                            // refills from remaining ingredients; empty result
-                            // means the grid can no longer craft.
                             let mut crafted_count: u16 = 0;
                             let expected_id = output_stack.item.id;
                             for _ in 0..reps {
@@ -1605,13 +1665,9 @@ impl BedrockClient {
                             total_crafted.item_count = crafted_count.min(u16::from(u8::MAX)) as u8;
                             created_item = Some(total_crafted);
 
-                            // Record updates for all grid slots so Bedrock client is notified of consumed ingredients!
-                            let is_player = screen_handler.window_type().is_none();
-                            let grid_size = if is_player { 4 } else { 9 };
                             for i in 0..grid_size {
                                 let grid_slot_index = 1 + i;
-                                let grid_slot =
-                                    screen_handler.get_behaviour().slots[grid_slot_index].clone();
+                                let grid_slot = slots[grid_slot_index].clone();
                                 let grid_stack = grid_slot.get_cloned_stack().await;
                                 record_update(
                                     &mut updates,
@@ -1896,6 +1952,53 @@ impl BedrockClient {
     }
 }
 
+/// Display-only result previews must never be move *sources* — they map to the
+/// real result slot and would mint free items without consumption.
+const fn is_result_preview_container(name: ContainerName) -> bool {
+    matches!(
+        name,
+        ContainerName::CraftingOutputPreview
+            | ContainerName::AnvilResultPreview
+            | ContainerName::SmithingTableResultPreview
+            | ContainerName::TradeResultPreview
+            | ContainerName::Trade2ResultPreview
+            | ContainerName::LoomResultPreview
+            | ContainerName::GrindstoneResultPreview
+            | ContainerName::StonecutterResultPreview
+            | ContainerName::CartographyResultPreview
+    )
+}
+
+fn consume_created_item(created_item: &mut Option<ItemStack>, count: u8) {
+    if let Some(stack) = created_item.as_mut() {
+        stack.decrement(count);
+        if stack.is_empty() {
+            *created_item = None;
+        }
+    }
+}
+
+async fn consume_created_output_source(
+    source_name: ContainerName,
+    count: u8,
+    created_item: &mut Option<ItemStack>,
+    screen_handler: &dyn ScreenHandler,
+) {
+    if source_name == ContainerName::CreatedOutput {
+        consume_created_item(created_item, count);
+    } else if source_name == ContainerName::Cursor {
+        let cursor_is_empty = screen_handler
+            .get_behaviour()
+            .cursor_stack
+            .lock()
+            .await
+            .is_empty();
+        if cursor_is_empty {
+            consume_created_item(created_item, count);
+        }
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 fn map_bedrock_container_slot(
     screen_handler: &dyn ScreenHandler,
@@ -1906,41 +2009,41 @@ fn map_bedrock_container_slot(
     let is_player_screen = screen_handler.window_type().is_none();
     let slot_count = screen_handler.get_behaviour().slots.len();
 
-    // Bound every mapped index so a crafted slot_id cannot panic the handler.
+    // Every mapped index is range-checked. No arm may return a raw usize.
     let in_range = |idx: usize| (idx < slot_count).then_some(idx);
 
-    match container_name {
+    let raw: Option<usize> = match container_name {
         ContainerName::HotBar => {
-            // Hotbar is always 9 slots; unbounded slot_id was a one-packet panic.
             if slot_id >= 9 {
-                return None;
-            }
-            if is_player_screen {
-                in_range(36 + slot_id as usize)
+                None
+            } else if is_player_screen {
+                Some(36 + slot_id as usize)
             } else {
-                in_range(container_slots + 27 + slot_id as usize)
+                Some(container_slots + 27 + slot_id as usize)
             }
         }
         ContainerName::Inventory | ContainerName::CombinedHotBarAndInventory => {
             if slot_id < 9 {
                 if is_player_screen {
-                    in_range(36 + slot_id as usize)
+                    Some(36 + slot_id as usize)
                 } else {
-                    in_range(container_slots + 27 + slot_id as usize)
+                    Some(container_slots + 27 + slot_id as usize)
                 }
             } else if slot_id < 36 {
                 if is_player_screen {
-                    in_range(slot_id as usize)
+                    Some(slot_id as usize)
                 } else {
-                    in_range(container_slots + (slot_id - 9) as usize)
+                    Some(container_slots + (slot_id - 9) as usize)
                 }
             } else {
                 None
             }
         }
-        ContainerName::Armor => (slot_id < 4).then(|| 5 + slot_id as usize),
-        ContainerName::Offhand => (slot_id == 0).then_some(45),
-        ContainerName::Cursor => None,
+        ContainerName::Armor => (slot_id < 4).then_some(5 + slot_id as usize),
+        // Player screen only; anvil/merchant etc. have <46 slots.
+        ContainerName::Offhand => (slot_id == 0 && is_player_screen).then_some(45),
+        // Cursor and virtual craft output — never real screen indices.
+        ContainerName::Cursor | ContainerName::CreatedOutput => None,
         ContainerName::CraftingInput => {
             if is_player_screen {
                 if slot_id < 4 {
@@ -1964,27 +2067,10 @@ fn map_bedrock_container_slot(
                 None
             }
         }
-        ContainerName::CraftingOutputPreview | ContainerName::CreatedOutput => {
-            if is_player_screen {
-                Some(0)
-            } else if let Some(window_type) = screen_handler.window_type() {
-                match window_type {
-                    pumpkin_data::screen::WindowType::Crafting => Some(0),
-                    pumpkin_data::screen::WindowType::Stonecutter => Some(1),
-                    pumpkin_data::screen::WindowType::Anvil
-                    | pumpkin_data::screen::WindowType::Furnace
-                    | pumpkin_data::screen::WindowType::BlastFurnace
-                    | pumpkin_data::screen::WindowType::Smoker
-                    | pumpkin_data::screen::WindowType::Grindstone
-                    | pumpkin_data::screen::WindowType::Merchant => Some(2),
-                    pumpkin_data::screen::WindowType::Loom
-                    | pumpkin_data::screen::WindowType::Smithing => Some(3),
-                    _ => None,
-                }
-            } else {
-                None
-            }
-        }
+        // Previews map for write-back/display only; get_slot_stack refuses them as free sources.
+        ContainerName::CraftingOutputPreview => (is_player_screen
+            || screen_handler.window_type() == Some(pumpkin_data::screen::WindowType::Crafting))
+        .then_some(0),
         ContainerName::AnvilInput => matches!(
             screen_handler.window_type(),
             Some(pumpkin_data::screen::WindowType::Anvil)
@@ -2155,7 +2241,8 @@ fn map_bedrock_container_slot(
         )
         .then_some(2),
         _ => ((slot_id as usize) < container_slots).then_some(slot_id as usize),
-    }
+    };
+    raw.and_then(in_range)
 }
 
 struct SlotUpdate {
@@ -2194,14 +2281,18 @@ async fn get_slot_stack(
     slot_info: &pumpkin_protocol::bedrock::server::item_stack_request::ItemStackRequestSlotInfo,
     created_item: Option<&ItemStack>,
 ) -> ItemStack {
-    // CreatedOutput is virtual: only the tracked craft result, never the real
-    // screen result slot (that would skip ingredient consumption).
-    if slot_info.container_name.container_name == ContainerName::CreatedOutput {
+    let name = slot_info.container_name.container_name;
+    // Virtual craft output only.
+    if name == ContainerName::CreatedOutput {
         return created_item
             .cloned()
             .unwrap_or_else(|| ItemStack::EMPTY.clone());
     }
-    if slot_info.container_name.container_name == ContainerName::Cursor {
+    // Result previews are display-only as *sources* — never copy real results free.
+    if is_result_preview_container(name) {
+        return ItemStack::EMPTY.clone();
+    }
+    if name == ContainerName::Cursor {
         let cursor_lock = screen_handler.get_behaviour().cursor_stack.lock().await;
         if cursor_lock.is_empty()
             && let Some(stack) = created_item
@@ -2210,11 +2301,7 @@ async fn get_slot_stack(
         }
         return cursor_lock.clone();
     }
-    if let Some(screen_slot) = map_bedrock_container_slot(
-        screen_handler,
-        slot_info.container_name.container_name,
-        slot_info.slot_id,
-    ) {
+    if let Some(screen_slot) = map_bedrock_container_slot(screen_handler, name, slot_info.slot_id) {
         screen_handler.get_behaviour().slots[screen_slot]
             .get_cloned_stack()
             .await
@@ -2273,5 +2360,38 @@ async fn update_slot_stack(
             .set_stack(new_stack.clone())
             .await;
         screen_handler.set_received_stack(screen_slot, new_stack);
+    }
+}
+
+#[cfg(test)]
+mod hardening_tests {
+    use super::*;
+
+    #[test]
+    fn result_preview_containers_are_flagged() {
+        assert!(is_result_preview_container(
+            ContainerName::CraftingOutputPreview
+        ));
+        assert!(is_result_preview_container(
+            ContainerName::AnvilResultPreview
+        ));
+        assert!(is_result_preview_container(
+            ContainerName::TradeResultPreview
+        ));
+        assert!(!is_result_preview_container(ContainerName::CreatedOutput));
+        assert!(!is_result_preview_container(ContainerName::HotBar));
+        assert!(!is_result_preview_container(ContainerName::FurnaceResult));
+    }
+
+    #[test]
+    fn consume_created_item_clears_when_empty() {
+        let mut created = Some(ItemStack::new(3, &pumpkin_data::item::Item::EMERALD));
+        consume_created_item(&mut created, 2);
+        assert_eq!(created.as_ref().unwrap().item_count, 1);
+        consume_created_item(&mut created, 1);
+        assert!(created.is_none());
+        // No panic when already none
+        consume_created_item(&mut created, 5);
+        assert!(created.is_none());
     }
 }

--- a/pumpkin/src/net/bedrock/play.rs
+++ b/pumpkin/src/net/bedrock/play.rs
@@ -355,7 +355,8 @@ impl BedrockClient {
 
         if input_data.get(InputData::StartFlying as usize) {
             let flying = { player.abilities.lock().await.flying };
-            if !flying {
+            // Reject free survival flight: only fly when the server granted may_fly.
+            if !flying && player.abilities.lock().await.allow_flying {
                 send_cancellable! {{
                     server;
                     PlayerToggleFlightEvent::new(player.clone(), true);
@@ -404,7 +405,15 @@ impl BedrockClient {
         packet: pumpkin_protocol::bedrock::server::player_auth_input::PlayerBlockAction,
     ) {
         use pumpkin_protocol::bedrock::server::player_action::Action as PlayerAction;
-        let action = PlayerAction::try_from(packet.action.0).unwrap();
+        let Ok(action) = PlayerAction::try_from(packet.action.0) else {
+            // Invalid action ids used to unwrap → panic hook shutdown.
+            tracing::debug!(
+                "Ignoring invalid bedrock block action {} from {}",
+                packet.action.0,
+                player.gameprofile.name
+            );
+            return;
+        };
         self.handle_player_action(
             player,
             server,
@@ -488,7 +497,7 @@ impl BedrockClient {
         player: &Arc<Player>,
         packet: SInventoryTransaction,
     ) {
-        tracing::info!("handle_inventory_action: packet={:?}", packet);
+        tracing::debug!("handle_inventory_action from {}", player.gameprofile.name);
         let mut inventory_updated = false;
         let mut updates = Vec::new();
         let result = 0u8;
@@ -546,6 +555,10 @@ impl BedrockClient {
             use pumpkin_protocol::bedrock::server::inventory_transaction::InventoryActionSource;
             let source_type = InventoryActionSource::from(action.source_type);
             if source_type == InventoryActionSource::World {
+                // Only creative may spawn world-source drops from client descriptors.
+                if !is_creative {
+                    continue;
+                }
                 let old_stack = descriptor_to_stack(&action.old_item, is_creative);
                 let new_stack = descriptor_to_stack(&action.new_item, is_creative);
                 if old_stack.is_empty() && !new_stack.is_empty() {
@@ -555,6 +568,11 @@ impl BedrockClient {
                 if let Some(screen_slot) =
                     map_bedrock_slot_to_screen_handler(window_id, action.inventory_slot)
                 {
+                    // Survival: never write arbitrary client item descriptors into slots.
+                    // Creative may set slots from the creative catalog.
+                    if !is_creative {
+                        continue;
+                    }
                     let item_stack = descriptor_to_stack(&action.new_item, is_creative);
 
                     let mut player_screen_handler = player.player_screen_handler.lock().await;
@@ -1259,12 +1277,17 @@ impl BedrockClient {
             let mut result = 0u8; // 0 = Success, 1 = Error
 
             for action in request.actions {
-                tracing::info!("Processing ItemStackRequestAction: {:?}", action);
+                tracing::debug!("Processing ItemStackRequestAction");
                 match action {
                     ItemStackRequestAction::CraftCreative {
                         creative_item_id,
                         repetitions,
                     } => {
+                        // Creative catalog is creative-only. Survival must not spawn free items.
+                        if player.gamemode.load() != GameMode::Creative {
+                            result = 1;
+                            break;
+                        }
                         let index = (creative_item_id.0.saturating_sub(1)) as usize;
                         if index < pumpkin_data::bedrock_creative::CREATIVE_ENTRIES.len() {
                             let entry = pumpkin_data::bedrock_creative::CREATIVE_ENTRIES[index];
@@ -1517,7 +1540,10 @@ impl BedrockClient {
                         repetitions,
                         ..
                     } => {
+                        // Bound repetitions; each take must consume a full set of inputs.
+                        const MAX_CRAFT_REPETITIONS: u8 = 64;
                         if repetitions > 0 {
+                            let reps = repetitions.min(MAX_CRAFT_REPETITIONS);
                             screen_handler.update_to_client().await;
 
                             let is_player = screen_handler.window_type().is_none();
@@ -1527,7 +1553,7 @@ impl BedrockClient {
                                 let grid_slot =
                                     screen_handler.get_behaviour().slots[grid_slot_index].clone();
                                 let grid_stack = grid_slot.get_cloned_stack().await;
-                                tracing::info!(
+                                tracing::debug!(
                                     "Crafting Grid slot {i} (slot index {grid_slot_index}): Item ID: {}, Count: {}",
                                     grid_stack.item.id,
                                     grid_stack.item_count
@@ -1543,16 +1569,25 @@ impl BedrockClient {
                                 break;
                             }
 
-                            let mut total_crafted = output_stack.clone();
-                            total_crafted.item_count =
-                                total_crafted.item_count.saturating_mul(repetitions);
-                            created_item = Some(total_crafted);
-
-                            for _ in 0..repetitions {
-                                output_slot
-                                    .on_take_item(player.as_ref(), &output_stack)
-                                    .await;
+                            // Verify the grid still has enough ingredients for `reps` crafts
+                            // by attempting takes one-by-one; stop early if a take empties output.
+                            let mut crafted_count: u16 = 0;
+                            for _ in 0..reps {
+                                let current = output_slot.get_cloned_stack().await;
+                                if current.is_empty() || current.item.id != output_stack.item.id {
+                                    break;
+                                }
+                                output_slot.on_take_item(player.as_ref(), &current).await;
+                                crafted_count = crafted_count
+                                    .saturating_add(u16::from(output_stack.item_count));
                             }
+                            if crafted_count == 0 {
+                                result = 1;
+                                break;
+                            }
+                            let mut total_crafted = output_stack.clone();
+                            total_crafted.item_count = crafted_count.min(u16::from(u8::MAX)) as u8;
+                            created_item = Some(total_crafted);
 
                             // Record updates for all grid slots so Bedrock client is notified of consumed ingredients!
                             let is_player = screen_handler.window_type().is_none();

--- a/pumpkin/src/net/bedrock/play.rs
+++ b/pumpkin/src/net/bedrock/play.rs
@@ -665,15 +665,19 @@ impl BedrockClient {
                 }
 
                 if data.action_type.0 == 0 {
-                    // Click block
+                    // Click block. Never trust client item_in_hand to spawn items
+                    // in survival — only creative may adopt the client descriptor.
                     let is_creative = player.gamemode.load() == GameMode::Creative;
-                    let client_stack = descriptor_to_stack(&data.item_in_hand, is_creative);
-
                     let held_item = player.inventory.held_item();
-                    if !client_stack.is_empty() {
-                        let mut server_stack = held_item.lock().await;
-                        if server_stack.is_empty() || server_stack.item.id != client_stack.item.id {
-                            *server_stack = client_stack.clone();
+                    if is_creative {
+                        let client_stack = descriptor_to_stack(&data.item_in_hand, true);
+                        if !client_stack.is_empty() {
+                            let mut server_stack = held_item.lock().await;
+                            if server_stack.is_empty()
+                                || server_stack.item.id != client_stack.item.id
+                            {
+                                *server_stack = client_stack;
+                            }
                         }
                     }
 
@@ -1343,6 +1347,16 @@ impl BedrockClient {
                         source,
                         destination,
                     } => {
+                        // CreatedOutput is only valid after a craft action set
+                        // `created_item`. Mapping it to the real result slot lets
+                        // clients copy craft output without consuming the grid.
+                        if source.container_name.container_name == ContainerName::CreatedOutput
+                            && created_item.is_none()
+                        {
+                            tracing::debug!("CreatedOutput move without tracked craft");
+                            result = 1;
+                            break;
+                        }
                         let mut source_stack =
                             get_slot_stack(&*screen_handler, &source, created_item.as_ref()).await;
                         if source_stack.is_empty() && created_item.is_none() {
@@ -1569,17 +1583,19 @@ impl BedrockClient {
                                 break;
                             }
 
-                            // Verify the grid still has enough ingredients for `reps` crafts
-                            // by attempting takes one-by-one; stop early if a take empties output.
+                            // Take one craft at a time. ResultSlot::on_take_item
+                            // refills from remaining ingredients; empty result
+                            // means the grid can no longer craft.
                             let mut crafted_count: u16 = 0;
+                            let expected_id = output_stack.item.id;
                             for _ in 0..reps {
                                 let current = output_slot.get_cloned_stack().await;
-                                if current.is_empty() || current.item.id != output_stack.item.id {
+                                if current.is_empty() || current.item.id != expected_id {
                                     break;
                                 }
+                                let batch = u16::from(current.item_count);
                                 output_slot.on_take_item(player.as_ref(), &current).await;
-                                crafted_count = crafted_count
-                                    .saturating_add(u16::from(output_stack.item_count));
+                                crafted_count = crafted_count.saturating_add(batch);
                             }
                             if crafted_count == 0 {
                                 result = 1;
@@ -1888,27 +1904,35 @@ fn map_bedrock_container_slot(
 ) -> Option<usize> {
     let container_slots = screen_handler.get_behaviour().container_slots;
     let is_player_screen = screen_handler.window_type().is_none();
+    let slot_count = screen_handler.get_behaviour().slots.len();
+
+    // Bound every mapped index so a crafted slot_id cannot panic the handler.
+    let in_range = |idx: usize| (idx < slot_count).then_some(idx);
 
     match container_name {
         ContainerName::HotBar => {
+            // Hotbar is always 9 slots; unbounded slot_id was a one-packet panic.
+            if slot_id >= 9 {
+                return None;
+            }
             if is_player_screen {
-                Some(36 + slot_id as usize)
+                in_range(36 + slot_id as usize)
             } else {
-                Some(container_slots + 27 + slot_id as usize)
+                in_range(container_slots + 27 + slot_id as usize)
             }
         }
         ContainerName::Inventory | ContainerName::CombinedHotBarAndInventory => {
             if slot_id < 9 {
                 if is_player_screen {
-                    Some(36 + slot_id as usize)
+                    in_range(36 + slot_id as usize)
                 } else {
-                    Some(container_slots + 27 + slot_id as usize)
+                    in_range(container_slots + 27 + slot_id as usize)
                 }
             } else if slot_id < 36 {
                 if is_player_screen {
-                    Some(slot_id as usize)
+                    in_range(slot_id as usize)
                 } else {
-                    Some(container_slots + (slot_id - 9) as usize)
+                    in_range(container_slots + (slot_id - 9) as usize)
                 }
             } else {
                 None
@@ -2170,10 +2194,12 @@ async fn get_slot_stack(
     slot_info: &pumpkin_protocol::bedrock::server::item_stack_request::ItemStackRequestSlotInfo,
     created_item: Option<&ItemStack>,
 ) -> ItemStack {
-    if let (ContainerName::CreatedOutput, Some(stack)) =
-        (slot_info.container_name.container_name, created_item)
-    {
-        return stack.clone();
+    // CreatedOutput is virtual: only the tracked craft result, never the real
+    // screen result slot (that would skip ingredient consumption).
+    if slot_info.container_name.container_name == ContainerName::CreatedOutput {
+        return created_item
+            .cloned()
+            .unwrap_or_else(|| ItemStack::EMPTY.clone());
     }
     if slot_info.container_name.container_name == ContainerName::Cursor {
         let cursor_lock = screen_handler.get_behaviour().cursor_stack.lock().await;

--- a/pumpkin/src/net/java/config.rs
+++ b/pumpkin/src/net/java/config.rs
@@ -246,16 +246,22 @@ impl JavaClient {
 
     pub async fn handle_config_acknowledged(&self, server: &Arc<Server>) -> PacketHandlerResult {
         debug!("Handling config acknowledgement");
-        self.connection_state.store(ConnectionState::Play);
 
         let profile = self.gameprofile.lock().await.clone();
-        let profile = profile.unwrap();
+        let Some(profile) = profile else {
+            // Missing profile (skipped login / proxy response) must not panic.
+            self.kick(TextComponent::text("Missing game profile")).await;
+            return PacketHandlerResult::Stop;
+        };
         let address = self.address.lock().await;
 
         if let Some(reason) = can_not_join(&profile, &address, server).await {
             self.kick(reason).await;
             return PacketHandlerResult::Stop;
         }
+
+        // Only enter Play after profile + join gates succeed.
+        self.connection_state.store(ConnectionState::Play);
 
         let config = self.config.lock().await;
         PacketHandlerResult::ReadyToPlay(profile, config.clone().unwrap_or_default())

--- a/pumpkin/src/net/java/config.rs
+++ b/pumpkin/src/net/java/config.rs
@@ -28,21 +28,6 @@ use tracing::{debug, trace, warn};
 
 const BRAND_CHANNEL_PREFIX: &str = "minecraft:brand";
 
-/// Once-marker for "known packs already answered" (F-AUTH-05).
-///
-/// Re-sending `SKnownPacks` is nearly free for the client, but every answer
-/// costs a full synced-registry clone + dump, so only the first one may be
-/// handled. The marker also suppresses further `send_known_packs` round-trips
-/// from the resource-pack-response path, the finding's second trigger.
-///
-/// The marker lives in `JavaClient::keep_alive_id`, which carries no meaningful
-/// value before Play-state keep-alives begin: the server never sends keep-alives
-/// during Config, config-state keep-alive handling additionally requires
-/// `wait_for_keep_alive` (never set outside Play), and the first Play keep-alive
-/// unconditionally overwrites the id before any comparison. `i64::MIN` cannot
-/// collide with a real id (millisecond timestamps since the epoch).
-const KNOWN_PACKS_ANSWERED: i64 = i64::MIN;
-
 impl JavaClient {
     pub async fn handle_client_information_config(
         &self,
@@ -156,7 +141,7 @@ impl JavaClient {
                 self.id
             );
         }
-        if self.keep_alive_id.load() == KNOWN_PACKS_ANSWERED {
+        if self.known_packs_answered.load(Ordering::Relaxed) {
             // Known packs were already answered (registries dumped, config
             // finished); a replayed response must not start another
             // known-packs round-trip (F-AUTH-05, second trigger).
@@ -184,12 +169,12 @@ impl JavaClient {
         _config_acknowledged: SKnownPacks,
         server: &Arc<Server>,
     ) -> Option<PacketHandlerResult> {
-        if self.keep_alive_id.load() == KNOWN_PACKS_ANSWERED {
+        if self.known_packs_answered.load(Ordering::Relaxed) {
             // Replay of an already-answered packet; do not run the registry dump again.
             debug!("Client {} re-sent known packs; ignoring", self.id);
             return None;
         }
-        self.keep_alive_id.store(KNOWN_PACKS_ANSWERED);
+        self.known_packs_answered.store(true, Ordering::Relaxed);
 
         debug!("Handling known packs");
         // let mut tags_to_send = Vec::new();

--- a/pumpkin/src/net/java/config.rs
+++ b/pumpkin/src/net/java/config.rs
@@ -28,6 +28,21 @@ use tracing::{debug, trace, warn};
 
 const BRAND_CHANNEL_PREFIX: &str = "minecraft:brand";
 
+/// Once-marker for "known packs already answered" (F-AUTH-05).
+///
+/// Re-sending `SKnownPacks` is nearly free for the client, but every answer
+/// costs a full synced-registry clone + dump, so only the first one may be
+/// handled. The marker also suppresses further `send_known_packs` round-trips
+/// from the resource-pack-response path, the finding's second trigger.
+///
+/// The marker lives in `JavaClient::keep_alive_id`, which carries no meaningful
+/// value before Play-state keep-alives begin: the server never sends keep-alives
+/// during Config, config-state keep-alive handling additionally requires
+/// `wait_for_keep_alive` (never set outside Play), and the first Play keep-alive
+/// unconditionally overwrites the id before any comparison. `i64::MIN` cannot
+/// collide with a real id (millisecond timestamps since the epoch).
+const KNOWN_PACKS_ANSWERED: i64 = i64::MIN;
+
 impl JavaClient {
     pub async fn handle_client_information_config(
         &self,
@@ -141,6 +156,16 @@ impl JavaClient {
                 self.id
             );
         }
+        if self.keep_alive_id.load() == KNOWN_PACKS_ANSWERED {
+            // Known packs were already answered (registries dumped, config
+            // finished); a replayed response must not start another
+            // known-packs round-trip (F-AUTH-05, second trigger).
+            debug!(
+                "Client {} re-sent a resource pack response after config finished; ignoring",
+                self.id
+            );
+            return;
+        }
         self.send_known_packs().await;
     }
 
@@ -159,6 +184,13 @@ impl JavaClient {
         _config_acknowledged: SKnownPacks,
         server: &Arc<Server>,
     ) -> Option<PacketHandlerResult> {
+        if self.keep_alive_id.load() == KNOWN_PACKS_ANSWERED {
+            // Replay of an already-answered packet; do not run the registry dump again.
+            debug!("Client {} re-sent known packs; ignoring", self.id);
+            return None;
+        }
+        self.keep_alive_id.store(KNOWN_PACKS_ANSWERED);
+
         debug!("Handling known packs");
         // let mut tags_to_send = Vec::new();
         let version = self.version.load();

--- a/pumpkin/src/net/java/login.rs
+++ b/pumpkin/src/net/java/login.rs
@@ -157,6 +157,10 @@ impl JavaClient {
                         e => TextComponent::text(e.to_string()),
                     })
                     .await;
+                    // Critical: kick() only schedules disconnect. Without return,
+                    // login falls through and finish_login() completes with the
+                    // unverified client-supplied profile (auth bypass).
+                    return;
                 }
             }
         }

--- a/pumpkin/src/net/java/login.rs
+++ b/pumpkin/src/net/java/login.rs
@@ -165,41 +165,9 @@ impl JavaClient {
             }
         }
 
-        // Don't allow duplicate UUIDs
-        if let Some(online_player) = &server.get_player_by_uuid(profile.id) {
-            debug!(
-                "Player (IP '{}', username '{}') tried to log in with the same UUID ('{}') as an online player (username '{}')",
-                &self.address.lock().await,
-                &profile.name,
-                &profile.id,
-                &online_player.gameprofile.name
-            );
-            self.kick(TextComponent::translate_cross(
-                translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
-                translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
-                [],
-            ))
-            .await;
-            return;
-        }
-
-        // Don't allow a duplicate username
-        if let Some(online_player) = &server.get_player_by_name(&profile.name) {
-            debug!(
-                "A player (IP '{}', attempted username '{}') tried to log in with the same username as an online player (UUID '{}', username '{}')",
-                &self.address.lock().await,
-                &profile.name,
-                &profile.id,
-                &online_player.gameprofile.name
-            );
-            self.kick(TextComponent::translate_cross(
-                translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
-                translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
-                [],
-            ))
-            .await;
-            return;
-        }
+        // Duplicate UUID/name is handled centrally in Server::add_player
+        // (kick-old, accept-new). Checking here would reject the new connection
+        // before that path runs, re-introducing ghost-reconnect lockout.
 
         self.finish_login(profile).await;
     }

--- a/pumpkin/src/net/java/login.rs
+++ b/pumpkin/src/net/java/login.rs
@@ -157,9 +157,9 @@ impl JavaClient {
                         e => TextComponent::text(e.to_string()),
                     })
                     .await;
-                    // Critical: kick() only schedules disconnect. Without return,
-                    // login falls through and finish_login() completes with the
-                    // unverified client-supplied profile (auth bypass).
+                    // Drop the client-supplied profile so a racing LoginAck cannot
+                    // spawn as the victim identity (F-AUTH-01).
+                    *gameprofile = None;
                     return;
                 }
             }
@@ -230,6 +230,9 @@ impl JavaClient {
             uuid::Uuid::new_v4(),
         );
         self.send_packet_now(&packet).await;
+        // Marks identity accepted; required before LoginAck → Config.
+        self.login_finished
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 
     async fn authenticate(
@@ -327,6 +330,20 @@ impl JavaClient {
 
     pub async fn handle_login_acknowledged(&self, server: &Server) {
         debug!("Handling login acknowledgement");
+        // Reject LoginAck unless finish_login completed (auth/offline/proxy).
+        // Without this, a crafted client stores a pre-auth profile and races
+        // into Config after a failed Mojang check (F-AUTH-01 residual).
+        if !self
+            .login_finished
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            self.kick(TextComponent::text("Login not complete")).await;
+            return;
+        }
+        if self.gameprofile.lock().await.is_none() {
+            self.kick(TextComponent::text("Missing game profile")).await;
+            return;
+        }
         self.connection_state.store(ConnectionState::Config);
         self.send_packet_now(&server.get_branding()).await;
 

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -86,6 +86,10 @@ pub struct JavaClient {
     /// Set only by `finish_login` after identity is accepted (online auth, offline
     /// finish, or verified proxy). `LoginAck` without this is an auth-bypass path.
     pub login_finished: AtomicBool,
+    /// Set once the client's first `SKnownPacks` answer has been handled. The
+    /// registry dump it triggers is expensive, so replays (and late
+    /// resource-pack responses) must not start another round-trip (F-AUTH-05).
+    pub known_packs_answered: AtomicBool,
     /// The client's configuration settings, Optional
     pub config: Mutex<Option<PlayerConfig>>,
     /// The Address used to connect to the Server, Send in the Handshake
@@ -161,6 +165,7 @@ impl JavaClient {
             id,
             gameprofile: Mutex::new(None),
             login_finished: AtomicBool::new(false),
+            known_packs_answered: AtomicBool::new(false),
             config: Mutex::new(None),
             server_address: Mutex::new("".into()),
             address: Mutex::new(address),

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -83,6 +83,9 @@ pub struct JavaClient {
     pub version: AtomicCell<JavaMinecraftVersion>,
     /// The client's game profile information.
     pub gameprofile: Mutex<Option<GameProfile>>,
+    /// Set only by `finish_login` after identity is accepted (online auth, offline
+    /// finish, or verified proxy). `LoginAck` without this is an auth-bypass path.
+    pub login_finished: AtomicBool,
     /// The client's configuration settings, Optional
     pub config: Mutex<Option<PlayerConfig>>,
     /// The Address used to connect to the Server, Send in the Handshake
@@ -157,6 +160,7 @@ impl JavaClient {
         Self {
             id,
             gameprofile: Mutex::new(None),
+            login_finished: AtomicBool::new(false),
             config: Mutex::new(None),
             server_address: Mutex::new("".into()),
             address: Mutex::new(address),
@@ -460,7 +464,10 @@ impl JavaClient {
 
     pub async fn get_packet(&self) -> Option<RawPacket> {
         let mut network_reader = self.network_reader.lock().await;
+        // Prefer the close branch so a kicked connection cannot race-process
+        // pipelined login/config packets after auth failure (F-AUTH-01 residual).
         tokio::select! {
+            biased;
             () = self.await_close_interrupt() => {
                 debug!("Canceling player packet processing");
                 None

--- a/pumpkin/src/net/mod.rs
+++ b/pumpkin/src/net/mod.rs
@@ -373,11 +373,16 @@ pub enum EncryptionError {
     AlreadyEncrypted,
 }
 
+/// Validates a player name for join/login.
+/// Rejects empty names, overlong names, control chars (incl. NUL), spaces, and
+/// the section sign (`§`) used for client format-code injection.
 fn is_valid_player_name(name: &str) -> bool {
-    if name.len() > 16 {
+    if name.is_empty() || name.len() > 16 {
         return false;
     }
-    !name.chars().any(|c| c.is_control() || c == ' ')
+    !name
+        .chars()
+        .any(|c| c.is_control() || c == ' ' || c == '\0' || c == '§')
 }
 
 #[derive(Clone, Copy)]
@@ -590,13 +595,19 @@ mod tests {
         );
     }
 
-    /// Test case for an empty string (length 0, but included for completeness).
+    /// Test case for an empty string — must be rejected (query `CString`, impersonation).
     #[test]
     fn invalid_empty_string() {
         let name = "";
+        assert!(!is_valid_player_name(name), "Empty string must be invalid");
+    }
+
+    #[test]
+    fn invalid_section_sign() {
+        let name = "Player§cName";
         assert!(
-            is_valid_player_name(name),
-            "Empty string should be valid (length <= 16 and no invalid chars)"
+            !is_valid_player_name(name),
+            "Section sign format codes must be rejected"
         );
     }
 

--- a/pumpkin/src/net/proxy/velocity.rs
+++ b/pumpkin/src/net/proxy/velocity.rs
@@ -82,6 +82,13 @@ fn read_game_profile(read: impl Read) -> Result<GameProfile, VelocityError> {
     let name = read
         .get_str()
         .map_err(|_| VelocityError::FailedReadProfileName)?;
+    // Bound + sanitize forwarded names (proxy path previously accepted ≤1 MiB garbage).
+    if name.is_empty()
+        || name.len() > 16
+        || name.chars().any(|c| c.is_control() || c == ' ' || c == '§')
+    {
+        return Err(VelocityError::FailedReadProfileName);
+    }
 
     let properties = read
         .get_list(|data| {

--- a/pumpkin/src/net/rcon/mod.rs
+++ b/pumpkin/src/net/rcon/mod.rs
@@ -18,11 +18,20 @@ pub struct RCONServer;
 
 impl RCONServer {
     pub async fn run(config: &RCONConfig, server: Arc<Server>) {
+        // Empty password is rejected at config validation; belt-and-suspenders here.
+        if config.password.is_empty() {
+            error!("RCON refused to start: password is empty");
+            return;
+        }
+
         let listener = tokio::net::TcpListener::bind(config.address).await.unwrap();
 
         let password = Arc::new(config.password.clone());
+        // Track live connections with an atomic so the counter is decremented on close,
+        // not immediately after spawn (previous code made max_connections a no-op).
+        let connections = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let max_connections = config.max_connections;
 
-        let mut connections = 0;
         while !SHOULD_STOP.load(Ordering::Relaxed) {
             let await_new_client = || async {
                 let t1 = listener.accept();
@@ -39,18 +48,24 @@ impl RCONServer {
                 break;
             };
 
-            if config.max_connections != 0 && connections >= config.max_connections {
+            let current = connections.load(Ordering::Relaxed);
+            if max_connections != 0 && current >= max_connections {
+                debug!("RCON connection from {address} rejected: max_connections reached");
+                drop(connection);
                 continue;
             }
 
-            connections += 1;
+            connections.fetch_add(1, Ordering::Relaxed);
             let mut client = RCONClient::new(connection, address);
 
             let password = password.clone();
             let server = server.clone();
-            tokio::spawn(async move { while !client.handle(&server, &password).await {} });
-            debug!("closed RCON connection");
-            connections -= 1;
+            let connections = connections.clone();
+            tokio::spawn(async move {
+                while !client.handle(&server, &password).await {}
+                connections.fetch_sub(1, Ordering::Relaxed);
+                debug!("closed RCON connection");
+            });
         }
     }
 }
@@ -155,8 +170,27 @@ impl RCONClient {
     }
 
     async fn read_bytes(&mut self) -> std::io::Result<bool> {
+        // Bound the staging buffer so a slowloris client cannot retain unbounded memory.
+        const MAX_INCOMING: usize = 64 * 1024;
+        if self.incoming.len() > MAX_INCOMING {
+            self.closed = true;
+            return Ok(true);
+        }
         let mut buf = [0; 1460];
-        let n = self.connection.read(&mut buf).await?;
+        let n = match tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            self.connection.read(&mut buf),
+        )
+        .await
+        {
+            Ok(Ok(n)) => n,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                // Read timeout
+                self.closed = true;
+                return Ok(true);
+            }
+        };
         if n == 0 {
             return Ok(true);
         }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -6,7 +6,9 @@ use crate::data::player_server::ServerPlayerData;
 use crate::entity::{EntityBase, NBTStorage};
 use crate::item::registry::ItemRegistry;
 use crate::net::authentication::fetch_mojang_public_keys;
-use crate::net::{ClientPlatform, DisconnectReason, EncryptionError, GameProfile, PlayerConfig};
+use crate::net::{
+    ClientPlatform, DisconnectReason, EncryptionError, GameProfile, PlayerConfig, can_not_join,
+};
 use crate::plugin::PluginManager;
 use crate::plugin::player::player_login::PlayerLoginEvent;
 use crate::plugin::server::server_broadcast::ServerBroadcastEvent;
@@ -23,6 +25,7 @@ use key_store::KeyStore;
 use pumpkin_config::{AdvancedConfiguration, BasicConfiguration};
 use pumpkin_data::dimension::Dimension;
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::translation;
 use pumpkin_util::permission::{PermissionManager, PermissionRegistry};
 use pumpkin_util::text::color::NamedColor;
 use pumpkin_world::dimension::into_level;
@@ -478,12 +481,36 @@ impl Server {
     /// # Note
     ///
     /// You still have to spawn the `Player` in a `World` to let them join and make them visible.
+    #[allow(clippy::too_many_lines)]
     pub async fn add_player(
         &self,
         client: Arc<ClientPlatform>,
         profile: GameProfile,
         config: Option<PlayerConfig>,
     ) -> Option<(Arc<Player>, Arc<World>)> {
+        // Centralized identity + moderation gates for every transport (Java,
+        // Bedrock, offline, proxy). Previously several paths skipped these.
+        let address = client.address().await;
+        if let Some(reason) = can_not_join(&profile, &address, self).await {
+            client.kick(DisconnectReason::Kicked, reason).await;
+            return None;
+        }
+        if self.get_player_by_uuid(profile.id).is_some()
+            || self.get_player_by_name(&profile.name).is_some()
+        {
+            client
+                .kick(
+                    DisconnectReason::Kicked,
+                    TextComponent::translate_cross(
+                        translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
+                        translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
+                        [],
+                    ),
+                )
+                .await;
+            return None;
+        }
+
         let gamemode = self.defaultgamemode.lock().await.gamemode;
 
         let (world, nbt) =

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -495,20 +495,30 @@ impl Server {
             client.kick(DisconnectReason::Kicked, reason).await;
             return None;
         }
-        if self.get_player_by_uuid(profile.id).is_some()
-            || self.get_player_by_name(&profile.name).is_some()
-        {
-            client
-                .kick(
-                    DisconnectReason::Kicked,
-                    TextComponent::translate_cross(
-                        translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
-                        translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
-                        [],
-                    ),
-                )
-                .await;
-            return None;
+
+        // Vanilla parity: kick the existing session and accept the new one.
+        // Reject-new left ghosts / stuck sessions locking out legit reconnects.
+        let dup_msg = TextComponent::translate_cross(
+            translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
+            translation::java::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN,
+            [],
+        );
+        if let Some(online) = self.get_player_by_uuid(profile.id) {
+            debug!(
+                "Duplicate UUID login for '{}'; kicking existing session",
+                profile.name
+            );
+            online.kick(DisconnectReason::Kicked, dup_msg.clone()).await;
+            online.remove().await;
+            self.remove_player(&online).await;
+        } else if let Some(online) = self.get_player_by_name(&profile.name) {
+            debug!(
+                "Duplicate name login for '{}'; kicking existing session",
+                profile.name
+            );
+            online.kick(DisconnectReason::Kicked, dup_msg).await;
+            online.remove().await;
+            self.remove_player(&online).await;
         }
 
         let gamemode = self.defaultgamemode.lock().await.gamemode;

--- a/pumpkin/src/server/ticker.rs
+++ b/pumpkin/src/server/ticker.rs
@@ -30,15 +30,26 @@ impl Ticker {
                 .fire(ServerTickStartEvent::new(tick_number))
                 .await;
 
-            if manager.is_sprinting() {
-                manager.start_sprint_tick_work();
-                server.tick().await;
+            // Run the tick body in a child task so a panic in world/player tick
+            // cannot kill this loop and leave a silently frozen world.
+            let server_tick = server.clone();
+            let tick_join = tokio::spawn(async move {
+                let manager = &server_tick.tick_rate_manager;
+                if manager.is_sprinting() {
+                    manager.start_sprint_tick_work();
+                    server_tick.tick().await;
 
-                if manager.end_sprint_tick_work() {
-                    manager.finish_tick_sprint(server);
+                    if manager.end_sprint_tick_work() {
+                        manager.finish_tick_sprint(&server_tick);
+                    }
+                } else {
+                    server_tick.tick().await;
                 }
-            } else {
-                server.tick().await;
+            });
+            if let Err(e) = tick_join.await {
+                tracing::error!(
+                    "Server tick panicked (#{tick_number}); world tick continues next interval: {e}"
+                );
             }
 
             let tick_duration_nanos = tick_start_time.elapsed().as_nanos() as i64;


### PR DESCRIPTION
Part 7 (final) of the hardening stack (stacked on #2514).

## Commits
- charge merchant/anvil output on verified take
- cap remaining Bedrock length-driven allocations
- settle Bedrock craft-output takes through slot hooks
- throttle registry dump, packet reserve, and panic reports
- fix Bedrock zigzag VarInt decode and cap remaining counts
- replace known-packs sentinel with a dedicated flag

## What and why
- Merchant/anvil charging moved into the result slot's take hook, so every verified take (pickup, shift-click, throw, swap) is charged exactly once and failed deliveries never charge; the Throw double-call is fixed. Completes the dupe fixes.
- The Bedrock created-item cursor mirror is single-authority (never a destination base; consumed as a source); all take paths settle through the slot's take hook exactly once; writes into take-only slots are rejected.
- Remaining Bedrock length-driven allocations capped (legacy transaction entries, inventory actions, emote list).
- known-packs registry dump answered once per connection (previously re-triggerable, a full deep-clone+dump per small packet); decompression buffer grows incrementally instead of trusting the client-declared length up front (pre-auth alloc/CPU amplification); crash reports only built for the first panic.
- Bedrock zigzag VarInt decode fixed for negative wire values (BlockPos, legacy ids); transaction/legacy counts, BitSet decode, and the shared Vec<u8> reader capped; known-packs guard uses a dedicated flag instead of a keep-alive sentinel.

## Tests
cargo test passes for all touched crates (35 pumpkin-nbt, 75 pumpkin-protocol, 21 pumpkin-inventory, 166 pumpkin), including exploit-sequence regression tests for the dupe and crash classes fixed in this stack.

## Notes
- This stack intentionally does not attempt full movement/reach anti-cheat, login/config timeouts, packet rate limits, Velocity message_id binding, query bounds, or the plugin permission model; those are documented as follow-ups.
- Detailed technical report was sent privately to the address in SECURITY.md.