### PR TITLE
Client version control

### DIFF
--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -114,13 +114,15 @@ impl LoadConfiguration for PumpkinConfig {
         let versions_cfg = &self.advanced.networking.java.versions;
         match versions_cfg.mode {
             VersionAccessMode::Range => {
-                if let Some(min) = &versions_cfg.min_version {
+                let min = &versions_cfg.min_version;
+                if !min.is_empty() {
                     assert!(
                         min.parse::<JavaMinecraftVersion>().is_ok(),
                         "networking.java.versions.min_version '{min}' is not a recognized Minecraft version"
                     );
                 }
-                if let Some(max) = &versions_cfg.max_version {
+                let max = &versions_cfg.max_version;
+                if !max.is_empty() {
                     assert!(
                         max.parse::<JavaMinecraftVersion>().is_ok(),
                         "networking.java.versions.max_version '{max}' is not a recognized Minecraft version"

--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -1,5 +1,7 @@
 use fun::FunConfig;
 use logging::LoggingConfig;
+use networking::versions::VersionAccessMode;
+use pumpkin_util::version::JavaMinecraftVersion;
 use pumpkin_util::world_seed::Seed;
 use pumpkin_util::{Difficulty, GameMode, PermissionLvl, random};
 use recipe::RecipeConfig;
@@ -106,6 +108,38 @@ impl LoadConfiguration for PumpkinConfig {
                 self.advanced.networking.java.online_mode,
                 "When allow_chat_reports is enabled, java.online_mode must be enabled"
             );
+        }
+
+        // Validate networking.java.versions
+        let versions_cfg = &self.advanced.networking.java.versions;
+        match versions_cfg.mode {
+            VersionAccessMode::Range => {
+                if let Some(min) = &versions_cfg.min_version {
+                    assert!(
+                        min.parse::<JavaMinecraftVersion>().is_ok(),
+                        "networking.java.versions.min_version '{min}' is not a recognized Minecraft version"
+                    );
+                }
+                if let Some(max) = &versions_cfg.max_version {
+                    assert!(
+                        max.parse::<JavaMinecraftVersion>().is_ok(),
+                        "networking.java.versions.max_version '{max}' is not a recognized Minecraft version"
+                    );
+                }
+            }
+            VersionAccessMode::Allowlist | VersionAccessMode::Denylist => {
+                assert!(
+                    !versions_cfg.versions.is_empty(),
+                    "networking.java.versions.versions must not be empty when mode is 'allowlist' or 'denylist'"
+                );
+                for v in &versions_cfg.versions {
+                    assert!(
+                        v.parse::<JavaMinecraftVersion>().is_ok(),
+                        "networking.java.versions.versions entry '{v}' is not a recognized Minecraft version"
+                    );
+                }
+            }
+            VersionAccessMode::Any | VersionAccessMode::Latest => {}
         }
     }
 }

--- a/pumpkin-config/src/networking/java.rs
+++ b/pumpkin-config/src/networking/java.rs
@@ -1,3 +1,4 @@
+use super::versions::VersionsConfig;
 use crate::{AuthenticationConfig, CompressionConfig};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -27,6 +28,9 @@ pub struct JavaConfig {
     pub motd: String,
     /// Authentication settings for client connections.
     pub authentication: AuthenticationConfig,
+    /// Which Minecraft client versions may join, and how the version is displayed in the
+    /// multiplayer server list.
+    pub versions: VersionsConfig,
 }
 
 impl Default for JavaConfig {
@@ -42,6 +46,7 @@ impl Default for JavaConfig {
             compression: CompressionConfig::default(),
             motd: "A blazingly fast Pumpkin server!".to_string(),
             authentication: AuthenticationConfig::default(),
+            versions: VersionsConfig::default(),
         }
     }
 }

--- a/pumpkin-config/src/networking/mod.rs
+++ b/pumpkin-config/src/networking/mod.rs
@@ -15,6 +15,7 @@ pub mod lan_broadcast;
 pub mod proxy;
 pub mod query;
 pub mod rcon;
+pub mod versions;
 
 /// Configuration for server networking features.
 ///

--- a/pumpkin-config/src/networking/versions.rs
+++ b/pumpkin-config/src/networking/versions.rs
@@ -9,15 +9,18 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Clone, Default, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum VersionAccessMode {
-    /// Only allow clients that are on the newest version the server supports. Whenever a
-    /// new Minecraft version is added to the server, the "allowed" version moves forward
-    /// with it automatically.
-    #[default]
-    Latest,
     /// Allow every version the server protocol implementation supports
-    /// (`LOWEST_SUPPORTED_MC_VERSION`..=`CURRENT_MC_VERSION`). This is the old/vanilla-like
-    /// behaviour: no restriction beyond what the server can already talk to.
+    /// (`LOWEST_SUPPORTED_MC_VERSION`..=`CURRENT_MC_VERSION`). This is the vanilla-like
+    /// default: no restriction beyond what the server can already talk to.
+    #[default]
     Any,
+    /// Only allow clients that are on `CURRENT_MC_VERSION` -- the newest version *this
+    /// server build* implements. Note this is tied to the server software's own version,
+    /// not necessarily the newest version publicly available to players; if the server
+    /// hasn't been updated yet (or was built against an upcoming/snapshot target), players
+    /// on an officially "latest" client can still get rejected here. Prefer `range` with an
+    /// explicit `min_version` if you want "recent versions only" without that surprise.
+    Latest,
     /// Only allow clients whose version falls within `min_version`..=`max_version`.
     Range,
     /// Only allow the versions listed in `versions`.
@@ -36,7 +39,7 @@ pub enum VersionAccessMode {
 #[serde(default)]
 pub struct VersionsConfig {
     /// Which strategy to use to decide whether a client may join:
-    /// `latest` (default) | `any` | `range` | `allowlist` | `denylist`.
+    /// `any` (default) | `latest` | `range` | `allowlist` | `denylist`.
     /// See [`VersionAccessMode`] for what each one does.
     pub mode: VersionAccessMode,
     /// The list of versions used by `allowlist`/`denylist` mode, e.g. `["1.21", "1.20.5"]`.
@@ -65,7 +68,7 @@ pub struct VersionsConfig {
 impl Default for VersionsConfig {
     fn default() -> Self {
         Self {
-            mode: VersionAccessMode::Latest,
+            mode: VersionAccessMode::Any,
             versions: Vec::new(),
             min_version: String::new(),
             max_version: String::new(),
@@ -170,26 +173,26 @@ mod tests {
     }
 
     #[test]
-    fn latest_is_the_default_mode() {
-        assert_eq!(VersionsConfig::default().mode, VersionAccessMode::Latest);
-    }
-
-    #[test]
-    fn latest_mode_only_allows_latest() {
-        let cfg = VersionsConfig::default();
-        let latest = v("1.21.9");
-        assert!(cfg.is_allowed(latest, latest));
-        assert!(!cfg.is_allowed(v("1.21.7"), latest));
+    fn any_is_the_default_mode() {
+        assert_eq!(VersionsConfig::default().mode, VersionAccessMode::Any);
     }
 
     #[test]
     fn any_mode_allows_everything() {
-        let cfg = VersionsConfig {
-            mode: VersionAccessMode::Any,
-            ..Default::default()
-        };
+        let cfg = VersionsConfig::default();
         assert!(cfg.is_allowed(v("1.20.5"), v("1.21.9")));
         assert!(cfg.is_allowed(v("1.21.9"), v("1.21.9")));
+    }
+
+    #[test]
+    fn latest_mode_only_allows_latest() {
+        let cfg = VersionsConfig {
+            mode: VersionAccessMode::Latest,
+            ..Default::default()
+        };
+        let latest = v("1.21.9");
+        assert!(cfg.is_allowed(latest, latest));
+        assert!(!cfg.is_allowed(v("1.21.7"), latest));
     }
 
     #[test]
@@ -267,7 +270,10 @@ mod tests {
         assert!(range.default_disconnect_message(latest).contains("1.8"));
         assert!(range.default_disconnect_message(latest).contains("1.12"));
 
-        let latest_only = VersionsConfig::default();
+        let latest_only = VersionsConfig {
+            mode: VersionAccessMode::Latest,
+            ..Default::default()
+        };
         assert!(
             latest_only
                 .default_disconnect_message(latest)

--- a/pumpkin-config/src/networking/versions.rs
+++ b/pumpkin-config/src/networking/versions.rs
@@ -103,8 +103,10 @@ impl VersionsConfig {
             VersionAccessMode::Any => true,
             VersionAccessMode::Latest => version == latest,
             VersionAccessMode::Range => {
-                let min = non_empty(&self.min_version).and_then(|s| s.parse::<JavaMinecraftVersion>().ok());
-                let max = non_empty(&self.max_version).and_then(|s| s.parse::<JavaMinecraftVersion>().ok());
+                let min = non_empty(&self.min_version)
+                    .and_then(|s| s.parse::<JavaMinecraftVersion>().ok());
+                let max = non_empty(&self.max_version)
+                    .and_then(|s| s.parse::<JavaMinecraftVersion>().ok());
                 match (min, max) {
                     (Some(min), Some(max)) => version >= min && version <= max,
                     (Some(min), None) => version >= min,
@@ -141,8 +143,7 @@ impl VersionsConfig {
     pub fn default_disconnect_message(&self, latest: JavaMinecraftVersion) -> String {
         match self.mode {
             VersionAccessMode::Any => {
-                "This server does not accept connections from your Minecraft version."
-                    .to_string()
+                "This server does not accept connections from your Minecraft version.".to_string()
             }
             VersionAccessMode::Latest => {
                 format!("This server only accepts the latest Minecraft version ({latest}).")

--- a/pumpkin-config/src/networking/versions.rs
+++ b/pumpkin-config/src/networking/versions.rs
@@ -80,7 +80,7 @@ impl Default for VersionsConfig {
 }
 
 /// Treats an empty string the same as "not set".
-fn non_empty(s: &str) -> Option<&str> {
+const fn non_empty(s: &str) -> Option<&str> {
     if s.is_empty() { None } else { Some(s) }
 }
 

--- a/pumpkin-config/src/networking/versions.rs
+++ b/pumpkin-config/src/networking/versions.rs
@@ -9,11 +9,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Clone, Default, PartialEq, Eq, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum VersionAccessMode {
-    /// Allow every version the server protocol implementation supports.
+    /// Only allow clients that are on the newest version the server supports. Whenever a
+    /// new Minecraft version is added to the server, the "allowed" version moves forward
+    /// with it automatically.
     #[default]
-    Any,
-    /// Only allow clients that are on the newest supported version.
     Latest,
+    /// Allow every version the server protocol implementation supports
+    /// (`LOWEST_SUPPORTED_MC_VERSION`..=`CURRENT_MC_VERSION`). This is the old/vanilla-like
+    /// behaviour: no restriction beyond what the server can already talk to.
+    Any,
     /// Only allow clients whose version falls within `min_version`..=`max_version`.
     Range,
     /// Only allow the versions listed in `versions`.
@@ -24,42 +28,57 @@ pub enum VersionAccessMode {
 
 /// Friendly, human-configurable version gating and Server List Ping (status/motd)
 /// version-text customization for Java Edition clients.
+///
+/// All the string fields below are intentionally always written out to `pumpkin.toml`
+/// (even when empty) so operators can see every knob that exists without having to read
+/// the source. An empty string means "not set / use the automatic default".
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct VersionsConfig {
-    /// Which strategy to use to decide whether a client may join. See [`VersionAccessMode`].
+    /// Which strategy to use to decide whether a client may join:
+    /// `latest` (default) | `any` | `range` | `allowlist` | `denylist`.
+    /// See [`VersionAccessMode`] for what each one does.
     pub mode: VersionAccessMode,
     /// The list of versions used by `allowlist`/`denylist` mode, e.g. `["1.21", "1.20.5"]`.
+    /// Ignored by every other mode.
     pub versions: Vec<String>,
-    /// Inclusive lower bound used by `range` mode, e.g. `"1.20.5"`.
-    pub min_version: Option<String>,
-    /// Inclusive upper bound used by `range` mode, e.g. `"1.21.9"`.
-    pub max_version: Option<String>,
-    /// Custom message shown to players who try to join with a disallowed version.
-    /// If unset, a sensible default message describing the rule is generated.
-    pub disconnect_message: Option<String>,
+    /// Inclusive lower bound used by `range` mode, e.g. `"1.20.5"`. Leave empty to mean
+    /// "no lower bound other than what the server supports". Ignored by every other mode.
+    pub min_version: String,
+    /// Inclusive upper bound used by `range` mode, e.g. `"1.21.9"`. Leave empty to mean
+    /// "no upper bound other than what the server supports". Ignored by every other mode.
+    pub max_version: String,
+    /// Custom message shown to players who try to join with a disallowed version. Leave
+    /// empty to auto-generate a message describing the active rule (e.g. which versions
+    /// are allowed).
+    pub disconnect_message: String,
     /// Overrides the `version.name` text shown in the multiplayer server list (Server List
-    /// Ping / status response) for clients that ARE allowed to join. If unset, the default
-    /// "min-max" text is used.
-    pub status_name: Option<String>,
+    /// Ping / status response) for clients that ARE allowed to join. Leave empty to use the
+    /// default "min-max" text.
+    pub status_name: String,
     /// Overrides the `version.name` text shown in the multiplayer server list for clients
-    /// that are NOT allowed to join (e.g. to show a custom "Outdated" label). If unset, the
-    /// client's own version-mismatch handling (greyed-out entry) is used.
-    pub status_name_disallowed: Option<String>,
+    /// that are NOT allowed to join (e.g. to show a custom "Outdated"/"Restricted" label).
+    /// Leave empty to use the client's own version-mismatch handling (greyed-out entry).
+    pub status_name_disallowed: String,
 }
 
 impl Default for VersionsConfig {
     fn default() -> Self {
         Self {
-            mode: VersionAccessMode::Any,
+            mode: VersionAccessMode::Latest,
             versions: Vec::new(),
-            min_version: None,
-            max_version: None,
-            disconnect_message: None,
-            status_name: None,
-            status_name_disallowed: None,
+            min_version: String::new(),
+            max_version: String::new(),
+            disconnect_message: String::new(),
+            status_name: String::new(),
+            status_name_disallowed: String::new(),
         }
     }
+}
+
+/// Treats an empty string the same as "not set".
+fn non_empty(s: &str) -> Option<&str> {
+    if s.is_empty() { None } else { Some(s) }
 }
 
 impl VersionsConfig {
@@ -81,14 +100,8 @@ impl VersionsConfig {
             VersionAccessMode::Any => true,
             VersionAccessMode::Latest => version == latest,
             VersionAccessMode::Range => {
-                let min = self
-                    .min_version
-                    .as_deref()
-                    .and_then(|s| s.parse::<JavaMinecraftVersion>().ok());
-                let max = self
-                    .max_version
-                    .as_deref()
-                    .and_then(|s| s.parse::<JavaMinecraftVersion>().ok());
+                let min = non_empty(&self.min_version).and_then(|s| s.parse::<JavaMinecraftVersion>().ok());
+                let max = non_empty(&self.max_version).and_then(|s| s.parse::<JavaMinecraftVersion>().ok());
                 match (min, max) {
                     (Some(min), Some(max)) => version >= min && version <= max,
                     (Some(min), None) => version >= min,
@@ -99,6 +112,24 @@ impl VersionsConfig {
             VersionAccessMode::Allowlist => self.parse_list().contains(&version),
             VersionAccessMode::Denylist => !self.parse_list().contains(&version),
         }
+    }
+
+    /// Returns the configured disconnect message, or `None` if it should be auto-generated.
+    #[must_use]
+    pub fn disconnect_message(&self) -> Option<&str> {
+        non_empty(&self.disconnect_message)
+    }
+
+    /// Returns the configured "allowed" status name override, if any.
+    #[must_use]
+    pub fn status_name(&self) -> Option<&str> {
+        non_empty(&self.status_name)
+    }
+
+    /// Returns the configured "disallowed" status name override, if any.
+    #[must_use]
+    pub fn status_name_disallowed(&self) -> Option<&str> {
+        non_empty(&self.status_name_disallowed)
     }
 
     /// Builds a human-readable disconnect message describing the active rule, used when
@@ -114,8 +145,8 @@ impl VersionsConfig {
                 format!("This server only accepts the latest Minecraft version ({latest}).")
             }
             VersionAccessMode::Range => {
-                let min = self.min_version.as_deref().unwrap_or("any");
-                let max = self.max_version.as_deref().unwrap_or("any");
+                let min = non_empty(&self.min_version).unwrap_or("any");
+                let max = non_empty(&self.max_version).unwrap_or("any");
                 format!("This server only accepts Minecraft versions between {min} and {max}.")
             }
             VersionAccessMode::Allowlist => format!(
@@ -139,29 +170,34 @@ mod tests {
     }
 
     #[test]
-    fn any_mode_allows_everything() {
-        let cfg = VersionsConfig::default();
-        assert!(cfg.is_allowed(v("1.20.5"), v("1.21.9")));
-        assert!(cfg.is_allowed(v("1.21.9"), v("1.21.9")));
+    fn latest_is_the_default_mode() {
+        assert_eq!(VersionsConfig::default().mode, VersionAccessMode::Latest);
     }
 
     #[test]
     fn latest_mode_only_allows_latest() {
-        let cfg = VersionsConfig {
-            mode: VersionAccessMode::Latest,
-            ..Default::default()
-        };
+        let cfg = VersionsConfig::default();
         let latest = v("1.21.9");
         assert!(cfg.is_allowed(latest, latest));
         assert!(!cfg.is_allowed(v("1.21.7"), latest));
     }
 
     #[test]
+    fn any_mode_allows_everything() {
+        let cfg = VersionsConfig {
+            mode: VersionAccessMode::Any,
+            ..Default::default()
+        };
+        assert!(cfg.is_allowed(v("1.20.5"), v("1.21.9")));
+        assert!(cfg.is_allowed(v("1.21.9"), v("1.21.9")));
+    }
+
+    #[test]
     fn range_mode_bounds_inclusive() {
         let cfg = VersionsConfig {
             mode: VersionAccessMode::Range,
-            min_version: Some("1.20.5".to_string()),
-            max_version: Some("1.21.4".to_string()),
+            min_version: "1.20.5".to_string(),
+            max_version: "1.21.4".to_string(),
             ..Default::default()
         };
         let latest = v("1.21.9");
@@ -170,6 +206,19 @@ mod tests {
         assert!(cfg.is_allowed(v("1.21"), latest));
         assert!(!cfg.is_allowed(v("1.21.5"), latest));
         assert!(!cfg.is_allowed(v("1.19.4"), latest));
+    }
+
+    #[test]
+    fn range_mode_empty_bound_is_open_ended() {
+        let cfg = VersionsConfig {
+            mode: VersionAccessMode::Range,
+            min_version: "1.21".to_string(),
+            max_version: String::new(),
+            ..Default::default()
+        };
+        let latest = v("1.21.9");
+        assert!(cfg.is_allowed(v("1.21.9"), latest));
+        assert!(!cfg.is_allowed(v("1.20.5"), latest));
     }
 
     #[test]
@@ -211,17 +260,36 @@ mod tests {
         let latest = v("1.21.9");
         let range = VersionsConfig {
             mode: VersionAccessMode::Range,
-            min_version: Some("1.8".to_string()),
-            max_version: Some("1.12".to_string()),
+            min_version: "1.8".to_string(),
+            max_version: "1.12".to_string(),
             ..Default::default()
         };
         assert!(range.default_disconnect_message(latest).contains("1.8"));
         assert!(range.default_disconnect_message(latest).contains("1.12"));
 
-        let latest_only = VersionsConfig {
-            mode: VersionAccessMode::Latest,
+        let latest_only = VersionsConfig::default();
+        assert!(
+            latest_only
+                .default_disconnect_message(latest)
+                .contains("1.21.9")
+        );
+    }
+
+    #[test]
+    fn empty_strings_are_treated_as_unset() {
+        let cfg = VersionsConfig::default();
+        assert_eq!(cfg.disconnect_message(), None);
+        assert_eq!(cfg.status_name(), None);
+        assert_eq!(cfg.status_name_disallowed(), None);
+
+        let cfg = VersionsConfig {
+            disconnect_message: "custom".to_string(),
+            status_name: "name".to_string(),
+            status_name_disallowed: "nope".to_string(),
             ..Default::default()
         };
-        assert!(latest_only.default_disconnect_message(latest).contains("1.21.9"));
+        assert_eq!(cfg.disconnect_message(), Some("custom"));
+        assert_eq!(cfg.status_name(), Some("name"));
+        assert_eq!(cfg.status_name_disallowed(), Some("nope"));
     }
 }

--- a/pumpkin-config/src/networking/versions.rs
+++ b/pumpkin-config/src/networking/versions.rs
@@ -1,0 +1,227 @@
+use pumpkin_util::version::JavaMinecraftVersion;
+use serde::{Deserialize, Serialize};
+
+/// Controls which Minecraft client versions are allowed to join the server.
+///
+/// This only restricts versions that the server's protocol implementation already
+/// supports (see `LOWEST_SUPPORTED_MC_VERSION`..=`CURRENT_MC_VERSION`). It cannot add
+/// support for versions the server doesn't implement.
+#[derive(Deserialize, Serialize, Clone, Default, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum VersionAccessMode {
+    /// Allow every version the server protocol implementation supports.
+    #[default]
+    Any,
+    /// Only allow clients that are on the newest supported version.
+    Latest,
+    /// Only allow clients whose version falls within `min_version`..=`max_version`.
+    Range,
+    /// Only allow the versions listed in `versions`.
+    Allowlist,
+    /// Allow every supported version except the ones listed in `versions`.
+    Denylist,
+}
+
+/// Friendly, human-configurable version gating and Server List Ping (status/motd)
+/// version-text customization for Java Edition clients.
+#[derive(Deserialize, Serialize, Clone)]
+#[serde(default)]
+pub struct VersionsConfig {
+    /// Which strategy to use to decide whether a client may join. See [`VersionAccessMode`].
+    pub mode: VersionAccessMode,
+    /// The list of versions used by `allowlist`/`denylist` mode, e.g. `["1.21", "1.20.5"]`.
+    pub versions: Vec<String>,
+    /// Inclusive lower bound used by `range` mode, e.g. `"1.20.5"`.
+    pub min_version: Option<String>,
+    /// Inclusive upper bound used by `range` mode, e.g. `"1.21.9"`.
+    pub max_version: Option<String>,
+    /// Custom message shown to players who try to join with a disallowed version.
+    /// If unset, a sensible default message describing the rule is generated.
+    pub disconnect_message: Option<String>,
+    /// Overrides the `version.name` text shown in the multiplayer server list (Server List
+    /// Ping / status response) for clients that ARE allowed to join. If unset, the default
+    /// "min-max" text is used.
+    pub status_name: Option<String>,
+    /// Overrides the `version.name` text shown in the multiplayer server list for clients
+    /// that are NOT allowed to join (e.g. to show a custom "Outdated" label). If unset, the
+    /// client's own version-mismatch handling (greyed-out entry) is used.
+    pub status_name_disallowed: Option<String>,
+}
+
+impl Default for VersionsConfig {
+    fn default() -> Self {
+        Self {
+            mode: VersionAccessMode::Any,
+            versions: Vec::new(),
+            min_version: None,
+            max_version: None,
+            disconnect_message: None,
+            status_name: None,
+            status_name_disallowed: None,
+        }
+    }
+}
+
+impl VersionsConfig {
+    /// Parses `versions` into recognized [`JavaMinecraftVersion`]s, silently skipping any
+    /// entries that don't match a known version string.
+    #[must_use]
+    pub fn parse_list(&self) -> Vec<JavaMinecraftVersion> {
+        self.versions
+            .iter()
+            .filter_map(|v| v.parse::<JavaMinecraftVersion>().ok())
+            .collect()
+    }
+
+    /// Returns whether a client on `version` is allowed to join, given the server's `latest`
+    /// supported version.
+    #[must_use]
+    pub fn is_allowed(&self, version: JavaMinecraftVersion, latest: JavaMinecraftVersion) -> bool {
+        match self.mode {
+            VersionAccessMode::Any => true,
+            VersionAccessMode::Latest => version == latest,
+            VersionAccessMode::Range => {
+                let min = self
+                    .min_version
+                    .as_deref()
+                    .and_then(|s| s.parse::<JavaMinecraftVersion>().ok());
+                let max = self
+                    .max_version
+                    .as_deref()
+                    .and_then(|s| s.parse::<JavaMinecraftVersion>().ok());
+                match (min, max) {
+                    (Some(min), Some(max)) => version >= min && version <= max,
+                    (Some(min), None) => version >= min,
+                    (None, Some(max)) => version <= max,
+                    (None, None) => true,
+                }
+            }
+            VersionAccessMode::Allowlist => self.parse_list().contains(&version),
+            VersionAccessMode::Denylist => !self.parse_list().contains(&version),
+        }
+    }
+
+    /// Builds a human-readable disconnect message describing the active rule, used when
+    /// `disconnect_message` isn't set.
+    #[must_use]
+    pub fn default_disconnect_message(&self, latest: JavaMinecraftVersion) -> String {
+        match self.mode {
+            VersionAccessMode::Any => {
+                "This server does not accept connections from your Minecraft version."
+                    .to_string()
+            }
+            VersionAccessMode::Latest => {
+                format!("This server only accepts the latest Minecraft version ({latest}).")
+            }
+            VersionAccessMode::Range => {
+                let min = self.min_version.as_deref().unwrap_or("any");
+                let max = self.max_version.as_deref().unwrap_or("any");
+                format!("This server only accepts Minecraft versions between {min} and {max}.")
+            }
+            VersionAccessMode::Allowlist => format!(
+                "This server only accepts these Minecraft versions: {}.",
+                self.versions.join(", ")
+            ),
+            VersionAccessMode::Denylist => format!(
+                "This server does not accept these Minecraft versions: {}.",
+                self.versions.join(", ")
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> JavaMinecraftVersion {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn any_mode_allows_everything() {
+        let cfg = VersionsConfig::default();
+        assert!(cfg.is_allowed(v("1.20.5"), v("1.21.9")));
+        assert!(cfg.is_allowed(v("1.21.9"), v("1.21.9")));
+    }
+
+    #[test]
+    fn latest_mode_only_allows_latest() {
+        let cfg = VersionsConfig {
+            mode: VersionAccessMode::Latest,
+            ..Default::default()
+        };
+        let latest = v("1.21.9");
+        assert!(cfg.is_allowed(latest, latest));
+        assert!(!cfg.is_allowed(v("1.21.7"), latest));
+    }
+
+    #[test]
+    fn range_mode_bounds_inclusive() {
+        let cfg = VersionsConfig {
+            mode: VersionAccessMode::Range,
+            min_version: Some("1.20.5".to_string()),
+            max_version: Some("1.21.4".to_string()),
+            ..Default::default()
+        };
+        let latest = v("1.21.9");
+        assert!(cfg.is_allowed(v("1.20.5"), latest));
+        assert!(cfg.is_allowed(v("1.21.4"), latest));
+        assert!(cfg.is_allowed(v("1.21"), latest));
+        assert!(!cfg.is_allowed(v("1.21.5"), latest));
+        assert!(!cfg.is_allowed(v("1.19.4"), latest));
+    }
+
+    #[test]
+    fn allowlist_only_allows_listed_versions() {
+        let cfg = VersionsConfig {
+            mode: VersionAccessMode::Allowlist,
+            versions: vec!["1.21".to_string(), "1.20.5".to_string()],
+            ..Default::default()
+        };
+        let latest = v("1.21.9");
+        assert!(cfg.is_allowed(v("1.21"), latest));
+        assert!(cfg.is_allowed(v("1.20.5"), latest));
+        assert!(!cfg.is_allowed(v("1.21.9"), latest));
+    }
+
+    #[test]
+    fn denylist_blocks_listed_versions_only() {
+        let cfg = VersionsConfig {
+            mode: VersionAccessMode::Denylist,
+            versions: vec!["1.20.5".to_string()],
+            ..Default::default()
+        };
+        let latest = v("1.21.9");
+        assert!(!cfg.is_allowed(v("1.20.5"), latest));
+        assert!(cfg.is_allowed(v("1.21.9"), latest));
+        assert!(cfg.is_allowed(v("1.21"), latest));
+    }
+
+    #[test]
+    fn version_round_trips_through_display_and_fromstr() {
+        for s in ["1.7.2", "1.8", "1.12.2", "1.16", "1.20.5", "1.21.9", "26.2"] {
+            assert_eq!(v(s).to_string(), s);
+        }
+        assert!("not-a-version".parse::<JavaMinecraftVersion>().is_err());
+    }
+
+    #[test]
+    fn default_disconnect_messages_are_descriptive() {
+        let latest = v("1.21.9");
+        let range = VersionsConfig {
+            mode: VersionAccessMode::Range,
+            min_version: Some("1.8".to_string()),
+            max_version: Some("1.12".to_string()),
+            ..Default::default()
+        };
+        assert!(range.default_disconnect_message(latest).contains("1.8"));
+        assert!(range.default_disconnect_message(latest).contains("1.12"));
+
+        let latest_only = VersionsConfig {
+            mode: VersionAccessMode::Latest,
+            ..Default::default()
+        };
+        assert!(latest_only.default_disconnect_message(latest).contains("1.21.9"));
+    }
+}

--- a/pumpkin-util/src/version.rs
+++ b/pumpkin-util/src/version.rs
@@ -265,6 +265,82 @@ impl std::fmt::Display for JavaMinecraftVersion {
     }
 }
 
+/// Error returned when a string doesn't match a known Minecraft version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownVersionError;
+
+impl std::fmt::Display for UnknownVersionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unrecognized Minecraft version")
+    }
+}
+
+impl std::error::Error for UnknownVersionError {}
+
+impl std::str::FromStr for JavaMinecraftVersion {
+    type Err = UnknownVersionError;
+
+    /// Parses a version string such as `"1.8"` or `"1.21.9"` into a [`JavaMinecraftVersion`].
+    ///
+    /// Matches the same strings produced by this type's [`Display`](std::fmt::Display) impl.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.trim() {
+            "1.7.2" => Self::V_1_7_2,
+            "1.7.6" => Self::V_1_7_6,
+            "1.8" => Self::V_1_8,
+            "1.9" => Self::V_1_9,
+            "1.9.1" => Self::V_1_9_1,
+            "1.9.2" => Self::V_1_9_2,
+            "1.9.3" => Self::V_1_9_3,
+            "1.10" => Self::V_1_10,
+            "1.11" => Self::V_1_11,
+            "1.11.1" => Self::V_1_11_1,
+            "1.12" => Self::V_1_12,
+            "1.12.1" => Self::V_1_12_1,
+            "1.12.2" => Self::V_1_12_2,
+            "1.13" => Self::V_1_13,
+            "1.13.1" => Self::V_1_13_1,
+            "1.13.2" => Self::V_1_13_2,
+            "1.14" => Self::V_1_14,
+            "1.14.1" => Self::V_1_14_1,
+            "1.14.2" => Self::V_1_14_2,
+            "1.14.3" => Self::V_1_14_3,
+            "1.14.4" => Self::V_1_14_4,
+            "1.15" => Self::V_1_15,
+            "1.15.1" => Self::V_1_15_1,
+            "1.15.2" => Self::V_1_15_2,
+            "1.16" => Self::V_1_16,
+            "1.16.1" => Self::V_1_16_1,
+            "1.16.2" => Self::V_1_16_2,
+            "1.16.3" => Self::V_1_16_3,
+            "1.16.4" => Self::V_1_16_4,
+            "1.17" => Self::V_1_17,
+            "1.17.1" => Self::V_1_17_1,
+            "1.18" => Self::V_1_18,
+            "1.18.2" => Self::V_1_18_2,
+            "1.19" => Self::V_1_19,
+            "1.19.1" => Self::V_1_19_1,
+            "1.19.3" => Self::V_1_19_3,
+            "1.19.4" => Self::V_1_19_4,
+            "1.20" => Self::V_1_20,
+            "1.20.2" => Self::V_1_20_2,
+            "1.20.3" => Self::V_1_20_3,
+            "1.20.5" => Self::V_1_20_5,
+            "1.21" => Self::V_1_21,
+            "1.21.2" => Self::V_1_21_2,
+            "1.21.4" => Self::V_1_21_4,
+            "1.21.5" => Self::V_1_21_5,
+            "1.21.6" => Self::V_1_21_6,
+            "1.21.7" => Self::V_1_21_7,
+            "1.21.9" => Self::V_1_21_9,
+            "1.21.11" => Self::V_1_21_11,
+            "26.1" => Self::V_26_1,
+            "26.2" => Self::V_26_2,
+            _ => return Err(UnknownVersionError),
+        })
+    }
+}
+
 /// Represents a specific version of the Minecraft Bedrock Edition protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 #[allow(non_camel_case_types)]

--- a/pumpkin/src/net/java/handshake.rs
+++ b/pumpkin/src/net/java/handshake.rs
@@ -7,13 +7,14 @@ use pumpkin_util::{text::TextComponent, version::JavaMinecraftVersion};
 use tracing::debug;
 
 use crate::net::java::JavaClient;
+use crate::server::Server;
 
 impl JavaClient {
-    pub async fn handle_handshake(&self, handshake: SHandShake) {
+    pub async fn handle_handshake(&self, server: &Server, handshake: SHandShake) {
         let version = handshake.protocol_version.0 as u32;
         *self.server_address.lock().await = handshake.server_address;
-        self.version
-            .store(JavaMinecraftVersion::from_protocol(version));
+        let parsed_version = JavaMinecraftVersion::from_protocol(version);
+        self.version.store(parsed_version);
 
         debug!("Handshake: next state is {:?}", &handshake.next_state);
         self.connection_state.store(handshake.next_state);
@@ -33,6 +34,19 @@ impl JavaClient {
                     [TextComponent::text(CURRENT_MC_VERSION.to_string())],
                 ))
                 .await;
+            } else {
+                // The client's version is within the range the protocol implementation
+                // supports. Now check the operator-configured allow/deny rules.
+                let versions_config = &server.advanced_config.networking.java.versions;
+                if !versions_config.is_allowed(parsed_version, CURRENT_MC_VERSION) {
+                    let message = versions_config
+                        .disconnect_message
+                        .clone()
+                        .unwrap_or_else(|| {
+                            versions_config.default_disconnect_message(CURRENT_MC_VERSION)
+                        });
+                    self.kick(TextComponent::text(message)).await;
+                }
             }
         }
     }

--- a/pumpkin/src/net/java/handshake.rs
+++ b/pumpkin/src/net/java/handshake.rs
@@ -40,8 +40,8 @@ impl JavaClient {
                 let versions_config = &server.advanced_config.networking.java.versions;
                 if !versions_config.is_allowed(parsed_version, CURRENT_MC_VERSION) {
                     let message = versions_config
-                        .disconnect_message
-                        .clone()
+                        .disconnect_message()
+                        .map(str::to_string)
                         .unwrap_or_else(|| {
                             versions_config.default_disconnect_message(CURRENT_MC_VERSION)
                         });

--- a/pumpkin/src/net/java/handshake.rs
+++ b/pumpkin/src/net/java/handshake.rs
@@ -39,12 +39,10 @@ impl JavaClient {
                 // supports. Now check the operator-configured allow/deny rules.
                 let versions_config = &server.advanced_config.networking.java.versions;
                 if !versions_config.is_allowed(parsed_version, CURRENT_MC_VERSION) {
-                    let message = versions_config
-                        .disconnect_message()
-                        .map(str::to_string)
-                        .unwrap_or_else(|| {
-                            versions_config.default_disconnect_message(CURRENT_MC_VERSION)
-                        });
+                    let message = versions_config.disconnect_message().map_or_else(
+                        || versions_config.default_disconnect_message(CURRENT_MC_VERSION),
+                        str::to_string,
+                    );
                     self.kick(TextComponent::text(message)).await;
                 }
             }

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -616,7 +616,7 @@ impl JavaClient {
         packet: &RawPacket,
     ) -> Result<Option<PacketHandlerResult>, ReadingError> {
         match self.connection_state.load() {
-            ConnectionState::HandShake => self.handle_handshake_packet(packet).await,
+            ConnectionState::HandShake => self.handle_handshake_packet(server, packet).await,
             ConnectionState::Status => self.handle_status_packet(server, packet).await,
             // TODO: Check config if transfer is enabled
             ConnectionState::Login | ConnectionState::Transfer => {
@@ -629,14 +629,18 @@ impl JavaClient {
 
     async fn handle_handshake_packet(
         &self,
+        server: &Arc<Server>,
         packet: &RawPacket,
     ) -> Result<Option<PacketHandlerResult>, ReadingError> {
         debug!("Handling handshake group");
         let mut payload = &packet.payload[..];
         match packet.id {
             0 => {
-                self.handle_handshake(SHandShake::read(&mut payload, &self.version.load())?)
-                    .await;
+                self.handle_handshake(
+                    server,
+                    SHandShake::read(&mut payload, &self.version.load())?,
+                )
+                .await;
                 Ok(None)
             }
             _ => Err(ReadingError::Message(format!(

--- a/pumpkin/src/net/java/status.rs
+++ b/pumpkin/src/net/java/status.rs
@@ -9,11 +9,12 @@ impl JavaClient {
     pub async fn handle_status_request(&self, server: &Server) {
         debug!("Handling status request");
         let status = server.get_status();
+        let versions_config = &server.advanced_config.networking.java.versions;
         self.send_packet_now(
             &status
                 .lock()
                 .await
-                .get_status_packet(self.version.load().protocol_version()),
+                .get_status_packet(self.version.load().protocol_version(), versions_config),
         )
         .await;
     }

--- a/pumpkin/src/server/connection_cache.rs
+++ b/pumpkin/src/server/connection_cache.rs
@@ -2,12 +2,14 @@ use crate::entity::player::Player;
 use base64::{Engine as _, engine::general_purpose};
 use core::error;
 use pumpkin_config::BasicConfiguration;
+use pumpkin_config::networking::versions::VersionsConfig;
 use pumpkin_data::packet::{CURRENT_MC_VERSION, LOWEST_SUPPORTED_MC_VERSION};
 use pumpkin_protocol::{
     Players, Sample, StatusResponse, Version,
     codec::var_int::VarInt,
     java::client::{config::CPluginMessage, status::CStatusResponse},
 };
+use pumpkin_util::version::JavaMinecraftVersion;
 use std::{fs, path::Path};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -77,17 +79,34 @@ impl CachedStatus {
         }
     }
 
-    pub fn get_status_packet(&self, client_protocol: i32) -> CStatusResponse {
+    pub fn get_status_packet(
+        &self,
+        client_protocol: i32,
+        versions_config: &VersionsConfig,
+    ) -> CStatusResponse {
         let mut response = self.status_response.clone();
 
         let supported_min = LOWEST_SUPPORTED_MC_VERSION.protocol_version();
         let supported_max = CURRENT_MC_VERSION.protocol_version();
 
-        if client_protocol >= supported_min
-            && client_protocol <= supported_max
-            && let Some(version) = &mut response.version
-        {
-            version.protocol = client_protocol as u32;
+        let in_supported_range =
+            client_protocol >= supported_min && client_protocol <= supported_max;
+        let client_version = JavaMinecraftVersion::from_protocol(client_protocol as u32);
+        let allowed =
+            in_supported_range && versions_config.is_allowed(client_version, CURRENT_MC_VERSION);
+
+        if let Some(version) = &mut response.version {
+            if allowed {
+                // Spoof the protocol number to the client's own, so clients on any
+                // permitted version don't see a "server out of date"/"client out of
+                // date" warning in the multiplayer list.
+                version.protocol = client_protocol as u32;
+                if let Some(name) = &versions_config.status_name {
+                    version.name.clone_from(name);
+                }
+            } else if let Some(name) = &versions_config.status_name_disallowed {
+                version.name.clone_from(name);
+            }
         }
 
         let json = serde_json::to_string(&response).expect("Failed to serialize status response");

--- a/pumpkin/src/server/connection_cache.rs
+++ b/pumpkin/src/server/connection_cache.rs
@@ -101,11 +101,11 @@ impl CachedStatus {
                 // permitted version don't see a "server out of date"/"client out of
                 // date" warning in the multiplayer list.
                 version.protocol = client_protocol as u32;
-                if let Some(name) = &versions_config.status_name {
-                    version.name.clone_from(name);
+                if let Some(name) = versions_config.status_name() {
+                    version.name = name.to_string();
                 }
-            } else if let Some(name) = &versions_config.status_name_disallowed {
-                version.name.clone_from(name);
+            } else if let Some(name) = versions_config.status_name_disallowed() {
+                version.name = name.to_string();
             }
         }
 


### PR DESCRIPTION
https://github.com/Pumpkin-MC/Pumpkin/issues/2613

Adds a configurable version-control system for Java Edition clients under networking.java.versions in pumpkin.toml.
