### PR TITLE
fix(block): make rain extinguish fire and hydrate farmland

### DIFF
--- a/pumpkin-util/src/biome.rs
+++ b/pumpkin-util/src/biome.rs
@@ -67,7 +67,7 @@ impl TemperatureModifier {
 /// Represents weather information for a biome, including temperature and precipitation.
 #[derive(Clone, Debug)]
 pub struct Weather {
-    #[expect(dead_code)]
+    /// Whether this biome has any precipitation at all (rain or snow).
     has_precipitation: bool,
     /// Base temperature of the biome.
     temperature: f32,
@@ -135,5 +135,23 @@ impl Weather {
         } else {
             modified_temperature
         }
+    }
+
+    /// Whether it is warm enough at the given position for precipitation to fall
+    /// as rain instead of snow.
+    ///
+    /// Mirrors vanilla `Biome#warmEnoughToRain`.
+    #[must_use]
+    pub fn warm_enough_to_rain(&self, x: i32, y: i32, z: i32, sea_level: i32) -> bool {
+        self.compute_temperature(f64::from(x), y, f64::from(z), sea_level) >= 0.15
+    }
+
+    /// Whether precipitation at the given position falls as rain.
+    ///
+    /// Mirrors vanilla `Biome#getPrecipitationAt(pos, seaLevel) == Precipitation.RAIN`:
+    /// biomes without precipitation get `NONE`, cold ones get `SNOW`.
+    #[must_use]
+    pub fn is_rain_at(&self, x: i32, y: i32, z: i32, sea_level: i32) -> bool {
+        self.has_precipitation && self.warm_enough_to_rain(x, y, z, sea_level)
     }
 }

--- a/pumpkin-util/src/biome.rs
+++ b/pumpkin-util/src/biome.rs
@@ -155,3 +155,48 @@ impl Weather {
         self.has_precipitation && self.warm_enough_to_rain(x, y, z, sea_level)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{TemperatureModifier, Weather};
+
+    /// Sea level position in a biome with no precipitation at all.
+    fn arid() -> Weather {
+        Weather::new(false, 2.0, TemperatureModifier::None, 0.0)
+    }
+
+    /// Warm enough for rain at sea level.
+    fn temperate() -> Weather {
+        Weather::new(true, 0.8, TemperatureModifier::None, 0.4)
+    }
+
+    /// Cold enough that precipitation falls as snow.
+    fn frozen() -> Weather {
+        Weather::new(true, 0.0, TemperatureModifier::None, 0.5)
+    }
+
+    #[test]
+    fn biomes_without_precipitation_never_rain() {
+        assert!(!arid().is_rain_at(0, 64, 0, 63));
+    }
+
+    #[test]
+    fn warm_biomes_rain() {
+        assert!(temperate().is_rain_at(0, 64, 0, 63));
+    }
+
+    #[test]
+    fn cold_biomes_snow_rather_than_rain() {
+        assert!(!frozen().is_rain_at(0, 64, 0, 63));
+        assert!(!frozen().warm_enough_to_rain(0, 64, 0, 63));
+    }
+
+    #[test]
+    fn temperature_falls_with_height_so_peaks_snow() {
+        let w = temperate();
+        assert!(w.warm_enough_to_rain(0, 64, 0, 63));
+        // Far above the sea level offset the temperature drop should push a
+        // marginally warm biome below the rain threshold.
+        assert!(!w.warm_enough_to_rain(0, 2000, 0, 63));
+    }
+}

