### PR TITLE
fix(entity): separate the entity tick counter from the ageable age 🤖🤖🤖

### DIFF
--- a/pumpkin/src/entity/ageable.rs
+++ b/pumpkin/src/entity/ageable.rs
@@ -1,7 +1,7 @@
 use pumpkin_data::meta_data_type::MetaDataType;
 use pumpkin_data::tracked_data::TrackedData;
 use pumpkin_protocol::java::client::play::Metadata;
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering::Relaxed};
+use std::sync::atomic::{AtomicI32, Ordering::Relaxed};
 
 use crate::entity::mob::Mob;
 
@@ -11,7 +11,6 @@ pub const FORCED_AGE_PARTICLE_TICKS: i32 = 40;
 pub struct AgeableData {
     pub forced_age: AtomicI32,
     pub forced_age_timer: AtomicI32,
-    pub age_locked: AtomicBool,
     pub age_lock_particle_timer: AtomicI32,
 }
 
@@ -20,7 +19,6 @@ impl Default for AgeableData {
         Self {
             forced_age: AtomicI32::new(0),
             forced_age_timer: AtomicI32::new(0),
-            age_locked: AtomicBool::new(false),
             age_lock_particle_timer: AtomicI32::new(0),
         }
     }
@@ -64,11 +62,22 @@ pub trait AgeableMob: Mob {
     }
 
     fn is_age_locked(&self) -> bool {
-        self.get_ageable_data().age_locked.load(Relaxed)
+        self.get_mob_entity()
+            .living_entity
+            .entity
+            .age_locked
+            .load(Relaxed)
     }
 
