### PR TITLE
fix: twisting vines checked the wrong support face

### DIFF
--- a/pumpkin/src/block/blocks/plant/fungus.rs
+++ b/pumpkin/src/block/blocks/plant/fungus.rs
@@ -1,5 +1,6 @@
-use crate::block::{BlockBehaviour, BlockFuture, BlockMetadata, CanPlaceAtArgs};
-use crate::block::{GetStateForNeighborUpdateArgs, blocks::plant::PlantBlockBase};
+use crate::block::{
+    BlockBehaviour, BlockFuture, BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs,
+};
 use pumpkin_data::BlockStateId;
 use pumpkin_data::tag::Taggable;
 use pumpkin_data::{Block, BlockId, tag};
@@ -13,39 +14,31 @@ impl BlockMetadata for FungusBlock {
     }
 }
 
+/// Vanilla gives every fungus its own support tag, chosen from the fungus being placed
+/// and not from the block it is standing on.
+fn has_support(block_accessor: &dyn BlockAccessor, fungus: &Block, position: &BlockPos) -> bool {
+    let ground = block_accessor.get_block(&position.down());
+    if fungus == &Block::WARPED_FUNGUS {
+        ground.has_tag(&tag::Block::MINECRAFT_SUPPORTS_WARPED_FUNGUS)
+    } else {
+        ground.has_tag(&tag::Block::MINECRAFT_SUPPORTS_CRIMSON_FUNGUS)
+    }
+}
+
 impl BlockBehaviour for FungusBlock {
     fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
-        <Self as PlantBlockBase>::can_place_at(self, args.block_accessor, args.position)
+        has_support(args.block_accessor, args.block, args.position)
     }
     fn get_state_for_neighbor_update<'a>(
         &'a self,
         args: GetStateForNeighborUpdateArgs<'a>,
     ) -> BlockFuture<'a, BlockStateId> {
         Box::pin(async move {
-            <Self as PlantBlockBase>::get_state_for_neighbor_update(
-                self,
-                args.world,
-                args.position,
-                args.state_id,
-            )
-            .await
+            if has_support(args.world, args.block, args.position) {
+                args.state_id
+            } else {
+                Block::AIR.default_state.id
+            }
         })
-    }
-}
-impl PlantBlockBase for FungusBlock {
-    fn can_plant_on_top(
-        &self,
-        block_accessor: &dyn pumpkin_world::world::BlockAccessor,
-        pos: &pumpkin_util::math::position::BlockPos,
-    ) -> bool {
-        let block = block_accessor.get_block(pos);
-
-        if block == &Block::WARPED_FUNGUS {
-            return block.has_tag(&tag::Block::MINECRAFT_SUPPORTS_WARPED_FUNGUS);
-        }
-        block.has_tag(&tag::Block::MINECRAFT_SUPPORTS_CRIMSON_FUNGUS)
-    }
-    fn can_place_at(&self, block_accessor: &dyn BlockAccessor, block_pos: &BlockPos) -> bool {
-        <Self as PlantBlockBase>::can_plant_on_top(self, block_accessor, &block_pos.down())
     }
 }

--- a/pumpkin/src/block/blocks/plant/roots.rs
+++ b/pumpkin/src/block/blocks/plant/roots.rs
@@ -3,10 +3,8 @@ use pumpkin_data::{Block, BlockId, BlockStateId, tag};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::world::BlockAccessor;
 
-use crate::block::BlockFuture;
 use crate::block::{
-    BlockBehaviour, BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs,
-    blocks::plant::PlantBlockBase,
+    BlockBehaviour, BlockFuture, BlockMetadata, CanPlaceAtArgs, GetStateForNeighborUpdateArgs,
 };
 
 pub struct RootsBlock;
@@ -17,9 +15,20 @@ impl BlockMetadata for RootsBlock {
     }
 }
 
+/// Vanilla gives every roots block its own support tag, chosen from the roots being placed
+/// and not from the block they are standing on.
+fn has_support(block_accessor: &dyn BlockAccessor, roots: &Block, position: &BlockPos) -> bool {
+    let ground = block_accessor.get_block(&position.down());
+    if roots == &Block::WARPED_ROOTS {
+        ground.has_tag(&tag::Block::MINECRAFT_SUPPORTS_WARPED_ROOTS)
+    } else {
+        ground.has_tag(&tag::Block::MINECRAFT_SUPPORTS_CRIMSON_ROOTS)
+    }
+}
+
 impl BlockBehaviour for RootsBlock {
     fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
-        <Self as PlantBlockBase>::can_place_at(self, args.block_accessor, args.position)
+        has_support(args.block_accessor, args.block, args.position)
     }
 
     fn get_state_for_neighbor_update<'a>(
