### PR TITLE
fix(block): correct berry bush and nether wart growth rates

### DIFF
--- a/pumpkin/src/block/blocks/plant/crop/nether_wart.rs
+++ b/pumpkin/src/block/blocks/plant/crop/nether_wart.rs
@@ -82,7 +82,7 @@ impl CropBlockBase for NetherWartBlock {
     async fn random_tick(&self, world: &Arc<World>, pos: &BlockPos) {
         let (block, state) = world.get_block_and_state_id(pos);
         let age = self.get_age(state, block);
-        if age < self.max_age() && rand::rng().random_range(0..=10) == 0 {
+        if age < self.max_age() && rand::rng().random_range(0..10) == 0 {
             world
                 .set_block_state(
                     pos,

--- a/pumpkin/src/block/blocks/plant/crop/sweet_berry_bush.rs
+++ b/pumpkin/src/block/blocks/plant/crop/sweet_berry_bush.rs
@@ -188,15 +188,13 @@ impl CropBlockBase for SweetBerryBushBlock {
             if state_above.is_full_cube() || state_above.is_solid() {
                 return;
             }
-            if rand::rng().random_range(0..=25) == 0 {
-                world
-                    .set_block_state(
-                        pos,
-                        self.state_with_age(block, state, age + 1),
-                        BlockFlags::NOTIFY_NEIGHBORS,
-                    )
-                    .await;
-            }
+            world
+                .set_block_state(
+                    pos,
+                    self.state_with_age(block, state, age + 1),
+                    BlockFlags::NOTIFY_NEIGHBORS,
+                )
+                .await;
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes #2582.

Sweet berry bushes applied a second random growth gate after the
vanilla-equivalent 1-in-5 check, reducing their effective growth chance
to approximately 1 in 130. This removes the duplicate inner gate while
preserving the block-state update.

Nether wart used the inclusive range `0..=10`, producing a 1-in-11
growth chance. This changes it to `0..10`, matching vanilla's 1-in-10
chance.

## Testing

Passed locally on Windows 10 with Rust 1.97.1:

- `cargo fmt --check` — passed
- `cargo clippy --all-targets --all-features` — passed
- `cargo test` — passed