+    /// The lock lives next to the age on [`crate::entity::Entity`] so that the
+    /// central age progression in [`crate::entity::Entity::tick_age`] can honour
+    /// it without having to know that this entity is ageable.
     fn set_age_locked(&self, locked: bool) {
-        self.get_ageable_data().age_locked.store(locked, Relaxed);
+        self.get_mob_entity()
+            .living_entity
+            .entity
+            .age_locked
+            .store(locked, Relaxed);
     }
 
     fn can_age_up(&self) -> bool {
@@ -127,15 +136,5 @@ pub trait AgeableMob: Mob {
 
     fn can_be_a_baby(&self) -> bool {
         true
-    }
-
-    fn ageable_ai_step(&self) {
-        if self.can_age_up() {
-            let age = self.get_age() + 1;
-            self.set_age(age);
-        } else if self.get_age() > 0 {
-            let age = self.get_age() - 1;
-            self.set_age(age);
-        }
     }
 }

--- a/pumpkin/src/entity/ai/goal/escape_danger.rs
+++ b/pumpkin/src/entity/ai/goal/escape_danger.rs
@@ -36,8 +36,8 @@ impl EscapeDangerGoal {
         if last_attacked == 0 {
             return false;
         }
-        let age = living.entity.age.load(Relaxed);
-        age - last_attacked < RECENT_DAMAGE_TICKS
+        let now = living.entity.tick_count.load(Relaxed);
+        now - last_attacked < RECENT_DAMAGE_TICKS
     }
 
     fn find_escape_target(mob: &dyn Mob) -> Option<Vector3<f64>> {

--- a/pumpkin/src/entity/ai/goal/mod.rs
+++ b/pumpkin/src/entity/ai/goal/mod.rs
@@ -37,6 +37,25 @@ pub const fn to_goal_ticks(server_ticks: i32) -> i32 {
     -(-server_ticks).div_euclid(2)
 }
 
+/// Whether this tick should run the full goal-selector pass, which re-evaluates
+/// `can_start`/`should_continue` and starts and stops goals, as opposed to only
+/// ticking the goals that are already running.
+///
+/// Mirrors vanilla `Mob#serverAiStep`: the full pass runs every other tick, and
+/// `entity_id` staggers it so that not every mob re-plans on the same tick. A
+/// mob that has just spawned always takes the full pass, so its goals can start
+/// without waiting for the alternation.
+///
+/// This deliberately keys off the *server* tick and the entity's own tick
+/// count. Using the ageable age here would mean babies, whose age is negative
+/// for their whole 20 minutes of childhood, never satisfy the warm-up check and
+/// so re-plan twice as often as vanilla — which also halves every interval that
+/// [`to_goal_ticks`] computes.
+#[must_use]
+pub const fn runs_full_goal_pass(server_tick: i32, entity_id: i32, entity_tick_count: i32) -> bool {
+    entity_tick_count <= 1 || server_tick.wrapping_add(entity_id) % 2 == 0
+}
+
 pub type GoalFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 pub trait Goal: Send + Sync {
@@ -281,3 +300,72 @@ impl<P> Default for ParentHandle<P> {
 // This is safe since we own everything.
 unsafe impl<P> Sync for ParentHandle<P> {}
 unsafe impl<P> Send for ParentHandle<P> {}
+
+#[cfg(test)]
+mod tests {
+    use super::{runs_full_goal_pass, to_goal_ticks};
+
+    #[test]
+    fn goal_ticks_halve_and_round_up() {
+        // `to_goal_ticks` assumes the caller is only re-evaluated every other
+        // tick, so an interval of n server ticks becomes ceil(n / 2) passes.
+        assert_eq!(to_goal_ticks(120), 60);
+        assert_eq!(to_goal_ticks(10), 5);
+        assert_eq!(to_goal_ticks(1), 1);
+        assert_eq!(to_goal_ticks(0), 0);
+    }
+
+    #[test]
+    fn full_goal_pass_alternates_every_other_tick() {
+        let (entity_id, tick_count) = (0, 100);
+        let passes: Vec<bool> = (0..6)
+            .map(|server_tick| runs_full_goal_pass(server_tick, entity_id, tick_count))
+            .collect();
+        assert_eq!(passes, vec![true, false, true, false, true, false]);
+    }
+
+    #[test]
+    fn full_goal_pass_is_staggered_by_entity_id() {
+        // Two mobs with adjacent ids must not re-plan on the same tick, which is
+        // the whole point of folding the id into the parity.
+        for server_tick in 0..8 {
+            assert_ne!(
+                runs_full_goal_pass(server_tick, 7, 100),
+                runs_full_goal_pass(server_tick, 8, 100),
+                "ids 7 and 8 collided on tick {server_tick}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_freshly_spawned_mob_always_takes_the_full_pass() {
+        // Vanilla's `tickCount > 1` warm-up: goals must be able to start on the
+        // first ticks without waiting for the alternation to come round.
+        for server_tick in 0..4 {
+            assert!(runs_full_goal_pass(server_tick, 1, 0));
+            assert!(runs_full_goal_pass(server_tick, 1, 1));
+        }
+    }
+
+    #[test]
+    fn a_settled_mob_skips_half_of_the_full_passes() {
+        // Regression: this gate used to key off the ageable age instead of a
+        // tick count. A baby's age stays negative for its whole 20 minutes of
+        // childhood, so the warm-up check never stopped applying and babies took
+        // the full pass on *every* tick — twice vanilla's decision rate, and
+        // twice the goal-selection work. Any mob past the warm-up must skip half
+        // the passes, which is also what every `to_goal_ticks` interval assumes.
+        let full_passes = (0..100)
+            .filter(|&tick| runs_full_goal_pass(tick, 3, 500))
+            .count();
+        assert_eq!(full_passes, 50);
+    }
+
+    #[test]
+    fn full_goal_pass_survives_tick_counter_wraparound() {
+        // The server tick count is an i32 that is only ever incremented, so the
+        // parity add must wrap rather than panic in a debug build.
+        assert!(runs_full_goal_pass(i32::MAX, 1, 100));
+        let _ = runs_full_goal_pass(i32::MAX, i32::MAX, 100);
+    }
+}

--- a/pumpkin/src/entity/ai/goal/mod.rs
+++ b/pumpkin/src/entity/ai/goal/mod.rs
@@ -41,19 +41,27 @@ pub const fn to_goal_ticks(server_ticks: i32) -> i32 {
 /// `can_start`/`should_continue` and starts and stops goals, as opposed to only
 /// ticking the goals that are already running.
 ///
-/// Mirrors vanilla `Mob#serverAiStep`: the full pass runs every other tick, and
-/// `entity_id` staggers it so that not every mob re-plans on the same tick. A
-/// mob that has just spawned always takes the full pass, so its goals can start
-/// without waiting for the alternation.
+/// Mirrors vanilla `Mob#serverAiStep`, which computes a single
+/// `idBasedTickCount = this.tickCount + this.getId()` and takes the reduced pass
+/// only when that is odd *and* `this.tickCount > 1`. So both terms come off the
+/// entity's own tick count: it drives the alternation, and `entity_id` merely
+/// staggers it so that not every mob re-plans on the same tick. A mob that has
+/// just spawned always takes the full pass, so its goals can start without
+/// waiting for the alternation.
 ///
-/// This deliberately keys off the *server* tick and the entity's own tick
-/// count. Using the ageable age here would mean babies, whose age is negative
-/// for their whole 20 minutes of childhood, never satisfy the warm-up check and
-/// so re-plan twice as often as vanilla — which also halves every interval that
-/// [`to_goal_ticks`] computes.
+/// Keying the alternation off the *server* tick instead would look equivalent —
+/// the two differ by a per-entity constant — but it is not: an entity that
+/// misses server ticks keeps its own counter contiguous while the server's runs
+/// on, so its parity would shift for reasons that have nothing to do with how
+/// often it has actually ticked.
+///
+/// Using the ageable age for either term, as this did before, means babies —
+/// whose age is negative for their whole 20 minutes of childhood — never satisfy
+/// the warm-up check and so re-plan twice as often as vanilla, which also halves
+/// every interval that [`to_goal_ticks`] computes.
 #[must_use]
-pub const fn runs_full_goal_pass(server_tick: i32, entity_id: i32, entity_tick_count: i32) -> bool {
-    entity_tick_count <= 1 || server_tick.wrapping_add(entity_id) % 2 == 0
+pub const fn runs_full_goal_pass(entity_id: i32, entity_tick_count: i32) -> bool {
+    entity_tick_count <= 1 || entity_tick_count.wrapping_add(entity_id) % 2 == 0
 }
 
 pub type GoalFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -317,9 +325,9 @@ mod tests {
 
     #[test]
     fn full_goal_pass_alternates_every_other_tick() {
-        let (entity_id, tick_count) = (0, 100);
-        let passes: Vec<bool> = (0..6)
-            .map(|server_tick| runs_full_goal_pass(server_tick, entity_id, tick_count))
+        let entity_id = 0;
+        let passes: Vec<bool> = (100..106)
+            .map(|entity_tick_count| runs_full_goal_pass(entity_id, entity_tick_count))
             .collect();
         assert_eq!(passes, vec![true, false, true, false, true, false]);
     }
@@ -328,11 +336,11 @@ mod tests {
     fn full_goal_pass_is_staggered_by_entity_id() {
         // Two mobs with adjacent ids must not re-plan on the same tick, which is
         // the whole point of folding the id into the parity.
-        for server_tick in 0..8 {
+        for entity_tick_count in 100..108 {
             assert_ne!(
-                runs_full_goal_pass(server_tick, 7, 100),
-                runs_full_goal_pass(server_tick, 8, 100),
-                "ids 7 and 8 collided on tick {server_tick}"
+                runs_full_goal_pass(7, entity_tick_count),
+                runs_full_goal_pass(8, entity_tick_count),
+                "ids 7 and 8 collided on entity tick {entity_tick_count}"
             );
         }
     }
@@ -340,10 +348,12 @@ mod tests {
     #[test]
     fn a_freshly_spawned_mob_always_takes_the_full_pass() {
         // Vanilla's `tickCount > 1` warm-up: goals must be able to start on the
-        // first ticks without waiting for the alternation to come round.
-        for server_tick in 0..4 {
-            assert!(runs_full_goal_pass(server_tick, 1, 0));
-            assert!(runs_full_goal_pass(server_tick, 1, 1));
+        // first ticks without waiting for the alternation to come round. Both
+        // parities of `entity_id` have to pass, since the id is the only other
+        // term and the warm-up must win regardless of it.
+        for entity_id in 0..4 {
+            assert!(runs_full_goal_pass(entity_id, 0));
+            assert!(runs_full_goal_pass(entity_id, 1));
         }
     }
 
@@ -355,17 +365,34 @@ mod tests {
         // the full pass on *every* tick — twice vanilla's decision rate, and
         // twice the goal-selection work. Any mob past the warm-up must skip half
         // the passes, which is also what every `to_goal_ticks` interval assumes.
-        let full_passes = (0..100)
-            .filter(|&tick| runs_full_goal_pass(tick, 3, 500))
+        let full_passes = (500..600)
+            .filter(|&entity_tick_count| runs_full_goal_pass(3, entity_tick_count))
             .count();
         assert_eq!(full_passes, 50);
     }
 
     #[test]
+    fn the_alternation_follows_the_entity_not_the_server() {
+        // Vanilla's `idBasedTickCount` is `this.tickCount + this.getId()`, so a
+        // mob that has ticked n times is at the same point in the alternation
+        // however long the server has been up. Keying off the server tick would
+        // shift an entity's parity whenever it missed a tick the server did not.
+        for entity_id in 0..4 {
+            for entity_tick_count in 2..20 {
+                assert_eq!(
+                    runs_full_goal_pass(entity_id, entity_tick_count),
+                    (entity_tick_count + entity_id) % 2 == 0,
+                    "id {entity_id} at entity tick {entity_tick_count}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn full_goal_pass_survives_tick_counter_wraparound() {
-        // The server tick count is an i32 that is only ever incremented, so the
+        // The entity tick count is an i32 that is only ever incremented, so the
         // parity add must wrap rather than panic in a debug build.
-        assert!(runs_full_goal_pass(i32::MAX, 1, 100));
-        let _ = runs_full_goal_pass(i32::MAX, i32::MAX, 100);
+        assert!(runs_full_goal_pass(1, i32::MAX));
+        let _ = runs_full_goal_pass(i32::MAX, i32::MAX);
     }
 }

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -1580,7 +1580,12 @@ impl LivingEntity {
 
         {
             let mut effects = self.active_effects.lock().await;
-            let entity_age = self.entity.age.load(Relaxed);
+            // Infinite effects have no duration of their own to count down, so
+            // the entity's own tick counter drives their periodic ticks. It has
+            // to be the tick counter rather than the ageable age: a baby's age
+            // is negative, and every branch of `should_apply_effect_tick` that
+            // guards on `duration <= 0` would refuse to fire.
+            let entity_ticks = self.entity.tick_count.load(Relaxed);
             for effect in effects.values_mut() {
                 if effect.duration == 0 {
                     effects_to_remove.push(effect.effect_type);
@@ -1588,7 +1593,7 @@ impl LivingEntity {
                 }
 
                 let tick_duration = if effect.duration == -1 {
-                    entity_age
+                    entity_ticks
                 } else {
                     effect.duration
                 };
@@ -2463,7 +2468,7 @@ impl EntityBase for LivingEntity {
                     self.last_attacker_id
                         .store(attacker.get_entity().entity_id, Relaxed);
                     self.last_attacked_time
-                        .store(self.entity.age.load(Relaxed), Relaxed);
+                        .store(self.entity.tick_count.load(Relaxed), Relaxed);
                 }
             }
 
@@ -2500,7 +2505,7 @@ impl EntityBase for LivingEntity {
                     self.last_attacker_id
                         .store(attacker.get_entity().entity_id, Relaxed);
                     self.last_attacked_time
-                        .store(self.entity.age.load(Relaxed), Relaxed);
+                        .store(self.entity.tick_count.load(Relaxed), Relaxed);
                 }
             }
 

--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -620,11 +620,8 @@ impl<T: Mob + Send + 'static> EntityBase for T {
 
             let entity_tick_count = mob_entity.living_entity.entity.tick_count.load(Relaxed);
             let entity_id = mob_entity.living_entity.entity.entity_id;
-            let full_goal_pass = crate::entity::ai::goal::runs_full_goal_pass(
-                server.tick_count.load(Relaxed),
-                entity_id,
-                entity_tick_count,
-            );
+            let full_goal_pass =
+                crate::entity::ai::goal::runs_full_goal_pass(entity_id, entity_tick_count);
 
             // 1. "Take" selectors out of the mutexes
             let mut target_selector = {

--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -292,7 +292,7 @@ impl MobEntity {
                 .store(target.get_entity().entity_id, Relaxed);
             self.living_entity
                 .last_attack_time
-                .store(self.living_entity.entity.age.load(Relaxed), Relaxed);
+                .store(self.living_entity.entity.tick_count.load(Relaxed), Relaxed);
         }
     }
 
@@ -618,8 +618,13 @@ impl<T: Mob + Send + 'static> EntityBase for T {
 
             self.mob_tick(caller).await;
 
-            let age = mob_entity.living_entity.entity.age.load(Relaxed);
+            let entity_tick_count = mob_entity.living_entity.entity.tick_count.load(Relaxed);
             let entity_id = mob_entity.living_entity.entity.entity_id;
+            let full_goal_pass = crate::entity::ai::goal::runs_full_goal_pass(
+                server.tick_count.load(Relaxed),
+                entity_id,
+                entity_tick_count,
+            );
 
             // 1. "Take" selectors out of the mutexes
             let mut target_selector = {
@@ -632,12 +637,12 @@ impl<T: Mob + Send + 'static> EntityBase for T {
             };
 
             // 2. Perform AI logic (No locks held, so .await is safe!)
-            if (age + entity_id) % 2 != 0 && age > 1 {
-                target_selector.tick_goals(self, false).await;
-                goals_selector.tick_goals(self, false).await;
-            } else {
+            if full_goal_pass {
                 target_selector.tick(self).await;
                 goals_selector.tick(self).await;
+            } else {
+                target_selector.tick_goals(self, false).await;
+                goals_selector.tick_goals(self, false).await;
             }
 
             // 3. "Put back" selectors

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -792,8 +792,25 @@ pub struct Entity {
     pub leashed_to: Mutex<Option<Arc<dyn EntityBase>>>,
     /// Cooldown before entity can mount again after dismounting
     pub riding_cooldown: AtomicI32,
-    /// The age of the entity in ticks. Negative values indicate a baby.
+    /// How many ticks this entity has been alive for, counting up from zero.
+    ///
+    /// This is vanilla's `Entity#tickCount`. Use it for anything that means
+    /// "time since I spawned"; it is not persisted and it never runs backwards.
+    /// Do not use [`Self::age`] for that — that field means something else.
+    pub tick_count: AtomicI32,
+    /// The ageable age of the entity, in ticks. This is vanilla's
+    /// `AgeableMob#age`, so it is *not* a monotonic tick counter:
+    ///
+    /// - negative means a baby, counting up towards zero,
+    /// - zero means an adult,
+    /// - positive is the breeding cooldown left behind by breeding, counting
+    ///   back down towards zero.
+    ///
+    /// It is persisted as the `Age` NBT tag. For "ticks since spawn" use
+    /// [`Self::tick_count`].
     pub age: AtomicI32,
+    /// Whether [`Self::age`] is frozen in place, from the `AgeLocked` NBT tag.
+    pub age_locked: AtomicBool,
 
     pub current_biome: ArcSwap<&'static Biome>,
     pub last_biome_update_pos: AtomicCell<BlockPos>,
@@ -936,7 +953,9 @@ impl Entity {
             leashed_to: Mutex::new(None),
 
             riding_cooldown: AtomicI32::new(0),
+            tick_count: AtomicI32::new(0),
             age: AtomicI32::new(0),
+            age_locked: AtomicBool::new(false),
             current_biome: ArcSwap::new(Arc::new(&Biome::PLAINS)),
             last_biome_update_pos: AtomicCell::new(BlockPos::new(floor_x, floor_y, floor_z)),
             portal_cooldown: AtomicU32::new(0),
@@ -1022,10 +1041,36 @@ impl Entity {
         metadata
     }
 
-    /// Sets the entity's age in ticks.
-    /// Negative values indicate that the entity is a baby.
+    /// Sets the entity's ageable age, in ticks. Negative values make it a baby.
+    ///
+    /// See [`Self::age`] for the full meaning; this is not the tick counter.
     pub fn set_age(&self, age: i32) {
         self.age.store(age, Relaxed);
+    }
+
+    /// One tick of [`Self::age`] progression, mirroring vanilla
+    /// `AgeableMob#aiStep`: a baby's negative age counts up towards zero and
+    /// the positive breeding cooldown counts back down towards zero, so an
+    /// adult that is not on cooldown stays at zero.
+    ///
+    /// Subtracting the sign does all three cases at once, and cannot overflow
+    /// because it only ever moves `age` one step closer to zero.
+    #[must_use]
+    pub const fn stepped_age(age: i32) -> i32 {
+        age - age.signum()
+    }
+
+    /// Advances [`Self::age`] by one tick unless the age is locked.
+    ///
+    /// Entities that are not ageable simply sit at an age of zero, for which
+    /// this is a no-op.
+    pub fn tick_age(&self) {
+        if self.age_locked.load(Relaxed) {
+            return;
+        }
+        let _ = self
+            .age
+            .fetch_update(Relaxed, Relaxed, |age| Some(Self::stepped_age(age)));
     }
 
     /// Adds a scoreboard tag to this entity.
@@ -2472,7 +2517,7 @@ impl Entity {
         // Vanilla parity: full-freeze damage is tick-phase based.
         if can_freeze
             && new_frozen_ticks >= Self::MAX_FROZEN_TICKS
-            && self.age.load(Ordering::Relaxed) % Self::FREEZE_DAMAGE_INTERVAL == 0
+            && self.tick_count.load(Ordering::Relaxed) % Self::FREEZE_DAMAGE_INTERVAL == 0
         {
             caller.damage(caller, 1.0, DamageType::FREEZE).await;
         }
@@ -3767,5 +3812,54 @@ mod tests {
                 "status mismatch at index {i}"
             );
         }
+    }
+
+    #[test]
+    fn stepped_age_walks_towards_adulthood() {
+        // A baby counts up towards zero, one tick at a time.
+        assert_eq!(
+            Entity::stepped_age(crate::entity::ageable::BABY_START_AGE),
+            -23999
+        );
+        assert_eq!(Entity::stepped_age(-2), -1);
+        assert_eq!(Entity::stepped_age(-1), 0);
+    }
+
+    #[test]
+    fn stepped_age_counts_the_breeding_cooldown_down() {
+        // A positive age is the cooldown left behind by breeding; vanilla walks
+        // it back down to zero rather than letting it grow.
+        assert_eq!(Entity::stepped_age(6000), 5999);
+        assert_eq!(Entity::stepped_age(2), 1);
+        assert_eq!(Entity::stepped_age(1), 0);
+    }
+
+    #[test]
+    fn stepped_age_leaves_adults_alone() {
+        // This is the regression that mattered: an adult must stay at zero
+        // instead of accumulating ticks, because the age is persisted as the
+        // `Age` NBT tag and vanilla reads a positive `Age` as a cooldown.
+        assert_eq!(Entity::stepped_age(0), 0);
+    }
+
+    #[test]
+    fn stepped_age_never_overflows_at_the_extremes() {
+        // Only ever moves one step closer to zero, so neither bound can wrap.
+        assert_eq!(Entity::stepped_age(i32::MIN), i32::MIN + 1);
+        assert_eq!(Entity::stepped_age(i32::MAX), i32::MAX - 1);
+    }
+
+    #[test]
+    fn a_baby_reaches_adulthood_in_the_vanilla_time() {
+        // 24000 ticks is 20 minutes, matching vanilla's baby duration.
+        let mut age = crate::entity::ageable::BABY_START_AGE;
+        let mut ticks = 0u32;
+        while age < 0 {
+            age = Entity::stepped_age(age);
+            ticks += 1;
+        }
+        assert_eq!(ticks, 24000);
+        // And it then stays an adult rather than drifting positive.
+        assert_eq!(Entity::stepped_age(age), 0);
     }
 }

--- a/pumpkin/src/entity/passive/villager/mod.rs
+++ b/pumpkin/src/entity/passive/villager/mod.rs
@@ -741,8 +741,8 @@ impl Mob for VillagerEntity {
         _caller: &'a Arc<dyn EntityBase>,
     ) -> crate::entity::EntityBaseFuture<'a, ()> {
         Box::pin(async move {
-            let age = self.get_entity().age.load(Ordering::Relaxed);
-            if age % 20 != 0 {
+            let ticks_alive = self.get_entity().tick_count.load(Ordering::Relaxed);
+            if ticks_alive % 20 != 0 {
                 return;
             }
 

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1091,7 +1091,7 @@ impl Player {
         self.living_entity.last_attack_time.store(
             self.living_entity
                 .entity
-                .age
+                .tick_count
                 .load(std::sync::atomic::Ordering::Relaxed),
             std::sync::atomic::Ordering::Relaxed,
         );
@@ -1993,7 +1993,7 @@ impl Player {
         self.tick_counter.fetch_add(1, Ordering::Relaxed);
         self.living_entity
             .entity
-            .age
+            .tick_count
             .fetch_add(1, Ordering::Relaxed);
         if let Some(sleeping_since) = self.sleeping_since.load()
             && sleeping_since < 101

--- a/pumpkin/src/entity/projectile/arrow.rs
+++ b/pumpkin/src/entity/projectile/arrow.rs
@@ -507,7 +507,9 @@ impl ArrowEntity {
         }
 
         // Skip owner for initial frames (5 ticks)
-        if Some(other_ent.entity_id) == self.owner_id && self_ent.age.load(Ordering::Relaxed) < 5 {
+        if Some(other_ent.entity_id) == self.owner_id
+            && self_ent.tick_count.load(Ordering::Relaxed) < 5
+        {
             return true;
         }
 

--- a/pumpkin/src/entity/projectile/mod.rs
+++ b/pumpkin/src/entity/projectile/mod.rs
@@ -234,7 +234,9 @@ impl ThrownItemEntity {
         }
 
         // Skip owner for initial frames
-        if Some(other_ent.entity_id) == self.owner_id && self_ent.age.load(Ordering::Relaxed) < 5 {
+        if Some(other_ent.entity_id) == self.owner_id
+            && self_ent.tick_count.load(Ordering::Relaxed) < 5
+        {
             return true;
         }
 

--- a/pumpkin/src/entity/projectile/trident.rs
+++ b/pumpkin/src/entity/projectile/trident.rs
@@ -137,7 +137,9 @@ impl TridentEntity {
         }
 
         // Skip owner for initial frames (5 ticks)
-        if Some(other_ent.entity_id) == self.owner_id && self_ent.age.load(Ordering::Relaxed) < 5 {
+        if Some(other_ent.entity_id) == self.owner_id
+            && self_ent.tick_count.load(Ordering::Relaxed) < 5
+        {
             return true;
         }
 

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
@@ -673,7 +673,7 @@ impl HostEntity for PluginHostState {
         let entity = entity_from_resource(self, &entity)?;
         Ok(entity
             .get_entity()
-            .age
+            .tick_count
             .load(std::sync::atomic::Ordering::Relaxed))
     }
 
@@ -685,7 +685,7 @@ impl HostEntity for PluginHostState {
         let entity = entity_from_resource(self, &entity)?;
         entity
             .get_entity()
-            .age
+            .tick_count
             .store(ticks, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -946,7 +946,9 @@ impl World {
                 let p_cache = players_cache.clone();
 
                 tasks.spawn(async move {
-                    e_clone.get_entity().age.fetch_add(1, Relaxed);
+                    let entity = e_clone.get_entity();
+                    entity.tick_count.fetch_add(1, Relaxed);
+                    entity.tick_age();
                     e_clone.tick(&e_clone, &s_clone).await;
 
                     let entity_inner = e_clone.get_entity();


### PR DESCRIPTION
## What changed

`Entity::age` was serving two different vanilla concepts at once:

- **`Entity#tickCount`** — ticks since spawn, only ever counting up.
- **`AgeableMob#age`** — negative for a baby counting up to zero, zero for an adult, positive for the breeding cooldown left behind by breeding and counting back *down* to zero.

The world entity tick did `age.fetch_add(1)` once per tick, which made the field usable as a tick counter but meant the ageable meaning was never actually implemented — a positive age grew instead of shrinking, and nothing ever consulted the age lock.

This PR adds `Entity::tick_count` for the tick-counter meaning and leaves `age` to mean only the ageable age, progressed per vanilla `AgeableMob#aiStep` by the new `Entity::tick_age`. Every "time since I spawned" reader moves to `tick_count`; the `age` readers that remain are all baby/adult checks (`< 0` / `>= 0`), which is what they always wanted.

Both fields are documented so the next reader does not have to rediscover the distinction.

## Why — four defects fell out of the overload

**1. Baby mobs re-planned their AI twice as often as vanilla.** The gate in `Mob`'s tick was `if (age + entity_id) % 2 != 0 && age > 1`, mirroring vanilla's

```java
int i = this.level().getServer().getTickCount() + this.getId();
if (i % 2 != 0 && this.tickCount > 1) { ...tickRunningGoals(false) } else { ...tick() }
```

but with `age` standing in for both `getTickCount()` and `tickCount`. A baby's age is negative for its whole 20 minutes of childhood, so `age > 1` never held, the light pass was never taken, and the full goal-selector pass — which re-evaluates `can_start`/`should_continue` for every goal — ran on *every* tick. That doubles the goal-selection work for every baby mob, and because ~14 goals size their intervals with `to_goal_ticks` on the assumption of being re-evaluated every other tick, it also halves all of those intervals. The gate is now `runs_full_goal_pass`, keyed off the server tick count and the entity's own tick count, matching vanilla.

**2. Infinite status effects never ticked on baby mobs.** `tick_effects` uses the entity's tick counter as the clock for effects with no duration of their own (`duration == -1`). A baby's negative age meant every `duration <= 0` guard in `should_apply_effect_tick` bailed out, so infinite Regeneration, Poison and Wither did nothing at all on a baby animal.

**3. Adult cows, pigs and chickens persisted a meaningless `Age` NBT tag.** Their age accumulated ticks-alive without bound, and `write_ageable_nbt` saves it as `Age`. An adult alive for an hour wrote `Age: 72000`, which vanilla reads back as a 72000-tick breeding cooldown. Adults now correctly sit at zero.

**4. `AgeLocked` and `ForcedAge` were inert.** Both are read and written in `read_ageable_nbt`/`write_ageable_nbt`, but the only code that consulted the lock was `AgeableMob::ageable_ai_step`, which was never called from anywhere. That dead function is removed, and `age_locked` moves next to `age` on `Entity` so the central progression can honour it without needing to know the entity is ageable.

Also repoints the plugin API's `get-ticks-lived`/`set-ticks-lived`. The WIT contract (`v0.1/world.wit`) declares those separately from `get-age`/`set-age`, but the host implementation backed both with the same field, so a plugin asking a baby cow how long it had lived got a negative number.

## Impact

Baby mobs now plan on vanilla's cadence rather than double-rate, which is also strictly less per-tick work. Infinite effects work on babies. Adult animals stop writing a bogus `Age` to disk, so worlds round-trip correctly and stay readable by vanilla. `AgeLocked` starts working.

Behaviour for players and for non-ageable mobs is unchanged: their age was always non-negative, so every reader that moved to `tick_count` sees the same values it saw before.

## Tests

11 new unit tests, all pure-function so they need no running server:

- `Entity::stepped_age` — babies count up, breeding cooldowns count down, adults stay at zero, no overflow at `i32::MIN`/`i32::MAX`, and a baby reaches adulthood in exactly 24000 ticks (vanilla's 20 minutes).
- `runs_full_goal_pass` — alternates every other tick, is staggered by entity id so neighbouring mobs do not re-plan on the same tick, always runs during the spawn warm-up, skips half the passes once settled (the regression in defect 1), and survives tick-counter wraparound.

Full local CI is green: `typos`, `cargo fmt --check`, `cargo clippy --all-targets --all-features`, the same in `--release`, `cargo nextest run` (449 passed), `cargo test --doc`, `cargo machete`.

## Known limitations

- `Player::tick_counter` now duplicates `Entity::tick_count`. I left it alone to keep this diff focused; unifying them would be a reasonable follow-up.
- `AgeableMob` is currently only implemented by cow, pig and chicken, so defects 3 and 4 were only observable on those three. The fix is in `Entity`, so it applies to whatever else adopts the trait.
- `ForcedAge` is now honoured only through `age_up`, which is the sole caller; it is still not applied when a forced-age baby reaches adulthood. Out of scope here.
- `stepped_age` applies to every entity, not just ageable ones. For anything that never sets an age this is a no-op, exactly as the previous unconditional increment was for non-ageable entities.
