### PR TITLE
Kill parrots with cookies

### DIFF
--- a/pumpkin/src/entity/passive/parrot.rs
+++ b/pumpkin/src/entity/passive/parrot.rs
@@ -1,14 +1,22 @@
-use std::sync::{Arc, Weak};
+use std::sync::{
+    Arc, Weak,
+    atomic::{AtomicBool, Ordering},
+};
 
+use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::item::Item;
+use pumpkin_data::item_stack::ItemStack;
+use pumpkin_inventory::screen_handler::InventoryPlayer;
 
 use crate::entity::{
-    Entity, NBTStorage,
+    Entity, EntityBaseFuture, NBTStorage,
     ai::goal::{
         look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal, swim::SwimGoal,
         wander_around::WanderAroundGoal,
     },
     mob::{Mob, MobEntity},
+    player::Player,
 };
 
 /// Represents a Parrot, a passive flying mob that can mimic nearby mob sounds.
@@ -16,13 +24,20 @@ use crate::entity::{
 /// Wiki: <https://minecraft.wiki/w/Parrot>
 pub struct ParrotEntity {
     pub mob_entity: MobEntity,
+    pub cookie_cooldown: Arc<AtomicBool>,
 }
 
 impl ParrotEntity {
     pub fn new(entity: Entity) -> Arc<Self> {
         let mob_entity = MobEntity::new(entity);
-        let parrot = Self { mob_entity };
+
+        let parrot = Self {
+            mob_entity,
+            cookie_cooldown: Arc::new(AtomicBool::new(false)),
+        };
+
         let mob_arc = Arc::new(parrot);
+
         let mob_weak: Weak<dyn Mob> = {
             let mob_arc: Arc<dyn Mob> = mob_arc.clone();
             Arc::downgrade(&mob_arc)
@@ -49,5 +64,47 @@ impl NBTStorage for ParrotEntity {}
 impl Mob for ParrotEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
+    }
+
+    fn mob_interact<'a>(
+        &'a self,
+        player: &'a Arc<Player>,
+        item_stack: &'a mut ItemStack,
+    ) -> EntityBaseFuture<'a, bool> {
+        Box::pin(async move {
+            if item_stack.item.id == Item::COOKIE.id {
+                // Prevent duplicate interaction packets consuming 2 cookies
+                if self.cookie_cooldown.swap(true, Ordering::Relaxed) {
+                    return true;
+                }
+
+                let cooldown = self.cookie_cooldown.clone();
+
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                    cooldown.store(false, Ordering::Relaxed);
+                });
+
+                // TODO: Parrot should get poison before dying.
+                // Bedrock should get fatal poison effect and not die.
+
+                if !player.has_infinite_materials() {
+                    item_stack.decrement(1);
+                }
+
+                let entity = &self.mob_entity.living_entity.entity;
+                let world = entity.world.load();
+
+                if let Some(dyn_self) = world.get_entity_by_id(entity.entity_id) {
+                    dyn_self
+                        .damage(&*dyn_self, f32::MAX, DamageType::MAGIC)
+                        .await;
+                }
+
+                return true;
+            }
+
+            self.mob_entity.mob_interact(player, item_stack).await
+        })
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Pumpkin-MC/Pumpkin/issues/2534.

## Changes

`ParrotEntity` previously had no interaction handler, meaning using a cookie on a parrot did nothing: the cookie remained in the inventory and the parrot was unaffected.

Since cookies are the only item that poison parrots, I added a check for when the player right-clicks a parrot while holding `Item::COOKIE`.

The implementation:
- Consumes the cookie only when the player is not in creative mode
- Adds a small debounce to prevent multiple cookies being consumed from a single click due to duplicate interaction packets
- Applies the cookie interaction damage to the parrot

Poison particles are not currently supported by Pumpkin, so they are not implemented yet.

## Testing

Tested with:
- 'cargo test -p pumpkin --lib'
- 'cargo clippy -p pumpkin --lib --tests'
- 'cargo fmt --all -- --check'

Results:
- `cargo test -p pumpkin --lib`: 160 tests passed
- `cargo clippy -p pumpkin --lib --tests`: passed
- `cargo fmt --all -- --check`: passed

Use this instead of https://github.com/Pumpkin-MC/Pumpkin/pull/2564 because that one give parrot the effect posion crashing.
