### PR TITLE
fix(block): bleach fire coral blocks when they dry out

### DIFF
--- a/pumpkin/src/block/blocks/coral/coral_block.rs
+++ b/pumpkin/src/block/blocks/coral/coral_block.rs
@@ -47,7 +47,7 @@ const fn get_dead_coral_block_type(id: BlockId) -> Option<&'static Block> {
     match id {
         BlockId::BRAIN_CORAL_BLOCK => Some(&Block::DEAD_BRAIN_CORAL_BLOCK),
         BlockId::BUBBLE_CORAL_BLOCK => Some(&Block::DEAD_BUBBLE_CORAL_BLOCK),
-        BlockId::FIRE_CORAL_BLOCK => Some(&Block::FIRE_CORAL_BLOCK),
+        BlockId::FIRE_CORAL_BLOCK => Some(&Block::DEAD_FIRE_CORAL_BLOCK),
         BlockId::HORN_CORAL_BLOCK => Some(&Block::DEAD_HORN_CORAL_BLOCK),
         BlockId::TUBE_CORAL_BLOCK => Some(&Block::DEAD_TUBE_CORAL_BLOCK),
         _ => None,


### PR DESCRIPTION
## Description

`get_dead_coral_block_type` in `pumpkin/src/block/blocks/coral/coral_block.rs` mapped `FIRE_CORAL_BLOCK` to itself instead of to `DEAD_FIRE_CORAL_BLOCK`:

```rust
BlockId::BRAIN_CORAL_BLOCK  => Some(&Block::DEAD_BRAIN_CORAL_BLOCK),
BlockId::BUBBLE_CORAL_BLOCK => Some(&Block::DEAD_BUBBLE_CORAL_BLOCK),
BlockId::FIRE_CORAL_BLOCK   => Some(&Block::FIRE_CORAL_BLOCK),      // <- self
BlockId::HORN_CORAL_BLOCK   => Some(&Block::DEAD_HORN_CORAL_BLOCK),
BlockId::TUBE_CORAL_BLOCK   => Some(&Block::DEAD_TUBE_CORAL_BLOCK),
```

`on_scheduled_tick` looks up this table and writes the result back with `set_block_state`, so for fire coral that was a no-op: a fire coral block left out of water stayed bright red forever while the other four colours bleached normally. The two sibling tables map it correctly (`coral_fan.rs` to `DEAD_FIRE_CORAL_FAN`, `coral_plant.rs` to `DEAD_FIRE_CORAL`), which is what makes this look like a typo rather than a deliberate exception.

There is a second effect, since `BlockMetadata::ids` is built from the same table: `FIRE_CORAL_BLOCK` was registered twice and `DEAD_FIRE_CORAL_BLOCK` was never registered at all. That is harmless today because dead coral short circuits earlier via `is_dead_coral`, but the same one line fixes it.

## Testing

- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` and `cargo fmt --check` are clean.

Suggested check on a server:

```
setblock 100 100 100 fire_coral_block
setblock 101 100 100 brain_coral_block
# after the scheduled tick
execute if block 101 100 100 dead_brain_coral_block run say control bleached
execute if block 100 100 100 dead_fire_coral_block run say fire bleached
```

Before this change the first succeeds and the second does not; after, both do.
