### PR TITLE
feat(dispenser): item-specific dispense behaviors (TNT, arrow)

### DIFF
--- a/pumpkin/src/block/blocks/redstone/dispenser.rs
+++ b/pumpkin/src/block/blocks/redstone/dispenser.rs
@@ -10,6 +10,10 @@ use crate::block::{
 };
 use crate::entity::item::ItemEntity;
 use crate::entity::projectile::arrow::{ArrowEntity, ArrowPickup};
+use crate::entity::projectile::egg::EggEntity;
+use crate::entity::projectile::lingering_potion::LingeringPotionEntity;
+use crate::entity::projectile::snowball::SnowballEntity;
+use crate::entity::projectile::splash_potion::SplashPotionEntity;
 use crate::entity::tnt::TNTEntity;
 use crate::entity::{Entity, EntityBase};
 
@@ -31,6 +35,108 @@ use pumpkin_util::text::TextComponent;
 use pumpkin_world::inventory::Inventory;
 use pumpkin_world::tick::TickPriority;
 use pumpkin_world::world::BlockFlags;
+
+struct ProjectileSettings {
+    entity: &'static EntityType,
+    power: f64,
+    uncertainty: f64,
+    facing_offset: f64,
+    up_nudge: f64,
+}
+
+/// Dispenser projectile settings, keyed by item id. Mirrors each item's
+/// vanilla `ProjectileItem.Settings` (position offset, power, uncertainty).
+///
+/// NOT included, and why:
+/// - Arrows (arrow/tipped/spectral) use the `ArrowEntity` path (owner/pickup) — handled separately.
+/// - Firework rocket: custom position function + dispense sound 1004 — does not fit this table.
+/// - Experience bottle (vanilla power 1.375, uncertainty 3.0): no projectile entity exists in Pumpkin yet.
+static PROJECTILES: &[(u16, ProjectileSettings)] = &[
+    // Default settings: power 1.1, uncertainty 6.0, offset 0.7, +0.1 up.
+    (
+        Item::SNOWBALL.id,
+        ProjectileSettings {
+            entity: &EntityType::SNOWBALL,
+            power: 1.1,
+            uncertainty: 6.0,
+            facing_offset: 0.7,
+            up_nudge: 0.1,
+        },
+    ),
+    (
+        Item::EGG.id,
+        ProjectileSettings {
+            entity: &EntityType::EGG,
+            power: 1.1,
+            uncertainty: 6.0,
+            facing_offset: 0.7,
+            up_nudge: 0.1,
+        },
+    ),
+    (
+        Item::BLUE_EGG.id,
+        ProjectileSettings {
+            entity: &EntityType::EGG,
+            power: 1.1,
+            uncertainty: 6.0,
+            facing_offset: 0.7,
+            up_nudge: 0.1,
+        },
+    ),
+    (
+        Item::BROWN_EGG.id,
+        ProjectileSettings {
+            entity: &EntityType::EGG,
+            power: 1.1,
+            uncertainty: 6.0,
+            facing_offset: 0.7,
+            up_nudge: 0.1,
+        },
+    ),
+    (
+        Item::SPLASH_POTION.id,
+        ProjectileSettings {
+            entity: &EntityType::SPLASH_POTION,
+            power: 1.1,
+            uncertainty: 6.0,
+            facing_offset: 0.7,
+            up_nudge: 0.1,
+        },
+    ),
+    (
+        Item::LINGERING_POTION.id,
+        ProjectileSettings {
+            entity: &EntityType::LINGERING_POTION,
+            power: 1.1,
+            uncertainty: 6.0,
+            facing_offset: 0.7,
+            up_nudge: 0.1,
+        },
+    ),
+    // Charges: full-block offset, no up-nudge, power 1.0, uncertainty 6.6666665.
+    // NOTE: SMALL_FIREBALL and WIND_CHARGE entities currently only expose `new_shot(shooter)`;
+    // they need an ownerless constructor before these rows can actually spawn from a dispenser.
+    (
+        Item::FIRE_CHARGE.id,
+        ProjectileSettings {
+            entity: &EntityType::SMALL_FIREBALL,
+            power: 1.0,
+            uncertainty: 6.666_666_5,
+            facing_offset: 1.0,
+            up_nudge: 0.0,
+        },
+    ),
+    (
+        Item::WIND_CHARGE.id,
+        ProjectileSettings {
+            entity: &EntityType::WIND_CHARGE,
+            power: 1.0,
+            uncertainty: 6.666_666_5,
+            facing_offset: 1.0,
+            up_nudge: 0.0,
+        },
+    ),
+];
 
 struct DispenserScreenFactory(Arc<dyn Inventory>);
 
