### PR TITLE
fix(commands): Give not working for numbers greater than 99

### DIFF
--- a/pumpkin/src/command/commands/give.rs
+++ b/pumpkin/src/command/commands/give.rs
@@ -92,7 +92,7 @@ impl CommandExecutor for Executor {
                             .add_child(TextComponent::text("]"))
                             .hover_event(HoverEvent::ShowItem {
                                 id: item_name.to_string().into(),
-                                count: Some(item_count),
+                                count: Some(item_count.min(99)),
                             }),
                         targets[0].get_display_name().await,
                     ],
@@ -108,7 +108,7 @@ impl CommandExecutor for Executor {
                             .add_child(TextComponent::text("]"))
                             .hover_event(HoverEvent::ShowItem {
                                 id: item_name.to_string().into(),
-                                count: Some(item_count),
+                                count: Some(item_count.min(99)),
                             }),
                         TextComponent::text(targets.len().to_string()),
                     ],


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Fixes `/give` command sending a broken item hover tooltip which kicks the player due to a malformed packet due to the broken tooltip having a count above 99.

This just caps the ShowItem hover event to 99, but doesn't change the amount of items or anything in gameplay.

Related issue https://github.com/Pumpkin-MC/Pumpkin/issues/2528
## Testing
- [x] `cargo check`
- [x] `cargo clippy --all-targets`
- [x] Manually ran:
    - [x]  `/give @p minecraft:firework_rocket 128`
    - [x] `/give @p minecraft:firework_rocket 1000`
    - [x] `/give @p minecraft:firework_rocket 10`

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
