### PR TITLE
fix: wire up gamerules that were never read

### DIFF
--- a/pumpkin/src/block/mod.rs
+++ b/pumpkin/src/block/mod.rs
@@ -444,18 +444,21 @@ pub async fn drop_loot(
     experience: bool,
     params: LootContextParameters,
 ) {
-    // Vanilla gates item drops on this rule in `Block#popResource`, but
-    // deliberately does not gate experience in `Block#popExperience`, so ore
-    // experience still drops with the rule off.
-    if world.level_info.load().game_rules.block_drops
-        && let Some(loot_table) = &block.loot_table
-    {
+    // Vanilla gates both item drops and experience on this rule, in
+    // `Block#popResource` and `Block#popExperience` respectively, so with the
+    // rule off an ore drops neither its item nor its experience orbs.
+    let block_drops = world.level_info.load().game_rules.block_drops;
+
+    if block_drops && let Some(loot_table) = &block.loot_table {
         for stack in loot_table.get_loot(params) {
             world.drop_stack(pos, stack).await;
         }
     }
 
-    if experience && let Some(experience) = &block.experience {
+    if block_drops
+        && experience
+        && let Some(experience) = &block.experience
+    {
         let mut random = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(get_seed()));
         let amount = experience.experience.get(&mut random);
         // TODO: Silk touch gives no exp

--- a/pumpkin/src/block/mod.rs
+++ b/pumpkin/src/block/mod.rs
@@ -444,7 +444,12 @@ pub async fn drop_loot(
     experience: bool,
     params: LootContextParameters,
 ) {
-    if let Some(loot_table) = &block.loot_table {
+    // Vanilla gates item drops on this rule in `Block#popResource`, but
+    // deliberately does not gate experience in `Block#popExperience`, so ore
+    // experience still drops with the rule off.
+    if world.level_info.load().game_rules.block_drops
+        && let Some(loot_table) = &block.loot_table
+    {
         for stack in loot_table.get_loot(params) {
             world.drop_stack(pos, stack).await;
         }

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -2064,6 +2064,18 @@ impl EntityBase for LivingEntity {
                 || damage_type == DamageType::LAVA
                 || damage_type == DamageType::HOT_FLOOR;
 
+            // Like fire and drowning damage, these are gated for players only;
+            // mobs still take them.
+            if self.entity.entity_type == &EntityType::PLAYER {
+                let game_rules = &world.level_info.load().game_rules;
+                if damage_type == DamageType::FALL && !game_rules.fall_damage {
+                    return false;
+                }
+                if damage_type == DamageType::FREEZE && !game_rules.freeze_damage {
+                    return false;
+                }
+            }
+
             // Fire damage can be prevented by either game rules or fire resistance
             if is_fire_damage {
                 // Check game rule for fire damage (only for players)

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -2532,6 +2532,7 @@ impl World {
         // This code follows the vanilla packet order
         let entity_id = player.entity_id();
         let gamemode = player.gamemode.load();
+        let level_info = self.level_info.load();
         debug!(
             "spawning player {}, entity id {}",
             player.gameprofile.name, entity_id
@@ -2567,9 +2568,9 @@ impl World {
                     .simulation_distance
                     .get()
                     .into(), // TODO: sim view dinstance
-                false,
-                true,
-                false,
+                level_info.game_rules.reduced_debug_info,
+                !level_info.game_rules.immediate_respawn,
+                level_info.game_rules.limited_crafting,
                 PlayerSpawnData::new(
                     self.dimension.clone(),
                     biome::hash_seed(self.level.seed.0), // seed


### PR DESCRIPTION
## Description

Six gamerules exist in `pumpkin-data` but nothing in `pumpkin/src` ever read them, so setting any of them had no effect. I found these by grepping every `GameRuleRegistry` field for read sites.

### `block_drops`

`World::break_block` gated drops only on `BlockFlags::SKIP_DROPS`, and `drop_loot` fed the loot table straight into `drop_stack`. `/gamerule block_drops false` did nothing.

Now gated in `drop_loot`, which has exactly two callers (block break and explosions) and so matches vanilla's scope. Vanilla checks this rule in `Block#popResource` but deliberately **not** in `Block#popExperience`, so ore experience still drops with the rule off; the gate is placed accordingly. It is deliberately not applied in `World::drop_stack`, which also serves `/loot`, chicken eggs, player death and vehicles.

### `fall_damage` and `freeze_damage`

Neither was read; `handle_fall_damage` checked only the immunity flags and the safe-fall attribute. These are now checked in the damage path directly alongside the `fire_damage` gate that was already there, which keeps all four player-damage rules in one place. Like the existing `fire_damage` and `drowning_damage` handling, they apply to players only, so mobs still take fall and freeze damage.

### `reduced_debug_info`, `immediate_respawn`, `limited_crafting`

These were passed to `CLogin` as hardcoded `false, true, false`. They now come from the gamerules. Note `immediate_respawn` is inverted at the wire because the protocol field is `enable_respawn_screen`.

## Testing

- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` and `cargo fmt --check` are clean.

Suggested checks on a server:

```
gamerule block_drops false
# break a stone block, then:
kill @e[type=item]          # echoes a count; expect 0, was 1

gamerule fall_damage false
tp <player> ~ ~60 ~         # expect no damage on landing

gamerule immediate_respawn true
# reconnect, then die: expect no death screen
```

## Known limitations

- The three login fields are only sent at join, so changing those rules mid-session still needs a reconnect. Vanilla re-sends a `ClientboundGameEvent` on change; that felt like a separate change rather than something to fold in here, but happy to add it if preferred.
- I have not exercised these on a live server yet. The reads are one-liners against `level_info.game_rules` following the existing `fire_damage` pattern, but flagging it rather than claiming verification I did not do.
