### PR TITLE
feat(plugin-api): expose ItemStack, uuid, event and command arg types

### DIFF
--- a/pumpkin-plugin-api/src/lib.rs
+++ b/pumpkin-plugin-api/src/lib.rs
@@ -44,7 +44,8 @@ pub mod scheduler;
 
 pub mod command {
     pub use crate::wit::pumpkin::plugin::command::{
-        Command, CommandError, CommandNode, CommandSender, ConsumedArgs,
+        Arg, ArgumentType, Command, CommandError, CommandNode, CommandSender, ConsumedArgs,
+        StringType,
     };
 }
 
@@ -53,9 +54,15 @@ pub use wit::pumpkin::plugin::{
     context::{Context, Server},
     data_components, entity,
     entity_types::EntityType,
-    gui, i18n, java_dialogs, java_packets, particles, permission, player, scoreboard, server, text,
-    world,
+    event::{self as events_wit, EventType},
+    gui, i18n, item_stack, java_dialogs, java_packets, particles, permission, player, scoreboard,
+    server, text, uuid, world,
 };
+
+// Convenience re-exports of commonly-used plugin types so plugin authors can
+// name them directly (e.g. build an `ItemStack` for a GUI or `/give`).
+pub use events::{EventHandler, FromIntoEvent};
+pub use wit::pumpkin::plugin::item_stack::ItemStack;
 
 pub mod java_dialog {
     pub use crate::wit::pumpkin::plugin::java_dialogs::{ActionButton, DialogBody, DialogType};


### PR DESCRIPTION
## What

Re-export the already-generated `item_stack`, `uuid`, and `event` WIT modules (plus a few convenience types) from `pumpkin-plugin-api`, so plugin authors can name them:

- `item_stack` + `ItemStack` (with its `new(registry_key, count)` constructor)
- `uuid`
- `event::{self as events_wit, EventType}`, plus `EventHandler` and `FromIntoEvent`
- command `Arg`, `ArgumentType`, `StringType`

## Why

These modules are generated by `wit_bindgen` and are already used internally (by `gui`, `player`, etc.), but they were never added to the public re-export list in `lib.rs`, so plugin authors can't name them:

- **`ItemStack` can't be constructed by a plugin** — it's only reachable by *inference* off methods like `player.get_inventory_item()`. That blocks building GUI icons (`gui.set_item(...)`), and commands like `/give`, `/i`, `/skull`.
- **`uuid` can't be named**, so plugins can't build one to pass to `server.get_player_by_uuid(...)` and have to hand-format the `{high, low}` fields.
- The command `Arg`/`ArgumentType`/`StringType` types and `EventHandler`/`FromIntoEvent` sit behind non-obvious paths (`command_wit`, `events::...`).

## Change

One file (`pumpkin-plugin-api/src/lib.rs`), purely additive re-exports. Compiles for `wasm32-wasip2`.

Revives #2325 (opened and self-closed unmerged by @dongzh1) — same intent, credit to them.
