### PR TITLE
feat(command): implement /locate biome

### DIFF
--- a/pumpkin-world/src/generation/generator/biome_finder.rs
+++ b/pumpkin-world/src/generation/generator/biome_finder.rs
@@ -1,0 +1,455 @@
+use pumpkin_data::{chunk::Biome, dimension::Dimension};
+use pumpkin_util::math::position::BlockPos;
+use rayon::prelude::*;
+
+use crate::{
+    biome::{BiomeSupplier, MultiNoiseBiomeSupplier, end::TheEndBiomeSupplier},
+    generation::noise::router::multi_noise_sampler::{
+        MultiNoiseSampler, MultiNoiseSamplerBuilderOptions,
+    },
+};
+
+use super::{VanillaGenerator, WorldGenerator};
+
+#[derive(Debug, Clone, Copy)]
+pub struct FoundBiome {
+    pub position: BlockPos,
+    pub biome: &'static Biome,
+}
+
+/// Finds the first matching biome using vanilla's horizontal spiral and
+/// vertical out-from-origin traversal.
+#[must_use]
+pub fn find_closest_biome(
+    generator: &WorldGenerator,
+    origin: BlockPos,
+    radius: i32,
+    horizontal_interval: i32,
+    vertical_interval: i32,
+    target_biomes: &[u8],
+) -> Option<FoundBiome> {
+    if horizontal_interval <= 0 || vertical_interval <= 0 || target_biomes.is_empty() {
+        return None;
+    }
+
+    let mut targets = [false; 256];
+    for &id in target_biomes {
+        targets[usize::from(id)] = true;
+    }
+
+    let dimension = generator.dimension();
+    let vertical_samples = out_from_origin(
+        origin.0.y,
+        dimension.min_y + 1,
+        dimension.min_y + dimension.height,
+        vertical_interval,
+    );
+
+    match generator {
+        WorldGenerator::Noise(generator) => find_noise_biome(
+            generator,
+            origin,
+            radius / horizontal_interval,
+            horizontal_interval,
+            &vertical_samples,
+            &targets,
+        ),
+        WorldGenerator::Flat(generator) => {
+            let name = generator
+                .biome
+                .strip_prefix("minecraft:")
+                .unwrap_or(&generator.biome);
+            let biome = Biome::from_name(name).unwrap_or(&Biome::PLAINS);
+            targets[usize::from(biome.id)].then(|| FoundBiome {
+                position: BlockPos::new(origin.0.x, vertical_samples[0], origin.0.z),
+                biome,
+            })
+        }
+    }
+}
+
+/// Parallel version of [`find_closest_biome`] for use on the generation pool.
+///
+/// Columns are evaluated in bounded batches and `find_first` preserves the
+/// exact vanilla traversal result even when later columns finish first.
+#[must_use]
+pub fn find_closest_biome_parallel(
+    generator: &WorldGenerator,
+    origin: BlockPos,
+    radius: i32,
+    horizontal_interval: i32,
+    vertical_interval: i32,
+    target_biomes: &[u8],
+) -> Option<FoundBiome> {
+    if horizontal_interval <= 0 || vertical_interval <= 0 || target_biomes.is_empty() {
+        return None;
+    }
+
+    let mut targets = [false; 256];
+    for &id in target_biomes {
+        targets[usize::from(id)] = true;
+    }
+
+    let dimension = generator.dimension();
+    let vertical_samples = out_from_origin(
+        origin.0.y,
+        dimension.min_y + 1,
+        dimension.min_y + dimension.height,
+        vertical_interval,
+    );
+
+    match generator {
+        WorldGenerator::Noise(generator) => find_noise_biome_parallel(
+            generator,
+            origin,
+            radius / horizontal_interval,
+            horizontal_interval,
+            &vertical_samples,
+            &targets,
+        ),
+        WorldGenerator::Flat(generator) => {
+            let name = generator
+                .biome
+                .strip_prefix("minecraft:")
+                .unwrap_or(&generator.biome);
+            let biome = Biome::from_name(name).unwrap_or(&Biome::PLAINS);
+            targets[usize::from(biome.id)].then(|| FoundBiome {
+                position: BlockPos::new(origin.0.x, vertical_samples[0], origin.0.z),
+                biome,
+            })
+        }
+    }
+}
+
+fn find_noise_biome(
+    generator: &VanillaGenerator,
+    origin: BlockPos,
+    horizontal_radius: i32,
+    horizontal_interval: i32,
+    vertical_samples: &[i32],
+    targets: &[bool; 256],
+) -> Option<FoundBiome> {
+    let mut sampler = MultiNoiseSampler::generate(
+        &generator.base_router.multi_noise,
+        &MultiNoiseSamplerBuilderOptions::new(0, 0, 0),
+    );
+
+    if generator.dimension == Dimension::THE_END {
+        find_with_supplier(
+            &TheEndBiomeSupplier,
+            &mut sampler,
+            origin,
+            horizontal_radius,
+            horizontal_interval,
+            vertical_samples,
+            targets,
+        )
+    } else if generator.dimension == Dimension::THE_NETHER {
+        find_with_supplier(
+            &MultiNoiseBiomeSupplier::NETHER,
+            &mut sampler,
+            origin,
+            horizontal_radius,
+            horizontal_interval,
+            vertical_samples,
+            targets,
+        )
+    } else {
+        find_with_supplier(
+            &MultiNoiseBiomeSupplier::OVERWORLD,
+            &mut sampler,
+            origin,
+            horizontal_radius,
+            horizontal_interval,
+            vertical_samples,
+            targets,
+        )
+    }
+}
+
+fn find_noise_biome_parallel(
+    generator: &VanillaGenerator,
+    origin: BlockPos,
+    horizontal_radius: i32,
+    horizontal_interval: i32,
+    vertical_samples: &[i32],
+    targets: &[bool; 256],
+) -> Option<FoundBiome> {
+    if generator.dimension == Dimension::THE_END {
+        find_with_supplier_parallel(
+            generator,
+            &TheEndBiomeSupplier,
+            origin,
+            horizontal_radius,
+            horizontal_interval,
+            vertical_samples,
+            targets,
+        )
+    } else if generator.dimension == Dimension::THE_NETHER {
+        find_with_supplier_parallel(
+            generator,
+            &MultiNoiseBiomeSupplier::NETHER,
+            origin,
+            horizontal_radius,
+            horizontal_interval,
+            vertical_samples,
+            targets,
+        )
+    } else {
+        find_with_supplier_parallel(
+            generator,
+            &MultiNoiseBiomeSupplier::OVERWORLD,
+            origin,
+            horizontal_radius,
+            horizontal_interval,
+            vertical_samples,
+            targets,
+        )
+    }
+}
+
+fn find_with_supplier(
+    supplier: &dyn BiomeSupplier,
+    sampler: &mut MultiNoiseSampler<'_>,
+    origin: BlockPos,
+    horizontal_radius: i32,
+    horizontal_interval: i32,
+    vertical_samples: &[i32],
+    targets: &[bool; 256],
+) -> Option<FoundBiome> {
+    visit_spiral(horizontal_radius, |offset_x, offset_z| {
+        let block_x = origin.0.x + offset_x * horizontal_interval;
+        let block_z = origin.0.z + offset_z * horizontal_interval;
+        let biome_x = block_x >> 2;
+        let biome_z = block_z >> 2;
+
+        for &block_y in vertical_samples {
+            let biome = supplier.biome(biome_x, block_y >> 2, biome_z, sampler);
+            if targets[usize::from(biome.id)] {
+                return Some(FoundBiome {
+                    position: BlockPos::new(block_x, block_y, block_z),
+                    biome,
+                });
+            }
+        }
+        None
+    })
+}
+
+fn find_with_supplier_parallel(
+    generator: &VanillaGenerator,
+    supplier: &(impl BiomeSupplier + Sync),
+    origin: BlockPos,
+    horizontal_radius: i32,
+    horizontal_interval: i32,
+    vertical_samples: &[i32],
+    targets: &[bool; 256],
+) -> Option<FoundBiome> {
+    const COLUMN_BATCH_SIZE: usize = 256;
+
+    let mut columns = Vec::with_capacity(
+        usize::try_from((i64::from(horizontal_radius) * 2 + 1).pow(2)).unwrap_or_default(),
+    );
+    visit_spiral(horizontal_radius, |offset_x, offset_z| {
+        columns.push((offset_x, offset_z));
+        None::<()>
+    });
+
+    for batch in columns.chunks(COLUMN_BATCH_SIZE) {
+        let found = batch
+            .par_iter()
+            .map_init(
+                || {
+                    MultiNoiseSampler::generate(
+                        &generator.base_router.multi_noise,
+                        &MultiNoiseSamplerBuilderOptions::new(0, 0, 0),
+                    )
+                },
+                |sampler, &(offset_x, offset_z)| {
+                    find_in_column(
+                        supplier,
+                        sampler,
+                        origin,
+                        offset_x,
+                        offset_z,
+                        horizontal_interval,
+                        vertical_samples,
+                        targets,
+                    )
+                },
+            )
+            .find_first(Option::is_some)
+            .flatten();
+
+        if found.is_some() {
+            return found;
+        }
+    }
+
+    None
+}
+
+#[expect(clippy::too_many_arguments)]
+fn find_in_column(
+    supplier: &impl BiomeSupplier,
+    sampler: &mut MultiNoiseSampler<'_>,
+    origin: BlockPos,
+    offset_x: i32,
+    offset_z: i32,
+    horizontal_interval: i32,
+    vertical_samples: &[i32],
+    targets: &[bool; 256],
+) -> Option<FoundBiome> {
+    let block_x = origin.0.x + offset_x * horizontal_interval;
+    let block_z = origin.0.z + offset_z * horizontal_interval;
+    let biome_x = block_x >> 2;
+    let biome_z = block_z >> 2;
+
+    for &block_y in vertical_samples {
+        let biome = supplier.biome(biome_x, block_y >> 2, biome_z, sampler);
+        if targets[usize::from(biome.id)] {
+            return Some(FoundBiome {
+                position: BlockPos::new(block_x, block_y, block_z),
+                biome,
+            });
+        }
+    }
+
+    None
+}
+
+fn visit_spiral<T>(radius: i32, mut visitor: impl FnMut(i32, i32) -> Option<T>) -> Option<T> {
+    if let Some(result) = visitor(0, 0) {
+        return Some(result);
+    }
+
+    let total = i64::from(radius * 2 + 1).pow(2);
+    let directions = [(1, 0), (0, 1), (-1, 0), (0, -1)];
+    let mut visited = 1i64;
+    let mut x = 0;
+    let mut z = 0;
+    let mut direction = 0usize;
+    let mut leg_length = 1;
+
+    while visited < total {
+        for _ in 0..leg_length {
+            let (dx, dz) = directions[direction];
+            x += dx;
+            z += dz;
+            visited += 1;
+            if let Some(result) = visitor(x, z) {
+                return Some(result);
+            }
+            if visited == total {
+                return None;
+            }
+        }
+
+        direction = (direction + 1) & 3;
+        if direction & 1 == 0 {
+            leg_length += 1;
+        }
+    }
+
+    None
+}
+
+fn out_from_origin(origin: i32, lower: i32, upper: i32, step: i32) -> Vec<i32> {
+    let origin = origin.clamp(lower, upper);
+    let mut values = Vec::with_capacity(((upper - lower) / step + 2) as usize);
+    values.push(origin);
+
+    let mut distance = step;
+    loop {
+        let above = origin.saturating_add(distance);
+        let below = origin.saturating_sub(distance);
+        let has_above = above <= upper;
+        let has_below = below >= lower;
+
+        if has_above {
+            values.push(above);
+        }
+        if has_below {
+            values.push(below);
+        }
+        if !has_above && !has_below {
+            break;
+        }
+        distance = distance.saturating_add(step);
+    }
+
+    values
+}
+
+#[cfg(test)]
+mod tests {
+    use pumpkin_data::{chunk::Biome, dimension::Dimension};
+    use pumpkin_util::{math::position::BlockPos, world_seed::Seed};
+
+    use crate::generation::generator::{GeneratorInit, VanillaGenerator, WorldGenerator};
+
+    use super::{
+        FoundBiome, find_closest_biome, find_closest_biome_parallel, out_from_origin, visit_spiral,
+    };
+
+    #[test]
+    fn spiral_matches_vanilla_order() {
+        let mut positions = Vec::new();
+        visit_spiral(1, |x, z| {
+            positions.push((x, z));
+            None::<()>
+        });
+        assert_eq!(
+            positions,
+            [
+                (0, 0),
+                (1, 0),
+                (1, 1),
+                (0, 1),
+                (-1, 1),
+                (-1, 0),
+                (-1, -1),
+                (0, -1),
+                (1, -1),
+            ]
+        );
+    }
+
+    #[test]
+    fn vertical_samples_move_out_from_origin() {
+        assert_eq!(
+            out_from_origin(64, -63, 320, 64),
+            [64, 128, 0, 192, 256, 320]
+        );
+    }
+
+    #[test]
+    fn parallel_search_preserves_serial_result() {
+        let generator = WorldGenerator::Noise(Box::new(VanillaGenerator::new(
+            Seed(12_345),
+            Dimension::OVERWORLD,
+        )));
+        let origin = BlockPos::new(173, 73, -241);
+
+        for targets in [
+            &[Biome::DESERT.id][..],
+            &[Biome::PLAINS.id][..],
+            &[Biome::BADLANDS.id, Biome::SWAMP.id][..],
+        ] {
+            let serial = find_closest_biome(&generator, origin, 512, 32, 64, targets);
+            let parallel = find_closest_biome_parallel(&generator, origin, 512, 32, 64, targets);
+            let comparable = |found: Option<FoundBiome>| {
+                found.map(|found| {
+                    (
+                        found.position.0.x,
+                        found.position.0.y,
+                        found.position.0.z,
+                        found.biome.id,
+                    )
+                })
+            };
+
+            assert_eq!(comparable(serial), comparable(parallel));
+        }
+    }
+}

