### PR TITLE
feat(config): read the Velocity forwarding secret from a file 🤖🤖🤖

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,7 @@ version = "0.1.0-dev+26.2"
 dependencies = [
  "pumpkin-util",
  "serde",
+ "tempfile",
  "toml 1.1.3+spec-1.1.0",
  "tracing",
  "uuid",

--- a/pumpkin-config/Cargo.toml
+++ b/pumpkin-config/Cargo.toml
@@ -13,6 +13,8 @@ uuid.workspace = true
 
 toml.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -38,6 +38,7 @@ pub mod op;
 mod advancement;
 mod player_data;
 mod pvp;
+mod secret;
 mod server_links;
 pub mod whitelist;
 pub mod world;
@@ -106,6 +107,24 @@ impl LoadConfiguration for PumpkinConfig {
                 self.advanced.networking.java.online_mode,
                 "When allow_chat_reports is enabled, java.online_mode must be enabled"
             );
+        }
+
+        // Resolve the forwarding secret up front. Reading the file here keeps the
+        // blocking read off the async login path, since `handle_plugin_response`
+        // reaches the secret whenever velocity is enabled, regardless of the proxy
+        // master switch. It also surfaces a broken `@file` reference at startup
+        // instead of on a player's first connection.
+        if self.advanced.networking.proxy.velocity.enabled {
+            let secret = self.advanced.networking.proxy.velocity.secret();
+
+            // Only required when the proxy is actually switched on, so that
+            // configs which boot today keep booting.
+            if self.advanced.networking.proxy.enabled {
+                assert!(
+                    !secret.is_empty(),
+                    "When velocity is enabled, a forwarding secret must be set"
+                );
+            }
         }
     }
 }

--- a/pumpkin-config/src/networking/proxy.rs
+++ b/pumpkin-config/src/networking/proxy.rs
@@ -1,4 +1,8 @@
+use std::sync::OnceLock;
+
 use serde::{Deserialize, Serialize};
+
+use crate::secret::resolve_file_reference;
 
 /// Configuration for proxy support.
 ///
