### PR TITLE
fix: honour the simulation_distance config instead of a hardcoded radius

### DIFF
--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -62,12 +62,34 @@ impl LoadConfiguration for PumpkinConfig {
         Path::new("pumpkin.toml")
     }
 
-    fn validate(&self) {
+    fn validate(&mut self) {
         self.basic.validate();
         self.advanced.validate();
 
         let min_vd = NonZeroU8::new(2).unwrap();
         let max_vd = NonZeroU8::new(64).unwrap();
+
+        // Vanilla's simulation-distance server property accepts 3 to 32,
+        // default 10, for multiplayer:
+        //   https://minecraft.wiki/w/Server.properties (see the
+        //   `simulation-distance` row, "integer (3-32)")
+        //   https://minecraft.wiki/w/Simulation_distance#Range_of_simulation_distance
+        // Vanilla does not crash the server over an out-of-range value here.
+        // The server.properties page documents that keys with invalid
+        // values are reset to their defaults when the file is regenerated
+        // on startup, and the distance that actually gets applied to the
+        // chunk/tick system is clamped rather than rejected -- see the
+        // inherited `Mth.clamp(watchDistance, 2, 32)` call in vanilla's
+        // chunk map, visible in a Paper rename-only bugfix that touches it:
+        //   https://github.com/PaperMC/Paper/commit/fc0e6c7e086876cce9676214e726a96dc1be209c
+        // simulation_distance used to be read by almost nothing in Pumpkin,
+        // so an out-of-range value sitting in an existing config was
+        // harmless. Now that it drives World::update_active_chunks, an
+        // assert! here would turn that into a startup panic on upgrade.
+        // Clamp and warn instead, so the server still starts and the
+        // operator can fix their config on their own schedule.
+        let min_sd = NonZeroU8::new(3).unwrap();
+        let max_sd = NonZeroU8::new(32).unwrap();
 
         // Validate Java
         assert!(
@@ -77,6 +99,12 @@ impl LoadConfiguration for PumpkinConfig {
         assert!(
             self.advanced.networking.java.view_distance <= max_vd,
             "Java View distance must be less than 64"
+        );
+        clamp_simulation_distance(
+            &mut self.advanced.networking.java.simulation_distance,
+            min_sd,
+            max_sd,
+            "Java",
         );
         if self.advanced.networking.java.online_mode {
             assert!(
@@ -94,6 +122,12 @@ impl LoadConfiguration for PumpkinConfig {
             self.advanced.networking.bedrock.view_distance <= max_vd,
             "Bedrock View distance must be less than 64"
         );
+        clamp_simulation_distance(
+            &mut self.advanced.networking.bedrock.simulation_distance,
+            min_sd,
+            max_sd,
+            "Bedrock",
+        );
         if self.advanced.networking.bedrock.online_mode {
             assert!(
                 self.advanced.networking.bedrock.encryption,
@@ -107,6 +141,31 @@ impl LoadConfiguration for PumpkinConfig {
                 "When allow_chat_reports is enabled, java.online_mode must be enabled"
             );
         }
+    }
+}
+
+/// Clamps a configured `simulation_distance` into `[min, max]` in place.
+///
+/// Logs a warning naming the configured value, the clamped value, and the
+/// valid range when a change was needed, so the operator can fix their
+/// config. See the sourcing and rationale in `PumpkinConfig::validate` for
+/// why this clamps instead of asserting.
+fn clamp_simulation_distance(
+    value: &mut NonZeroU8,
+    min: NonZeroU8,
+    max: NonZeroU8,
+    platform: &str,
+) {
+    let clamped = (*value).clamp(min, max);
+    if clamped != *value {
+        warn!(
+            "{platform} simulation_distance ({}) is outside the valid range {}-{}; clamping to {}",
+            value.get(),
+            min.get(),
+            max.get(),
+            clamped.get()
+        );
+        *value = clamped;
     }
 }
 
@@ -248,7 +307,7 @@ pub trait LoadConfiguration {
         }
         let path = config_dir.join(Self::get_path());
 
-        let config = if path.exists() {
+        let mut config = if path.exists() {
             let file_content = fs::read_to_string(&path).unwrap_or_else(|_| {
                 panic!("Couldn't read configuration file at {}", path.display())
             });
@@ -355,5 +414,9 @@ pub trait LoadConfiguration {
     fn get_path() -> &'static Path;
 
     /// Validates the configuration after loading or merging.
-    fn validate(&self);
+    ///
+    /// Takes `&mut self` because validation may need to correct recoverable
+    /// out-of-range values in place (see `PumpkinConfig::validate` for an
+    /// example with `simulation_distance`) rather than panicking.
+    fn validate(&mut self);
 }

--- a/pumpkin/src/world/chunker.rs
+++ b/pumpkin/src/world/chunker.rs
@@ -25,6 +25,27 @@ pub fn get_view_distance(player: &Player) -> NonZeroU8 {
         .clamp(NonZeroU8::new(2).unwrap(), max_view_distance)
 }
 
+/// Returns the configured simulation distance for a player's client platform.
+///
+/// Unlike view distance, simulation distance is not something the client
+/// negotiates down: it is a server-authoritative setting (vanilla's
+/// `simulation-distance` server property), so we return the configured
+/// value directly rather than clamping it against a per-player preference.
+#[must_use]
+pub fn get_simulation_distance(player: &Player) -> NonZeroU8 {
+    let server = player.world().server.upgrade().unwrap();
+    match player.client.as_ref() {
+        ClientPlatform::Java(_) => server.advanced_config.networking.java.simulation_distance,
+        ClientPlatform::Bedrock(_) => {
+            server
+                .advanced_config
+                .networking
+                .bedrock
+                .simulation_distance
+        }
+    }
+}
+
 // Checks if the target chunk is within the view distance
 // of the center chunk. Uses Chebyshev distance.
 #[must_use]

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -28,7 +28,10 @@ pub mod time;
 
 use crate::block::RandomTickArgs;
 use crate::world::chunker::is_within_view_distance;
-use crate::world::{chunker::get_view_distance, loot::LootContextParameters};
+use crate::world::{
+    chunker::{get_simulation_distance, get_view_distance},
+    loot::LootContextParameters,
+};
 use crate::{block::BlockEvent, entity::item::ItemEntity};
 use crate::{
     block::{
@@ -320,9 +323,14 @@ impl World {
         let mut active_chunks = FxHashSet::default();
         for player in self.players.load().iter() {
             let center = player.get_entity().chunk_pos.load();
-            // TODO: gamerule for view distance/ticking distance
-            for dx in -8..=8 {
-                for dy in -8..=8 {
+            // Use the configured simulation distance (server-authoritative,
+            // per client platform) rather than a hardcoded radius, so entity
+            // AI ticking, block entity ticking, random ticks and mob spawning
+            // (which all read `active_chunks`) follow the same setting vanilla
+            // uses for ticking eligibility.
+            let radius = get_simulation_distance(player).get() as i32;
+            for dx in -radius..=radius {
+                for dy in -radius..=radius {
                     active_chunks.insert(center.add_raw(dx, dy));
                 }
             }


### PR DESCRIPTION
`World::update_active_chunks` built a hardcoded 17x17 box per player:

```rust
// TODO: gamerule for view distance/ticking distance
for dx in -8..=8 { for dy in -8..=8 { active_chunks.insert(center.add_raw(dx, dy)); } }
```

Meanwhile `simulation_distance` is defined in config with a default of 10 and read by nothing outside the Bedrock start game packet and the WASM plugin API. So mobs froze about two chunks closer than vanilla, and changing the setting did nothing.

This is not a new discovery. Merged PR #2341 already documents it verbatim in its notes: "active_chunks is currently a hardcoded 17x17 (radius 8) per player, slightly tighter than the default simulation distance (10), a pre-existing limitation shared with block-entity ticking and spawning."

The same `active_chunks` set gates entity AI ticking, block entity ticking, random ticks and mob spawning, so wiring it up fixes all four together. I grepped the four consumers and none of them carries its own hardcoded radius; they all just read the set. The one nearby literal, `MAGIC_NUMBER = 17 * 17` in `natural_spawner.rs`, is vanilla's own mob density normalisation divisor and is fixed in vanilla too, so it is left alone.

Radius is resolved per player inside the existing loop, so mixed Java and Bedrock sessions each contribute their own platform's configured value.

## On clamping rather than asserting

An earlier draft of this added startup asserts. I backed that out. `simulation_distance` was previously unread, so an existing server can have any value in its config and never have noticed, and an assert would turn that into a panic on upgrade over a value that used to be harmless. That also cuts directly against #2612, which removes two startup panics on recoverable conditions.

So the value is clamped into vanilla's documented range of 3 to 32 with a warning naming both the configured and the effective value. Clamping happens once in `validate`, which is the single choke point all four readers pass through, so the per-tick path gains no work.

On what vanilla does with an out of range value: the wiki documents the property as an integer 3 to 32 defaulting to 10, and states that invalid values are reset to defaults rather than rejected (https://minecraft.wiki/w/Server.properties, https://minecraft.wiki/w/Simulation_distance). Paper's chunk map patch shows the applied value passing through `Mth.clamp(watchDistance, 2, 32)`. I want to be honest that this second one is a patched fork rather than raw vanilla, which I could not obtain, so treat the clamp-versus-default question as supported but not proven. Either way we clamp rather than panic.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin -p pumpkin-config --all-targets` clean.

No regression test: exercising this needs a full Server, World and Player fixture with a live ClientPlatform, and neither `chunker.rs` nor the config crate has existing test scaffolding to extend.

Not verified in game.
