### PR TITLE
fix: double-tall plant worldgen & consumable on-consume effects (milk/honey)

### DIFF
--- a/pumpkin-world/src/generation/feature/features/simple_block.rs
+++ b/pumpkin-world/src/generation/feature/features/simple_block.rs
@@ -1,4 +1,7 @@
-use pumpkin_data::Block;
+use pumpkin_data::block_properties::{
+    BlockProperties, DoubleBlockHalf, SmallDripleafLikeProperties, TallSeagrassLikeProperties,
+};
+use pumpkin_data::{Block, BlockState};
 use pumpkin_util::{math::position::BlockPos, random::RandomGenerator};
 
 use crate::generation::proto_chunk::GenerationCache;
@@ -25,6 +28,38 @@ impl SimpleBlockFeature {
         let block_accessor: &dyn BlockAccessor = chunk;
         if !block_registry.can_place_at(block, state, block_accessor, &pos) {
             return false;
+        }
+
+        // Vanilla places both halves of DoublePlantBlocks here (DoublePlantBlock.placeAt)
+        if TallSeagrassLikeProperties::handles_block_id(block.id) {
+            let upper_pos = pos.up();
+            if !chunk.is_air(&upper_pos.0) {
+                return false;
+            }
+            chunk.set_block_state(&pos.0, state);
+            let mut upper_props = TallSeagrassLikeProperties::from_state_id(state.id, block);
+            upper_props.half = DoubleBlockHalf::Upper;
+            chunk.set_block_state(
+                &upper_pos.0,
+                BlockState::from_id(upper_props.to_state_id(block)),
+            );
+            return true;
+        }
+
+        // ... and SmallDripleafBlocks (SmallDripleafBlock.placeAt)
+        if SmallDripleafLikeProperties::handles_block_id(block.id) {
+            let upper_pos = pos.up();
+            if !chunk.is_air(&upper_pos.0) {
+                return false;
+            }
+            chunk.set_block_state(&pos.0, state);
+            let mut upper_props = SmallDripleafLikeProperties::from_state_id(state.id, block);
+            upper_props.half = DoubleBlockHalf::Upper;
+            chunk.set_block_state(
+                &upper_pos.0,
+                BlockState::from_id(upper_props.to_state_id(block)),
+            );
+            return true;
         }
 
         // TODO: check things..

--- a/pumpkin/src/block/blocks/plant/tall_plant.rs
+++ b/pumpkin/src/block/blocks/plant/tall_plant.rs
@@ -68,7 +68,7 @@ impl BlockBehaviour for TallPlantBlock {
             }
 
             let (other_block, other_state_id) = args.world.get_block_and_state_id(&other_block_pos);
-            if Self::ids().contains(&other_block.id) {
+            if other_block.id == args.block.id {
                 let other_props =
                     TallSeagrassLikeProperties::from_state_id(other_state_id, other_block);
                 let opposite_half = match tall_plant_props.half {
@@ -86,6 +86,9 @@ impl BlockBehaviour for TallPlantBlock {
         Box::pin(async move {
             let mut tall_plant_props =
                 TallSeagrassLikeProperties::from_state_id(args.state_id, args.block);
+            if tall_plant_props.half != DoubleBlockHalf::Lower {
+                return;
+            }
             tall_plant_props.half = DoubleBlockHalf::Upper;
             args.world
                 .set_block_state(
@@ -107,7 +110,7 @@ impl BlockBehaviour for TallPlantBlock {
                 DoubleBlockHalf::Lower => args.position.up(),
             };
             let (other_block, other_state_id) = args.world.get_block_and_state_id(&other_block_pos);
-            if Self::ids().contains(&other_block.id) {
+            if other_block.id == args.block.id {
                 let other_props =
                     TallSeagrassLikeProperties::from_state_id(other_state_id, other_block);
                 let opposite_half = match tall_plant_props.half {

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -40,8 +40,8 @@ use pumpkin_data::attributes::Attributes;
 use pumpkin_data::damage::DeathMessageType;
 use pumpkin_data::data_component_impl::Operation;
 use pumpkin_data::data_component_impl::{
-    AttributeModifiersImpl, BlocksAttacksImpl, DeathProtectionImpl, EnchantmentsImpl,
-    EquipmentSlot, EquippableImpl, FoodImpl,
+    AttributeModifiersImpl, BlocksAttacksImpl, ConsumableImpl, ConsumeEffect, DeathProtectionImpl,
+    EnchantmentsImpl, EquipmentSlot, EquippableImpl, FoodImpl, IDSet, IdOr,
 };
 use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::entity::{EntityPose, EntityStatus, EntityType};
@@ -2695,6 +2695,77 @@ impl EntityBase for LivingEntity {
                         let effects = crate::item::potion::PotionContents::read_potion_effects(item);
                         crate::item::potion::PotionContents::apply_effects_to(self, effects, 1.0, crate::item::potion::PotionApplicationSource::Normal).await;
                         is_potion = true;
+                    }
+
+                    // Handle consumable component effects (milk clears all effects,
+                    // honey bottles remove poison, etc.)
+                    if let Some(consumable) = item.get_data_component::<ConsumableImpl>() {
+                        for consume_effect in &*consumable.effects {
+                            match consume_effect {
+                                ConsumeEffect::ClearAllEffects => {
+                                    if let Some(player) = caller.get_player() {
+                                        player.remove_all_effects().await;
+                                    } else {
+                                        let effect_types: Vec<&'static StatusEffect> = self
+                                            .active_effects
+                                            .lock()
+                                            .await
+                                            .keys()
+                                            .copied()
+                                            .collect();
+                                        for effect_type in effect_types {
+                                            self.remove_effect(effect_type).await;
+                                        }
+                                    }
+                                }
+                                ConsumeEffect::RemoveEffects(id_set) => {
+                                    if let IDSet::IDs(ids) = id_set {
+                                        for effect_type in ids.iter() {
+                                            self.remove_effect(effect_type).await;
+                                        }
+                                    }
+                                }
+                                ConsumeEffect::ApplyEffects((effects, probability)) => {
+                                    if rand::rng().random::<f32>() < *probability {
+                                        let resolved = effects
+                                            .iter()
+                                            .filter_map(|instance| {
+                                                StatusEffect::from_minecraft_name(
+                                                    &instance.effect_id,
+                                                )
+                                                .map(|effect_type| {
+                                                    (
+                                                        effect_type,
+                                                        instance.duration,
+                                                        instance.amplifier as u8,
+                                                        instance.ambient,
+                                                        instance.show_particles,
+                                                        instance.show_icon,
+                                                    )
+                                                })
+                                            })
+                                            .collect();
+                                        crate::item::potion::PotionContents::apply_effects_to(
+                                            self,
+                                            resolved,
+                                            1.0,
+                                            crate::item::potion::PotionApplicationSource::Normal,
+                                        )
+                                        .await;
+                                    }
+                                }
+                                ConsumeEffect::TeleportRandomly(_) => {
+                                    warn!("ConsumeEffect::TeleportRandomly is not yet implemented");
+                                }
+                                ConsumeEffect::PlaySound(sound) => {
+                                    if let IdOr::Id(sound) = sound {
+                                        let world = self.entity.world.load();
+                                        let pos = self.entity.pos.load();
+                                        world.play_sound(*sound, SoundCategory::Players, &pos);
+                                    }
+                                }
+                            }
+                        }
                     }
 
                     if let Some(player) = caller.get_player() {


### PR DESCRIPTION
Double-tall plants

Fixed world generation so double-tall plants (rose bushes, sunflowers, lilacs, peonies, tall grass, large ferns, pitcher plants, small dripleaf) place both the bottom and top halves.
Fixed neighbor updates so tall plants only stay if the other half is the same plant, matching vanilla behavior.

Milk & consumable effects

Fixed consumable effects not being applied after finishing an item.
Added support for:
clear_all_effects (milk)
remove_effects (honey bottle)
apply_effects (suspicious stew)
play_sound
teleport_randomly (chorus fruit) is not implemented yet and currently logs a warning.