### PR TITLE
fix(entity): implement per-player entity tracking

### DIFF
--- a/crates/pumpkin-config/src/entity_tracking.rs
+++ b/crates/pumpkin-config/src/entity_tracking.rs
@@ -1,0 +1,137 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the distance at which entities are sent to clients.
+#[derive(Deserialize, Serialize)]
+#[serde(default)]
+pub struct EntityTrackingConfig {
+    /// Tracking range, in chunks, for entity types without an explicit override.
+    pub default_range: u32,
+    /// Per-entity tracking range overrides, in chunks.
+    pub ranges: BTreeMap<String, u32>,
+}
+
+impl Default for EntityTrackingConfig {
+    fn default() -> Self {
+        let ranges = [
+            ("marker", 0),
+            ("arrow", 4),
+            ("breeze_wind_charge", 4),
+            ("cod", 4),
+            ("dragon_fireball", 4),
+            ("egg", 4),
+            ("ender_pearl", 4),
+            ("experience_bottle", 4),
+            ("eye_of_ender", 4),
+            ("fireball", 4),
+            ("firework_rocket", 4),
+            ("fishing_bobber", 4),
+            ("lingering_potion", 4),
+            ("llama_spit", 4),
+            ("pufferfish", 4),
+            ("salmon", 4),
+            ("small_fireball", 4),
+            ("snowball", 4),
+            ("spectral_arrow", 4),
+            ("splash_potion", 4),
+            ("trident", 4),
+            ("tropical_fish", 4),
+            ("wind_charge", 4),
+            ("wither_skull", 4),
+            ("bat", 5),
+            ("dolphin", 5),
+            ("evoker_fangs", 6),
+            ("experience_orb", 6),
+            ("item", 6),
+            ("allay", 8),
+            ("bee", 8),
+            ("blaze", 8),
+            ("bogged", 8),
+            ("cat", 8),
+            ("cave_spider", 8),
+            ("chest_minecart", 8),
+            ("command_block_minecart", 8),
+            ("creaking", 8),
+            ("creeper", 8),
+            ("drowned", 8),
+            ("enderman", 8),
+            ("endermite", 8),
+            ("evoker", 8),
+            ("fox", 8),
+            ("furnace_minecart", 8),
+            ("guardian", 8),
+            ("hoglin", 8),
+            ("hopper_minecart", 8),
+            ("husk", 8),
+            ("illusioner", 8),
+            ("magma_cube", 8),
+            ("minecart", 8),
+            ("mule", 8),
+            ("ominous_item_spawner", 8),
+            ("parched", 8),
+            ("parrot", 8),
+            ("phantom", 8),
+            ("piglin", 8),
+            ("piglin_brute", 8),
+            ("pillager", 8),
+            ("rabbit", 8),
+            ("shulker_bullet", 8),
+            ("silverfish", 8),
+            ("skeleton", 8),
+            ("snow_golem", 8),
+            ("spawner_minecart", 8),
+            ("spider", 8),
+            ("squid", 8),
+            ("stray", 8),
+            ("tnt_minecart", 8),
+            ("vex", 8),
+            ("vindicator", 8),
+            ("witch", 8),
+            ("wither_skeleton", 8),
+            ("zoglin", 8),
+            ("zombie", 8),
+            ("zombie_villager", 8),
+            ("zombified_piglin", 8),
+            ("end_crystal", 16),
+            ("lightning_bolt", 16),
+            ("warden", 16),
+            ("mannequin", 32),
+            ("player", 32),
+        ]
+        .into_iter()
+        .map(|(entity, range)| (entity.to_owned(), range))
+        .collect();
+
+        Self {
+            default_range: 10,
+            ranges,
+        }
+    }
+}
+
+impl EntityTrackingConfig {
+    /// Returns the configured tracking range for an entity type, or the default range.
+    #[must_use]
+    pub fn range_for(&self, entity: &str) -> u32 {
+        self.ranges
+            .get(entity)
+            .copied()
+            .unwrap_or(self.default_range)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EntityTrackingConfig;
+
+    #[test]
+    fn uses_override_or_default_range() {
+        let config = EntityTrackingConfig::default();
+
+        assert_eq!(config.range_for("marker"), 0);
+        assert_eq!(config.range_for("arrow"), 4);
+        assert_eq!(config.range_for("player"), 32);
+        assert_eq!(config.range_for("pig"), 10);
+    }
+}

--- a/crates/pumpkin-config/src/lib.rs
+++ b/crates/pumpkin-config/src/lib.rs
@@ -46,6 +46,7 @@ mod commands;
 mod chat;
 /// Chunk loading and saving configuration options.
 pub mod chunk;
+mod entity_tracking;
 /// Lighting engine configuration options.
 pub mod lighting;
 /// Operator permission level configuration options.
@@ -61,6 +62,7 @@ pub mod whitelist;
 pub mod world;
 
 use advancement::AdvancementConfig;
+pub use entity_tracking::EntityTrackingConfig;
 use networking::NetworkingConfig;
 use player_data::PlayerDataConfig;
 use resource_pack::ResourcePackConfig;
@@ -161,6 +163,8 @@ pub struct AdvancedConfiguration {
     pub plugins: PluginsConfig,
     /// Advancement configuration
     pub advancement: AdvancementConfig,
+    /// Client entity tracking range configuration.
+    pub entity_tracking: EntityTrackingConfig,
 }
 
 /// Basic configuration for core server settings.

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 use arc_swap::ArcSwap;
 use crossbeam::atomic::AtomicCell;
 use crossbeam::channel::Receiver;
+use dashmap::DashSet;
 use pumpkin_data::dimension::Dimension;
 use pumpkin_data::meta_data_type::MetaDataType;
 use pumpkin_data::tracked_data::TrackedData;
@@ -529,6 +530,11 @@ pub struct Player {
     pub item_cooldowns: Mutex<HashMap<String, ItemCooldown>>,
     pub experience_pick_up_delay: Mutex<u32>,
     pub chunk_manager: Mutex<ChunkManager>,
+    /// Terrain chunks that have actually been queued to this client.
+    ///
+    /// Entity pairing is gated on this set so an entity can never arrive before
+    /// the chunk that contains it.
+    pub delivered_chunks: DashSet<Vector2<i32>>,
     pub has_played_before: AtomicBool,
     pub chat_session: Arc<Mutex<ChatSession>>,
     pub signature_cache: Mutex<MessageCache>,
@@ -782,6 +788,7 @@ impl Player {
                 world.level.chunk_listener.add_global_chunk_listener(),
                 world.clone(),
             )),
+            delivered_chunks: DashSet::new(),
             last_sent_xp: AtomicI32::new(-1),
             last_sent_health: AtomicI32::new(-1),
             last_sent_food: AtomicU8::new(0),
@@ -962,6 +969,7 @@ impl Player {
             .increment_custom(statistics::CustomStatistic::LeaveGame, 1);
         let world = self.world();
         world.remove_player(self, true).await;
+        self.delivered_chunks.clear();
 
         let cylindrical = self.watched_section.load();
         self.chunk_manager.lock().await.clean_up(&world.level);
@@ -2099,8 +2107,19 @@ impl Player {
         };
         if let Some(chunk_of_chunks) = chunk_of_chunks {
             let client = self.client.clone();
+            let player = self.clone();
+            let world = self.world();
             tokio::spawn(async move {
-                client.send_chunks(&chunk_of_chunks).await;
+                let delivered_chunks = client.send_chunks(&chunk_of_chunks).await;
+                if player.world().uuid != world.uuid {
+                    return;
+                }
+                let watched_section = player.watched_section.load();
+                for chunk in delivered_chunks {
+                    if watched_section.is_within_distance(chunk.x, chunk.y) {
+                        player.delivered_chunks.insert(chunk);
+                    }
+                }
             });
             if let ClientPlatform::Bedrock(bedrock_client) = self.client.as_ref()
                 && !self.bedrock_spawned.load(Ordering::Relaxed)
@@ -2753,6 +2772,7 @@ impl Player {
     }
 
     pub async fn unload_watched_chunks(&self, world: &World) {
+        self.delivered_chunks.clear();
         let radial_chunks = self.watched_section.load().all_chunks_within();
         let level = &world.level;
         let chunks_to_clean = level.mark_chunks_as_not_watched(radial_chunks).await;

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -498,6 +498,8 @@ pub struct Player {
     pub awaiting_teleport: Mutex<Option<(VarInt, Vector3<f64>)>>,
     /// The coordinates of the chunk section the player is currently watching.
     pub watched_section: AtomicCell<Cylindrical>,
+    /// Position used for the last entity tracking update.
+    pub last_entity_tracking_pos: AtomicCell<Vector3<f64>>,
     /// The last time the player performed an action (for idle timeout).
     pub last_action_time: AtomicCell<Instant>,
     /// The ping in millis.
@@ -754,6 +756,7 @@ impl Player {
                 // Since 1 is not possible in vanilla it is used as uninit
                 NonZeroU8::new(1).unwrap_or(NonZeroU8::MIN),
             )),
+            last_entity_tracking_pos: AtomicCell::new(Vector3::new(0.0, 100.0, 0.0)),
             last_action_time: AtomicCell::new(std::time::Instant::now()),
             ping: AtomicU32::new(0),
             last_attacked_ticks: AtomicU32::new(0),
@@ -2131,6 +2134,10 @@ impl Player {
                     .await;
                 self.bedrock_spawned.store(true, Ordering::Relaxed);
             }
+        }
+        let position = self.position();
+        if self.last_entity_tracking_pos.swap(position) != position {
+            self.world().update_entity_tracking_for_player(self);
         }
         self.tick_counter.fetch_add(1, Ordering::Relaxed);
         self.living_entity

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -2120,6 +2120,7 @@ impl Player {
                         player.delivered_chunks.insert(chunk);
                     }
                 }
+                world.update_entity_tracking_for_player(&player);
             });
             if let ClientPlatform::Bedrock(bedrock_client) = self.client.as_ref()
                 && !self.bedrock_spawned.load(Ordering::Relaxed)

