### PR TITLE
fix(worldgen): give the stronghold room chest a block entity

### DIFF
--- a/pumpkin-world/src/generation/structure/structures/stronghold/square_room.rs
+++ b/pumpkin-world/src/generation/structure/structures/stronghold/square_room.rs
@@ -24,6 +24,10 @@ use crate::{
 
 use crate::world::WorldPortalExt;
 
+/// Loot table of the chest in the room variant that has one, matching vanilla
+/// `StrongholdPieces$RoomCrossing`.
+const CROSSING_LOOT_TABLE: &str = "minecraft:chests/stronghold_crossing";
+
 pub struct SquareRoomPiece {
     piece: StrongholdPiece,
     room_type: u32,
@@ -272,8 +276,7 @@ impl StructurePieceBase for SquareRoomPiece {
                 inner.add_block(chunk, ladder, 9, 3, 3, &box_limit);
 
                 // Chest
-                // p.add_chest(chunk, &box_limit, random, 3, 4, 8, LootTables::StrongholdCrossingChest);
-                inner.add_block(chunk, Block::CHEST.default_state, 3, 4, 8, &box_limit);
+                inner.add_chest(chunk, &box_limit, random, 3, 4, 8, CROSSING_LOOT_TABLE);
             }
             _ => {}
         }


### PR DESCRIPTION
## Description

The chest in the stronghold square room was placed with `add_block` and a bare `Block::CHEST.default_state`, so no chest block entity was ever created for it. Opening a chest and resolving a double chest both look the block entity up first (`chests.rs` calls `get_block_entity` on the clicked position and on the paired neighbour), which is why the chest can neither be opened nor connected to a chest placed next to it.

`add_chest` already exists next to it and does the right thing: it writes the block state and the matching block entity with a loot table and seed, as the nether fortress corridors already do. The intended call was sitting commented out one line above.

Vanilla `StrongholdPieces$RoomCrossing` places this chest at the same local position with `BuiltInLootTables.STRONGHOLD_CROSSING`, and `assets/loot_table/chests/stronghold_crossing.json` is already shipped. Vanilla also consumes one random long here for the loot table seed, which `add_chest` does and the previous code did not.

The stronghold corridor and library chests are still commented out entirely, which is a separate gap and left alone here.

Fixes #1759

## Testing

`cargo test -p pumpkin-world`, `cargo clippy -p pumpkin-world` and `cargo fmt --check` pass. Generating the reported seed to assert the block entity would need a worldgen fixture the repo does not have, so the position and loot table were checked against vanilla `StrongholdPieces` instead.
