### PR TITLE
fix: stone pressure plates should not trigger on items and arrows

### DIFF
--- a/pumpkin/src/block/blocks/redstone/pressure_plate/plate.rs
+++ b/pumpkin/src/block/blocks/redstone/pressure_plate/plate.rs
@@ -1,7 +1,7 @@
 use pumpkin_data::{
     Block, BlockDirection, BlockId, BlockState, BlockStateId,
     block_properties::BlockProperties,
-    tag::{self},
+    tag::{self, Taggable},
 };
 use pumpkin_util::math::{boundingbox::BoundingBox, position::BlockPos};
 use pumpkin_world::world::BlockFlags;
@@ -98,10 +98,28 @@ impl PressurePlate for PressurePlateBlock {
         if props.powered { 15 } else { 0 }
     }
 
-    async fn calculate_redstone_output(&self, world: &World, _block: &Block, pos: &BlockPos) -> u8 {
+    async fn calculate_redstone_output(&self, world: &World, block: &Block, pos: &BlockPos) -> u8 {
         // TODO: this is bad use real box
         let aabb = BoundingBox::from_block(pos);
-        if !world.get_entities_at_box(&aabb).is_empty()
+
+        // Stone-family plates (stone, polished blackstone) only react to living entities
+        // (players and mobs); wooden plates react to any entity, including dropped items
+        // and projectiles like arrows.
+        // https://minecraft.wiki/w/Polished_Blackstone_Pressure_Plate:
+        // "A polished blackstone pressure plate ... can detect only players and mobs."
+        // https://minecraft.wiki/w/Wooden_Pressure_Plate:
+        // "A wooden pressure plate is activated by all entities (including players, mobs,
+        // items, arrows, experience orbs, fishing bobs, etc.)."
+        if block.has_tag(&tag::Block::MINECRAFT_STONE_PRESSURE_PLATES) {
+            if !world.get_players_at_box(&aabb).is_empty()
+                || world
+                    .get_entities_at_box(&aabb)
+                    .iter()
+                    .any(|entity| entity.get_living_entity().is_some())
+            {
+                return 15;
+            }
+        } else if !world.get_entities_at_box(&aabb).is_empty()
             || !world.get_players_at_box(&aabb).is_empty()
         {
             return 15;


### PR DESCRIPTION
`PressurePlateBlock` covers both the wooden tag and the stone tag with a single `calculate_redstone_output` that counts any entity in the bounding box. So a dropped item, a spent arrow, or an experience orb activates a stone or polished blackstone pressure plate.

Vanilla activation differs by family:

- Wooden plates are activated by all entities, including items, arrows and experience orbs. https://minecraft.wiki/w/Wooden_Pressure_Plate
- Stone and polished blackstone plates detect only players and mobs. https://minecraft.wiki/w/Polished_Blackstone_Pressure_Plate

Corroborated by the general pressure plate page, which notes that a stone plate cannot be activated by a minecart but can be activated by the minecart's passenger: https://minecraft.wiki/w/Pressure_Plate

Dispatch is on `tag::Block::MINECRAFT_STONE_PRESSURE_PLATES` rather than hardcoded block ids, matching how the codebase already dispatches on tags elsewhere. For that family the count now includes players plus entities whose `get_living_entity()` resolves.

That accessor turns out to line up exactly with the vanilla rule: it returns `None` for items, minecarts, boats and every projectile, and `Some` only for living entities, mobs and players. Wooden plates keep the existing count-everything behaviour unchanged.

Weighted pressure plates live in their own file with their own counting rules and are untouched here, since #2589 already touches that file.

## Verification

`cargo fmt --check` and `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets` clean.

Not verified in game.
