### PR TITLE
feat(world): add find_nearest_biome for /locate biome

### DIFF
--- a/pumpkin-world/src/biome/biome_finder.rs
+++ b/pumpkin-world/src/biome/biome_finder.rs
@@ -1,0 +1,46 @@
+use crate::{
+    biome::Biome, biome::BiomeSupplier,
+    generation::noise::router::multi_noise_sampler::MultiNoiseSampler,
+};
+use pumpkin_data::dimension::Dimension;
+use pumpkin_util::math::position::BlockPos;
+
+// NOT 100% parity with vanilla (Doesn't use "iterateInSquare")
+pub fn find_nearest_biome(
+    origin: BlockPos,
+    target: &'static Biome,
+    max_radius: i32,
+    supplier: &impl BiomeSupplier,
+    sampler: &mut MultiNoiseSampler<'_>,
+    dim: &Dimension,
+) -> Option<BlockPos> {
+    const H_INTERVAL: i32 = 32;
+    const V_INTERVAL: i32 = 64;
+    let max_radius_cells = max_radius / H_INTERVAL;
+    let top_y = dim.min_y + dim.height - 1;
+
+    // This probably could be optimized to just use 2 for loops
+    for radius in 0..=max_radius_cells {
+        for dx in -radius..=radius {
+            for dz in -radius..=radius {
+                if dx.abs() != radius && dz.abs() != radius {
+                    continue; // skip interior, keep ring edge only
+                }
+                // block coords: origin + offset*interval
+                let bx = origin.0.x + dx * H_INTERVAL;
+                let bz = origin.0.z + dz * H_INTERVAL;
+
+                let mut by = dim.min_y;
+                while by <= top_y {
+                    if supplier.biome(bx >> 2, by >> 2, bz >> 2, sampler) == target {
+                        return Some(BlockPos::new(bx, by, bz));
+                    }
+
+                    by += V_INTERVAL;
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/pumpkin-world/src/biome/mod.rs
+++ b/pumpkin-world/src/biome/mod.rs
@@ -5,6 +5,7 @@ use enum_dispatch::enum_dispatch;
 use pumpkin_data::chunk::{Biome, BiomeTree, NETHER_BIOME_SOURCE, OVERWORLD_BIOME_SOURCE};
 
 use crate::generation::noise::router::multi_noise_sampler::MultiNoiseSampler;
+pub mod biome_finder;
 pub mod end;
 pub mod multi_noise;
 pub mod position_finder;


### PR DESCRIPTION
Ports vanilla's BiomeSource biome search as a ring-by-ring spiral (nearest-ring-first) with a vertical scan for 3D/cave biomes. Command wiring and the noise-sampler accessor follow separately.

<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Implements `/locate biome <biome>`, closing #2230 (biome subcommand only).

Minecraft biomes are 3D (since 1.18), so this locates the nearest block whose sampled biome matches the requested one, scanning both horizontally and vertically. Only checks every 32 blocks horizontally and every 64 blocks vertically.

## Testing
- Unit test for `find_nearest_biome`: fixed seed + `Dimension::OVERWORLD`, asserts a
  known biome resolves to the expected coordinates.
- Manual: `/locate biome minecraft:desert` and a cave biome (e.g.
  `minecraft:lush_caves`) in a fresh world; verified returned coords land in the
  target biome via `/tp` + F3.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
