### PR TITLE
fix: four mob AI goal bugs

### DIFF
--- a/pumpkin/src/entity/ai/goal/creeper_ignite.rs
+++ b/pumpkin/src/entity/ai/goal/creeper_ignite.rs
@@ -19,29 +19,36 @@ impl CreeperIgniteGoal {
             creeper,
         }
     }
+
+    /// Vanilla `SwellGoal.canUse`: an already lit fuse keeps the goal alive regardless of
+    /// distance, otherwise the swell only begins with a target inside 3 blocks.
+    async fn can_swell(&self, mob: &dyn Mob) -> bool {
+        if self.creeper.fuse_speed.load(Ordering::Relaxed) > 0 {
+            return true;
+        }
+
+        let target_lock = mob.get_mob_entity().target.lock().await;
+        if let Some(target) = target_lock.as_ref() {
+            let dist_sq = mob
+                .get_entity()
+                .pos
+                .load()
+                .squared_distance_to_vec(&target.get_entity().pos.load());
+            return dist_sq < 9.0;
+        }
+
+        false
+    }
 }
 
 impl Goal for CreeperIgniteGoal {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
-        Box::pin(async move {
-            let creeper = mob.get_mob_entity();
-            let target_lock = creeper.target.lock().await;
+        Box::pin(async move { self.can_swell(mob).await })
+    }
 
-            if self.creeper.fuse_speed.load(Ordering::Relaxed) > 0 {
-                return true;
-            }
-
-            if let Some(target) = target_lock.as_ref() {
-                let dist_sq = mob
-                    .get_entity()
-                    .pos
-                    .load()
-                    .squared_distance_to_vec(&target.get_entity().pos.load());
-                return dist_sq < 9.0;
-            }
-
-            false
-        })
+    /// Vanilla `SwellGoal` inherits `canContinueToUse` from `Goal`, which returns `canUse()`.
+    fn should_continue<'a>(&'a self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
+        Box::pin(async move { self.can_swell(mob).await })
     }
 
     fn start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
@@ -51,11 +58,9 @@ impl Goal for CreeperIgniteGoal {
         })
     }
 
