### PR TITLE
fix(enderman): synchronize teleport landing

### DIFF
--- a/crates/pumpkin/src/entity/mob/enderman.rs
+++ b/crates/pumpkin/src/entity/mob/enderman.rs
@@ -21,10 +21,7 @@ use pumpkin_data::{
     tracked_data::TrackedData,
 };
 use pumpkin_nbt::compound::NbtCompound;
-use pumpkin_protocol::{
-    codec::var_int::VarInt,
-    java::client::play::{CEntityPositionSync, Metadata},
-};
+use pumpkin_protocol::{codec::var_int::VarInt, java::client::play::Metadata};
 use pumpkin_util::math::{boundingbox::BoundingBox, position::BlockPos, vector3::Vector3};
 use rand::RngExt;
 
@@ -180,38 +177,31 @@ impl EndermanEntity {
         let block_x = x.floor() as i32;
         let mut block_y = target_y.floor() as i32;
         let block_z = z.floor() as i32;
-        let mut found_ground = false;
-        loop {
+        let ground_pos = loop {
             let below_pos = BlockPos::new(block_x, block_y - 1, block_z);
             let below_state = world.get_block_state(&below_pos);
             if below_state.is_solid() {
-                found_ground = true;
-                break;
+                break Some(below_pos);
             }
             if block_y <= world.dimension.min_y {
-                break;
+                break None;
             }
             block_y -= 1;
             target_y = block_y as f64;
-        }
+        };
+        let Some(ground_pos) = ground_pos else {
+            return false;
+        };
 
-        if !found_ground {
+        if world
+            .get_fluid(&ground_pos)
+            .has_tag(&tag::Fluid::MINECRAFT_WATER)
+        {
             return false;
         }
 
-        let dest_pos = BlockPos::new(block_x, block_y, block_z);
-        let dest_fluid = world.get_fluid(&dest_pos);
-        if dest_fluid.has_tag(&tag::Fluid::MINECRAFT_WATER) {
-            return false;
-        }
-
-        let half_width = 0.3;
-        let height = 2.9;
-        let bb = BoundingBox::new(
-            Vector3::new(x - half_width, target_y, z - half_width),
-            Vector3::new(x + half_width, target_y + height, z + half_width),
-        );
-        if !world.is_space_empty(bb) {
+        let bb = BoundingBox::new_from_pos(x, target_y, z, &entity.entity_dimension.load());
+        if !world.is_space_empty(bb) || world.contains_any_liquid(bb) {
             return false;
         }
 
@@ -244,19 +234,7 @@ impl EndermanEntity {
             }
         }
 
-        entity.set_pos(new_pos);
-        let chunk_pos = entity.chunk_pos.load();
-        world.broadcast_to_chunk(
-            chunk_pos,
-            &CEntityPositionSync::new(
-                entity.entity_id.into(),
-                new_pos,
-                Vector3::new(0.0, 0.0, 0.0),
-                entity.yaw.load(),
-                entity.pitch.load(),
-                entity.on_ground.load(Ordering::Relaxed),
-            ),
-        );
+        entity.teleport(new_pos, None, None, world.clone());
 
         self.mob_entity
             .navigator

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -3075,7 +3075,7 @@ impl Entity {
             &CEntityPositionSync::new(
                 self.entity_id.into(),
                 position,
-                Vector3::new(0.0, 0.0, 0.0),
+                self.velocity.load(),
                 yaw.unwrap_or(self.yaw.load()),
                 pitch.unwrap_or(self.pitch.load()),
                 self.on_ground.load(Ordering::SeqCst),

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1497,6 +1497,28 @@ impl World {
         false
     }
 
+    pub fn contains_any_liquid(&self, bounding_box: BoundingBox) -> bool {
+        let min_x = bounding_box.min.x.floor() as i32;
+        let max_x = bounding_box.max.x.ceil() as i32;
+        let min_y = bounding_box.min.y.floor() as i32;
+        let max_y = bounding_box.max.y.ceil() as i32;
+        let min_z = bounding_box.min.z.floor() as i32;
+        let max_z = bounding_box.max.z.ceil() as i32;
+
+        for x in min_x..max_x {
+            for y in min_y..max_y {
+                for z in min_z..max_z {
+                    let pos = BlockPos::new(x, y, z);
+                    if self.get_fluid_and_fluid_state(&pos).0.id != Fluid::EMPTY.id {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
     // FlowingFluid.getFlow()
     pub fn get_fluid_velocity(
         &self,


### PR DESCRIPTION
## Description

Endermen could teleport to a position in the air and then appear to walk there instead of landing on the terrain below.

There were two separate problems causing this. The destination search did not fully match the official server behavior, and successful teleports updated the position without updating Pumpkin’s movement cache. The next relative movement packet could therefore be calculated from the old position, making the client apply part of the teleport twice.

The destination search now scans downward for solid ground, rejects water and other liquids, checks collisions using the Enderman’s actual dimensions and stops the teleport when no valid landing position exists.

Successful teleports now use the shared entity teleport path. This updates both the server position and the last position sent to clients before any relative movement updates are generated. Absolute position synchronization also preserves the entity’s current velocity.

## Testing
I shot an Enderman with projectiles such as arrows for around 10 minutes to repeatedly trigger its teleportation.

It consistently landed on valid terrain and never teleported into the air, water or anywhere else it was not supposed to. It also no longer appeared to walk in the air after teleporting.