### PR TITLE
fix: make the target block actually emit redstone power

### DIFF
--- a/pumpkin/src/block/blocks/redstone/target_block.rs
+++ b/pumpkin/src/block/blocks/redstone/target_block.rs
@@ -1,9 +1,79 @@
-use pumpkin_macros::pumpkin_block;
+use std::sync::Arc;
 
-use crate::block::{BlockBehaviour, BlockFuture, EmitsRedstonePowerArgs};
+use pumpkin_data::BlockDirection;
+use pumpkin_data::block_properties::{
+    Axis, BlockProperties, LightWeightedPressurePlateLikeProperties,
+};
+use pumpkin_macros::pumpkin_block;
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::vector3::Vector3;
+use pumpkin_world::tick::TickPriority;
+use pumpkin_world::world::BlockFlags;
+
+use crate::block::{
+    BlockBehaviour, BlockFuture, EmitsRedstonePowerArgs, GetRedstonePowerArgs, OnScheduledTickArgs,
+};
+use crate::world::World;
+
+/// The `target` block shares its state layout (a single `power` property) with the
+/// weighted pressure plates, so the generated properties type is named after them.
+type TargetProperties = LightWeightedPressurePlateLikeProperties;
 
 #[pumpkin_block("minecraft:target")]
 pub struct TargetBlock;
+
+impl TargetBlock {
+    /// Signal strength of a dead centre hit.
+    pub const MAX_POWER: u8 = 15;
+    /// Ticks a target stays powered after being hit by an arrow or a trident.
+    pub const PERSISTENT_PROJECTILE_DELAY: u8 = 20;
+    /// Ticks a target stays powered after being hit by any other projectile.
+    pub const PROJECTILE_DELAY: u8 = 8;
+
+    /// Applies the redstone power of a projectile hit and schedules the reset back to zero.
+    ///
+    /// Returns the signal strength the hit is worth. As in vanilla, the power is only
+    /// applied when no reset is queued for this position yet, so a target that is already
+    /// lit up keeps its original signal until the reset runs.
+    pub async fn trigger(
+        world: &Arc<World>,
+        position: &BlockPos,
+        face: BlockDirection,
+        hit_pos: Vector3<f64>,
+        delay: u8,
+    ) -> u8 {
+        let power = Self::calculate_power(face, hit_pos);
+        let (block, state_id) = world.get_block_and_state_id(position);
+        if world.is_block_tick_scheduled(position, block) {
+            return power;
+        }
+
+        let mut props = TargetProperties::from_state_id(state_id, block);
+        props.power = power;
+        world
+            .set_block_state(position, props.to_state_id(block), BlockFlags::NOTIFY_ALL)
+            .await;
+        world.schedule_block_tick(block, *position, delay, TickPriority::Normal);
+        power
+    }
+
+    /// The closer the hit is to the centre of the hit face, the stronger the signal.
+    /// `offset` is the largest of the two in face distances from that centre, so the
+    /// signal only reaches 15 on a dead centre hit.
+    fn calculate_power(face: BlockDirection, hit_pos: Vector3<f64>) -> u8 {
+        let x = (hit_pos.x - hit_pos.x.floor() - 0.5).abs();
+        let y = (hit_pos.y - hit_pos.y.floor() - 0.5).abs();
+        let z = (hit_pos.z - hit_pos.z.floor() - 0.5).abs();
+        let offset = match face.to_axis() {
+            Axis::X => y.max(z),
+            Axis::Y => x.max(z),
+            Axis::Z => x.max(y),
+        };
+        let power =
+            (f64::from(Self::MAX_POWER) * ((0.5 - offset) / 0.5).clamp(0.0, 1.0)).ceil() as u8;
+        power.max(1)
+    }
+}
 
 impl BlockBehaviour for TargetBlock {
     fn emits_redstone_power<'a>(
@@ -11,5 +81,32 @@ impl BlockBehaviour for TargetBlock {
         _args: EmitsRedstonePowerArgs<'a>,
     ) -> BlockFuture<'a, bool> {
         Box::pin(async move { true })
+    }
+
+    fn get_weak_redstone_power<'a>(
+        &'a self,
+        args: GetRedstonePowerArgs<'a>,
+    ) -> BlockFuture<'a, u8> {
+        Box::pin(async move { TargetProperties::from_state_id(args.state.id, args.block).power })
+    }
+
+    // Vanilla only overrides `getWeakRedstonePower` for the target block, so strong power
+    // stays at the default of 0 and a target never powers the block it is next to.
+
+    fn on_scheduled_tick<'a>(&'a self, args: OnScheduledTickArgs<'a>) -> BlockFuture<'a, ()> {
+        Box::pin(async move {
+            let state = args.world.get_block_state(args.position);
+            let mut props = TargetProperties::from_state_id(state.id, args.block);
+            if props.power != 0 {
+                props.power = 0;
+                args.world
+                    .set_block_state(
+                        args.position,
+                        props.to_state_id(args.block),
+                        BlockFlags::NOTIFY_ALL,
+                    )
+                    .await;
+            }
+        })
     }
 }

