### PR TITLE
feat(server): support F3+2 tick debug sample chart

### DIFF
--- a/pumpkin-protocol/src/java/client/play/debug_sample.rs
+++ b/pumpkin-protocol/src/java/client/play/debug_sample.rs
@@ -1,0 +1,37 @@
+use pumpkin_data::packet::clientbound::PLAY_DEBUG_SAMPLE;
+use pumpkin_macros::java_packet;
+use pumpkin_util::version::JavaMinecraftVersion;
+
+use crate::ser::NetworkWriteExt;
+use crate::{ClientPacket, VarInt};
+
+#[java_packet(PLAY_DEBUG_SAMPLE)]
+pub struct CDebugSample<'a> {
+    pub sample: &'a [i64],
+    pub sample_type: VarInt,
+}
+
+impl<'a> CDebugSample<'a> {
+    #[must_use]
+    pub const fn new(sample: &'a [i64], sample_type: VarInt) -> Self {
+        Self {
+            sample,
+            sample_type,
+        }
+    }
+}
+
+impl ClientPacket for CDebugSample<'_> {
+    fn write_packet_data(
+        &self,
+        mut write: impl std::io::Write,
+        _version: &JavaMinecraftVersion,
+    ) -> Result<(), crate::ser::WritingError> {
+        write.write_var_int(&VarInt(self.sample.len() as i32))?;
+        for &val in self.sample {
+            write.write_i64_be(val)?;
+        }
+        write.write_var_int(&self.sample_type)?;
+        Ok(())
+    }
+}

--- a/pumpkin-protocol/src/java/client/play/mod.rs
+++ b/pumpkin-protocol/src/java/client/play/mod.rs
@@ -218,3 +218,6 @@ pub use update_mob_effect::*;
 pub use update_objectives::*;
 pub use update_score::*;
 pub use worldevent::*;
+
+mod debug_sample;
+pub use debug_sample::*;

--- a/pumpkin-protocol/src/java/server/play/debug_sample_subscription.rs
+++ b/pumpkin-protocol/src/java/server/play/debug_sample_subscription.rs
@@ -1,0 +1,20 @@
+use crate::{
+    ServerPacket, VarInt,
+    ser::{NetworkReadExt, ReadingError},
+};
+use pumpkin_data::packet::serverbound::PLAY_DEBUG_SAMPLE_SUBSCRIPTION;
+use pumpkin_macros::java_packet;
+use pumpkin_util::version::JavaMinecraftVersion;
+
+#[java_packet(PLAY_DEBUG_SAMPLE_SUBSCRIPTION)]
+pub struct SDebugSampleSubscription {
+    pub sample_type: VarInt,
+}
+
+impl<'a> ServerPacket<'a> for SDebugSampleSubscription {
+    fn read(bytebuf: &mut &'a [u8], _version: &JavaMinecraftVersion) -> Result<Self, ReadingError> {
+        Ok(Self {
+            sample_type: bytebuf.get_var_int()?,
+        })
+    }
+}

--- a/pumpkin-protocol/src/java/server/play/debug_subscription_request.rs
+++ b/pumpkin-protocol/src/java/server/play/debug_subscription_request.rs
@@ -1,0 +1,20 @@
+use crate::{
+    ServerPacket, VarInt,
+    ser::{NetworkReadExt, ReadingError},
+};
+use pumpkin_data::packet::serverbound::PLAY_DEBUG_SUBSCRIPTION_REQUEST;
+use pumpkin_macros::java_packet;
+use pumpkin_util::version::JavaMinecraftVersion;
+
+#[java_packet(PLAY_DEBUG_SUBSCRIPTION_REQUEST)]
+pub struct SDebugSubscriptionRequest {
+    pub sample_type: VarInt,
+}
+
+impl<'a> ServerPacket<'a> for SDebugSubscriptionRequest {
+    fn read(bytebuf: &mut &'a [u8], _version: &JavaMinecraftVersion) -> Result<Self, ReadingError> {
+        Ok(Self {
+            sample_type: bytebuf.get_var_int()?,
+        })
+    }
+}

--- a/pumpkin-protocol/src/java/server/play/mod.rs
+++ b/pumpkin-protocol/src/java/server/play/mod.rs
@@ -105,3 +105,9 @@ pub use test_instance_block_action::*;
 
 mod set_test_block;
 pub use set_test_block::*;
