### PR TITLE
perf: Make WasmPlugins be Arc<WasmPlugin> instead of Box<Arc<WasmPlugin>>

### DIFF
--- a/pumpkin/src/plugin/api/mod.rs
+++ b/pumpkin/src/plugin/api/mod.rs
@@ -39,26 +39,16 @@ pub trait Plugin: Send + Sync + 'static {
     /// Asynchronous method called when the plugin is loaded.
     ///
     /// This method initializes the plugin within the server context.
-    ///
-    /// # Parameters
-    /// - `_server`: Reference to the server's context.
-    ///
-    /// # Returns
-    /// - `Ok(())` on success, or `Err(String)` on failure.
-    fn on_load(&mut self, _server: Arc<Context>) -> PluginFuture<'_, Result<(), String>> {
+    #[expect(unused)]
+    fn on_load(&self, server: Arc<Context>) -> PluginFuture<'_, Result<(), String>> {
         Box::pin(async move { Ok(()) })
     }
 
     /// Asynchronous method called when the plugin is unloaded.
     ///
     /// This method cleans up resources when the plugin is removed from the server context.
-    ///
-    /// # Parameters
-    /// - `_server`: Reference to the server's context.
-    ///
-    /// # Returns
-    /// - `Ok(())` on success, or `Err(String)` on failure.
-    fn on_unload(&mut self, _server: Arc<Context>) -> PluginFuture<'_, Result<(), String>> {
+    #[expect(unused)]
+    fn on_unload(&self, server: Arc<Context>) -> PluginFuture<'_, Result<(), String>> {
         Box::pin(async move { Ok(()) })
     }
 }

--- a/pumpkin/src/plugin/loader/mod.rs
+++ b/pumpkin/src/plugin/loader/mod.rs
@@ -1,5 +1,5 @@
 use crate::plugin::{PluginMetadata, api::Plugin, loader::wasm::wasm_host::PluginInitError};
-use std::{any::Any, path::Path, pin::Pin};
+use std::{any::Any, path::Path, pin::Pin, sync::Arc};
 use thiserror::Error;
 
 pub mod native;
@@ -9,7 +9,7 @@ pub type PluginLoadFuture<'a> = Pin<
     Box<
         dyn Future<
                 Output = Result<
-                    (Box<dyn Plugin>, PluginMetadata, Box<dyn Any + Send + Sync>),
+                    (Arc<dyn Plugin>, PluginMetadata, Box<dyn Any + Send + Sync>),
                     LoaderError,
                 >,
             > + Send

--- a/pumpkin/src/plugin/loader/native.rs
+++ b/pumpkin/src/plugin/loader/native.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use std::{any::Any, sync::Arc};
 
 use libloading::Library;
 
@@ -49,7 +49,7 @@ impl PluginLoader for NativePluginLoader {
             };
 
             Ok((
-                plugin_factory(),
+                Arc::from(plugin_factory()),
                 metadata.clone(),
                 Box::new(library) as Box<dyn Any + Send + Sync>,
             ))

--- a/pumpkin/src/plugin/loader/native.rs
+++ b/pumpkin/src/plugin/loader/native.rs
@@ -1,4 +1,7 @@
-use std::{any::Any, sync::{Arc, LazyLock}};
+use std::{
+    any::Any,
+    sync::{Arc, LazyLock},
+};
 
 use libloading::Library;
 
@@ -52,13 +55,8 @@ impl PluginLoader for NativePluginLoader {
             };
 
             Ok((
-<<<<<<< HEAD
                 Arc::from(plugin_factory()),
-                metadata.clone(),
-=======
-                plugin_factory(),
                 metadata,
->>>>>>> master
                 Box::new(library) as Box<dyn Any + Send + Sync>,
             ))
         })

