### PR TITLE
fix(entity): spawn one child per breeding pair, not one per parent 🤖🤖🤖

### DIFF
--- a/pumpkin/src/entity/ai/goal/breed.rs
+++ b/pumpkin/src/entity/ai/goal/breed.rs
@@ -60,8 +60,33 @@ impl BreedGoal {
         closest.map(|(_, e)| e)
     }
 
+    /// Which of the two partners is the one that spawns the child.
+    ///
+    /// Both partners run their own [`BreedGoal`], find each other as a mate, and
+    /// count their timers up in lockstep, so both reach the point of breeding on
+    /// the same tick and each would spawn a child of its own. Having one side
+    /// re-read the other's in-love state is not enough to stop that: the world
+    /// ticks entities concurrently on a `JoinSet`, so both sides can observe the
+    /// not-yet-bred state before either of them writes.
+    ///
+    /// Deciding it from the entity ids instead needs no shared state and cannot
+    /// race, because both sides compute the same answer from the same two ids.
+    #[must_use]
+    pub const fn spawns_the_child(entity_id: i32, mate_entity_id: i32) -> bool {
+        entity_id < mate_entity_id
+    }
+
     async fn breed(mob: &dyn Mob, mate: &dyn EntityBase) {
         let mob_entity = mob.get_mob_entity();
+
+        // `tick` keeps running on the ticks in between goal re-evaluations, so
+        // this can be reached again after the pair has already bred. Breeding
+        // consumes the in-love state and puts both parents on cooldown, so once
+        // that is gone there is nothing left to breed.
+        if !mob_entity.is_in_love() || !mob_entity.is_breeding_ready() {
+            return;
+        }
+
         let entity = mob.get_entity();
         let world = entity.world.load();
 
@@ -168,7 +193,10 @@ impl Goal for BreedGoal {
 
             self.timer += 1;
 
-            if self.timer >= 60 && dist_sq < 9.0 {
+            if self.timer >= 60
+                && dist_sq < 9.0
+                && Self::spawns_the_child(mob.get_entity().entity_id, mate.get_entity().entity_id)
+            {
                 Self::breed(mob, mate.as_ref()).await;
             }
         })
@@ -180,5 +208,47 @@ impl Goal for BreedGoal {
 
     fn controls(&self) -> Controls {
         Controls::MOVE | Controls::LOOK
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BreedGoal;
+
+    #[test]
+    fn exactly_one_partner_spawns_the_child() {
+        // The property that matters: for a pair, asking from both sides must
+        // yield exactly one "yes". Two yeses is the reported bug (two babies);
+        // two noes would mean breeding silently never produces anything.
+        let pairs = [(1, 2), (2, 1), (7, 400), (400, 7), (-5, 3), (3, -5), (0, 1)];
+        for (a, b) in pairs {
+            assert_ne!(
+                BreedGoal::spawns_the_child(a, b),
+                BreedGoal::spawns_the_child(b, a),
+                "ids {a} and {b} did not agree on a single parent"
+            );
+        }
+    }
+
+    #[test]
+    fn the_lower_entity_id_is_the_one_that_spawns() {
+        assert!(BreedGoal::spawns_the_child(1, 2));
+        assert!(!BreedGoal::spawns_the_child(2, 1));
+    }
+
+    #[test]
+    fn a_mob_is_never_its_own_partner() {
+        // `find_mate` skips candidates sharing our uuid, so equal ids should not
+        // reach this. If one ever did, declining is the safe direction: it costs
+        // a missed child rather than spawning one from a single parent.
+        assert!(!BreedGoal::spawns_the_child(42, 42));
+    }
+
+    #[test]
+    fn negative_entity_ids_still_pick_one_side() {
+        // Entity ids are i32 and Bedrock paths can hand out negatives, so the
+        // comparison must not depend on them being positive.
+        assert!(BreedGoal::spawns_the_child(i32::MIN, i32::MAX));
+        assert!(!BreedGoal::spawns_the_child(i32::MAX, i32::MIN));
     }
 }


### PR DESCRIPTION
Fixes #2532.

## What changed

Breeding two animals produced **two** babies. Both partners run their own `BreedGoal`, both find each other via `find_mate`, and both count `timer` up in lockstep — so both reach `timer >= 60` on the same tick, and `breed()` spawned a child for each of them.

Two changes:

1. **Decide which partner spawns the child, from the two entity ids.** `BreedGoal::spawns_the_child(entity_id, mate_entity_id)` is `entity_id < mate_entity_id`, so exactly one side of any pair says yes.
2. **Guard `breed()` against re-entry** on `!is_in_love() || !is_breeding_ready()`.

## Why it has to be an id comparison rather than a state re-check

The obvious fix is to have `breed()` re-read the partner's in-love state and bail if it's already been consumed. That is not sufficient here. `World::tick` spawns each entity's tick into a `tokio::task::JoinSet`, so entity ticks run **concurrently** — both partners can execute `BreedGoal::tick` at the same time and both observe the not-yet-bred state before either one writes. Any read-then-write guard has a window.

Comparing the two entity ids has no window: both sides compute the same answer from the same two inputs, with no shared state to race on. The re-entry guard is still worth having, but for a different reason — see below.

## Why the second guard is needed too

`BreedGoal::should_run_every_tick()` is `true`, so `tick` runs on every tick, but `should_continue` — which contains the `self.timer < 60` stop condition — is only re-evaluated on the full goal-selector pass, i.e. every *other* tick. So on the tick after the pair breeds, `tick` can run again with `timer == 61` and still satisfy `timer >= 60 && dist_sq < 9.0`, spawning a second child before the goal is stopped. Breeding consumes the in-love state and puts both parents on a 6000-tick cooldown, so refusing when that state is gone closes the window.

## This explains the reported asymmetry

The issue notes cows *always* producing two babies but pigs only sometimes. That follows from the above: when the two partners' goals were a tick out of phase, whether the second one got stopped by `should_continue` before its own `tick` reached 60 depended on the order the two entity tick tasks happened to run in that server tick. In phase → both always bred. Out of phase → it depended on scheduling.

## Impact

One child per successful breeding, as in vanilla. Both parents still get their in-love state cleared and a 6000-tick breeding cooldown, and the breeder still gets the `AnimalsBred` stat and the `BredAnimal` advancement exactly once, so those are no longer double-counted either.

## Tests

4 unit tests, pure-function so no server is needed. The important one asserts the actual invariant rather than the implementation: for a pair, asking from both sides yields exactly one yes — two yeses is this bug, two noes would mean breeding silently stopped working. Also covers negative entity ids (Bedrock paths can hand those out) and the equal-id case.

Full local CI green: `typos`, `cargo fmt --check`, `cargo clippy --all-targets --all-features`, the same in `--release`, `cargo nextest run` (443 passed), `cargo test --doc`, `cargo machete`.

## Known limitations

- The lower-id partner is the one that spawns, so if *its* goal is not running (preempted by a higher-priority goal holding `MOVE`) while the higher-id one's is, no child is spawned on that attempt. Both animals stay in love, so the next attempt succeeds once the lower-id goal runs again. In practice both goals run, since breeding already requires mutual love and a mutual `find_mate`.
- Unlike vanilla, `breed()` still does not set the parents' `Age` to 6000; Pumpkin tracks the post-breeding cooldown in a separate `breeding_cooldown` field, which has the same effect. Left alone deliberately to keep this change scoped.
- The baby spawns at the initiating parent's position rather than between the two parents. Pre-existing, not touched here.
