### PR TITLE
fix(player): cost hunger for attacking and mining

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -122,6 +122,14 @@ const MAX_PREVIOUS_MESSAGES: u8 = 20; // Vanilla: 20
 
 pub const DATA_VERSION: i32 = 4903; // 26.2
 
+/// Food exhaustion applied for every block a player mines.
+///
+/// Vanilla: `Block#playerDestroy` calls `player.causeFoodExhaustion(0.005F)`.
+/// `ServerPlayerGameMode#destroyBlock` only reaches `playerDestroy` for
+/// non-creative players holding a tool that can harvest the block, so callers
+/// must apply the same gating.
+pub const MINE_BLOCK_EXHAUSTION: f32 = 0.005; // Vanilla: 0.005F
+
 struct HeapNode(i32, Vector2<i32>, Weak<ChunkData>);
 
 impl Eq for HeapNode {}
@@ -1161,6 +1169,11 @@ impl Player {
             Self::combat_weapon_durability_cost(&stack)
         })
         .await;
+
+        // Vanilla `Player#attack` ends the successful-hit branch with
+        // `causeFoodExhaustion(0.1F)`. Only landed hits exhaust; the miss/no-damage
+        // case returned early above.
+        self.add_exhaustion(0.1).await;
 
         if config.swing {}
     }

--- a/pumpkin/src/net/bedrock/play.rs
+++ b/pumpkin/src/net/bedrock/play.rs
@@ -49,7 +49,10 @@ use pumpkin_world::world::BlockFlags;
 
 use crate::{
     block::{BlockHitResult, registry::BlockActionResult},
-    entity::{EntityBase, player::Player},
+    entity::{
+        EntityBase,
+        player::{MINE_BLOCK_EXHAUSTION, Player},
+    },
     net::{DisconnectReason, bedrock::BedrockClient},
     plugin::player::{
         item_held::PlayerItemHeldEvent,
@@ -1093,6 +1096,7 @@ impl BedrockClient {
                     let speed = crate::block::calc_block_breaking(player, state, block).await;
                     if speed >= 1.0 {
                         let broken_state = world.get_block_state(&location);
+                        let can_harvest = player.can_harvest(broken_state, block).await;
                         let new_state = world
                             .break_block(
                                 &location,
@@ -1106,6 +1110,9 @@ impl BedrockClient {
                                 .broken(&world, block, player, &location, server, broken_state)
                                 .await;
                             player.apply_tool_damage_for_block_break(broken_state).await;
+                            if can_harvest {
+                                player.add_exhaustion(MINE_BLOCK_EXHAUSTION).await;
+                            }
                         }
                     } else {
                         player.mining.store(true, Ordering::Relaxed);
@@ -1151,6 +1158,9 @@ impl BedrockClient {
                             .broken(&world, block, player, &location, server, state)
                             .await;
                         player.apply_tool_damage_for_block_break(state).await;
+                        if block_drop {
+                            player.add_exhaustion(MINE_BLOCK_EXHAUSTION).await;
+                        }
                     }
                 }
             }

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -16,7 +16,7 @@ use crate::block::{self};
 use crate::entity::EntityBase;
 use crate::entity::equipment_break_status;
 use crate::entity::player::statistics::{CustomStatistic, StatisticCategory};
-use crate::entity::player::{ChatMode, ChatSession, Player};
+use crate::entity::player::{ChatMode, ChatSession, MINE_BLOCK_EXHAUSTION, Player};
 use crate::error::PumpkinError;
 use crate::log_at_level;
 use crate::net::PlayerConfig;
@@ -1981,6 +1981,7 @@ impl JavaClient {
                         // Instant break
                         if speed >= 1.0 {
                             let broken_state = world.get_block_state(&position);
+                            let can_harvest = player.can_harvest(broken_state, block).await;
                             let new_state = world
                                 .break_block(
                                     &position,
@@ -1994,6 +1995,9 @@ impl JavaClient {
                                     .broken(&world, block, player, &position, server, broken_state)
                                     .await;
                                 player.apply_tool_damage_for_block_break(broken_state).await;
+                                if can_harvest {
+                                    player.add_exhaustion(MINE_BLOCK_EXHAUSTION).await;
+                                }
                                 let item_id = player.inventory().held_item().lock().await.item.id;
                                 player
                                     .increment_stat(StatisticCategory::Used, item_id as i32, 1)
@@ -2078,6 +2082,9 @@ impl JavaClient {
                             .await;
 
                         player.apply_tool_damage_for_block_break(state).await;
+                        if block_drop {
+                            player.add_exhaustion(MINE_BLOCK_EXHAUSTION).await;
+                        }
                         let item_id = player.inventory().held_item().lock().await.item.id;
                         player
                             .increment_stat(StatisticCategory::Used, item_id as i32, 1)


### PR DESCRIPTION
## Description

**What vanilla does (1.21):** `Player.attack` calls `causeFoodExhaustion(0.1F)` on a hit that lands, and `Block.playerDestroy` calls `causeFoodExhaustion(0.005F)` per block mined.

**What Pumpkin did:** `add_exhaustion` was only ever called from the Hunger status effect and from jumping and sprinting. Attacking and mining cost nothing, so a player could fight and mine indefinitely without the hunger bar moving, and hunger was effectively cosmetic.

**Change:** adds the attack exhaustion at the end of `Player::attack`, and the mining exhaustion at the four player block-break call sites (two Java, two Bedrock).

Everything downstream was already correct and did not need touching: `hunger.rs` matches vanilla `FoodData` (4.0 exhaustion converts to one saturation or food point, the two-tier regen timers, the peaceful check, starvation).

Notes on gating, which is already handled and was not added here:

- `Player::add_exhaustion` early-returns on `abilities.invulnerable`, which `set_for_gamemode` sets for Creative and Spectator. That mirrors vanilla `causeFoodExhaustion`'s `if (!this.abilities.invulnerable)`.
- Peaceful is handled in the hunger tick, as in vanilla `FoodData.tick`.
- The attack path early-returns when `damage_with_context` reports no damage, so a miss costs nothing and sweep secondary victims correctly do not each add exhaustion.

## Testing

- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` and `cargo fmt --check` are clean.

Suggested check: `gamerule natural_health_regeneration false` to isolate, top the player up, then break a few hundred blocks and watch the hunger bar move where it previously did not.

## Known limitations

- **Swimming exhaustion is not included.** `progress_motion` only implements the `onGround` branch of the movement statistics, and adding swimming needs the full else-if chain plus 3D distance, on top of `Player::is_swimming` which is itself an approximation carrying a TODO. Better as its own change than bolted on here.
- **Bare-handed mining costs no exhaustion**, because the call sites sit inside the existing `can_harvest` branch. I believe that matches vanilla, where `destroyBlock` only reaches `playerDestroy` with the correct tool, but I am flagging it as the least certain part of this change rather than asserting it.
- The three constants are from vanilla rather than derived from anything in this repo. Worth a maintainer's eye. Note that the `exhaustion: 0.1` field on `player_attack` in `damage_type.rs` looks like corroboration but is not: that is the victim-side `DamageSource` exhaustion, a separate mechanic which is generated but never read anywhere.
- Not verified on a live server.
