### PR TITLE
feat(entity): spawn a baby when using a matching spawn egg on an animal

### DIFF
--- a/crates/pumpkin/src/entity/passive/animal.rs
+++ b/crates/pumpkin/src/entity/passive/animal.rs
@@ -1,12 +1,26 @@
 use std::sync::Arc;
 
+use pumpkin_data::entity::{EntityType, entity_from_egg};
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::particle::Particle;
 use pumpkin_data::sound::{Sound, SoundCategory};
+use uuid::Uuid;
 
-use crate::entity::{EntityBaseFuture, mob::Mob, player::Player};
+use crate::entity::{
+    EntityBaseFuture, ageable::BABY_START_AGE, mob::Mob, player::Player, r#type::from_type,
+};
+use crate::item::items::spawn_egg::apply_entity_variant;
 use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_util::math::vector3::Vector3;
+
+/// Whether `item_stack` is the spawn egg for `entity_type`.
+///
+/// Vanilla `SpawnEggItem.spawnsEntity`: only an egg for the mob's own type spawns a
+/// baby from it. Any other spawn egg is left to the normal use-on-block path, which
+/// places a new adult next to the mob.
+fn is_spawn_egg_for(item_stack: &ItemStack, entity_type: &EntityType) -> bool {
+    entity_from_egg(item_stack.item.id).is_some_and(|egg_type| egg_type == entity_type)
+}
 
 pub trait Animal: Mob {
     fn is_food(&self, item_stack: &ItemStack) -> bool;
@@ -36,6 +50,35 @@ pub trait Animal: Mob {
         mob_entity.set_love_ticks(in_love, love_cause);
     }
 
+    /// Spawns a baby of this mob's own type at its position and consumes one egg,
+    /// mirroring vanilla `SpawnEggItem.spawnOffspringFromSpawnEgg`.
+    fn spawn_baby_from_egg<'a>(
+        &'a self,
+        player: &'a Arc<Player>,
+        item_stack: &'a mut ItemStack,
+    ) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            let entity = &self.get_mob_entity().living_entity.entity;
+            let world = entity.world.load();
+            let baby = from_type(
+                entity.entity_type,
+                entity.pos.load(),
+                &world,
+                Uuid::new_v4(),
+            );
+
+            // `init_data_tracker` derives the baby flag from a negative age and runs as
+            // part of `spawn_entity`, so the age has to be set before spawning.
+            baby.get_entity().set_age(BABY_START_AGE);
+            // Vanilla `snapTo(pos, 0.0F, 0.0F)`.
+            baby.get_entity().set_rotation(0.0, 0.0);
+            apply_entity_variant(item_stack, baby.as_ref());
+
+            world.spawn_entity(baby).await;
+            item_stack.decrement_unless_creative(player.gamemode.load(), 1);
+        })
+    }
+
     fn animal_interact<'a>(
         &'a self,
         player: &'a Arc<Player>,
@@ -44,6 +87,15 @@ pub trait Animal: Mob {
     ) -> EntityBaseFuture<'a, bool> {
         Box::pin(async move {
             let mob_entity = self.get_mob_entity();
+
+            // Vanilla runs this in `Mob.checkAndHandleImportantInteractions`, ahead of
+            // any food handling. No spawn egg is a breeding item, so the order only
+            // matters for staying close to vanilla.
+            if is_spawn_egg_for(item_stack, mob_entity.living_entity.entity.entity_type) {
+                self.spawn_baby_from_egg(player, item_stack).await;
+                return true;
+            }
+
             if self.is_food(item_stack) {
                 let age = mob_entity
                     .living_entity
@@ -103,5 +155,34 @@ pub trait Animal: Mob {
 
             mob_entity.mob_interact(player, item_stack).await
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_spawn_egg_for;
+    use pumpkin_data::entity::EntityType;
+    use pumpkin_data::item::Item;
+    use pumpkin_data::item_stack::ItemStack;
+
+    #[test]
+    fn matching_egg_is_recognized() {
+        let stack = ItemStack::new(1, &Item::COW_SPAWN_EGG);
+        assert!(is_spawn_egg_for(&stack, &EntityType::COW));
+    }
+
+    /// The wrong egg has to fall through, otherwise using a cow egg on a pig would
+    /// spawn a baby pig instead of placing a cow.
+    #[test]
+    fn egg_for_another_mob_is_not_recognized() {
+        let stack = ItemStack::new(1, &Item::COW_SPAWN_EGG);
+        assert!(!is_spawn_egg_for(&stack, &EntityType::PIG));
+        assert!(!is_spawn_egg_for(&stack, &EntityType::CHICKEN));
+    }
+
+    #[test]
+    fn a_non_egg_item_is_not_recognized() {
+        let stack = ItemStack::new(1, &Item::WHEAT);
+        assert!(!is_spawn_egg_for(&stack, &EntityType::COW));
     }
 }

--- a/pumpkin/src/entity/passive/animal.rs
+++ b/pumpkin/src/entity/passive/animal.rs
@@ -1,11 +1,25 @@
 use std::sync::Arc;
 
+use pumpkin_data::entity::{EntityType, entity_from_egg};
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::particle::Particle;
 use pumpkin_data::sound::{Sound, SoundCategory};
+use uuid::Uuid;
 
-use crate::entity::{EntityBaseFuture, mob::Mob, player::Player};
+use crate::entity::{
+    EntityBaseFuture, ageable::BABY_START_AGE, mob::Mob, player::Player, r#type::from_type,
+};
+use crate::item::items::spawn_egg::apply_entity_variant;
 use pumpkin_util::math::vector3::Vector3;
+
+/// Whether `item_stack` is the spawn egg for `entity_type`.
+///
+/// Vanilla `SpawnEggItem.spawnsEntity`: only an egg for the mob's own type spawns a
+/// baby from it. Any other spawn egg is left to the normal use-on-block path, which
+/// places a new adult next to the mob.
+fn is_spawn_egg_for(item_stack: &ItemStack, entity_type: &EntityType) -> bool {
+    entity_from_egg(item_stack.item.id).is_some_and(|egg_type| egg_type == entity_type)
+}
 
 pub trait Animal: Mob {
     fn is_food(&self, item_stack: &ItemStack) -> bool;
@@ -35,6 +49,35 @@ pub trait Animal: Mob {
         mob_entity.set_love_ticks(in_love, love_cause);
     }
 
+    /// Spawns a baby of this mob's own type at its position and consumes one egg,
+    /// mirroring vanilla `SpawnEggItem.spawnOffspringFromSpawnEgg`.
+    fn spawn_baby_from_egg<'a>(
+        &'a self,
+        player: &'a Arc<Player>,
+        item_stack: &'a mut ItemStack,
+    ) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            let entity = &self.get_mob_entity().living_entity.entity;
+            let world = entity.world.load();
+            let baby = from_type(
+                entity.entity_type,
+                entity.pos.load(),
+                &world,
+                Uuid::new_v4(),
+            );
+
+            // `init_data_tracker` derives the baby flag from a negative age and runs as
+            // part of `spawn_entity`, so the age has to be set before spawning.
+            baby.get_entity().set_age(BABY_START_AGE);
+            // Vanilla `snapTo(pos, 0.0F, 0.0F)`.
+            baby.get_entity().set_rotation(0.0, 0.0);
+            apply_entity_variant(item_stack, baby.as_ref());
+
+            world.spawn_entity(baby).await;
+            item_stack.decrement_unless_creative(player.gamemode.load(), 1);
+        })
+    }
+
     fn animal_interact<'a>(
         &'a self,
         player: &'a Arc<Player>,