--- a/pumpkin/src/entity/projectile/arrow.rs
+++ b/pumpkin/src/entity/projectile/arrow.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 
-use crate::entity::projectile::ProjectileHit;
+use crate::block::blocks::redstone::target_block::TargetBlock;
+use crate::entity::projectile::{ProjectileHit, on_target_block_hit};
 use crate::{
     entity::{
         Entity, EntityBase, EntityBaseFuture, NBTStorage, living::LivingEntity, player::Player,
@@ -352,10 +353,7 @@ impl EntityBase for ArrowEntity {
 
             match hit {
                 ProjectileHit::Block {
-                    pos,
-                    face: _,
-                    hit_pos,
-                    ..
+                    pos, face, hit_pos, ..
                 } => {
                     // Arrow hit a block - stick into it
                     self.in_ground.store(true, Ordering::Relaxed);
@@ -364,10 +362,15 @@ impl EntityBase for ArrowEntity {
 
                     let block = world.get_block(&pos);
                     if block == &pumpkin_data::Block::TARGET {
-                        let player_opt = self.owner_id.and_then(|id| world.get_player_by_id(id));
-                        if let Some(player) = player_opt {
-                            player.trigger_advancement(crate::entity::player::advancement::trigger::AdvancementTrigger::Bullseye).await;
-                        }
+                        on_target_block_hit(
+                            &world,
+                            &pos,
+                            face,
+                            hit_pos,
+                            self.owner_id,
+                            TargetBlock::PERSISTENT_PROJECTILE_DELAY,
+                        )
+                        .await;
                     }
 
                     // Stop the arrow

--- a/pumpkin/src/entity/projectile/mod.rs
+++ b/pumpkin/src/entity/projectile/mod.rs
@@ -1,5 +1,8 @@
 use super::{Entity, EntityBase, NBTStorage, living::LivingEntity};
+use crate::block::blocks::redstone::target_block::TargetBlock;
+use crate::entity::player::advancement::trigger::AdvancementTrigger;
 use crate::server::Server;
+use crate::world::World;
 use pumpkin_data::BlockDirection;
 use pumpkin_data::entity::EntityType;
 use pumpkin_protocol::java::client::play::CEntityVelocity;
@@ -39,6 +42,40 @@ pub fn is_projectile(entity_type: &EntityType) -> bool {
         || *entity_type == EntityType::FIREBALL
         || *entity_type == EntityType::SMALL_FIREBALL
         || *entity_type == EntityType::FISHING_BOBBER
+}
+
+/// Minimum horizontal distance between the shooter and the impact for `adventure/bullseye`.
+const BULLSEYE_MIN_HORIZONTAL_DISTANCE: f64 = 30.0;
+
+/// Powers a target block that a projectile just hit and grants the `adventure/bullseye`
+/// advancement to the shooter when the hit was worth a full signal from far enough away.
+pub async fn on_target_block_hit(
+    world: &Arc<World>,
+    position: &BlockPos,
+    face: BlockDirection,
+    hit_pos: Vector3<f64>,
+    owner_id: Option<i32>,
+    delay: u8,
+) {
+    let power = TargetBlock::trigger(world, position, face, hit_pos, delay).await;
+    if power != TargetBlock::MAX_POWER {
+        return;
+    }
+    let Some(player) = owner_id.and_then(|id| world.get_player_by_id(id)) else {
+        return;
+    };
+    let distance = player
+        .living_entity
+        .entity
+        .pos
+        .load()
+        .sub(&hit_pos)
+        .horizontal_length();
+    if distance >= BULLSEYE_MIN_HORIZONTAL_DISTANCE {
+        player
+            .trigger_advancement(AdvancementTrigger::Bullseye)
+            .await;
+    }
 }
 
 pub struct ThrownItemEntity {

--- a/pumpkin/src/entity/projectile/trident.rs
+++ b/pumpkin/src/entity/projectile/trident.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 use tokio::sync::Mutex;
 
 use crate::{
+    block::blocks::redstone::target_block::TargetBlock,
     entity::{
         Entity, EntityBase, EntityBaseFuture, NBTStorage, living::LivingEntity, player::Player,
     },
@@ -18,8 +19,8 @@ use pumpkin_util::math::boundingbox::BoundingBox;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 
-use super::ProjectileHit;
 use super::arrow::ArrowPickup;
+use super::{ProjectileHit, on_target_block_hit};
 
 pub struct TridentEntity {
     pub entity: Entity,
@@ -314,10 +315,24 @@ impl EntityBase for TridentEntity {
             let world = entity.world.load();
 
             match hit {
-                ProjectileHit::Block { pos, hit_pos, .. } => {
+                ProjectileHit::Block {
+                    pos, face, hit_pos, ..
+                } => {
                     self.in_ground.store(true, Ordering::Relaxed);
                     self.shake_time.store(7, Ordering::Relaxed);
                     *self.last_block_pos.write().unwrap() = Some(pos);
+
+                    if world.get_block(&pos) == &pumpkin_data::Block::TARGET {
+                        on_target_block_hit(
+                            &world,
+                            &pos,
+                            face,
+                            hit_pos,
+                            self.owner_id,
+                            TargetBlock::PERSISTENT_PROJECTILE_DELAY,
+                        )
+                        .await;
+                    }
 
                     // Stop the trident
                     entity.velocity.store(Vector3::new(0.0, 0.0, 0.0));


### PR DESCRIPTION
Related to #1402.

## What

The target block cannot emit redstone power. Shooting it does nothing, and even `/setblock ~ ~ ~ target[power=15]` emits no signal.

## Why

`pumpkin/src/block/blocks/redstone/target_block.rs` was, in its entirety:

```rust
impl BlockBehaviour for TargetBlock {
    fn emits_redstone_power<'a>(&'a self, _args: EmitsRedstonePowerArgs<'a>) -> BlockFuture<'a, bool> {
        Box::pin(async move { true })
    }
}
```

It is registered and declares itself a signal source, but implements no power getter, so it inherits the default `get_weak_redstone_power` returning 0. It also never reads its own `power` blockstate, which the generated data does have with 16 states.

## How

**Weak power** now returns the `power` property from the block state. Vanilla `TargetBlock` overrides only `getWeakRedstonePower` and leaves `getStrongRedstonePower` at the `AbstractBlock` default of 0, so a target does not strongly power the block it sits against. I matched that rather than implementing both, since implementing strong power would let a target power through a solid block, which vanilla does not do.

**Hit behaviour.** Arrow and trident block hits now set the power and schedule the reset. The power is vanilla's geometry: the per-axis distance from the hit point to the face centre, taking the greater of the two in-face components, then `max(1, ceil(15 * clamp((0.5 - offset) / 0.5, 0, 1)))`. `ProjectileHit::Block` already carried both `face` and `hit_pos`, so this is the real formula rather than an approximation. The reset is scheduled 20 ticks out, and re-application is skipped when a tick is already queued for that position, which is how vanilla ignores re-hits inside the window.

The arrow impact code already detected `Block::TARGET`; it just used it only for the advancement.

**Bullseye advancement.** It was granted unconditionally for any arrow touching any target, from any range. The vanilla criterion is signal strength 15 *and* at least 30 blocks horizontal distance, so it is now gated on both.

## Scope

Only arrows and tridents trigger targets here. Vanilla also allows snowballs, eggs, ender pearls, wind charges, potions, fishing bobbers and others, at a shorter 8-tick reset. The constant for that delay is defined and currently unused, so wiring up the remaining projectiles is a small follow-up per projectile rather than a rework. I kept this to the path that already had target-detection code in it.

Also not included: vanilla increments a `TARGET_HIT` statistic on hit.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

Not verified in game. The weak-power half is the part I am confident in and is independently useful, since it makes `/setblock` and datapack-driven targets work on its own; if you would rather take that alone and leave the hit geometry for a follow-up, I am happy to split this.
