### PR TITLE
fix: let console and RCON run /fill and /setworldspawn

### DIFF
--- a/pumpkin/src/command/commands/fill.rs
+++ b/pumpkin/src/command/commands/fill.rs
@@ -272,7 +272,9 @@ impl CommandExecutor for Executor {
             let mut context = Context {
                 block_state_id,
                 option_filter: BlockPredicateArgumentConsumer::find_arg(args, ARG_FILTER)?,
-                world: sender.world().ok_or(CommandError::InvalidRequirement)?,
+                world: sender
+                    .world_or_first(server)
+                    .ok_or(CommandError::InvalidRequirement)?,
                 placed_blocks: 0,
                 to_update: Vec::new(),
 

--- a/pumpkin/src/command/commands/setblock.rs
+++ b/pumpkin/src/command/commands/setblock.rs
@@ -43,18 +43,9 @@ impl CommandExecutor for Executor {
             let block = BlockArgumentConsumer::find_arg(args, ARG_BLOCK)?;
             let block_state_id = block.default_state.id;
             let mode = self.0;
-            let world = match sender {
-                CommandSender::Console | CommandSender::Rcon(_) | CommandSender::Dummy => {
-                    let guard = server.worlds.load();
-
-                    guard
-                        .first()
-                        .cloned()
-                        .ok_or(CommandError::InvalidRequirement)?
-                }
-                CommandSender::Player(player) => player.world().clone(),
-                CommandSender::CommandBlock(_, w) => w.clone(),
-            };
+            let world = sender
+                .world_or_first(server)
+                .ok_or(CommandError::InvalidRequirement)?;
             let pos = BlockPosArgumentConsumer::find_loaded_arg(args, ARG_BLOCK_POS, &world)?;
 
             let success = match mode {

--- a/pumpkin/src/command/commands/setworldspawn.rs
+++ b/pumpkin/src/command/commands/setworldspawn.rs
@@ -102,7 +102,7 @@ async fn setworldspawn(
     yaw: f32,
     pitch: f32,
 ) -> Result<i32, CommandError> {
-    let Some(world) = sender.world() else {
+    let Some(world) = sender.world_or_first(server) else {
         return Err(CommandError::CommandFailed(TextComponent::text(
             "Failed to get world.",
         )));

--- a/pumpkin/src/command/commands/teleport.rs
+++ b/pumpkin/src/command/commands/teleport.rs
@@ -57,14 +57,9 @@ fn resolve_sender_world(
     sender: &CommandSender,
     server: &crate::server::Server,
 ) -> std::sync::Arc<World> {
-    sender.world().unwrap_or_else(|| {
-        server
-            .worlds
-            .load()
-            .first()
-            .expect("Server should have at least one world")
-            .clone()
-    })
+    sender
+        .world_or_first(server)
+        .expect("Server should have at least one world")
 }
 
 struct EntitiesToEntityExecutor;

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -223,11 +223,24 @@ impl CommandSender {
     #[must_use]
     pub fn world(&self) -> Option<Arc<World>> {
         match self {
-            // TODO: maybe return first world when console
+            // These senders are not bound to a world. Use `world_or_first` to
+            // fall back to the first world instead.
             Self::Console | Self::Rcon(..) | Self::Dummy => None,
             Self::Player(p) => Some(p.living_entity.entity.world.load_full()),
             Self::CommandBlock(_, w) => Some(w.clone()),
         }
+    }
+
+    /// Returns the world this sender acts in, falling back to the server's
+    /// first world for senders that are not bound to one.
+    ///
+    /// Console, RCON and dummy senders have no world of their own, so like
+    /// vanilla they operate on the first (overworld) world. Returns [`None`]
+    /// only when the server has no worlds loaded at all.
+    #[must_use]
+    pub fn world_or_first(&self, server: &Server) -> Option<Arc<World>> {
+        self.world()
+            .or_else(|| server.worlds.load().first().cloned())
     }
 
     #[must_use]


### PR DESCRIPTION
## What

`/fill` and `/setworldspawn` fail from the server console and RCON. `/setblock` at the same coordinates works, which is what makes it look like a bug rather than a restriction.

Reproduced on a live server over RCON:

```
setblock 8 101 8 minecraft:stone     => Block placed
fill 5 101 5 7 101 7 minecraft:stone => Internal error (See logs for details)
```

with this in the log:

```
ERROR pumpkin::command::dispatcher: Error while parsing command
"fill 5 101 5 7 101 7 minecraft:stone": a requirement that was expected was not met.
```

## Why

`CommandSender::world()` returns `None` for console and RCON, with the fix already noted as a TODO:

```rust
pub fn world(&self) -> Option<Arc<World>> {
    match self {
        // TODO: maybe return first world when console
        Self::Console | Self::Rcon(..) | Self::Dummy => None,
```

`fill.rs` and `setworldspawn.rs` then do `sender.world().ok_or(CommandError::InvalidRequirement)?` and fail.

The intended behaviour is already established elsewhere in the tree: `setblock.rs`, `item.rs`, `particle.rs` and `summon.rs` each carry their own inline copy falling back to `server.worlds.load().first()`, and `teleport.rs` has a private `resolve_sender_world` helper doing the same. `CommandSender::into_source` already routes `Dummy` through `get_world_and_spawn_point`. So five call sites had independently worked around the `None`, and the two that did not are the two that are broken. Vanilla behaves the same way: server-console commands default to the overworld.

## How

Adds `CommandSender::world_or_first(&self, server: &Server)`, which is `world()` with the first-world fallback, and points the failing call sites at it.

`world()` itself is deliberately left alone. It is part of the versioned WASM plugin ABI (`wit/v0_1`, `world() -> option<world>`), so changing its signature or semantics would break already-published v0.1 plugins. The new method is purely additive.

Also folds the duplicate logic in `setblock.rs` and `teleport.rs` into the shared helper. Both keep their exact previous behaviour: `setblock` still returns `InvalidRequirement` on an empty world list, and `teleport` still panics there rather than converting to an error, since changing that would alter error semantics at four sites for a condition that cannot occur in practice.

`item.rs`, `particle.rs` and `summon.rs` are left as-is. They compute a default spawn position inside the same match, so they are not pure world lookups and folding them in would widen this past a bug fix. Happy to do it in a follow-up.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` both clean.

Not yet re-run against a live server with this patch applied; the reproduction above is from the unpatched build. I will confirm the `/fill` case on my test server and report back.
