### PR TITLE
fix: swimming flickers between swimming and standing pose

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -853,7 +853,6 @@ impl LivingEntity {
                 && !self.entity.on_ground.load(SeqCst)
                 && self.entity.water_height.load() > self.get_swim_height();
             self.entity.set_swimming(should_swim).await;
-            
         } else if self.entity.swimming.load(SeqCst) {
             self.entity.set_swimming(false).await;
         }

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -844,6 +844,21 @@ impl LivingEntity {
 
         let touching_water = self.entity.touching_water.load(SeqCst);
 
+        // Update swimming state: entity is swimming when in water with movement input
+        // and not on ground (matches vanilla LivingEntity#updateSwimming)
+        if touching_water {
+            let input = self.movement_input.load();
+            let has_forward_input = (input.x * input.x + input.z * input.z) > 0.0;
+            let should_swim = has_forward_input
+                && !self.entity.on_ground.load(SeqCst)
+                && self.entity.water_height.load() > self.get_swim_height();
+            self.entity
+                .set_swimming(should_swim)
+                .await;
+        } else if self.entity.swimming.load(SeqCst) {
+            self.entity.set_swimming(false).await;
+        }
+
         // Strider is the only entity that has canWalkOnFluid = false
 
         if (touching_water || self.entity.touching_lava.load(SeqCst))

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -852,9 +852,8 @@ impl LivingEntity {
             let should_swim = has_forward_input
                 && !self.entity.on_ground.load(SeqCst)
                 && self.entity.water_height.load() > self.get_swim_height();
-            self.entity
-                .set_swimming(should_swim)
-                .await;
+            self.entity.set_swimming(should_swim).await;
+            
         } else if self.entity.swimming.load(SeqCst) {
             self.entity.set_swimming(false).await;
         }

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -2551,10 +2551,10 @@ impl Entity {
         self.sneaking.load(Ordering::Relaxed)
     }
 
-    pub async fn set_swimming(&self, invisible: bool) {
-        if self.swimming.load(Ordering::Relaxed) != invisible {
-            self.swimming.store(invisible, Relaxed);
-            self.set_flag(Flag::Swimming, invisible).await;
+    pub async fn set_swimming(&self, swimming: bool) {
+        if self.swimming.load(Ordering::Relaxed) != swimming {
+            self.swimming.store(swimming, Relaxed);
+            self.set_flag(Flag::Swimming, swimming).await;
         }
     }
 

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1650,7 +1650,7 @@ impl Player {
         self.sleeping_since.load().is_some()
     }
 
-        async fn is_swimming(&self, flying: bool) -> bool {
+    async fn is_swimming(&self, flying: bool) -> bool {
         let entity = self.get_entity();
 
         entity.swimming.load(Ordering::Relaxed)

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1650,15 +1650,10 @@ impl Player {
         self.sleeping_since.load().is_some()
     }
 
-    async fn is_swimming(&self, flying: bool) -> bool {
+        async fn is_swimming(&self, flying: bool) -> bool {
         let entity = self.get_entity();
-        let swim_height = self.living_entity.get_swim_height();
 
-        // TODO: Replace this inferred check with vanilla-equivalent swimming state tracking
-        // (LivingEntity#updateSwimming + entity swimming flag).
-        entity.touching_water.load(Ordering::Relaxed)
-            && entity.water_height.load() > swim_height
-            && entity.is_sprinting()
+        entity.swimming.load(Ordering::Relaxed)
             && !entity.on_ground.load(Ordering::Relaxed)
             && !flying
             && !entity.has_vehicle().await


### PR DESCRIPTION
the is_swimming check was gating on is_sprinting() which is wrong. in vanilla you just need to be moving in water to swim, you don't need to sprint. since the sprint state flickers back and forth while in water the pose would rapidly toggle between swimming and standing every few ticks.

added proper swimming state updates in tick_movement so the entity swimming flag gets set correctly based on movement input + water + not on ground, then changed player is_swimming to just read that flag. matches what vanilla does in LivingEntity#updateSwimming.

also fixed a small typo in set_swimming where the parameter had the wrong name.