### PR TITLE
feat(block): melt ice in bright light

### DIFF
--- a/pumpkin/src/block/blocks/ice.rs
+++ b/pumpkin/src/block/blocks/ice.rs
@@ -1,0 +1,52 @@
+use pumpkin_data::{Block, dimension::Dimension};
+use pumpkin_macros::pumpkin_block;
+use pumpkin_world::world::BlockFlags;
+
+use crate::block::{BlockBehaviour, BlockFuture, RandomTickArgs};
+
+#[pumpkin_block("minecraft:ice")]
+pub struct IceBlock;
+
+impl BlockBehaviour for IceBlock {
+    fn random_tick<'a>(&'a self, args: RandomTickArgs<'a>) -> BlockFuture<'a, ()> {
+        Box::pin(async move {
+            // `IceBlock.randomTick` melts once the block light exceeds
+            // `11 - state.getLightBlock()`. Java's `getLightBlock()` is `BlockState::opacity`
+            // here, and ice has an opacity of 1, so the effective threshold is a block light
+            // level above 10 (one lower than the flat `> 11` used for snow layers).
+            let opacity = args.world.get_block_state(args.position).opacity;
+            if args.world.get_block_light_level(args.position).unwrap_or(0)
+                <= 11u8.saturating_sub(opacity)
+            {
+                return;
+            }
+
+            // `IceBlock.melt`: ultrawarm dimensions evaporate the ice, everything else leaves
+            // a water source behind. Melting never drops an ice item, so the state is
+            // overwritten instead of broken.
+            if args.world.dimension == Dimension::THE_NETHER {
+                args.world
+                    .set_block_state(
+                        args.position,
+                        Block::AIR.default_state.id,
+                        BlockFlags::NOTIFY_ALL,
+                    )
+                    .await;
+                return;
+            }
+
+            args.world
+                .set_block_state(
+                    args.position,
+                    Block::WATER.default_state.id,
+                    BlockFlags::NOTIFY_ALL,
+                )
+                .await;
+            // `level.neighborChanged(pos, Blocks.WATER, null)`: tell the fresh water source
+            // about its own surroundings so that it starts flowing right away.
+            args.world
+                .update_neighbor(args.position, &Block::WATER)
+                .await;
+        })
+    }
+}

--- a/pumpkin/src/block/blocks/mod.rs
+++ b/pumpkin/src/block/blocks/mod.rs
@@ -85,6 +85,7 @@ pub mod dirt_path;
 pub mod dragon_egg;
 pub mod falling;
 pub mod grass_block;
+pub mod ice;
 pub mod infested;
 pub mod powder_snow;
 pub mod snow;

--- a/pumpkin/src/block/registry.rs
+++ b/pumpkin/src/block/registry.rs
@@ -40,6 +40,7 @@ use crate::block::blocks::glazed_terracotta::GlazedTerracottaBlock;
 use crate::block::blocks::grass_block::GrassBlock;
 use crate::block::blocks::grindstone::GrindstoneBlock;
 use crate::block::blocks::hay::HayBlock;
+use crate::block::blocks::ice::IceBlock;
 use crate::block::blocks::infested::InfestedBlock;
 use crate::block::blocks::iron_bars::IronBarsBlock;
 use crate::block::blocks::jigsaw::JigsawBlock;
@@ -296,6 +297,7 @@ pub fn default_registry() -> Arc<BlockRegistry> {
     manager.register(BarrierBlock);
     manager.register(MangroveRootsBlock);
     manager.register(LayeredSnowBlock);
+    manager.register(IceBlock);
     manager.register(CobwebBlock);
     manager.register(WitherRoseBlock);
     manager.register(FungusBlock);


### PR DESCRIPTION
## Description

**What vanilla does (1.21):** `IceBlock.randomTick` melts ice when the block light exceeds `11 - state.getLightBlock()`. `melt()` sets water in normal dimensions and removes the block in ultrawarm ones, then notifies neighbours. Only `ice` melts; packed ice and blue ice never do.

**What Pumpkin did:** there was no `ice.rs` and no behaviour registered for `Block::ICE`, so the random tick was delivered and discarded. Ice next to a torch never turned to water, and ice placed in the Nether persisted.

**Change:** adds `IceBlock` with a `random_tick`, mirroring the existing `snow.rs` melt structure, and registers it.

**On the light threshold.** This is `11 - opacity` computed from the live state rather than hardcoded. `BlockState::opacity` is Pumpkin's generated equivalent of vanilla `getLightBlock` (its own doc says "how much light is subtracted as it passes through this block"), and the lighting engine uses that same field as the per-block attenuation. `minecraft:ice` is generated with `opacity: 1`, so the effective threshold is block light `> 10`, one lower than snow's flat `> 11`. Spot checks line up with vanilla: stone 15, glass 0, water 1, packed ice and blue ice 15.

`state_flags` confirms the scope: `ice` carries the random-tick bit while `packed_ice` and `blue_ice` do not, matching vanilla.

This uses `set_block_state` rather than `break_block`, because vanilla's `melt()` drops nothing; `break_block` would have wrongly dropped an ice item.

## Testing

- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` and `cargo fmt --check` are clean.

Suggested check:

```
setblock 100 70 100 ice
setblock 101 70 100 torch
# after a random tick
execute if block 100 70 100 water run say melted
```

## Known limitations

- **Ultrawarm is detected as "is the Nether"**, because `Dimension` has no `ultrawarm` field. That follows the existing convention in `block/fluid/lava.rs`, which does the same with the same comment. A custom datapack dimension declaring `ultrawarm: true` would melt to water rather than evaporating.
- `IceBlock.playerDestroy`, where mining ice without Silk Touch leaves water, is still unimplemented and out of scope here.
- The melt formula's shape is recalled from vanilla rather than read from a source in this repo; the constant itself is derived from the generated data as described above.
- Not verified on a live server.
