### PR TITLE
fix(net): acknowledge block changes per packet, not on keep-alive 🤖🤖🤖

### DIFF
--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -275,13 +275,6 @@ impl JavaClient {
                     self.last_keep_alive_time.store(Instant::now());
                     let packet = pumpkin_protocol::java::client::play::CKeepAlive::new(keep_alive_id);
                     self.enqueue_packet(&packet).await;
-
-                    let seq = self.packet_sequence.swap(-1, Ordering::Relaxed);
-                    if seq != -1 {
-                        self
-                            .send_packet_now(&CAcknowledgeBlockChange::new(seq.into()))
-                            .await;
-                    }
                 }
 
                 // INCOMING PACKETS
@@ -310,6 +303,17 @@ impl JavaClient {
                                 e
                             );
                         }
+                    }
+
+                    // Flush the block-change acknowledgement as soon as the packet that set the
+                    // sequence is handled, rather than deferring to the keep-alive tick. Otherwise
+                    // an interaction that changes no block (e.g. bone meal on a mature crop, or a
+                    // failed growth roll) leaves the client's prediction pending until the next
+                    // keep-alive, blocking further interaction with that block.
+                    let seq = self.packet_sequence.swap(-1, Ordering::Relaxed);
+                    if seq != -1 {
+                        self.send_packet_now(&CAcknowledgeBlockChange::new(seq.into()))
+                            .await;
                     }
                 }
             }


### PR DESCRIPTION
## Description

`CAcknowledgeBlockChange` — which resolves the client's block-interaction prediction — was only flushed inside the keep-alive branch (~every 15s). Interactions that change no block (e.g. using an item on a block where nothing happens) therefore left the client's prediction pending until the next keep-alive, blocking further use on that block until the player interacted elsewhere.

This flushes the pending sequence acknowledgement immediately after each play packet is handled. It only sends when a sequence was actually set, so non-interaction packets add no traffic.

## Testing

Reproduced with repeated no-op item uses (bone meal on a fully-grown crop) which previously froze further right-clicks until interacting with a different block; after the change each click registers immediately. `cargo clippy --all-targets` (debug + release), `cargo fmt --check`, tests, and typos all pass.