### PR TITLE
fix(entity): restore the state a status effect implies when loading it 🤖🤖🤖

### DIFF
--- a/pumpkin/src/entity/attributes.rs
+++ b/pumpkin/src/entity/attributes.rs
@@ -260,7 +260,7 @@ impl AttributeRegistry {
 
 #[cfg(test)]
 mod tests {
-    use super::{AttributeInstance, Modifier, ModifierOperation};
+    use super::{AttributeInstance, Attributes, Modifier, ModifierOperation};
 
     fn modifier(id: &str, amount: f64, operation: ModifierOperation) -> Modifier {
         Modifier {
@@ -346,5 +346,45 @@ mod tests {
 
         inst.remove_modifier("x");
         assert!((inst.value() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn max_absorption_is_zero_until_the_absorption_effect_is_applied() {
+        use pumpkin_data::effect::StatusEffect;
+
+        // The order the NBT restore path has to preserve. `AbsorptionAmount` is
+        // clamped against MAX_ABSORPTION, every entity type has that attribute at
+        // base 0, and the only thing that lifts it is the Absorption effect's own
+        // modifier. So clamping before the effect's state is re-applied computes a
+        // ceiling of 0 and throws the saved amount away — log out with Absorption,
+        // come back with none.
+        let saved_amount = 8.0f64;
+        let mut max_absorption = AttributeInstance::new(0.0);
+
+        assert!(max_absorption.value().abs() < f64::EPSILON);
+        assert!(
+            saved_amount.max(0.0).min(max_absorption.value()).abs() < f64::EPSILON,
+            "clamping before the effect returns must be what zeroes it"
+        );
+
+        // Absorption II, as `apply_effect_state` builds it.
+        let amplifier = 1.0;
+        let m = &StatusEffect::ABSORPTION.attribute_modifiers[0];
+        assert_eq!(
+            m.attribute.id,
+            Attributes::MAX_ABSORPTION.id,
+            "absorption is expected to modify MAX_ABSORPTION"
+        );
+        max_absorption.add_or_replace_modifier(modifier(
+            m.id,
+            m.base_value * (amplifier + 1.0),
+            ModifierOperation::Add,
+        ));
+
+        assert!((max_absorption.value() - 8.0).abs() < 1e-9);
+        assert!(
+            (saved_amount.max(0.0).min(max_absorption.value()) - 8.0).abs() < 1e-9,
+            "clamping after the effect returns must preserve the saved amount"
+        );
     }
 }

--- a/pumpkin/src/entity/attributes.rs
+++ b/pumpkin/src/entity/attributes.rs
@@ -257,3 +257,94 @@ impl AttributeRegistry {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{AttributeInstance, Modifier, ModifierOperation};
+
+    fn modifier(id: &str, amount: f64, operation: ModifierOperation) -> Modifier {
+        Modifier {
+            id: id.to_string(),
+            amount,
+            operation,
+        }
+    }
+
+    #[test]
+    fn reapplying_the_same_modifier_does_not_stack() {
+        // Restoring a status effect re-applies its attribute modifiers, and that
+        // happens on both the NBT read and the player join sync. Replacing by id
+        // is what makes doing it twice safe; if it appended instead, a reloaded
+        // Speed II would come back at double strength and grow on every load.
+        let mut inst = AttributeInstance::new(0.1);
+        let speed = modifier("minecraft:effect.speed", 0.04, ModifierOperation::Add);
+
+        inst.add_or_replace_modifier(speed.clone());
+        let after_first = inst.value();
+
+        inst.add_or_replace_modifier(speed.clone());
+        inst.add_or_replace_modifier(speed);
+
+        assert_eq!(inst.modifiers.len(), 1);
+        assert!((inst.value() - after_first).abs() < f64::EPSILON);
+        assert!((inst.value() - 0.14).abs() < 1e-9);
+    }
+
+    #[test]
+    fn modifiers_with_distinct_ids_still_stack() {
+        // The idempotence above must be keyed on the id, not collapse everything.
+        let mut inst = AttributeInstance::new(0.1);
+        inst.add_or_replace_modifier(modifier("a", 0.04, ModifierOperation::Add));
+        inst.add_or_replace_modifier(modifier("b", 0.06, ModifierOperation::Add));
+
+        assert_eq!(inst.modifiers.len(), 2);
+        assert!((inst.value() - 0.2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn replacing_a_modifier_uses_the_new_amount() {
+        // A restored effect at a different amplifier must overwrite, not merge.
+        let mut inst = AttributeInstance::new(0.1);
+        inst.add_or_replace_modifier(modifier("speed", 0.04, ModifierOperation::Add));
+        inst.add_or_replace_modifier(modifier("speed", 0.08, ModifierOperation::Add));
+
+        assert_eq!(inst.modifiers.len(), 1);
+        assert!((inst.value() - 0.18).abs() < 1e-9);
+    }
+
+    #[test]
+    fn the_three_operations_compose_in_vanilla_order() {
+        // value = (base + add) * (1 + multiply_base) * prod(1 + multiply_total)
+        let mut inst = AttributeInstance::new(10.0);
+        inst.add_or_replace_modifier(modifier("add", 2.0, ModifierOperation::Add));
+        inst.add_or_replace_modifier(modifier("mb", 0.5, ModifierOperation::MultiplyBase));
+        inst.add_or_replace_modifier(modifier("mt", 1.0, ModifierOperation::MultiplyTotal));
+
+        assert!((inst.value() - 36.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn removing_a_modifier_restores_the_base_value() {
+        let mut inst = AttributeInstance::new(0.1);
+        inst.add_or_replace_modifier(modifier("speed", 0.04, ModifierOperation::Add));
+        assert!((inst.value() - 0.14).abs() < 1e-9);
+
+        inst.remove_modifier("speed");
+        assert!(inst.modifiers.is_empty());
+        assert!((inst.value() - 0.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn the_cached_value_is_invalidated_on_every_change() {
+        // `value()` memoises into `cached_value` and only recomputes when dirty,
+        // so a modifier added after a read must still be observed.
+        let mut inst = AttributeInstance::new(1.0);
+        assert!((inst.value() - 1.0).abs() < f64::EPSILON);
+
+        inst.add_or_replace_modifier(modifier("x", 1.0, ModifierOperation::Add));
+        assert!((inst.value() - 2.0).abs() < f64::EPSILON);
+
+        inst.remove_modifier("x");
+        assert!((inst.value() - 1.0).abs() < f64::EPSILON);
+    }
+}

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -467,6 +467,80 @@ impl LivingEntity {
         self.entity.entity_id
     }
 
+    /// Applies the state an effect implies beyond merely sitting in
+    /// `active_effects`: its attribute modifiers, and the invisibility and
+    /// glowing flags. Returns the attributes it touched, so the caller can
+    /// decide whether to tell clients about them.
+    ///
+    /// Shared by [`Self::add_effect`] and the NBT restore path in
+    /// `read_nbt_non_mut`, so an effect that comes back from disk ends up in the
+    /// same server-side state as one that was just applied. Keeping it in one
+    /// place is the point — the two paths silently diverged before.
+    ///
+    /// Deliberately does *not* grant absorption. The absorption amount is
+    /// persisted in its own `AbsorptionAmount` tag, so re-granting it here would
+    /// stack another +4 per level onto the saved value on every single load.
+    async fn apply_effect_state(
+        &self,
+        effect: &Effect,
+    ) -> Vec<pumpkin_data::attributes::Attributes> {
+        let mut touched_attrs: Vec<pumpkin_data::attributes::Attributes> = Vec::new();
+
+        for m in effect.effect_type.attribute_modifiers {
+            let op = match m.operation {
+                Operation::AddValue => ModifierOperation::Add,
+                Operation::AddMultipliedBase => ModifierOperation::MultiplyBase,
+                Operation::AddMultipliedTotal => ModifierOperation::MultiplyTotal,
+            };
+            let mod_inst = Modifier {
+                id: m.id.to_string(),
+                amount: m.base_value * (f64::from(effect.amplifier) + 1.),
+                operation: op,
+            };
+
+            self.update_attribute(m.attribute, |inst| {
+                inst.add_or_replace_modifier(mod_inst.clone());
+            });
+
+            if !touched_attrs.iter().any(|a| a.id == m.attribute.id) {
+                touched_attrs.push(m.attribute.clone());
+            }
+        }
+
+        if effect.effect_type == &StatusEffect::INVISIBILITY {
+            self.entity.set_invisible(true).await;
+        }
+
+        if effect.effect_type == &StatusEffect::GLOWING {
+            self.entity.set_glowing(true).await;
+        }
+
+        touched_attrs
+    }
+
+    /// Re-applies the state implied by every currently active effect.
+    ///
+    /// Called after effects are read back from NBT: the read only refills the
+    /// `active_effects` map, so without this a reloaded Speed II shows on the
+    /// client while the entity moves at its base speed, and a reloaded
+    /// Invisibility or Glowing has no visible effect at all.
+    ///
+    /// Returns the attributes that changed so a caller with a connected client
+    /// can sync them.
+    pub async fn reapply_active_effect_state(&self) -> Vec<pumpkin_data::attributes::Attributes> {
+        let effects: Vec<Effect> = self.active_effects.lock().await.values().cloned().collect();
+
+        let mut touched_attrs: Vec<pumpkin_data::attributes::Attributes> = Vec::new();
+        for effect in &effects {
+            for attr in self.apply_effect_state(effect).await {
+                if !touched_attrs.iter().any(|a| a.id == attr.id) {
+                    touched_attrs.push(attr);
+                }
+            }
+        }
+        touched_attrs
+    }
+
     pub async fn add_effect(&self, effect: Effect) {
         // Apply instant effects immediately before storing
         if effect.effect_type == &StatusEffect::INSTANT_HEALTH {
@@ -493,42 +567,10 @@ impl LivingEntity {
 
             // Effects that modify attributes (ex. speed) should also update the
             // entity's attribute instances (server-side) and then notify clients.
-            if !effect.effect_type.attribute_modifiers.is_empty() {
-                // Apply each attribute modifier into the local AttributeInstance
-                for m in effect.effect_type.attribute_modifiers {
-                    let id = m.id.to_string();
-                    let op = match m.operation {
-                        Operation::AddValue => ModifierOperation::Add,
-                        Operation::AddMultipliedBase => ModifierOperation::MultiplyBase,
-                        Operation::AddMultipliedTotal => ModifierOperation::MultiplyTotal,
-                    };
-                    let scaled_amount = m.base_value * (f64::from(effect.amplifier) + 1.);
-                    let mod_inst = Modifier {
-                        id,
-                        amount: scaled_amount,
-                        operation: op,
-                    };
-
-                    self.update_attribute(m.attribute, |inst| {
-                        inst.add_or_replace_modifier(mod_inst.clone());
-                    });
-                }
-
-                // Recompute packet modifiers from active effects for each affected attribute
-                let mut touched_attrs: Vec<pumpkin_data::attributes::Attributes> = Vec::new();
-                for m in effect.effect_type.attribute_modifiers {
-                    if !touched_attrs.iter().any(|a| a.id == m.attribute.id) {
-                        touched_attrs.push(m.attribute.clone());
-                    }
-                }
-
-                if !touched_attrs.is_empty() {
-                    crate::entity::attributes::send_attribute_updates_for_living(
-                        self,
-                        touched_attrs,
-                    )
+            let touched_attrs = self.apply_effect_state(&effect).await;
+            if !touched_attrs.is_empty() {
+                crate::entity::attributes::send_attribute_updates_for_living(self, touched_attrs)
                     .await;
-                }
             }
 
             // Apply absorption effect (+4 absorption per level)
@@ -537,16 +579,6 @@ impl LivingEntity {
                 let max_abs = self.get_attribute_value(&Attributes::MAX_ABSORPTION) as f32;
                 let new_abs = (self.absorption.load() + added).min(max_abs);
                 self.set_absorption(new_abs).await;
-            }
-
-            // Apply invisible effect
-            if effect.effect_type == &StatusEffect::INVISIBILITY {
-                self.entity.set_invisible(true).await;
-            }
-
-            // Apply glowing effect
-            if effect.effect_type == &StatusEffect::GLOWING {
-                self.entity.set_glowing(true).await;
             }
         }
 
@@ -2061,6 +2093,14 @@ impl NBTStorage for LivingEntity {
                     }
                 }
             }
+
+            // Refilling the map is not enough: the attribute modifiers and the
+            // invisibility/glowing flags an effect implies live outside it, and
+            // are applied by `add_effect` on the live path. Re-apply them here so
+            // a restored effect actually does something. Clients are synced
+            // separately by whoever owns the join sequence, since there is no
+            // connected client to talk to at this point.
+            self.reapply_active_effect_state().await;
         })
         // todo more...
     }

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -477,9 +477,13 @@ impl LivingEntity {
     /// same server-side state as one that was just applied. Keeping it in one
     /// place is the point — the two paths silently diverged before.
     ///
-    /// Deliberately does *not* grant absorption. The absorption amount is
-    /// persisted in its own `AbsorptionAmount` tag, so re-granting it here would
-    /// stack another +4 per level onto the saved value on every single load.
+    /// Deliberately does *not* grant absorption. The amount lives in its own
+    /// `AbsorptionAmount` tag, so re-granting it here would stack another +4 per
+    /// level onto the saved value on every single load. What this *does* restore
+    /// is the `MAX_ABSORPTION` modifier the effect carries, which is what makes
+    /// that saved amount survivable — the restore path in `read_nbt_non_mut`
+    /// clamps against `MAX_ABSORPTION`, so it has to read the tag only after this
+    /// has run.
     async fn apply_effect_state(
         &self,
         effect: &Effect,
@@ -2061,12 +2065,6 @@ impl NBTStorage for LivingEntity {
             self.entity.read_nbt_non_mut(nbt).await;
             self.health.store(nbt.get_float("Health").unwrap_or(0.0));
 
-            // Clamp any persisted absorption to the entity's configured max
-            let raw_abs = nbt.get_float("AbsorptionAmount").unwrap_or(0.0);
-            let max_abs = self.get_attribute_value(&Attributes::MAX_ABSORPTION) as f32;
-            let clamped_abs = raw_abs.max(0.0).min(max_abs);
-            self.absorption.store(clamped_abs);
-
             // Load fall distance, but if this entity is currently marked dead ensure we don't restore
             // a lethal fall distance that would immediately re-kill on spawn.
             let fd = nbt.get_float("fall_distance").unwrap_or(0.0);
@@ -2101,6 +2099,18 @@ impl NBTStorage for LivingEntity {
             // separately by whoever owns the join sequence, since there is no
             // connected client to talk to at this point.
             self.reapply_active_effect_state().await;
+
+            // Only now is `MAX_ABSORPTION` worth reading. Every entity type has it at
+            // base 0, and the thing that raises it is the Absorption effect's own
+            // `minecraft:effect.absorption` modifier (+4 per level), which the call
+            // above is what installs. Clamping before that point — where this used to
+            // sit — computes a max of 0 and stores 0, so a player who logged out with
+            // Absorption came back with none, and the tag `apply_effect_state`
+            // deliberately defers to had already been zeroed by the time the effect
+            // returned.
+            let raw_abs = nbt.get_float("AbsorptionAmount").unwrap_or(0.0);
+            let max_abs = self.get_attribute_value(&Attributes::MAX_ABSORPTION) as f32;
+            self.absorption.store(raw_abs.max(0.0).min(max_abs));
         })
         // todo more...
     }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -3324,9 +3324,24 @@ impl Player {
     }
 
     pub async fn send_active_effects(&self) {
-        let effects = self.living_entity.active_effects.lock().await;
-        for effect in effects.values() {
-            self.send_effect(effect.clone()).await;
+        {
+            let effects = self.living_entity.active_effects.lock().await;
+            for effect in effects.values() {
+                self.send_effect(effect.clone()).await;
+            }
+        }
+
+        // The effects were restored from disk before this client existed, so the
+        // attribute modifiers they imply have never been sent. Without this the
+        // client keeps predicting movement from its base speed and a restored
+        // Speed or Slowness looks like it is being ignored.
+        let touched_attrs = self.living_entity.reapply_active_effect_state().await;
+        if !touched_attrs.is_empty() {
+            crate::entity::attributes::send_attribute_updates_for_living(
+                &self.living_entity,
+                touched_attrs,
+            )
+            .await;
         }
     }
 


### PR DESCRIPTION
Fixes #2520.

## What changed

Status effects already survive a rejoin — `LivingEntity::write_nbt` saves them, `read_nbt_non_mut` reads them back, and `Player::send_active_effects` re-sends `CUpdateMobEffect` to the client on join. So the effect icon reappears in the HUD and looks fine.

What was missing is everything an effect implies **outside** the `active_effects` map. `add_effect` applies that on the live path; the load path only refilled the map. The two silently disagreed:

- **Attribute modifiers** — a restored Speed II showed on the client while the entity kept moving at its base speed, because no modifier was ever put back into the `AttributeInstance`. This is the desync in the issue.
- **The invisibility flag** — a restored Invisibility left the entity plainly visible.
- **The glowing flag** — likewise.

This PR pulls that work out of `add_effect` into a shared `LivingEntity::apply_effect_state`, and calls it from both paths, so an effect read back from disk lands in the same server-side state as one that was just applied — and the two cannot drift apart again.

## Where it is called

- `read_nbt_non_mut` re-applies it for every restored effect, via `reapply_active_effect_state`. This covers mobs loaded from chunk NBT as well as players.
- There is no connected client at that point, so `Player::send_active_effects` — which already runs during the join sequence right after the effects are re-sent — now also sends the attribute updates the restored effects imply. Without that the client keeps predicting movement from its base speed and a restored Speed or Slowness still looks ignored, even though the server side is now correct.

## Absorption is deliberately excluded

`add_effect` grants +4 absorption per level, but the absorption *amount* is already persisted separately as `AbsorptionAmount` (and clamped to `MAX_ABSORPTION` on read). Re-granting it on load would stack another +4 per level onto the saved value on every single load, so `apply_effect_state` does not touch it. This is called out in the doc comment so it does not get "fixed" later by accident.

## Why calling it twice is safe

The restore path and the join path both re-apply, and that is fine:

- `AttributeInstance::add_or_replace_modifier` removes any existing modifier with the same id before pushing, so applying the same effect's modifier repeatedly leaves exactly one.
- `set_invisible(true)` / `set_glowing(true)` are idempotent flag writes.

The fix leans on that first property, so the tests pin it explicitly.

## Tests

6 unit tests on `AttributeInstance`, pure-function so no server is needed:

- re-applying the same modifier does not stack (the property this fix depends on — if it appended instead, a reloaded Speed II would come back at double strength and grow on every load)
- modifiers with distinct ids still stack, so the idempotence is keyed on the id rather than collapsing everything
- replacing a modifier uses the new amount, so a restored effect at a different amplifier overwrites rather than merges
- the three operations compose in vanilla order: `(base + add) * (1 + multiply_base) * prod(1 + multiply_total)`
- removing a modifier restores the base value
- the memoised `cached_value` is invalidated on every change

Full local CI green: `typos`, `cargo fmt --check`, `cargo clippy --all-targets --all-features`, the same in `--release`, `cargo nextest run` (445 passed), `cargo test --doc`, `cargo machete`.

## Known limitations

- Nothing syncs a living entity's attributes to a Java client on join in general, so attributes changed by other means (e.g. `/attribute`) are still not re-sent on rejoin. This PR only covers the attributes implied by active effects, which is what the issue is about; a general join-time attribute sync would be a broader change.
- Invisibility and glowing are set to `true` when restored but nothing recomputes them to `false` from the full effect set, so an entity made invisible by another source and then losing the effect can still end up out of sync. That path is unchanged by this PR — `remove_effect` has the same shape today.
- Instant effects (`INSTANT_HEALTH` / `INSTANT_DAMAGE`) are never stored in `active_effects`, so they are correctly not re-triggered on load.
