### PR TITLE
fix: do not abort startup on recoverable IO, and keep sky light across save

### DIFF
--- a/pumpkin-world/src/chunk/format/mod.rs
+++ b/pumpkin-world/src/chunk/format/mod.rs
@@ -378,9 +378,19 @@ impl ChunkData {
     fn internal_to_bytes(&self) -> Result<Bytes, ChunkSerializingError> {
         use pumpkin_nbt::tag::NbtTag;
 
-        fn extract_light_ref(light: Option<&LightContainer>) -> Option<&[u8]> {
+        /// Encodes a light container into the nibble array Anvil stores per section.
+        ///
+        /// An absent array on disk carries no value of its own, so a uniform container
+        /// can only be omitted when it holds the value the reader assumes for a missing
+        /// tag. Any other uniform value has to be materialized, otherwise it is silently
+        /// replaced by that assumed value on the next load.
+        fn light_to_disk(light: Option<&LightContainer>) -> Option<Box<[i8]>> {
             match light {
-                Some(LightContainer::Full(data)) => Some(data.as_ref()),
+                Some(LightContainer::Full(data)) => Some(data.iter().map(|&x| x as i8).collect()),
+                Some(LightContainer::Empty(value)) if *value != 0 => {
+                    let nibbles = (value << 4 | value) as i8;
+                    Some(vec![nibbles; LightContainer::ARRAY_SIZE].into_boxed_slice())
+                }
                 _ => None,
             }
         }
@@ -470,14 +480,12 @@ impl ChunkData {
             section_comp.put_compound("biomes", b_comp);
 
             // block_light
-            if let Some(light_data) = extract_light_ref(light_lock.block_light.get(i)) {
-                let bytes: Box<[i8]> = light_data.iter().map(|&x| x as i8).collect();
+            if let Some(bytes) = light_to_disk(light_lock.block_light.get(i)) {
                 section_comp.put("BlockLight", NbtTag::ByteArray(bytes));
             }
 
             // sky_light
-            if let Some(light_data) = extract_light_ref(light_lock.sky_light.get(i)) {
-                let bytes: Box<[i8]> = light_data.iter().map(|&x| x as i8).collect();
+            if let Some(bytes) = light_to_disk(light_lock.sky_light.get(i)) {
                 section_comp.put("SkyLight", NbtTag::ByteArray(bytes));
             }
 

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -60,6 +60,28 @@ pub type LoggerOption = Option<(ReadlineLogWrapper, LevelFilter, LoggingConfig)>
 pub static LOGGER_IMPL: LazyLock<Arc<OnceLock<LoggerOption>>> =
     LazyLock::new(|| Arc::new(OnceLock::new()));
 
+/// Builds the rolling file logger, or `None` if it is disabled or cannot be set up.
+///
+/// This runs before any subscriber is installed, so a panic here would reach the
+/// operator as a bare backtrace with no message. Report the cause on stderr and keep
+/// the console logger instead, which is still enough to run a server.
+#[expect(clippy::print_stderr)]
+fn init_file_logger(level: LevelFilter, file: &str) -> Option<GzipRollingLogger> {
+    if file.is_empty() {
+        return None;
+    }
+
+    match GzipRollingLogger::new(level, file.to_string()) {
+        Ok(file_logger) => Some(file_logger),
+        Err(e) => {
+            eprintln!(
+                "Failed to initialize the file logger 'logs/{file}' ({e}); continuing with console logging only"
+            );
+            None
+        }
+    }
+}
+
 #[expect(clippy::print_stderr)]
 pub fn init_logger(advanced_config: &AdvancedConfiguration) {
     use tracing_subscriber::EnvFilter;
@@ -85,14 +107,7 @@ pub fn init_logger(advanced_config: &AdvancedConfiguration) {
             EnvFilter::new(level_str)
         });
 
-        let file_logger: Option<GzipRollingLogger> = if advanced_config.logging.file.is_empty() {
-            None
-        } else {
-            Some(
-                GzipRollingLogger::new(level, advanced_config.logging.file.clone())
-                    .expect("Failed to initialize file logger."),
-            )
-        };
+        let file_logger = init_file_logger(level, &advanced_config.logging.file);
 
         let (logger, rl): (
             Box<dyn std::io::Write + Send + 'static>,

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -184,7 +184,11 @@ impl Server {
             let dat_path = world_path.join(LEVEL_DAT_FILE_NAME);
             if dat_path.exists() {
                 let backup_path = world_path.join(LEVEL_DAT_BACKUP_FILE_NAME);
-                fs::copy(dat_path, backup_path).unwrap();
+                // A failed backup is not fatal: the real level.dat is untouched, so keep
+                // going rather than aborting startup on e.g. an unwritable world directory.
+                if let Err(err) = fs::copy(dat_path, backup_path) {
+                    warn!("Failed to back up level.dat: {err}");
+                }
             }
         }
         let level_info = level_info.unwrap_or_else(|err| {


### PR DESCRIPTION
The first two I hit while deploying a server, so they are reproduced rather than theoretical.

## 1. The server aborts if it cannot back up level.dat

```rust
let backup_path = world_path.join(LEVEL_DAT_BACKUP_FILE_NAME);
fs::copy(dat_path, backup_path).unwrap();
```

Real crash report from my own deployment:

```
Message: called `Result::unwrap()` on an `Err` value: Os { code: 1, kind: PermissionDenied }
Panic Location: pumpkin/src/server/mod.rs:187:49
```

An unwritable world directory aborts startup entirely. That is inconsistent with the code immediately below it, which handles a *missing or unreadable* `level_info` with a `warn!` and a default. Failing to write a backup copy is strictly milder than that, since the authoritative file is untouched.

Now warns and continues.

## 2. A failed file-logger setup panics with an unreadable message

```rust
GzipRollingLogger::new(level, advanced_config.logging.file.clone())
    .expect("Failed to initialize file logger.")
```

This runs before the logger exists, so the message is swallowed and the operator sees only a bare backtrace. What I actually saw was `7: pumpkin::init_logger` and nothing else, which cost me real time before I found the cause by other means.

Every failure `GzipRollingLogger::new` can produce is filesystem I/O on the `logs/` directory: `create_dir_all`, `File::create`, or gzipping an existing `latest.log`. None of them mean the server cannot serve players, and console output still goes to stdout, which is what journald and Docker capture anyway. So this now prints the path and the OS error to stderr and continues with console logging only, rather than dying over a read-only or full `logs/` directory.

The setup is extracted into a small function, which was needed because inlining the match pushed `init_logger` past the `too_many_lines` limit.

## 3. Sky light of `Empty(15)` is lost across save and load

The writer drops non-`Full` light containers while the reader materialises a missing tag as `Empty(0)`, so a sky section saved as uniformly-lit would reload uniformly dark.

Fixed on the **writer** side: `Empty(v)` for non-zero `v` is now materialised into a real nibble array. `Empty(0)` is still omitted, since 0 is exactly what the reader assumes, so that case was already lossless.

I want to be explicit that I chose the writer deliberately, because the reader-side fix looks smaller and is wrong. "A missing SkyLight tag means 15" would light up every enclosed all-air section below terrain that vanilla derives as 0, turning a dark-section bug into a silent false-bright one. Vanilla's rule is positional: a `DataLayer` is written only when it has a backing array, sections above `topSection` are omitted and read as 15, and sections below it are derived by repeating the nearest layer above. Getting that right on the reader needs `topSection` tracking plus a per-dimension sky-light decision.

**Honest caveat:** I could not find a path that produces this symptom on a Pumpkin-generated world today. Every live producer ends up `Full` and is written out, and the one `Empty(15)` producer lives in a `ProtoChunk` the Lighting stage immediately overwrites. So this closes a latent trap rather than a reproducible bug. Say the word if you would rather not carry it.

## Related, found while investigating, not fixed here

**Vanilla-imported worlds genuinely do go dark above terrain.** A vanilla chunk with `isLightOn: true` omits SkyLight for its above-terrain sections, Pumpkin reads those as `Empty(0)`, and `needs_relighting` refuses to relight because `isLightOn` is true. Fixing it needs the top-down derivation described above, so it is feature-sized rather than a bug fix.

**`CLightUpdate` looks wrong on two counts**, and it cannot be right, since vanilla serialises it and `CChunkData` through the same structure:

- *Mask offset.* `CChunkData` uses `bit_index = section_index + 1` and sets the below-world and above-world padding bits. `CLightUpdate` uses `bit_index = section_index` with no padding. Vanilla's masks span `minSection - 1 ..= maxSection + 1`, so every section's light lands one section too low.
- *Nibble order.* `CLightUpdate` applies `rotate_right(4)` to swap nibbles; `CChunkData` writes raw. `LightContainer::get` uses low-nibble-for-even-index, which is the vanilla wire layout, so no swap is correct.

Symptom would be light correct on chunk load and wrong after a block change. This is on top of `CLightUpdate` having no send sites at all, which I filed as part of #2592.

**`get_sky_light_level` returns 15 out of bounds**, and worse than it first appears: `section_index` is an unsigned cast, so a `y` *below* the world wraps to a huge index and takes the same branch, giving 15 where 0 is correct. Above build height 15 is vanilla-correct, so the fix is a signed bounds check rather than flipping the constant. It also disagrees with `storage.rs`, which returns 0 for the same condition.

Happy to take any of these as follow-ups.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin -p pumpkin-world --all-targets` clean.

Bugs 1 and 2 are reproduced from a real deployment. Bug 3 is reasoned from the codec, not observed.
