### PR TITLE
fix: correct CLightUpdate mask offset and nibble order

### DIFF
--- a/pumpkin-protocol/src/java/client/play/light_update.rs
+++ b/pumpkin-protocol/src/java/client/play/light_update.rs
@@ -15,6 +15,59 @@ use std::io::Write;
 #[java_packet(PLAY_LIGHT_UPDATE)]
 pub struct CLightUpdate<'a>(pub &'a ChunkData);
 
+/// Computes the four light bitset masks (sky mask, block mask, empty sky mask,
+/// empty block mask) for a chunk's light sections.
+///
+/// Vanilla's light masks span sections `minSection - 1 ..= maxSection + 1`: bit 0 is the
+/// always-empty section below the world, bits `1..=num_sections` are the real chunk
+/// sections, and bit `num_sections + 1` is the always-empty section above the world.
+/// This must match `CChunkData`'s light section encoding exactly, since vanilla serialises
+/// both packets' light data through the identical `ClientboundLightUpdatePacketData`
+/// structure.
+fn compute_light_masks(
+    sky_light: &[LightContainer],
+    block_light: &[LightContainer],
+) -> (u64, u64, u64, u64) {
+    let num_sections = sky_light.len();
+
+    let mut sky_light_empty_mask = 0u64;
+    let mut block_light_empty_mask = 0u64;
+    let mut sky_light_mask = 0u64;
+    let mut block_light_mask = 0u64;
+
+    // Bit 0 represents the section below the world (always empty)
+    sky_light_empty_mask |= 1 << 0;
+    block_light_empty_mask |= 1 << 0;
+
+    // Bits 1..=num_sections represent the actual world sections
+    for section_index in 0..num_sections {
+        let bit_index = section_index + 1; // Offset by 1 for the below-world section
+
+        if let LightContainer::Full(_) = &sky_light[section_index] {
+            sky_light_mask |= 1 << bit_index;
+        } else {
+            sky_light_empty_mask |= 1 << bit_index;
+        }
+
+        if let LightContainer::Full(_) = &block_light[section_index] {
+            block_light_mask |= 1 << bit_index;
+        } else {
+            block_light_empty_mask |= 1 << bit_index;
+        }
+    }
+
+    // Bit num_sections+1 represents the section above the world (always empty)
+    sky_light_empty_mask |= 1 << (num_sections + 1);
+    block_light_empty_mask |= 1 << (num_sections + 1);
+
+    (
+        sky_light_mask,
+        block_light_mask,
+        sky_light_empty_mask,
+        block_light_empty_mask,
+    )
+}
+
 impl ClientPacket for CLightUpdate<'_> {
     fn write_packet_data(
         &self,
@@ -37,27 +90,8 @@ impl ClientPacket for CLightUpdate<'_> {
             .map_err(|_| WritingError::Message("light_engine lock poisoned".into()))?;
         let num_sections = light_engine.sky_light.len();
 
-        let mut sky_light_empty_mask = 0u64;
-        let mut block_light_empty_mask = 0u64;
-        let mut sky_light_mask = 0u64;
-        let mut block_light_mask = 0u64;
-
-        // Bits 0..num_sections represent the sections including padding
-        for section_index in 0..num_sections {
-            let bit_index = section_index;
-
-            if let LightContainer::Full(_) = &light_engine.sky_light[section_index] {
-                sky_light_mask |= 1 << bit_index;
-            } else {
-                sky_light_empty_mask |= 1 << bit_index;
-            }
-
-            if let LightContainer::Full(_) = &light_engine.block_light[section_index] {
-                block_light_mask |= 1 << bit_index;
-            } else {
-                block_light_empty_mask |= 1 << bit_index;
-            }
-        }
+        let (sky_light_mask, block_light_mask, sky_light_empty_mask, block_light_empty_mask) =
+            compute_light_masks(&light_engine.sky_light, &light_engine.block_light);
 
         // Write Sky Light Mask
         write.write_bitset(&BitSet(Box::new([sky_light_mask as i64])))?;
@@ -74,14 +108,8 @@ impl ClientPacket for CLightUpdate<'_> {
         write.write_var_int(&VarInt(sky_light_mask.count_ones() as i32))?;
         for section_index in 0..num_sections {
             if let LightContainer::Full(data) = &light_engine.sky_light[section_index] {
-                // Ensure network nibble ordering matches client expectations
-                // by swapping high/low nibbles per byte.
                 write.write_var_int(&light_data_size)?;
-                let mut swapped = Vec::with_capacity(data.len());
-                for &b in data {
-                    swapped.push(b.rotate_right(4));
-                }
-                write.write_slice(&swapped)?;
+                write.write_slice(data.as_ref())?;
             }
         }
 
@@ -90,14 +118,58 @@ impl ClientPacket for CLightUpdate<'_> {
         for section_index in 0..num_sections {
             if let LightContainer::Full(data) = &light_engine.block_light[section_index] {
                 write.write_var_int(&light_data_size)?;
-                let mut swapped = Vec::with_capacity(data.len());
-                for &b in data {
-                    swapped.push(b.rotate_right(4));
-                }
-                write.write_slice(&swapped)?;
+                write.write_slice(data.as_ref())?;
             }
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_light_masks;
+    use pumpkin_world::chunk::format::LightContainer;
+
+    #[test]
+    fn light_masks_pad_below_and_above_world_sections() {
+        // 3 real sections: index 0 full, index 1 empty, index 2 full.
+        let sky_light = vec![
+            LightContainer::new_filled(15),
+            LightContainer::new_empty(0),
+            LightContainer::new_filled(7),
+        ];
+        let block_light = vec![
+            LightContainer::new_empty(0),
+            LightContainer::new_filled(3),
+            LightContainer::new_empty(0),
+        ];
+
+        let (sky_mask, block_mask, sky_empty_mask, block_empty_mask) =
+            compute_light_masks(&sky_light, &block_light);
+
+        // Real sections live at bits 1..=num_sections; bit 0 (below world) and
+        // bit num_sections + 1 (above world) must always be set in the empty masks,
+        // matching CChunkData's encoding and vanilla's minSection-1..=maxSection+1 span.
+        assert_eq!(sky_mask, (1 << 1) | (1 << 3));
+        assert_eq!(sky_empty_mask, (1 << 0) | (1 << 2) | (1 << 4));
+
+        assert_eq!(block_mask, 1 << 2);
+        assert_eq!(block_empty_mask, (1 << 0) | (1 << 1) | (1 << 3) | (1 << 4));
+    }
+
+    #[test]
+    fn light_masks_always_set_below_and_above_world_bits_even_when_fully_lit() {
+        let sky_light = vec![LightContainer::new_filled(15); 4];
+        let block_light = vec![LightContainer::new_filled(15); 4];
+
+        let (sky_mask, _block_mask, sky_empty_mask, block_empty_mask) =
+            compute_light_masks(&sky_light, &block_light);
+
+        // Bit 0 and bit num_sections + 1 (here, bit 5) represent the always-empty
+        // below/above-world padding sections and must never be reported as lit.
+        assert_eq!(sky_mask, (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4));
+        assert_eq!(sky_empty_mask, (1 << 0) | (1 << 5));
+        assert_eq!(block_empty_mask, (1 << 0) | (1 << 5));
     }
 }


### PR DESCRIPTION
CLightUpdate disagrees with CChunkData on two independent points. They cannot both be right, because vanilla serialises both through the identical `ClientboundLightUpdatePacketData`.

## Mask offset

`chunk_data.rs` uses `bit_index = section_index + 1` and explicitly sets bit 0 for the always-empty section below the world and bit `num_sections + 1` for the one above. `light_update.rs` used a bare `bit_index = section_index` with no padding bits at all.

Vanilla's own constructor does use a bare `mask.set(sectionIndex)`, but only because `getLightSectionCount()` and `getMinLightSection()` already bake in one padding section at each end. Pumpkin's `ChunkLight` holds only the real chunk sections with no padding, so to produce the same wire mask the encoder has to add the offset explicitly, which is exactly what CChunkData was already doing. CLightUpdate under-counted by two bits and misaligned every real section by one.

Verified against the vanilla constructor as it appears in diff context in Leaf's `ver/26.2` rewrite patch, mirrored in Mint: https://raw.githubusercontent.com/MenthaMC/Mint/dev/26.2/mint-server/minecraft-patches/features/0063-Leaf-Rewrite-ClientboundLightUpdatePacketData-MIME-V.patch

Corroborated by Starlight, whose nibble cache is sized `(maxLightSection - minLightSection + 1) + 2` with the comment "add two extra sections for buffer": https://raw.githubusercontent.com/PaperMC/Starlight/fabric/src/main/java/ca/spottedleaf/starlight/common/light/SkyStarLightEngine.java

## Nibble order

`light_update.rs` applied `rotate_right(4)` to swap the nibbles of every byte before writing. `chunk_data.rs` writes them raw.

Vanilla's `DataLayer` convention is low nibble for even index, high nibble for odd, with no transformation on serialise. Starlight's `SWMRNibbleArray` documents exactly that and its `toVanillaNibble()` is a straight clone with no byte transformation: https://raw.githubusercontent.com/PaperMC/Starlight/fabric/src/main/java/ca/spottedleaf/starlight/common/light/SWMRNibbleArray.java

Pumpkin's own `LightContainer::get` already uses the same convention, so the in-memory bytes are already in wire format and the swap was wrong.

## Scope

Only `light_update.rs` is changed. `chunk_data.rs` was checked and is correct on both points.

Adds two unit tests for the mask encoding, covering mixed full and empty sections and the all-lit case, both asserting the padding bits.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin -p pumpkin-protocol --all-targets` clean. New tests pass.

Not verified in game, and it cannot be: `CLightUpdate` currently has zero send sites anywhere in the tree, which I filed separately as part of #2592. This makes the packet correct for when it is wired up. Adding send sites is deliberately out of scope here.
