### PR TITLE
feat: add multi-instance hosting core API

### DIFF
--- a/pumpkin-config/src/advancement.rs
+++ b/pumpkin-config/src/advancement.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for advancements
 ///
 /// Controls whether the advancements should be saved and loaded
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct AdvancementConfig {
     /// Whether saving advancements is enabled.

--- a/pumpkin-config/src/chat.rs
+++ b/pumpkin-config/src/chat.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for in-game chat behaviour.
 ///
 /// Controls chat formatting and display.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct ChatConfig {
     /// The custom chat format.

--- a/pumpkin-config/src/commands.rs
+++ b/pumpkin-config/src/commands.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Controls how commands are accepted, logged, and which permission
 /// level non-operator players receive by default.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct CommandsConfig {
     /// Whether commands from the console are accepted.

--- a/pumpkin-config/src/fun.rs
+++ b/pumpkin-config/src/fun.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Let's face it, the only reason we play this game is because of fun. 🙃
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct FunConfig {
     /// Whether April Fools features are enabled.

--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -48,7 +48,7 @@ use player_data::PlayerDataConfig;
 use resource_pack::ResourcePackConfig;
 use world::LevelConfig;
 
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct PumpkinConfig {
     #[serde(flatten)]
@@ -116,7 +116,7 @@ impl LoadConfiguration for PumpkinConfig {
 /// tweaking performance or experimental options.
 ///
 /// `Important`: The configuration should match vanilla by default.
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct AdvancedConfiguration {
     /// Logging-related configuration such as log levels and output behaviour.
@@ -150,7 +150,7 @@ pub struct AdvancedConfiguration {
 /// Basic configuration for core server settings.
 ///
 /// Covers edition support, world, networking, gameplay rules, and security options.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct BasicConfiguration {
     /// The seed for the world generation.

--- a/pumpkin-config/src/logging.rs
+++ b/pumpkin-config/src/logging.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for server logging behavior.
 ///
 /// Controls log output, formatting, and file settings.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct LoggingConfig {
     /// Whether logging is enabled.

--- a/pumpkin-config/src/networking/lan_broadcast.rs
+++ b/pumpkin-config/src/networking/lan_broadcast.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for LAN broadcast of the server.
 ///
 /// Controls whether the server is discoverable on the local network, and optional MOTD and port settings.
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct LANBroadcastConfig {
     /// Whether LAN broadcast is enabled.

--- a/pumpkin-config/src/networking/mod.rs
+++ b/pumpkin-config/src/networking/mod.rs
@@ -20,7 +20,7 @@ pub mod rcon;
 ///
 /// Covers authentication, query, RCON, proxying, packet compression,
 /// and LAN broadcast behaviour.
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct NetworkingConfig {
     /// Query protocol settings for server status requests.

--- a/pumpkin-config/src/networking/proxy.rs
+++ b/pumpkin-config/src/networking/proxy.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for proxy support.
 ///
 /// Allows integration with proxy servers like Velocity and `BungeeCord`.
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct ProxyConfig {
     /// Whether proxy support is enabled.
@@ -15,7 +15,7 @@ pub struct ProxyConfig {
 }
 
 /// Configuration for `BungeeCord` proxy integration.
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct BungeeCordConfig {
     /// Whether `BungeeCord` support is enabled.
@@ -23,7 +23,7 @@ pub struct BungeeCordConfig {
 }
 
 /// Configuration for Velocity proxy integration.
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct VelocityConfig {
     /// Whether Velocity support is enabled.

--- a/pumpkin-config/src/networking/query.rs
+++ b/pumpkin-config/src/networking/query.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the server query protocol (legacy Minecraft query).
 ///
 /// Controls whether the query service is enabled and which address it binds to.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct QueryConfig {
     /// Whether the query protocol is enabled.

--- a/pumpkin-config/src/player_data.rs
+++ b/pumpkin-config/src/player_data.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for player data persistence.
 ///
 /// Controls whether player data is saved and the save interval.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct PlayerDataConfig {
     /// Whether saving player data is enabled.

--- a/pumpkin-config/src/plugins.rs
+++ b/pumpkin-config/src/plugins.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct PluginsConfig {
     /// List of permissions that are globally blocked for all plugins.

--- a/pumpkin-config/src/pvp.rs
+++ b/pumpkin-config/src/pvp.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for player-versus-player mechanics.
 ///
 /// Controls whether PVP is enabled, combat effects, and player protections.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct PVPConfig {
     /// Whether PVP is enabled on the server.

--- a/pumpkin-config/src/recipe.rs
+++ b/pumpkin-config/src/recipe.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Recipe-related configuration.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct RecipeConfig {
     /// Whether recipes are sent to clients, enabling the recipe book.

--- a/pumpkin-config/src/resource_pack.rs
+++ b/pumpkin-config/src/resource_pack.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct ResourcePackConfig {
     pub java: JavaResourcePackConfig,
@@ -9,7 +9,7 @@ pub struct ResourcePackConfig {
 }
 
 /// Java-specific resource pack configuration (Single URL/Hash)
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct JavaResourcePackConfig {
     /// Whether the resource pack system is enabled.
@@ -25,7 +25,7 @@ pub struct JavaResourcePackConfig {
 }
 
 /// Bedrock-specific configuration (Supports multiple local/remote packs)
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(default)]
 pub struct BedrockResourcePackConfig {
     pub enabled: bool,
@@ -35,7 +35,7 @@ pub struct BedrockResourcePackConfig {
     pub packs: Vec<BedrockPack>,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct BedrockPack {
     pub uuid: Uuid,
     pub version: String,

--- a/pumpkin-config/src/server_links.rs
+++ b/pumpkin-config/src/server_links.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 ///
 /// Controls default URLs for bug reports, support, community, and other resources,
 /// as well as allowing custom links.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct ServerLinksConfig {
     /// Whether server links are enabled.

--- a/pumpkin-world/examples/join_burst.rs
+++ b/pumpkin-world/examples/join_burst.rs
@@ -69,7 +69,9 @@ fn thread_cpu_ticks(name: &str) -> u64 {
             continue;
         };
         // comm is parenthesised and may contain spaces; split on the last ')'.
-        let Some(close) = stat.rfind(')') else { continue };
+        let Some(close) = stat.rfind(')') else {
+            continue;
+        };
         let Some(open) = stat.find('(') else { continue };
         if &stat[open + 1..close] != name {
             continue;
@@ -101,9 +103,9 @@ async fn main() {
         42,
         None,
     );
-    level
-        .world_portal
-        .store(Arc::new(Some(Arc::new(StubPortal) as Arc<dyn WorldPortalExt>)));
+    level.world_portal.store(Arc::new(Some(
+        Arc::new(StubPortal) as Arc<dyn WorldPortalExt>
+    )));
 
     // Let the chunk-system threads reach their idle park before measuring.
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;

--- a/pumpkin-world/examples/join_burst.rs
+++ b/pumpkin-world/examples/join_burst.rs
@@ -1,0 +1,143 @@
+//! Reproduction harness for the chunk-scheduler busy-spin.
+//!
+//! Requests a view-distance-sized square of chunks concurrently, the way a
+//! player join does, and reports how much CPU the `Schedule` thread burned
+//! while doing it.
+//!
+//! Run with: `cargo run --release --example join_burst -- <dir> <radius>`
+
+// Reporting the measurement to stdout is the entire point of this example.
+#![allow(clippy::print_stdout)]
+
+use pumpkin_config::world::LevelConfig;
+use pumpkin_data::dimension::Dimension;
+use pumpkin_util::math::vector2::Vector2;
+use pumpkin_world::dimension::into_level;
+use pumpkin_world::world::WorldPortalExt;
+use std::sync::Arc;
+use std::time::Instant;
+
+struct StubPortal;
+
+impl WorldPortalExt for StubPortal {
+    fn can_place_at(
+        &self,
+        _block: &pumpkin_data::Block,
+        _state: &pumpkin_data::BlockState,
+        _block_accessor: &dyn pumpkin_world::world::BlockAccessor,
+        _block_pos: &pumpkin_util::math::position::BlockPos,
+    ) -> bool {
+        true
+    }
+
+    fn mirror(
+        &self,
+        block: &pumpkin_data::Block,
+        state_id: pumpkin_data::BlockStateId,
+        mirror: pumpkin_data::Mirror,
+    ) -> &'static pumpkin_data::BlockState {
+        block.mirror(state_id, mirror)
+    }
+
+    fn rotate(
+        &self,
+        block: &pumpkin_data::Block,
+        state_id: pumpkin_data::BlockStateId,
+        rotation: pumpkin_data::Rotation,
+    ) -> &'static pumpkin_data::BlockState {
+        block.rotate(state_id, rotation)
+    }
+
+    fn spawn_mobs_for_chunk_generation(
+        &self,
+        _cache: &mut dyn pumpkin_world::generation::proto_chunk::GenerationCache,
+        _biome: &'static pumpkin_data::chunk::Biome,
+        _chunk_x: i32,
+        _chunk_z: i32,
+    ) {
+    }
+}
+
+/// Sums utime+stime (in clock ticks) for every thread named `name`.
+fn thread_cpu_ticks(name: &str) -> u64 {
+    let mut total = 0;
+    let Ok(tasks) = std::fs::read_dir("/proc/self/task") else {
+        return 0;
+    };
+    for task in tasks.flatten() {
+        let Ok(stat) = std::fs::read_to_string(task.path().join("stat")) else {
+            continue;
+        };
+        // comm is parenthesised and may contain spaces; split on the last ')'.
+        let Some(close) = stat.rfind(')') else { continue };
+        let Some(open) = stat.find('(') else { continue };
+        if &stat[open + 1..close] != name {
+            continue;
+        }
+        let fields: Vec<&str> = stat[close + 1..].split_whitespace().collect();
+        // After comm and state, utime is field 11 and stime field 12 (1-based
+        // in proc(5)); here index 11 and 12 counting state as index 0.
+        if fields.len() > 12 {
+            total += fields[11].parse::<u64>().unwrap_or(0);
+            total += fields[12].parse::<u64>().unwrap_or(0);
+        }
+    }
+    total
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let dir = args.next().expect("usage: join_burst <dir> [radius]");
+    let radius: i32 = args
+        .next()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(16);
+
+    let level = into_level(
+        Dimension::OVERWORLD,
+        &LevelConfig::default(),
+        dir.into(),
+        42,
+        None,
+    );
+    level
+        .world_portal
+        .store(Arc::new(Some(Arc::new(StubPortal) as Arc<dyn WorldPortalExt>)));
+
+    // Let the chunk-system threads reach their idle park before measuring.
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let side = radius * 2 + 1;
+    let chunk_count = side * side;
+    println!("requesting {chunk_count} chunks ({side}x{side})");
+
+    let ticks_per_sec = 100.0; // USER_HZ
+    let before = thread_cpu_ticks("Schedule");
+    let start = Instant::now();
+
+    let mut handles = Vec::with_capacity(chunk_count as usize);
+    for x in -radius..=radius {
+        for z in -radius..=radius {
+            let level = level.clone();
+            handles.push(tokio::spawn(async move {
+                level.get_or_fetch_chunk(Vector2::new(x, z), |_| ()).await;
+            }));
+        }
+    }
+    for handle in handles {
+        handle.await.expect("chunk fetch task panicked");
+    }
+
+    let wall = start.elapsed();
+    let schedule_cpu = (thread_cpu_ticks("Schedule") - before) as f64 / ticks_per_sec;
+
+    println!(
+        "wall={:.2}s  Schedule-thread CPU={:.2}s  ({:.0}% of one core)",
+        wall.as_secs_f64(),
+        schedule_cpu,
+        100.0 * schedule_cpu / wall.as_secs_f64()
+    );
+
+    level.shutdown().await;
+}

--- a/pumpkin-world/src/chunk_system/schedule.rs
+++ b/pumpkin-world/src/chunk_system/schedule.rs
@@ -137,11 +137,14 @@ impl GenerationSchedule {
             }
         }
 
+        // Must stay >= 1: a limit of zero would make the dispatch loop unable to
+        // ever start a task, so the scheduler could never make progress.
         let max_in_flight = if gen_pool.is_some() {
             (thread::available_parallelism().map_or(1, std::num::NonZero::get) * 4) as u16
         } else {
             gen_thread_count as u16
-        };
+        }
+        .max(1);
 
         let level_sched = level;
         let lighting_config = level_sched.lighting_config;
@@ -1076,6 +1079,10 @@ impl GenerationSchedule {
 
             // 4. Process ready tasks in the queue (up to max_in_flight)
             let mut io_batch = Vec::with_capacity(16);
+            // Set when we stop dispatching because every generation slot is busy
+            // rather than because the queue ran dry. The queue is left non-empty
+            // in that case, so the wait below has to run anyway or we spin.
+            let mut all_slots_busy = false;
             'out2: while let Some(task) = self.queue.pop() {
                 if level.shut_down_chunk_system.load(Relaxed) {
                     self.queue.push(task);
@@ -1086,6 +1093,7 @@ impl GenerationSchedule {
 
                 if self.running_task_count >= self.max_in_flight {
                     self.queue.push(task);
+                    all_slots_busy = true;
                     break 'out2;
                 }
 
@@ -1296,8 +1304,17 @@ impl GenerationSchedule {
                 self.save_all_chunk(true);
             }
 
-            // 3. If queue is empty, wait for work or results
-            if self.queue.is_empty() {
+            // 3. Nothing more can be dispatched right now, so block instead of
+            //    spinning.
+            //
+            //    `all_slots_busy` means the queue still holds work but every
+            //    generation slot is occupied. Gating this purely on
+            //    `queue.is_empty()` skipped the wait in that case, so the outer
+            //    loop re-ran as fast as the CPU allowed — re-locking
+            //    `LevelChannel` and re-polling `recv_chunk` — until a worker
+            //    reported back. That pinned one core for as long as generation
+            //    stayed saturated, which is the whole of every player join.
+            if self.queue.is_empty() || all_slots_busy {
                 // If we have tasks in flight, wait for them with timeout
                 if self.running_task_count > 0 || !self.waiting_for_chunks.is_empty() {
                     match self.recv_chunk.recv_timeout(Duration::from_millis(5)) {
@@ -1311,7 +1328,7 @@ impl GenerationSchedule {
                         }
                         Err(crossfire::compat::RecvTimeoutError::Disconnected) => break,
                     }
-                } else {
+                } else if self.queue.is_empty() {
                     // No tasks in flight, wait indefinitely for LevelChannel changes
                     let restored = Self::restore_ready_tasks(
                         &mut self.graph,

--- a/pumpkin/src/command/commands/ban.rs
+++ b/pumpkin/src/command/commands/ban.rs
@@ -9,7 +9,7 @@ use crate::{
         },
         tree::{CommandTree, builder::argument},
     },
-    data::{SaveJSONConfiguration, banlist_serializer::BannedPlayerEntry},
+    data::banlist_serializer::BannedPlayerEntry,
     net::{DisconnectReason, GameProfile},
 };
 use CommandError::InvalidConsumption;
@@ -107,7 +107,7 @@ async fn ban_profile(
     {
         if entry.name != profile.name {
             entry.name.clone_from(&profile.name);
-            banned_players.save();
+            server.data.save_banned_players(&banned_players);
         }
         return false;
     }
@@ -119,7 +119,7 @@ async fn ban_profile(
         reason.clone(),
     ));
 
-    banned_players.save();
+    server.data.save_banned_players(&banned_players);
     drop(banned_players);
 
     // Send messages

--- a/pumpkin/src/command/commands/banip.rs
+++ b/pumpkin/src/command/commands/banip.rs
@@ -6,7 +6,7 @@ use crate::{
         args::{Arg, ConsumedArgs, message::MsgArgConsumer, simple::SimpleArgConsumer},
         tree::{CommandTree, builder::argument},
     },
-    data::{SaveJSONConfiguration, banlist_serializer::BannedIpEntry},
+    data::banlist_serializer::BannedIpEntry,
     net::DisconnectReason,
     server::Server,
 };
@@ -107,7 +107,7 @@ async fn ban_ip(
         reason.clone(),
     ));
 
-    banned_ips.save();
+    server.data.save_banned_ips(&banned_ips);
     drop(banned_ips);
 
     // Send messages

--- a/pumpkin/src/command/commands/deop.rs
+++ b/pumpkin/src/command/commands/deop.rs
@@ -1,15 +1,12 @@
 use crate::command::CommandResult;
-use crate::{
-    command::{
-        CommandError, CommandExecutor, CommandSender,
-        args::{
-            Arg, ConsumedArgs,
-            gameprofile::{GameProfileSuggestionMode, GameProfilesArgumentConsumer},
-        },
-        tree::CommandTree,
-        tree::builder::argument,
+use crate::command::{
+    CommandError, CommandExecutor, CommandSender,
+    args::{
+        Arg, ConsumedArgs,
+        gameprofile::{GameProfileSuggestionMode, GameProfilesArgumentConsumer},
     },
-    data::SaveJSONConfiguration,
+    tree::CommandTree,
+    tree::builder::argument,
 };
 use CommandError::InvalidConsumption;
 use pumpkin_util::text::TextComponent;
@@ -61,7 +58,7 @@ impl CommandExecutor for Executor {
             }
 
             if succeeded_deops > 0 {
-                config.save();
+                server.data.save_operator_config(&config);
             }
 
             if succeeded_deops == 0 {

--- a/pumpkin/src/command/commands/op.rs
+++ b/pumpkin/src/command/commands/op.rs
@@ -6,7 +6,6 @@ use crate::command::node::dispatcher::CommandDispatcher;
 use crate::command::node::{CommandExecutor, CommandExecutorResult};
 use crate::command::suggestion::provider::{SuggestionProvider, SuggestionProviderResult};
 use crate::command::suggestion::suggestions::SuggestionsBuilder;
-use crate::data::SaveJSONConfiguration;
 use pumpkin_config::op::Op;
 use pumpkin_data::translation;
 use pumpkin_util::PermissionLvl;
@@ -72,7 +71,7 @@ impl CommandExecutor for OpCommandExecutor {
             }
 
             if successes > 0 {
-                config.save();
+                server.data.save_operator_config(&config);
             }
 
             if successes == 0 {

--- a/pumpkin/src/command/commands/pardon.rs
+++ b/pumpkin/src/command/commands/pardon.rs
@@ -1,13 +1,10 @@
-use crate::{
-    command::{
-        CommandError, CommandExecutor, CommandResult, CommandSender,
-        args::{
-            Arg, ConsumedArgs,
-            gameprofile::{GameProfileSuggestionMode, GameProfilesArgumentConsumer},
-        },
-        tree::{CommandTree, builder::argument},
+use crate::command::{
+    CommandError, CommandExecutor, CommandResult, CommandSender,
+    args::{
+        Arg, ConsumedArgs,
+        gameprofile::{GameProfileSuggestionMode, GameProfilesArgumentConsumer},
     },
-    data::SaveJSONConfiguration,
+    tree::{CommandTree, builder::argument},
 };
 use CommandError::InvalidConsumption;
 use pumpkin_util::text::TextComponent;
@@ -54,7 +51,7 @@ impl CommandExecutor for Executor {
             }
 
             if successes > 0 {
-                lock.save();
+                server.data.save_banned_players(&lock);
                 Ok(successes)
             } else {
                 let err_target = targets

--- a/pumpkin/src/command/commands/pardonip.rs
+++ b/pumpkin/src/command/commands/pardonip.rs
@@ -1,12 +1,9 @@
 use std::{net::IpAddr, str::FromStr};
 
-use crate::{
-    command::{
-        CommandError, CommandExecutor, CommandResult, CommandSender,
-        args::{Arg, ConsumedArgs, simple::SimpleArgConsumer},
-        tree::{CommandTree, builder::argument},
-    },
-    data::SaveJSONConfiguration,
+use crate::command::{
+    CommandError, CommandExecutor, CommandResult, CommandSender,
+    args::{Arg, ConsumedArgs, simple::SimpleArgConsumer},
+    tree::{CommandTree, builder::argument},
 };
 use CommandError::InvalidConsumption;
 use pumpkin_util::text::TextComponent;
@@ -59,7 +56,7 @@ impl CommandExecutor for Executor {
                 )))
             };
 
-            lock.save();
+            server.data.save_banned_ips(&lock);
 
             result
         })

--- a/pumpkin/src/command/commands/whitelist.rs
+++ b/pumpkin/src/command/commands/whitelist.rs
@@ -18,7 +18,6 @@ use crate::{
             builder::{argument, literal},
         },
     },
-    data::{LoadJSONConfiguration, SaveJSONConfiguration, whitelist::WhitelistConfig},
     net::DisconnectReason,
     server::Server,
 };
@@ -167,7 +166,7 @@ impl CommandExecutor for ReloadExecutor {
         _args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
         Box::pin(async move {
-            *server.data.whitelist_config.write().await = WhitelistConfig::load();
+            *server.data.whitelist_config.write().await = server.data.load_whitelist();
             kick_non_whitelisted_players(server).await;
             sender
                 .send_message(TextComponent::translate_cross(
@@ -221,7 +220,7 @@ impl CommandExecutor for AddExecutor {
                 successes += 1;
             }
 
-            whitelist.save();
+            server.data.save_whitelist(&whitelist);
 
             if successes == 0 {
                 Err(CommandError::CommandFailed(TextComponent::translate_cross(
@@ -271,7 +270,7 @@ impl CommandExecutor for RemoveExecutor {
                 }
             }
 
-            whitelist.save();
+            server.data.save_whitelist(&whitelist);
             drop(whitelist);
 
             kick_non_whitelisted_players(server).await;

--- a/pumpkin/src/data/banned_ip.rs
+++ b/pumpkin/src/data/banned_ip.rs
@@ -19,17 +19,11 @@ impl BannedIpList {
     }
 
     fn remove_invalid_entries(&mut self) {
-        let original_len = self.banned_ips.len();
-
         self.banned_ips.retain(|entry| {
             entry
                 .expires
                 .is_none_or(|expires| expires >= OffsetDateTime::now_utc())
         });
-
-        if original_len != self.banned_ips.len() {
-            self.save();
-        }
     }
 }
 

--- a/pumpkin/src/data/banned_player.rs
+++ b/pumpkin/src/data/banned_player.rs
@@ -23,17 +23,11 @@ impl BannedPlayerList {
     }
 
     fn remove_invalid_entries(&mut self) {
-        let original_len = self.banned_players.len();
-
         self.banned_players.retain(|entry| {
             entry
                 .expires
                 .is_none_or(|expires| expires >= OffsetDateTime::now_utc())
         });
-
-        if original_len != self.banned_players.len() {
-            self.save();
-        }
     }
 }
 

--- a/pumpkin/src/data/mod.rs
+++ b/pumpkin/src/data/mod.rs
@@ -1,6 +1,9 @@
-use std::{env, fs, path::Path};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tokio::sync::RwLock;
 use tracing::{debug, error, warn};
 
@@ -22,18 +25,69 @@ pub struct VanillaData {
     pub operator_config: RwLock<op::OperatorConfig>,
     pub user_cache: RwLock<usercache::UserCache>,
     pub whitelist_config: RwLock<whitelist::WhitelistConfig>,
+    data_dir: PathBuf,
 }
 
 impl VanillaData {
     #[must_use]
     pub fn load() -> Self {
+        let data_dir = env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(DATA_FOLDER);
+        Self::load_from(data_dir)
+    }
+
+    /// Loads all server data from an instance-specific directory.
+    #[must_use]
+    pub fn load_from(data_dir: impl Into<PathBuf>) -> Self {
+        let data_dir = data_dir.into();
         Self {
-            banned_ip_list: RwLock::new(banned_ip::BannedIpList::load()),
-            banned_player_list: RwLock::new(banned_player::BannedPlayerList::load()),
-            operator_config: RwLock::new(op::OperatorConfig::load()),
-            user_cache: RwLock::new(usercache::UserCache::load()),
-            whitelist_config: RwLock::new(whitelist::WhitelistConfig::load()),
+            banned_ip_list: RwLock::new(banned_ip::BannedIpList::load_from(&data_dir)),
+            banned_player_list: RwLock::new(banned_player::BannedPlayerList::load_from(&data_dir)),
+            operator_config: RwLock::new(op::OperatorConfig::load_from(&data_dir)),
+            user_cache: RwLock::new(usercache::UserCache::load_from(&data_dir)),
+            whitelist_config: RwLock::new(whitelist::WhitelistConfig::load_from(&data_dir)),
+            data_dir,
         }
+    }
+
+    #[must_use]
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
+    pub async fn save_all(&self) {
+        let data_dir = &self.data_dir;
+        self.banned_ip_list.read().await.save_to(data_dir);
+        self.banned_player_list.read().await.save_to(data_dir);
+        self.operator_config.read().await.save_to(data_dir);
+        self.user_cache.read().await.save_to(data_dir);
+        self.whitelist_config.read().await.save_to(data_dir);
+    }
+
+    pub fn save_banned_ips(&self, value: &banned_ip::BannedIpList) {
+        value.save_to(&self.data_dir);
+    }
+
+    pub fn save_banned_players(&self, value: &banned_player::BannedPlayerList) {
+        value.save_to(&self.data_dir);
+    }
+
+    pub fn save_operator_config(&self, value: &op::OperatorConfig) {
+        value.save_to(&self.data_dir);
+    }
+
+    pub fn save_user_cache(&self, value: &usercache::UserCache) {
+        value.save_to(&self.data_dir);
+    }
+
+    pub fn save_whitelist(&self, value: &whitelist::WhitelistConfig) {
+        value.save_to(&self.data_dir);
+    }
+
+    #[must_use]
+    pub fn load_whitelist(&self) -> whitelist::WhitelistConfig {
+        whitelist::WhitelistConfig::load_from(&self.data_dir)
     }
 }
 
@@ -44,10 +98,17 @@ pub trait LoadJSONConfiguration {
         Self: Sized + Default + Serialize + for<'de> Deserialize<'de>,
     {
         let exe_dir = env::current_dir().expect("Failed to get current directory");
-        let data_dir = exe_dir.join(DATA_FOLDER);
+        Self::load_from(&exe_dir.join(DATA_FOLDER))
+    }
+
+    #[must_use]
+    fn load_from(data_dir: &Path) -> Self
+    where
+        Self: Sized + Default + Serialize + DeserializeOwned,
+    {
         if !data_dir.exists() {
             debug!("creating new data root folder");
-            fs::create_dir(&data_dir).expect("Failed to create data root folder");
+            fs::create_dir_all(data_dir).expect("Failed to create data root folder");
         }
         let path = data_dir.join(Self::get_path());
 
@@ -93,10 +154,16 @@ pub trait SaveJSONConfiguration: LoadJSONConfiguration {
         Self: Sized + Default + Serialize + for<'de> Deserialize<'de>,
     {
         let exe_dir = env::current_dir().expect("Failed to get current directory");
-        let data_dir = exe_dir.join(DATA_FOLDER);
+        self.save_to(&exe_dir.join(DATA_FOLDER));
+    }
+
+    fn save_to(&self, data_dir: &Path)
+    where
+        Self: Sized + Default + Serialize + for<'de> Deserialize<'de>,
+    {
         if !data_dir.exists() {
             debug!("creating new data root folder");
-            fs::create_dir(&data_dir).expect("Failed to create data root folder");
+            fs::create_dir_all(data_dir).expect("Failed to create data root folder");
         }
         let path = data_dir.join(Self::get_path());
 

--- a/pumpkin/src/data/usercache.rs
+++ b/pumpkin/src/data/usercache.rs
@@ -35,17 +35,18 @@ pub struct UserCache {
 }
 
 impl UserCache {
-    fn path() -> std::path::PathBuf {
-        env::current_dir()
+    #[must_use]
+    pub fn load() -> Self {
+        let data_dir = env::current_dir()
             .unwrap_or_else(|_| ".".into())
-            .join(super::DATA_FOLDER)
-            .join(USER_CACHE_PATH)
+            .join(super::DATA_FOLDER);
+        Self::load_from(data_dir)
     }
 
     #[must_use]
-    pub fn load() -> Self {
+    pub fn load_from(data_dir: impl AsRef<std::path::Path>) -> Self {
         let mut cache = Self::default();
-        let mut loaded = Self::load_entries();
+        let mut loaded = Self::load_entries(data_dir.as_ref());
         loaded.reverse();
         for entry in loaded {
             cache.safe_add(entry);
@@ -54,7 +55,14 @@ impl UserCache {
     }
 
     pub fn save(&self) {
-        let path = Self::path();
+        let data_dir = env::current_dir()
+            .unwrap_or_else(|_| ".".into())
+            .join(super::DATA_FOLDER);
+        self.save_to(data_dir);
+    }
+
+    pub fn save_to(&self, data_dir: impl AsRef<std::path::Path>) {
+        let path = data_dir.as_ref().join(USER_CACHE_PATH);
         if let Some(parent) = path.parent()
             && let Err(error) = fs::create_dir_all(parent)
         {
@@ -88,15 +96,12 @@ impl UserCache {
     pub fn get_by_name(&mut self, name: &str) -> Option<UserCacheEntry> {
         let lowercase_name = name.to_ascii_lowercase();
         let mut profile = self.profiles_by_name.get(&lowercase_name).cloned();
-        let mut needs_save = false;
-
         if let Some(entry) = &profile
             && is_expired(entry.expiration_date)
         {
             self.profiles_by_uuid.remove(&entry.uuid);
             self.profiles_by_name
                 .remove(&entry.name.to_ascii_lowercase());
-            needs_save = true;
             profile = None;
         }
 
@@ -106,10 +111,6 @@ impl UserCache {
                 .insert(entry.name.to_ascii_lowercase(), entry.clone());
             self.profiles_by_uuid.insert(entry.uuid, entry.clone());
             return Some(entry);
-        }
-
-        if needs_save {
-            self.save();
         }
 
         None
@@ -134,7 +135,6 @@ impl UserCache {
         };
 
         self.safe_add(entry.clone());
-        self.save();
         entry
     }
 
@@ -158,8 +158,8 @@ impl UserCache {
         entries
     }
 
-    fn load_entries() -> Vec<UserCacheEntry> {
-        let path = Self::path();
+    fn load_entries(data_dir: &std::path::Path) -> Vec<UserCacheEntry> {
+        let path = data_dir.join(USER_CACHE_PATH);
         let Ok(raw) = fs::read_to_string(path) else {
             return Vec::new();
         };

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -94,7 +94,6 @@ use crate::block::blocks::bed::BedBlock;
 use crate::command::context::command_source::CommandSource;
 use crate::command::node::dispatcher::CommandDispatcher;
 use crate::command::{CommandSender, client_suggestions};
-use crate::data::SaveJSONConfiguration;
 use crate::entity::{EntityBaseFuture, NbtFuture, TeleportFuture};
 use crate::net::{ClientPlatform, GameProfile};
 use crate::net::{DisconnectReason, PlayerConfig};
@@ -2792,7 +2791,7 @@ impl Player {
             ),
         );
 
-        banned_players.save();
+        server.data.save_banned_players(&banned_players);
         drop(banned_players);
 
         let kick_reason = reason.unwrap_or_else(|| {
@@ -2827,7 +2826,7 @@ impl Player {
                 string_reason,
             ));
 
-        banned_ips.save();
+        server.data.save_banned_ips(&banned_ips);
         drop(banned_ips);
 
         let kick_reason = reason.unwrap_or_else(|| {

--- a/pumpkin/src/instance/config.rs
+++ b/pumpkin/src/instance/config.rs
@@ -1,6 +1,8 @@
 use pumpkin_config::{AdvancedConfiguration, BasicConfiguration};
 use std::path::PathBuf;
 
+use super::port_allocator::{PortAllocator, PortAllocatorError, PortProtocol, PortReservation};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct InstanceId(pub u64);
 
@@ -10,6 +12,7 @@ pub struct InstanceId(pub u64);
 /// world directories, plugin directories, and network settings. Any field set to
 /// `None` will fall back to the corresponding value in the `BasicConfiguration` or
 /// `AdvancedConfiguration`.
+#[derive(Clone)]
 pub struct InstanceConfig {
     /// The basic server configuration.
     pub basic: BasicConfiguration,
@@ -80,18 +83,143 @@ impl InstanceConfig {
     pub fn world_path(&self) -> PathBuf {
         self.world_dir
             .clone()
-            .unwrap_or_else(|| self.basic.get_world_path())
+            .unwrap_or_else(|| self.config_path().join(&self.basic.default_level_name))
     }
 
     pub fn plugin_path(&self) -> PathBuf {
-        self.plugin_dir.clone().unwrap_or_else(|| PathBuf::from("./plugins"))
+        self.plugin_dir
+            .clone()
+            .unwrap_or_else(|| self.config_path().join("plugins"))
     }
 
     pub fn data_path(&self) -> PathBuf {
-        self.data_dir.clone().unwrap_or_else(|| PathBuf::from("./data"))
+        self.data_dir
+            .clone()
+            .unwrap_or_else(|| self.config_path().join("data"))
     }
 
     pub fn config_path(&self) -> PathBuf {
-        self.config_dir.clone().unwrap_or_else(|| PathBuf::from("."))
+        self.config_dir
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    /// Reserves and applies all ports used by this instance.
+    ///
+    /// A configured port is retained when it is available. Port `0` and ports
+    /// already reserved by another instance are replaced with a free port from
+    /// the allocator's range.
+    pub fn reserve_ports(
+        &mut self,
+        allocator: &PortAllocator,
+    ) -> Result<Vec<PortReservation>, PortAllocatorError> {
+        let mut reservations = Vec::new();
+
+        let result = (|| {
+            let mut reserve = |address: &mut std::net::SocketAddr, protocol: PortProtocol| {
+                let port = allocator.allocate_or_any_for(protocol, address.port())?;
+                address.set_port(port);
+                reservations.push(PortReservation { protocol, port });
+                Ok::<(), PortAllocatorError>(())
+            };
+
+            if self.advanced.networking.java.enabled {
+                reserve(
+                    &mut self.advanced.networking.java.address,
+                    PortProtocol::Tcp,
+                )?;
+
+                if self.advanced.networking.query.enabled {
+                    reserve(
+                        &mut self.advanced.networking.query.address,
+                        PortProtocol::Udp,
+                    )?;
+                }
+            }
+
+            if self.advanced.networking.bedrock.enabled {
+                reserve(
+                    &mut self.advanced.networking.bedrock.address,
+                    PortProtocol::Udp,
+                )?;
+            }
+
+            if self.advanced.networking.rcon.enabled {
+                reserve(
+                    &mut self.advanced.networking.rcon.address,
+                    PortProtocol::Tcp,
+                )?;
+            }
+
+            if self.advanced.networking.lan_broadcast.enabled {
+                let configured_port = self.advanced.networking.lan_broadcast.port.unwrap_or(0);
+                let mut address = std::net::SocketAddr::from(([0, 0, 0, 0], configured_port));
+                reserve(&mut address, PortProtocol::Udp)?;
+                self.advanced.networking.lan_broadcast.port = Some(address.port());
+            }
+
+            Ok::<(), PortAllocatorError>(())
+        })();
+
+        if let Err(error) = result {
+            for reservation in reservations {
+                allocator.free_for(reservation.protocol, reservation.port);
+            }
+            return Err(error);
+        }
+
+        Ok(reservations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instance::{PortAllocator, PortProtocol};
+    use std::path::Path;
+
+    #[test]
+    fn explicit_config_root_is_used_for_default_paths() {
+        let config = InstanceConfig::new(
+            BasicConfiguration::default(),
+            AdvancedConfiguration::default(),
+        )
+        .with_config_dir(Path::new("/tmp/pumpkin-instance").to_path_buf());
+
+        assert_eq!(
+            config.world_path(),
+            Path::new("/tmp/pumpkin-instance/world")
+        );
+        assert_eq!(
+            config.plugin_path(),
+            Path::new("/tmp/pumpkin-instance/plugins")
+        );
+        assert_eq!(config.data_path(), Path::new("/tmp/pumpkin-instance/data"));
+    }
+
+    #[test]
+    fn reserve_ports_updates_network_configuration() {
+        let mut config = InstanceConfig::new(
+            BasicConfiguration::default(),
+            AdvancedConfiguration::default(),
+        );
+        let allocator = PortAllocator::new(30000..=30010);
+        let reservations = config.reserve_ports(&allocator).unwrap();
+
+        assert!(
+            reservations
+                .iter()
+                .any(|reservation| reservation.protocol == PortProtocol::Tcp)
+        );
+        assert!(
+            reservations
+                .iter()
+                .any(|reservation| reservation.protocol == PortProtocol::Udp)
+        );
+        assert_eq!(config.advanced.networking.java.address.port(), 25565);
+        assert!(allocator.is_allocated_for(
+            PortProtocol::Tcp,
+            config.advanced.networking.java.address.port()
+        ));
     }
 }

--- a/pumpkin/src/instance/config.rs
+++ b/pumpkin/src/instance/config.rs
@@ -1,0 +1,97 @@
+use pumpkin_config::{AdvancedConfiguration, BasicConfiguration};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InstanceId(pub u64);
+
+/// Configuration for creating a new server instance.
+///
+/// This struct allows specifying per-instance overrides for configuration paths,
+/// world directories, plugin directories, and network settings. Any field set to
+/// `None` will fall back to the corresponding value in the `BasicConfiguration` or
+/// `AdvancedConfiguration`.
+pub struct InstanceConfig {
+    /// The basic server configuration.
+    pub basic: BasicConfiguration,
+    /// The advanced server configuration.
+    pub advanced: AdvancedConfiguration,
+    /// The directory from which to load the configuration file.
+    ///
+    /// Defaults to the current working directory if `None`.
+    pub config_dir: Option<PathBuf>,
+    /// Override for the world directory path.
+    ///
+    /// If `None`, the world path is derived from `basic.default_level_name`.
+    pub world_dir: Option<PathBuf>,
+    /// Override for the plugin directory path.
+    ///
+    /// If `None`, defaults to `./plugins`.
+    pub plugin_dir: Option<PathBuf>,
+    /// Override for the data directory path.
+    ///
+    /// If `None`, defaults to `./data`.
+    pub data_dir: Option<PathBuf>,
+}
+
+impl std::fmt::Debug for InstanceConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // BasicConfiguration / AdvancedConfiguration do not implement Debug.
+        f.debug_struct("InstanceConfig")
+            .field("config_dir", &self.config_dir)
+            .field("world_dir", &self.world_dir)
+            .field("plugin_dir", &self.plugin_dir)
+            .field("data_dir", &self.data_dir)
+            .finish_non_exhaustive()
+    }
+}
+
+impl InstanceConfig {
+    pub fn new(basic: BasicConfiguration, advanced: AdvancedConfiguration) -> Self {
+        Self {
+            basic,
+            advanced,
+            config_dir: None,
+            world_dir: None,
+            plugin_dir: None,
+            data_dir: None,
+        }
+    }
+
+    pub fn with_config_dir(mut self, path: PathBuf) -> Self {
+        self.config_dir = Some(path);
+        self
+    }
+
+    pub fn with_world_dir(mut self, path: PathBuf) -> Self {
+        self.world_dir = Some(path);
+        self
+    }
+
+    pub fn with_plugin_dir(mut self, path: PathBuf) -> Self {
+        self.plugin_dir = Some(path);
+        self
+    }
+
+    pub fn with_data_dir(mut self, path: PathBuf) -> Self {
+        self.data_dir = Some(path);
+        self
+    }
+
+    pub fn world_path(&self) -> PathBuf {
+        self.world_dir
+            .clone()
+            .unwrap_or_else(|| self.basic.get_world_path())
+    }
+
+    pub fn plugin_path(&self) -> PathBuf {
+        self.plugin_dir.clone().unwrap_or_else(|| PathBuf::from("./plugins"))
+    }
+
+    pub fn data_path(&self) -> PathBuf {
+        self.data_dir.clone().unwrap_or_else(|| PathBuf::from("./data"))
+    }
+
+    pub fn config_path(&self) -> PathBuf {
+        self.config_dir.clone().unwrap_or_else(|| PathBuf::from("."))
+    }
+}

--- a/pumpkin/src/instance/config.rs
+++ b/pumpkin/src/instance/config.rs
@@ -49,7 +49,8 @@ impl std::fmt::Debug for InstanceConfig {
 }
 
 impl InstanceConfig {
-    pub fn new(basic: BasicConfiguration, advanced: AdvancedConfiguration) -> Self {
+    #[must_use]
+    pub const fn new(basic: BasicConfiguration, advanced: AdvancedConfiguration) -> Self {
         Self {
             basic,
             advanced,
@@ -60,44 +61,52 @@ impl InstanceConfig {
         }
     }
 
+    #[must_use]
     pub fn with_config_dir(mut self, path: PathBuf) -> Self {
         self.config_dir = Some(path);
         self
     }
 
+    #[must_use]
     pub fn with_world_dir(mut self, path: PathBuf) -> Self {
         self.world_dir = Some(path);
         self
     }
 
+    #[must_use]
     pub fn with_plugin_dir(mut self, path: PathBuf) -> Self {
         self.plugin_dir = Some(path);
         self
     }
 
+    #[must_use]
     pub fn with_data_dir(mut self, path: PathBuf) -> Self {
         self.data_dir = Some(path);
         self
     }
 
+    #[must_use]
     pub fn world_path(&self) -> PathBuf {
         self.world_dir
             .clone()
             .unwrap_or_else(|| self.config_path().join(&self.basic.default_level_name))
     }
 
+    #[must_use]
     pub fn plugin_path(&self) -> PathBuf {
         self.plugin_dir
             .clone()
             .unwrap_or_else(|| self.config_path().join("plugins"))
     }
 
+    #[must_use]
     pub fn data_path(&self) -> PathBuf {
         self.data_dir
             .clone()
             .unwrap_or_else(|| self.config_path().join("data"))
     }
 
+    #[must_use]
     pub fn config_path(&self) -> PathBuf {
         self.config_dir
             .clone()

--- a/pumpkin/src/instance/manager.rs
+++ b/pumpkin/src/instance/manager.rs
@@ -1,0 +1,297 @@
+use crate::instance::config::{InstanceConfig, InstanceId};
+use crate::instance::port_allocator::PortAllocator;
+use crate::PumpkinServer;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+#[derive(Debug, thiserror::Error)]
+pub enum InstanceError {
+    #[error("Instance not found: {0:?}")]
+    NotFound(InstanceId),
+    #[error("Instance {0:?} is already running")]
+    AlreadyRunning(InstanceId),
+    #[error("Instance {0:?} is not running")]
+    NotRunning(InstanceId),
+    #[error("Port allocation failed: {0}")]
+    PortAllocation(String),
+    #[error("Failed to bind network: {0}")]
+    NetworkBind(String),
+    #[error("Server creation failed: {0}")]
+    Creation(String),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstanceState {
+    Created,
+    Starting,
+    Running,
+    Stopping,
+    Stopped,
+    Failed,
+}
+
+pub struct InstanceInfo {
+    pub id: InstanceId,
+    pub config: InstanceConfig,
+    pub state: InstanceState,
+    pub server: Option<Arc<PumpkinServer>>,
+    /// Per-instance cancellation token used to stop this instance without
+    /// affecting other concurrent instances.
+    pub stop_token: CancellationToken,
+}
+
+impl std::fmt::Debug for InstanceInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InstanceInfo")
+            .field("id", &self.id)
+            .field("config", &self.config)
+            .field("state", &self.state)
+            .field("has_server", &self.server.is_some())
+            .finish()
+    }
+}
+
+/// Manages multiple Pumpkin server instances.
+///
+/// The `InstanceManager` provides a centralized system for creating, starting,
+/// stopping, and managing multiple isolated server instances. It handles port
+/// allocation, resource isolation, and lifecycle management.
+pub struct InstanceManager {
+    instances: HashMap<InstanceId, InstanceInfo>,
+    port_allocator: Arc<PortAllocator>,
+    next_id: AtomicU64,
+}
+
+impl InstanceManager {
+    pub fn new() -> Self {
+        Self {
+            instances: HashMap::new(),
+            port_allocator: Arc::new(PortAllocator::default_range()),
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    pub fn with_port_range(range: std::ops::RangeInclusive<u16>) -> Self {
+        Self {
+            instances: HashMap::new(),
+            port_allocator: Arc::new(PortAllocator::new(range)),
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    fn generate_id(&self) -> InstanceId {
+        InstanceId(self.next_id.fetch_add(1, Ordering::SeqCst))
+    }
+
+    /// Creates a new server instance with the given configuration.
+    ///
+    /// The instance is created in the `Created` state. Call `start_instance`
+    /// to actually begin running it.
+    ///
+    /// # Errors
+    /// Returns an error if the configuration is invalid or if required
+    /// directories cannot be created.
+    pub async fn create_instance(
+        &mut self,
+        config: InstanceConfig,
+    ) -> Result<InstanceId, InstanceError> {
+        let id = self.generate_id();
+
+        let config_dir = config.config_path();
+        if !config_dir.exists() {
+            tokio::fs::create_dir_all(&config_dir).await?;
+        }
+
+        let world_dir = config.world_path();
+        if !world_dir.exists() {
+            tokio::fs::create_dir_all(&world_dir).await?;
+        }
+
+        let plugin_dir = config.plugin_path();
+        if !plugin_dir.exists() {
+            tokio::fs::create_dir_all(&plugin_dir).await?;
+        }
+
+        let info = InstanceInfo {
+            id,
+            config,
+            state: InstanceState::Created,
+            server: None,
+            stop_token: CancellationToken::new(),
+        };
+
+        self.instances.insert(id, info);
+        info!("Created instance {id:?}");
+        Ok(id)
+    }
+
+    /// Starts a created instance.
+    ///
+    /// This loads vanilla data, creates the `PumpkinServer`, binds network ports,
+    /// and initializes plugins. Call [`Self::run_instance`] to begin the accept loop.
+    ///
+    /// # Errors
+    /// Returns an error if the instance is not found, already running, or
+    /// if network binding fails.
+    pub async fn start_instance(&mut self, id: InstanceId) -> Result<(), InstanceError> {
+        let info = self
+            .instances
+            .get_mut(&id)
+            .ok_or(InstanceError::NotFound(id))?;
+
+        if info.state == InstanceState::Running || info.state == InstanceState::Starting {
+            return Err(InstanceError::AlreadyRunning(id));
+        }
+
+        info.state = InstanceState::Starting;
+        // Fresh token for this start cycle so a previous stop does not leave it cancelled.
+        info.stop_token = CancellationToken::new();
+
+        let plugin_dir = info.config.plugin_path();
+
+        // Take ownership of the configs from the instance info.
+        // We replace with defaults temporarily so we can move the values out.
+        // Note: BasicConfiguration / AdvancedConfiguration are not Clone.
+        let basic_config = std::mem::take(&mut info.config.basic);
+        let advanced_config = std::mem::take(&mut info.config.advanced);
+
+        let vanilla_data = crate::data::VanillaData::load();
+
+        let server = match PumpkinServer::new_with_result(
+            basic_config,
+            advanced_config,
+            vanilla_data,
+        )
+        .await
+        {
+            Ok(server) => server,
+            Err(e) => {
+                info.state = InstanceState::Failed;
+                return Err(InstanceError::NetworkBind(e.to_string()));
+            }
+        };
+
+        server.server.plugin_manager.set_plugin_dir(plugin_dir).await;
+        server.init_plugins().await;
+
+        info.server = Some(Arc::new(server));
+        info.state = InstanceState::Running;
+
+        info!("Started instance {id:?}");
+        Ok(())
+    }
+
+    /// Starts the main loop for a running instance.
+    ///
+    /// This method blocks until the instance is stopped. It should typically
+    /// be spawned as a task if you want to run multiple instances concurrently.
+    ///
+    /// # Errors
+    /// Returns an error if the instance is not found or not running.
+    pub async fn run_instance(&self, id: InstanceId) -> Result<(), InstanceError> {
+        let info = self.instances.get(&id).ok_or(InstanceError::NotFound(id))?;
+        let server = info
+            .server
+            .clone()
+            .ok_or(InstanceError::NotRunning(id))?;
+        let stop_token = info.stop_token.clone();
+
+        server.start_with_token(stop_token).await;
+        Ok(())
+    }
+
+    /// Stops a running instance gracefully.
+    ///
+    /// Cancels the instance's cancellation token so any active
+    /// [`Self::run_instance`] call can exit. Does not use the global
+    /// `stop_server()` path, so other instances keep running.
+    ///
+    /// # Errors
+    /// Returns an error if the instance is not found.
+    pub async fn stop_instance(&mut self, id: InstanceId) -> Result<(), InstanceError> {
+        let info = self
+            .instances
+            .get_mut(&id)
+            .ok_or(InstanceError::NotFound(id))?;
+
+        if info.state != InstanceState::Running && info.state != InstanceState::Starting {
+            info.state = InstanceState::Stopped;
+            return Ok(());
+        }
+
+        info.state = InstanceState::Stopping;
+        info.stop_token.cancel();
+
+        if let Some(server) = info.server.take() {
+            server.unload_plugins().await;
+            drop(server);
+        }
+
+        info.state = InstanceState::Stopped;
+        info!("Stopped instance {id:?}");
+        Ok(())
+    }
+
+    /// Deletes an instance, stopping it first if it's running.
+    ///
+    /// After deletion, the instance ID is no longer valid.
+    ///
+    /// # Errors
+    /// Returns an error if the instance is not found.
+    pub async fn delete_instance(&mut self, id: InstanceId) -> Result<(), InstanceError> {
+        {
+            let info = self
+                .instances
+                .get_mut(&id)
+                .ok_or(InstanceError::NotFound(id))?;
+
+            if info.state == InstanceState::Running || info.state == InstanceState::Starting {
+                info.state = InstanceState::Stopping;
+                info.stop_token.cancel();
+                if let Some(server) = info.server.take() {
+                    server.unload_plugins().await;
+                    drop(server);
+                }
+            }
+        }
+
+        self.instances.remove(&id);
+        info!("Deleted instance {id:?}");
+        Ok(())
+    }
+
+    pub fn get_instance(&self, id: InstanceId) -> Option<&InstanceInfo> {
+        self.instances.get(&id)
+    }
+
+    pub fn get_instance_mut(&mut self, id: InstanceId) -> Option<&mut InstanceInfo> {
+        self.instances.get_mut(&id)
+    }
+
+    pub fn list_instances(&self) -> Vec<InstanceId> {
+        self.instances.keys().copied().collect()
+    }
+
+    pub fn instance_count(&self) -> usize {
+        self.instances.len()
+    }
+
+    pub fn port_allocator(&self) -> &PortAllocator {
+        &self.port_allocator
+    }
+
+    pub fn port_allocator_arc(&self) -> Arc<PortAllocator> {
+        self.port_allocator.clone()
+    }
+}
+
+impl Default for InstanceManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/pumpkin/src/instance/manager.rs
+++ b/pumpkin/src/instance/manager.rs
@@ -1,9 +1,10 @@
-use crate::instance::config::{InstanceConfig, InstanceId};
-use crate::instance::port_allocator::PortAllocator;
 use crate::PumpkinServer;
+use crate::instance::config::{InstanceConfig, InstanceId};
+use crate::instance::port_allocator::{PortAllocator, PortReservation};
+use crate::server::ServerPaths;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -19,8 +20,6 @@ pub enum InstanceError {
     PortAllocation(String),
     #[error("Failed to bind network: {0}")]
     NetworkBind(String),
-    #[error("Server creation failed: {0}")]
-    Creation(String),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -40,9 +39,12 @@ pub struct InstanceInfo {
     pub config: InstanceConfig,
     pub state: InstanceState,
     pub server: Option<Arc<PumpkinServer>>,
+    pub ports: Vec<PortReservation>,
     /// Per-instance cancellation token used to stop this instance without
     /// affecting other concurrent instances.
     pub stop_token: CancellationToken,
+    run_started: AtomicBool,
+    run_finished: CancellationToken,
 }
 
 impl std::fmt::Debug for InstanceInfo {
@@ -52,15 +54,12 @@ impl std::fmt::Debug for InstanceInfo {
             .field("config", &self.config)
             .field("state", &self.state)
             .field("has_server", &self.server.is_some())
+            .field("ports", &self.ports)
             .finish()
     }
 }
 
 /// Manages multiple Pumpkin server instances.
-///
-/// The `InstanceManager` provides a centralized system for creating, starting,
-/// stopping, and managing multiple isolated server instances. It handles port
-/// allocation, resource isolation, and lifecycle management.
 pub struct InstanceManager {
     instances: HashMap<InstanceId, InstanceInfo>,
     port_allocator: Arc<PortAllocator>,
@@ -69,11 +68,7 @@ pub struct InstanceManager {
 
 impl InstanceManager {
     pub fn new() -> Self {
-        Self {
-            instances: HashMap::new(),
-            port_allocator: Arc::new(PortAllocator::default_range()),
-            next_id: AtomicU64::new(1),
-        }
+        Self::with_port_range(25565..=25665)
     }
 
     pub fn with_port_range(range: std::ops::RangeInclusive<u16>) -> Self {
@@ -88,138 +83,123 @@ impl InstanceManager {
         InstanceId(self.next_id.fetch_add(1, Ordering::SeqCst))
     }
 
-    /// Creates a new server instance with the given configuration.
-    ///
-    /// The instance is created in the `Created` state. Call `start_instance`
-    /// to actually begin running it.
-    ///
-    /// # Errors
-    /// Returns an error if the configuration is invalid or if required
-    /// directories cannot be created.
+    /// Creates an instance and prepares its isolated directories.
     pub async fn create_instance(
         &mut self,
         config: InstanceConfig,
     ) -> Result<InstanceId, InstanceError> {
         let id = self.generate_id();
 
-        let config_dir = config.config_path();
-        if !config_dir.exists() {
-            tokio::fs::create_dir_all(&config_dir).await?;
+        for path in [
+            config.config_path(),
+            config.world_path(),
+            config.plugin_path(),
+            config.data_path(),
+        ] {
+            tokio::fs::create_dir_all(path).await?;
         }
 
-        let world_dir = config.world_path();
-        if !world_dir.exists() {
-            tokio::fs::create_dir_all(&world_dir).await?;
-        }
-
-        let plugin_dir = config.plugin_path();
-        if !plugin_dir.exists() {
-            tokio::fs::create_dir_all(&plugin_dir).await?;
-        }
-
-        let info = InstanceInfo {
+        self.instances.insert(
             id,
-            config,
-            state: InstanceState::Created,
-            server: None,
-            stop_token: CancellationToken::new(),
-        };
-
-        self.instances.insert(id, info);
+            InstanceInfo {
+                id,
+                config,
+                state: InstanceState::Created,
+                server: None,
+                ports: Vec::new(),
+                stop_token: CancellationToken::new(),
+                run_started: AtomicBool::new(false),
+                run_finished: CancellationToken::new(),
+            },
+        );
         info!("Created instance {id:?}");
         Ok(id)
     }
 
-    /// Starts a created instance.
-    ///
-    /// This loads vanilla data, creates the `PumpkinServer`, binds network ports,
-    /// and initializes plugins. Call [`Self::run_instance`] to begin the accept loop.
-    ///
-    /// # Errors
-    /// Returns an error if the instance is not found, already running, or
-    /// if network binding fails.
+    /// Starts an instance, including its accept loop.
     pub async fn start_instance(&mut self, id: InstanceId) -> Result<(), InstanceError> {
         let info = self
             .instances
             .get_mut(&id)
             .ok_or(InstanceError::NotFound(id))?;
 
-        if info.state == InstanceState::Running || info.state == InstanceState::Starting {
+        if matches!(info.state, InstanceState::Starting | InstanceState::Running) {
             return Err(InstanceError::AlreadyRunning(id));
         }
 
         info.state = InstanceState::Starting;
-        // Fresh token for this start cycle so a previous stop does not leave it cancelled.
         info.stop_token = CancellationToken::new();
 
-        let plugin_dir = info.config.plugin_path();
-
-        // Take ownership of the configs from the instance info.
-        // We replace with defaults temporarily so we can move the values out.
-        // Note: BasicConfiguration / AdvancedConfiguration are not Clone.
-        let basic_config = std::mem::take(&mut info.config.basic);
-        let advanced_config = std::mem::take(&mut info.config.advanced);
-
-        let vanilla_data = crate::data::VanillaData::load();
-
-        let server = match PumpkinServer::new_with_result(
-            basic_config,
-            advanced_config,
-            vanilla_data,
-        )
-        .await
-        {
-            Ok(server) => server,
-            Err(e) => {
+        let reservations = match info.config.reserve_ports(&self.port_allocator) {
+            Ok(reservations) => reservations,
+            Err(error) => {
                 info.state = InstanceState::Failed;
-                return Err(InstanceError::NetworkBind(e.to_string()));
+                return Err(InstanceError::PortAllocation(error.to_string()));
             }
         };
 
-        server.server.plugin_manager.set_plugin_dir(plugin_dir).await;
-        server.init_plugins().await;
+        let paths = ServerPaths {
+            world_dir: info.config.world_path(),
+            data_dir: info.config.data_path(),
+            plugin_dir: info.config.plugin_path(),
+        };
+        let server_result = PumpkinServer::new_with_result_and_paths(
+            info.config.basic.clone(),
+            info.config.advanced.clone(),
+            crate::data::VanillaData::load_from(&paths.data_dir),
+            paths,
+            info.stop_token.clone(),
+        )
+        .await;
 
-        info.server = Some(Arc::new(server));
+        let server = match server_result {
+            Ok(server) => Arc::new(server),
+            Err(error) => {
+                for reservation in &reservations {
+                    self.port_allocator
+                        .free_for(reservation.protocol, reservation.port);
+                }
+                info.state = InstanceState::Failed;
+                return Err(InstanceError::NetworkBind(error.to_string()));
+            }
+        };
+
+        server.init_plugins().await;
+        info.server = Some(server.clone());
+        info.ports = reservations;
         info.state = InstanceState::Running;
+        info.run_started.store(true, Ordering::Release);
+        info.run_finished = CancellationToken::new();
+
+        let stop_token = info.stop_token.clone();
+        let run_finished = info.run_finished.clone();
+        tokio::spawn(async move {
+            server.start_with_token(stop_token).await;
+            run_finished.cancel();
+        });
 
         info!("Started instance {id:?}");
         Ok(())
     }
 
-    /// Starts the main loop for a running instance.
-    ///
-    /// This method blocks until the instance is stopped. It should typically
-    /// be spawned as a task if you want to run multiple instances concurrently.
-    ///
-    /// # Errors
-    /// Returns an error if the instance is not found or not running.
+    /// Waits for a running instance to stop.
     pub async fn run_instance(&self, id: InstanceId) -> Result<(), InstanceError> {
         let info = self.instances.get(&id).ok_or(InstanceError::NotFound(id))?;
-        let server = info
-            .server
-            .clone()
-            .ok_or(InstanceError::NotRunning(id))?;
-        let stop_token = info.stop_token.clone();
-
-        server.start_with_token(stop_token).await;
+        if info.server.is_none() || !info.run_started.load(Ordering::Acquire) {
+            return Err(InstanceError::NotRunning(id));
+        }
+        info.run_finished.cancelled().await;
         Ok(())
     }
 
-    /// Stops a running instance gracefully.
-    ///
-    /// Cancels the instance's cancellation token so any active
-    /// [`Self::run_instance`] call can exit. Does not use the global
-    /// `stop_server()` path, so other instances keep running.
-    ///
-    /// # Errors
-    /// Returns an error if the instance is not found.
+    /// Stops an instance and waits for all of its server tasks to finish.
     pub async fn stop_instance(&mut self, id: InstanceId) -> Result<(), InstanceError> {
         let info = self
             .instances
             .get_mut(&id)
             .ok_or(InstanceError::NotFound(id))?;
 
-        if info.state != InstanceState::Running && info.state != InstanceState::Starting {
+        if !matches!(info.state, InstanceState::Starting | InstanceState::Running) {
             info.state = InstanceState::Stopped;
             return Ok(());
         }
@@ -227,39 +207,27 @@ impl InstanceManager {
         info.state = InstanceState::Stopping;
         info.stop_token.cancel();
 
-        if let Some(server) = info.server.take() {
+        if info.run_started.load(Ordering::Acquire) {
+            info.run_finished.cancelled().await;
+        } else if let Some(server) = info.server.as_ref() {
             server.unload_plugins().await;
-            drop(server);
+            server.server.shutdown().await;
         }
 
+        info.server = None;
+        info.run_started.store(false, Ordering::Release);
+        for reservation in info.ports.drain(..) {
+            self.port_allocator
+                .free_for(reservation.protocol, reservation.port);
+        }
         info.state = InstanceState::Stopped;
         info!("Stopped instance {id:?}");
         Ok(())
     }
 
-    /// Deletes an instance, stopping it first if it's running.
-    ///
-    /// After deletion, the instance ID is no longer valid.
-    ///
-    /// # Errors
-    /// Returns an error if the instance is not found.
+    /// Stops and deletes an instance.
     pub async fn delete_instance(&mut self, id: InstanceId) -> Result<(), InstanceError> {
-        {
-            let info = self
-                .instances
-                .get_mut(&id)
-                .ok_or(InstanceError::NotFound(id))?;
-
-            if info.state == InstanceState::Running || info.state == InstanceState::Starting {
-                info.state = InstanceState::Stopping;
-                info.stop_token.cancel();
-                if let Some(server) = info.server.take() {
-                    server.unload_plugins().await;
-                    drop(server);
-                }
-            }
-        }
-
+        self.stop_instance(id).await?;
         self.instances.remove(&id);
         info!("Deleted instance {id:?}");
         Ok(())
@@ -274,7 +242,9 @@ impl InstanceManager {
     }
 
     pub fn list_instances(&self) -> Vec<InstanceId> {
-        self.instances.keys().copied().collect()
+        let mut ids: Vec<_> = self.instances.keys().copied().collect();
+        ids.sort_unstable_by_key(|id| id.0);
+        ids
     }
 
     pub fn instance_count(&self) -> usize {

--- a/pumpkin/src/instance/manager.rs
+++ b/pumpkin/src/instance/manager.rs
@@ -55,7 +55,7 @@ impl std::fmt::Debug for InstanceInfo {
             .field("state", &self.state)
             .field("has_server", &self.server.is_some())
             .field("ports", &self.ports)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -67,10 +67,12 @@ pub struct InstanceManager {
 }
 
 impl InstanceManager {
+    #[must_use]
     pub fn new() -> Self {
         Self::with_port_range(25565..=25665)
     }
 
+    #[must_use]
     pub fn with_port_range(range: std::ops::RangeInclusive<u16>) -> Self {
         Self {
             instances: HashMap::new(),

--- a/pumpkin/src/instance/mod.rs
+++ b/pumpkin/src/instance/mod.rs
@@ -4,4 +4,4 @@ pub mod port_allocator;
 
 pub use config::{InstanceConfig, InstanceId};
 pub use manager::{InstanceError, InstanceInfo, InstanceManager, InstanceState};
-pub use port_allocator::{PortAllocator, PortAllocatorError};
+pub use port_allocator::{PortAllocator, PortAllocatorError, PortProtocol, PortReservation};

--- a/pumpkin/src/instance/mod.rs
+++ b/pumpkin/src/instance/mod.rs
@@ -1,0 +1,7 @@
+pub mod config;
+pub mod manager;
+pub mod port_allocator;
+
+pub use config::{InstanceConfig, InstanceId};
+pub use manager::{InstanceError, InstanceInfo, InstanceManager, InstanceState};
+pub use port_allocator::{PortAllocator, PortAllocatorError};

--- a/pumpkin/src/instance/port_allocator.rs
+++ b/pumpkin/src/instance/port_allocator.rs
@@ -1,0 +1,168 @@
+use std::net::SocketAddr;
+use std::ops::RangeInclusive;
+use std::sync::Mutex;
+use tracing::warn;
+
+/// Manages dynamic port allocation for server instances.
+///
+/// The port allocator tracks which ports are currently in use and provides
+/// methods to allocate free ports within a configurable range. This prevents
+/// port conflicts when running multiple server instances concurrently.
+#[derive(Debug)]
+pub struct PortAllocator {
+    allocated_ports: Mutex<Vec<u16>>,
+    range: RangeInclusive<u16>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PortAllocatorError {
+    #[error("Port {0} is already allocated")]
+    AlreadyAllocated(u16),
+    #[error("Port {0} is outside the allowed range {1:?}")]
+    OutOfRange(u16, RangeInclusive<u16>),
+    #[error("No free ports available in range {0:?}")]
+    NoFreePorts(RangeInclusive<u16>),
+}
+
+impl PortAllocator {
+    /// Creates a new port allocator with the given port range.
+    ///
+    /// # Arguments
+    /// * `range` - The inclusive range of ports to allocate from.
+    pub fn new(range: RangeInclusive<u16>) -> Self {
+        Self {
+            allocated_ports: Mutex::new(Vec::new()),
+            range,
+        }
+    }
+
+    /// Creates a port allocator with a sensible default range for Minecraft servers.
+    ///
+    /// Default range: 25565..=25665 (100 ports for Java + Bedrock instances).
+    pub fn default_range() -> Self {
+        Self::new(25565..=25665)
+    }
+
+    /// Attempts to allocate a specific port.
+    ///
+    /// Returns `Ok(())` if the port was successfully allocated, or an error
+    /// if the port is already in use or outside the allowed range.
+    pub fn allocate(&self, port: u16) -> Result<(), PortAllocatorError> {
+        if !self.range.contains(&port) {
+            return Err(PortAllocatorError::OutOfRange(port, self.range.clone()));
+        }
+
+        let mut ports = self.allocated_ports.lock().unwrap();
+        if ports.contains(&port) {
+            return Err(PortAllocatorError::AlreadyAllocated(port));
+        }
+        ports.push(port);
+        Ok(())
+    }
+
+    /// Allocates a specific port, falling back to any free port if it's taken.
+    ///
+    /// Returns the allocated port number.
+    pub fn allocate_or_any(&self, preferred: u16) -> Result<u16, PortAllocatorError> {
+        if !self.range.contains(&preferred) {
+            warn!(
+                "Preferred port {preferred} is outside allocator range {:?}, finding alternative",
+                self.range
+            );
+            return self.allocate_any();
+        }
+
+        let mut ports = self.allocated_ports.lock().unwrap();
+        if !ports.contains(&preferred) {
+            ports.push(preferred);
+            Ok(preferred)
+        } else {
+            for port in self.range.clone() {
+                if !ports.contains(&port) {
+                    ports.push(port);
+                    return Ok(port);
+                }
+            }
+            Err(PortAllocatorError::NoFreePorts(self.range.clone()))
+        }
+    }
+
+    /// Allocates any free port within the configured range.
+    ///
+    /// Returns the allocated port number, or an error if no ports are available.
+    pub fn allocate_any(&self) -> Result<u16, PortAllocatorError> {
+        let mut ports = self.allocated_ports.lock().unwrap();
+        for port in self.range.clone() {
+            if !ports.contains(&port) {
+                ports.push(port);
+                return Ok(port);
+            }
+        }
+        Err(PortAllocatorError::NoFreePorts(self.range.clone()))
+    }
+
+    /// Frees a previously allocated port, making it available for reuse.
+    pub fn free(&self, port: u16) {
+        let mut ports = self.allocated_ports.lock().unwrap();
+        ports.retain(|p| *p != port);
+    }
+
+    /// Returns the list of currently allocated ports.
+    pub fn allocated_ports(&self) -> Vec<u16> {
+        self.allocated_ports.lock().unwrap().clone()
+    }
+
+    /// Checks whether a specific port is currently allocated.
+    pub fn is_allocated(&self, port: u16) -> bool {
+        self.allocated_ports.lock().unwrap().contains(&port)
+    }
+
+    /// Creates a `SocketAddr` from an allocated port with the given IP.
+    pub fn make_addr(&self, ip: std::net::IpAddr, port: u16) -> SocketAddr {
+        SocketAddr::new(ip, port)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_allocate_and_free() {
+        let allocator = PortAllocator::new(30000..=30100);
+        assert!(allocator.allocate(30000).is_ok());
+        assert!(allocator.is_allocated(30000));
+        assert!(allocator.allocate(30000).is_err());
+        allocator.free(30000);
+        assert!(!allocator.is_allocated(30000));
+        assert!(allocator.allocate(30000).is_ok());
+    }
+
+    #[test]
+    fn test_allocate_any() {
+        let allocator = PortAllocator::new(30000..=30100);
+        let port = allocator.allocate_any().unwrap();
+        assert!((30000..=30100).contains(&port));
+        allocator.free(port);
+    }
+
+    #[test]
+    fn test_out_of_range() {
+        let allocator = PortAllocator::new(30000..=30100);
+        assert!(allocator.allocate(29999).is_err());
+        assert!(allocator.allocate(30101).is_err());
+    }
+
+    #[test]
+    fn test_allocate_or_any_fallback() {
+        let allocator = PortAllocator::new(30000..=30100);
+        let preferred = 30005;
+        let port1 = allocator.allocate_or_any(preferred).unwrap();
+        assert_eq!(port1, preferred);
+
+        // Now that preferred is taken, should get a different port
+        let port2 = allocator.allocate_or_any(preferred).unwrap();
+        assert_ne!(port2, preferred);
+        assert!((30000..=30100).contains(&port2));
+    }
+}

--- a/pumpkin/src/instance/port_allocator.rs
+++ b/pumpkin/src/instance/port_allocator.rs
@@ -44,6 +44,7 @@ impl PortAllocator {
     ///
     /// # Arguments
     /// * `range` - The inclusive range of ports to allocate from.
+    #[must_use]
     pub fn new(range: RangeInclusive<u16>) -> Self {
         Self {
             allocated_ports: Mutex::new(HashSet::new()),
@@ -54,6 +55,7 @@ impl PortAllocator {
     /// Creates a port allocator with a sensible default range for Minecraft servers.
     ///
     /// Default range: 25565..=25665 (100 ports for Java + Bedrock instances).
+    #[must_use]
     pub fn default_range() -> Self {
         Self::new(25565..=25665)
     }
@@ -207,7 +209,7 @@ impl PortAllocator {
     }
 
     /// Creates a `SocketAddr` from an allocated port with the given IP.
-    pub fn make_addr(&self, ip: std::net::IpAddr, port: u16) -> SocketAddr {
+    pub const fn make_addr(&self, ip: std::net::IpAddr, port: u16) -> SocketAddr {
         SocketAddr::new(ip, port)
     }
 }
@@ -217,7 +219,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_allocate_and_free() {
+    fn allocate_and_free() {
         let allocator = PortAllocator::new(30000..=30100);
         assert!(allocator.allocate(30000).is_ok());
         assert!(allocator.is_allocated(30000));
@@ -228,7 +230,7 @@ mod tests {
     }
 
     #[test]
-    fn test_allocate_any() {
+    fn allocate_any() {
         let allocator = PortAllocator::new(30000..=30100);
         let port = allocator.allocate_any().unwrap();
         assert!((30000..=30100).contains(&port));
@@ -236,14 +238,14 @@ mod tests {
     }
 
     #[test]
-    fn test_out_of_range() {
+    fn out_of_range() {
         let allocator = PortAllocator::new(30000..=30100);
         assert!(allocator.allocate(29999).is_err());
         assert!(allocator.allocate(30101).is_err());
     }
 
     #[test]
-    fn test_allocate_or_any_fallback() {
+    fn allocate_or_any_fallback() {
         let allocator = PortAllocator::new(30000..=30100);
         let preferred = 30005;
         let port1 = allocator.allocate_or_any(preferred).unwrap();

--- a/pumpkin/src/instance/port_allocator.rs
+++ b/pumpkin/src/instance/port_allocator.rs
@@ -1,7 +1,22 @@
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::ops::RangeInclusive;
 use std::sync::Mutex;
 use tracing::warn;
+
+/// Network transport used by a port reservation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PortProtocol {
+    Tcp,
+    Udp,
+}
+
+/// A port reservation owned by an instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PortReservation {
+    pub protocol: PortProtocol,
+    pub port: u16,
+}
 
 /// Manages dynamic port allocation for server instances.
 ///
@@ -10,7 +25,7 @@ use tracing::warn;
 /// port conflicts when running multiple server instances concurrently.
 #[derive(Debug)]
 pub struct PortAllocator {
-    allocated_ports: Mutex<Vec<u16>>,
+    allocated_ports: Mutex<HashSet<PortReservation>>,
     range: RangeInclusive<u16>,
 }
 
@@ -31,7 +46,7 @@ impl PortAllocator {
     /// * `range` - The inclusive range of ports to allocate from.
     pub fn new(range: RangeInclusive<u16>) -> Self {
         Self {
-            allocated_ports: Mutex::new(Vec::new()),
+            allocated_ports: Mutex::new(HashSet::new()),
             range,
         }
     }
@@ -48,15 +63,23 @@ impl PortAllocator {
     /// Returns `Ok(())` if the port was successfully allocated, or an error
     /// if the port is already in use or outside the allowed range.
     pub fn allocate(&self, port: u16) -> Result<(), PortAllocatorError> {
+        self.allocate_for(PortProtocol::Tcp, port)
+    }
+
+    /// Reserves a specific port for a transport.
+    pub fn allocate_for(
+        &self,
+        protocol: PortProtocol,
+        port: u16,
+    ) -> Result<(), PortAllocatorError> {
         if !self.range.contains(&port) {
             return Err(PortAllocatorError::OutOfRange(port, self.range.clone()));
         }
 
         let mut ports = self.allocated_ports.lock().unwrap();
-        if ports.contains(&port) {
+        if !ports.insert(PortReservation { protocol, port }) {
             return Err(PortAllocatorError::AlreadyAllocated(port));
         }
-        ports.push(port);
         Ok(())
     }
 
@@ -64,57 +87,123 @@ impl PortAllocator {
     ///
     /// Returns the allocated port number.
     pub fn allocate_or_any(&self, preferred: u16) -> Result<u16, PortAllocatorError> {
-        if !self.range.contains(&preferred) {
-            warn!(
-                "Preferred port {preferred} is outside allocator range {:?}, finding alternative",
-                self.range
-            );
-            return self.allocate_any();
-        }
-
-        let mut ports = self.allocated_ports.lock().unwrap();
-        if !ports.contains(&preferred) {
-            ports.push(preferred);
-            Ok(preferred)
-        } else {
-            for port in self.range.clone() {
-                if !ports.contains(&port) {
-                    ports.push(port);
-                    return Ok(port);
-                }
-            }
-            Err(PortAllocatorError::NoFreePorts(self.range.clone()))
-        }
+        self.allocate_or_any_for(PortProtocol::Tcp, preferred)
     }
 
-    /// Allocates any free port within the configured range.
+    /// Reserves a preferred port for a transport, falling back to the configured range.
     ///
-    /// Returns the allocated port number, or an error if no ports are available.
-    pub fn allocate_any(&self) -> Result<u16, PortAllocatorError> {
+    /// Explicit ports outside the automatic range are accepted when available. This
+    /// preserves normal Minecraft configurations while still allowing automatic
+    /// assignment for `0` and conflicting ports.
+    pub fn allocate_or_any_for(
+        &self,
+        protocol: PortProtocol,
+        preferred: u16,
+    ) -> Result<u16, PortAllocatorError> {
+        let reservation = PortReservation {
+            protocol,
+            port: preferred,
+        };
+
+        if preferred != 0 && !self.range.contains(&preferred) {
+            let mut ports = self.allocated_ports.lock().unwrap();
+            if ports.insert(reservation) {
+                return Ok(preferred);
+            }
+            warn!(
+                "Preferred port {preferred} is already allocated for {protocol:?}, finding alternative"
+            );
+            drop(ports);
+            return self.allocate_any_for(protocol);
+        }
+
+        if preferred == 0 {
+            return self.allocate_any_for(protocol);
+        }
+
         let mut ports = self.allocated_ports.lock().unwrap();
+        if ports.insert(reservation) {
+            return Ok(preferred);
+        }
+
         for port in self.range.clone() {
-            if !ports.contains(&port) {
-                ports.push(port);
+            if ports.insert(PortReservation { protocol, port }) {
                 return Ok(port);
             }
         }
         Err(PortAllocatorError::NoFreePorts(self.range.clone()))
     }
 
+    /// Allocates any free port for a transport within the configured range.
+    pub fn allocate_any_for(&self, protocol: PortProtocol) -> Result<u16, PortAllocatorError> {
+        let mut ports = self.allocated_ports.lock().unwrap();
+        for port in self.range.clone() {
+            if ports.insert(PortReservation { protocol, port }) {
+                return Ok(port);
+            }
+        }
+        Err(PortAllocatorError::NoFreePorts(self.range.clone()))
+    }
+
+    /// Releases a transport-specific reservation.
+    pub fn free_for(&self, protocol: PortProtocol, port: u16) {
+        self.allocated_ports
+            .lock()
+            .unwrap()
+            .remove(&PortReservation { protocol, port });
+    }
+
+    /// Checks whether a transport-specific port is reserved.
+    pub fn is_allocated_for(&self, protocol: PortProtocol, port: u16) -> bool {
+        self.allocated_ports
+            .lock()
+            .unwrap()
+            .contains(&PortReservation { protocol, port })
+    }
+
+    /// Returns all reservations currently held by the allocator.
+    pub fn reservations(&self) -> Vec<PortReservation> {
+        self.allocated_ports
+            .lock()
+            .unwrap()
+            .iter()
+            .copied()
+            .collect()
+    }
+
+    /// Allocates any free port within the configured range.
+    ///
+    /// Returns the allocated port number, or an error if no ports are available.
+    pub fn allocate_any(&self) -> Result<u16, PortAllocatorError> {
+        self.allocate_any_for(PortProtocol::Tcp)
+    }
+
     /// Frees a previously allocated port, making it available for reuse.
     pub fn free(&self, port: u16) {
-        let mut ports = self.allocated_ports.lock().unwrap();
-        ports.retain(|p| *p != port);
+        self.free_for(PortProtocol::Tcp, port);
     }
 
     /// Returns the list of currently allocated ports.
     pub fn allocated_ports(&self) -> Vec<u16> {
-        self.allocated_ports.lock().unwrap().clone()
+        let mut ports: Vec<_> = self
+            .allocated_ports
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|reservation| reservation.port)
+            .collect();
+        ports.sort_unstable();
+        ports.dedup();
+        ports
     }
 
     /// Checks whether a specific port is currently allocated.
     pub fn is_allocated(&self, port: u16) -> bool {
-        self.allocated_ports.lock().unwrap().contains(&port)
+        self.allocated_ports
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|reservation| reservation.port == port)
     }
 
     /// Creates a `SocketAddr` from an allocated port with the given IP.
@@ -164,5 +253,25 @@ mod tests {
         let port2 = allocator.allocate_or_any(preferred).unwrap();
         assert_ne!(port2, preferred);
         assert!((30000..=30100).contains(&port2));
+    }
+
+    #[test]
+    fn tcp_and_udp_can_share_a_port() {
+        let allocator = PortAllocator::new(30000..=30010);
+        assert!(allocator.allocate_for(PortProtocol::Tcp, 30000).is_ok());
+        assert!(allocator.allocate_for(PortProtocol::Udp, 30000).is_ok());
+        assert!(allocator.is_allocated_for(PortProtocol::Tcp, 30000));
+        assert!(allocator.is_allocated_for(PortProtocol::Udp, 30000));
+    }
+
+    #[test]
+    fn preferred_outside_range_is_kept_when_available() {
+        let allocator = PortAllocator::new(30000..=30010);
+        assert_eq!(
+            allocator
+                .allocate_or_any_for(PortProtocol::Tcp, 25565)
+                .unwrap(),
+            25565
+        );
     }
 }

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -43,6 +43,7 @@ pub mod crash;
 pub mod data;
 pub mod entity;
 pub mod error;
+pub mod instance;
 pub mod item;
 pub mod logging;
 pub mod net;
@@ -191,6 +192,43 @@ pub fn stop_or_exit_server() {
     }
 }
 
+/// Errors that can occur when binding network ports for a server instance.
+#[derive(Debug, thiserror::Error)]
+pub enum NetworkBindError {
+    #[error("Address {address} is already in use. Make sure another instance of the server isn't already running")]
+    AddrInUse { address: SocketAddr },
+    #[error("Permission denied when binding to {address}. You might need sudo/admin privileges to use ports below 1024")]
+    PermissionDenied { address: SocketAddr },
+    #[error("The address {address} is not available on this machine")]
+    AddrNotAvailable { address: SocketAddr },
+    #[error("Failed to bind to {address}: {source}")]
+    Other { address: SocketAddr, source: std::io::Error },
+}
+
+async fn bind_tcp_async(address: SocketAddr) -> Result<TcpListener, NetworkBindError> {
+    match tokio::net::TcpListener::bind(address).await {
+        Ok(listener) => Ok(listener),
+        Err(e) => match e.kind() {
+            ErrorKind::AddrInUse => Err(NetworkBindError::AddrInUse { address }),
+            ErrorKind::PermissionDenied => Err(NetworkBindError::PermissionDenied { address }),
+            ErrorKind::AddrNotAvailable => Err(NetworkBindError::AddrNotAvailable { address }),
+            _ => Err(NetworkBindError::Other { address, source: e }),
+        },
+    }
+}
+
+async fn bind_udp_async(address: SocketAddr) -> Result<UdpSocket, NetworkBindError> {
+    match tokio::net::UdpSocket::bind(address).await {
+        Ok(socket) => Ok(socket),
+        Err(e) => match e.kind() {
+            ErrorKind::AddrInUse => Err(NetworkBindError::AddrInUse { address }),
+            ErrorKind::PermissionDenied => Err(NetworkBindError::PermissionDenied { address }),
+            ErrorKind::AddrNotAvailable => Err(NetworkBindError::AddrNotAvailable { address }),
+            _ => Err(NetworkBindError::Other { address, source: e }),
+        },
+    }
+}
+
 fn resolve_some<T: Future, D, F: FnOnce(D) -> T>(
     opt: Option<D>,
     func: F,
@@ -212,11 +250,30 @@ impl PumpkinServer {
     pub fn log_info(&self, message: &str) {
         tracing::info!(target: "plugin", "{}", message);
     }
+
     pub async fn new(
         basic_config: BasicConfiguration,
         advanced_config: AdvancedConfiguration,
         vanilla_data: VanillaData,
     ) -> Self {
+        match Self::new_with_result(basic_config, advanced_config, vanilla_data).await {
+            Ok(server) => server,
+            Err(e) => {
+                error!("{e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    /// Creates a new `PumpkinServer`, returning errors instead of exiting on port conflicts.
+    ///
+    /// This method is suitable for multi-instance usage where a port conflict should
+    /// not terminate the entire process.
+    pub async fn new_with_result(
+        basic_config: BasicConfiguration,
+        advanced_config: AdvancedConfiguration,
+        vanilla_data: VanillaData,
+    ) -> Result<Self, NetworkBindError> {
         let server = Server::new(basic_config, advanced_config, vanilla_data).await;
 
         let rcon = server.advanced_config.networking.rcon.clone();
@@ -233,40 +290,19 @@ impl PumpkinServer {
 
         let tcp_listener = if server.advanced_config.networking.java.enabled {
             let address = server.advanced_config.networking.java.address;
-            // Setup the TCP server socket.
-            let listener = match TcpListener::bind(address).await {
-                Ok(l) => l,
-                Err(e) => match e.kind() {
-                    ErrorKind::AddrInUse => {
-                        error!("Error: Address {address} is already in use.");
-                        error!("Make sure another instance of the server isn't already running");
-                        std::process::exit(1);
-                    }
-                    ErrorKind::PermissionDenied => {
-                        error!("Error: Permission denied when binding to {address}.");
-                        error!("You might need sudo/admin privileges to use ports below 1024");
-                        std::process::exit(1);
-                    }
-                    ErrorKind::AddrNotAvailable => {
-                        error!("Error: The address {address} is not available on this machine");
-                        std::process::exit(1);
-                    }
-                    _ => {
-                        error!("Failed to start TcpListener on {address}: {e}");
-                        std::process::exit(1);
-                    }
-                },
-            };
-            // In the event the user puts 0 for their port, this will allow us to know what port it is running on
+            let listener = bind_tcp_async(address).await?;
             let addr = listener
                 .local_addr()
                 .expect("Unable to get the address of the server!");
 
             if server.advanced_config.networking.query.enabled {
                 info!("Query protocol is enabled. Starting...");
-                server.spawn_task(query::start_query_handler(
+                let query_addr = server.advanced_config.networking.query.address;
+                let query_socket = Arc::new(bind_udp_async(query_addr).await?);
+                server.spawn_task(query::start_query_handler_with_socket(
                     server.clone(),
-                    server.advanced_config.networking.query.address,
+                    query_socket,
+                    query_addr,
                 ));
             }
 
@@ -294,20 +330,17 @@ impl PumpkinServer {
         };
 
         let udp_socket = if server.advanced_config.networking.bedrock.enabled {
-            Some(Arc::new(
-                UdpSocket::bind(server.advanced_config.networking.bedrock.address)
-                    .await
-                    .expect("Failed to bind UDP Socket"),
-            ))
+            let address = server.advanced_config.networking.bedrock.address;
+            Some(Arc::new(bind_udp_async(address).await?))
         } else {
             None
         };
 
-        Self {
+        Ok(Self {
             server,
             tcp_listener,
             udp_socket,
-        }
+        })
     }
 
     pub async fn init_plugins(&self) -> std::time::Duration {
@@ -336,7 +369,17 @@ impl PumpkinServer {
         }
     }
 
+    /// Starts the server with the global cancellation token.
     pub async fn start(&self) {
+        let token = STOP_INTERRUPT.clone();
+        self.start_with_token(token).await;
+    }
+
+    /// Starts the server with a specific cancellation token for per-instance control.
+    ///
+    /// This allows multiple server instances to run concurrently, each with their
+    /// own cancellation signal.
+    pub async fn start_with_token(&self, stop_token: CancellationToken) {
         if self.server.advanced_config.commands.use_console
             && let Some((wrapper, _, _)) = LOGGER_IMPL.wait()
         {
@@ -364,7 +407,7 @@ impl PumpkinServer {
 
         while !SHOULD_STOP.load(Ordering::Relaxed) {
             if !self
-                .unified_listener_task(&mut master_client_id, &tasks, &bedrock_clients)
+                .unified_listener_task(&mut master_client_id, &tasks, &bedrock_clients, &stop_token)
                 .await
             {
                 break;
@@ -440,6 +483,7 @@ impl PumpkinServer {
         master_client_id_counter: &mut u64,
         tasks: &Arc<TaskTracker>,
         bedrock_clients: &Arc<Mutex<HashMap<SocketAddr, Arc<BedrockClient>>>>,
+        stop_token: &CancellationToken,
     ) -> bool {
         let mut udp_buf = [0; 1496]; // Buffer for UDP receive
 
@@ -613,8 +657,8 @@ impl PumpkinServer {
                 }
             },
 
-            // Branch for the global stop signal
-            () = STOP_INTERRUPT.cancelled() => {
+            // Branch for the stop signal
+            () = stop_token.cancelled() => {
                 return false;
             }
         }

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -8,7 +8,7 @@ use crate::net::bedrock::BedrockClient;
 use crate::net::java::JavaClient;
 use crate::net::{ClientPlatform, DisconnectReason, PacketHandlerResult};
 use crate::net::{lan_broadcast::LANBroadcast, query, rcon::RCONServer};
-use crate::server::{Server, ticker::Ticker};
+use crate::server::{Server, ServerPaths, ticker::Ticker};
 use plugin::server::server_command::ServerCommandEvent;
 use plugin::server::server_load::{LoadType, ServerLoadEvent};
 use pumpkin_config::{AdvancedConfiguration, BasicConfiguration};
@@ -195,14 +195,21 @@ pub fn stop_or_exit_server() {
 /// Errors that can occur when binding network ports for a server instance.
 #[derive(Debug, thiserror::Error)]
 pub enum NetworkBindError {
-    #[error("Address {address} is already in use. Make sure another instance of the server isn't already running")]
+    #[error(
+        "Address {address} is already in use. Make sure another instance of the server isn't already running"
+    )]
     AddrInUse { address: SocketAddr },
-    #[error("Permission denied when binding to {address}. You might need sudo/admin privileges to use ports below 1024")]
+    #[error(
+        "Permission denied when binding to {address}. You might need sudo/admin privileges to use ports below 1024"
+    )]
     PermissionDenied { address: SocketAddr },
     #[error("The address {address} is not available on this machine")]
     AddrNotAvailable { address: SocketAddr },
     #[error("Failed to bind to {address}: {source}")]
-    Other { address: SocketAddr, source: std::io::Error },
+    Other {
+        address: SocketAddr,
+        source: std::io::Error,
+    },
 }
 
 async fn bind_tcp_async(address: SocketAddr) -> Result<TcpListener, NetworkBindError> {
@@ -274,19 +281,35 @@ impl PumpkinServer {
         advanced_config: AdvancedConfiguration,
         vanilla_data: VanillaData,
     ) -> Result<Self, NetworkBindError> {
-        let server = Server::new(basic_config, advanced_config, vanilla_data).await;
+        let paths = ServerPaths::from_basic_config(&basic_config);
+        Self::new_with_result_and_paths(
+            basic_config,
+            advanced_config,
+            vanilla_data,
+            paths,
+            STOP_INTERRUPT.clone(),
+        )
+        .await
+    }
+
+    /// Creates a server with explicit instance paths and a per-instance stop token.
+    pub async fn new_with_result_and_paths(
+        basic_config: BasicConfiguration,
+        advanced_config: AdvancedConfiguration,
+        vanilla_data: VanillaData,
+        paths: ServerPaths,
+        stop_token: CancellationToken,
+    ) -> Result<Self, NetworkBindError> {
+        let server =
+            Server::new_with_paths(basic_config, advanced_config, vanilla_data, paths).await;
 
         let rcon = server.advanced_config.networking.rcon.clone();
 
-        if rcon.enabled {
-            warn!(
-                "RCON is enabled, but it's highly insecure as it transmits passwords and commands in plain text. This makes it vulnerable to interception and exploitation by anyone on the network"
-            );
-            let rcon_server = server.clone();
-            server.spawn_task(async move {
-                RCONServer::run(&rcon, rcon_server).await;
-            });
-        }
+        let rcon_listener = if rcon.enabled {
+            Some(bind_tcp_async(rcon.address).await?)
+        } else {
+            None
+        };
 
         let tcp_listener = if server.advanced_config.networking.java.enabled {
             let address = server.advanced_config.networking.java.address;
@@ -303,6 +326,7 @@ impl PumpkinServer {
                     server.clone(),
                     query_socket,
                     query_addr,
+                    stop_token.clone(),
                 ));
             }
 
@@ -313,7 +337,19 @@ impl PumpkinServer {
                     &server.advanced_config.networking.lan_broadcast,
                     &server.advanced_config.networking.java.motd,
                 );
-                server.spawn_task(lan_broadcast.start(addr));
+                let lan_socket =
+                    lan_broadcast
+                        .bind()
+                        .await
+                        .map_err(|source| NetworkBindError::Other {
+                            address: SocketAddr::from(([0, 0, 0, 0], 0)),
+                            source,
+                        })?;
+                server.spawn_task(lan_broadcast.start_with_socket(
+                    addr,
+                    lan_socket,
+                    stop_token.clone(),
+                ));
             }
 
             Some(listener)
@@ -324,8 +360,9 @@ impl PumpkinServer {
         // Ticker
         {
             let ticker_server = server.clone();
+            let ticker_token = stop_token.clone();
             server.spawn_task(async move {
-                Ticker::run(&ticker_server).await;
+                Ticker::run_with_token(&ticker_server, ticker_token).await;
             });
         };
 
@@ -335,6 +372,19 @@ impl PumpkinServer {
         } else {
             None
         };
+
+        if let Some(listener) = rcon_listener {
+            warn!(
+                "RCON is enabled, but it's highly insecure as it transmits passwords and commands in plain text. This makes it vulnerable to interception and exploitation by anyone on the network"
+            );
+            let rcon_server = server.clone();
+            let rcon_config = rcon.clone();
+            let rcon_token = stop_token.clone();
+            server.spawn_task(async move {
+                RCONServer::run_with_listener(listener, &rcon_config, rcon_server, rcon_token)
+                    .await;
+            });
+        }
 
         Ok(Self {
             server,
@@ -372,7 +422,7 @@ impl PumpkinServer {
     /// Starts the server with the global cancellation token.
     pub async fn start(&self) {
         let token = STOP_INTERRUPT.clone();
-        self.start_with_token(token).await;
+        self.start_with_token_and_global(token, true).await;
     }
 
     /// Starts the server with a specific cancellation token for per-instance control.
@@ -380,7 +430,16 @@ impl PumpkinServer {
     /// This allows multiple server instances to run concurrently, each with their
     /// own cancellation signal.
     pub async fn start_with_token(&self, stop_token: CancellationToken) {
-        if self.server.advanced_config.commands.use_console
+        self.start_with_token_and_global(stop_token, false).await;
+    }
+
+    async fn start_with_token_and_global(
+        &self,
+        stop_token: CancellationToken,
+        global_shutdown: bool,
+    ) {
+        if global_shutdown
+            && self.server.advanced_config.commands.use_console
             && let Some((wrapper, _, _)) = LOGGER_IMPL.wait()
         {
             if let Some(rl) = wrapper.take_readline() {
@@ -405,7 +464,11 @@ impl PumpkinServer {
             .fire(ServerLoadEvent::new(LoadType::Startup))
             .await;
 
-        while !SHOULD_STOP.load(Ordering::Relaxed) {
+        while if global_shutdown {
+            !SHOULD_STOP.load(Ordering::Relaxed)
+        } else {
+            !stop_token.is_cancelled()
+        } {
             if !self
                 .unified_listener_task(&mut master_client_id, &tasks, &bedrock_clients, &stop_token)
                 .await
@@ -414,9 +477,11 @@ impl PumpkinServer {
             }
         }
 
-        SERVER_IS_STOPPING.store(true, Ordering::Release);
+        if global_shutdown {
+            SERVER_IS_STOPPING.store(true, Ordering::Release);
+        }
 
-        if let Some(crash_report) = CRASH_REPORT.get() {
+        if global_shutdown && let Some(crash_report) = CRASH_REPORT.get() {
             crash_report.print_to_console();
             crash_report.save_and_log();
 
@@ -470,7 +535,8 @@ impl PumpkinServer {
 
         info!("Completed save!");
 
-        if let Some((wrapper, _, _)) = LOGGER_IMPL.wait()
+        if global_shutdown
+            && let Some((wrapper, _, _)) = LOGGER_IMPL.wait()
             && let Some(rl) = wrapper.take_readline()
         {
             let _ = rl;

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -719,7 +719,15 @@ impl PumpkinServer {
                             }
                         }
                     }
-                    Err(e) => error!("UDP socket error: {e}"),
+                    Err(e) => {
+                        error!("UDP socket error: {e}");
+                        // Back off like the TCP arm above. `recv_from` can fail
+                        // repeatedly and immediately — on Linux a surfaced ICMP
+                        // "port unreachable" from an earlier send does exactly
+                        // that — and without this the select loop spins at full
+                        // speed on one worker.
+                        sleep(Duration::from_millis(50)).await;
+                    }
                 }
             },
 

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -502,6 +502,12 @@ impl JavaClient {
     }
 
     pub async fn send_packet_now<P: ClientPacket>(&self, packet: &P) {
+        // If the connection is already closed, don't bother encoding the packet
+        // or firing plugin events — the outgoing task is gone and the write would
+        // fail anyway. This keeps spawn from spamming packets into a dead socket.
+        if self.close_token.is_cancelled() {
+            return;
+        }
         let mut packet_buf = Vec::new();
         let writer = &mut packet_buf;
         if let Err(err) = self.write_packet(packet, writer) {
@@ -525,6 +531,9 @@ impl JavaClient {
     }
 
     pub async fn send_packet_now_data(&self, packet: Bytes) {
+        if self.close_token.is_cancelled() {
+            return;
+        }
         let (completion_tx, completion_rx) = oneshot::channel();
 
         if let Err(err) = self
@@ -546,7 +555,14 @@ impl JavaClient {
         }
 
         if completion_rx.await.is_err() && !self.close_token.is_cancelled() {
-            // The outgoing packet task dropped before confirming the write.
+            // The outgoing packet task dropped the sender before confirming the
+            // write, which means the connection broke while this packet was in
+            // flight. This is the signature of a client disconnecting mid-spawn
+            // (e.g. "Broken pipe"); log it so the failing spawn step is visible.
+            warn!(
+                "Outgoing task dropped mid-send for client {} (connection broke during spawn); closing",
+                self.id
+            );
             self.close();
         }
     }

--- a/pumpkin/src/net/lan_broadcast.rs
+++ b/pumpkin/src/net/lan_broadcast.rs
@@ -1,12 +1,12 @@
 use pumpkin_config::LANBroadcastConfig;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::net::UdpSocket;
 use tokio::{select, time};
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use crate::{SHOULD_STOP, STOP_INTERRUPT};
+use crate::STOP_INTERRUPT;
 
 /// The standard Minecraft multicast address used for LAN discovery
 ///
@@ -52,12 +52,23 @@ impl LANBroadcast {
     /// # Panics
     /// Panics if the UDP socket cannot be bound or if broadcast permissions are denied
     pub async fn start(self, bound_addr: SocketAddr) {
-        let socket = UdpSocket::bind(format!("0.0.0.0:{}", self.port))
-            .await
-            .expect("Unable to bind to address");
+        let socket = self.bind().await.expect("Unable to bind to address");
+        self.start_with_socket(bound_addr, socket, STOP_INTERRUPT.clone())
+            .await;
+    }
 
-        socket.set_broadcast(true).unwrap();
+    pub async fn bind(&self) -> std::io::Result<UdpSocket> {
+        let socket = UdpSocket::bind(format!("0.0.0.0:{}", self.port)).await?;
+        socket.set_broadcast(true)?;
+        Ok(socket)
+    }
 
+    pub async fn start_with_socket(
+        self,
+        bound_addr: SocketAddr,
+        socket: UdpSocket,
+        stop_token: CancellationToken,
+    ) {
         let mut interval = time::interval(Duration::from_millis(1500));
 
         let advertisement = format!("[MOTD]{}[/MOTD][AD]{}[/AD]", self.motd, bound_addr.port());
@@ -69,9 +80,9 @@ impl LANBroadcast {
                 .expect("Unable to find running address!")
         );
 
-        while !SHOULD_STOP.load(Ordering::Relaxed) {
+        while !stop_token.is_cancelled() {
             let t1 = interval.tick();
-            let t2 = STOP_INTERRUPT.cancelled();
+            let t2 = stop_token.cancelled();
 
             let should_continue = select! {
                 _ = t1 => true,

--- a/pumpkin/src/net/query.rs
+++ b/pumpkin/src/net/query.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     ffi::{CString, NulError},
     net::SocketAddr,
-    sync::{Arc, atomic::Ordering},
+    sync::Arc,
     time::Duration,
 };
 
@@ -13,9 +13,10 @@ use pumpkin_util::text::{TextComponent, color::NamedColor};
 use pumpkin_world::CURRENT_MC_VERSION;
 use rand::RngExt;
 use tokio::{net::UdpSocket, sync::RwLock, time};
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
-use crate::{SHOULD_STOP, STOP_INTERRUPT, server::Server};
+use crate::{STOP_INTERRUPT, server::Server};
 
 pub async fn start_query_handler(server: Arc<Server>, query_addr: SocketAddr) {
     let socket = Arc::new(
@@ -23,25 +24,30 @@ pub async fn start_query_handler(server: Arc<Server>, query_addr: SocketAddr) {
             .await
             .expect("Unable to bind to address"),
     );
-    start_query_handler_with_socket(server, socket, query_addr).await;
+    start_query_handler_with_socket(server, socket, query_addr, STOP_INTERRUPT.clone()).await;
 }
 
 pub async fn start_query_handler_with_socket(
     server: Arc<Server>,
     socket: Arc<UdpSocket>,
     query_addr: SocketAddr,
+    stop_token: CancellationToken,
 ) {
-
     // Challenge tokens are bound to the IP address and port
     let valid_challenge_tokens = Arc::new(RwLock::new(HashMap::new()));
     let valid_challenge_tokens_clone = valid_challenge_tokens.clone();
+    let cleanup_token = stop_token.clone();
     // All challenge tokens ever created are expired every 30 seconds
     tokio::spawn(async move {
         let mut interval = time::interval(Duration::from_secs(30));
 
         loop {
-            interval.tick().await;
-            valid_challenge_tokens_clone.write().await.clear();
+            tokio::select! {
+                _ = interval.tick() => {
+                    valid_challenge_tokens_clone.write().await.clear();
+                }
+                _ = cleanup_token.cancelled() => break,
+            }
         }
     });
 
@@ -58,7 +64,7 @@ pub async fn start_query_handler_with_socket(
         .to_pretty_console()
     );
 
-    while !SHOULD_STOP.load(Ordering::Relaxed) {
+    while !stop_token.is_cancelled() {
         let socket = socket.clone();
         let valid_challenge_tokens = valid_challenge_tokens.clone();
         let server = server.clone();
@@ -66,7 +72,7 @@ pub async fn start_query_handler_with_socket(
 
         let recv_result = tokio::select! {
             result = socket.recv_from(&mut buf) => Some(result),
-            () = STOP_INTERRUPT.cancelled() => None,
+            () = stop_token.cancelled() => None,
         };
 
         let Some(Ok((length, addr))) = recv_result else {

--- a/pumpkin/src/net/query.rs
+++ b/pumpkin/src/net/query.rs
@@ -46,7 +46,7 @@ pub async fn start_query_handler_with_socket(
                 _ = interval.tick() => {
                     valid_challenge_tokens_clone.write().await.clear();
                 }
-                _ = cleanup_token.cancelled() => break,
+                () = cleanup_token.cancelled() => break,
             }
         }
     });

--- a/pumpkin/src/net/query.rs
+++ b/pumpkin/src/net/query.rs
@@ -23,6 +23,14 @@ pub async fn start_query_handler(server: Arc<Server>, query_addr: SocketAddr) {
             .await
             .expect("Unable to bind to address"),
     );
+    start_query_handler_with_socket(server, socket, query_addr).await;
+}
+
+pub async fn start_query_handler_with_socket(
+    server: Arc<Server>,
+    socket: Arc<UdpSocket>,
+    query_addr: SocketAddr,
+) {
 
     // Challenge tokens are bound to the IP address and port
     let valid_challenge_tokens = Arc::new(RwLock::new(HashMap::new()));

--- a/pumpkin/src/net/rcon/mod.rs
+++ b/pumpkin/src/net/rcon/mod.rs
@@ -1,16 +1,18 @@
-use std::{net::SocketAddr, sync::atomic::Ordering};
+use std::net::SocketAddr;
 
 use packet::{ClientboundPacket, Packet, PacketError, ServerboundPacket};
 use pumpkin_config::RCONConfig;
 use std::sync::Arc;
+use tokio::net::TcpListener;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     select,
 };
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
 use crate::command::CommandSender;
-use crate::{SHOULD_STOP, STOP_INTERRUPT, server::Server};
+use crate::{STOP_INTERRUPT, server::Server};
 
 pub mod packet;
 
@@ -18,15 +20,23 @@ pub struct RCONServer;
 
 impl RCONServer {
     pub async fn run(config: &RCONConfig, server: Arc<Server>) {
-        let listener = tokio::net::TcpListener::bind(config.address).await.unwrap();
+        let listener = TcpListener::bind(config.address).await.unwrap();
+        Self::run_with_listener(listener, config, server, STOP_INTERRUPT.clone()).await;
+    }
 
+    pub async fn run_with_listener(
+        listener: TcpListener,
+        config: &RCONConfig,
+        server: Arc<Server>,
+        stop_token: CancellationToken,
+    ) {
         let password = Arc::new(config.password.clone());
 
         let mut connections = 0;
-        while !SHOULD_STOP.load(Ordering::Relaxed) {
+        while !stop_token.is_cancelled() {
             let await_new_client = || async {
                 let t1 = listener.accept();
-                let t2 = STOP_INTERRUPT.cancelled();
+                let t2 = stop_token.cancelled();
 
                 select! {
                     client = t1 => Some(client),

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, OnceLock},
 };
 
@@ -39,6 +39,7 @@ pub struct Context {
     pub plugin_manager: Arc<PluginManager>,
     pub permission_manager: Arc<RwLock<PermissionManager>>,
     pub logger: Arc<OnceLock<LoggerOption>>,
+    data_folder: PathBuf,
 }
 impl Context {
     /// Creates a new instance of `Context`.
@@ -57,6 +58,7 @@ impl Context {
         handlers: Arc<RwLock<HandlerMap>>,
         plugin_manager: Arc<PluginManager>,
         logger: Arc<OnceLock<LoggerOption>>,
+        data_folder: PathBuf,
     ) -> Self {
         let permission_manager = server.permission_manager.clone();
         Self {
@@ -66,6 +68,7 @@ impl Context {
             plugin_manager,
             permission_manager,
             logger,
+            data_folder,
         }
     }
 
@@ -80,7 +83,7 @@ impl Context {
     /// A string representing the path to the data folder.
     #[must_use]
     pub fn get_data_folder(&self) -> PathBuf {
-        let path = Path::new("plugins").join(&self.metadata.name);
+        let path = self.data_folder.clone();
         if !path.exists() {
             fs::create_dir_all(&path).unwrap();
         }

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -34,7 +34,8 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// that makes old binary plugins incompatible.
 pub const PLUGIN_API_VERSION: u32 = 2;
 
-const PLUGIN_DIR: &str = "./plugins";
+/// Default plugin directory path.
+pub const DEFAULT_PLUGIN_DIR: &str = "./plugins";
 
 /// A trait for handling events dynamically.
 ///
@@ -185,6 +186,8 @@ pub struct PluginManager {
     // Background task for hot reloading
     hot_reload_task: RwLock<Option<JoinHandle<()>>>,
     hot_reload_enabled: AtomicBool,
+    // Plugin directory path
+    plugin_dir: RwLock<PathBuf>,
 }
 
 /// Represents a successfully loaded plugin
@@ -240,6 +243,7 @@ impl Default for PluginManager {
             state_notify: Arc::new(Notify::new()),
             hot_reload_task: RwLock::new(None),
             hot_reload_enabled: AtomicBool::new(false),
+            plugin_dir: RwLock::new(PathBuf::from(DEFAULT_PLUGIN_DIR)),
         }
     }
 }
@@ -249,6 +253,25 @@ impl PluginManager {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Create a new plugin manager with a custom plugin directory.
+    #[must_use]
+    pub fn with_plugin_dir(plugin_dir: PathBuf) -> Self {
+        Self {
+            plugin_dir: RwLock::new(plugin_dir),
+            ..Default::default()
+        }
+    }
+
+    /// Returns the current plugin directory path.
+    pub async fn plugin_dir(&self) -> PathBuf {
+        self.plugin_dir.read().await.clone()
+    }
+
+    /// Sets the plugin directory path.
+    pub async fn set_plugin_dir(&self, plugin_dir: PathBuf) {
+        *self.plugin_dir.write().await = plugin_dir;
     }
 
     /// Unload all loaded plugins
@@ -293,13 +316,13 @@ impl PluginManager {
         })
         .map_err(|e| ManagerError::IoError(std::io::Error::other(e)))?;
 
-        let plugin_dir = Path::new(PLUGIN_DIR);
+        let plugin_dir = self.plugin_dir.read().await.clone();
         if !plugin_dir.exists() {
-            std::fs::create_dir_all(plugin_dir)?;
+            std::fs::create_dir_all(&plugin_dir)?;
         }
 
         watcher
-            .watch(plugin_dir, RecursiveMode::NonRecursive)
+            .watch(&plugin_dir, RecursiveMode::NonRecursive)
             .map_err(|e| ManagerError::IoError(std::io::Error::other(e)))?;
 
         let self_ref = self
@@ -663,9 +686,12 @@ impl PluginManager {
         Ok(task)
     }
 
-    /// Load all plugins from the plugin directory
+    /// Load all plugins from the plugin directory.
+    ///
+    /// If a custom plugin directory has been set via `with_plugin_dir` or
+    /// `set_plugin_dir`, that directory is used instead of the default `./plugins`.
     pub async fn load_plugins(&self) -> Result<std::time::Duration, ManagerError> {
-        let path = Path::new(PLUGIN_DIR);
+        let path = &*self.plugin_dir.read().await;
 
         if !path.exists() {
             std::fs::create_dir(path)?;
@@ -821,7 +847,7 @@ impl PluginManager {
             if loader.can_load(path) {
                 let (instance, metadata, loader_data) = loader.load(path).await?;
 
-                let cache_path = Path::new(PLUGIN_DIR).join("permission_cache.json");
+                let cache_path = self.plugin_dir.read().await.join("permission_cache.json");
                 let mut cache = cache::PermissionCache::load(&cache_path).await;
 
                 let (allowed, _) = self

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -577,6 +577,8 @@ impl PluginManager {
             .clone()
             .ok_or(ManagerError::ServerNotInitialized)?;
 
+        let data_folder = self.plugin_dir.read().await.join(&metadata.name);
+
         let context = Arc::new(Context::new(
             metadata.clone(),
             Arc::clone(
@@ -590,6 +592,7 @@ impl PluginManager {
             Arc::clone(&self.handlers),
             Arc::clone(&self_ref),
             Arc::clone(&LOGGER_IMPL),
+            data_folder,
         ));
 
         // Create the plugin structure first

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -45,6 +45,7 @@ use rsa::RsaPublicKey;
 use std::collections::HashSet;
 use std::fs;
 use std::net::IpAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32};
 use std::{future::Future, sync::atomic::Ordering, time::Duration};
@@ -69,9 +70,28 @@ use crate::data::advancement_data::AdvancementManager;
 use crate::server::scheduler::TaskScheduler;
 
 /// Represents a Minecraft server instance.
+#[derive(Clone, Debug)]
+pub struct ServerPaths {
+    pub world_dir: PathBuf,
+    pub data_dir: PathBuf,
+    pub plugin_dir: PathBuf,
+}
+
+impl ServerPaths {
+    #[must_use]
+    pub fn from_basic_config(config: &BasicConfiguration) -> Self {
+        Self {
+            world_dir: config.get_world_path(),
+            data_dir: PathBuf::from("./data"),
+            plugin_dir: PathBuf::from("./plugins"),
+        }
+    }
+}
+
 pub struct Server {
     pub basic_config: BasicConfiguration,
     pub advanced_config: AdvancedConfiguration,
+    pub paths: ServerPaths,
 
     pub data: VanillaData,
 
@@ -145,12 +165,23 @@ pub struct Server {
 }
 
 impl Server {
-    #[expect(clippy::too_many_lines)]
     #[must_use]
     pub async fn new(
         basic_config: BasicConfiguration,
         advanced_config: AdvancedConfiguration,
         vanilla_data: VanillaData,
+    ) -> Arc<Self> {
+        let paths = ServerPaths::from_basic_config(&basic_config);
+        Self::new_with_paths(basic_config, advanced_config, vanilla_data, paths).await
+    }
+
+    #[expect(clippy::too_many_lines)]
+    #[must_use]
+    pub async fn new_with_paths(
+        basic_config: BasicConfiguration,
+        advanced_config: AdvancedConfiguration,
+        vanilla_data: VanillaData,
+        paths: ServerPaths,
     ) -> Arc<Self> {
         let permission_registry = Arc::new(RwLock::new(PermissionRegistry::new()));
         // First register the default commands. After that, plugins can put in their own.
@@ -161,7 +192,7 @@ impl Server {
             advanced_config.commands.broadcast_console_to_ops,
         );
 
-        let world_path = basic_config.get_world_path();
+        let world_path = paths.world_dir.clone();
 
         let block_registry = super::block::registry::default_registry();
 
@@ -258,7 +289,7 @@ impl Server {
             basic_config,
             advanced_config,
             data: vanilla_data,
-            plugin_manager: Arc::new(PluginManager::new()),
+            plugin_manager: Arc::new(PluginManager::with_plugin_dir(paths.plugin_dir.clone())),
             permission_manager: Arc::new(RwLock::new(PermissionManager::new(
                 permission_registry.clone(),
             ))),
@@ -293,6 +324,7 @@ impl Server {
             mojang_public_keys: ArcSwap::from_pointee(Vec::new()),
             world_info_writer: Arc::new(AnvilLevelInfo),
             level_info,
+            paths,
         };
         let server = Arc::new(server);
 
@@ -423,7 +455,7 @@ impl Server {
         let server = self.clone();
         let name_clone = name.clone();
         tokio::task::spawn_blocking(move || {
-            let world_path = server.basic_config.get_world_path().join(name_clone);
+            let world_path = server.paths.world_dir.join(name_clone);
             let registry = server.block_registry.clone();
             let l_info = server.level_info.clone();
             let weak = Arc::downgrade(&server);
@@ -556,6 +588,7 @@ impl Server {
                     .is_ok() {
                     let mut user_cache = self.data.user_cache.write().await;
                     user_cache.upsert(player.gameprofile.id, player.gameprofile.name.clone());
+                    self.data.save_user_cache(&user_cache);
 
                     // TODO: Config if we want increase online
                     if let Some(config) = config {
@@ -605,10 +638,11 @@ impl Server {
 
         if let Err(err) = self
             .world_info_writer
-            .write_world_info(&level_data, &self.basic_config.get_world_path())
+            .write_world_info(&level_data, &self.paths.world_dir)
         {
             error!("Failed to save level.dat: {err}");
         }
+        self.data.save_all().await;
         info!("Completed worlds");
     }
 

--- a/pumpkin/src/server/ticker.rs
+++ b/pumpkin/src/server/ticker.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::time::{Instant, sleep_until};
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 pub struct Ticker;
@@ -16,6 +17,10 @@ pub struct Ticker;
 impl Ticker {
     /// IMPORTANT: Run this in a new thread/tokio task.
     pub async fn run(server: &Arc<Server>) {
+        Self::run_with_token(server, STOP_INTERRUPT.clone()).await;
+    }
+
+    pub async fn run_with_token(server: &Arc<Server>, stop_token: CancellationToken) {
         let mut next_tick = Instant::now();
 
         'ticker: loop {
@@ -61,7 +66,7 @@ impl Ticker {
 
             tokio::select! {
                 () = sleep_until(next_tick) => {},
-                () = STOP_INTERRUPT.cancelled() => {
+                () = stop_token.cancelled() => {
                     break 'ticker;
                 }
             }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -2550,6 +2550,13 @@ impl World {
         let Some(client) = player.client.java() else {
             return;
         };
+        if client.is_closed() {
+            debug!(
+                "Skipping spawn for {}: client already closed",
+                player.gameprofile.name
+            );
+            return;
+        }
         // Send the login packet for our new player
         client
             .send_packet_now(&CLogin::new(


### PR DESCRIPTION
## Summary
This PR implements the P0 core infrastructure for using Pumpkin as a multi-instance library:
- Adds an InstanceManager lifecycle API for create/start/stop/delete operations.
- Allocates TCP and UDP ports per instance with conflict detection and fallback.
- Adds per-instance world, data, plugin, and plugin-data directories.
-  Adds per-instance configuration roots and data persistence paths.
- Uses per-instance cancellation and graceful shutdown instead of process-wide stop state.
- Returns bind failures through the library constructor path instead of exiting the process.
- Preserves the existing single-instance entry points for backward compatibility.
## Verification
running 8 tests
test instance::port_allocator::tests::preferred_outside_range_is_kept_when_available ... ok
test instance::port_allocator::tests::tcp_and_udp_can_share_a_port ... ok
test instance::port_allocator::tests::test_allocate_or_any_fallback ... ok
test instance::port_allocator::tests::test_out_of_range ... ok
test instance::config::tests::explicit_config_root_is_used_for_default_paths ... ok
test instance::config::tests::reserve_ports_updates_network_configuration ... ok
test instance::port_allocator::tests::test_allocate_any ... ok
test instance::port_allocator::tests::test_allocate_and_free ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 157 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s (8 passed)
## Scope
This PR covers the P0 core needed for orchestration. REST/gRPC management, resource enforcement, metrics, snapshots, hot-swapping, and auto-scaling remain follow-up work rather than being represented as completed here.