--- a/pumpkin/src/plugin/loader/wasm/mod.rs
+++ b/pumpkin/src/plugin/loader/wasm/mod.rs
@@ -9,22 +9,24 @@ use crate::plugin::{
 
 pub mod wasm_host;
 
-impl Plugin for Arc<WasmPlugin> {
-    fn on_load(&mut self, context: Arc<Context>) -> PluginFuture<'_, Result<(), String>> {
+impl Plugin for WasmPlugin {
+    fn on_load(&self, context: Arc<Context>) -> PluginFuture<'_, Result<(), String>> {
         Box::pin(async move {
-            self.as_ref()
-                .on_load(context)
+            // More qualified syntax to not call the current on_load function recursively and instead call
+            // WasmPlugin::on_load
+            Self::on_load(self, context)
                 .await
-                .map_err(|err| err.to_string())?
+                .map_err(|err| err.to_string())
+                .flatten()
         })
     }
 
-    fn on_unload(&mut self, context: Arc<Context>) -> PluginFuture<'_, Result<(), String>> {
+    fn on_unload(&self, context: Arc<Context>) -> PluginFuture<'_, Result<(), String>> {
         Box::pin(async move {
-            self.as_ref()
-                .on_unload(context)
+            Self::on_unload(self, context)
                 .await
-                .map_err(|err| err.to_string())?
+                .map_err(|err| err.to_string())
+                .flatten()
         })
     }
 }
@@ -39,7 +41,7 @@ impl PluginLoader for WasmPluginLoader {
             let (plugin, metadata) = runtime.init_plugin(&path).await?;
 
             Ok((
-                Box::new(plugin) as Box<dyn Plugin>,
+                plugin as Arc<dyn Plugin>,
                 metadata,
                 Box::new(()) as Box<dyn Any + Send + Sync>,
             ))

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -193,7 +193,7 @@ pub struct PluginManager {
 /// - Windows: Plugin cannot be unloaded, it can be only active or not
 struct LoadedPlugin {
     metadata: PluginMetadata,
-    instance: Option<Box<dyn Plugin>>,
+    instance: Option<Arc<dyn Plugin>>,
     loader: Arc<dyn PluginLoader>,
     loader_data: Option<Box<dyn Any + Send + Sync>>,
     is_active: bool,
@@ -535,7 +535,7 @@ impl PluginManager {
     #[expect(clippy::too_many_lines)]
     async fn spawn_plugin_initialization(
         &self,
-        mut instance: Box<dyn Plugin>,
+        instance: Arc<dyn Plugin>,
         metadata: PluginMetadata,
         loader_data: Box<dyn Any + Send + Sync>,
         loader: Arc<dyn PluginLoader>,
@@ -733,7 +733,7 @@ impl PluginManager {
         let mut plugins_map: HashMap<
             String,
             (
-                Box<dyn Plugin>,
+                Arc<dyn Plugin>,
                 PluginMetadata,
                 Box<dyn Any + Send + Sync>,
                 Arc<dyn PluginLoader>,
@@ -944,7 +944,7 @@ impl PluginManager {
             plugins.remove(index)
         };
 
-        if let Some(mut instance) = plugin.instance.take() {
+        if let Some(instance) = plugin.instance.take() {
             instance.on_unload(plugin.context.clone()).await.ok();
         }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Because the `Plugin` trait requires `&mut self` for both `on_load` and `on_unload`, it previously required that `WasmPlugin` was `Box<Arc<T>>` instead of just `Arc<T>`, even though `WasmPlugin` doesn't need a mutable reference (`Arc` is needed because there is a `Weak` being created). `Plugin` now only requires `&self`, which breaks compatibility with existing native plugins (like PatchBukkit), but is very easy to fix for these plugins (if they previously needed a mutable reference they can use interior mutability types).
(PatchBukkit doesn't require `&mut self` actually)

Overall the performance of WASM plugins may be very very slightly improved (assuming the compiler didn't optimize the double reference).

<img width="843" height="77" alt="image" src="https://github.com/user-attachments/assets/66e58822-312b-4f39-802b-a87c97fbb44e" />

## Testing
I tested that WASM plugins work. I wasn't able to test whether the PatchBukkit plugin could be loaded (with a patch to make the plugin compatible again) because it failed to build, I might be able to test it later though.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