-    fn stop<'a>(&'a mut self, _mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
-        Box::pin(async move {
-            self.creeper.set_fuse_speed(-1);
-        })
-    }
+    // Vanilla `SwellGoal.stop` only clears the cached target, it never resets the fuse.
+    // We track the target through the mob itself, so there is nothing to clear here and
+    // `tick` stays the single owner of the fuse speed.
 
     fn tick<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, ()> {
         Box::pin(async move {

--- a/pumpkin/src/entity/ai/goal/look_at_entity.rs
+++ b/pumpkin/src/entity/ai/goal/look_at_entity.rs
@@ -8,7 +8,6 @@ use pumpkin_data::entity::EntityType;
 use rand::RngExt;
 use std::sync::{Arc, Weak};
 
-#[expect(dead_code)]
 pub struct LookAtEntityGoal {
     goal_control: Controls,
     target: Option<Arc<dyn EntityBase>>,
@@ -93,16 +92,28 @@ impl Goal for LookAtEntityGoal {
             }
 
             let world = mob_entity.living_entity.entity.world.load();
-            let mob_pos = mob_entity.living_entity.entity.pos.load();
 
-            if *self.target_type == EntityType::PLAYER {
-                self.target = world
-                    .get_closest_player(mob_pos, self.range.into())
-                    .map(|p: Arc<Player>| p as Arc<dyn EntityBase>);
+            // Vanilla searches from `mob.getX(), mob.getEyeY(), mob.getZ()`
+            let mut search_pos = mob_entity.living_entity.entity.pos.load();
+            search_pos.y = mob_entity.living_entity.entity.get_eye_y();
+
+            let candidate = if *self.target_type == EntityType::PLAYER {
+                world
+                    .get_closest_player(search_pos, self.range.into())
+                    .map(|p: Arc<Player>| p as Arc<dyn EntityBase>)
             } else {
-                self.target =
-                    world.get_closest_entity(mob_pos, self.range.into(), Some(&[self.target_type]));
-            }
+                world.get_closest_entity(search_pos, self.range.into(), Some(&[self.target_type]))
+            };
+
+            // Vanilla runs candidates through the goal's `TargetingConditions`, which rejects
+            // entities that are not part of the game (spectators) or out of range
+            let target = candidate.filter(|candidate| {
+                candidate.get_living_entity().is_some_and(|living| {
+                    self.target_predicate
+                        .test(&world, Some(&mob_entity.living_entity), living)
+                })
+            });
+            self.target = target;
 
             self.target.is_some()
         })

--- a/pumpkin/src/entity/ai/goal/move_to_target_pos.rs
+++ b/pumpkin/src/entity/ai/goal/move_to_target_pos.rs
@@ -161,9 +161,10 @@ impl<M: MoveToTargetPos> Goal for MoveToTargetPosGoal<M> {
         Box::pin(async {
             Self::start_moving_to_target(mob);
             self.trying_time = 0;
-            let random = mob.get_random().random_range(0..MIN_WAITING_TIME);
-            self.safe_waiting_time =
-                mob.get_random().random_range(random..MIN_WAITING_TIME) + MIN_WAITING_TIME;
+            // Vanilla: `nextInt(nextInt(1200) + 1200) + 1200`, so the bound is itself drawn
+            // from [1200, 2400) and the result lands in [1200, 3600).
+            let bound = mob.get_random().random_range(0..MIN_WAITING_TIME) + MIN_WAITING_TIME;
+            self.safe_waiting_time = mob.get_random().random_range(0..bound) + MIN_WAITING_TIME;
         })
     }
 

--- a/pumpkin/src/entity/mob/creeper.rs
+++ b/pumpkin/src/entity/mob/creeper.rs
@@ -85,7 +85,11 @@ impl CreeperEntity {
     }
 
     pub fn set_fuse_speed(&self, speed: i32) {
-        self.fuse_speed.store(speed, Ordering::Relaxed);
+        // Vanilla keeps this in synched entity data, which only marks the entry dirty (and so
+        // only broadcasts) when the value actually changes.
+        if self.fuse_speed.swap(speed, Ordering::Relaxed) == speed {
+            return;
+        }
         self.mob_entity.living_entity.entity.send_meta_data(
             &[Metadata::new(
                 TrackedData::FUSE_ID,

--- a/pumpkin/src/entity/passive/iron_golem.rs
+++ b/pumpkin/src/entity/passive/iron_golem.rs
@@ -43,10 +43,10 @@ impl IronGolemEntity {
             goal_selector.add_goal(8, Box::new(RandomLookAroundGoal::default()));
 
             target_selector.add_goal(1, Box::new(RevengeGoal::new(true)));
-            target_selector.add_goal(
-                2,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::PLAYER, false),
-            );
+            // Vanilla targets players through `NearestAttackableTargetGoal<>(..., this::isAngryAt)`,
+            // so a golem only goes after a player it already holds a grudge against. We have no
+            // per player anger state yet, so we leave players to `RevengeGoal` instead of
+            // attacking every player on sight.
             target_selector.add_goal(
                 3,
                 ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::ZOMBIE, true),


### PR DESCRIPTION
Four goal bugs found while auditing mob AI against vanilla. Grouped because each is small; happy to split.

## 1. Creepers cancel their fuse at 3 blocks instead of 7

`CreeperIgniteGoal` has no `should_continue`, so it inherits the trait default returning `false` and is stopped on every evaluation tick. `stop()` then did `set_fuse_speed(-1)`, and the restart in the same pass needs `can_start`, which with the fuse cleared falls through to a `dist_sq < 9.0` check. So the swell only survives while the player is inside 3 blocks.

Vanilla `SwellGoal.canContinueToUse()` is the inherited default `return this.canUse()`, `canUse()` short-circuits on `swellDir > 0`, and `stop()` only clears the cached target. The fuse is reset to -1 solely from `tick()`. The wiki puts the cancel distance at 7 blocks regardless of difficulty.

Fixed by extracting the `canUse` logic, adding `should_continue`, and removing the reset from `stop()` so `tick()` is the only thing that touches the fuse. `tick()` already had the >7 block reset.

Second effect worth noting: `set_fuse_speed` broadcasts a metadata packet, and `tick()` called it unconditionally every tick, so a primed creeper was spamming every client with the same value. `set_fuse_speed` now returns early when the value is unchanged, matching vanilla's synched-entity-data semantics of only broadcasting on change.

`tick()` still carries a pre-existing `// TODO: line of sight check`. I left it: there is no raycast helper for this anywhere (`blaze_attack.rs` hardcodes `has_line_of_sight = true`), so adding one is its own change.

## 2. Iron golems attack every player on sight

```rust
target_selector.add_goal(2, ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::PLAYER, false));
```

`with_default` installs no predicate, so the golem targets the nearest player unconditionally, and `MeleeAttackGoal` at priority 1 makes it chase and hit. Vanilla is `new NearestAttackableTargetGoal<>(this, Player.class, 10, true, false, this::isAngryAt)`, gated on per-player anger, and a player-built golem never attacks players at all.

I checked whether anger state exists to gate on. It does not: the only hit is `EndermanEntity.angry`, a single global bool with its own TODO about an angerable system. There is no per-player grudge anywhere.

So rather than approximate anger, I removed the unconditional PLAYER target goal and left `RevengeGoal`. Golems now retaliate when hit but do not attack on sight, which is much closer to vanilla than the current behaviour. If per-player anger lands later this should become a predicate instead.

## 3. `LookAtEntityGoal` builds a target predicate and never applies it

`create_target_predicate` constructs a predicate, stores it behind `#[expect(dead_code)]`, and nothing reads it. `can_start` instead takes the raw nearest entity, which filters nothing, so mobs turn to stare at spectator-mode players.

The candidate is now filtered through the stored predicate before being assigned, and the search origin moved to eye height to match vanilla.

Caveat: `TargetPredicate::test` is sync and never invokes its async `predicate` closure field, so the `notRiding` sub-predicate still does not run. That is pre-existing and shared with `ActiveTargetGoal`, `RevengeGoal` and `TeleportTowardsPlayerGoal`; making `test` async touches four call sites and belongs in its own change. The spectator symptom is fixed.

## 4. `MoveToTargetPosGoal` draws `safe_waiting_time` from the wrong distribution

```rust
let random = mob.get_random().random_range(0..MIN_WAITING_TIME);
self.safe_waiting_time = mob.get_random().random_range(random..MIN_WAITING_TIME) + MIN_WAITING_TIME;
```

Vanilla is `nextInt(nextInt(1200) + 1200) + 1200`, so the bound is itself in [1200, 2400) and the result is [1200, 3600). This drew from [random, 1200) and added 1200, giving [1200, 2400) with a skewed lower tail, so mobs abandoned a target position sooner than they should.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

Not verified in game. The creeper distance and the golem behaviour are both straightforward to check by hand if you want them confirmed before merging.
