### PR TITLE
fix: find the nearest valid target, not the nearest target

### DIFF
--- a/pumpkin/src/entity/ai/goal/active_target.rs
+++ b/pumpkin/src/entity/ai/goal/active_target.rs
@@ -93,35 +93,30 @@ impl ActiveTargetGoal {
         let mut search_pos = mob.living_entity.entity.pos.load();
         search_pos.y += mob.living_entity.entity.entity_dimension.load().eye_height as f64;
 
-        if self.target_type == &EntityType::PLAYER {
-            let potential_player = world
-                .get_closest_player(search_pos, follow_range)
-                .map(|p: Arc<Player>| p as Arc<dyn EntityBase>);
+        // Vanilla evaluates the target conditions per candidate inside the search, so the result is
+        // the nearest *valid* target. Testing only the nearest candidate would make a single
+        // invalid entity (for example an invulnerable creative player) hide every target behind it.
+        let tester = &mob.living_entity;
+        let target_predicate = &self.target_predicate;
 
-            if let Some(potential_entity) = potential_player
-                && let Some(living) = potential_entity.get_living_entity()
-                && self
-                    .target_predicate
-                    .test(&world, Some(&mob.living_entity), living)
-            {
-                self.target = Some(potential_entity);
-                return;
-            }
+        self.target = if self.target_type == &EntityType::PLAYER {
+            world
+                .get_closest_player_where(search_pos, follow_range, |player| {
+                    target_predicate.test(&world, Some(tester), &player.living_entity)
+                })
+                .map(|p: Arc<Player>| p as Arc<dyn EntityBase>)
         } else {
-            let potential_entity =
-                world.get_closest_entity(search_pos, follow_range, Some(&[self.target_type]));
-
-            if let Some(potential_entity) = potential_entity
-                && let Some(living) = potential_entity.get_living_entity()
-                && self
-                    .target_predicate
-                    .test(&world, Some(&mob.living_entity), living)
-            {
-                self.target = Some(potential_entity);
-                return;
-            }
-        }
-        self.target = None;
+            world.get_closest_entity_where(
+                search_pos,
+                follow_range,
+                Some(&[self.target_type]),
+                |entity| {
+                    entity
+                        .get_living_entity()
+                        .is_some_and(|living| target_predicate.test(&world, Some(tester), living))
+                },
+            )
+        };
     }
 }
 

--- a/pumpkin/src/entity/ai/goal/avoid_entity.rs
+++ b/pumpkin/src/entity/ai/goal/avoid_entity.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::{Controls, Goal, GoalFuture};
-use crate::entity::{EntityBase, ai::pathfinder::NavigatorGoal, mob::Mob};
+use crate::entity::{EntityBase, ai::pathfinder::NavigatorGoal, living::LivingEntity, mob::Mob};
 use pumpkin_data::entity::EntityType;
 use pumpkin_util::math::{position::BlockPos, vector3::Vector3};
 use rand::RngExt;
@@ -44,12 +44,25 @@ impl AvoidEntityGoal {
         let pos = entity.pos.load();
         let world = entity.world.load();
 
+        // The validity check runs per candidate inside the search, so a nearer but invalid threat
+        // (a dead entity or a spectator) does not hide a valid one standing behind it.
         if self.flee_type == &EntityType::PLAYER {
             world
-                .get_closest_player(pos, self.flee_distance)
+                .get_closest_player_where(pos, self.flee_distance, |player| {
+                    player.living_entity.is_part_of_game()
+                })
                 .map(|p| p as Arc<dyn EntityBase>)
         } else {
-            world.get_closest_entity(pos, self.flee_distance, Some(&[self.flee_type]))
+            world.get_closest_entity_where(
+                pos,
+                self.flee_distance,
+                Some(&[self.flee_type]),
+                |entity| {
+                    entity
+                        .get_living_entity()
+                        .is_some_and(LivingEntity::is_part_of_game)
+                },
+            )
         }
     }
 

