### PR TITLE
fix: stop bedrock players from swimming in air

### DIFF
--- a/crates/pumpkin-protocol/src/bedrock/client/set_actor_data.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/set_actor_data.rs
@@ -32,11 +32,7 @@ impl Default for EntityMetadata {
 impl EntityMetadata {
     #[must_use]
     pub fn new() -> Self {
-        let mut map = HashMap::new();
-        map.insert(entity_data_key::FLAGS, MetadataValue::Long(0));
-        map.insert(entity_data_key::FLAGS_TWO, MetadataValue::Long(0));
-        map.insert(entity_data_key::PLAYER_FLAGS, MetadataValue::Byte(0));
-        Self(map)
+        Self(HashMap::new())
     }
 }
 
@@ -431,4 +427,18 @@ pub mod entity_data_flag {
     pub const CAN_USE_VERTICAL_MOVEMENT_ACTION: u32 = 125;
     pub const ROTATION_LOCKED_TO_VEHICLE: u32 = 126;
     pub const COUNT: u32 = 127;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EntityMetadata, entity_data_key};
+
+    #[test]
+    fn partial_metadata_does_not_reset_flags() {
+        let metadata = EntityMetadata::new();
+
+        assert!(!metadata.0.contains_key(&entity_data_key::FLAGS));
+        assert!(!metadata.0.contains_key(&entity_data_key::FLAGS_TWO));
+        assert!(!metadata.0.contains_key(&entity_data_key::PLAYER_FLAGS));
+    }
 }