+
+mod debug_subscription_request;
+pub use debug_subscription_request::*;
+
+mod debug_sample_subscription;
+pub use debug_sample_subscription::*;

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -473,6 +473,7 @@ pub struct Player {
     pub last_food_saturation: AtomicBool,
     /// The player's permission level.
     pub permission_lvl: AtomicCell<PermissionLvl>,
+    pub subscribed_debug_sample: AtomicBool,
     /// Whether the client has reported that it has loaded.
     pub client_loaded: AtomicBool,
     pub bedrock_spawned: AtomicBool,
@@ -706,6 +707,7 @@ impl Player {
             last_sent_health: AtomicI32::new(-1),
             last_sent_food: AtomicU8::new(0),
             last_food_saturation: AtomicBool::new(true),
+            subscribed_debug_sample: AtomicBool::new(false),
             has_played_before: AtomicBool::new(false),
             chat_session: Arc::new(Mutex::new(ChatSession::default())), // Placeholder value until the player actually sets their session id
             signature_cache: Mutex::new(MessageCache::default()),

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -16,13 +16,14 @@ use pumpkin_protocol::java::server::play::{
     SAttack, SBundleItemSelected, SChangeGameMode, SChatCommand, SChatMessage, SChunkBatch,
     SClickSlot, SClientCommand, SClientInformationPlay, SClientTickEnd, SCloseContainer,
     SCommandSuggestion, SConfirmTeleport, SContainerButtonClick,
-    SCookieResponse as SPCookieResponse, SCustomPayload, SInteract, SJigsawGenerate, SMoveVehicle,
-    SPaddleBoat, SPickItemFromBlock, SPlaceRecipe, SPlayPingRequest, SPlayerAbilities,
-    SPlayerAction, SPlayerCommand, SPlayerInput, SPlayerLoaded, SPlayerPosition,
-    SPlayerPositionRotation, SPlayerRotation, SPlayerSession, SRecipeBookChangeSettings,
-    SRecipeBookSeenRecipe, SRenameItem, SSeenAdvancement, SSelectTrade, SSetCommandBlock,
-    SSetCreativeSlot, SSetHeldItem, SSetJigsawBlock, SSetPlayerGround, SSetTestBlock, SSwingArm,
-    STeleportToEntity, STestInstanceBlockAction, SUpdateSign, SUseItem, SUseItemOn,
+    SCookieResponse as SPCookieResponse, SCustomPayload, SDebugSampleSubscription,
+    SDebugSubscriptionRequest, SInteract, SJigsawGenerate, SMoveVehicle, SPaddleBoat,
+    SPickItemFromBlock, SPlaceRecipe, SPlayPingRequest, SPlayerAbilities, SPlayerAction,
+    SPlayerCommand, SPlayerInput, SPlayerLoaded, SPlayerPosition, SPlayerPositionRotation,
+    SPlayerRotation, SPlayerSession, SRecipeBookChangeSettings, SRecipeBookSeenRecipe, SRenameItem,
+    SSeenAdvancement, SSelectTrade, SSetCommandBlock, SSetCreativeSlot, SSetHeldItem,
+    SSetJigsawBlock, SSetPlayerGround, SSetTestBlock, SSwingArm, STeleportToEntity,
+    STestInstanceBlockAction, SUpdateSign, SUseItem, SUseItemOn,
 };
 use pumpkin_protocol::packet::MultiVersionJavaPacket;
 use pumpkin_protocol::{
@@ -1010,6 +1011,18 @@ impl JavaClient {
             }
             id if id == SSetTestBlock::to_id(version) => {
                 self.handle_set_test_block(player, &SSetTestBlock::read(&mut payload, &version)?);
+            }
+            id if id == SDebugSubscriptionRequest::to_id(version) => {
+                self.handle_debug_subscription_request(
+                    player,
+                    &SDebugSubscriptionRequest::read(&mut payload, &version)?,
+                );
+            }
+            id if id == SDebugSampleSubscription::to_id(version) => {
+                self.handle_debug_sample_subscription(
+                    player,
+                    &SDebugSampleSubscription::read(&mut payload, &version)?,
+                );
             }
             id if id == SPlayerPosition::to_id(version) => {
                 self.handle_position(

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -2931,4 +2931,28 @@ impl JavaClient {
             packet.position, packet.mode, packet.message
         );
     }
+
+    pub fn handle_debug_subscription_request(
+        &self,
+        player: &Arc<Player>,
+        packet: &pumpkin_protocol::java::server::play::SDebugSubscriptionRequest,
+    ) {
+        if player.permission_lvl.load() >= PermissionLvl::Two && packet.sample_type.0 == 0 {
+            player
+                .subscribed_debug_sample
+                .store(true, Ordering::Relaxed);
+        }
+    }
+
+    pub fn handle_debug_sample_subscription(
+        &self,
+        player: &Arc<Player>,
+        packet: &pumpkin_protocol::java::server::play::SDebugSampleSubscription,
+    ) {
+        if player.permission_lvl.load() >= PermissionLvl::Two && packet.sample_type.0 == 0 {
+            player
+                .subscribed_debug_sample
+                .store(true, Ordering::Relaxed);
+        }
+    }
 }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -942,6 +942,29 @@ impl Server {
 
         self.aggregated_tick_times_nanos
             .fetch_add(tick_duration_nanos - old_time, Ordering::Relaxed);
+
+        let target_tick_nanos = self.tick_rate_manager.nanoseconds_per_tick();
+        let idle_nanos = target_tick_nanos.saturating_sub(tick_duration_nanos);
+
+        let sample_slice = [
+            tick_duration_nanos.max(target_tick_nanos),
+            tick_duration_nanos,
+            0,
+            idle_nanos,
+        ];
+        let packet = pumpkin_protocol::java::client::play::CDebugSample::new(
+            &sample_slice,
+            pumpkin_protocol::codec::var_int::VarInt(0),
+        );
+        for world in self.worlds.load().iter() {
+            for player in world.players.load().iter() {
+                if player.subscribed_debug_sample.load(Ordering::Relaxed)
+                    && player.permission_lvl.load() >= pumpkin_util::PermissionLvl::Two
+                {
+                    player.client.try_enqueue_packet(&packet);
+                }
+            }
+        }
     }
 
     /// Gets the rolling average tick time over the last 100 ticks, in nanoseconds.


### PR DESCRIPTION
## Description

Adds support for the Vanilla `F3+2` tick sample debug chart (`CDebugSample` packet & `SDebugSampleSubscription`).

- Implements `CDebugSample`, `SDebugSampleSubscription`, and `SDebugSubscriptionRequest` in `pumpkin-protocol`.
- Subscribes OP players to sample broadcasts.
- Calculates target tick bounds dynamically using `ServerTickRateManager::nanoseconds_per_tick` so the chart scales properly at higher TPS.

## Testing

- Tested in game on Java 26.2 client.
- Verified that the graph renders properly at different tick speeds.
