### PR TITLE
fix: sky light below the world read as full bright

### DIFF
--- a/pumpkin-world/src/lighting/runtime.rs
+++ b/pumpkin-world/src/lighting/runtime.rs
@@ -450,21 +450,28 @@ impl DynamicLightEngine {
         let (chunk_coordinate, relative) = position.chunk_and_chunk_relative_position();
         level
             .read_chunk_sync(&chunk_coordinate, |chunk| {
-                let section_index =
-                    (relative.y - chunk.section.min_y) as usize / BlockPalette::SIZE;
+                // Signed offset first. The unsigned cast used to run before the
+                // sign check, so a `y` below `min_y` wrapped to a huge index,
+                // hit the out-of-bounds branch, and read as full bright.
+                // Vanilla is 15 above the build height and 0 below the world.
+                let offset = relative.y - chunk.section.min_y;
+                if offset < 0 {
+                    return 0;
+                }
+                let section_index = offset as usize / BlockPalette::SIZE;
 
                 let light_engine = chunk
                     .light_engine
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
-                // Bounds check for section index (lock the light engine)
+                // Above the top of the stored sections: open sky.
                 if section_index >= light_engine.sky_light.len() {
                     return 15;
                 }
 
                 light_engine.sky_light[section_index].get(
                     relative.x as usize,
-                    (relative.y - chunk.section.min_y) as usize % BlockPalette::SIZE,
+                    offset as usize % BlockPalette::SIZE,
                     relative.z as usize,
                 )
             })
@@ -527,21 +534,26 @@ impl DynamicLightEngine {
         let (chunk_coordinate, relative) = position.chunk_and_chunk_relative_position();
         level
             .read_chunk_sync(&chunk_coordinate, |chunk| {
-                let section_index =
-                    (relative.y - chunk.section.min_y) as usize / BlockPalette::SIZE;
+                // Same sign-before-cast rule as `get_sky_light_level_sync`:
+                // below the world is 0, above the build height is 15.
+                let offset = relative.y - chunk.section.min_y;
+                if offset < 0 {
+                    return 0;
+                }
+                let section_index = offset as usize / BlockPalette::SIZE;
 
                 let light_engine = chunk
                     .light_engine
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
-                // Bounds check for section index (lock the light engine)
+                // Above the top of the stored sections: open sky.
                 if section_index >= light_engine.sky_light.len() {
                     return 15;
                 }
 
                 light_engine.sky_light[section_index].get(
                     relative.x as usize,
-                    (relative.y - chunk.section.min_y) as usize % BlockPalette::SIZE,
+                    offset as usize % BlockPalette::SIZE,
                     relative.z as usize,
                 )
             })

--- a/pumpkin-world/src/lighting/storage.rs
+++ b/pumpkin-world/src/lighting/storage.rs
@@ -109,14 +109,18 @@ pub fn get_sky_light(cache: &Cache, pos: BlockPos) -> u8 {
     match &cache.chunks[idx] {
         Chunk::Level(c) => {
             let light_engine = c.light_engine.lock().unwrap();
+            // Above the stored sections is open sky, 15, matching vanilla and
+            // the runtime getters in `runtime.rs`. This used to return 0, so
+            // the two paths disagreed about the same position. Below the world
+            // stays 0 via `get_section_y` returning `None` above.
             if section_y >= light_engine.sky_light.len() {
-                return 0;
+                return 15;
             }
             light_engine.sky_light[section_y].get(x, y, z)
         }
         Chunk::Proto(c) => {
             if section_y >= c.light.sky_light.len() {
-                return 0;
+                return 15;
             }
             c.light.sky_light[section_y].get(x, y, z)
         }


### PR DESCRIPTION
Both sky light getters cast (y - min_y) to usize before checking its sign, so any position below the world wrapped to a huge section index and returned 15, full bright, where vanilla returns 0. The offset is now sign-checked before the cast, and the cached-storage path that returned 0 for above-the-build-height positions now returns 15 to match both vanilla and the runtime getters.