### PR TITLE
fix: preserve block state when waxing and scraping copper, and consume the item

### DIFF
--- a/pumpkin/src/item/items/axe.rs
+++ b/pumpkin/src/item/items/axe.rs
@@ -1,12 +1,10 @@
 use std::pin::Pin;
 
 use crate::entity::player::Player;
+use crate::item::items::state_with_properties_of;
 use crate::item::{ItemBehaviour, ItemMetadata};
 use crate::server::Server;
-use pumpkin_data::block_properties::BlockProperties;
-use pumpkin_data::block_properties::{OakDoorLikeProperties, PaleOakWoodLikeProperties};
 use pumpkin_data::item_stack::ItemStack;
-use pumpkin_data::tag::Taggable;
 use pumpkin_data::{Block, tag};
 use pumpkin_data::{BlockDirection, BlockId};
 use pumpkin_util::GameMode;
@@ -42,39 +40,12 @@ impl ItemBehaviour for AxeItem {
             // If there is a strip equivalent.
             let changed = if let Some(replacement) = replacement_block {
                 let new_block = replacement.to_block();
-                let new_state_id = if block.has_tag(&tag::Block::MINECRAFT_LOGS) {
-                    let log_information = world.get_block_state_id(&location);
-                    let log_props =
-                        PaleOakWoodLikeProperties::from_state_id(log_information, block);
-                    // create new properties for the new log.
-                    let mut new_log_properties = PaleOakWoodLikeProperties::default(new_block);
-                    new_log_properties.axis = log_props.axis;
-
-                    // create new properties for the new log.
-
-                    // Set old axis to the new log.
-                    new_log_properties.axis = log_props.axis;
-                    new_log_properties.to_state_id(new_block)
-                }
-                // Let's check if It's a door
-                else if block.has_tag(&tag::Block::MINECRAFT_DOORS) {
-                    // get block state of the old log.
-                    let door_information = world.get_block_state_id(&location);
-                    // get the log properties
-                    let door_props = OakDoorLikeProperties::from_state_id(door_information, block);
-                    // create new properties for the new log.
-                    let mut new_door_properties = OakDoorLikeProperties::default(new_block);
-                    // Set old axis to the new log.
-                    new_door_properties.facing = door_props.facing;
-                    new_door_properties.open = door_props.open;
-                    new_door_properties.half = door_props.half;
-                    new_door_properties.hinge = door_props.hinge;
-                    new_door_properties.powered = door_props.powered;
-                    new_door_properties.to_state_id(new_block)
-                } else {
-                    new_block.default_state.id
-                };
-                // TODO Implements trapdoors when It's implemented
+                // Every block listed below shares its property set with its
+                // replacement, so carrying the state over keeps the axis of a
+                // log, the facing of a stair, the type of a slab, the lit state
+                // of a bulb, waterlogging, and so on.
+                let old_state_id = world.get_block_state_id(&location);
+                let new_state_id = state_with_properties_of(block, old_state_id, new_block);
                 world
                     .set_block_state(&location, new_state_id, BlockFlags::NOTIFY_ALL)
                     .await;

--- a/pumpkin/src/item/items/honeycomb.rs
+++ b/pumpkin/src/item/items/honeycomb.rs
@@ -7,15 +7,13 @@ use crate::block::entities::BlockEntity;
 use crate::block::entities::sign::SignBlockEntity;
 use crate::block::registry::BlockActionResult;
 use crate::entity::player::Player;
+use crate::item::items::state_with_properties_of;
 use crate::item::{ItemBehaviour, ItemMetadata};
 use crate::server::Server;
-use pumpkin_data::block_properties::BlockProperties;
-use pumpkin_data::block_properties::OakDoorLikeProperties;
+use pumpkin_data::Block;
 use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
-use pumpkin_data::tag::Taggable;
 use pumpkin_data::world::WorldEvent;
-use pumpkin_data::{Block, tag};
 use pumpkin_data::{BlockDirection, BlockId};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
@@ -32,7 +30,7 @@ impl ItemMetadata for HoneyCombItem {
 impl ItemBehaviour for HoneyCombItem {
     fn use_on_block<'a>(
         &'a self,
-        _item: &'a mut ItemStack,
+        item: &'a mut ItemStack,
         player: &'a Player,
         location: BlockPos,
         _face: BlockDirection,
@@ -43,39 +41,27 @@ impl ItemBehaviour for HoneyCombItem {
         Box::pin(async move {
             let world = player.world();
 
-            // First we try to strip the block. by getting his equivalent and applying it the axis.
+            // We wax the block by getting its waxed equivalent.
             let replacement = get_waxed_equivalent(block.id);
-            // If there is a strip equivalent.
-            if let Some(replacement) = replacement {
-                // get block state of the old log.
-                // get the log properties
-                // create new properties for the new log.
+            // If there is a waxed equivalent.
+            let changed = if let Some(replacement) = replacement {
                 let new_block = replacement.to_block();
-
-                let new_state_id = if block.has_tag(&tag::Block::MINECRAFT_DOORS)
-                    && block.has_tag(&tag::Block::MINECRAFT_DOORS)
-                {
-                    // get block state of the old log.
-                    let door_information = world.get_block_state_id(&location);
-                    // get the log properties
-                    let door_props = OakDoorLikeProperties::from_state_id(door_information, block);
-                    // create new properties for the new log.
-                    let mut new_door_properties = OakDoorLikeProperties::default(new_block);
-                    // Set old axis to the new log.
-                    new_door_properties.facing = door_props.facing;
-                    new_door_properties.open = door_props.open;
-                    new_door_properties.half = door_props.half;
-                    new_door_properties.hinge = door_props.hinge;
-                    new_door_properties.powered = door_props.powered;
-                    new_door_properties.to_state_id(new_block)
-                } else {
-                    new_block.default_state.id
-                };
-
-                // TODO Implements trapdoors
+                // A waxed block always has the same property set as its unwaxed
+                // counterpart, so carrying the state over keeps the facing of a
+                // stair, the type of a slab, the lit state of a bulb,
+                // waterlogging, and so on.
+                let old_state_id = world.get_block_state_id(&location);
+                let new_state_id = state_with_properties_of(block, old_state_id, new_block);
                 world
                     .set_block_state(&location, new_state_id, BlockFlags::NOTIFY_ALL)
                     .await;
+                true
+            } else {
+                false
+            };
+
+            if changed {
+                item.decrement_unless_creative(player.gamemode.load(), 1);
             }
         })
     }

--- a/pumpkin/src/item/items/ignite/fire_charge.rs
+++ b/pumpkin/src/item/items/ignite/fire_charge.rs
@@ -28,7 +28,7 @@ impl ItemMetadata for FireChargeItem {
 impl ItemBehaviour for FireChargeItem {
     fn use_on_block<'a>(
         &'a self,
-        _item: &'a mut ItemStack,
+        item: &'a mut ItemStack,
         player: &'a Player,
         location: BlockPos,
         face: BlockDirection,
@@ -37,7 +37,7 @@ impl ItemBehaviour for FireChargeItem {
         _server: &'a Server,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
         Box::pin(async move {
-            Ignition::ignite_block(
+            let ignited = Ignition::ignite_block(
                 |world: Arc<World>, pos: BlockPos, new_state_id: BlockStateId| async move {
                     world
                         .set_block_state(&pos, new_state_id, BlockFlags::NOTIFY_ALL)
@@ -51,6 +51,10 @@ impl ItemBehaviour for FireChargeItem {
                 block,
             )
             .await;
+
+            if ignited {
+                item.decrement_unless_creative(player.gamemode.load(), 1);
+            }
         })
     }
 

--- a/pumpkin/src/item/items/mod.rs
+++ b/pumpkin/src/item/items/mod.rs
@@ -60,11 +60,40 @@ use ignite::fire_charge::FireChargeItem;
 use ignite::flint_and_steel::FlintAndSteelItem;
 use ink_sac::InkSacItem;
 use mace::MaceItem;
+use pumpkin_data::{Block, BlockStateId};
 use shovel::ShovelItem;
 use snowball::SnowBallItem;
 use std::sync::Arc;
 use swords::SwordItem;
 use trident::TridentItem;
+
+/// Returns the state of `new_block` that carries over every property it shares
+/// with `old_block` in `old_state_id`.
+///
+/// This is the equivalent of vanilla's `Block#withPropertiesOf`, which is what
+/// stripping, waxing, scraping and de-oxidizing use so the replacement block
+/// keeps its facing, waterlogging, slab type, and so on. Falls back to the
+/// default state when either block carries no properties.
+#[must_use]
+pub fn state_with_properties_of(
+    old_block: &Block,
+    old_state_id: BlockStateId,
+    new_block: &Block,
+) -> BlockStateId {
+    let default_state_id = new_block.default_state.id;
+    // `from_properties` panics for blocks without any property, so only copy
+    // when both sides actually carry state.
+    if new_block.properties(default_state_id).is_none() {
+        return default_state_id;
+    }
+    old_block
+        .properties(old_state_id)
+        .map_or(default_state_id, |properties| {
+            new_block
+                .from_properties(&properties.to_props())
+                .to_state_id(new_block)
+        })
+}
 
 #[must_use]
 pub fn default_registry() -> Arc<ItemRegistry> {


### PR DESCRIPTION
Two bugs in the same code path, found while auditing tool and item interactions against vanilla.

## 1. Waxing and scraping copper throw away the block's state

`pumpkin/src/item/items/axe.rs` and `pumpkin/src/item/items/honeycomb.rs` both hand-copy properties for exactly two block families, logs and doors, and fall back to the default state for everything else:

```rust
} else {
    new_block.default_state.id
};
```

Every other copper family loses its state silently:

| block | lost | visible result |
|---|---|---|
| `cut_copper_stairs` | facing, half, shape, waterlogged | the stair rotates to face north, bottom half |
| `cut_copper_slab` | type | **a double slab becomes a single bottom slab, deleting one slab** |
| `copper_grate` | waterlogged | the water in the grate disappears |
| `copper_bulb` | lit, powered | a lit bulb turns off and anything reading it desyncs |
| `copper_trapdoor` | facing, half, open, powered, waterlogged | the trapdoor resets to closed, north, bottom |

The double slab case is the worst of these since it destroys an item with no indication.

Vanilla's `HoneycombItem.getWaxed` and `WeatheringCopper.getPrevious` both go through `Block#withPropertiesOf`, which copies every property the two blocks share.

This replaces both hand-written paths with a shared `state_with_properties_of` helper built on the generic property API the repo already uses in `ignition.rs`, `bucket.rs`, `ender_eye.rs` and `signs.rs`.

I did not assume the generic copy was safe. I parsed the generated block data and checked all 117 pairs across the three tables (stripping, waxing, oxidation): every pair maps to the *identical* properties struct on both sides, which is stronger than merely sharing property names. The 24 property-less copper blocks take the `default_state` fallback, which is correct for them. No pair needed special handling.

Side effects of the change: copper trapdoors now work, which the old path had a `// TODO Implements trapdoors` for; and a condition reading `has_tag(DOORS) && has_tag(DOORS)`, the same tag twice, becomes unnecessary and is removed rather than fixed.

## 2. Honeycomb and fire charge are never consumed in survival

`honeycomb.rs` and `ignite/fire_charge.rs` both take `_item: &mut ItemStack` and never touch it. The only stack decrement after `use_on_block` lives in `net/java/play.rs` and is gated on `Block::from_item_id(item_id)` returning `Some`, that is, block items only. Neither of these is a block item, so **one honeycomb waxes unlimited copper and one fire charge lights unlimited fires**.

Both now call `decrement_unless_creative` on a successful interaction. Honeycomb had no notion of success, so it gains a `changed` flag like the axe already has; fire charge reuses the boolean `Ignition::ignite_block` already returns, matching how `flint_and_steel.rs` gates its `damage_item`. Checked that this cannot double decrement, since the block-item path is never entered for either.

## Deliberately not included

- The newer copper blocks (`copper_bars`, `copper_chain`, `copper_lantern`, `copper_chest`, `copper_golem_statue`, `lightning_rod` and their weathered and waxed forms) are absent from the wax and oxidation tables entirely, so waxing or scraping them is still a no-op. That is roughly 72 table entries and belongs in its own change.
- The block path plays no sound or particles. `honeycomb.rs` already emits `ParticlesAndSoundWaxOn` on the sign path, so the two paths in the same file are inconsistent, but adding them is separate work.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

Not verified in game. The property-set equality claim above is from parsing the generated data rather than from observation, so if the double slab case in particular is worth a manual check before merging, that is the one I would look at.