@@ -43,6 +86,15 @@ pub trait Animal: Mob {
     ) -> EntityBaseFuture<'a, bool> {
         Box::pin(async move {
             let mob_entity = self.get_mob_entity();
+
+            // Vanilla runs this in `Mob.checkAndHandleImportantInteractions`, ahead of
+            // any food handling. No spawn egg is a breeding item, so the order only
+            // matters for staying close to vanilla.
+            if is_spawn_egg_for(item_stack, mob_entity.living_entity.entity.entity_type) {
+                self.spawn_baby_from_egg(player, item_stack).await;
+                return true;
+            }
+
             if self.is_food(item_stack) {
                 let age = mob_entity
                     .living_entity
@@ -101,5 +153,34 @@ pub trait Animal: Mob {
 
             mob_entity.mob_interact(player, item_stack).await
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_spawn_egg_for;
+    use pumpkin_data::entity::EntityType;
+    use pumpkin_data::item::Item;
+    use pumpkin_data::item_stack::ItemStack;
+
+    #[test]
+    fn matching_egg_is_recognized() {
+        let stack = ItemStack::new(1, &Item::COW_SPAWN_EGG);
+        assert!(is_spawn_egg_for(&stack, &EntityType::COW));
+    }
+
+    /// The wrong egg has to fall through, otherwise using a cow egg on a pig would
+    /// spawn a baby pig instead of placing a cow.
+    #[test]
+    fn egg_for_another_mob_is_not_recognized() {
+        let stack = ItemStack::new(1, &Item::COW_SPAWN_EGG);
+        assert!(!is_spawn_egg_for(&stack, &EntityType::PIG));
+        assert!(!is_spawn_egg_for(&stack, &EntityType::CHICKEN));
+    }
+
+    #[test]
+    fn a_non_egg_item_is_not_recognized() {
+        let stack = ItemStack::new(1, &Item::WHEAT);
+        assert!(!is_spawn_egg_for(&stack, &EntityType::COW));
     }
 }


### PR DESCRIPTION
## Description

Fixes #2536.

Vanilla handles this in `Mob.checkAndHandleImportantInteractions`, before any food interaction: a spawn egg used on a mob of its own type spawns a baby at that mob's position and consumes one egg, rather than placing a new adult next to it. `SpawnEggItem` in Pumpkin only implements `use_on_block`, so right-clicking a mob with an egg did nothing.

This adds the check to `Animal::animal_interact`, mirroring `SpawnEggItem.spawnOffspringFromSpawnEgg`: same-type egg only, baby spawned at the parent's position with yaw/pitch 0, variant components applied from the egg, one egg consumed.

Scope worth being explicit about: vanilla does this for every mob, this does it for the four Pumpkin currently models as breedable (chicken, cow, pig, sheep). Those are the mobs that already produce babies through `BreedGoal`, so no mob gains a baby state it couldn't already have. Extending it further is a matter of more mobs implementing `Animal`, not of changing this code.

The baby is flagged by its negative age, the same way `BreedGoal::breed` does it. `init_data_tracker` reads that age during `spawn_entity` and sends the client-side baby flag, which is why the age is set before the entity is spawned.

## Testing

`cargo test -p pumpkin --lib` (160 pass), `cargo clippy -p pumpkin --lib --tests`, `cargo fmt --all -- --check`.

Three unit tests cover the type guard, which is the part that decides between spawning a baby and falling through: a cow egg matches a cow, doesn't match a pig or chicken, and a non-egg item doesn't match at all. Spawning itself needs a world, so it isn't covered by an automated test.
