### PR TITLE
fix: make the weather cycle actually run, and only where it should

### DIFF
--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1151,6 +1151,10 @@ impl World {
             )
         };
 
+        // This guard is held across the awaits below, including the `level_time` lock taken in
+        // the night-skip branch, so it establishes a `weather` -> `level_time` lock order.
+        // Nothing may take the `weather` lock while holding `level_time`, or the two paths can
+        // deadlock.
         let mut weather = self.weather.lock().await;
         weather.tick_weather(self);
 

--- a/pumpkin/src/world/weather.rs
+++ b/pumpkin/src/world/weather.rs
@@ -78,24 +78,34 @@ impl Weather {
     }
 
     pub fn tick_weather(&mut self, world: &World) {
-        if !self.weather_cycle_enabled {
-            self.advance_weather_cycle();
-        }
+        // Re-read the weather cycle game rule every tick so changes apply without a restart.
+        self.weather_cycle_enabled = world.level_info.load().game_rules.advance_weather;
 
-        // Update visual transitions
-        self.old_rain_level = self.rain_level;
-        self.old_thunder_level = self.thunder_level;
+        // Vanilla wraps both the cycle and the level interpolation in
+        // `if (this.dimensionType().hasSkyLight())`, so a dimension without sky light (the
+        // Nether) never rolls into rain or a thunderstorm and its levels stay frozen. The
+        // broadcasts below stay outside the gate, as in vanilla: with the levels frozen the
+        // old and new values are equal, so nothing is ever sent for such a dimension anyway.
+        if world.dimension.has_skylight {
+            if self.weather_cycle_enabled {
+                self.advance_weather_cycle(world);
+            }
 
-        if self.raining {
-            self.rain_level = (self.rain_level + WEATHER_TRANSITION_SPEED).min(1.0);
-        } else {
-            self.rain_level = (self.rain_level - WEATHER_TRANSITION_SPEED).max(0.0);
-        }
+            // Update visual transitions
+            self.old_rain_level = self.rain_level;
+            self.old_thunder_level = self.thunder_level;
 
-        if self.thundering {
-            self.thunder_level = (self.thunder_level + WEATHER_TRANSITION_SPEED).min(1.0);
-        } else {
-            self.thunder_level = (self.thunder_level - WEATHER_TRANSITION_SPEED).max(0.0);
+            if self.raining {
+                self.rain_level = (self.rain_level + WEATHER_TRANSITION_SPEED).min(1.0);
+            } else {
+                self.rain_level = (self.rain_level - WEATHER_TRANSITION_SPEED).max(0.0);
+            }
+
+            if self.thundering {
+                self.thunder_level = (self.thunder_level + WEATHER_TRANSITION_SPEED).min(1.0);
+            } else {
+                self.thunder_level = (self.thunder_level - WEATHER_TRANSITION_SPEED).max(0.0);
+            }
         }
 
         // Broadcast level changes if needed
@@ -114,8 +124,9 @@ impl Weather {
         }
     }
 
-    fn advance_weather_cycle(&mut self) {
-        // Removed async since there are no await calls
+    fn advance_weather_cycle(&mut self, world: &World) {
+        let was_raining = self.raining;
+
         if self.clear_weather_time > 0 {
             self.clear_weather_time -= 1;
             self.thunder_time = i32::from(!self.thundering);
@@ -148,10 +159,28 @@ impl Weather {
                 self.rain_time = rand::rng().random_range(RAIN_DELAY_MIN..=RAIN_DELAY_MAX);
             }
         }
+
+        // Vanilla broadcasts the rain state whenever the natural cycle flips it, otherwise
+        // clients never learn that it started or stopped raining. This uses the same
+        // transition check `set_weather_parameters` does for the `/weather` command path.
+        // The packet order is not identical to vanilla: vanilla sends the level packets, then
+        // the begin/end event, then the levels again, and it re-sends the levels
+        // unconditionally, while we send begin/end here and only send a level packet when the
+        // value actually changed. Clients handle either order.
+        if was_raining != self.raining {
+            if was_raining {
+                world.broadcast_packet_all(&CGameEvent::new(GameEvent::EndRaining, 0.0));
+            } else {
+                world.broadcast_packet_all(&CGameEvent::new(GameEvent::BeginRaining, 0.0));
+            }
+        }
     }
 
     pub fn reset_weather_cycle(&mut self, world: &World) {
-        self.set_weather_parameters(world, 0, 0, false, false);
+        // Vanilla's `resetWeatherCycle` only clears the rain and thunder state; it leaves
+        // `clearWeatherTime` alone, so sleeping through the night must not cancel an active
+        // `/weather clear <duration>`.
+        self.set_weather_parameters(world, self.clear_weather_time, 0, false, false);
     }
 }
 


### PR DESCRIPTION
## What

Weather never starts on its own. `/weather rain` works, but a server left alone stays clear forever.

## Why

`Weather::tick_weather` had:

```rust
if !self.weather_cycle_enabled {
    self.advance_weather_cycle();
}
```

The condition is inverted relative to vanilla, and `weather_cycle_enabled` was initialised to `true` and then never written by anything. So the expression was always `false` and `advance_weather_cycle` has never executed in this codebase. The rain and thunder timers never counted down.

It was also not connected to the game rule at all. `advance_weather` (the 25w44a rename of `doWeatherCycle`) was simply never read.

## How

Read `advance_weather` from the game rules each tick and correct the condition.

Because this resurrects a function that had never run, two things downstream of it had to be fixed in the same change, or turning it on would be a regression:

**Sky light gate.** `Server::tick_worlds` ticks every loaded dimension and each has its own `Mutex<Weather>`, so with the cycle live the Nether would independently roll into thunderstorms. It would also be unclearable, since `/weather` only touches `worlds.first()`. Vanilla wraps the whole weather update in `if (dimensionType().hasSkyLight())`, so this does the same, gating both the cycle and the rain and thunder level interpolation. The level broadcasts stay outside the gate, matching vanilla's control flow; with the interpolation frozen the old and new values stay equal so they never fire anyway.

**Transition broadcast.** `advance_weather_cycle` flipped `raining` and broadcast nothing. Only `set_weather_parameters`, the `/weather` path, sent `BeginRaining` and `EndRaining`. So naturally occurring weather would have changed on the server while every client still believed it was clear. It now sends the same events on transition, mirroring vanilla's `if (bl != this.isRaining())` block.

Also, `reset_weather_cycle` routed through `set_weather_parameters` with `clear_weather_time` zeroed, so sleeping through the night cancelled an active `/weather clear <duration>`. Vanilla's `resetWeatherCycle` deliberately leaves that field alone. Fixed.

## Notes

The reroll ranges are unchanged. I briefly "fixed" them to `nextInt(bound) + base` semantics before checking the version: since 23w03a vanilla uses `UniformInt.of(min, max)` through `Mth.randomBetweenInclusive`, so the existing inclusive `..=` bounds against 180000 / 24000 / 15600 were already exactly right.

Pre-existing issues I found while working on this and deliberately did not fold in:

- Weather state is never persisted to `level.dat`, so it resets on restart.
- The join handshake only sends weather state `if weather.raining`, dropping a thundering-but-not-raining state.
- `tick_spawning_chunk` gates lightning on the raw `raining && thundering` booleans rather than vanilla's `rainLevel > 0.2` / `thunderLevel > 0.9`, and is missing the `isRainingAt` heightmap, sky-visibility and biome-precipitation checks (there is a `// TODO` and an `if true` there today). That last one means the End, whose dimension type does have sky light in 26.x, can still get lightning. It needs its own change.
- `tick_environment` holds the weather lock across awaits, establishing a weather then level_time lock order. I added a comment noting it rather than restructuring.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

Not verified in game. Natural rain is up to 150 minutes out by design, which makes it impractical to observe on a test server; the parts I could check statically are the gate, the broadcast and the game rule wiring. Happy to be told if the sky light gate should be scoped differently.