--- a/crates/pumpkin/src/net/bedrock/mod.rs
+++ b/crates/pumpkin/src/net/bedrock/mod.rs
@@ -59,7 +59,7 @@ use crate::{
 };
 use arc_swap::ArcSwap;
 use pumpkin_protocol::bedrock::server::login::ClientData;
-use pumpkin_util::version::BedrockMinecraftVersion;
+use pumpkin_util::{math::vector2::Vector2, version::BedrockMinecraftVersion};
 use pumpkin_world::level::SyncChunk;
 
 pub struct OutgoingPacket {
@@ -262,17 +262,17 @@ impl BedrockClient {
         self.close().await;
     }
 
-    pub async fn send_chunks(&self, chunks: &[SyncChunk]) {
+    pub async fn send_chunks(&self, chunks: &[SyncChunk]) -> Vec<Vector2<i32>> {
         let player = self.player.load_full();
         let Some(player) = player.as_ref() else {
             debug!(
                 "send_chunks: player not set yet, dropping {} chunks",
                 chunks.len()
             );
-            return;
+            return Vec::new();
         };
         let Some(server) = player.world().server.upgrade() else {
-            return;
+            return Vec::new();
         };
 
         let mut valid_chunks = Vec::with_capacity(chunks.len());
@@ -285,11 +285,12 @@ impl BedrockClient {
         }
 
         if valid_chunks.is_empty() {
-            return;
+            return Vec::new();
         }
 
         let mut serialize_tasks = Vec::with_capacity(valid_chunks.len());
         for chunk in valid_chunks {
+            let position = Vector2::new(chunk.x, chunk.z);
             serialize_tasks.push(tokio::task::spawn_blocking(move || {
                 let mut packet_payload = Vec::new();
                 let packet = CLevelChunk {
@@ -299,7 +300,7 @@ impl BedrockClient {
                 };
                 packet
                     .write_packet(&mut packet_payload)
-                    .map(|()| packet_payload)
+                    .map(|()| (position, packet_payload))
             }));
         }
 
@@ -315,7 +316,7 @@ impl BedrockClient {
         let mut packets_to_enqueue = Vec::with_capacity(encoded_payloads.len());
         {
             let encoder = self.network_writer.read().await;
-            for payload in encoded_payloads {
+            for (position, payload) in encoded_payloads {
                 let mut packet_buf = Vec::new();
                 match encoder.write_game_packet(
                     CLevelChunk::PACKET_ID as u16,
@@ -324,14 +325,17 @@ impl BedrockClient {
                     &payload,
                     &mut packet_buf,
                 ) {
-                    Ok(()) => packets_to_enqueue.push(packet_buf),
+                    Ok(()) => packets_to_enqueue.push((position, packet_buf)),
                     Err(err) => error!("Failed to write game packet wrapper: {err}"),
                 }
             }
         }
-        for packet_buf in packets_to_enqueue {
+        let mut delivered_chunks = Vec::with_capacity(packets_to_enqueue.len());
+        for (position, packet_buf) in packets_to_enqueue {
             self.enqueue_packet_data(packet_buf.into()).await;
+            delivered_chunks.push(position);
         }
+        delivered_chunks
     }
 
     pub fn set_player(&self, player: Arc<Player>) {

--- a/crates/pumpkin/src/net/java/mod.rs
+++ b/crates/pumpkin/src/net/java/mod.rs
@@ -35,8 +35,8 @@ use pumpkin_protocol::{
     },
     ser::{NetworkWriteExt, WritingError},
 };
-use pumpkin_util::text::TextComponent;
 use pumpkin_util::version::JavaMinecraftVersion;
+use pumpkin_util::{math::vector2::Vector2, text::TextComponent};
 use tokio::{
     io::{BufReader, BufWriter},
     net::tcp::{OwnedReadHalf, OwnedWriteHalf},
@@ -276,20 +276,21 @@ impl JavaClient {
         }
     }
 
-    pub async fn send_chunks(&self, chunks: &[SyncChunk]) {
+    pub async fn send_chunks(&self, chunks: &[SyncChunk]) -> Vec<Vector2<i32>> {
         let player = self.player.load_full();
         let Some(player) = player.as_ref() else {
             debug!(
                 "send_chunks: player not set yet, dropping {} chunks",
                 chunks.len()
             );
-            return;
+            return Vec::new();
         };
         let Some(server) = player.world().server.upgrade() else {
-            return;
+            return Vec::new();
         };
 
         self.send_packet_now(&CChunkBatchStart).await;
+        let mut delivered_chunks = Vec::with_capacity(chunks.len());
         for chunk in chunks {
             let mut event = ChunkSend::new(player.world(), chunk.clone());
             server.plugin_manager.fire(&server, &mut event).await;
@@ -308,9 +309,11 @@ impl JavaClient {
                 continue;
             }
             self.send_packet_now_data(buf.into()).await;
+            delivered_chunks.push(Vector2::new(chunk.x, chunk.z));
         }
-        self.send_packet_now(&CChunkBatchEnd::new(chunks.len() as u16))
+        self.send_packet_now(&CChunkBatchEnd::new(delivered_chunks.len() as u16))
             .await;
+        delivered_chunks
     }
 
     pub async fn enqueue_packet<P: ClientPacket>(&self, packet: &P) {

--- a/crates/pumpkin/src/net/java/play.rs
+++ b/crates/pumpkin/src/net/java/play.rs
@@ -1766,12 +1766,11 @@ impl JavaClient {
             .map(|p| Arc::clone(p) as Arc<dyn EntityBase>)
             .or_else(|| world.get_entity_by_id(entity_id.0));
         let Some(target) = target else {
-            self.kick(TextComponent::translate_cross(
-                translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED,
-                translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED,
-                [],
-            ))
-            .await;
+            debug!(
+                "Player id {} attacked entity id {}, which was not found",
+                player.entity_id(),
+                entity_id.0
+            );
             return;
         };
         if let Some(player_victim) = &player_target {
@@ -1902,13 +1901,11 @@ impl JavaClient {
 
                 'after: {
                     if event.action == ActionType::Attack {
-                        error!(
-                            "Player id {} interacted with entity id {}, which was not found.",
+                        debug!(
+                            "Player id {} attacked entity id {}, which was not found",
                             player.entity_id(),
                             event.entity_id
                         );
-                        self.kick(TextComponent::translate_cross(translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED, translation::java::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED, [],))
-                        .await;
                     }
                 }
             }}

--- a/crates/pumpkin/src/net/mod.rs
+++ b/crates/pumpkin/src/net/mod.rs
@@ -16,6 +16,7 @@ use pumpkin_data::translation;
 use pumpkin_protocol::{BClientPacket, ClientPacket, Property};
 use pumpkin_util::{
     Hand, ProfileAction,
+    math::vector2::Vector2,
     text::TextComponent,
     version::{BedrockMinecraftVersion, JavaMinecraftVersion},
 };
@@ -256,7 +257,7 @@ impl ClientPlatform {
         }
     }
 
-    pub async fn send_chunks(&self, chunks: &[SyncChunk]) {
+    pub async fn send_chunks(&self, chunks: &[SyncChunk]) -> Vec<Vector2<i32>> {
         match self {
             Self::Java(java) => java.send_chunks(chunks).await,
             Self::Bedrock(bedrock) => bedrock.send_chunks(chunks).await,

--- a/crates/pumpkin/src/world/chunker.rs
+++ b/crates/pumpkin/src/world/chunker.rs
@@ -100,6 +100,7 @@ pub async fn update_position(player: &Arc<Player>) {
     for chunk in &unloading_chunks {
         player.delivered_chunks.remove(chunk);
     }
+    world.update_entity_tracking_for_player(player);
 
     if let ClientPlatform::Java(client) = player.client.as_ref() {
         for chunk in &unloading_chunks {

--- a/crates/pumpkin/src/world/chunker.rs
+++ b/crates/pumpkin/src/world/chunker.rs
@@ -97,6 +97,10 @@ pub async fn update_position(player: &Arc<Player>) {
     };
     player.watched_section.store(new_cylindrical);
 
+    for chunk in &unloading_chunks {
+        player.delivered_chunks.remove(chunk);
+    }
+
     if let ClientPlatform::Java(client) = player.client.as_ref() {
         for chunk in &unloading_chunks {
             client

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -102,7 +102,10 @@ impl World {
             && (entity_position.x - player_position.x).abs() <= tracking_range
             && (entity_position.z - player_position.z).abs() <= tracking_range;
         let player_id = player.gameprofile.id;
-        let mut viewers = tracker.viewers.lock().unwrap();
+        let mut viewers = tracker
+            .viewers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         if should_track {
             if viewers.insert(player_id) {
@@ -118,7 +121,10 @@ impl World {
             return;
         };
 
-        let viewers = tracker.viewers.into_inner().unwrap();
+        let viewers = tracker
+            .viewers
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for player_id in viewers {
             if let Some(player) = self.get_player_by_uuid(player_id) {
                 send_remove_entity(&player, entity_id);
@@ -129,7 +135,11 @@ impl World {
     pub fn remove_player_from_entity_tracking(&self, player: &Player) {
         let player_id = player.gameprofile.id;
         for tracker in &self.entity_trackers {
-            tracker.viewers.lock().unwrap().remove(&player_id);
+            tracker
+                .viewers
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remove(&player_id);
         }
     }
 }

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -1,0 +1,133 @@
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
+
+use pumpkin_protocol::{
+    bedrock::client::remove_actor::CRemoveActor,
+    codec::{var_int::VarInt, var_long::VarLong},
+    java::client::play::CRemoveEntities,
+};
+use pumpkin_util::math::{get_section_cord, vector2::Vector2};
+use rustc_hash::FxHashSet;
+use uuid::Uuid;
+
+use crate::{
+    entity::{EntityBase, player::Player},
+    net::ClientPlatform,
+};
+
+use super::World;
+
+pub(super) struct EntityTracker {
+    entity: Arc<dyn EntityBase>,
+    tracked_chunk: AtomicU64,
+    viewers: Mutex<FxHashSet<Uuid>>,
+}
+
+impl EntityTracker {
+    fn new(entity: Arc<dyn EntityBase>) -> Self {
+        let chunk = entity_chunk(entity.as_ref());
+        Self {
+            entity,
+            tracked_chunk: AtomicU64::new(chunk_key(chunk)),
+            viewers: Mutex::new(FxHashSet::default()),
+        }
+    }
+}
+
+impl World {
+    pub fn register_entity_tracking(&self, entity: Arc<dyn EntityBase>) {
+        let entity_id = entity.get_entity().entity_id;
+        self.entity_trackers
+            .insert(entity_id, EntityTracker::new(entity));
+        self.update_entity_tracking_for_entity_id(entity_id, true);
+    }
+
+    pub fn update_entity_tracking_for_player(&self, player: &Arc<Player>) {
+        for tracker in &self.entity_trackers {
+            Self::update_pairing(tracker.value(), player);
+        }
+    }
+
+    pub fn update_entity_tracking_for_entity(&self, entity: &Arc<dyn EntityBase>) {
+        self.update_entity_tracking_for_entity_id(entity.get_entity().entity_id, false);
+    }
+
+    fn update_entity_tracking_for_entity_id(&self, entity_id: i32, force: bool) {
+        let Some(tracker) = self.entity_trackers.get(&entity_id) else {
+            return;
+        };
+
+        let chunk = entity_chunk(tracker.entity.as_ref());
+        tracker.entity.get_entity().chunk_pos.store(chunk);
+        let previous_chunk = tracker
+            .tracked_chunk
+            .swap(chunk_key(chunk), Ordering::Relaxed);
+        if !force && previous_chunk == chunk_key(chunk) {
+            return;
+        }
+
+        for player in self.players.load().iter() {
+            Self::update_pairing(tracker.value(), player);
+        }
+    }
+
+    fn update_pairing(tracker: &EntityTracker, player: &Arc<Player>) {
+        let chunk = entity_chunk(tracker.entity.as_ref());
+        let should_track = player.delivered_chunks.contains(&chunk);
+        let player_id = player.gameprofile.id;
+        let mut viewers = tracker.viewers.lock().unwrap();
+
+        if should_track {
+            if viewers.insert(player_id) {
+                player.client.try_enqueue_spawn_packet(&tracker.entity);
+            }
+        } else if viewers.remove(&player_id) {
+            send_remove_entity(player, tracker.entity.get_entity().entity_id);
+        }
+    }
+
+    pub fn remove_entity_tracking(&self, entity_id: i32) {
+        let Some((_, tracker)) = self.entity_trackers.remove(&entity_id) else {
+            return;
+        };
+
+        let viewers = tracker.viewers.into_inner().unwrap();
+        for player_id in viewers {
+            if let Some(player) = self.get_player_by_uuid(player_id) {
+                send_remove_entity(&player, entity_id);
+            }
+        }
+    }
+
+    pub fn remove_player_from_entity_tracking(&self, player: &Player) {
+        let player_id = player.gameprofile.id;
+        for tracker in &self.entity_trackers {
+            tracker.viewers.lock().unwrap().remove(&player_id);
+        }
+    }
+}
+
+fn entity_chunk(entity: &dyn EntityBase) -> Vector2<i32> {
+    let position = entity.get_entity().pos.load();
+    Vector2::new(
+        get_section_cord(position.x.floor() as i32),
+        get_section_cord(position.z.floor() as i32),
+    )
+}
+
+fn chunk_key(chunk: Vector2<i32>) -> u64 {
+    (u64::from(chunk.x as u32) << 32) | u64::from(chunk.y as u32)
+}
+
+fn send_remove_entity(player: &Player, entity_id: i32) {
+    match player.client.as_ref() {
+        ClientPlatform::Java(java) => {
+            java.try_enqueue_packet(&CRemoveEntities::new(&[VarInt(entity_id)]));
+        }
+        ClientPlatform::Bedrock(bedrock) => {
+            bedrock.try_enqueue_packet(&CRemoveActor::new(VarLong(i64::from(entity_id))));
+        }
+    }
+}

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -75,7 +75,14 @@ impl World {
 
     fn update_pairing(tracker: &EntityTracker, player: &Arc<Player>) {
         let chunk = entity_chunk(tracker.entity.as_ref());
-        let should_track = player.delivered_chunks.contains(&chunk);
+        let entity = tracker.entity.get_entity();
+        let entity_position = entity.pos.load();
+        let player_position = player.position();
+        let tracking_range = f64::from(client_tracking_range(entity.entity_type)) * 16.0;
+        let should_track = tracking_range > 0.0
+            && player.delivered_chunks.contains(&chunk)
+            && (entity_position.x - player_position.x).abs() <= tracking_range
+            && (entity_position.z - player_position.z).abs() <= tracking_range;
         let player_id = player.gameprofile.id;
         let mut viewers = tracker.viewers.lock().unwrap();
 
@@ -106,6 +113,72 @@ impl World {
         for tracker in &self.entity_trackers {
             tracker.viewers.lock().unwrap().remove(&player_id);
         }
+    }
+}
+
+/// Vanilla 26.2 client tracking ranges, measured in chunks.
+fn client_tracking_range(entity_type: &pumpkin_data::entity::EntityType) -> i32 {
+    match entity_type.resource_name {
+        "marker" => 0,
+        "arrow" | "breeze_wind_charge" | "cod" | "dragon_fireball" | "egg" | "ender_pearl"
+        | "experience_bottle" | "eye_of_ender" | "fireball" | "firework_rocket"
+        | "fishing_bobber" | "lingering_potion" | "llama_spit" | "pufferfish" | "salmon"
+        | "small_fireball" | "snowball" | "spectral_arrow" | "splash_potion" | "trident"
+        | "tropical_fish" | "wind_charge" | "wither_skull" => 4,
+        "bat" | "dolphin" => 5,
+        "evoker_fangs" | "experience_orb" | "item" => 6,
+        "allay"
+        | "bee"
+        | "blaze"
+        | "bogged"
+        | "cat"
+        | "cave_spider"
+        | "chest_minecart"
+        | "command_block_minecart"
+        | "creaking"
+        | "creeper"
+        | "drowned"
+        | "enderman"
+        | "endermite"
+        | "evoker"
+        | "fox"
+        | "furnace_minecart"
+        | "guardian"
+        | "hoglin"
+        | "hopper_minecart"
+        | "husk"
+        | "illusioner"
+        | "magma_cube"
+        | "minecart"
+        | "mule"
+        | "ominous_item_spawner"
+        | "parched"
+        | "parrot"
+        | "phantom"
+        | "piglin"
+        | "piglin_brute"
+        | "pillager"
+        | "rabbit"
+        | "shulker_bullet"
+        | "silverfish"
+        | "skeleton"
+        | "snow_golem"
+        | "spawner_minecart"
+        | "spider"
+        | "squid"
+        | "stray"
+        | "tnt_minecart"
+        | "vex"
+        | "vindicator"
+        | "witch"
+        | "wither_skeleton"
+        | "zoglin"
+        | "zombie"
+        | "zombie_villager"
+        | "zombified_piglin" => 8,
+        "end_crystal" | "lightning_bolt" | "warden" => 16,
+        "mannequin" | "player" => 32,
+        _ => 10,
     }
 }
 

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -45,8 +45,15 @@ impl World {
     }
 
     pub fn update_entity_tracking_for_player(&self, player: &Arc<Player>) {
+        let Some(server) = self.server.upgrade() else {
+            return;
+        };
         for tracker in &self.entity_trackers {
-            Self::update_pairing(tracker.value(), player);
+            Self::update_pairing(
+                tracker.value(),
+                player,
+                &server.advanced_config.entity_tracking,
+            );
         }
     }
 
@@ -68,17 +75,28 @@ impl World {
             return;
         }
 
+        let Some(server) = self.server.upgrade() else {
+            return;
+        };
         for player in self.players.load().iter() {
-            Self::update_pairing(tracker.value(), player);
+            Self::update_pairing(
+                tracker.value(),
+                player,
+                &server.advanced_config.entity_tracking,
+            );
         }
     }
 
-    fn update_pairing(tracker: &EntityTracker, player: &Arc<Player>) {
+    fn update_pairing(
+        tracker: &EntityTracker,
+        player: &Arc<Player>,
+        config: &pumpkin_config::EntityTrackingConfig,
+    ) {
         let chunk = entity_chunk(tracker.entity.as_ref());
         let entity = tracker.entity.get_entity();
         let entity_position = entity.pos.load();
         let player_position = player.position();
-        let tracking_range = f64::from(client_tracking_range(entity.entity_type)) * 16.0;
+        let tracking_range = f64::from(config.range_for(entity.entity_type.resource_name)) * 16.0;
         let should_track = tracking_range > 0.0
             && player.delivered_chunks.contains(&chunk)
             && (entity_position.x - player_position.x).abs() <= tracking_range
@@ -113,72 +131,6 @@ impl World {
         for tracker in &self.entity_trackers {
             tracker.viewers.lock().unwrap().remove(&player_id);
         }
-    }
-}
-
-/// Vanilla 26.2 client tracking ranges, measured in chunks.
-fn client_tracking_range(entity_type: &pumpkin_data::entity::EntityType) -> i32 {
-    match entity_type.resource_name {
-        "marker" => 0,
-        "arrow" | "breeze_wind_charge" | "cod" | "dragon_fireball" | "egg" | "ender_pearl"
-        | "experience_bottle" | "eye_of_ender" | "fireball" | "firework_rocket"
-        | "fishing_bobber" | "lingering_potion" | "llama_spit" | "pufferfish" | "salmon"
-        | "small_fireball" | "snowball" | "spectral_arrow" | "splash_potion" | "trident"
-        | "tropical_fish" | "wind_charge" | "wither_skull" => 4,
-        "bat" | "dolphin" => 5,
-        "evoker_fangs" | "experience_orb" | "item" => 6,
-        "allay"
-        | "bee"
-        | "blaze"
-        | "bogged"
-        | "cat"
-        | "cave_spider"
-        | "chest_minecart"
-        | "command_block_minecart"
-        | "creaking"
-        | "creeper"
-        | "drowned"
-        | "enderman"
-        | "endermite"
-        | "evoker"
-        | "fox"
-        | "furnace_minecart"
-        | "guardian"
-        | "hoglin"
-        | "hopper_minecart"
-        | "husk"
-        | "illusioner"
-        | "magma_cube"
-        | "minecart"
-        | "mule"
-        | "ominous_item_spawner"
-        | "parched"
-        | "parrot"
-        | "phantom"
-        | "piglin"
-        | "piglin_brute"
-        | "pillager"
-        | "rabbit"
-        | "shulker_bullet"
-        | "silverfish"
-        | "skeleton"
-        | "snow_golem"
-        | "spawner_minecart"
-        | "spider"
-        | "squid"
-        | "stray"
-        | "tnt_minecart"
-        | "vex"
-        | "vindicator"
-        | "witch"
-        | "wither_skeleton"
-        | "zoglin"
-        | "zombie"
-        | "zombie_villager"
-        | "zombified_piglin" => 8,
-        "end_crystal" | "lightning_bolt" | "warden" => 16,
-        "mannequin" | "player" => 32,
-        _ => 10,
     }
 }
 

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -18,6 +18,7 @@ use std::{
 use tracing::{debug, error, info, trace, warn};
 
 pub mod chunker;
+mod entity_tracker;
 pub mod explosion;
 pub mod loot;
 pub mod map;
@@ -199,6 +200,7 @@ pub struct World {
     /// A map of active entities within the world, keyed by their unique UUID.
     /// This does not include players.
     pub entities: ArcSwap<Vec<Arc<dyn EntityBase>>>,
+    entity_trackers: DashMap<i32, entity_tracker::EntityTracker>,
     /// The world's scoreboard, used for tracking scores, objectives, and display information.
     pub scoreboard: Mutex<Scoreboard>,
     /// The world's worldborder, defining the playable area and controlling its expansion or contraction.
@@ -305,6 +307,7 @@ impl World {
             level_info,
             players: ArcSwap::new(Arc::new(Vec::new())),
             entities: ArcSwap::new(Arc::new(Vec::new())),
+            entity_trackers: DashMap::new(),
             scoreboard: Mutex::new(Scoreboard::default()),
             worldborder: Mutex::new(Worldborder::new(0.0, 0.0, 5.999_996_8E7, 0, 5, 300)),
             level_time: Mutex::new(LevelTime::new()),
@@ -972,6 +975,7 @@ impl World {
         let entities_to_tick = self.entities.load();
         let entity_count = entities_to_tick.len();
         let server_for_entities = server.clone();
+        let world_for_entities = self.clone();
         let active_chunks = self.active_chunks.load();
 
         let entity_future = async move {
@@ -996,10 +1000,12 @@ impl World {
                 let e_clone = entity.clone();
                 let s_clone = server_for_entities.clone();
                 let p_cache = players_cache.clone();
+                let world = world_for_entities.clone();
 
                 tasks.spawn(async move {
                     e_clone.get_entity().age.fetch_add(1, Relaxed);
                     e_clone.tick(&e_clone, &s_clone).await;
+                    world.update_entity_tracking_for_entity(&e_clone);
 
                     let entity_inner = e_clone.get_entity();
                     let entity_pos = entity_inner.pos.load();
@@ -3762,33 +3768,23 @@ impl World {
                         entity.read_nbt_non_mut(entity_nbt).await;
                         entity.init_data_tracker().await;
 
-                        let base_entity = entity.get_entity();
                         // Clear velocity so the client does not replay the drop
                         // animation; residual velocity from the original drop is
                         // stale data.
-                        base_entity.velocity.store(Vector3::default());
-
-                        player.client.enqueue_spawn_packet(&entity).await;
+                        entity
+                            .get_entity()
+                            .velocity
+                            .store(Vector3::default());
                         entities_to_add.push(entity);
                     }
 
-                    if !entities_to_add.is_empty() {
-                        world.entities.rcu(|current_entities| {
-                            let mut new_entities = (**current_entities).clone();
-                            new_entities.extend(entities_to_add.iter().cloned());
-                            new_entities
-                        });
+                    for entity in entities_to_add {
+                        world.add_entity_silent(entity).await;
                     }
                 } else {
-                    // The chunk's entities are already live (another watcher loaded
-                    // them). Just send this player the spawn packets for the live
-                    // entities currently in this chunk.
-                    for entity in world.entities.load().iter() {
-                        let base_entity = entity.get_entity();
-                        if base_entity.chunk_pos.load() == position {
-                            player.client.enqueue_spawn_packet(entity).await;
-                        }
-                    }
+                    // Another watcher already made these entities live. Pairing is
+                    // deferred until this player's terrain batch completes.
+                    world.update_entity_tracking_for_player(&player);
                 }
             }
 
@@ -4137,6 +4133,7 @@ impl World {
         player: &Arc<Player>,
         fire_event: bool,
     ) -> Option<Arc<Player>> {
+        self.remove_player_from_entity_tracking(player);
         let mut removed_player: Option<Arc<Player>> = None;
 
         self.players.rcu(|current_list| {
@@ -4205,8 +4202,6 @@ impl World {
     }
 
     pub fn spawn_entity_non_save(&self, entity: &Arc<dyn EntityBase>) {
-        let _base_entity = entity.get_entity();
-        self.broadcast_entity_spawn(entity);
         self.spawn_state.load().add_entity(self, entity.as_ref());
 
         self.entities.rcu(|current_entities| {
@@ -4214,27 +4209,12 @@ impl World {
             new_entities.push(entity.clone());
             new_entities
         });
+        self.register_entity_tracking(entity.clone());
     }
 
     pub async fn spawn_entity(&self, entity: Arc<dyn EntityBase>) {
-        self.broadcast_entity_spawn(&entity);
         entity.init_data_tracker().await;
         self.add_entity_silent(entity).await;
-    }
-
-    pub fn broadcast_entity_spawn(&self, entity: &Arc<dyn EntityBase>) {
-        let base_entity = entity.get_entity();
-        let chunk_pos = base_entity.chunk_pos.load();
-
-        let players = self.players.load();
-        for player in players.iter() {
-            let center = player.get_entity().chunk_pos.load();
-            let view_distance = get_view_distance(player).get() as i32;
-
-            if is_within_view_distance(chunk_pos, center, view_distance) {
-                player.client.try_enqueue_spawn_packet(entity);
-            }
-        }
     }
 
     #[allow(clippy::unused_async)]
@@ -4263,6 +4243,7 @@ impl World {
             new_entities.push(entity.clone());
             new_entities
         });
+        self.register_entity_tracking(entity);
     }
 
     #[allow(clippy::unused_async)]
@@ -4274,13 +4255,7 @@ impl World {
             new_entities.retain(|e| e.get_entity().entity_uuid != base_entity.entity_uuid);
             new_entities
         });
-
-        let chunk_pos = base_entity.chunk_pos.load();
-        self.broadcast_to_chunk_editioned_sync(
-            chunk_pos,
-            &CRemoveEntities::new(&[base_entity.entity_id.into()]),
-            &CRemoveActor::new(VarLong(base_entity.entity_id as i64)),
-        );
+        self.remove_entity_tracking(base_entity.entity_id);
     }
 
     pub async fn remove_entities_in_chunks(
@@ -4297,7 +4272,11 @@ impl World {
             let mut new_entities = (**current_entities).clone();
             new_entities.retain(|entity| {
                 let base_entity = entity.get_entity();
-                let pos = base_entity.chunk_pos.load();
+                let entity_pos = base_entity.pos.load();
+                let pos = Vector2::new(
+                    get_section_cord(entity_pos.x.floor() as i32),
+                    get_section_cord(entity_pos.z.floor() as i32),
+                );
                 if chunks_set.contains(&pos) {
                     entities_to_remove.push(entity.clone());
                     false
@@ -4309,6 +4288,7 @@ impl World {
         });
 
         for entity in entities_to_remove {
+            self.remove_entity_tracking(entity.get_entity().entity_id);
             self.save_entity(&entity).await;
             self.spawn_state.load().remove_entity(self, entity.as_ref());
         }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -400,8 +400,14 @@ impl World {
     /// currently in; the chunk is rewritten from scratch every unload cycle, so
     /// there is nothing stale to deduplicate.
     async fn save_entity(&self, entity: &Arc<dyn EntityBase>) {
-        let current_chunk = entity.get_entity().block_pos.load().chunk_position();
+        let base_entity = entity.get_entity();
+        if !base_entity.entity_type.saveable {
+            return;
+        }
+
+        let current_chunk = base_entity.block_pos.load().chunk_position();
         let mut nbt = NbtCompound::new();
+        base_entity.write_nbt(&mut nbt).await;
         entity.write_nbt(&mut nbt).await;
         let chunk = self.level.get_entity_chunk(current_chunk).await;
         chunk.data.lock().await.push(nbt);
@@ -3765,6 +3771,7 @@ impl World {
                         // Pos is zero since it will be read from nbt.
                         let entity =
                             from_type(entity_type, Vector3::new(0.0, 0.0, 0.0), &world, uuid);
+                        entity.get_entity().read_nbt_non_mut(entity_nbt).await;
                         entity.read_nbt_non_mut(entity_nbt).await;
                         entity.init_data_tracker().await;
 

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -405,7 +405,11 @@ impl World {
             return;
         }
 
-        let current_chunk = base_entity.block_pos.load().chunk_position();
+        let position = base_entity.pos.load();
+        let current_chunk = Vector2::new(
+            get_section_cord(position.x.floor() as i32),
+            get_section_cord(position.z.floor() as i32),
+        );
         let mut nbt = NbtCompound::new();
         base_entity.write_nbt(&mut nbt).await;
         entity.write_nbt(&mut nbt).await;


### PR DESCRIPTION
## Description

Entities are currently not properly removed from the client when their chunks are unloaded. This causes ghost entities to remain visible, allows mobs to appear before their terrain is loaded and can disconnect players when they attack an entity that no longer exists on the server. The purpose of these changes is to implement a proper entity tracking lifecycle and keep the client and server synchronized.

Pumpkin sends entity spawn packets based on view distance. When the player travels away, Pumpkin sends `CUnloadChunk`, but it does not send `CRemoveEntities`. If the chunk has no remaining watchers, Pumpkin removes the entity from the world, but the client continues rendering it because it never received a removal packet.

I checked Mojang's 26.2 implementation. Each entity keeps a set of players currently tracking it, pairing only happens after the player has actually received the entity's terrain chunk, and the tracking state is recalculated every tick. I used a similar approach, but adapted it to Pumpkin's async architecture so tracking is only recalculated when something relevant changes:

- A chunk is sent or unloaded
- A player crosses a chunk boundary
- An entity crosses a chunk boundary
- An entity is spawned or removed

When a pairing becomes invalid, `CRemoveEntities` is immediately sent to that player. Entities are also registered before their spawn packet is sent. This should give us the same observable behavior as the official server without recalculating every entity for every stationary player each tick.

While testing this, I also found that some entities were saved without their base NBT because their custom NBT implementation was empty. This caused `Entity has no ID` messages when those chunks were loaded again. Base entity data is now always saved and loaded together with any custom data. Fast-moving entities such as projectiles and minecarts also use their live position when deciding which chunk they should be saved in.

Attacking an entity ID that no longer exists is now ignored like vanilla instead of disconnecting the player. The separate check for attacking your own entity ID is unchanged.

## Testing
Besides the cargo/fmt/clippy checks I have done, I had worries about performance impact. So i did a small benchmark:

I tested both upstream and this branch using the same world, one connected player and 500 armor stands.

Upstream averaged 23.9% CPU, while this branch averaged 24.4% CPU. Median tick time stayed around 1.4 ms on both, and the P95/P99 results were also within normal run-to-run variance.

I could not find any measurable performance regression from the new tracking system. I did movement-heavy benchmarks too but the results were excluded because chunk generation made the runs too inconsistent for a fair comparison.

I have I7 10700K and 16 GB RAM DDR4. Though we need a larger test in the future. 