### PR TITLE
docs: fix broken chunk loading image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 and customizable experience. It prioritizes performance and player enjoyment while adhering to the core mechanics of the game.
 <div align="center">
 
-![Pumpkin Chunk Loading](./assets/pumpkin_chunk_loading.gif)
+![Pumpkin Chunk Loading](./assets/pumpkin-chunk-loading.webp)
 
 </div>
 


### PR DESCRIPTION
## Description
Commit https://github.com/Pumpkin-MC/Pumpkin/commit/a95685720974105203ca79c54020d4d8bb31e8b8 changed the image link extension in `README.md` to `.gif` and renamed the file to `pumpkin-chunk-loading.webp`, resulting in a broken image on the main repository page.

I updated the link in `README.md` to point to the correct file path `./assets/pumpkin-chunk-loading.webp`

## Testing
- [x] Verified that the Pumpkin Chunk Loading is now renders correctly in `README.md`
