### PR TITLE
fix: execute subcommands never ran their modifiers

### DIFF
--- a/pumpkin/src/command/context/command_context.rs
+++ b/pumpkin/src/command/context/command_context.rs
@@ -216,17 +216,26 @@ impl<'a> ContextChain<'a> {
     #[must_use]
     pub fn try_flatten(root: &CommandContext<'a>) -> Option<Self> {
         let mut modifiers = Vec::new();
-        let mut current = root;
+        let mut current = Arc::new(root.clone());
 
         loop {
-            if let Some(child) = current.get_child() {
-                modifiers.push(child.clone());
-                current = child;
-            } else {
-                return current
-                    .command
-                    .is_some()
-                    .then(|| Self::new(modifiers, Arc::new(current.clone())));
+            // A context holds the modifier of the node that redirected away from it,
+            // so it is the *parent* of each link that carries the modifier to run,
+            // never the child. Pushing the child here would skip the first modifier
+            // (dropping conditions such as `execute if block`) and would instead run
+            // the trailing executable context's own modifier.
+            let child = current.get_child().cloned();
+            match child {
+                Some(child) => {
+                    modifiers.push(current);
+                    current = child;
+                }
+                None => {
+                    return current
+                        .command
+                        .is_some()
+                        .then(|| Self::new(modifiers, current));
+                }
             }
         }
     }

--- a/pumpkin/src/command/node/dispatcher.rs
+++ b/pumpkin/src/command/node/dispatcher.rs
@@ -952,7 +952,11 @@ mod test {
     use crate::command::context::command_source::CommandSource;
     use crate::command::errors::error_types::DISPATCHER_UNKNOWN_COMMAND;
     use crate::command::node::dispatcher::CommandDispatcher;
-    use crate::command::node::{CommandExecutor, CommandExecutorResult};
+    use crate::command::node::{
+        CommandExecutor, CommandExecutorResult, RedirectModifier, RedirectModifierResult,
+        Redirection,
+    };
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn unknown_command() {
@@ -1088,6 +1092,46 @@ mod test {
         let source = CommandSource::dummy();
         assert_eq!(dispatcher.execute_input("a 5", &source).await, Ok(5));
         assert_eq!(dispatcher.execute_input("b 7", &source).await, Ok(7));
+    }
+
+    /// A redirect modifier which yields no sources must stop the redirected
+    /// command from running at all. This is what gates `execute if ...`.
+    #[tokio::test]
+    async fn conditional_redirect_gates_execution() {
+        fn satisfied<'a>(context: &'a CommandContext) -> RedirectModifierResult<'a> {
+            Box::pin(async move { Ok(vec![context.source.clone()]) })
+        }
+
+        fn unsatisfied<'a>(_context: &'a CommandContext) -> RedirectModifierResult<'a> {
+            Box::pin(async move { Ok(vec![]) })
+        }
+
+        let executor: for<'c> fn(&'c CommandContext) -> CommandExecutorResult<'c> =
+            |_| Box::pin(async move { Ok(1) });
+
+        let mut dispatcher = CommandDispatcher::new();
+        dispatcher.register(CommandArgumentBuilder::new("target", "A command").executes(executor));
+        dispatcher.register(
+            CommandArgumentBuilder::new("gate", "A command gating what follows it")
+                .then(LiteralArgumentBuilder::new("open").redirect_with_modifier(
+                    Redirection::Root,
+                    RedirectModifier::Custom(Arc::new(satisfied)),
+                ))
+                .then(LiteralArgumentBuilder::new("shut").redirect_with_modifier(
+                    Redirection::Root,
+                    RedirectModifier::Custom(Arc::new(unsatisfied)),
+                )),
+        );
+
+        let source = CommandSource::dummy();
+        assert_eq!(
+            dispatcher.execute_input("gate open target", &source).await,
+            Ok(1)
+        );
+        assert_eq!(
+            dispatcher.execute_input("gate shut target", &source).await,
+            Ok(0)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes the first item in #2592.

## What

`execute if block` runs its command whether or not the block matches, and `unless` behaves identically. Reproduced on a live server over RCON:

```
setblock 8 101 8 minecraft:stone
execute if block 8 101 8 minecraft:stone run seed   ->  Seed: [...]
execute if block 8 101 8 minecraft:air   run seed   ->  Seed: [...]   <- should not run
execute unless block 8 101 8 minecraft:air run seed ->  Seed: [...]
```

## Why

It turned out not to be in the condition functions at all. `ContextChain::try_flatten` walks the context list and pushes each **child** onto the modifier list, where Brigadier pushes the **current** context:

```rust
loop {
    if let Some(child) = current.get_child() {
        modifiers.push(child.clone());   // pushes the child
        current = child;
    } else {
        ...
    }
}
```

A context carries the redirect modifier of the node that redirected *away* from it. For `execute if block <pos> <block> run seed` the modifier lives on the **root** context, whose last parsed node is the `block` argument holding `Redirection` plus `execute_if_block_modifier`. The child context is `run <command>`, whose modifier is the default `KeepSource`.

So the chain was built as `modifiers = [child]` with `execute = child`, the same context twice. `run_modifier` short-circuits on `KeepSource` before ever calling `sources()`, so `execute_if_block_modifier` and `execute_unless_block_modifier` were **never invoked**. Not computed and discarded, simply never reached.

The fix is to push `current` rather than the child.

## Scope is wider than the reported symptom

The same defect silently broke every other subcommand in the tree, since they all route through this path. Fixed by the same change:

- `if` / `unless` for `entity`, `block`, `loaded`, `dimension`
- `as`, `at`, `in`, `positioned`, `rotated`, `align`, `anchored`, `facing`

So `execute as @a run ...` was running once as the original source rather than once per target. The condition functions in `execute.rs` were already correct and are untouched.

## Test

Added `conditional_redirect_gates_execution` to the existing test module in `dispatcher.rs`, following the surrounding `#[tokio::test]` / `execute_input` convention. It registers a command whose two literals redirect to root with a satisfied and an unsatisfied modifier, and asserts the command runs in one case and not the other.

I checked it actually catches the bug rather than just passing: with `try_flatten` reverted to the old form it fails with `left: Ok(1), right: Ok(0)`, which is exactly the reported symptom.

## The other half of #2592

Block state syntax like `minecraft:wheat[age=0]` is a separate root cause and I did not fold it in. There are two independent block argument parsers, neither of which handles brackets: the newer one stops consuming at `[` because it is not in the allowed character class, and the legacy one hands the whole token to `Block::from_name`. Both have `Item = &'static Block`, and consumers use `block.default_state.id`, so real support means changing the argument's item type to a resolved block state and threading it through `setblock`, `fill`, `clone` and `execute if block`. That is a materially different change.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean. `cargo test -p pumpkin --lib command::` passes, 90 tests.

Not re-verified on the live server, since it is running an older build.
