### PR TITLE
fix: stop stdin console task on EOF

### DIFF
--- a/crates/pumpkin/src/lib.rs
+++ b/crates/pumpkin/src/lib.rs
@@ -635,21 +635,21 @@ fn setup_stdin_console(server: Arc<Server>) {
         }
     });
     tokio::spawn(async move {
-        while !SHOULD_STOP.load(Ordering::Relaxed) {
-            if let Some(command) = rx.recv().await {
-                let mut event = ServerCommandEvent::new(command.clone());
-                server.plugin_manager.fire(&server, &mut event).await;
-                if !event.cancelled {
-                    server
-                        .command_dispatcher
-                        .read()
-                        .await
-                        .handle_command(
-                            &command::CommandSender::Console.into_source(&server).await,
-                            command.as_str(),
-                        )
-                        .await;
-                }
+        while !SHOULD_STOP.load(Ordering::Relaxed)
+            && let Some(command) = rx.recv().await
+        {
+            let mut event = ServerCommandEvent::new(command.clone());
+            server.plugin_manager.fire(&server, &mut event).await;
+            if !event.cancelled {
+                server
+                    .command_dispatcher
+                    .read()
+                    .await
+                    .handle_command(
+                        &command::CommandSender::Console.into_source(&server).await,
+                        command.as_str(),
+                    )
+                    .await;
             }
         }
     });


### PR DESCRIPTION
## Description

Fixes a busy loop in the stdin console task when Pumpkin runs without interactive input, such as under systemd or Docker.

When stdin reaches EOF, the command channel closes and `recv()` immediately returns `None`. The previous loop kept polling the closed channel, causing a Tokio worker to consume a full CPU core. The task now exits when the channel closes.

In testing, idle CPU usage dropped from 137.3% to around 0.3–0.4%.

## Testing

Tested by running Pumpkin with stdin redirected from `/dev/null`, reproducing a non-interactive systemd or container environment.

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `cargo clippy --release --all-targets --all-features`
- `cargo build --verbose --release`
- `cargo test`

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
