### PR TITLE
fix(item): prevent stacking items with different components

### DIFF
--- a/pumpkin-data/src/item_stack/mod.rs
+++ b/pumpkin-data/src/item_stack/mod.rs
@@ -579,6 +579,11 @@ impl ItemStack {
         if self.item != other.item {
             return false;
         }
+
+        if self.patch.len() != other.patch.len() {
+            return false;
+        }
+
         for (id, data) in &self.patch {
             let mut not_found = true;
             'out: for (other_id, other_data) in &other.patch {
@@ -743,6 +748,20 @@ mod tests {
     /// Helper: creates a fresh Iron Sword (max_damage 250, damage 0).
     fn iron_sword() -> ItemStack {
         ItemStack::new(1, &Item::IRON_SWORD)
+    }
+
+    #[test]
+    fn items_with_different_components_are_not_equal_in_either_direction() {
+        let plain = ItemStack::new(1, &Item::COAL);
+
+        let mut customized = ItemStack::new(1, &Item::COAL);
+        customized
+            .patch
+            .push((DataComponent::Unbreakable, Some(UnbreakableImpl.to_dyn())));
+
+        assert!(!plain.are_items_and_components_equal(&customized));
+        assert!(!customized.are_items_and_components_equal(&plain));
+        assert!(customized.are_items_and_components_equal(&customized.clone()));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #2618.

`ItemStack::are_items_and_components_equal` only checked component patches
present on the left-hand stack. When the existing stack had no component
patches, an incoming stack with additional components could incorrectly be
considered equal.

This requires both stacks to contain the same number of component patches
before comparing their component IDs and values, making the comparison
symmetric.

## Testing

- `cargo fmt --check` — passed
- `cargo test -p pumpkin-data` — 36 passed
- `cargo build -p pumpkin` — passed
- Manually tested plain then customized items — remained separate
- Manually tested customized then plain items — remained separate
- Manually tested two identically customized items — stacked correctly