### PR TITLE
Clamp proto_chunk out of bounds array access

### DIFF
--- a/pumpkin-world/src/generation/proto_chunk.rs
+++ b/pumpkin-world/src/generation/proto_chunk.rs
@@ -446,7 +446,9 @@ impl ProtoChunk {
     #[inline]
     #[must_use]
     pub fn get_block_state_raw(&self, x: i32, y: i32, z: i32) -> BlockStateId {
-        let index = self.local_pos_to_block_index(x, y, z);
+        let index = self
+            .local_pos_to_block_index(x, y, z)
+            .clamp(0, self.flat_block_map.len() - 1);
         self.flat_block_map[index]
     }
 
@@ -505,7 +507,7 @@ impl ProtoChunk {
             x & biome_coords::from_block(15),
             y - biome_coords::from_block(self.bottom_y() as i32),
             z & biome_coords::from_block(15),
-        );
+        ).clamp(0, self.flat_biome_map.len() - 1);
         self.flat_biome_map[index]
     }
 

--- a/pumpkin-world/src/generation/proto_chunk.rs
+++ b/pumpkin-world/src/generation/proto_chunk.rs
@@ -503,11 +503,13 @@ impl ProtoChunk {
     #[inline]
     #[must_use]
     pub fn get_biome_id(&self, x: i32, y: i32, z: i32) -> u8 {
-        let index = self.local_biome_pos_to_biome_index(
-            x & biome_coords::from_block(15),
-            y - biome_coords::from_block(self.bottom_y() as i32),
-            z & biome_coords::from_block(15),
-        ).clamp(0, self.flat_biome_map.len() - 1);
+        let index = self
+            .local_biome_pos_to_biome_index(
+                x & biome_coords::from_block(15),
+                y - biome_coords::from_block(self.bottom_y() as i32),
+                z & biome_coords::from_block(15),
+            )
+            .clamp(0, self.flat_biome_map.len() - 1);
         self.flat_biome_map[index]
     }
 

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -256,16 +256,11 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
     } else {
         // It's a subsequent panic; let's just alert about it.
         tracing::error!(
-            "{}: {}",
+            "{}: {panic_info}",
             TextComponent::text("Encountered panic while shutting down")
                 .color(Color::Named(NamedColor::Red))
                 .bold()
-                .to_pretty_console(),
-            payload
-                .downcast_ref::<&str>()
-                .copied()
-                .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
-                .unwrap_or("<unknown>")
+                .to_pretty_console()
         );
     }
 }


### PR DESCRIPTION
this may break worldgen but this is a quickfix rather than a in-depth fix.

## Description
Should fix #2560
Out of bounds access
## Testing
Testing done by hand on default cargo build settings.
