### PR TITLE
fix: three redstone timing and output bugs

### DIFF
--- a/pumpkin/src/block/blocks/redstone/buttons.rs
+++ b/pumpkin/src/block/blocks/redstone/buttons.rs
@@ -6,6 +6,8 @@ use pumpkin_data::BlockStateId;
 use pumpkin_data::HorizontalFacingExt;
 use pumpkin_data::block_properties::AttachFace;
 use pumpkin_data::block_properties::BlockProperties;
+use pumpkin_data::tag;
+use pumpkin_data::tag::Taggable;
 use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::tick::TickPriority;
@@ -40,7 +42,9 @@ async fn click_button(world: &Arc<World>, block_pos: &BlockPos) {
                 BlockFlags::NOTIFY_ALL,
             )
             .await;
-        let delay = if block == &Block::STONE_BUTTON {
+        // Vanilla presses stone-like buttons (stone and polished blackstone) for
+        // 20 ticks and every wooden button for 30.
+        let delay = if block.has_tag(&tag::Block::MINECRAFT_STONE_BUTTONS) {
             20
         } else {
             30

--- a/pumpkin/src/block/blocks/redstone/pressure_plate/weighted.rs
+++ b/pumpkin/src/block/blocks/redstone/pressure_plate/weighted.rs
@@ -114,7 +114,9 @@ impl PressurePlate for WeightedPressurePlateBlock {
         let len = world.get_entities_at_box(&aabb).len() + world.get_players_at_box(&aabb).len();
         let len = len.min(weight);
         if len > 0 {
-            let f = (weight.min(len) / weight) as f32;
+            // Vanilla casts both operands to float before dividing, so the output
+            // scales with the entity count instead of collapsing to 0 or 15.
+            let f = weight.min(len) as f32 / weight as f32;
             return (f * 15.0).ceil() as u8;
         }
         0

--- a/pumpkin/src/block/entities/hopper.rs
+++ b/pumpkin/src/block/entities/hopper.rs
@@ -76,7 +76,14 @@ impl BlockEntity for HopperBlockEntity {
         Box::pin(async move {
             self.ticked_game_time
                 .store(world.get_world_age().await, Ordering::Relaxed);
-            if self.cooldown_time.fetch_sub(1, Ordering::Relaxed) <= 0 {
+            // Vanilla decrements first and then tests the new value, so the transfer
+            // happens on the tick the counter reaches 0. `fetch_sub` returns the
+            // *previous* value, so the comparison is against 1 rather than 0;
+            // gating on 0 here spent an extra tick and made hoppers run every 9
+            // ticks instead of 8. This stays a single atomic read-modify-write
+            // because a neighbouring hopper can write this field from its own
+            // concurrently spawned tick task.
+            if self.cooldown_time.fetch_sub(1, Ordering::Relaxed) <= 1 {
                 self.cooldown_time.store(0, Ordering::Relaxed);
                 let state = HopperLikeProperties::from_state_id(
                     world.get_block_state(&self.position).id,


### PR DESCRIPTION
Three small, independent timing and output bugs found while auditing redstone components against vanilla. Grouped because each is a few lines; happy to split if you would rather review them separately.

Related to #1402.

## 1. Weighted pressure plates only ever output 0 or 15

`pumpkin/src/block/blocks/redstone/pressure_plate/weighted.rs`

```rust
let len = len.min(weight);
if len > 0 {
    let f = (weight.min(len) / weight) as f32;
    return (f * 15.0).ceil() as u8;
}
```

`weight` and `len` are both `usize`, so this is integer division, and the cast to `f32` happens after it. Since `len` was already clamped to `weight`, the quotient is `0` for every count below the maximum and `1` at the maximum. A gold plate outputs 0 for 1 to 14 entities and 15 at 15; an iron plate outputs 0 for 1 to 149 and 15 at 150.

Vanilla `WeightedPressurePlateBlock.getRedstoneOutput` casts each operand first:

```java
float f = (float)Math.min(this.weight, i) / (float)this.weight;
return Mth.ceil(f * 15.0F);
```

Fixed by casting before dividing. The resulting table matches the wiki: gold plate 1 entity gives 1 and scales 1:1 to 15; iron plate gives 1 for 1 to 10 entities, then a step every 10, reaching 15 at 141.

## 2. Polished blackstone buttons stay pressed for 30 ticks instead of 20

`pumpkin/src/block/blocks/redstone/buttons.rs`

```rust
let delay = if block == &Block::STONE_BUTTON { 20 } else { 30 };
```

`ButtonBlock` is registered from the `minecraft:buttons` tag, which includes `polished_blackstone_button`, but only `STONE_BUTTON` is special cased, so polished blackstone gets the wooden 30-tick delay. Vanilla gives it 20.

The generated data already has the right tag for this: `minecraft:stone_buttons` is exactly `["stone_button", "polished_blackstone_button"]`, so the equality check becomes a `has_tag` call. That also means a future stone-family button is handled without touching this line again.

## 3. Hoppers transfer every 9 ticks instead of 8

`pumpkin/src/block/entities/hopper.rs`

```rust
if self.cooldown_time.fetch_sub(1, Ordering::Relaxed) <= 0 {
```

`fetch_sub` returns the value *before* the subtraction, so this fires when the old value was already at or below 0, one tick later than intended. Vanilla decrements and then tests the new value:

```java
be.transferCooldown--;
if (!be.needsCooldown()) { be.setTransferCooldown(0); insertAndExtract(...); }
```

With the cooldown of 8 written after a successful transfer, vanilla moves again on the 8th following tick and this moved on the 9th, so hoppers ran at about 2.22 items per second instead of the documented 2.5.

The fix is to compare against 1 rather than 0. I first wrote this as a load, `saturating_sub`, then store, which reads more clearly, but backed it out: block entities are ticked as concurrently spawned tasks, and `add_one_item` writes `cooldown_time` on a *neighbouring* hopper, so a non-atomic read-modify-write here could lose that write entirely rather than merely racing by one tick. Keeping the single atomic operation preserves the existing behaviour under that race. There is a note in `tick_rate_manager.rs` about the same `fetch_sub` pitfall, so this is a known sharp edge in the codebase.

Freshly placed hoppers seed `cooldown_time` at -1 and still fire on their first tick, unchanged.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

The weighted plate table was checked arithmetically at every step boundary rather than spot checked, including the exact tie at 10 entities on the iron plate, which rounds to 1 and not 2.

Not verified in game. I have a test server but no reliable way to read a redstone signal strength back over RCON yet.
