### PR TITLE
fix: nether chunk height, portal travel stalls, block acks and log spam

### DIFF
--- a/pumpkin-world/src/chunk_system/chunk_state.rs
+++ b/pumpkin-world/src/chunk_system/chunk_state.rs
@@ -205,6 +205,13 @@ impl Chunk {
     }
 
     fn build_level_sections(proto_chunk: &ProtoChunk, dimension: &Dimension) -> ChunkSections {
+        // The proto chunk must be allocated with the dimension's full storage height,
+        // otherwise the reads below run past the end of its block/biome buffers.
+        debug_assert_eq!(
+            proto_chunk.height() as i32,
+            dimension.height,
+            "proto chunk height does not match the dimension height"
+        );
         let total_sections = dimension.height as usize / BlockPalette::SIZE;
         let biome_min_y = biome_coords::from_block(dimension.min_y);
         let block_sections = (0..total_sections)

--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -78,6 +78,11 @@ pub struct GenerationSchedule {
     listener: Arc<ChunkListener>,
     lighting_config: LightingEngineConfig,
     last_unload: std::time::Instant,
+    /// Chunks whose generation failure has already been reported. A failing chunk is
+    /// re-queued and will usually fail again the same way every time, so the details are
+    /// logged once per chunk and every repeat is demoted to debug instead of flooding
+    /// the console.
+    reported_generation_failures: HashSetType<ChunkPos>,
 }
 
 impl GenerationSchedule {
@@ -171,6 +176,7 @@ impl GenerationSchedule {
                     chunk_map: HashMap::default(),
                     lighting_config,
                     last_unload: std::time::Instant::now(),
+                    reported_generation_failures: HashSetType::default(),
                 };
                 scheduler.work(&level_sched);
             })