--- a/pumpkin/src/entity/ai/goal/beg.rs
+++ b/pumpkin/src/entity/ai/goal/beg.rs
@@ -70,7 +70,12 @@ impl Goal for BegGoal {
             let pos = entity.pos.load();
             let radius = self.beg_distance_sq.sqrt();
 
-            let Some(player) = world.get_closest_player(pos, radius) else {
+            // The validity check runs per candidate inside the search, so a nearer spectator does
+            // not hide a valid player behind it. Vanilla also tests the held item after the
+            // search, and that check needs to lock the inventory, so it stays below.
+            let Some(player) = world.get_closest_player_where(pos, radius, |player| {
+                player.living_entity.is_part_of_game()
+            }) else {
                 return false;
             };
 

--- a/pumpkin/src/entity/ai/goal/teleport_towards_player.rs
+++ b/pumpkin/src/entity/ai/goal/teleport_towards_player.rs
@@ -51,20 +51,17 @@ impl TeleportTowardsPlayerGoal {
             .living_entity
             .get_attribute_value(&Attributes::FOLLOW_RANGE);
 
-        let player = world.get_closest_player(pos, follow_range)?;
-
-        if !player.get_entity().is_alive() {
-            return None;
-        }
-
-        let living = player.get_living_entity()?;
-        if !self.target_predicate.test(
-            &world,
-            Some(&self.enderman.mob_entity.living_entity),
-            living,
-        ) {
-            return None;
-        }
+        // The target conditions are evaluated per candidate so that a nearer but invalid player
+        // (a spectator or an invulnerable creative player) does not hide a valid one behind it.
+        // Vanilla also folds the staring check into the search, but that needs a raycast and
+        // cannot run inside the synchronous predicate, so it stays below.
+        let player = world.get_closest_player_where(pos, follow_range, |player| {
+            self.target_predicate.test(
+                &world,
+                Some(&self.enderman.mob_entity.living_entity),
+                &player.living_entity,
+            )
+        })?;
 
         if self.enderman.is_player_staring(&player).await || self.enderman.is_angry() {
             return Some(player);

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -3874,9 +3874,33 @@ impl World {
     }
 
     pub fn get_closest_player(&self, pos: Vector3<f64>, radius: f64) -> Option<Arc<Player>> {
-        let players = self.get_nearby_players(pos, radius);
-        players
-            .iter()
+        self.get_closest_player_where(pos, radius, |_| true)
+    }
+
+    /// Gets the closest player to a position that satisfies a predicate.
+    ///
+    /// The predicate is evaluated for every candidate inside the search, so the returned player is
+    /// the nearest one that *passes* it, not merely the nearest one overall. This mirrors vanilla,
+    /// where the targeting conditions are part of the search instead of a check applied afterwards.
+    ///
+    /// # Arguments
+    ///
+    /// * `pos` - The position to search around.
+    /// * `radius` - The radius to search within.
+    /// * `predicate` - A predicate function, which has to be `true` for a player to be considered.
+    ///
+    /// # Returns
+    ///
+    /// The closest player that passes the predicate, or None if no player does.
+    pub fn get_closest_player_where(
+        &self,
+        pos: Vector3<f64>,
+        radius: f64,
+        predicate: impl Fn(&Player) -> bool,
+    ) -> Option<Arc<Player>> {
+        self.get_nearby_players(pos, radius)
+            .into_iter()
+            .filter(|player| predicate(player))
             .min_by(|a, b| {
                 a.get_entity()
                     .pos
@@ -3885,7 +3909,6 @@ impl World {
                     .partial_cmp(&b.get_entity().pos.load().squared_distance_to_vec(&pos))
                     .unwrap()
             })
-            .cloned()
     }
 
     /// Gets the closest entity to a position, with optional filtering by entity type.
@@ -3905,34 +3928,48 @@ impl World {
         radius: f64,
         entity_types: Option<&[&'static EntityType]>,
     ) -> Option<Arc<dyn EntityBase>> {
-        // Get regular entities
-        let entities = self.get_nearby_entities(pos, radius);
+        self.get_closest_entity_where(pos, radius, entity_types, |_| true)
+    }
 
-        // Filter by entity type if specified
-        let filtered_entities = if let Some(types) = entity_types {
-            entities
-                .into_iter()
-                .filter(|(_, entity)| {
-                    let entity_type = entity.get_entity().entity_type;
-                    types.contains(&entity_type)
-                })
-                .collect::<HashMap<_, _>>()
-        } else {
-            entities
-        };
-
-        // Find the closest entity
-        filtered_entities
-            .iter()
+    /// Gets the closest entity to a position that satisfies a predicate, with optional filtering
+    /// by entity type.
+    ///
+    /// The predicate is evaluated for every candidate inside the search, so the returned entity is
+    /// the nearest one that *passes* it, not merely the nearest one overall. This mirrors vanilla,
+    /// where the targeting conditions are part of the search instead of a check applied afterwards.
+    ///
+    /// # Arguments
+    ///
+    /// * `pos` - The position to search around.
+    /// * `radius` - The radius to search within.
+    /// * `entity_types` - Optional array of entity types to filter by. If None, all entity types are included.
+    /// * `predicate` - A predicate function, which has to be `true` for an entity to be considered.
+    ///
+    /// # Returns
+    ///
+    /// The closest entity that matches the filter criteria and passes the predicate, or None if no
+    /// entity does.
+    pub fn get_closest_entity_where(
+        &self,
+        pos: Vector3<f64>,
+        radius: f64,
+        entity_types: Option<&[&'static EntityType]>,
+        predicate: impl Fn(&dyn EntityBase) -> bool,
+    ) -> Option<Arc<dyn EntityBase>> {
+        self.get_nearby_entities(pos, radius)
+            .into_values()
+            .filter(|entity| {
+                entity_types.is_none_or(|types| types.contains(&entity.get_entity().entity_type))
+                    && predicate(entity.as_ref())
+            })
             .min_by(|a, b| {
-                a.1.get_entity()
+                a.get_entity()
                     .pos
                     .load()
                     .squared_distance_to_vec(&pos)
-                    .partial_cmp(&b.1.get_entity().pos.load().squared_distance_to_vec(&pos))
+                    .partial_cmp(&b.get_entity().pos.load().squared_distance_to_vec(&pos))
                     .unwrap()
             })
-            .map(|p| p.1.clone())
     }
 
     /// Adds entities to the provided [`Vec`] that satisfy a particular condition and are


### PR DESCRIPTION
## What

Target searches pick the nearest candidate and *then* test the predicate, so a candidate that fails the predicate aborts the whole search rather than falling through to the next one.

```rust
let potential_player = world.get_closest_player(search_pos, follow_range)  // no predicate
    .map(|p: Arc<Player>| p as Arc<dyn EntityBase>);
if let Some(potential_entity) = potential_player
    && let Some(living) = potential_entity.get_living_entity()
    && self.target_predicate.test(&world, Some(&mob.living_entity), living)
{ self.target = Some(potential_entity); return; }
...
self.target = None;   // nearest failed, so give up entirely
```

`World::get_closest_player` and `get_closest_entity` are pure `min_by(distance)` with no filter.

Vanilla `NearestAttackableTargetGoal.findTarget()` passes `TargetingConditions` *into* `getNearestPlayer` / `getNearestEntity`, which evaluate them per candidate, so the result is the nearest **valid** target.

## Why it matters right now

`TargetPredicate::test` rejects invulnerable entities via `can_take_damage()`, and Pumpkin marks both Creative and Spectator players invulnerable. So a single Creative or Spectator player standing nearer than a Survival player makes every hostile mob in range acquire **no** target at all. On a server with staff in Creative, mobs near them stop aggroing entirely.

## How

I surveyed the callers before touching the API: 12 call sites, and only 6 want a predicate. The other 6 (bat, chase player, lava, fire, and two in look at entity) genuinely want the unconditional nearest. So rather than change signatures, this adds:

- `get_closest_player_where(pos, radius, predicate)`
- `get_closest_entity_where(pos, radius, entity_types, predicate)`

with the predicate applied in a `filter` before `min_by`, and the existing two methods delegating with `|_| true`. Unrelated callers are untouched.

Updated to use them: `active_target.rs` (the actual bug, and the trailing `self.target = None` fallthrough is gone), `teleport_towards_player.rs`, `avoid_entity.rs`, `beg.rs`.

The predicates are sync closures, so `TargetPredicate::test` stays sync and nothing ripples.

## Relationship to #2387

Worth flagging: #2387 adds Creative/Spectator rejection *inside* `TargetPredicate::test` for #1760. Under the current nearest-then-filter ordering, every additional rejection reason makes the shadowing worse rather than better, because a rejected candidate blocks the search instead of falling through. #2387 lands correctly on top of this; merged on its own it widens the set of players who silently blank out every nearby mob's targeting.

## Known gaps, not restructured

Two vanilla selectors are genuinely async and cannot go inside a sync predicate:

- **Enderman staring.** Vanilla puts `isLookingAtMe` inside `startAggroTargetConditions`, so it is part of the search. Pumpkin's `is_player_staring` ends in an awaited raycast, so it stays outside. Residual: a nearer non-staring survival player still shadows a farther staring one. The Creative/Spectator half is fixed.
- **Beg goal held-item check**, which awaits inventory locks. This matches vanilla anyway, since `BegGoal.canUse()` also does nearest-then-check.

Also: `avoid_entity.rs` filters on `is_part_of_game` rather than a full attackable predicate. Vanilla uses `TargetingConditions.forCombat()` there, but Pumpkin's `TargetPredicate::test` adds a Peaceful-difficulty rejection that vanilla's conditions do not have, so wiring in the full predicate would stop villagers fleeing on Peaceful. That looks like a separate `TargetPredicate` bug; flagging rather than fixing it here.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

Not verified in game. The Creative-player case is easy to reproduce by hand: stand in Creative next to a Survival player in front of a zombie.
