### PR TITLE
fix(plugin): read native plugin METADATA through its LazyLock

### DIFF
--- a/pumpkin/src/plugin/loader/native.rs
+++ b/pumpkin/src/plugin/loader/native.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::LazyLock;
 
 use libloading::Library;
 
@@ -35,10 +36,13 @@ impl PluginLoader for NativePluginLoader {
             }
 
             // 2. Extract Metadata (METADATA)
+            // `#[plugin_impl]` exports this as a `LazyLock`, since `PluginMetadata`
+            // owns its strings and can't be built in a const.
             let metadata = unsafe {
-                &**library
-                    .get::<*const PluginMetadata>(b"METADATA")
-                    .map_err(|_| LoaderError::MetadataMissing)?
+                let metadata = library
+                    .get::<*const LazyLock<PluginMetadata>>(b"METADATA")
+                    .map_err(|_| LoaderError::MetadataMissing)?;
+                (**metadata).clone()
             };
 
             // 3. Extract Plugin Factory (plugin)
@@ -50,7 +54,7 @@ impl PluginLoader for NativePluginLoader {
 
             Ok((
                 plugin_factory(),
-                metadata.clone(),
+                metadata,
                 Box::new(library) as Box<dyn Any + Send + Sync>,
             ))
         })


### PR DESCRIPTION
## What's broken

Native plugins load with empty metadata. Name and version come out as empty
strings, and depending on what happens to be in the uninitialised memory the
server either misbehaves or dies outright:

- `Loaded  ()` instead of `Loaded myplugin (0.1.0)`
- `Context::get_data_folder()` returns `plugins/` instead of `plugins/<name>/`
- `Context::register_permission()` rejects every node with
  `Permission x:y must use the plugin's namespace ()` — and unregistered nodes
  are always denied, so plugin permissions cannot work at all
- cloning the metadata can request an absurd allocation and abort the process:
  `memory allocation of 140714225389211 bytes failed`

That last one is #2434.

## Cause

`native.rs` reads the symbol as `*const PluginMetadata`. That was correct when
it was written (#725, April 2025): back then `PluginMetadata` held
`&'static str` fields, so `#[plugin_impl]` could export it as a plain
const-initialised `static`.

#1675 gave `PluginMetadata` owned `String` and `Vec` fields. Those cannot be
built in a const, so the macro switched to
`static METADATA: LazyLock<PluginMetadata>`. The loader was not updated, so it
now reinterprets the internal representation of an unforced `LazyLock` as a
`PluginMetadata`.

This is worth stating explicitly because #2435 and #2475 both diagnose the
crash as rustc layout drift between toolchains. It is not: I reproduced it with
plugin and server built from the identical source tree with the identical
toolchain. #2475's plausibility checks are useful defence in depth, but on their
own they would turn the crash into a permanent "metadata appears corrupt"
rejection for every correctly-built native plugin.

## Fix

Read the symbol as a pointer to the `LazyLock` and deref it, which forces
initialisation before the metadata is read.

## Testing

Built a real plugin (registers permissions, events and a command) against this
build and loaded it on a dedicated server.

- before: `Failed to initialize plugin : ... must use the plugin's namespace ()`,
  then an abort on a later run
- after: `Loaded scarecrow (0.1.0)`, permissions register, data folder is
  `plugins/scarecrow/`, server starts and shuts down cleanly

One question for maintainers: should `PLUGIN_API_VERSION` be bumped to 3 as part
of this? #1675 changed the metadata representation without bumping it, so a
plugin built before that commit still passes the version gate and would now be
misread in the opposite direction. I left it at 2 tho.