@@ -857,7 +863,7 @@ impl GenerationSchedule {
                                 let public_chunk = chunk.clone();
                                 if was_public {
                                     self.public_chunk_map.insert(new_pos, public_chunk);
-                                    info!(
+                                    debug!(
                                         "Notifying players: regenerated chunk at {:?} (was already public)",
                                         new_pos
                                     );
@@ -961,10 +967,19 @@ impl GenerationSchedule {
                 stage,
                 error,
             } => {
-                error!(
-                    "Received generation failure notification for chunk {:?} at stage {:?}: {}",
-                    fail_pos, stage, error
-                );
+                // Report each broken chunk once; the retry loop below would otherwise
+                // print the same failure every time it comes back around.
+                if self.reported_generation_failures.insert(fail_pos) {
+                    error!(
+                        "Received generation failure notification for chunk {:?} at stage {:?}: {} (further failures for this chunk are logged at debug level)",
+                        fail_pos, stage, error
+                    );
+                } else {
+                    debug!(
+                        "Received generation failure notification for chunk {:?} at stage {:?}: {}",
+                        fail_pos, stage, error
+                    );
+                }
 
                 if let Some(mut holder) = self.chunk_map.remove(&pos) {
                     let target_stage = holder.target_stage;
@@ -1016,7 +1031,8 @@ impl GenerationSchedule {
 
                     self.chunk_map.insert(pos, holder);
 
-                    warn!(
+                    // Part of the failure report above, which is already rate limited.
+                    debug!(
                         "Chunk {:?} reset to None and re-queued for regeneration (target: {:?})",
                         pos, target_stage
                     );

--- a/pumpkin-world/src/chunk_system/worker_logic.rs
+++ b/pumpkin-world/src/chunk_system/worker_logic.rs
@@ -249,7 +249,9 @@ pub fn run_generation(
                 })
                 .unwrap_or("Unknown panic payload");
 
-            error!("Chunk generation FAILED at {pos:?} ({stage:?}): {msg}");
+            // The scheduler reports this once per chunk (and rate limits repeats), so
+            // logging it here as well only doubles the noise on a retry loop.
+            debug!("Chunk generation FAILED at {pos:?} ({stage:?}): {msg}");
 
             RecvChunk::GenerationFailure {
                 pos,

--- a/pumpkin-world/src/generation/carver/mod.rs
+++ b/pumpkin-world/src/generation/carver/mod.rs
@@ -160,7 +160,9 @@ pub fn carve(chunk: &mut ProtoChunk, generator: &VanillaGenerator) {
 
     let mut context = CarvingContext {
         min_y: generator.dimension.min_y as i8,
-        height: generator.dimension.logical_height as u16,
+        // Must match `ProtoChunk`'s storage height, not `logical_height`
+        // (the Nether's logical height is 128 while its chunks are 256 tall).
+        height: generator.dimension.height as u16,
         random_config: &generator.random_config,
         surface_noise: &generator.terrain_cache.surface_noise,
         secondary_noise: &generator.terrain_cache.secondary_noise,
@@ -404,7 +406,9 @@ fn with_carve_run_options<F>(
     });
     let mut context = CarvingContext {
         min_y: generator.dimension.min_y as i8,
-        height: generator.dimension.logical_height as u16,
+        // Must match `ProtoChunk`'s storage height, not `logical_height`
+        // (the Nether's logical height is 128 while its chunks are 256 tall).
+        height: generator.dimension.height as u16,
         random_config: &generator.random_config,
         surface_noise: &generator.terrain_cache.surface_noise,
         secondary_noise: &generator.terrain_cache.secondary_noise,

--- a/pumpkin-world/src/generation/proto_chunk.rs
+++ b/pumpkin-world/src/generation/proto_chunk.rs
@@ -178,7 +178,12 @@ impl ProtoChunk {
     #[must_use]
     pub fn new(x: i32, z: i32, generator: &super::generator::WorldGenerator) -> Self {
         let dimension = generator.dimension();
-        let height = dimension.logical_height as u16;
+        // This must be the dimension's *storage* height, not `logical_height`.
+        // `logical_height` is only the cap for portals/mob AI (the Nether reports 128
+        // while its chunks are still 256 blocks tall). Sizing the block/biome/light
+        // buffers by it made every read above y=128 in the Nether run off the end of
+        // `flat_block_map` when the chunk was converted to a level chunk.
+        let height = dimension.height as u16;
         let section_count = (height as usize) / 16;
 
         let default_block = match generator {
@@ -423,6 +428,9 @@ impl ProtoChunk {
 
     #[inline]
     const fn local_pos_to_block_index(&self, x: i32, y: i32, z: i32) -> usize {
+        debug_assert!(x >= 0 && x < CHUNK_DIM as i32, "local x out of range");
+        debug_assert!(z >= 0 && z < CHUNK_DIM as i32, "local z out of range");
+        debug_assert!(y >= 0 && y < self.height as i32, "local y out of range");
         self.height() as usize * CHUNK_DIM as usize * x as usize
             + CHUNK_DIM as usize * y as usize
             + z as usize

--- a/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod test {
+    use crate::chunk::CHUNK_AREA;
     use crate::chunk_system::chunk_state::StagedChunkEnum;
     use crate::generation::{generator::WorldGenerator, get_world_gen, proto_chunk::ProtoChunk};
     use pumpkin_data::dimension::Dimension;
@@ -103,5 +104,46 @@ mod test {
             has_surface_blocks,
             "Top of the world must contain surface blocks (grass/dirt/sand/water)"
         );
+    }
+
+    /// The Nether reports `logical_height` 128 (the portal/mob-AI cap) but its chunks
+    /// are `height` 256 blocks tall. Sizing the proto chunk by the logical height made
+    /// `Chunk::build_level_sections` — which walks the full dimension height — index
+    /// past the end of `flat_block_map` and panic during chunk generation.
+    #[test]
+    fn nether_proto_chunk_covers_full_dimension_height() {
+        let seed = Seed(0);
+        let world_gen =
+            get_world_gen(seed, Dimension::THE_NETHER, false, Vec::new(), String::new());
+        let mut chunk = ProtoChunk::new(-5, 3, &world_gen);
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+
+        let height = Dimension::THE_NETHER.height;
+        assert_eq!(
+            i32::from(chunk.height()),
+            height,
+            "Proto chunk must be allocated with the dimension's storage height"
+        );
+        assert_eq!(chunk.flat_block_map.len(), CHUNK_AREA * height as usize);
+
+        chunk.step_to_biomes(generator);
+
+        // Mirrors the access pattern of `Chunk::build_level_sections`.
+        for y in 0..height {
+            for x in 0..16 {
+                for z in 0..16 {
+                    let _ = chunk.get_block_state_raw(x, y, z);
+                }
+            }
+        }
+        for y in 0..(height / 4) {
+            for x in 0..4 {
+                for z in 0..4 {
+                    let _ = chunk.get_biome_id(x, y, z);
+                }
+            }
+        }
     }
 }

--- a/pumpkin-world/src/generation/structure/mod.rs
+++ b/pumpkin-world/src/generation/structure/mod.rs
@@ -133,9 +133,8 @@ pub fn try_generate_structure(
 
     if let Some(pos) = structure_pos {
         // Get the biome at the structure's starting position.
-        // Clamp biome Y to the chunk's valid range — structure start_pos.y may exceed
-        // the chunk's logical height (e.g. nether fossils use full height 256 but
-        // ProtoChunk only covers logical_height 128).
+        // Clamp biome Y to the chunk's valid range — a structure's start_pos.y is not
+        // guaranteed to sit inside this chunk's vertical bounds.
         let biome_y = biome_coords::from_block(pos.start_pos.0.y);
         let biome_height = (chunk.height() >> 2) as i32;
         let biome_bottom = biome_coords::from_block(chunk.bottom_y() as i32);

--- a/pumpkin-world/src/poi/mod.rs
+++ b/pumpkin-world/src/poi/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io::{Cursor, Read, Write};
 use std::path::{Path, PathBuf};
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 use flate2::Compression;
 use flate2::read::ZlibDecoder;
@@ -491,7 +491,7 @@ impl PoiStorage {
         }
 
         if saved > 0 {
-            info!("Saved {saved} POI region(s)");
+            debug!("Saved {saved} POI region(s)");
         }
         Ok(())
     }

--- a/pumpkin/src/block/blocks/end_portal.rs
+++ b/pumpkin/src/block/blocks/end_portal.rs
@@ -23,7 +23,8 @@ impl BlockBehaviour for EndPortalBlock {
             if Arc::ptr_eq(&target_world, args.world) {
                 return;
             }
-            tracing::info!(
+            // Fires for every portal block the entity touches, every tick.
+            tracing::trace!(
                 "End portal collision at {:?}, targeting world {:?}",
                 args.position,
                 target_world.dimension.minecraft_name

--- a/pumpkin/src/block/blocks/nether_portal.rs
+++ b/pumpkin/src/block/blocks/nether_portal.rs
@@ -81,7 +81,9 @@ impl BlockBehaviour for NetherPortalBlock {
                 return;
             }
 
-            tracing::info!(
+            // Fires for every portal block the entity touches, every tick it stands in
+            // one - far too hot for info level.
+            tracing::trace!(
                 "Nether portal collision at {:?}, targeting world {:?}",
                 args.position,
                 target_world.dimension.minecraft_name

--- a/pumpkin/src/block/entities/end_portal.rs
+++ b/pumpkin/src/block/entities/end_portal.rs
@@ -50,6 +50,12 @@ impl BlockEntity for EndPortalBlockEntity {
         Box::pin(async {})
     }
 
+    fn chunk_data_nbt(&self) -> Option<NbtCompound> {
+        // Empty compound is enough for the client to instantiate the end portal
+        // renderer; without this, live activation never sends CBlockEntityData.
+        Some(NbtCompound::new())
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1354,14 +1354,24 @@ impl Player {
 
         let respawn_guard = self.respawn_point.lock().await;
         let respawn_point = respawn_guard.as_ref()?;
-        let world = self.world();
-        let pos = &respawn_point.position;
-        let (block, state_id) = world.get_block_and_state_id(pos);
+        let dimension = respawn_point.dimension.clone();
+        let pos = respawn_point.position;
+        let yaw = respawn_point.yaw;
+        let force = respawn_point.force;
+        drop(respawn_guard);
+
+        // Validate the bed/anchor in the stored spawn dimension, not the death world.
+        let server = self.world().server.upgrade()?;
+        let world = server.get_world_from_dimension(&dimension);
+        let chunk_pos = pumpkin_util::math::vector2::Vector2::new(pos.0.x >> 4, pos.0.z >> 4);
+        world.level.get_or_fetch_chunk(chunk_pos, |_| ()).await;
+
+        let (block, state_id) = world.get_block_and_state_id(&pos);
 
         // If force is set (from /spawnpoint command), validate position is safe
-        if respawn_point.force {
+        if force {
             // For forced spawn, check if both the block and block above allow mob spawn
-            let block_state = world.get_block_state(pos);
+            let block_state = world.get_block_state(&pos);
             let above_state = world.get_block_state(&pos.up());
 
             // Check if blocks are passable (non-solid or air)
@@ -1376,13 +1386,13 @@ impl Player {
                 );
                 debug!(
                     "Returning forced spawn point at {:?}, dimension: {:?}",
-                    position, respawn_point.dimension
+                    position, dimension
                 );
                 return Some(CalculatedRespawnPoint {
                     position,
-                    yaw: respawn_point.yaw,
+                    yaw,
                     pitch: 0.0,
-                    dimension: respawn_point.dimension.clone(),
+                    dimension,
                 });
             }
             return None;
@@ -1395,14 +1405,12 @@ impl Player {
 
             // Try positions around the bed based on facing direction
             // Vanilla tries multiple offset patterns; we use a simplified version
-            if let Some(spawn_pos) =
-                Self::find_bed_spawn_position(&world, pos, facing, respawn_point.yaw)
-            {
+            if let Some(spawn_pos) = Self::find_bed_spawn_position(&world, &pos, facing, yaw) {
                 return Some(CalculatedRespawnPoint {
                     position: spawn_pos,
-                    yaw: respawn_point.yaw,
+                    yaw,
                     pitch: 0.0,
-                    dimension: respawn_point.dimension.clone(),
+                    dimension,
                 });
             }
             return None;
@@ -1419,14 +1427,14 @@ impl Player {
             }
 
             // Try positions around the anchor
-            if let Some(spawn_pos) = Self::find_anchor_spawn_position(&world, pos) {
+            if let Some(spawn_pos) = Self::find_anchor_spawn_position(&world, &pos) {
                 // Decrement charges after successful respawn position found
                 let new_charges = charges - 1;
                 let mut new_props = anchor_props;
                 new_props.charges = new_charges;
                 world
                     .set_block_state(
-                        pos,
+                        &pos,
                         new_props.to_state_id(block),
                         pumpkin_world::world::BlockFlags::NOTIFY_ALL,
                     )
@@ -1434,9 +1442,9 @@ impl Player {
 
                 return Some(CalculatedRespawnPoint {
                     position: spawn_pos,
-                    yaw: respawn_point.yaw,
+                    yaw,
                     pitch: 0.0,
-                    dimension: respawn_point.dimension.clone(),
+                    dimension,
                 });
             }
             return None;
@@ -1905,6 +1913,11 @@ impl Player {
 
     #[expect(clippy::too_many_lines)]
     pub async fn tick(self: &Arc<Self>, server: &Server) {
+        // Confirm the block changes this client predicted since the last tick. Without
+        // this the client keeps drawing its prediction (e.g. the fire from flint and
+        // steel) until something else updates that position.
+        self.client.ack_block_changes().await;
+
         if let Some(camera_id) = self.camera_target_id.load() {
             if camera_id == self.entity_id() {
                 self.camera_target_id.store(None);
@@ -5036,14 +5049,14 @@ impl InventoryPlayer for Player {
                     use pumpkin_protocol::codec::var_uint::VarUInt;
 
                     let window_id = packet.window_id;
-                    tracing::info!(
+                    tracing::trace!(
                         "enqueue_slot_packet: window_id={}, slot={}",
                         window_id,
                         packet.slot
                     );
 
                     if window_id == 0 {
-                        tracing::info!(
+                        tracing::trace!(
                             "enqueue_slot_packet: window_id is 0, sending CInventorySlot to Bedrock client"
                         );
                         let slot_idx = packet.slot as usize;
@@ -5173,7 +5186,7 @@ impl InventoryPlayer for Player {
                     };
                     use pumpkin_protocol::codec::var_uint::VarUInt;
 
-                    tracing::info!(
+                    tracing::trace!(
                         "enqueue_slot_set_packet: slot={}, sending CInventorySlot to Bedrock client",
                         packet.slot.0
                     );

--- a/pumpkin/src/item/items/ender_eye.rs
+++ b/pumpkin/src/item/items/ender_eye.rs
@@ -8,6 +8,7 @@ use crate::item::{ItemBehaviour, ItemMetadata};
 use crate::server::Server;
 use crate::world::World;
 use crate::world::portal::end::EndPortal;
+use pumpkin_data::block_properties::BlockProperties;
 use pumpkin_data::entity::EntityType;
 use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
@@ -21,6 +22,8 @@ use pumpkin_world::generation::generator::structure_finder::find_nearest_structu
 use pumpkin_world::world::BlockFlags;
 
 use crate::entity::player::Player;
+
+type EndPortalFrameProperties = pumpkin_data::block_properties::EndPortalFrameLikeProperties;
 
 pub struct EnderEyeItem;
 
@@ -48,25 +51,19 @@ impl ItemBehaviour for EnderEyeItem {
 
             let world = player.world();
             let state_id = world.get_block_state_id(&location);
+            let mut props = EndPortalFrameProperties::from_state_id(state_id, block);
 
             // Skip if the frame already holds an eye.
-            let props_raw = block.properties(state_id).unwrap().to_props();
-            if props_raw.iter().any(|(k, v)| *k == "eye" && *v == "true") {
+            if props.eye {
                 return;
             }
 
-            // Build new state with eye=true.
-            let props: Vec<(&str, &str)> = props_raw
-                .iter()
-                .map(|(k, v)| if *k == "eye" { (*k, "true") } else { (*k, *v) })
-                .collect();
-
-            let new_state_id = block.from_properties(&props).to_state_id(block);
+            props.eye = true;
+            let new_state_id = props.to_state_id(block);
             world
                 .set_block_state(&location, new_state_id, BlockFlags::NOTIFY_LISTENERS)
                 .await;
-            // Consume one item.
-            item.decrement(1);
+            item.decrement_unless_creative(player.gamemode.load(), 1);
             world.sync_world_event(WorldEvent::EndPortalFrameFill, location, 0);
 
             // Try to complete the portal.
@@ -128,7 +125,12 @@ impl ItemBehaviour for EnderEyeItem {
             );
 
             player.trigger_advancement(crate::entity::player::advancement::trigger::AdvancementTrigger::LaunchedEyeOfEnder).await;
-            player.inventory.held_item().lock().await.decrement(1);
+            player
+                .inventory
+                .held_item()
+                .lock()
+                .await
+                .decrement_unless_creative(player.gamemode.load(), 1);
         })
     }
 

--- a/pumpkin/src/item/items/ignite/fire_charge.rs
+++ b/pumpkin/src/item/items/ignite/fire_charge.rs
@@ -28,7 +28,7 @@ impl ItemMetadata for FireChargeItem {
 impl ItemBehaviour for FireChargeItem {
     fn use_on_block<'a>(
         &'a self,
-        _item: &'a mut ItemStack,
+        item: &'a mut ItemStack,
         player: &'a Player,
         location: BlockPos,
         face: BlockDirection,
@@ -37,13 +37,11 @@ impl ItemBehaviour for FireChargeItem {
         _server: &'a Server,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
         Box::pin(async move {
-            Ignition::ignite_block(
+            let ignited = Ignition::ignite_block(
                 |world: Arc<World>, pos: BlockPos, new_state_id: BlockStateId| async move {
                     world
                         .set_block_state(&pos, new_state_id, BlockFlags::NOTIFY_ALL)
                         .await;
-
-                    world.play_block_sound(Sound::ItemFirechargeUse, SoundCategory::Blocks, pos);
                 },
                 player,
                 location,
@@ -51,6 +49,16 @@ impl ItemBehaviour for FireChargeItem {
                 block,
             )
             .await;
+
+            if ignited {
+                let sound_pos = location.offset(face.to_offset());
+                player.world().play_block_sound(
+                    Sound::ItemFirechargeUse,
+                    SoundCategory::Blocks,
+                    sound_pos,
+                );
+                item.decrement_unless_creative(player.gamemode.load(), 1);
+            }
         })
     }
 

--- a/pumpkin/src/item/items/ignite/ignition.rs
+++ b/pumpkin/src/item/items/ignite/ignition.rs
@@ -2,6 +2,9 @@ use crate::block::blocks::fire::FireBlockBase;
 use crate::block::blocks::fire::fire::FireBlock;
 use crate::entity::player::Player;
 use crate::world::World;
+use crate::world::portal::nether::NetherPortal;
+use pumpkin_data::block_properties::HorizontalAxis;
+use pumpkin_data::dimension::Dimension;
 use pumpkin_data::fluid::Fluid;
 use pumpkin_data::{Block, BlockDirection, BlockStateId};
 use pumpkin_util::math::position::BlockPos;
@@ -27,7 +30,6 @@ impl Ignition {
         if world.get_fluid(&location).name != Fluid::EMPTY.name {
             return false;
         }
-        let fire_block = FireBlockBase::get_fire_type(&world, &pos);
 
         let state_id = world.get_block_state_id(&location);
 
@@ -36,6 +38,13 @@ impl Ignition {
             return true;
         }
 
+        // Light a Nether portal without placing fire first (vanilla onPlace creates
+        // portal immediately; placing fire then replacing it causes a client flicker).
+        if try_light_nether_portal(&world, &pos, face).await {
+            return true;
+        }
+
+        let fire_block = FireBlockBase::get_fire_type(&world, &pos);
         let state_id = FireBlock.get_state_for_position(&world, &fire_block, &pos);
         if FireBlockBase::can_place_at(&world, &pos) {
             ignite_logic(world.clone(), pos, state_id).await;
@@ -44,6 +53,31 @@ impl Ignition {
 
         false
     }
+}
+
+async fn try_light_nether_portal(
+    world: &Arc<World>,
+    pos: &BlockPos,
+    face: BlockDirection,
+) -> bool {
+    let dimension = &world.dimension;
+    if dimension != &Dimension::OVERWORLD && dimension != &Dimension::THE_NETHER {
+        return false;
+    }
+
+    let first_axis = if face.is_horizontal() {
+        face.rotate_counter_clockwise()
+            .to_horizontal_axis()
+            .unwrap_or(HorizontalAxis::X)
+    } else {
+        HorizontalAxis::X
+    };
+
+    if let Some(portal) = NetherPortal::get_new_portal(world, pos, first_axis) {
+        portal.create(world).await;
+        return true;
+    }
+    false
 }
 
 fn can_be_lit(block: &Block, state_id: BlockStateId) -> Option<BlockStateId> {

--- a/pumpkin/src/net/bedrock/play.rs
+++ b/pumpkin/src/net/bedrock/play.rs
@@ -488,7 +488,7 @@ impl BedrockClient {
         player: &Arc<Player>,
         packet: SInventoryTransaction,
     ) {
-        tracing::info!("handle_inventory_action: packet={:?}", packet);
+        tracing::trace!("handle_inventory_action: packet={:?}", packet);
         let mut inventory_updated = false;
         let mut updates = Vec::new();
         let result = 0u8;
@@ -1259,7 +1259,7 @@ impl BedrockClient {
             let mut result = 0u8; // 0 = Success, 1 = Error
 
             for action in request.actions {
-                tracing::info!("Processing ItemStackRequestAction: {:?}", action);
+                tracing::trace!("Processing ItemStackRequestAction: {:?}", action);
                 match action {
                     ItemStackRequestAction::CraftCreative {
                         creative_item_id,
@@ -1527,7 +1527,7 @@ impl BedrockClient {
                                 let grid_slot =
                                     screen_handler.get_behaviour().slots[grid_slot_index].clone();
                                 let grid_stack = grid_slot.get_cloned_stack().await;
-                                tracing::info!(
+                                tracing::trace!(
                                     "Crafting Grid slot {i} (slot index {grid_slot_index}): Item ID: {}, Count: {}",
                                     grid_stack.item.id,
                                     grid_stack.item_count

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -248,6 +248,19 @@ impl JavaClient {
         PacketHandlerResult::Stop
     }
 
+    /// Acknowledges every block change the client has predicted locally since the last
+    /// call. Until this is sent, the client keeps showing its *predicted* block (for
+    /// example the fire it drew when you used flint and steel), even though the server
+    /// already placed something else there. Vanilla sends this at the end of every tick
+    /// the client's action was handled in, so this must be called once per tick.
+    pub async fn ack_block_changes(&self) {
+        let seq = self.packet_sequence.swap(-1, Ordering::Relaxed);
+        if seq != -1 {
+            self.send_packet_now(&CAcknowledgeBlockChange::new(seq.into()))
+                .await;
+        }
+    }
+
     pub async fn progress_player_packets(&self, player: &Arc<Player>, server: &Arc<Server>) {
         let mut keep_alive_interval = tokio::time::interval(std::time::Duration::from_secs(15));
 
@@ -275,13 +288,6 @@ impl JavaClient {
                     self.last_keep_alive_time.store(Instant::now());
                     let packet = pumpkin_protocol::java::client::play::CKeepAlive::new(keep_alive_id);
                     self.enqueue_packet(&packet).await;
-
-                    let seq = self.packet_sequence.swap(-1, Ordering::Relaxed);
-                    if seq != -1 {
-                        self
-                            .send_packet_now(&CAcknowledgeBlockChange::new(seq.into()))
-                            .await;
-                    }
                 }
 
                 // INCOMING PACKETS

--- a/pumpkin/src/net/mod.rs
+++ b/pumpkin/src/net/mod.rs
@@ -157,6 +157,15 @@ impl ClientPlatform {
         }
     }
 
+    /// Confirms the client's locally predicted block changes. Must run every tick,
+    /// otherwise the client keeps rendering blocks it predicted but the server rejected
+    /// or replaced (ghost blocks).
+    pub async fn ack_block_changes(&self) {
+        if let Self::Java(java) = self {
+            java.ack_block_changes().await;
+        }
+    }
+
     pub fn java_version(&self) -> JavaMinecraftVersion {
         match self {
             Self::Java(java) => java.version.load(),

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1037,6 +1037,51 @@ impl World {
             .insert(position, block_state_id);
     }
 
+    /// Sets many block states without neighbor updates, registering all client updates
+    /// under a single lock so a tick cannot flush a partial fill (e.g. Nether portals).
+    pub async fn set_block_states_force_batch(
+        self: &Arc<Self>,
+        positions: &[BlockPos],
+        block_state_id: BlockStateId,
+    ) {
+        let mut changed = Vec::with_capacity(positions.len());
+        for position in positions {
+            let (chunk_coordinate, relative) = position.chunk_and_chunk_relative_position();
+            let replaced = self
+                .level
+                .read_chunk_sync(&chunk_coordinate, |chunk| {
+                    let replaced = chunk.set_block_absolute_y(
+                        relative.x as usize,
+                        relative.y,
+                        relative.z as usize,
+                        block_state_id,
+                    );
+                    if replaced != block_state_id && !chunk.is_dirty() {
+                        chunk.mark_dirty(true);
+                    }
+                    replaced
+                })
+                .unwrap_or(Block::AIR.default_state.id);
+
+            if replaced != block_state_id {
+                changed.push(*position);
+            }
+        }
+
+        {
+            let mut unsent = self.unsent_block_changes.lock().await;
+            for position in &changed {
+                unsent.insert(*position, block_state_id);
+            }
+        }
+
+        for position in &changed {
+            self.level
+                .light_engine
+                .update_lighting_at(&self.level, *position);
+        }
+    }
+
     pub async fn flush_block_updates(&self) {
         let mut block_state_updates_by_chunk_section: HashMap<
             Vector3<i32>,
@@ -3302,6 +3347,7 @@ impl World {
         };
 
         // Get respawn position and dimension
+        let had_respawn_point = player.respawn_point.lock().await.is_some();
         let (position, yaw, pitch, respawn_dimension) =
             if let Some(respawn) = player.calculate_respawn_point().await {
                 (
@@ -3311,18 +3357,26 @@ impl World {
                     respawn.dimension,
                 )
             } else {
-                // No valid respawn point - send notification and use world spawn
-                player
-                    .client
-                    .send_packet_now(&CGameEvent::new(GameEvent::NoRespawnBlockAvailable, 0.0))
-                    .await;
+                // Invalid/missing bed or anchor — notify only if one was set.
+                if had_respawn_point {
+                    player
+                        .client
+                        .send_packet_now(&CGameEvent::new(GameEvent::NoRespawnBlockAvailable, 0.0))
+                        .await;
+                }
+
+                // Vanilla always falls back to the Overworld world spawn.
+                let overworld = self.server.upgrade().map_or_else(
+                    || self.clone(),
+                    |server| server.get_world_from_dimension(&Dimension::OVERWORLD),
+                );
 
                 // FIXME: This spawn position calculation is incorrect. Should use vanilla's
                 // proper spawn position calculation (see #1381). The y-level calculation
                 // needs to account for spawn radius and find a safe spawn position.
                 let chunk_pos = Vector2::new(spawn_x >> 4, spawn_z >> 4);
-                self.level.get_or_fetch_chunk(chunk_pos, |_| ()).await;
-                let top = self.get_top_block(Vector2::new(spawn_x, spawn_z));
+                overworld.level.get_or_fetch_chunk(chunk_pos, |_| ()).await;
+                let top = overworld.get_top_block(Vector2::new(spawn_x, spawn_z));
 
                 (
                     Vector3::new(
@@ -3332,7 +3386,7 @@ impl World {
                     ),
                     spawn_yaw,
                     spawn_pitch,
-                    self.dimension.clone(),
+                    overworld.dimension.clone(),
                 )
             };
 

--- a/pumpkin/src/world/portal/end.rs
+++ b/pumpkin/src/world/portal/end.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use pumpkin_data::world::WorldEvent;
 use pumpkin_data::{Block, BlockDirection, BlockId, block_properties::BlockProperties};
 use pumpkin_util::math::{position::BlockPos, vector3::Vector3};
 use pumpkin_world::world::BlockFlags;
@@ -15,39 +16,32 @@ impl EndPortal {
     const FRAME_BLOCK_ID: BlockId = Self::FRAME_BLOCK.id;
 
     pub async fn get_new_portal(world: &Arc<World>, pos: BlockPos) {
-        let mid_pos = Self::get_mid_pos(world, pos);
-        if let Some(mid_pos) = mid_pos
-            && Self::is_valid_portal(world, mid_pos)
-        {
-            Self::create_portal(world, mid_pos).await;
+        for mid_pos in Self::candidate_centers(world, pos) {
+            if Self::is_valid_portal(world, mid_pos) {
+                Self::create_portal(world, mid_pos).await;
+                return;
+            }
         }
     }
 
-    fn get_mid_pos(world: &World, pos: BlockPos) -> Option<BlockPos> {
+    /// Possible portal centers for a frame block: 2 steps in its facing direction,
+    /// with lateral offsets covering the three frames on that side.
+    fn candidate_centers(world: &World, pos: BlockPos) -> Vec<BlockPos> {
         let (block, state) = world.get_block_and_state_id(&pos);
         if block != &Self::FRAME_BLOCK {
-            return None;
+            return Vec::new();
         }
 
         let properties = EndPortalFrameProperties::from_state_id(state, block);
         let facing_dir = properties.facing;
-        let left_pos = pos.offset_dir(facing_dir.rotate_clockwise().to_offset(), 1);
-        let right_pos = pos.offset_dir(facing_dir.rotate_counter_clockwise().to_offset(), 1);
-
-        let left_block = world.get_block(&left_pos);
-        let right_block = world.get_block(&right_pos);
-
-        let offset = match (left_block.id, right_block.id) {
-            (Self::FRAME_BLOCK_ID, Self::FRAME_BLOCK_ID) => 0, // Middle block
-            (Self::FRAME_BLOCK_ID, _) => -1,                   // Right block (offset left)
-            (_, Self::FRAME_BLOCK_ID) => 1,                    // Left block (offset right)
-            _ => return None,
-        };
-
-        Some(
-            pos.offset_dir(facing_dir.to_offset(), 2)
-                .offset_dir(facing_dir.rotate_counter_clockwise().to_offset(), offset),
-        )
+        let mut candidates = Vec::with_capacity(3);
+        for lateral in -1..=1 {
+            candidates.push(
+                pos.offset_dir(facing_dir.to_offset(), 2)
+                    .offset_dir(facing_dir.rotate_counter_clockwise().to_offset(), lateral),
+            );
+        }
+        candidates
     }
 
     fn is_valid_portal(world: &World, pos: BlockPos) -> bool {
@@ -72,11 +66,10 @@ impl EndPortal {
             let right_properties =
                 EndPortalFrameProperties::from_state_id(right_state, right_block);
 
-            let facing = dir.to_facing();
-
-            if left_properties.facing != facing.opposite()
-                || mid_properties.facing != facing.opposite()
-                || right_properties.facing != facing.opposite()
+            // Frames on this side face toward the center (opposite of outward dir).
+            if left_properties.facing != dir.opposite()
+                || mid_properties.facing != dir.opposite()
+                || right_properties.facing != dir.opposite()
             {
                 return false;
             }
@@ -89,16 +82,22 @@ impl EndPortal {
     }
 
     async fn create_portal(world: &Arc<World>, pos: BlockPos) {
+        let portal_state = Block::END_PORTAL.default_state.id;
+        let mut positions = Vec::with_capacity(9);
         for x in -1..=1 {
             for z in -1..=1 {
-                world
-                    .set_block_state(
-                        &pos.offset(Vector3::new(x, 0, z)),
-                        Block::END_PORTAL.default_state.id,
-                        BlockFlags::NOTIFY_LISTENERS,
-                    )
-                    .await;
+                positions.push(pos.offset(Vector3::new(x, 0, z)));
             }
         }
+
+        // Place one-by-one so EndPortalBlock::placed attaches block entities and
+        // broadcasts CBlockEntityData (requires chunk_data_nbt on the BE).
+        for position in &positions {
+            world
+                .set_block_state(position, portal_state, BlockFlags::NOTIFY_LISTENERS)
+                .await;
+        }
+
+        world.sync_world_event(WorldEvent::SoundEndPortalSpawn, pos, 0);
     }
 }

--- a/pumpkin/src/world/portal/nether.rs
+++ b/pumpkin/src/world/portal/nether.rs
@@ -14,6 +14,9 @@ use crate::world::World;
 
 const SEARCH_RADIUS_NETHER: i32 = 128;
 const SEARCH_RADIUS_OVERWORLD: i32 = 128;
+/// Horizontal radius, in blocks, searched for a spot to build a new portal when no
+/// existing portal is nearby. Vanilla (`PortalForcer::createPortal`) uses 16.
+const PORTAL_PLACEMENT_RADIUS: i32 = 16;
 
 #[derive(Debug, Clone)]
 pub struct PortalSearchResult {
@@ -265,22 +268,18 @@ impl NetherPortal {
         let mut props = NetherPortalLikeProperties::default(&Block::NETHER_PORTAL);
         props.axis = self.axis;
         let state = props.to_state_id(&Block::NETHER_PORTAL);
-        let blocks = BlockPos::iterate(
+        let blocks: Vec<BlockPos> = BlockPos::iterate(
             self.lower_conor,
             self.lower_conor
                 .offset_dir(BlockDirection::Up.to_offset(), self.height as i32 - 1)
                 .offset_dir(self.negative_direction.to_offset(), self.width as i32 - 1),
-        );
+        )
+        .collect();
+
+        world.set_block_states_force_batch(&blocks, state).await;
 
         let mut poi_storage = world.portal_poi.lock().await;
         for pos in blocks {
-            world
-                .set_block_state(
-                    &pos,
-                    state,
-                    BlockFlags::NOTIFY_LISTENERS | BlockFlags::FORCE_STATE,
-                )
-                .await;
             poi_storage.add_portal(pos);
         }
     }
@@ -504,8 +503,28 @@ impl NetherPortal {
                 continue;
             }
 
+            // The portal we are travelling *to* is almost never in a loaded chunk - we
+            // are standing in the other dimension. The reads below are synchronous, so
+            // without pulling the chunk in first every known portal looks like air, the
+            // search fails, and we build a duplicate portal next to the one we should
+            // have reused.
+            let _ = world.get_block_state_async(&pos).await;
+
             if world.get_block(&pos) != &Block::NETHER_PORTAL {
                 continue;
+            }
+
+            // A frame can cross a chunk border, so make sure the neighbours are in
+            // memory before the shape check. Already-loaded chunks are a cheap lookup.
+            for offset_x in -1..=1i32 {
+                for offset_z in -1..=1i32 {
+                    let probe = BlockPos(Vector3::new(
+                        pos.0.x + offset_x * 16,
+                        pos.0.y,
+                        pos.0.z + offset_z * 16,
+                    ));
+                    let _ = world.get_block_state_async(&probe).await;
+                }
             }
 
             for axis in [HorizontalAxis::X, HorizontalAxis::Z] {
@@ -557,7 +576,6 @@ impl NetherPortal {
         );
         let min_y = world.min_y;
         let max_y = min_y + world.dimension.height - 1;
-        let worldborder = world.worldborder.lock().await;
 
         let top_y_limit = if world.dimension.has_ceiling {
             (min_y + world.dimension.logical_height - 1).min(max_y)
@@ -571,13 +589,44 @@ impl NetherPortal {
             BlockDirection::South // Fixed: positive Z direction
         };
 
+        // Pull every chunk the scan can touch into memory up front. The scan below reads
+        // hundreds of thousands of blocks; doing that through the async
+        // `get_block_state_async` path (which re-resolves the chunk, and may await a
+        // chunk load, per block) stalled the whole server tick for seconds while a
+        // player stood in a portal.
+        // +3 so the frame-fit checks, which reach a couple of blocks past the scan area,
+        // stay inside pre-loaded chunks too.
+        let probe_radius = PORTAL_PLACEMENT_RADIUS + 3;
+        let min_chunk_x = (target_pos.0.x - probe_radius) >> 4;
+        let max_chunk_x = (target_pos.0.x + probe_radius) >> 4;
+        let min_chunk_z = (target_pos.0.z - probe_radius) >> 4;
+        let max_chunk_z = (target_pos.0.z + probe_radius) >> 4;
+        for chunk_x in min_chunk_x..=max_chunk_x {
+            for chunk_z in min_chunk_z..=max_chunk_z {
+                let probe = BlockPos(Vector3::new(chunk_x << 4, min_y, chunk_z << 4));
+                let _ = world.get_block_state_async(&probe).await;
+            }
+        }
+
+        let worldborder = world.worldborder.lock().await;
+
         let mut ideal_pos: Option<(BlockPos, HorizontalAxis, f64)> = None;
         let mut acceptable_pos: Option<(BlockPos, HorizontalAxis, f64)> = None;
 
-        for offset_x in -32..=32 {
-            for offset_z in -32..=32 {
+        for offset_x in -PORTAL_PLACEMENT_RADIUS..=PORTAL_PLACEMENT_RADIUS {
+            for offset_z in -PORTAL_PLACEMENT_RADIUS..=PORTAL_PLACEMENT_RADIUS {
                 let check_x = target_pos.0.x + offset_x;
                 let check_z = target_pos.0.z + offset_z;
+
+                // The horizontal distance alone is a lower bound on the final squared
+                // distance, so a column that cannot beat the best ideal spot found so far
+                // can be skipped outright. This does not change which spot wins.
+                if let Some((_, _, best_dist)) = &ideal_pos {
+                    let horizontal_dist = f64::from(offset_x * offset_x + offset_z * offset_z);
+                    if horizontal_dist >= *best_dist {
+                        continue;
+                    }
+                }
 
                 if !worldborder.contains_block(check_x, check_z) {
                     continue;
@@ -601,14 +650,21 @@ impl NetherPortal {
                 let mut y = start_y;
                 while y >= min_y {
                     let pos = BlockPos(Vector3::new(check_x, y, check_z));
-                    let state = world.get_block_state_async(&pos).await;
+                    // Never treat an unloaded chunk as open air; that would let us drop a
+                    // portal into terrain we cannot see.
+                    let Some(state) = world.get_block_state_if_loaded(&pos) else {
+                        y -= 1;
+                        continue;
+                    };
 
                     if Self::is_valid_portal_air(state) {
                         let mut bottom_y = y;
                         while bottom_y > min_y {
                             let below = BlockPos(Vector3::new(check_x, bottom_y - 1, check_z));
-                            let below_state = world.get_block_state_async(&below).await;
-                            if !Self::is_valid_portal_air(below_state) {
+                            if !world
+                                .get_block_state_if_loaded(&below)
+                                .is_some_and(Self::is_valid_portal_air)
+                            {
                                 break;
                             }
                             bottom_y -= 1;
@@ -619,23 +675,18 @@ impl NetherPortal {
                             let floor_pos = BlockPos(Vector3::new(check_x, bottom_y, check_z));
 
                             for check_axis in [HorizontalAxis::X, HorizontalAxis::Z] {
-                                if Self::is_valid_portal_pos_async(world, floor_pos, check_axis, 0)
-                                    .await
-                                {
+                                if Self::is_valid_portal_pos(world, floor_pos, check_axis, 0) {
                                     let dist = f64::from(target_pos.0.squared_distance_to(
                                         floor_pos.0.x,
                                         floor_pos.0.y,
                                         floor_pos.0.z,
                                     ));
 
-                                    let is_ideal = Self::is_valid_portal_pos_async(
-                                        world, floor_pos, check_axis, -1,
-                                    )
-                                    .await
-                                        && Self::is_valid_portal_pos_async(
-                                            world, floor_pos, check_axis, 1,
-                                        )
-                                        .await;
+                                    let is_ideal =
+                                        Self::is_valid_portal_pos(world, floor_pos, check_axis, -1)
+                                            && Self::is_valid_portal_pos(
+                                                world, floor_pos, check_axis, 1,
+                                            );
 
                                     if is_ideal {
                                         if ideal_pos.is_none()
@@ -686,7 +737,9 @@ impl NetherPortal {
         state.replaceable() && !state.is_liquid()
     }
 
-    async fn is_valid_portal_pos_async(
+    /// Synchronous: every chunk this touches is pre-loaded by [`Self::find_safe_location`]
+    /// before the scan starts, so this must not do async block fetches in its hot loop.
+    fn is_valid_portal_pos(
         world: &Arc<World>,
         floor_pos: BlockPos,
         axis: HorizontalAxis,
@@ -710,7 +763,9 @@ impl NetherPortal {
                     .offset_dir(perpendicular.to_offset(), perpendicular_offset)
                     .offset_dir(BlockDirection::Up.to_offset(), height);
 
-                let state = world.get_block_state_async(&pos).await;
+                let Some(state) = world.get_block_state_if_loaded(&pos) else {
+                    return false;
+                };
 
                 if height < 0 {
                     if !state.is_solid_block() {


### PR DESCRIPTION
ProtoChunk was sized from dimension.logical_height (128 in the Nether) while chunk sections use dimension.height (256), so every Nether chunk panicked with an index out of bounds at the Full stage.

find_safe_location did an async block fetch per block over a 65x65 area, stalling the tick for seconds. Chunks are now preloaded and the scan is synchronous, with vanilla's 16 block radius.

search_for_portal read POI candidates synchronously from unloaded chunks, so existing portals were never reused and a duplicate was built every trip.

CAcknowledgeBlockChange was only sent on the 15s keep-alive timer, leaving client predicted blocks (fire in portal frames) on screen for seconds.

Per-tick portal collision logs and repeated chunk generation failures no longer spam the console.