@@ -203,28 +309,96 @@ impl BlockBehaviour for DispenserBlock {
                                 .spawn_entity(Arc::new(arrow) as Arc<dyn EntityBase>)
                                 .await;
                         }
-                        _ => {
-                            let mut position = args.position.to_centered_f64().add(&(facing * 0.7));
+                        id => {
+                            if let Some((_, settings)) = PROJECTILES.iter().find(|p| p.0 == id) {
+                                let position = args.position.to_centered_f64()
+                                    + facing * settings.facing_offset
+                                    + Vector3::new(0.0, settings.up_nudge, 0.0);
 
-                            position.y -= match props.facing {
-                                Facing::Up | Facing::Down => 0.125,
-                                _ => 0.15625,
-                            };
+                                let entity =
+                                    Entity::new(args.world.clone(), position, settings.entity);
 
-                            let entity =
-                                Entity::new(args.world.clone(), position, &EntityType::ITEM);
-                            let rd = rng().random::<f64>().mul_add(0.1, 0.2);
+                                // Distinct projectile structs can't be built generically from
+                                // `&EntityType`, so match to construct the right one, then apply
+                                // the shared velocity (power/uncertainty from the table).
+                                let projectile: Option<Arc<dyn EntityBase>> = match settings.entity.id
+                                {
+                                    id if id == EntityType::SNOWBALL.id => {
+                                        let e = SnowballEntity::new(entity);
+                                        e.thrown.set_velocity(
+                                            facing.x,
+                                            facing.y,
+                                            facing.z,
+                                            settings.power,
+                                            settings.uncertainty,
+                                        );
+                                        Some(Arc::new(e) as Arc<dyn EntityBase>)
+                                    }
+                                    id if id == EntityType::EGG.id => {
+                                        let e = EggEntity::new(entity);
+                                        e.thrown.set_velocity(
+                                            facing.x,
+                                            facing.y,
+                                            facing.z,
+                                            settings.power,
+                                            settings.uncertainty,
+                                        );
+                                        Some(Arc::new(e) as Arc<dyn EntityBase>)
+                                    }
+                                    id if id == EntityType::SPLASH_POTION.id => {
+                                        let e = SplashPotionEntity::new(entity);
+                                        e.thrown.set_velocity(
+                                            facing.x,
+                                            facing.y,
+                                            facing.z,
+                                            settings.power,
+                                            settings.uncertainty,
+                                        );
+                                        Some(Arc::new(e) as Arc<dyn EntityBase>)
+                                    }
+                                    id if id == EntityType::LINGERING_POTION.id => {
+                                        let e = LingeringPotionEntity::new(entity);
+                                        e.thrown.set_velocity(
+                                            facing.x,
+                                            facing.y,
+                                            facing.z,
+                                            settings.power,
+                                            settings.uncertainty,
+                                        );
+                                        Some(Arc::new(e) as Arc<dyn EntityBase>)
+                                    }
+                                    // FIRE_CHARGE / WIND_CHARGE: entities only expose
+                                    // `new_shot(shooter)` — need an ownerless constructor first.
+                                    _ => None,
+                                };
 
-                            let velocity = Vector3::new(
-                                triangle(&mut rng(), facing.x * rd, 0.017_227_5 * 6.),
-                                triangle(&mut rng(), 0.2, 0.017_227_5 * 6.),
-                                triangle(&mut rng(), facing.z * rd, 0.017_227_5 * 6.),
-                            );
+                                if let Some(projectile) = projectile {
+                                    args.world.spawn_entity(projectile).await;
+                                }
+                            } else {
+                                let mut position =
+                                    args.position.to_centered_f64().add(&(facing * 0.7));
 
-                            let item_entity = Arc::new(ItemEntity::new_with_velocity(
-                                entity, drop_item, velocity, 40,
-                            ));
-                            args.world.spawn_entity(item_entity).await;
+                                position.y -= match props.facing {
+                                    Facing::Up | Facing::Down => 0.125,
+                                    _ => 0.15625,
+                                };
+
+                                let entity =
+                                    Entity::new(args.world.clone(), position, &EntityType::ITEM);
+                                let rd = rng().random::<f64>().mul_add(0.1, 0.2);
+
+                                let velocity = Vector3::new(
+                                    triangle(&mut rng(), facing.x * rd, 0.017_227_5 * 6.),
+                                    triangle(&mut rng(), 0.2, 0.017_227_5 * 6.),
+                                    triangle(&mut rng(), facing.z * rd, 0.017_227_5 * 6.),
+                                );
+
+                                let item_entity = Arc::new(ItemEntity::new_with_velocity(
+                                    entity, drop_item, velocity, 40,
+                                ));
+                                args.world.spawn_entity(item_entity).await;
+                            }
                         }
                     }
 

