### PR TITLE
fix: honour the randomTickSpeed game rule

### DIFF
--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -47,6 +47,15 @@ use tokio_util::task::TaskTracker;
 pub type SyncChunk = Arc<ChunkData>;
 pub type SyncEntityChunk = Arc<ChunkEntityData>;
 
+/// Upper bound applied to the `randomTickSpeed` game rule before it is used for sampling.
+///
+/// A chunk section holds 16 * 16 * 16 = 4096 blocks, so sampling 4096 positions per section
+/// already gives every block roughly one expected random tick per game tick. Anything beyond
+/// that adds cost without adding behaviour, and the game rule itself is stored as an
+/// unbounded signed integer, so it has to be capped somewhere to keep the per-tick work
+/// (and the allocations it drives) bounded.
+pub const MAX_RANDOM_TICK_SPEED: u32 = 4096;
+
 /// The `Level` module provides functionality for working with chunks within or outside a Minecraft world.
 ///
 /// Key features include:
@@ -500,51 +509,66 @@ impl Level {
         });
     }
 
-    pub fn get_tick_data(&self, active_chunks: &FxHashSet<Vector2<i32>>) -> TickData {
+    /// `random_tick_speed` is the amount of positions sampled per chunk section per tick, as
+    /// controlled by the `randomTickSpeed` game rule. A value of 0 disables random ticks.
+    /// Callers are expected to have clamped it to [`MAX_RANDOM_TICK_SPEED`].
+    pub fn get_tick_data(
+        &self,
+        active_chunks: &FxHashSet<Vector2<i32>>,
+        random_tick_speed: u32,
+    ) -> TickData {
+        let samples_per_section = random_tick_speed.min(MAX_RANDOM_TICK_SPEED) as usize;
+        // No capacity hint for `random_ticks`: the number of samples that survive the
+        // `has_random_ticks` filter is not knowable up front, and any estimate derived from
+        // `random_tick_speed` would scale with a value the user controls.
         let mut ticks = TickData {
             block_ticks: Vec::new(),
             fluid_ticks: Vec::new(),
-            random_ticks: Vec::with_capacity(active_chunks.len() * 3),
+            random_ticks: Vec::new(),
         };
 
-        // 1. Process active chunks (random ticks, block entities)
-        for pos in active_chunks {
-            if let Some(chunk) = self.loaded_chunks.get(pos) {
-                let chunk = chunk.value();
-                let chunk_x_base = chunk.x * 16;
-                let chunk_z_base = chunk.z * 16;
-                let section_count = chunk.section.count;
+        // 1. Process active chunks (random ticks)
+        // A `randomTickSpeed` of 0 means no positions are sampled at all
+        if samples_per_section != 0 {
+            for pos in active_chunks {
+                if let Some(chunk) = self.loaded_chunks.get(pos) {
+                    let chunk = chunk.value();
+                    let chunk_x_base = chunk.x * 16;
+                    let chunk_z_base = chunk.z * 16;
+                    let section_count = chunk.section.count;
 
-                // Use the bitmask to skip sections
-                let mask = chunk.section.randomly_ticking_mask.load(Ordering::Relaxed);
-                if mask != 0 {
-                    let sections = chunk.section.block_sections.read().unwrap();
-                    let min_y = chunk.section.min_y;
+                    // Use the bitmask to skip sections
+                    let mask = chunk.section.randomly_ticking_mask.load(Ordering::Relaxed);
+                    if mask != 0 {
+                        let sections = chunk.section.block_sections.read().unwrap();
+                        let min_y = chunk.section.min_y;
 
-                    for i in 0..section_count {
-                        if (mask & (1 << i)) == 0 {
-                            continue;
-                        }
-                        let y_base = min_y + (i as i32 * 16);
-                        for _ in 0..3 {
-                            let r = rand::random::<u32>();
-                            let x_offset = (r & 0xF) as usize;
-                            let z_offset = (r >> 8 & 0xF) as usize;
-                            let y_in_section = ((r >> 4) & 0xF) as usize;
+                        for i in 0..section_count {
+                            if (mask & (1 << i)) == 0 {
+                                continue;
+                            }
+                            let y_base = min_y + (i as i32 * 16);
+                            for _ in 0..samples_per_section {
+                                let r = rand::random::<u32>();
+                                let x_offset = (r & 0xF) as usize;
+                                let z_offset = (r >> 8 & 0xF) as usize;
+                                let y_in_section = ((r >> 4) & 0xF) as usize;
 
-                            let block_state_id = sections[i].get(x_offset, y_in_section, z_offset);
-                            let tick_block = has_random_ticks(block_state_id);
-                            let tick_fluid = has_random_ticking_fluid(block_state_id);
-                            if tick_block || tick_fluid {
-                                ticks.random_ticks.push(RandomTickSample {
-                                    position: BlockPos::new(
-                                        chunk_x_base + x_offset as i32,
-                                        y_base + y_in_section as i32,
-                                        chunk_z_base + z_offset as i32,
-                                    ),
-                                    tick_block,
-                                    tick_fluid,
-                                });
+                                let block_state_id =
+                                    sections[i].get(x_offset, y_in_section, z_offset);
+                                let tick_block = has_random_ticks(block_state_id);
+                                let tick_fluid = has_random_ticking_fluid(block_state_id);
+                                if tick_block || tick_fluid {
+                                    ticks.random_ticks.push(RandomTickSample {
+                                        position: BlockPos::new(
+                                            chunk_x_base + x_offset as i32,
+                                            y_base + y_in_section as i32,
+                                            chunk_z_base + z_offset as i32,
+                                        ),
+                                        tick_block,
+                                        tick_fluid,
+                                    });
+                                }
                             }
                         }
                     }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -135,7 +135,10 @@ use pumpkin_world::{
     CURRENT_BEDROCK_MC_VERSION, biome, chunk::io::Dirtiable, inventory::Inventory,
 };
 use pumpkin_world::{chunk::ChunkData, world::BlockAccessor};
-use pumpkin_world::{level::Level, tick::TickPriority};
+use pumpkin_world::{
+    level::{Level, MAX_RANDOM_TICK_SPEED},
+    tick::TickPriority,
+};
 pub use pumpkin_world::{world::BlockFlags, world_info::LevelData};
 use rand::seq::SliceRandom;
 use rand::{RngExt, rng};
@@ -1177,7 +1180,16 @@ impl World {
     #[expect(clippy::too_many_lines)]
     pub async fn tick_chunks(self: &Arc<Self>) {
         let active_chunks = self.active_chunks.load();
-        let tick_data = self.level.get_tick_data(&active_chunks);
+        // The game rule is an unbounded signed integer, so clamp it: a value of 0 (or below)
+        // disables random ticks entirely, and the upper bound keeps the per-tick sampling work
+        // bounded no matter what `/gamerule randomTickSpeed` was given
+        let random_tick_speed = self
+            .level_info
+            .load()
+            .game_rules
+            .random_tick_speed
+            .clamp(0, i64::from(MAX_RANDOM_TICK_SPEED)) as u32;
+        let tick_data = self.level.get_tick_data(&active_chunks, random_tick_speed);
 
         // ONE JoinSet for all chunk operations
         let mut chunk_tasks = tokio::task::JoinSet::new();


### PR DESCRIPTION
## What

`/gamerule random_tick_speed` does nothing. Setting it to `0` does not stop random ticks, and raising it does not speed them up.

## Why

`Level::get_tick_data` samples a hardcoded 3 positions per chunk section per tick:

```rust
for _ in 0..3 {
    let r = rand::random::<u32>();
```

`random_tick_speed` exists in the generated game rule data and round-trips through `level.dat`, but nothing in the tick path ever reads it.

## How

The value is threaded in from `World::tick_chunks`, which reads it from the level info on each tick so `/gamerule` applies immediately rather than at restart. A value of `0` skips the sampling entirely, matching vanilla's `if (randomTickSpeed > 0)` guard. Scheduled block and fluid ticks stay outside that guard and keep running at `0`, which is also what vanilla does.

`pumpkin-world` has no access to the game rules, so this is a parameter rather than a new dependency edge. `get_tick_data` has exactly one caller.

## The cap

The value is clamped to `MAX_RANDOM_TICK_SPEED = 4096`, the block count of a chunk section, past which every block in a section already gets roughly one expected random tick per game tick.

This is not cosmetic. The game rule argument is an unbounded `i64`, and the old capacity hint was:

```rust
random_ticks: Vec::with_capacity(active_chunks.len() * 3),
```

With the rule wired up and no cap, `active_chunks` is 289 entries per player and `RandomTickSample` is 16 bytes, so `random_tick_speed = i64::MAX` asks for about 19.8 TB every tick. That is below `isize::MAX`, so it does not raise the catchable capacity-overflow panic; it reaches the allocator, fails, and `handle_alloc_error` aborts the process. Even `100000` would allocate and free roughly 462 MB per tick per world. Since the rule was previously inert, wiring it up without a cap would have introduced a one-command server kill.

I dropped the capacity hint rather than scaling it. It multiplied by chunk *columns* while the loop pushes per *section* and then filters on `has_random_ticks`, so it both under- and over-counted; plain `Vec::new` growth is bounded by the samples that actually survive the filter.

The command argument itself is left unbounded. `init_command_tree` builds one `BoundedNumArgumentConsumer::<i64>` shared by every integer game rule, so adding min/max there would apply to all of them. Vanilla also accepts arbitrary values and only bounds the interpretation.

## Why this one matters beyond itself

At the hardcoded rate a *specific* block is random-ticked about once every 68 seconds. That makes gameplay behaviour effectively untestable: I spent a while chasing what looked like broken ice melting, snow melting and grass spreading on a live server, and all three were sampling noise from tests that had a 7 to 25 percent chance of observing the behaviour at all. With this fix and `random_tick_speed` raised, the same checks resolve in seconds.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin -p pumpkin-world --all-targets` clean.

Not yet confirmed in game, for the circular reason above: confirming it requires the fix. I will report back once I have it running on my test server.

## Note for existing worlds

A world whose `level.dat` already carries a non-default `random_tick_speed` will start honouring it. Worlds that never set it default to 3 and are unaffected.