@@ -27,28 +36,11 @@ impl BlockBehaviour for RootsBlock {
         args: GetStateForNeighborUpdateArgs<'a>,
     ) -> BlockFuture<'a, BlockStateId> {
         Box::pin(async move {
-            <Self as PlantBlockBase>::get_state_for_neighbor_update(
-                self,
-                args.world,
-                args.position,
-                args.state_id,
-            )
-            .await
+            if has_support(args.world, args.block, args.position) {
+                args.state_id
+            } else {
+                Block::AIR.default_state.id
+            }
         })
-    }
-}
-
-impl PlantBlockBase for RootsBlock {
-    fn can_plant_on_top(&self, block_accessor: &dyn BlockAccessor, pos: &BlockPos) -> bool {
-        let block_below = block_accessor.get_block(pos);
-        if block_below == &Block::WARPED_ROOTS {
-            block_below.has_tag(&tag::Block::MINECRAFT_SUPPORTS_WARPED_ROOTS)
-        } else {
-            block_below.has_tag(&tag::Block::MINECRAFT_SUPPORTS_CRIMSON_ROOTS)
-        }
-    }
-
-    fn can_place_at(&self, block_accessor: &dyn BlockAccessor, block_pos: &BlockPos) -> bool {
-        self.can_plant_on_top(block_accessor, &block_pos.down())
     }
 }

--- a/pumpkin/src/block/blocks/plant/twisting_vines.rs
+++ b/pumpkin/src/block/blocks/plant/twisting_vines.rs
@@ -79,7 +79,9 @@ impl PlantBlockBase for TwistingVinesBlock {
         {
             return true;
         }
-        if support_block_state.is_side_solid(pumpkin_data::BlockDirection::Down)
+        // Twisting vines grow upwards, so the sturdy face we need is the top face of the
+        // block below. Weeping vines are the mirrored case and check the bottom face.
+        if support_block_state.is_side_solid(pumpkin_data::BlockDirection::Up)
             && support_block.is_solid()
         {
             return true;


### PR DESCRIPTION
## Twisting vines check the wrong support face

`twisting_vines.rs` tested `is_side_solid(BlockDirection::Down)` on the block below. Twisting vines grow upward, so the sturdy face required of the block below is its **top** face. This looks like a copy from `weeping_vines.rs`, where `Down` is correct because weeping vines grow downward and hang from the block above. `kelp.rs`, the other upward grower, already uses `Up`.

Vanilla `GrowingPlantBlock.canSurvive` tests `isFaceSturdy` against `growthDirection`:

```java
BlockPos blockpos = pos.relative(this.growthDirection.getOpposite());
BlockState blockstate = level.getBlockState(blockpos);
return !this.canAttachTo(blockstate) ? false
    : blockstate.is(getHeadBlock()) || blockstate.is(getBodyBlock())
   || blockstate.isFaceSturdy(level, blockpos, this.growthDirection);
```

`TwistingVinesBlock` passes `Direction.UP` to super, `WeepingVinesBlock` passes `Direction.DOWN`, and neither overrides `canAttachTo`.

The difference is only visible on partial blocks, since on nylium both faces are sturdy. A top slab or upside-down stair has a sturdy top face but not a sturdy bottom face: vanilla allows twisting vines there and this refused them. A bottom slab is the mirror case, where vanilla refuses and this allowed them.

## Fungus and roots dispatch on the wrong block

`fungus.rs` and `roots.rs` read the **ground** block and then compared it against `Block::WARPED_FUNGUS` / `Block::WARPED_ROOTS` to choose which support tag to check. Those are the plants, not the ground, so the warped branch was unreachable and everything fell through to the crimson tag.

This is currently a no-op, and I want to be upfront about that: I checked the generated tag data and in 26.2 `supports_crimson_fungus`, `supports_warped_fungus`, `supports_crimson_roots` and `supports_warped_roots` are byte-identical lists (the dirt family, mycelium, farmland, both nyliums, soul soil). So the wrong branch produced the right answer by accident. I fixed it because the comparison is unambiguously wrong and those tags are Mojang-owned data that can diverge in any version. Say the word if you would rather not carry a no-op change.

It was introduced in #1693, which added these blocks.

## Deliberately not touched

- **Bone meal on fungus is entirely unimplemented.** There is no `BonemealableBlock` equivalent in the codebase; `BONE_MEAL` appears only in composter, bamboo, bamboo sapling, sweet berry bush and sea pickles. Growing huge fungi from bone meal means building that infrastructure plus a server-side path into the worldgen feature, which is a port rather than a bug fix.
- **Huge fungus worldgen** is a stub (random 50/50 warped/crimson, no biome check, fixed cap geometry), but #2518 is already fixing exactly that against #2466, so I stayed out of the file.
- **Nylium has no block behaviour registered at all**, so no spread and no bone meal vegetation. Absent rather than wrong.
- **No random tick growth for twisting or weeping vines.** Also absent rather than wrong.
- The extra `&& support_block.is_solid()` gate in twisting, weeping and kelp has no counterpart in vanilla's `canSurvive`, but it is applied consistently across all three and I could not construct a concrete divergent case, so changing it would be speculative.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

Not verified in game. The slab case above is easy to check by hand if you want it confirmed.