--- a/pumpkin/src/block/blocks/redstone/dispenser.rs
+++ b/pumpkin/src/block/blocks/redstone/dispenser.rs
@@ -9,12 +9,15 @@ use crate::block::{
     OnPlaceArgs, OnScheduledTickArgs, PlacedArgs,
 };
 use crate::entity::item::ItemEntity;
+use crate::entity::projectile::arrow::{ArrowEntity, ArrowPickup};
+use crate::entity::tnt::TNTEntity;
 use crate::entity::{Entity, EntityBase};
 
 use crate::block::entities::dispenser::DispenserBlockEntity;
 use pumpkin_data::BlockStateId;
 use pumpkin_data::block_properties::{BlockProperties, Facing};
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::item::Item;
 use pumpkin_data::translation;
 use pumpkin_data::world::WorldEvent;
 use pumpkin_inventory::generic_container_screen_handler::create_generic_3x3;
@@ -164,29 +167,66 @@ impl BlockBehaviour for DispenserBlock {
                         args.block,
                     );
 
-                    // No specific dispenser behaviors are registered yet, so dispense item into the world
+                    // Dispatch on the item type; the default arm ejects it as an item entity.
                     let drop_item = item.split(1);
                     let facing = to_normal(props.facing);
-                    let mut position = args.position.to_centered_f64().add(&(facing * 0.7));
 