--- a/pumpkin-world/src/generation/generator/mod.rs
+++ b/pumpkin-world/src/generation/generator/mod.rs
@@ -9,6 +9,7 @@ use super::noise::router::proto_noise_router::ProtoNoiseRouters;
 use crate::generation::proto_chunk::TerrainCache;
 use crate::generation::{GlobalRandomConfig, Seed};
 
+pub mod biome_finder;
 pub mod structure_finder;
 
 pub trait GeneratorInit {

--- a/pumpkin/src/command/argument_types/mod.rs
+++ b/pumpkin/src/command/argument_types/mod.rs
@@ -232,6 +232,7 @@ pub mod nbt;
 pub mod objective;
 pub mod range;
 pub mod resource_key;
+pub mod resource_or_tag;
 pub mod slot;
 pub mod team;
 pub mod team_color;

--- a/pumpkin/src/command/argument_types/resource_or_tag.rs
+++ b/pumpkin/src/command/argument_types/resource_or_tag.rs
@@ -1,0 +1,144 @@
+use std::{pin::Pin, string::ToString};
+
+use pumpkin_data::{
+    biome::Biome,
+    tag::{RegistryKey, get_registry_key_tags},
+};
+use pumpkin_util::{identifier::Identifier, version::JavaMinecraftVersion};
+
+use crate::command::{
+    argument_types::{
+        FromStringReader,
+        argument_type::{ArgumentType, JavaClientArgumentType},
+    },
+    context::command_context::CommandContext,
+    errors::command_syntax_error::CommandSyntaxError,
+    string_reader::StringReader,
+    suggestion::suggestions::{Suggestions, SuggestionsBuilder},
+};
+
+pub static BIOME_REGISTRY: Identifier = Identifier::vanilla_static("worldgen/biome");
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceOrTag {
+    pub identifier: Identifier,
+    pub is_tag: bool,
+}
+
+impl ResourceOrTag {
+    #[must_use]
+    pub fn printable(&self) -> String {
+        if self.is_tag {
+            format!("#{}", self.identifier)
+        } else {
+            self.identifier.to_string()
+        }
+    }
+}
+
+pub struct ResourceOrTagArgument {
+    registry: Identifier,
+    registry_key: RegistryKey,
+}
+
+impl ResourceOrTagArgument {
+    #[must_use]
+    pub fn biome() -> Self {
+        Self {
+            registry: BIOME_REGISTRY.clone(),
+            registry_key: RegistryKey::WorldgenBiome,
+        }
+    }
+
+    pub fn get<'a>(
+        context: &'a CommandContext,
+        name: &str,
+    ) -> Result<&'a ResourceOrTag, CommandSyntaxError> {
+        context.get_argument(name)
+    }
+
+    fn direct_suggestions() -> Vec<String> {
+        Biome::ALL
+            .iter()
+            .map(|biome| format!("minecraft:{}", biome.registry_id))
+            .collect()
+    }
+
+    fn tag_suggestions(&self) -> Vec<String> {
+        get_registry_key_tags(JavaMinecraftVersion::V_26_2, self.registry_key)
+            .into_iter()
+            .flat_map(|tags| tags.keys())
+            .map(|tag| format!("#{tag}"))
+            .collect()
+    }
+}
+
+impl ArgumentType for ResourceOrTagArgument {
+    type Item = ResourceOrTag;
+
+    fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
+        let is_tag = reader.peek() == Some('#');
+        if is_tag {
+            reader.skip();
+        }
+
+        Ok(ResourceOrTag {
+            identifier: Identifier::from_reader(reader)?,
+            is_tag,
+        })
+    }
+
+    fn list_suggestions(
+        &self,
+        _context: &CommandContext,
+        suggestions_builder: SuggestionsBuilder,
+    ) -> Pin<Box<dyn Future<Output = Suggestions> + Send>> {
+        let direct = Self::direct_suggestions();
+        let tags = self.tag_suggestions();
+        Box::pin(async move {
+            suggestions_builder
+                .filter_and_suggest_iter(direct)
+                .filter_and_suggest_iter(tags)
+                .build()
+        })
+    }
+
+    fn client_side_parser(&self) -> JavaClientArgumentType {
+        JavaClientArgumentType::ResourceOrTag {
+            identifier: self.registry.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ResourceOrTag, ResourceOrTagArgument};
+    use crate::command::{
+        argument_types::argument_type::ArgumentType, string_reader::StringReader,
+    };
+    use pumpkin_util::identifier::Identifier;
+
+    #[test]
+    fn parses_direct_resource() {
+        let mut reader = StringReader::new("minecraft:plains");
+        assert_eq!(
+            ResourceOrTagArgument::biome().parse(&mut reader),
+            Ok(ResourceOrTag {
+                identifier: Identifier::parse("minecraft:plains").unwrap(),
+                is_tag: false,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_tag() {
+        let mut reader = StringReader::new("#minecraft:is_overworld");
+        assert_eq!(
+            ResourceOrTagArgument::biome().parse(&mut reader),
+            Ok(ResourceOrTag {
+                identifier: Identifier::parse("minecraft:is_overworld").unwrap(),
+                is_tag: true,
+            })
+        );
+    }
+}

--- a/pumpkin/src/command/commands/locate.rs
+++ b/pumpkin/src/command/commands/locate.rs
@@ -1,0 +1,197 @@
+use std::{borrow::Cow, sync::Arc, time::Instant};
+
+use pumpkin_data::{
+    biome::Biome,
+    tag::{RegistryKey, get_tag_ids},
+    translation,
+};
+use pumpkin_util::{
+    PermissionLvl,
+    math::position::BlockPos,
+    permission::{Permission, PermissionDefault, PermissionRegistry},
+    text::{TextComponent, click::ClickEvent, color::NamedColor, hover::HoverEvent},
+};
+use tokio::sync::oneshot;
+
+use crate::command::{
+    argument_builder::{ArgumentBuilder, argument, command, literal},
+    argument_types::resource_or_tag::{ResourceOrTag, ResourceOrTagArgument},
+    context::command_context::CommandContext,
+    errors::error_types::CommandErrorType,
+    node::{CommandExecutor, CommandExecutorResult, dispatcher::CommandDispatcher},
+};
+
+const DESCRIPTION: &str = "Locates the closest biome.";
+const PERMISSION: &str = "minecraft:command.locate";
+
+const MAX_BIOME_SEARCH_RADIUS: i32 = 6400;
+const BIOME_SAMPLE_RESOLUTION_HORIZONTAL: i32 = 32;
+const BIOME_SAMPLE_RESOLUTION_VERTICAL: i32 = 64;
+
+static ERROR_BIOME_NOT_FOUND: CommandErrorType<1> = CommandErrorType::new(
+    translation::java::COMMANDS_LOCATE_BIOME_NOT_FOUND,
+    translation::java::COMMANDS_LOCATE_BIOME_NOT_FOUND,
+);
+
+struct LocateBiomeExecutor;
+
+impl CommandExecutor for LocateBiomeExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let requested = ResourceOrTagArgument::get(context, "biome")?;
+            let target_biomes = resolve_biomes(requested).ok_or_else(|| {
+                ERROR_BIOME_NOT_FOUND
+                    .create_without_context(TextComponent::text(requested.printable()))
+            })?;
+
+            let source_position = context.source.position;
+            let origin = BlockPos::new(
+                source_position.x.floor() as i32,
+                source_position.y.floor() as i32,
+                source_position.z.floor() as i32,
+            );
+            let world_gen = Arc::clone(&context.world().level.world_gen);
+            let generation_pool = context.world().level.gen_pool.clone();
+            let (sender, receiver) = oneshot::channel();
+            let started = Instant::now();
+
+            let locate = move || {
+                let result =
+                    pumpkin_world::generation::generator::biome_finder::find_closest_biome_parallel(
+                        &world_gen,
+                        origin,
+                        MAX_BIOME_SEARCH_RADIUS,
+                        BIOME_SAMPLE_RESOLUTION_HORIZONTAL,
+                        BIOME_SAMPLE_RESOLUTION_VERTICAL,
+                        &target_biomes,
+                    );
+                let _ = sender.send(result);
+            };
+
+            if let Some(pool) = generation_pool {
+                pool.spawn(locate);
+            } else {
+                drop(tokio::task::spawn_blocking(locate));
+            }
+
+            let result = receiver.await.ok().flatten().ok_or_else(|| {
+                ERROR_BIOME_NOT_FOUND
+                    .create_without_context(TextComponent::text(requested.printable()))
+            })?;
+
+            let distance = distance_3d(origin, result.position);
+            let coordinates = coordinate_component(result.position);
+            let found_name = if requested.is_tag {
+                format!(
+                    "{} (minecraft:{})",
+                    requested.printable(),
+                    result.biome.registry_id
+                )
+            } else {
+                requested.printable()
+            };
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_LOCATE_BIOME_SUCCESS,
+                        translation::java::COMMANDS_LOCATE_BIOME_SUCCESS,
+                        [
+                            TextComponent::text(found_name.clone()),
+                            coordinates,
+                            TextComponent::text(distance.to_string()),
+                        ],
+                    ),
+                    false,
+                )
+                .await;
+
+            tracing::info!(
+                "Locating element {found_name} took {} ms",
+                started.elapsed().as_millis()
+            );
+
+            Ok(distance)
+        })
+    }
+}
+
+fn resolve_biomes(requested: &ResourceOrTag) -> Option<Vec<u8>> {
+    if requested.is_tag {
+        get_tag_ids(
+            RegistryKey::WorldgenBiome,
+            &requested.identifier.to_string(),
+        )
+        .map(|ids| ids.iter().filter_map(|&id| u8::try_from(id).ok()).collect())
+    } else {
+        (requested.identifier.namespace() == "minecraft")
+            .then(|| Biome::from_name(requested.identifier.path()))
+            .flatten()
+            .map(|biome| vec![biome.id])
+    }
+}
+
+fn coordinate_component(position: BlockPos) -> TextComponent {
+    let y = position.0.y.to_string();
+    let coordinates = format!("{} {y} {}", position.0.x, position.0.z);
+
+    TextComponent::wrap_in_square_brackets(
+        TextComponent::translate_cross(
+            translation::java::CHAT_COORDINATES,
+            translation::java::CHAT_COORDINATES,
+            [
+                TextComponent::text(position.0.x.to_string()),
+                TextComponent::text(y),
+                TextComponent::text(position.0.z.to_string()),
+            ],
+        )
+        .color_named(NamedColor::Green)
+        .click_event(ClickEvent::SuggestCommand {
+            command: Cow::Owned(coordinates),
+        })
+        .hover_event(HoverEvent::show_text(TextComponent::translate_cross(
+            translation::java::CHAT_COORDINATES_TOOLTIP,
+            translation::java::CHAT_COORDINATES_TOOLTIP,
+            [],
+        ))),
+    )
+}
+
+fn distance_3d(from: BlockPos, to: BlockPos) -> i32 {
+    let dx = i64::from(to.0.x) - i64::from(from.0.x);
+    let dy = i64::from(to.0.y) - i64::from(from.0.y);
+    let dz = i64::from(to.0.z) - i64::from(from.0.z);
+    ((dx * dx + dy * dy + dz * dz) as f32).sqrt().floor() as i32
+}
+
+pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION,
+        DESCRIPTION,
+        PermissionDefault::Op(PermissionLvl::Two),
+    ));
+
+    dispatcher.register(
+        command("locate", DESCRIPTION).requires(PERMISSION).then(
+            literal("biome").then(
+                argument("biome", ResourceOrTagArgument::biome()).executes(LocateBiomeExecutor),
+            ),
+        ),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use pumpkin_util::math::position::BlockPos;
+
+    use super::distance_3d;
+
+    #[test]
+    fn biome_distance_includes_height() {
+        assert_eq!(
+            distance_3d(BlockPos::new(0, 0, 0), BlockPos::new(3, 4, 0)),
+            5
+        );
+    }
+}

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -35,6 +35,7 @@ mod item;
 mod kick;
 mod kill;
 mod list;