--- a/pumpkin/src/block/blocks/farmland.rs
+++ b/pumpkin/src/block/blocks/farmland.rs
@@ -69,8 +69,9 @@ impl BlockBehaviour for FarmlandBlock {
 
     fn random_tick<'a>(&'a self, args: RandomTickArgs<'a>) -> BlockFuture<'a, ()> {
         Box::pin(async move {
-            // TODO: add rain check. Remember to check which one is most optimized.
-            if is_water_nearby(args.world, args.position) {
+            if is_water_nearby(args.world, args.position)
+                || args.world.is_raining_at(&args.position.up()).await
+            {
                 let mut props = FarmlandProperties::default(args.block);
                 props.moisture = 7;
                 args.world
@@ -118,6 +119,8 @@ fn can_place_at(world: &dyn BlockAccessor, block_pos: &BlockPos) -> bool {
     !state.is_solid() // TODO: add fence gate block
 }
 
+/// Mirrors vanilla `FarmBlock#isNearWater`, which tests the *fluid* state of every
+/// position in the box so that waterlogged blocks count as a water source too.
 fn is_water_nearby(world: &Arc<World>, block_pos: &BlockPos) -> bool {
     for dx in -4..=4 {
         for dy in 0..=1 {
@@ -127,8 +130,10 @@ fn is_water_nearby(world: &Arc<World>, block_pos: &BlockPos) -> bool {
                     y: dy,
                     z: dz,
                 });
-                //TODO this should use tag water. It does not seem to work rn.
-                if world.get_block(&check_pos) == &Block::WATER {
+                if world
+                    .get_fluid(&check_pos)
+                    .has_tag(&tag::Fluid::MINECRAFT_WATER)
+                {
                     return true;
                 }
             }

--- a/pumpkin/src/block/blocks/fire/fire.rs
+++ b/pumpkin/src/block/blocks/fire/fire.rs
@@ -118,15 +118,16 @@ impl FireBlock {
     /// Whether it is raining on this position or on any of its four horizontal
     /// neighbours, matching vanilla `FireBlock#isNearRain`.
     async fn is_near_rain(world: &World, pos: &BlockPos) -> bool {
-        // Cheap early out so we don't take the weather lock five times per call.
+        // Check the weather once here rather than once per position, since
+        // this runs for every burning block and every spread candidate.
         if !world.is_raining().await {
             return false;
         }
-        world.is_raining_at(pos).await
-            || world.is_raining_at(&pos.west()).await
-            || world.is_raining_at(&pos.east()).await
-            || world.is_raining_at(&pos.north()).await
-            || world.is_raining_at(&pos.south()).await
+        world.is_raining_at_unchecked(pos)
+            || world.is_raining_at_unchecked(&pos.west())
+            || world.is_raining_at_unchecked(&pos.east())
+            || world.is_raining_at_unchecked(&pos.north())
+            || world.is_raining_at_unchecked(&pos.south())
     }
 
     // Get burn odds for a block, used in try_spreading_fire
@@ -164,7 +165,9 @@ impl FireBlock {
             // Bound the `Rng` temporary to a statement so it is not held across the
             // `is_near_rain` await point.
             let can_persist = rand::rng().random_range(0..(age + 10) as i32) < 5;
-            if can_persist && !Self::is_near_rain(world.as_ref(), pos).await {
+            // Vanilla `FireBlock#checkBurnOut` tests this position only; the
+            // five position `isNearRain` form is used for spreading.
+            if can_persist && !world.is_raining_at(pos).await {
                 let new_age = (age + (rand::rng().random_range(0..5) / 4)).min(15) as u8;
                 let state_id = self.get_state_for_position(world.as_ref(), &Block::FIRE, pos);
                 let mut fire_props = FireProperties::from_state_id(state_id, &Block::FIRE);

--- a/pumpkin/src/block/blocks/fire/fire.rs
+++ b/pumpkin/src/block/blocks/fire/fire.rs
@@ -115,10 +115,18 @@ impl FireBlock {
         total_burn_chance
     }
 
-    const fn is_near_rain(_world: &World, _pos: &BlockPos) -> bool {
-        // TODO: Implement proper rain checking when weather is implemented
-        // For now, return false to allow fire to work
-        false
+    /// Whether it is raining on this position or on any of its four horizontal
+    /// neighbours, matching vanilla `FireBlock#isNearRain`.
+    async fn is_near_rain(world: &World, pos: &BlockPos) -> bool {
+        // Cheap early out so we don't take the weather lock five times per call.
+        if !world.is_raining().await {
+            return false;
+        }
+        world.is_raining_at(pos).await
+            || world.is_raining_at(&pos.west()).await
+            || world.is_raining_at(&pos.east()).await
+            || world.is_raining_at(&pos.north()).await
+            || world.is_raining_at(&pos.south()).await
     }
 
     // Get burn odds for a block, used in try_spreading_fire
@@ -153,9 +161,10 @@ impl FireBlock {
         let odds = Self::get_burn_odds(block);
         if rand::rng().random_range(0..chance) < odds {
             let old_block = block;
-            if rand::rng().random_range(0..(age + 10) as i32) < 5
-                && !Self::is_near_rain(world.as_ref(), pos)
-            {
+            // Bound the `Rng` temporary to a statement so it is not held across the
+            // `is_near_rain` await point.
+            let can_persist = rand::rng().random_range(0..(age + 10) as i32) < 5;
+            if can_persist && !Self::is_near_rain(world.as_ref(), pos).await {
                 let new_age = (age + (rand::rng().random_range(0..5) / 4)).min(15) as u8;
                 let state_id = self.get_state_for_position(world.as_ref(), &Block::FIRE, pos);
                 let mut fire_props = FireProperties::from_state_id(state_id, &Block::FIRE);
@@ -303,7 +312,7 @@ impl BlockBehaviour for FireBlock {
             let age = fire_props.age;
 
             // Check if rain should extinguish the fire
-            if !infiniburn && Self::is_near_rain(world.as_ref(), pos) {
+            if !infiniburn && Self::is_near_rain(world.as_ref(), pos).await {
                 let rain_chance = 0.2 + (age as f32) * 0.03;
                 if rand::random::<f32>() < rain_chance {
                     world
@@ -454,9 +463,12 @@ impl BlockBehaviour for FireBlock {
                                     odds /= 2; // Fire spreads 50% slower
                                 }
 
-                                if odds > 0
-                                    && rand::rng().random_range(0..rate) <= odds
-                                    && !Self::is_near_rain(world.as_ref(), &offset_pos)
+                                // Bound the `Rng` temporary to a statement so it is not
+                                // held across the `is_near_rain` await point.
+                                let can_ignite =
+                                    odds > 0 && rand::rng().random_range(0..rate) <= odds;
+                                if can_ignite
+                                    && !Self::is_near_rain(world.as_ref(), &offset_pos).await
                                 {
                                     let spread_age = (new_age + rand::rng().random_range(0..5) / 4)
                                         .min(15)

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1731,19 +1731,29 @@ impl World {
 
     /// Whether rain is currently falling onto `pos`.
     ///
-    /// Mirrors vanilla `Level#isRainingAt`: it has to be raining, the position has to
-    /// see the sky, nothing motion blocking may sit above it, and the biome there has
-    /// to have rain as its precipitation (so not snow and not "no precipitation").
+    /// Mirrors vanilla `Level#isRainingAt`: it has to be raining, the topmost
+    /// motion blocking block has to be at or below `pos`, the position has to
+    /// see the sky, and the biome there has to have rain as its precipitation
+    /// (so not snow, and not "no precipitation").
     pub async fn is_raining_at(&self, pos: &BlockPos) -> bool {
-        if !self.is_raining().await {
+        self.is_raining().await && self.is_raining_at_unchecked(pos)
+    }
+
+    /// [`Self::is_raining_at`] without re-checking that it is raining at all.
+    ///
+    /// Callers that already know the world is raining use this so a single
+    /// check does not take the weather lock once per position.
+    pub(crate) fn is_raining_at_unchecked(&self, pos: &BlockPos) -> bool {
+        // The heightmap runs first: it is cheaper than reaching into the light
+        // engine and it is maintained on every block change.
+        //
+        // `get_heightmap_height` returns the Y of the topmost matching block,
+        // whereas vanilla's `Heightmap#getFirstAvailable` returns that Y plus
+        // one, hence the `+ 1` before comparing.
+        if self.get_heightmap_height(MotionBlocking, pos.0.x, pos.0.z) + 1 > pos.0.y {
             return false;
         }
         if !self.can_see_sky(pos) {
-            return false;
-        }
-        // Our heightmaps store the Y of the topmost matching block, while vanilla's
-        // `Heightmap#getFirstAvailable` stores that Y plus one, hence the `+ 1` here.
-        if self.get_heightmap_height(MotionBlocking, pos.0.x, pos.0.z) + 1 > pos.0.y {
             return false;
         }
         self.get_biome(pos)
@@ -4436,10 +4446,18 @@ impl World {
 
     /// Whether `position` has an unobstructed view of the sky.
     ///
-    /// Mirrors vanilla `LevelReader#canSeeSky`, which checks the raw (not
-    /// day/night darkened) sky light against the maximum light level.
+    /// Mirrors vanilla `BlockAndTintGetter#canSeeSky`, which checks the raw
+    /// (not day/night darkened) sky light against the maximum light level.
     #[must_use]
     pub fn can_see_sky(&self, position: &BlockPos) -> bool {
+        // Out of range lookups report full sky light, so reject them here
+        // rather than letting a position below or above the world claim to
+        // see the sky.
+        if position.0.y < self.dimension.min_y
+            || position.0.y >= self.dimension.min_y + self.dimension.height
+        {
+            return false;
+        }
         self.get_sky_light_level(position) >= MAX_LIGHT_LEVEL
     }
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -163,6 +163,9 @@ type FlowingFluidProperties = pumpkin_data::fluid::FlowingWaterLikeFluidProperti
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+/// The highest light level a block position can have, vanilla `LightLayer#getMaxLightLevel`.
+const MAX_LIGHT_LEVEL: u8 = 15;
+
 impl PumpkinError for GetBlockError {
     fn is_kick(&self) -> bool {
         false
@@ -1724,6 +1727,28 @@ impl World {
             let raining = weather.raining;
             weather.set_weather_parameters(self, 0, 0, raining, thundering);
         }
+    }
+
+    /// Whether rain is currently falling onto `pos`.
+    ///
+    /// Mirrors vanilla `Level#isRainingAt`: it has to be raining, the position has to
+    /// see the sky, nothing motion blocking may sit above it, and the biome there has
+    /// to have rain as its precipitation (so not snow and not "no precipitation").
+    pub async fn is_raining_at(&self, pos: &BlockPos) -> bool {
+        if !self.is_raining().await {
+            return false;
+        }
+        if !self.can_see_sky(pos) {
+            return false;
+        }
+        // Our heightmaps store the Y of the topmost matching block, while vanilla's
+        // `Heightmap#getFirstAvailable` stores that Y plus one, hence the `+ 1` here.
+        if self.get_heightmap_height(MotionBlocking, pos.0.x, pos.0.z) + 1 > pos.0.y {
+            return false;
+        }
+        self.get_biome(pos)
+            .weather
+            .is_rain_at(pos.0.x, pos.0.y, pos.0.z, self.sea_level)
     }
 
     /// Gets the y position of the first non air block from the top down
@@ -4407,6 +4432,15 @@ impl World {
         self.level
             .light_engine
             .get_sky_light_level(&self.level, position)
+    }
+
+    /// Whether `position` has an unobstructed view of the sky.
+    ///
+    /// Mirrors vanilla `LevelReader#canSeeSky`, which checks the raw (not
+    /// day/night darkened) sky light against the maximum light level.
+    #[must_use]
+    pub fn can_see_sky(&self, position: &BlockPos) -> bool {
+        self.get_sky_light_level(position) >= MAX_LIGHT_LEVEL
     }
 
     pub fn set_block_light_level(&self, position: &BlockPos, light_level: u8) {


### PR DESCRIPTION
## Description

Rain currently has no effect on two blocks that vanilla says it should. This adds the shared primitive both need and wires up the two consumers.

### `World::is_raining_at`

Mirrors vanilla `Level#isRainingAt`: it must be raining, the topmost motion blocking block must be at or below the position, the position must see the sky, and the biome's precipitation there must be rain rather than snow or none.

One detail worth review: Pumpkin's `get_heightmap_height` returns the Y of the topmost matching block, whereas vanilla's `Heightmap#getFirstAvailable` returns that Y **plus one**. The repo states this itself in `ChunkHeightmaps::update`, which does `self.get(...) + 1`. So the comparison here carries a `+ 1`. Fire at y=64 on grass at y=63 gives `63 + 1 > 64` = false, i.e. not rejected, matching vanilla. Fire is not motion blocking (`state_flags` has neither the solid nor liquid bit) so it does not raise its own heightmap and cannot mask itself.

`can_see_sky` mirrors `BlockAndTintGetter#canSeeSky`, a raw sky light comparison against the maximum light level, and rejects positions outside the world because an out of range lookup reports full sky light.

### Fire

`FireBlock::is_near_rain` was a hardcoded `false` behind a "when weather is implemented" TODO. Weather has since been implemented, so the two call sites were correctly placed but permanently dead: fire never extinguished in rain and spread freely through storms.

Note the two call sites are deliberately different, matching vanilla: `checkBurnOut` tests **only its own position** (`!level.isRainingAt(pos)`), while the spread loop uses the five position `isNearRain`.

### Farmland

Vanilla dries farmland only when `!isNearWater(pos) && !isRainingAt(pos.above())`, and `isNearWater` tests the **fluid** state so waterlogged blocks count. Pumpkin had neither: it compared block identity, so water hidden under a slab never hydrated, and it had no rain check at all. Both TODOs in that file asked for exactly this.

## Testing

- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin -p pumpkin-util --all-targets` is clean, as is `cargo fmt --check`.
- Four unit tests added for the biome precipitation helpers (no precipitation never rains, warm biomes rain, cold biomes snow, temperature falls with height).
- Verified the fluid tag genuinely covers both `water` and `flowing_water` and does not match lava, and that `get_fluid` maps waterlogged blocks to `FLOWING_WATER`.

## Known limitations, called out deliberately

- **Rain does not start on its own.** `Weather::tick_weather` advances the cycle when `weather_cycle_enabled` is **false**, and that field defaults to `true` and is never wired to the `doWeatherCycle` gamerule. So this is only observable after `/weather rain`. That inversion looks like a separate pre-existing bug; happy to fix it in its own PR rather than smuggle it in here.
- **Worlds imported from vanilla.** Sections saved without a `SkyLight` array load as sky light 0, and `needs_relighting` returns false because `isLightOn` is set, so `can_see_sky` is false in open air and this silently does nothing. That is a pre-existing light round trip gap, not introduced here, but it does bound where this fix takes effect. The heightmap test runs first partly for this reason. If maintainers would rather drop the sky light clause entirely and rely on the heightmap, that is a one line change and arguably more robust than vanilla parity here.
- `is_water_nearby` scans 162 positions and `get_fluid` allocates for blocks with properties. That is pre-existing, but this change makes it run more often; a non-allocating waterlogged fast path would be a sensible follow up.
- Two behaviours in one PR because they share the new primitive. Happy to split if preferred.
