### PR TITLE
feat(plugin): add get-process-memory and cheapen get-sys-info

### DIFF
--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
@@ -53,17 +53,14 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
         let (total_memory, used_memory, process_memory) = if need_ram {
             sys.refresh_memory();
 
-            let process_memory = match sysinfo::get_current_pid() {
-                Ok(pid) => {
-                    sys.refresh_processes_specifics(
-                        sysinfo::ProcessesToUpdate::Some(&[pid]),
-                        true,
-                        sysinfo::ProcessRefreshKind::nothing().with_memory(),
-                    );
-                    sys.process(pid).map(sysinfo::Process::memory)
-                }
-                Err(_) => None,
-            };
+            let process_memory = sysinfo::get_current_pid().map_or(None, |pid| {
+                sys.refresh_processes_specifics(
+                    sysinfo::ProcessesToUpdate::Some(&[pid]),
+                    true,
+                    sysinfo::ProcessRefreshKind::nothing().with_memory(),
+                );
+                sys.process(pid).map(sysinfo::Process::memory)
+            });
 
             (
                 Some(sys.total_memory()),

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
@@ -50,25 +50,11 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             sys.cpus().len() as u32
         });
 
-        let (total_memory, used_memory, process_memory) = if need_ram {
+        let (total_memory, used_memory) = if need_ram {
             sys.refresh_memory();
-
-            let process_memory = sysinfo::get_current_pid().map_or(None, |pid| {
-                sys.refresh_processes_specifics(
-                    sysinfo::ProcessesToUpdate::Some(&[pid]),
-                    true,
-                    sysinfo::ProcessRefreshKind::nothing().with_memory(),
-                );
-                sys.process(pid).map(sysinfo::Process::memory)
-            });
-
-            (
-                Some(sys.total_memory()),
-                Some(sys.used_memory()),
-                process_memory,
-            )
+            (Some(sys.total_memory()), Some(sys.used_memory()))
         } else {
-            (None, None, None)
+            (None, None)
         };
 
         let (os_name, os_version) = if need_os {
@@ -81,11 +67,35 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             cpu_count,
             total_memory,
             used_memory,
-            process_memory,
             os_name,
             os_version,
             pumpkin_version: env!("CARGO_PKG_VERSION").to_string(),
         })
+    }
+
+    async fn get_process_memory(
+        &mut self,
+        _res: Resource<Server>,
+    ) -> wasmtime::Result<Option<u64>> {
+        let has_ram = self
+            .permissions
+            .iter()
+            .any(|perm| perm == permissions::SYS_INFO || perm == permissions::SYS_INFO_RAM);
+        if !has_ram {
+            return Ok(None);
+        }
+
+        let Ok(pid) = sysinfo::get_current_pid() else {
+            return Ok(None);
+        };
+
+        let mut sys = sysinfo::System::new();
+        sys.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::Some(&[pid]),
+            true,
+            sysinfo::ProcessRefreshKind::nothing().with_memory(),
+        );
+        Ok(sys.process(pid).map(sysinfo::Process::memory))
     }
 
     async fn get_difficulty(&mut self, res: Resource<Server>) -> wasmtime::Result<Difficulty> {

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
@@ -36,30 +36,55 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
     async fn get_sys_info(&mut self, _res: Resource<Server>) -> wasmtime::Result<SysInfo> {
         let has_perm = |p: &str| self.permissions.iter().any(|perm| perm == p);
 
-        let mut sys = sysinfo::System::new_all();
-        sys.refresh_all();
+        let need_cpu = has_perm(permissions::SYS_INFO) || has_perm(permissions::SYS_INFO_CPU);
+        let need_ram = has_perm(permissions::SYS_INFO) || has_perm(permissions::SYS_INFO_RAM);
+        let need_os = has_perm(permissions::SYS_INFO) || has_perm(permissions::SYS_INFO_OS);
 
-        let cpu_count = (has_perm(permissions::SYS_INFO) || has_perm(permissions::SYS_INFO_CPU))
-            .then(|| sys.cpus().len() as u32);
+        // Only refresh the counters the caller is allowed to see. A full
+        // `System::new_all()` / `refresh_all()` scans every process on the host
+        // and is far too expensive for plugins that poll this on a timer.
+        let mut sys = sysinfo::System::new();
 
-        let (total_memory, used_memory) =
-            if has_perm(permissions::SYS_INFO) || has_perm(permissions::SYS_INFO_RAM) {
-                (Some(sys.total_memory()), Some(sys.used_memory()))
-            } else {
-                (None, None)
+        let cpu_count = need_cpu.then(|| {
+            sys.refresh_cpu_all();
+            sys.cpus().len() as u32
+        });
+
+        let (total_memory, used_memory, process_memory) = if need_ram {
+            sys.refresh_memory();
+
+            let process_memory = match sysinfo::get_current_pid() {
+                Ok(pid) => {
+                    sys.refresh_processes_specifics(
+                        sysinfo::ProcessesToUpdate::Some(&[pid]),
+                        true,
+                        sysinfo::ProcessRefreshKind::nothing().with_memory(),
+                    );
+                    sys.process(pid).map(sysinfo::Process::memory)
+                }
+                Err(_) => None,
             };
 
-        let (os_name, os_version) =
-            if has_perm(permissions::SYS_INFO) || has_perm(permissions::SYS_INFO_OS) {
-                (sysinfo::System::name(), sysinfo::System::os_version())
-            } else {
-                (None, None)
-            };
+            (
+                Some(sys.total_memory()),
+                Some(sys.used_memory()),
+                process_memory,
+            )
+        } else {
+            (None, None, None)
+        };
+
+        let (os_name, os_version) = if need_os {
+            (sysinfo::System::name(), sysinfo::System::os_version())
+        } else {
+            (None, None)
+        };
 
         Ok(SysInfo {
             cpu_count,
             total_memory,
             used_memory,
+            process_memory,
             os_name,
             os_version,
             pumpkin_version: env!("CARGO_PKG_VERSION").to_string(),


### PR DESCRIPTION
## Description

Depends on Pumpkin-MC/pumpkin-plugin-wit#23.

Earlier draft extended `sys-info` with `process-memory`. That would break already-built v0.1 plugins, because changing a returned record changes the imported function type and fails `instantiate_pre` without record subtyping.

This PR now:

- leaves `sys-info` unchanged
- adds `get-process-memory` for process RSS (same RAM permissions)
- refreshes only the counters the caller is allowed to see in `get-sys-info`, instead of `System::new_all()` + `refresh_all()`

## Testing

- Confirmed the WIT change is additive (new method, no record shape change)
- Host `get-process-memory` uses a single-pid memory refresh
- Permission gating matches existing `sys.info` / `sys.info.ram` checks