### PR TITLE
fix: require light for crops, stems and berry bushes to grow

### DIFF
--- a/pumpkin/src/block/blocks/plant/crop/gourds/stem.rs
+++ b/pumpkin/src/block/blocks/plant/crop/gourds/stem.rs
@@ -1,7 +1,10 @@
 use crate::block::{
     BlockBehaviour, BlockFuture, BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs,
     RandomTickArgs,
-    blocks::plant::{PlantBlockBase, crop::get_available_moisture},
+    blocks::plant::{
+        PlantBlockBase,
+        crop::{MIN_GROWTH_LIGHT, get_available_moisture},
+    },
 };
 use pumpkin_data::{
     Block, BlockDirection, BlockId, BlockStateId,
@@ -77,7 +80,9 @@ impl BlockBehaviour for StemBlock {
 
     fn random_tick<'a>(&'a self, args: RandomTickArgs<'a>) -> BlockFuture<'a, ()> {
         Box::pin(async move {
-            // TODO add light level check
+            if args.world.get_raw_brightness(args.position, 0) < MIN_GROWTH_LIGHT {
+                return;
+            }
             let f: f32 = get_available_moisture(args.world, args.position, args.block).await;
             if rand::rng().random_range(0..=(25.0 / f).floor() as i32) == 0 {
                 let (block, state) = args.world.get_block_and_state_id(args.position);

--- a/pumpkin/src/block/blocks/plant/crop/mod.rs
+++ b/pumpkin/src/block/blocks/plant/crop/mod.rs
@@ -49,6 +49,9 @@ trait CropBlockBase: PlantBlockBase {
     }
 
     async fn random_tick(&self, world: &Arc<World>, pos: &BlockPos) {
+        if world.get_raw_brightness(pos, 0) < MIN_GROWTH_LIGHT {
+            return;
+        }
         let (block, state) = world.get_block_and_state_id(pos);
         let age = self.get_age(state, block);
         if age < self.max_age() {
@@ -76,9 +79,13 @@ trait CropBlockBase: PlantBlockBase {
             }
         }
     }
-
-    //TODO add impl for light level
 }
+
+/// Raw brightness a crop or stem needs to advance a growth stage.
+///
+/// Vanilla checks `getRawBrightness(pos, 0)`, so the sky light is not reduced
+/// by the time of day and crops keep growing at night.
+pub const MIN_GROWTH_LIGHT: u8 = 9;
 
 pub async fn get_available_moisture(world: &Arc<World>, pos: &BlockPos, block: &Block) -> f32 {
     let mut moisture = 1.0;

--- a/pumpkin/src/block/blocks/plant/crop/sweet_berry_bush.rs
+++ b/pumpkin/src/block/blocks/plant/crop/sweet_berry_bush.rs
@@ -143,6 +143,9 @@ impl BlockBehaviour for SweetBerryBushBlock {
                 return;
             }
             if rand::rng().random_range(0..5) == 0 {
+                // Resolves to this type's own `CropBlockBase::random_tick` below,
+                // not the default in `crop::mod`, so the light is only checked
+                // once and only above the bush.
                 <Self as CropBlockBase>::random_tick(self, args.world, args.position).await;
             }
         })

--- a/pumpkin/src/block/blocks/plant/crop/sweet_berry_bush.rs
+++ b/pumpkin/src/block/blocks/plant/crop/sweet_berry_bush.rs
@@ -4,7 +4,10 @@ use crate::{
     block::{
         BlockBehaviour, BlockFuture, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, NormalUseArgs,
         OnEntityCollisionArgs, RandomTickArgs, UseWithItemArgs,
-        blocks::plant::{PlantBlockBase, crop::CropBlockBase},
+        blocks::plant::{
+            PlantBlockBase,
+            crop::{CropBlockBase, MIN_GROWTH_LIGHT},
+        },
         registry::BlockActionResult,
     },
     world::World,
@@ -134,6 +137,11 @@ impl BlockBehaviour for SweetBerryBushBlock {
 
     fn random_tick<'a>(&'a self, args: RandomTickArgs<'a>) -> BlockFuture<'a, ()> {
         Box::pin(async move {
+            // Vanilla checks the light above the bush rather than at it, so
+            // this cannot rely on the generic crop tick's own check.
+            if args.world.get_raw_brightness(&args.position.up(), 0) < MIN_GROWTH_LIGHT {
+                return;
+            }
             if rand::rng().random_range(0..5) == 0 {
                 <Self as CropBlockBase>::random_tick(self, args.world, args.position).await;
             }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -4391,10 +4391,22 @@ impl World {
         replaced_block_state_id
     }
 
-    pub fn get_max_local_raw_brightness(&self, pos: &BlockPos) -> u8 {
-        let sky_light = self.get_sky_light_level(pos);
+    /// The greater of the block light and the sky light reduced by
+    /// `ambient_darkness`, matching vanilla's `getRawBrightness`.
+    ///
+    /// Pass `0` for checks that must ignore the time of day, such as crop
+    /// growth.
+    pub fn get_raw_brightness(&self, pos: &BlockPos, ambient_darkness: u8) -> u8 {
+        let sky_light = self
+            .get_sky_light_level(pos)
+            .saturating_sub(ambient_darkness);
         let block_light = self.get_block_light_level(pos).unwrap_or(0);
-        sky_light.max(block_light) // TODO: getSkyDarken
+        sky_light.max(block_light)
+    }
+
+    pub fn get_max_local_raw_brightness(&self, pos: &BlockPos) -> u8 {
+        // TODO: pass the sky darken value here once it is tracked.
+        self.get_raw_brightness(pos, 0)
     }
 
     pub fn get_block_light_level(&self, position: &BlockPos) -> Option<u8> {


### PR DESCRIPTION
## Description

**What vanilla does (1.21):** `CropBlock#randomTick` and `StemBlock#randomTick` both begin with `if (level.getRawBrightness(pos, 0) >= 9)`. `SweetBerryBushBlock#randomTick` uses the same threshold but samples `pos.above()` rather than the plant's own position. The `0` matters: it is the ambient darkness argument, so sky light is *not* reduced by the time of day and crops keep growing at night. `AttachedStemBlock` does not tick randomly at all, and nether wart, sugar cane and cactus are deliberately ungated in vanilla.

**What Pumpkin did:** all three growth paths advanced a stage on every random tick with no light check, with `//TODO add impl for light level` markers in the crop and stem paths. A sealed, unlit room grew wheat, carrots, potatoes, beetroot and gourd stems at full speed.

**Change:**

- New `World::get_raw_brightness(pos, ambient_darkness)`, which is vanilla's `getRawBrightness`: the greater of the block light and the sky light reduced by the given ambient darkness. The growth checks pass `0`.
- Crops, stems and berry bushes return early below brightness 9. Berry bushes check the block above, as vanilla does, so they gate separately from the shared crop tick.
- `get_max_local_raw_brightness` now delegates to the new function and keeps its existing `TODO: getSkyDarken`.

**Why not just call the existing `get_max_local_raw_brightness`?** It is named after vanilla's skyDarken-aware accessor and carries a TODO to become that. It happens to return `getRawBrightness(pos, 0)` today *only because that TODO is unimplemented*. Its other callers (bat and slime spawn checks) genuinely want the skyDarken behaviour, so whoever implements that TODO would silently stop crops growing outdoors at night, and the breakage would look like their fault. Splitting the two makes each call site state what it actually wants.

**Impact / known limitations:**

- A server running the non-default `lighting = "dark"` mode fills all light with zero, so this stops growth entirely there. Previously that mode had no gameplay effect.
- Bone meal is correctly unaffected: vanilla's `isBonemealSuccess` returns `true` regardless of light, and Pumpkin has no bone meal implementation yet.
- Saplings, bamboo and mushrooms have related light rules that are still missing; they are out of scope here and left with their existing TODOs.

## Testing

- `cargo clippy -p pumpkin --all-targets` and `cargo fmt --check` pass with the workspace deny-level lints, and with `RUSTFLAGS="-D warnings"`.
- Verified the vanilla thresholds and the `pos` vs `pos.above()` distinction against the 1.21 sources rather than trusting the TODO comments; the crop check moved from `pos.up()` to `pos` between 1.12 and 1.14, so older references disagree.

Suggested manual check on a server: place farmland, water and `minecraft:wheat[age=0]` inside a sealed dark box, set `gamerule random_tick_speed 1000`, and confirm it no longer advances; repeat with a torch and confirm it does.