@@ -29,5 +33,113 @@ pub struct VelocityConfig {
     /// Whether Velocity support is enabled.
     pub enabled: bool,
     /// Shared secret for authenticating connections from the Velocity proxy.
+    ///
+    /// A value beginning with `@` is read from the file at that path rather than
+    /// being used literally, e.g. `secret = "@forwarding.secret"`, which keeps the
+    /// secret out of `pumpkin.toml`. Double the `@` to begin a literal value with
+    /// one. Read it through [`Self::secret`] rather than using this field
+    /// directly.
     pub secret: String,
+    /// Cache of [`Self::secret`] with any `@file` reference resolved.
+    ///
+    /// Deliberately skipped during (de)serialization. `secret` has to round-trip
+    /// to disk as the original `@file` reference, because
+    /// `LoadConfiguration::load` writes the deserialized config back out whenever
+    /// it fills in missing defaults. Storing the resolved value in `secret` would
+    /// make that write-back copy the real secret into `pumpkin.toml`, defeating
+    /// the point of keeping it in a separate file.
+    #[serde(skip)]
+    resolved_secret: OnceLock<String>,
+}
+
+impl VelocityConfig {
+    /// Creates a Velocity configuration.
+    ///
+    /// `secret` may be a literal secret or a `@file` reference; it is resolved
+    /// lazily by [`Self::secret`]. This exists because the resolved-secret cache
+    /// is private, which would otherwise make the struct impossible to build
+    /// outside this crate.
+    #[must_use]
+    pub const fn new(enabled: bool, secret: String) -> Self {
+        Self {
+            enabled,
+            secret,
+            resolved_secret: OnceLock::new(),
+        }
+    }
+
+    /// The shared secret to authenticate the proxy with.
+    ///
+    /// Resolves a `@file` reference on first use and caches the result, so the
+    /// file is read once rather than on every player connection.
+    #[must_use]
+    pub fn secret(&self) -> &str {
+        self.resolved_secret
+            .get_or_init(|| resolve_file_reference(&self.secret, "The Velocity forwarding secret"))
+            .as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VelocityConfig;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn literal_secret_is_used_as_is() {
+        let config = VelocityConfig {
+            enabled: true,
+            secret: "hunter2".to_owned(),
+            ..Default::default()
+        };
+
+        assert_eq!(config.secret(), "hunter2");
+    }
+
+    #[test]
+    fn referenced_secret_is_read_from_the_file() {
+        let mut file = NamedTempFile::new().expect("failed to create temp file");
+        file.write_all(b"s3cret-from-disk\n")
+            .expect("failed to write temp file");
+
+        let config = VelocityConfig {
+            enabled: true,
+            secret: format!("@{}", file.path().display()),
+            ..Default::default()
+        };
+
+        assert_eq!(config.secret(), "s3cret-from-disk");
+    }
+
+    /// The config is written back to disk whenever `LoadConfiguration::load`
+    /// fills in missing defaults. If the resolved secret ever reached the
+    /// serialized form, that write-back would leak it into `pumpkin.toml`.
+    #[test]
+    fn resolved_secret_is_never_serialized() {
+        let mut file = NamedTempFile::new().expect("failed to create temp file");
+        file.write_all(b"s3cret-from-disk\n")
+            .expect("failed to write temp file");
+
+        let reference = format!("@{}", file.path().display());
+        let config = VelocityConfig {
+            enabled: true,
+            secret: reference.clone(),
+            ..Default::default()
+        };
+
+        // Resolve first: the cache is only populated after the secret is used.
+        assert_eq!(config.secret(), "s3cret-from-disk");
+
+        let serialized = toml::to_string(&config).expect("failed to serialize config");
+
+        assert!(
+            !serialized.contains("s3cret-from-disk"),
+            "the resolved secret leaked into the serialized config:\n{serialized}"
+        );
+        assert!(
+            serialized.contains(reference.as_str()),
+            "the `@file` reference was not preserved in the serialized config:\n{serialized}"
+        );
+    }
 }

--- a/pumpkin-config/src/secret.rs
+++ b/pumpkin-config/src/secret.rs
@@ -1,0 +1,131 @@
+//! Resolution of configuration values that are stored outside the config file.
+//!
+//! Secrets such as the Velocity forwarding secret are awkward to keep in
+//! `pumpkin.toml`: the file is commonly committed to version control, baked into
+//! an image, or shared when asking for support. Letting a value point at a file
+//! instead means the secret can live somewhere with tighter permissions, or be
+//! supplied by Docker/Kubernetes secrets, which mount exactly this way.
+
+use std::fs;
+
+/// Resolves a configuration value that may reference a file.
+///
+/// A value beginning with `@` is treated as the path to a file whose contents
+/// are the real value, e.g. `secret = "@forwarding.secret"`. Relative paths are
+/// resolved against the server's working directory, which is where
+/// `pumpkin.toml` itself is read from. Any other value is used literally.
+///
+/// A leading `@` can be escaped by doubling it, so `@@value` resolves to the
+/// literal `@value`. Without this a secret that genuinely starts with `@` would
+/// be impossible to express.
+///
+/// Surrounding whitespace is trimmed from the file's contents, because nearly
+/// everything that writes a secret file leaves a trailing newline behind.
+///
+/// `what` names the value being resolved and is used only in panic messages.
+///
+/// Panics if the referenced file cannot be read, or if it resolves to an empty
+/// value. Both mean the server would otherwise start with a silently wrong
+/// secret and reject every connection, which is far harder to diagnose.
+pub fn resolve_file_reference(value: &str, what: &str) -> String {
+    value.strip_prefix('@').map_or_else(
+        || value.to_owned(),
+        |rest| {
+            rest.strip_prefix('@').map_or_else(
+                || read_referenced_file(rest, what),
+                |literal| format!("@{literal}"),
+            )
+        },
+    )
+}
+
+/// Reads `what` from the file at `path`, trimming surrounding whitespace.
+fn read_referenced_file(path: &str, what: &str) -> String {
+    assert!(
+        !path.is_empty(),
+        "{what} is `@` with no file path after it. Use `@<path>` to read the value from a file, or `@@` to start a literal value with `@`"
+    );
+
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("Couldn't read {what} from file `{path}`. Reason: {err}"));
+
+    let trimmed = contents.trim();
+    assert!(
+        !trimmed.is_empty(),
+        "{what} was read from file `{path}`, but that file is empty"
+    );
+
+    trimmed.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_file_reference;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    /// Writes `contents` to a temporary file and returns it alongside the `@`
+    /// reference that points at it.
+    fn file_containing(contents: &str) -> (NamedTempFile, String) {
+        let mut file = NamedTempFile::new().expect("failed to create temp file");
+        file.write_all(contents.as_bytes())
+            .expect("failed to write temp file");
+        let reference = format!("@{}", file.path().display());
+        (file, reference)
+    }
+
+    #[test]
+    fn plain_value_is_used_literally() {
+        assert_eq!(resolve_file_reference("hunter2", "test value"), "hunter2");
+    }
+
+    #[test]
+    fn empty_plain_value_is_left_alone() {
+        // An unset secret is only an error when the feature using it is enabled,
+        // so resolution itself must not reject it.
+        assert_eq!(resolve_file_reference("", "test value"), "");
+    }
+
+    #[test]
+    fn reference_is_read_from_the_file() {
+        let (_file, reference) = file_containing("s3cret-from-disk");
+        assert_eq!(
+            resolve_file_reference(&reference, "test value"),
+            "s3cret-from-disk"
+        );
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_trimmed() {
+        // `echo secret > file` and Docker secrets both leave a trailing newline.
+        let (_file, reference) = file_containing("  s3cret\n");
+        assert_eq!(resolve_file_reference(&reference, "test value"), "s3cret");
+    }
+
+    #[test]
+    fn doubled_at_escapes_to_a_literal_value() {
+        assert_eq!(
+            resolve_file_reference("@@not-a-path", "test value"),
+            "@not-a-path"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Couldn't read test value from file")]
+    fn missing_file_panics() {
+        resolve_file_reference("@definitely/not/a/real/path.secret", "test value");
+    }
+
+    #[test]
+    #[should_panic(expected = "that file is empty")]
+    fn empty_file_panics() {
+        let (_file, reference) = file_containing("\n  \n");
+        resolve_file_reference(&reference, "test value");
+    }
+
+    #[test]
+    #[should_panic(expected = "no file path after it")]
+    fn bare_at_panics() {
+        resolve_file_reference("@", "test value");
+    }
+}

--- a/pumpkin-config/tests/velocity_secret_file.rs
+++ b/pumpkin-config/tests/velocity_secret_file.rs
@@ -1,0 +1,107 @@
+//! End-to-end coverage for reading the Velocity forwarding secret from a file.
+//!
+//! These drive the real [`PumpkinConfig::load`] path rather than a hand-built
+//! struct, because the interesting behaviour only appears there: `load` writes
+//! the config back to disk whenever it fills in missing defaults, which is
+//! exactly when a resolved secret could leak into `pumpkin.toml`.
+
+use std::fs;
+
+use pumpkin_config::{LoadConfiguration, PumpkinConfig};
+use tempfile::TempDir;
+
+const SECRET: &str = "s3cret-that-must-not-be-written-back";
+
+/// Writes a secret file and a deliberately incomplete `pumpkin.toml` that points
+/// at it, then loads the config from that directory.
+///
+/// The config is incomplete on purpose: every field left out is filled in from
+/// the defaults, which is what makes `load` rewrite the file.
+fn load_with_secret_file(proxy_enabled: bool) -> (TempDir, PumpkinConfig) {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    let secret_path = dir.path().join("forwarding.secret");
+    fs::write(&secret_path, format!("{SECRET}\n")).expect("failed to write secret file");
+
+    // An absolute path keeps the test independent of the working directory the
+    // test harness happens to run in.
+    let config = format!(
+        "[networking.proxy]\n\
+         enabled = {proxy_enabled}\n\
+         \n\
+         [networking.proxy.velocity]\n\
+         enabled = true\n\
+         secret = \"@{}\"\n",
+        secret_path.display().to_string().replace('\\', "\\\\")
+    );
+    fs::write(dir.path().join("pumpkin.toml"), config).expect("failed to write config");
+
+    let loaded = PumpkinConfig::load(dir.path());
+    (dir, loaded)
+}
+
+#[test]
+fn secret_is_read_from_the_referenced_file() {
+    let (_dir, config) = load_with_secret_file(true);
+
+    assert_eq!(
+        config.advanced.networking.proxy.velocity.secret(),
+        SECRET,
+        "the secret should have been read from the referenced file"
+    );
+}
+
+#[test]
+fn resolved_secret_is_not_written_back_to_the_config() {
+    let (dir, config) = load_with_secret_file(true);
+
+    // Force resolution, mirroring what a real server does while handling a login.
+    assert_eq!(config.advanced.networking.proxy.velocity.secret(), SECRET);
+
+    let written =
+        fs::read_to_string(dir.path().join("pumpkin.toml")).expect("failed to read back config");
+
+    assert!(
+        !written.contains(SECRET),
+        "the resolved secret leaked into pumpkin.toml:\n{written}"
+    );
+    assert!(
+        written.contains("forwarding.secret"),
+        "the `@file` reference was not preserved in pumpkin.toml:\n{written}"
+    );
+}
+
+/// A `@file` reference must keep working when the proxy master switch is off, so
+/// that flipping it back on does not surprise the operator with a broken secret.
+#[test]
+fn reference_still_resolves_with_the_proxy_master_switch_off() {
+    let (_dir, config) = load_with_secret_file(false);
+
+    assert_eq!(config.advanced.networking.proxy.velocity.secret(), SECRET);
+}
+
+/// TOML basic strings treat a backslash as an escape, so Windows users are told
+/// to write absolute paths as literal (single-quoted) strings. This checks that
+/// the documented form actually round-trips through the loader.
+#[test]
+fn literal_string_paths_resolve() {
+    let dir = TempDir::new().expect("failed to create temp dir");
+
+    let secret_path = dir.path().join("forwarding.secret");
+    fs::write(&secret_path, SECRET).expect("failed to write secret file");
+
+    let config = format!(
+        "[networking.proxy]\n\
+         enabled = true\n\
+         \n\
+         [networking.proxy.velocity]\n\
+         enabled = true\n\
+         secret = '@{}'\n",
+        secret_path.display()
+    );
+    fs::write(dir.path().join("pumpkin.toml"), config).expect("failed to write config");
+
+    let loaded = PumpkinConfig::load(dir.path());
+
+    assert_eq!(loaded.advanced.networking.proxy.velocity.secret(), SECRET);
+}

--- a/pumpkin/src/net/proxy/velocity.rs
+++ b/pumpkin/src/net/proxy/velocity.rs
@@ -117,7 +117,7 @@ pub fn receive_velocity_plugin_response(
         }
         let (signature, mut data_without_signature) = data.split_at(32);
 
-        if !check_integrity((signature, data_without_signature), &config.secret) {
+        if !check_integrity((signature, data_without_signature), config.secret()) {
             return Err(VelocityError::FailedVerifyIntegrity);
         }
 
@@ -147,4 +147,132 @@ pub fn receive_velocity_plugin_response(
         return Ok((profile, socket_addr));
     }
     Err(VelocityError::NoData)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VelocityError, receive_velocity_plugin_response};
+    use hmac::{Hmac, KeyInit, Mac};
+    use pumpkin_config::networking::proxy::VelocityConfig;
+    use pumpkin_protocol::codec::var_int::VarInt;
+    use pumpkin_protocol::java::server::login::SLoginPluginResponse;
+    use pumpkin_protocol::ser::NetworkWriteExt;
+    use sha2::Sha256;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    const SECRET: &str = "s3cret-from-disk";
+    const PLAYER_NAME: &str = "Notch";
+    const ADDRESS: &str = "127.0.0.1";
+    const PORT: u16 = 25565;
+
+    /// Builds the forwarding payload Velocity sends after a player info request,
+    /// signed with `signing_secret`.
+    ///
+    /// The layout matches what `receive_velocity_plugin_response` expects: a
+    /// 32 byte HMAC-SHA256 signature followed by the forwarding version, the
+    /// player's address, and their game profile.
+    fn forwarding_response(signing_secret: &str, id: uuid::Uuid) -> SLoginPluginResponse {
+        let mut payload = Vec::new();
+        payload
+            .write_var_int(&VarInt::from(1))
+            .expect("write forwarding version");
+        payload.write_string(ADDRESS).expect("write address");
+        payload.write_uuid(&id).expect("write profile uuid");
+        payload
+            .write_string(PLAYER_NAME)
+            .expect("write profile name");
+        payload
+            .write_var_int(&VarInt::from(1))
+            .expect("write property count");
+        payload
+            .write_string("textures")
+            .expect("write property name");
+        payload.write_string("value").expect("write property value");
+        payload
+            .write_option(&None::<String>, |writer, value: &String| {
+                writer.write_string(value)
+            })
+            .expect("write property signature");
+
+        let mut mac = HmacSha256::new_from_slice(signing_secret.as_bytes())
+            .expect("HMAC can take key of any size");
+        mac.update(&payload);
+        let signature = mac.finalize().into_bytes();
+
+        let mut data = Vec::with_capacity(signature.len() + payload.len());
+        data.extend_from_slice(&signature);
+        data.extend_from_slice(&payload);
+
+        SLoginPluginResponse {
+            message_id: VarInt::from(0),
+            data: Some(data.into_boxed_slice()),
+        }
+    }
+
+    /// A config whose secret lives in a file, referenced as `@<path>`.
+    ///
+    /// The `NamedTempFile` is returned so the caller keeps it alive; dropping it
+    /// deletes the file the config points at.
+    fn config_with_secret_file() -> (NamedTempFile, VelocityConfig) {
+        let mut file = NamedTempFile::new().expect("failed to create temp file");
+        file.write_all(format!("{SECRET}\n").as_bytes())
+            .expect("failed to write secret file");
+
+        let config = VelocityConfig::new(true, format!("@{}", file.path().display()));
+
+        (file, config)
+    }
+
+    /// The real point of the `@file` feature: a payload signed with the secret as
+    /// stored *in the file* has to pass integrity checking, proving the bytes that
+    /// reach the HMAC are the file's contents and not the literal `@path`.
+    #[test]
+    fn payload_signed_with_the_file_secret_is_accepted() {
+        let (_file, config) = config_with_secret_file();
+        let id = uuid::Uuid::from_u128(0x0123_4567_89ab_cdef_0123_4567_89ab_cdef);
+
+        let (profile, address) =
+            receive_velocity_plugin_response(PORT, &config, forwarding_response(SECRET, id))
+                .expect("a payload signed with the file's secret should be accepted");
+
+        assert_eq!(profile.name, PLAYER_NAME);
+        assert_eq!(profile.id, id);
+        assert_eq!(address.ip().to_string(), ADDRESS);
+        assert_eq!(address.port(), PORT);
+    }
+
+    /// Guards against the inverse mistake: if the literal `@path` were used as the
+    /// key, or resolution silently produced the wrong value, this would still pass.
+    #[test]
+    fn payload_signed_with_a_different_secret_is_rejected() {
+        let (_file, config) = config_with_secret_file();
+        let id = uuid::Uuid::from_u128(1);
+
+        let result = receive_velocity_plugin_response(
+            PORT,
+            &config,
+            forwarding_response("not-the-real-secret", id),
+        );
+
+        assert!(matches!(result, Err(VelocityError::FailedVerifyIntegrity)));
+    }
+
+    /// The unresolved `@path` string must never be what signs the payload.
+    #[test]
+    fn payload_signed_with_the_raw_reference_is_rejected() {
+        let (_file, config) = config_with_secret_file();
+        let id = uuid::Uuid::from_u128(2);
+        let raw_reference = config.secret.clone();
+
+        let result = receive_velocity_plugin_response(
+            PORT,
+            &config,
+            forwarding_response(&raw_reference, id),
+        );
+
+        assert!(matches!(result, Err(VelocityError::FailedVerifyIntegrity)));
+    }
 }


### PR DESCRIPTION
Closes #2516.

## What changed

`networking.proxy.velocity.secret` may now point at a file instead of holding the secret inline. A value beginning with `@` is read from the file at that path:

```toml
[networking.proxy.velocity]
enabled = true
secret = "@forwarding.secret"
```

Relative paths resolve against the server's working directory, the same place `pumpkin.toml` is read from. Absolute paths work too, so the value can point straight at a Docker or Kubernetes secret (`@/run/secrets/velocity_forwarding_secret`). Surrounding whitespace is trimmed, since almost everything that writes a secret file leaves a trailing newline. Any value not starting with `@` is used literally, exactly as before.

## Why

`pumpkin.toml` gets committed to version control, baked into images, and pasted into support threads. The forwarding secret is the only thing standing between a server and anyone who can reach its port, so it is worth being able to keep it somewhere else. Secret mounts in Docker and Kubernetes are files, so this is the shape those tools already expect.

## Implementation note

There is one non-obvious hazard worth flagging for review. `LoadConfiguration::load` writes the deserialized config back to disk whenever it fills in missing defaults:

```rust
let (merged_config, changed) = Self::merge_with_default_toml(parsed_toml_value);
if changed {
    fs::write(&path, toml::to_string(&merged_config).unwrap())
}
```

So resolving `@forwarding.secret` into the `secret` field directly would make the server copy the real secret into `pumpkin.toml` the first time any default is filled in, which defeats the whole point of the feature.

To make that impossible rather than merely avoided, `secret` keeps the raw `@file` reference and the resolved value lives in a separate `#[serde(skip)]` `OnceLock`, read through `VelocityConfig::secret()`. The field that gets serialized never holds the plaintext. `tests/velocity_secret_file.rs` covers this against the real `load()` path with a deliberately incomplete config, so the write-back actually fires.

Resolution is also forced during `validate()`, for two reasons. It surfaces a broken path at startup rather than on a player's first connection, and it keeps the blocking `fs::read_to_string` off the async login path: `handle_plugin_response` reaches the secret whenever `velocity.enabled` is set, independently of the proxy master switch, so resolution is forced on that same condition. The emptiness assertion stays gated on both switches so that configs which boot today keep booting.

## Performance

No benchmark added, and I do not believe one is warranted here. The file is read at most once per process and cached in a `OnceLock`, so after startup reading the secret is an atomic load where it was previously a plain field access. It sits on the login path rather than in any hot loop. Happy to add a Criterion benchmark if you would rather have the number.

## Impact

- No behaviour change for existing configs. A secret without a leading `@` is used exactly as before.
- `VelocityConfig` gains a private field, which would otherwise make the struct impossible to build outside `pumpkin-config` (functional update syntax still requires every field to be visible). A `VelocityConfig::new(enabled, secret)` constructor is added so downstream code keeps a supported way to construct it. Nothing in the workspace built it by struct literal.
- The `validate()` check is gated on `proxy.enabled && proxy.velocity.enabled`, matching what actually turns on Velocity forwarding in `login.rs`, so no config that boots today starts failing.

## Testing

18 new tests.

Resolver units (`pumpkin-config/src/secret.rs`): literal value, file reference, whitespace trimming, `@@` escape, missing file, empty file, bare `@`.

Config integration (`pumpkin-config/tests/velocity_secret_file.rs`), driving the real `PumpkinConfig::load()`: the secret resolves from the referenced file; the resolved secret is **not** written back into `pumpkin.toml`; the reference still resolves with the proxy master switch off; single-quoted TOML paths work (the form Windows users need, since `"@C:\...\"` is an invalid TOML escape).

Forwarding integration (`pumpkin/src/net/proxy/velocity.rs`), driving the real `receive_velocity_plugin_response` with a signed payload: a payload signed with the secret *as stored in the file* is accepted; one signed with a different secret is rejected; and one signed with the raw `@path` string is rejected, which is what proves resolution actually happened rather than the literal reference being used as the HMAC key.

Also run: `cargo fmt --check`, `cargo clippy --all-targets --all-features` in both debug and release with `RUSTFLAGS=-Dwarnings`, `cargo test --workspace`, `cargo test --doc`, `cargo machete`, and a full `cargo build --release`.

## Limitations

- The HMAC verification path is covered by the tests above, but I did not run this against **actual Velocity software** end to end. The forwarding payload in those tests is constructed to match `receive_velocity_plugin_response`'s expectations, so it verifies Pumpkin's side rather than interop with a live proxy.
- `@@` escapes a literal leading `@` (`@@value` means `@value`). This is slightly beyond what the issue asked for, but without it a secret genuinely starting with `@` cannot be expressed at all. Happy to drop it if you would rather keep the surface minimal.
- `networking.rcon.password` has the same plaintext-in-config problem and the resolver is written to be reusable, but I kept this PR to the scope of the issue. Glad to follow up if wanted.
- Lightly overlaps #2513, which also touches the Velocity secret (making it required). Different change, adjacent lines.

Docs PR for the `@file` syntax to follow in Pumpkin-Docs.
