### PR TITLE
fix: note block base instruments, and hopper chain cooldown field

### DIFF
--- a/pumpkin/src/block/blocks/note.rs
+++ b/pumpkin/src/block/blocks/note.rs
@@ -222,5 +222,10 @@ const fn is_base_block(instrument: NoteblockInstrument) -> bool {
             | NoteblockInstrument::Didgeridoo
             | NoteblockInstrument::Bit
             | NoteblockInstrument::Banjo
+            | NoteblockInstrument::Pling
+            | NoteblockInstrument::Trumpet
+            | NoteblockInstrument::TrumpetExposed
+            | NoteblockInstrument::TrumpetWeathered
+            | NoteblockInstrument::TrumpetOxidized
     )
 }

--- a/pumpkin/src/block/entities/hopper.rs
+++ b/pumpkin/src/block/entities/hopper.rs
@@ -276,8 +276,10 @@ impl HopperBlockEntity {
                         && hopper.cooldown_time.load(Ordering::Relaxed) <= 8
                     {
                         if let Some(from_hopper) = from.as_any().downcast_ref::<Self>() {
-                            if from_hopper.cooldown_time.load(Ordering::Relaxed)
-                                >= hopper.cooldown_time.load(Ordering::Relaxed)
+                            // The destination gets a shorter cooldown when it has
+                            // already ticked at least as recently as the source.
+                            if hopper.ticked_game_time.load(Ordering::Relaxed)
+                                >= from_hopper.ticked_game_time.load(Ordering::Relaxed)
                             {
                                 hopper.cooldown_time.store(7, Ordering::Relaxed);
                             } else {


### PR DESCRIPTION
Two unrelated bugs, both one-liners. Related to #1402 for the hopper half.

## 1. Note blocks cannot play pling or trumpet

`is_base_block` omits `Pling` and the four `Trumpet` variants:

```rust
const fn is_base_block(instrument: NoteblockInstrument) -> bool {
    matches!(instrument,
        NoteblockInstrument::Harp | Basedrum | Snare | Hat | Bass | Flute | Bell
        | Guitar | Chime | Xylophone | IronXylophone | CowBell | Didgeridoo | Bit | Banjo)
}
```

All five are already handled in `convert_instrument_to_sound` in the same file, and the repo's own generated data maps `glowstone -> pling` and `copper_block -> trumpet`, so the data and the sound mapping are both there. Only this predicate is missing them.

Three symptoms follow:

- `get_state_with_instrument` treats glowstone or copper **below** a note block as not-a-base-block and substitutes `Harp`, so a note block on glowstone plays harp rather than pling.
- The same function then wrongly treats glowstone or copper **above** a note block as a mob-head-style instrument.
- `on_synced_block_event` gates pitching on `is_base_block`, so a pling or trumpet state would play at fixed pitch instead of the tuned note.

I was confident about `Pling` from the vanilla source but wanted to confirm the trumpets rather than trust the wiki, since they are newer. The decisive argument is structural: vanilla's `setInstrument` falls back to `HARP` unless the block below is tunable, and this repo's own data maps copper below a note block to trumpet. If trumpet were not a base-block instrument that mapping could never be reached. That is corroborated by Paper's `Instrument` javadoc, which words all five as "note block is **on top of** a [glowstone/copper/...] block" while every mob-head instrument is worded "Head is on top of **the note block**", and by the wiki giving the trumpets a pitch range where mob heads have none.

Two naming notes for anyone comparing against vanilla: the accessors are `isTunable()` and `hasCustomSound()`, and the third `Type` constant is `CUSTOM`.

## 2. Hopper chains compare the wrong field

```rust
if from_hopper.cooldown_time.load(Ordering::Relaxed) >= hopper.cooldown_time.load(Ordering::Relaxed)
{ hopper.cooldown_time.store(7, Ordering::Relaxed); }
else { hopper.cooldown_time.store(8, Ordering::Relaxed); }
```

Vanilla compares the two hoppers' last-ticked game time, not their cooldowns:

```java
int j = 0;
if (from instanceof HopperBlockEntity hopperBlockEntity2
    && hopperBlockEntity.lastTickTime >= hopperBlockEntity2.lastTickTime) { j = 1; }
hopperBlockEntity.setTransferCooldown(8 - j);
```

The giveaway is local: `HopperBlockEntity::ticked_game_time` is stored every tick and read nowhere in the repo. The comparison direction was also flipped, since vanilla tests destination against source.

This is what decides whether a downstream hopper in a chain skips a tick, so chain throughput and phase were both wrong.

Confirmed the direction against two verbatim vanilla copies: Forge 26.1.2 (`dHopper.getLastUpdateTime() >= sHopper.getLastUpdateTime()`) and Lithium (`receivingHopper.tickedGameTime >= hopperBlockEntity.tickedGameTime`).

While there I checked the outer `cooldown_time <= 8` guard and left it alone: it is vanilla's `!isOnCustomCooldown()`, not `isDisabled()`, so it is already correct.

This does not overlap #2589, which fixes the separate `fetch_sub` off-by-one in `tick` in the same file. That line is untouched here, so the two are independent, though whichever lands second may want a trivial rebase.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

Not verified in game. The note block half is easy to check by hand: place a note block on glowstone and listen for pling.