+mod locate;
 mod loot;
 mod me;
 mod msg;
@@ -183,6 +184,7 @@ pub async fn default_dispatcher(
     op::register(&mut dispatcher, registry);
     random::register(&mut dispatcher, registry);
     list::register(&mut dispatcher, registry);
+    locate::register(&mut dispatcher, registry);
     loot::register(&mut dispatcher, registry);
     seed::register(&mut dispatcher, registry);
     saveall::register(&mut dispatcher, registry);


### PR DESCRIPTION
## Description
Pumpkin is missing /locate biome, even though biome generation already has everything needed to locate biomes without generating chunks.

Vanilla searches up to 6400 blocks away by moving in a horizontal spiral around the player. It samples every 32 blocks horizontally and every 64 blocks vertically, returning the first matching biome it finds. This works, but it can end up checking around 160,000 horizontal positions and almost one million biome samples sequentially.

I kept the same search radius, sampling intervals and traversal order, but process the horizontal positions in bounded parallel batches. The first result still follows vanilla’s exact search order, even if a later position finishes processing first. The search also runs outside the async runtime so it does not block the server while it is working.

Biome names and biome tags are both supported, with proper suggestions, clickable coordinates, vanilla feedback and the same 3D distance calculation as the official 26.2 server.

Structure locating is intentionally not included. Supporting it accurately requires a proper structure-query API and better structure-generation parity, which should be handled separately instead of modifying core world generation as part of the locate command
  
## Testing
I compared the implementation directly against the official 26.2 server code and verified the search radius, horizontal spiral, vertical sampling order, first-match behavior, coordinates and distance calculation.

I also tested the parallel search against the serial vanilla-order implementation using multiple origins and biome targets. Both returned the same biome and position every time.
