### PR TITLE
fix: clear the pathfinder node cache between searches

### DIFF
--- a/pumpkin/src/entity/ai/pathfinder/pathfinding_context.rs
+++ b/pumpkin/src/entity/ai/pathfinder/pathfinding_context.rs
@@ -1,5 +1,6 @@
 use pumpkin_data::{
     Block, BlockState,
+    block_properties::{BlockProperties, CampfireLikeProperties},
     fluid::Fluid,
     tag::{self, Taggable},
 };
@@ -115,9 +116,16 @@ impl PathfindingContext {
         if block.id == Block::FIRE.id
             || block.id == Block::SOUL_FIRE.id
             || block.id == Block::MAGMA_BLOCK.id
-            || block.id == Block::CAMPFIRE.id
-            || block.id == Block::SOUL_CAMPFIRE.id
             || block.id == Block::LAVA_CAULDRON.id
+        {
+            return PathType::DamageFire;
+        }
+
+        // Vanilla `NodeEvaluator.isBurningBlock` gates campfires on
+        // `CampfireBlock.isLitCampfire(state)`, so an extinguished campfire is not a
+        // fire hazard and must not poison the surrounding nodes with `DangerFire`.
+        if (block.id == Block::CAMPFIRE.id || block.id == Block::SOUL_CAMPFIRE.id)
+            && CampfireLikeProperties::from_state_id(state_id, block).lit
         {
             return PathType::DamageFire;
         }

--- a/pumpkin/src/entity/ai/pathfinder/walk_node_evaluator.rs
+++ b/pumpkin/src/entity/ai/pathfinder/walk_node_evaluator.rs
@@ -337,6 +337,11 @@ impl NodeEvaluator for WalkNodeEvaluator {
 
         self.base.context = Some(context);
         self.base.mob_data = Some(mob_data);
+        // Vanilla `NodeEvaluator.prepare` clears the node map at the start of every
+        // search. Without this, `get_node` hands back nodes carrying mutated state
+        // from previous searches (`closed`, and `cost_malus` through its monotonic
+        // `max`), and the map grows without bound for the lifetime of the mob.
+        self.base.nodes.clear();
         self.path_types_cache.clear();
     }
 


### PR DESCRIPTION
## The main bug

`WalkNodeEvaluator::prepare` clears the path type cache but not the node map:

```rust
fn prepare(&mut self, context: PathfindingContext, mob_data: MobData) {
    self.base.entity_width = mob_data.get_bb_width();
    ...
    self.path_types_cache.clear();   // this one
}                                     // base.nodes is not
```

`base.nodes` is only cleared by `reset()`, and `reset()` and `done()` have no call sites anywhere in the tree. `Navigator` owns one `WalkNodeEvaluator` for the mob's lifetime, and `MobEntity::tick` takes the navigator and puts the same one back, so the map persists across every path that mob ever computes.

Three consequences, all real:

**Closed doors and fences become permanently unwalkable.** Nodes are marked `closed = true` for `Fence`, `DoorWoodClosed` and `DoorIronClosed`. `find_accepted_node` refreshes `path_type` and `cost_malus` on a reused node but never clears `closed`, and `is_neighbor_valid` rejects any closed neighbour. So once a mob has evaluated a position holding a closed wooden door, that position stays unwalkable *for that mob* even after the door is opened or the fence is broken.

**Cost malus accumulates across searches.** `n.cost_malus = penalty.max(n.cost_malus)` is vanilla's monotonic max, which is correct *within* one search. Applied to a stale node it maxes across all previous searches too, so for example a water malus sticks to a position after the water is gone.

**Unbounded memory.** Every position a mob ever evaluated stays in the map for its lifetime.

Vanilla `NodeEvaluator.prepare` clears `nodes` before each search. The rest of Pumpkin's `prepare` is a line-for-line port, including the three identical `entity_width/height/depth` assignments, so this looks like a dropped line rather than a design decision.

Fixed with `self.base.nodes.clear()` in `prepare` rather than calling `reset()`, since `reset()` also nulls `context` and `mob_data` which `prepare` is in the middle of assigning. `reset()` and `done()` are still dead; I left them rather than deleting them, since `done()` matches vanilla's lifecycle and may be wanted later.

This may be relevant to #2519, which describes pathfinding cycles: stale node reuse looks like a plausible contributor, though I have not confirmed that.

## Second, smaller fix

Unlit campfires were classified as fire hazards, so mobs pathed around extinguished campfires and treated the surrounding blocks as dangerous.

I was not confident enough in my recollection of vanilla here to change it on memory, so I verified it. Citizens2 ships per-NMS-revision verbatim copies of the vanilla pathfinder, and `v26_2_R1` matches this target exactly:

```java
static boolean isBurningBlock(BlockState var0) {
    return var0.is(BlockTags.FIRE) || var0.is(Blocks.LAVA) || var0.is(Blocks.MAGMA_BLOCK)
            || CampfireBlock.isLitCampfire(var0) || var0.is(Blocks.LAVA_CAULDRON);
}
```

So the campfire branch is gated on `isLitCampfire` and the others are not. The campfire ids are now split out of the flat `||` chain and gated on the `lit` property.

## Verified as correct and deliberately not touched

The jump check comparing a squared horizontal distance against an unsquared width looks like the classic squared-vs-unsquared bug, but it matches vanilla `MoveControl.tick`, which is `d*d + e*e < Math.max(1.0F, this.mob.getBbWidth())`. Same in `move_control.rs`. Leaving both.

## Found while reading, not fixed here

- `can_start_at` uses `path_type.is_passable() && !self.has_collisions(pos)`. The same Citizens2 revision shows vanilla is `pathType != PathType.OPEN && this.mvmt.getPathfindingMalus(pathType) >= 0.0F`, so Pumpkin diverges three ways: no `!= Open` check, the static default malus instead of the mob's overridden one, and a collision test vanilla does not have. I did not change it because it is not a safe drop-in: vanilla's `getStart` always returns a start node and `canStartAt` only picks which corner to use, whereas Pumpkin's `get_start` returns `None` when every candidate fails. Making the check stricter under that structure turns "pick a different start block" into "pathfinding fails outright". Needs `get_start`'s control flow ported alongside it.
- `is_diagonal_valid` is missing vanilla's large-mob early-out.
- `GoalSelector::remove_goal` and `BaseNodeEvaluator::is_position_in_bounds` both have real bugs but zero call sites.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

Not verified in game.
