### PR TITLE
fix(combat): don't apply extra knockback on a plain attack

### DIFF
--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -1504,7 +1504,11 @@ impl Player {
         );
 
         if victim.get_living_entity().is_some() {
-            let mut knockback_strength = 1.0 + f64::from(knockback_level);
+            // Vanilla `Player.attack` adds `LivingEntity.getKnockback()` - the Knockback
+            // enchantment bonus, halved - plus 0.5 for a sprint attack, on top of the base
+            // knockback the victim's damage handling applies. A plain hit adds nothing.
+            // `handle_knockback` halves `strength`, so these are twice the vanilla amount.
+            let mut knockback_strength = f64::from(knockback_level);
             match attack_type {
                 AttackType::Knockback => knockback_strength += 1.0,
                 AttackType::Sweeping => {
@@ -1545,7 +1549,10 @@ impl Player {
                 }
                 _ => {}
             }
-            if config.knockback {
+            // Vanilla only pushes the victim when the extra knockback is non-zero;
+            // `Entity::knockback` halves the current velocity, so calling it with 0.0
+            // would still slow the victim down.
+            if config.knockback && knockback_strength > 0.0 {
                 combat::handle_knockback(attacker_entity, victim.as_ref(), knockback_strength);
             }
         }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1097,7 +1097,11 @@ impl Player {
         );
 
         if victim.get_living_entity().is_some() {
-            let mut knockback_strength = 1.0 + f64::from(knockback_level);
+            // Vanilla `Player.attack` adds `LivingEntity.getKnockback()` - the Knockback
+            // enchantment bonus, halved - plus 0.5 for a sprint attack, on top of the base
+            // knockback the victim's damage handling applies. A plain hit adds nothing.
+            // `handle_knockback` halves `strength`, so these are twice the vanilla amount.
+            let mut knockback_strength = f64::from(knockback_level);
             match attack_type {
                 AttackType::Knockback => knockback_strength += 1.0,
                 AttackType::Sweeping => {
@@ -1141,7 +1145,10 @@ impl Player {
                 }
                 _ => {}
             }
-            if config.knockback {
+            // Vanilla only pushes the victim when the extra knockback is non-zero;
+            // `Entity::knockback` halves the current velocity, so calling it with 0.0
+            // would still slow the victim down.
+            if config.knockback && knockback_strength > 0.0 {
                 combat::handle_knockback(attacker_entity, victim_entity, knockback_strength);
             }
         }


### PR DESCRIPTION
## Description

`Player::attack` seeded the extra knockback strength with a constant `1.0`, so every hit pushed the victim on top of the base knockback `LivingEntity` already applies when it takes damage.

Vanilla `Player.attack` passes `getKnockback() + (sprint ? 0.5 : 0.0)` to `causeExtraKnockback`, where `getKnockback()` is the Knockback enchantment bonus halved. A plain hit contributes nothing. Both of those terms were already correct here once `handle_knockback` halves its argument; only the constant was extra, which made every attack push the victim 0.5 harder than vanilla.

Armor stands are where this becomes visible: `ArmorStandEntity::damage_with_context` never applies base knockback, so a plain hit should not move them at all. They should only be pushed when the attacker sprints or carries Knockback.

The call is now also guarded on a non-zero strength, matching vanilla's `if (knockbackAmount > 0.0F)`. `Entity::knockback` halves the victim's current velocity, so calling it with `0.0` would still slow the victim down and drop the attacker's own speed.

Fixes #1620

## Testing

`cargo test -p pumpkin`, `cargo clippy -p pumpkin` and `cargo fmt --check` pass. The change is inside the async attack path, which the existing unit tests do not reach, so the values were verified against vanilla `Player.attack` / `LivingEntity.getKnockback` and the Knockback enchantment definition (`base 1.0`, `per_level_above_first 1.0`) rather than a new test.
