### PR TITLE
Build- and run-time optimizations in debug mode

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-gnu]
+# Use LLVM's lld instead of the default for (likely) faster linking
+rustflags = [
+    "-C", "link-arg=-fuse-ld=lld",
+]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-# Use LLVM's lld instead of the default for (likely) faster linking
-rustflags = [
-    "-C", "link-arg=-fuse-ld=lld",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,11 @@ debug = 1
 [profile.dev.package."*"]
 opt-level = 3
 
+[profile.dev.package.wasmtime]
+opt-level = 1
+[profile.dev.package.cranelift-codegen]
+opt-level = 1
+
 [profile.release]
 lto = true
 strip = "debuginfo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,15 @@ edition = "2024"
 rust-version = "1.95"
 license = "GPL-3.0"
 
+[profile.dev]
+lto = false
+opt-level = 0
+incremental = true
+debug = 1
+
+[profile.dev.package."*"]
+opt-level = 3
+
 [profile.release]
 lto = true
 strip = "debuginfo"


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Building pumpkin, even in debug mode, can take a long time and produce a very resource-intensive binary (my experience was that it used close to 100% CPU while being much slower than the release mode binary).

**The fix for a resource-intensive debug binary:** All dependencies (which does not include workspace members[^1]) are compiled at `opt-level=3` (the maximum, esentially release mode) while workspace members are compiled at `opt-level=0`. On my machine this made the server use almost no CPU.

**Attempts to make the build times faster:** I was not really able to improve the build times of debug mode through the `Cargo.toml` (`debug=1` might improve it too, while hopefully not removing too much debug information). Instead, I made rustc use the `lld` linker instead of the default (which seems to be cc[^2]). This had the following impact:
- default (cc): 1m 11s
- lld: 40s

Additionally, `cargo +nightly check -Zcargo-lints --workspace --all-targets`[^3] showed the following unused dependencies:
- `cipher`
- `crossbeam-utils`
- `lru`
- `signature`
- `xxhash-rust`
As the cargo docs mention too, it could show false positives in specific cases which is why I decided to not remove these dependencies, but it might be something to consider.

Here's a flamegraph for building `pumpkin` only (after changing one file). This uses the default linker (the linking step takes the most time):
<img width="1702" height="297" alt="image" src="https://github.com/user-attachments/assets/6340606e-e9fc-40ed-a8b9-b86768756c48" />
I don't have a flamegraph for the lld linker, but might be able to generate one later.

## Testing
I did not observe an impact on the functionality of Pumpkin.

I'm not sure whether lld is pre-installed on basically every system. If not, might want to switch back to the default linker.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)

[^1]: https://doc.rust-lang.org/cargo/reference/profiles.html#overrides
[^2]: https://stackoverflow.com/questions/57812916/how-do-i-change-the-default-rustc-cargo-linker
[^3]: https://doc.rust-lang.org/cargo/guide/build-performance.html#removing-unused-dependencies