-                    position.y -= match props.facing {
-                        Facing::Up | Facing::Down => 0.125,
-                        _ => 0.15625,
-                    };
+                    match drop_item.get_item().id {
+                        id if id == Item::TNT.id => {
+                            // Vanilla: block in front of the dispenser, centered on X/Z,
+                            // at the block's bottom on Y (no +0.5 on Y).
+                            let position = Vector3::new(
+                                args.position.0.x as f64 + facing.x + 0.5,
+                                args.position.0.y as f64 + facing.y,
+                                args.position.0.z as f64 + facing.z + 0.5,
+                            );
 
-                    let entity = Entity::new(args.world.clone(), position, &EntityType::ITEM);
-                    let rd = rng().random::<f64>().mul_add(0.1, 0.2);
+                            let entity =
+                                Entity::new(args.world.clone(), position, &EntityType::TNT);
 
-                    let velocity = Vector3::new(
-                        triangle(&mut rng(), facing.x * rd, 0.017_227_5 * 6.),
-                        triangle(&mut rng(), 0.2, 0.017_227_5 * 6.),
-                        triangle(&mut rng(), facing.z * rd, 0.017_227_5 * 6.),
-                    );
+                            let tnt_entity = Arc::new(TNTEntity::new(entity, 4.0, 80));
+                            args.world.spawn_entity(tnt_entity).await;
+                        }
+                        id if id == Item::ARROW.id => {
+                            // Vanilla: block center + 0.7 in the facing direction, nudged up 0.1.
+                            let position = args.position.to_centered_f64()
+                                + facing * 0.7
+                                + Vector3::new(0.0, 0.1, 0.0);
+                            let arrow_entity =
+                                Entity::new(args.world.clone(), position, &EntityType::ARROW);
+                            let mut arrow = ArrowEntity::new(arrow_entity, None);
+                            arrow.pickup = ArrowPickup::Allowed;
 
-                    let item_entity = Arc::new(ItemEntity::new_with_velocity(
-                        entity, drop_item, velocity, 40,
-                    ));
-                    args.world.spawn_entity(item_entity).await;
+                            arrow.set_velocity(facing.x, facing.y, facing.z, 1.1, 6.0);
+
+                            args.world
+                                .spawn_entity(Arc::new(arrow) as Arc<dyn EntityBase>)
+                                .await;
+                        }
+                        _ => {
+                            let mut position = args.position.to_centered_f64().add(&(facing * 0.7));
+
+                            position.y -= match props.facing {
+                                Facing::Up | Facing::Down => 0.125,
+                                _ => 0.15625,
+                            };
+
+                            let entity =
+                                Entity::new(args.world.clone(), position, &EntityType::ITEM);
+                            let rd = rng().random::<f64>().mul_add(0.1, 0.2);
+
+                            let velocity = Vector3::new(
+                                triangle(&mut rng(), facing.x * rd, 0.017_227_5 * 6.),
+                                triangle(&mut rng(), 0.2, 0.017_227_5 * 6.),
+                                triangle(&mut rng(), facing.z * rd, 0.017_227_5 * 6.),
+                            );
+
+                            let item_entity = Arc::new(ItemEntity::new_with_velocity(
+                                entity, drop_item, velocity, 40,
+                            ));
+                            args.world.spawn_entity(item_entity).await;
+                        }
+                    }
 
                     args.world.sync_world_event(
                         WorldEvent::SoundDispenserDispense,


### PR DESCRIPTION
## Description

Adds item-specific dispenser behaviors, moving toward vanilla parity. Previously the
dispenser ejected **every** item as a floating item entity (vanilla's default fallback).
This introduces a dispatch on the item type so specific items get their real behavior,
with the item-ejection path kept as the default.

Implemented so far:
- **TNT** — primes a `TNTEntity` in the block in front (fuse 80, power 4.0), matching vanilla's spawn position and defaults.
- **Arrow** — fires an ownerless `ArrowEntity` (pickup allowed) from the block face along the facing direction (power 1.1, uncertainty 6.0).

This is an incremental PR (draft) — more behaviors will land as follow-up commits.
The checklist below tracks the full vanilla behavior set.

## Scope / status

- [x] TNT (prime)
- [x] Arrow (shoot)

### Projectiles
- [ ] Tipped Arrow
- [ ] Spectral Arrow
- [ ] Snowball
- [ ] Egg (+ Blue Egg, Brown Egg)
- [ ] Experience Bottle
- [ ] Splash Potion
- [ ] Lingering Potion
- [ ] Firework Rocket
- [ ] Fire Charge
- [ ] Wind Charge

### Buckets
- [ ] Empty Bucket (pick up fluid / fish)
- [ ] Water Bucket
- [ ] Lava Bucket
- [ ] Powder Snow Bucket
- [ ] Fish buckets (Cod, Salmon, Pufferfish, Tropical Fish, Axolotl, Tadpole)

### Vehicles
- [ ] Boats & Chest Boats (Oak, Spruce, Birch, Jungle, Acacia, Dark Oak, Mangrove, Cherry, Pale Oak)
- [ ] Bamboo Raft & Bamboo Chest Raft
- [ ] Minecart + Chest / Furnace / Hopper / TNT / Command Block Minecart

### Placement / interaction
- [ ] Flint and Steel (ignite)
- [ ] Bone Meal (grow)
- [ ] Shears (shear sheep / carve pumpkin / harvest honey)
- [ ] Brush
- [ ] Armor Stand (place)
- [ ] Carved Pumpkin (place + summon snow/iron golem)
- [ ] Shulker Box (+ 16 coloured variants)
- [ ] Glowstone (charge respawn anchor)
- [ ] Honeycomb (wax copper)
- [ ] Wither Skeleton Skull (place + summon wither)

### Equip / spawn
- [ ] Equippable items (armor, elytra, wolf armor, saddle, horse armor) — equip on nearby entity
- [ ] Spawn Eggs (all — spawn mob)

### Fixes / correctness
- [ ] Per-behavior dispense sounds — TNT should play `ENTITY_TNT_PRIMED`, projectiles world event `1002`, instead of the generic dispenser-dispense sound currently used for all branches.

## Testing

- [x] `cargo build` and `cargo clippy --all-targets` — clean, no warnings.
- [x] In-game: verified TNT primes in the correct block and arrows fire in the right direction with correct spawn position.
- [ ] Unit tests where practical.