--- a/crates/pumpkin/src/entity/breath.rs
+++ b/crates/pumpkin/src/entity/breath.rs
@@ -71,7 +71,8 @@ impl BreathManager {
             let new_air = (prev - AIR_DEPLETION_RATE).max(0);
             if new_air != prev {
                 self.air_supply.store(new_air, Ordering::Relaxed);
-                if let Some(server) = player.world().server.upgrade() {
+                let server = player.world().server.upgrade();
+                if let Some(server) = server {
                     let mut event = crate::plugin::api::events::entity::entity_air_change::EntityAirChangeEvent::new(
                         player.entity_id(),
                         new_air,

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -475,12 +475,12 @@ impl LivingEntity {
             self.heal(heal_amount);
         } else if effect.effect_type == &StatusEffect::INSTANT_DAMAGE {
             let damage_amount = 6.0 * (1 << effect.amplifier) as f32;
-            if let Some(dyn_self) = self
+            let dyn_self = self
                 .entity
                 .world
                 .load()
-                .get_entity_by_id(self.entity.entity_id)
-            {
+                .get_entity_by_id(self.entity.entity_id);
+            if let Some(dyn_self) = dyn_self {
                 dyn_self
                     .damage(&*dyn_self, damage_amount, DamageType::MAGIC)
                     .await;
@@ -1679,12 +1679,12 @@ impl LivingEntity {
             }
         } else if effect_type == &StatusEffect::WITHER {
             let damage_amount = 1.0;
-            if let Some(dyn_self) = self
+            let dyn_self = self
                 .entity
                 .world
                 .load()
-                .get_entity_by_id(self.entity.entity_id)
-            {
+                .get_entity_by_id(self.entity.entity_id);
+            if let Some(dyn_self) = dyn_self {
                 dyn_self
                     .damage(&*dyn_self, damage_amount, DamageType::WITHER)
                     .await;

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -2899,6 +2899,14 @@ impl Entity {
             let pose = pose as i32;
             let mut bedrock_meta = EntityMetadata::new();
             bedrock_meta.set(entity_data_key::POSE_INDEX, MetadataValue::Int(pose));
+            bedrock_meta.set(
+                entity_data_key::WIDTH,
+                MetadataValue::Float(dimension.width),
+            );
+            bedrock_meta.set(
+                entity_data_key::HEIGHT,
+                MetadataValue::Float(dimension.height),
+            );
             self.send_meta_data(
                 &[Metadata::new(
                     TrackedData::POSE,

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -4003,7 +4003,8 @@ impl Player {
             self.close_handled_screen().await;
         }
 
-        if let Some(server) = self.world().server.upgrade() {
+        let server = self.world().server.upgrade();
+        if let Some(server) = server {
             let mut event =
                 crate::plugin::api::events::inventory::inventory_open::InventoryOpenEvent::new(
                     self.clone(),

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -1738,12 +1738,11 @@ impl Player {
 
     async fn is_swimming(&self, flying: bool) -> bool {
         let entity = self.get_entity();
-        let swim_height = self.living_entity.get_swim_height();
+        let touching_water = entity.touching_water.load(Ordering::Relaxed);
+        let can_start_swimming = entity.water_height.load() > self.living_entity.get_swim_height();
 
-        // TODO: Replace this inferred check with vanilla-equivalent swimming state tracking
-        // (LivingEntity#updateSwimming + entity swimming flag).
-        entity.touching_water.load(Ordering::Relaxed)
-            && entity.water_height.load() > swim_height
+        touching_water
+            && (entity.swimming.load(Ordering::Relaxed) || can_start_swimming)
             && entity.is_sprinting()
             && !entity.on_ground.load(Ordering::Relaxed)
             && !flying
@@ -1773,9 +1772,11 @@ impl Player {
         }
 
         let flying = self.is_flying().await;
+        let swimming = self.is_swimming(flying).await;
+        entity.set_swimming(swimming).await;
         let desired_pose = if self.is_sleeping() {
             EntityPose::Sleeping
-        } else if self.is_swimming(flying).await {
+        } else if swimming {
             EntityPose::Swimming
         } else if entity.is_fall_flying() {
             EntityPose::FallFlying

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -2229,7 +2229,8 @@ impl Player {
         packet_id: i32,
         payload: Bytes,
     ) -> bool {
-        if let Some(server) = self.world().server.upgrade() {
+        let server = self.world().server.upgrade();
+        if let Some(server) = server {
             let mut event =
                 PacketSentEvent::new(self.clone(), packet_id, payload, Arc::new(packet));
             server.plugin_manager.fire(&server, &mut event).await;
@@ -2239,7 +2240,8 @@ impl Player {
     }
 
     pub async fn fire_packet_sent_no_obj(self: &Arc<Self>, packet_id: i32, payload: Bytes) -> bool {
-        if let Some(server) = self.world().server.upgrade() {
+        let server = self.world().server.upgrade();
+        if let Some(server) = server {
             // This is a dummy object to satisfy the non-optional requirement in WIT
             // In the future we should make all packets 'static or have a way to represent raw packets in WIT
             struct RawPacket;
@@ -3794,7 +3796,8 @@ impl Player {
 
     /// Add experience points to the player.
     pub async fn add_experience_points(self: &Arc<Self>, mut added_points: i32) {
-        if let Some(server) = self.world().server.upgrade() {
+        let server = self.world().server.upgrade();
+        if let Some(server) = server {
             let mut event = PlayerExpChangeEvent::new(self.clone(), added_points);
             server.plugin_manager.fire(&server, &mut event).await;
             added_points = event.amount;
@@ -3930,7 +3933,8 @@ impl Player {
             wt
         };
 
-        if let Some(server) = self.living_entity.entity.world.load().server.upgrade() {
+        let server = self.living_entity.entity.world.load().server.upgrade();
+        if let Some(server) = server {
             let mut event =
                 crate::plugin::api::events::player::inventory_close::InventoryCloseEvent::new(
                     self,
@@ -4363,7 +4367,8 @@ impl Player {
         drop(perm_manager);
 
         let mut event = PlayerPermissionCheckEvent::new(self.clone(), node.to_string(), result);
-        if let Some(server_arc) = self.world().server.upgrade() {
+        let server_arc = self.world().server.upgrade();
+        if let Some(server_arc) = server_arc {
             server_arc
                 .plugin_manager
                 .fire(&server_arc, &mut event)
@@ -5657,7 +5662,8 @@ impl InventoryPlayer for Player {
             debug!("Player::award_experience called with amount={amount}");
             if amount > 0 {
                 debug!("Player: adding {amount} experience points");
-                if let Some(player) = self.world().get_player_by_uuid(self.gameprofile.id) {
+                let player = self.world().get_player_by_uuid(self.gameprofile.id);
+                if let Some(player) = player {
                     player.add_experience_points(amount).await;
                 }
             }

--- a/crates/pumpkin/src/item/items/ignite/flint_and_steel.rs
+++ b/crates/pumpkin/src/item/items/ignite/flint_and_steel.rs
@@ -35,8 +35,10 @@ impl ItemBehaviour for FlintAndSteelItem {
         _server: &'a Server,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
         Box::pin(async move {
-            if let Some(server_ref) = player.world().server.upgrade() {
-                let player_arc = player.world().get_player_by_uuid(player.gameprofile.id);
+            let world = player.world();
+            let server_ref = world.server.upgrade();
+            if let Some(server_ref) = server_ref {
+                let player_arc = world.get_player_by_uuid(player.gameprofile.id);
                 let mut event =
                     crate::plugin::api::events::block::block_ignite::BlockIgniteEvent::new(
                         location,

--- a/crates/pumpkin/src/net/bedrock/play.rs
+++ b/crates/pumpkin/src/net/bedrock/play.rs
@@ -1802,7 +1802,8 @@ impl BedrockClient {
             return;
         }
         let previous_slot = player.inventory.get_selected_slot();
-        if let Some(server) = player.world().server.upgrade() {
+        let server = player.world().server.upgrade();
+        if let Some(server) = server {
             let mut event = PlayerItemHeldEvent::new(player.clone(), previous_slot, slot);
             server.plugin_manager.fire(&server, &mut event).await;
             let is_cancelled = {

--- a/crates/pumpkin/src/net/java/play.rs
+++ b/crates/pumpkin/src/net/java/play.rs
@@ -849,7 +849,8 @@ impl JavaClient {
             return;
         }
         let pos = command.pos;
-        if let Some(block_entity) = player.world().get_block_entity(&pos) {
+        let block_entity = player.world().get_block_entity(&pos);
+        if let Some(block_entity) = block_entity {
             if block_entity.resource_location() != CommandBlockEntity::ID {
                 warn!("Client tried to change Command block but not Command block entity found");
                 return;
@@ -937,7 +938,8 @@ impl JavaClient {
             return;
         }
         let pos = jigsaw.pos;
-        if let Some(block_entity) = player.world().get_block_entity(&pos) {
+        let block_entity = player.world().get_block_entity(&pos);
+        if let Some(block_entity) = block_entity {
             if block_entity.resource_location() != JigsawBlockEntity::ID {
                 warn!("Client tried to change Jigsaw block but not Jigsaw block entity found");
                 return;

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
@@ -995,16 +995,16 @@ pub struct CustomWasmGoal {
     pub goal_id: u32,
 }
 
+fn current_mob_entity(mob: &dyn Mob) -> Option<Arc<dyn crate::entity::EntityBase>> {
+    let entity = mob.get_entity();
+    entity.world.load().get_entity_by_id(entity.entity_id)
+}
+
 impl Goal for CustomWasmGoal {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async {
             let mut store = self.plugin.store.lock().await;
-            if let Some(entity_arc) = mob
-                .get_entity()
-                .world
-                .load()
-                .get_entity_by_id(mob.get_entity().entity_id)
-            {
+            if let Some(entity_arc) = current_mob_entity(mob) {
                 match self.plugin.plugin_instance {
                     PluginInstance::V0_1(ref plugin) => {
                         let server = store.data_mut().server.clone().unwrap();
@@ -1030,12 +1030,7 @@ impl Goal for CustomWasmGoal {
     fn should_continue<'a>(&'a self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async {
             let mut store = self.plugin.store.lock().await;
-            if let Some(entity_arc) = mob
-                .get_entity()
-                .world
-                .load()
-                .get_entity_by_id(mob.get_entity().entity_id)
-            {
+            if let Some(entity_arc) = current_mob_entity(mob) {
                 match self.plugin.plugin_instance {
                     PluginInstance::V0_1(ref plugin) => {
                         let server = store.data_mut().server.clone().unwrap();
@@ -1061,12 +1056,7 @@ impl Goal for CustomWasmGoal {
     fn start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
         Box::pin(async {
             let mut store = self.plugin.store.lock().await;
-            if let Some(entity_arc) = mob
-                .get_entity()
-                .world
-                .load()
-                .get_entity_by_id(mob.get_entity().entity_id)
-            {
+            if let Some(entity_arc) = current_mob_entity(mob) {
                 match self.plugin.plugin_instance {
                     PluginInstance::V0_1(ref plugin) => {
                         let server = store.data_mut().server.clone().unwrap();
@@ -1089,12 +1079,7 @@ impl Goal for CustomWasmGoal {
     fn tick<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
         Box::pin(async {
             let mut store = self.plugin.store.lock().await;
-            if let Some(entity_arc) = mob
-                .get_entity()
-                .world
-                .load()
-                .get_entity_by_id(mob.get_entity().entity_id)
-            {
+            if let Some(entity_arc) = current_mob_entity(mob) {
                 match self.plugin.plugin_instance {
                     PluginInstance::V0_1(ref plugin) => {
                         let server = store.data_mut().server.clone().unwrap();
@@ -1117,12 +1102,7 @@ impl Goal for CustomWasmGoal {
     fn stop<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
         Box::pin(async {
             let mut store = self.plugin.store.lock().await;
-            if let Some(entity_arc) = mob
-                .get_entity()
-                .world
-                .load()
-                .get_entity_by_id(mob.get_entity().entity_id)
-            {
+            if let Some(entity_arc) = current_mob_entity(mob) {
                 match self.plugin.plugin_instance {
                     PluginInstance::V0_1(ref plugin) => {
                         let server = store.data_mut().server.clone().unwrap();

--- a/crates/pumpkin/src/server/mod.rs
+++ b/crates/pumpkin/src/server/mod.rs
@@ -414,11 +414,12 @@ impl Server {
     pub async fn create_world(self: &Arc<Self>, name: String, dimension: Dimension) -> Arc<World> {
         {
             let worlds = self.worlds.load();
-            if let Some(world) = worlds
+            let world = worlds
                 .iter()
                 .find(|w| w.get_world_name() == name && w.dimension == dimension)
-            {
-                return world.clone();
+                .cloned();
+            if let Some(world) = world {
+                return world;
             }
         }
 

--- a/crates/pumpkin/src/world/dragon_fight.rs
+++ b/crates/pumpkin/src/world/dragon_fight.rs
@@ -688,8 +688,12 @@ impl DragonFight {
             .collect();
 
         for uid in &to_remove {
-            if let Some(p) = players.iter().find(|p| &p.gameprofile.id == uid) {
-                p.remove_bossbar(self.bossbar_uuid).await;
+            let player = players
+                .iter()
+                .find(|player| &player.gameprofile.id == uid)
+                .cloned();
+            if let Some(player) = player {
+                player.remove_bossbar(self.bossbar_uuid).await;
             }
             self.bossbar_players.retain(|u| u != uid);
         }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -4146,10 +4146,10 @@ impl World {
         self.players.rcu(|current_list| {
             let mut new_list = (**current_list).clone();
             // Find the player before we filter them out
-            if let Some(pos) = new_list
+            let pos = new_list
                 .iter()
-                .position(|p| p.gameprofile.id == player.gameprofile.id)
-            {
+                .position(|p| p.gameprofile.id == player.gameprofile.id);
+            if let Some(pos) = pos {
                 removed_player = Some(new_list.remove(pos));
             }
             new_list


### PR DESCRIPTION
## Description
- Built on this PR so clients with version 26.30 can connect: https://github.com/Pumpkin-MC/Pumpkin/pull/2450
- Bedrock players were able to swim in air after breaking the water surface. Issue was caused by EntityMetadata inserting these:
`FLAGS = 0`
`FLAGS_TWO = 0`
`PLAYER_FLAGS = 0`
- From what I gather they are responsible for swimming pose changes but they also clear gravity once the player surfaces which results in them swimming in the air. This PR fixes this issue.

## Testing
- cargo test -p pumpkin-protocol
- cargo test -p pumpkin-world bedrock_palette
- cargo fmt --all -- --check
- Connected using Bedrock 26.30, dove into water, surfaced and tried to swim upwards into the air. Could not. Issue is fixed. 