### PR TITLE
fix: four item interaction bugs

### DIFF
--- a/pumpkin/src/block/blocks/plant/bamboo.rs
+++ b/pumpkin/src/block/blocks/plant/bamboo.rs
@@ -235,15 +235,17 @@ fn count_bamboo_above(world: &World, pos: &BlockPos) -> usize {
 async fn bone_meal(world: Arc<World>, position: &BlockPos) {
     let bamboo_below = count_bamboo_below(&world, position);
 
-    let growth_amount = rand::rng().random_range(1..=3);
+    let growth_amount = rand::rng().random_range(1..=2);
 
     for (bamboo_above, _) in (count_bamboo_above(&world, position)..).zip(0..growth_amount) {
         let current_total_height = bamboo_above + bamboo_below + 1;
 
+        // `next_pos` is the topmost bamboo of the stalk, so the free space we grow into is the
+        // block above it. Vanilla reads `STAGE` from the top stalk and grows from there too.
         let next_pos = position.up_height(bamboo_above as i32);
         let next_state = world.get_block_state(&next_pos);
 
-        if !next_state.is_air() || current_total_height >= 16 {
+        if current_total_height >= 16 || !world.get_block_state(&next_pos.up()).is_air() {
             return;
         }
 
@@ -252,7 +254,7 @@ async fn bone_meal(world: Arc<World>, position: &BlockPos) {
             return;
         }
 
-        update_leaves_and_grow(Arc::clone(&world), position).await;
+        update_leaves_and_grow(Arc::clone(&world), &next_pos).await;
     }
 }
 

--- a/pumpkin/src/item/items/axe.rs
+++ b/pumpkin/src/item/items/axe.rs
@@ -42,7 +42,10 @@ impl ItemBehaviour for AxeItem {
             // If there is a strip equivalent.
             let changed = if let Some(replacement) = replacement_block {
                 let new_block = replacement.to_block();
-                let new_state_id = if block.has_tag(&tag::Block::MINECRAFT_LOGS) {
+                // Bamboo blocks are pillars too, but they are not part of the logs tag.
+                let new_state_id = if block.has_tag(&tag::Block::MINECRAFT_LOGS)
+                    || block == &Block::BAMBOO_BLOCK
+                {
                     let log_information = world.get_block_state_id(&location);
                     let log_props =
                         PaleOakWoodLikeProperties::from_state_id(log_information, block);
@@ -127,6 +130,11 @@ const fn get_stripped_equivalent(id: BlockId) -> Option<BlockId> {
         BlockId::MANGROVE_WOOD => Some(BlockId::STRIPPED_MANGROVE_WOOD),
         BlockId::CHERRY_WOOD => Some(BlockId::STRIPPED_CHERRY_WOOD),
         BlockId::PALE_OAK_WOOD => Some(BlockId::STRIPPED_PALE_OAK_WOOD),
+        BlockId::CRIMSON_STEM => Some(BlockId::STRIPPED_CRIMSON_STEM),
+        BlockId::WARPED_STEM => Some(BlockId::STRIPPED_WARPED_STEM),
+        BlockId::CRIMSON_HYPHAE => Some(BlockId::STRIPPED_CRIMSON_HYPHAE),
+        BlockId::WARPED_HYPHAE => Some(BlockId::STRIPPED_WARPED_HYPHAE),
+        BlockId::BAMBOO_BLOCK => Some(BlockId::STRIPPED_BAMBOO_BLOCK),
         _ => None,
     }
 }

--- a/pumpkin/src/item/items/hoe.rs
+++ b/pumpkin/src/item/items/hoe.rs
@@ -69,13 +69,17 @@ impl ItemBehaviour for HoeItem {
                     }
                 }
 
-                world
-                    .set_block_state(
-                        &location,
-                        future_block.default_state.id,
-                        BlockFlags::NOTIFY_ALL,
-                    )
-                    .await;
+                // Vanilla returns PASS without touching the block when nothing is tilled,
+                // otherwise the rewrite would reset properties such as `snowy` on grass blocks.
+                if changed {
+                    world
+                        .set_block_state(
+                            &location,
+                            future_block.default_state.id,
+                            BlockFlags::NOTIFY_ALL,
+                        )
+                        .await;
+                }
 
                 //Also rooted_dirt drop a hanging_root
                 if block == &Block::ROOTED_DIRT {

--- a/pumpkin/src/item/items/ignite/ignition.rs
+++ b/pumpkin/src/item/items/ignite/ignition.rs
@@ -3,7 +3,8 @@ use crate::block::blocks::fire::fire::FireBlock;
 use crate::entity::player::Player;
 use crate::world::World;
 use pumpkin_data::fluid::Fluid;
-use pumpkin_data::{Block, BlockDirection, BlockStateId};
+use pumpkin_data::tag::Taggable;
+use pumpkin_data::{Block, BlockDirection, BlockStateId, tag};
 use pumpkin_util::math::position::BlockPos;
 use std::sync::Arc;
 
@@ -47,18 +48,24 @@ impl Ignition {
 }
 
 fn can_be_lit(block: &Block, state_id: BlockStateId) -> Option<BlockStateId> {
+    // Vanilla only lights the clicked block itself for campfires, candles and candle cakes.
+    // See `CampfireBlock::canLight`, `CandleBlock::canLight` and `CandleCakeBlock::canLight`.
+    // Everything else that merely carries a `lit` property (furnaces, redstone lamps, copper
+    // bulbs, ...) must fall through to placing a fire block instead.
+    if !block.has_tag(&tag::Block::MINECRAFT_CAMPFIRES)
+        && !block.has_tag(&tag::Block::MINECRAFT_CANDLES)
+        && !block.has_tag(&tag::Block::MINECRAFT_CANDLE_CAKES)
+    {
+        return None;
+    }
+
     let mut props = {
         let props = &block.properties(state_id)?;
         props.to_props()
     };
 
-    if let Some((_, value)) = props.iter_mut().find(|(k, _)| *k == "extinguished") {
-        *value = "false";
-    } else if let Some((_, value)) = props.iter_mut().find(|(k, _)| *k == "lit") {
-        *value = "true";
-    } else {
-        return None;
-    }
+    let (_, value) = props.iter_mut().find(|(k, _)| *k == "lit")?;
+    *value = "true";
 
     let new_state_id = block.from_properties(&props).to_state_id(block);
 


### PR DESCRIPTION
Four unrelated bugs in tool and item interactions, found while auditing against vanilla. Grouped because each is small; happy to split.

## 1. Flint and steel and fire charge light any block with a `lit` property

`can_be_lit` searched the property list by name rather than checking which block it is:

```rust
} else if let Some((_, value)) = props.iter_mut().find(|(k, _)| *k == "lit") {
    *value = "true";
}
```

Blocks carrying `lit` include campfires and candles (correct) but also furnace, smoker, blast_furnace, redstone_lamp, redstone_torch, redstone_wall_torch, redstone_ore, deepslate_redstone_ore and every copper_bulb.

Both are reachable. `RedstoneLamp` implements no use handler, so the click falls straight through to the item path. Furnaces are reachable by sneaking, since `call_use_item_on` is skipped when the player is sneaking with an item.

Vanilla gates the in-place light path on exactly three predicates, `CampfireBlock.canLight`, `CandleBlock.canLight` and `CandleCakeBlock.canLight`, each of which tests tag membership. Now gated on the `campfires`, `candles` and `candle_cakes` tags. I cross-checked those tags against the repo's own generated data and they match the vanilla sets exactly (2, 17 and 17 entries).

The `"extinguished"` branch above it was dead: no block in the generated data or the assets has that property, and the only repo hits are two advancement strings. Removed.

## 2. The hoe wipes `snowy` when it tills nothing

`set_block_state` sat outside the `if changed` guard, so a click that tills nothing (bottom face, or a block sitting on top) still rewrote the block to its **default** state. Grass blocks carry `snowy`, so a grass block under a snow layer fails the air-above check and then gets reset to `snowy=false`, visibly turning green under the snow.

Vanilla returns `PASS` and touches nothing on both of its early exits. Moved the call inside the guard.

## 3. Bone meal on bamboo can never grow it

```rust
let next_pos = position.up_height(bamboo_above as i32);
let next_state = world.get_block_state(&next_pos);
if !next_state.is_air() || current_total_height >= 16 { return; }
```

`next_pos` is the topmost bamboo block, not the space above it, so `next_state` is always bamboo and the function returns on the first iteration every time.

Vanilla `BambooStalkBlock.performBonemeal` requires `blockPos.above()` to be air, where `blockPos` is the top stalk. Two further deviations in the same function: it rolled `1..=3` where vanilla is `1 + nextInt(2)`, and it passed the original position to the growth call rather than the top stalk.

All three corrected.

## 4. The axe cannot strip nether stems, hyphae or bamboo

`get_stripped_equivalent` covered the 9 overworld log types and 9 wood types then fell to `_ => None`, missing `crimson_stem`, `warped_stem`, `crimson_hyphae`, `warped_hyphae` and `bamboo_block`.

One extra line was needed beyond the five arms: the axis-copy path is gated on the `logs` tag, and `bamboo_block` is not in it, so a sideways bamboo block would have snapped to `axis=y` when stripped. The four nether stems and hyphae are in `logs` and needed nothing.

Note this file is also touched by #2590, which replaces the hand-written property copying with a generic one. These do not conflict logically, but whichever lands second will need a trivial rebase.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

Not verified in game. Each vanilla claim above was checked against a version-matched source rather than from memory, since I have been caught out on this project before by behaviour that changed between versions.
