### PR TITLE
fix(world): stop the chunk writer dropping NBT it does not model 🤖🤖🤖

### DIFF
--- a/pumpkin-world/src/chunk/format/mod.rs
+++ b/pumpkin-world/src/chunk/format/mod.rs
@@ -152,6 +152,84 @@ where
     })
 }
 
+/// Root NBT keys that `ChunkData::internal_to_bytes` writes itself.
+///
+/// Some are recomputed from live state (`DataVersion`, `xPos`/`yPos`/`zPos`, `Status`,
+/// `sections`, `isLightOn`, `InhabitedTime`); the rest are echoed back out of a typed
+/// field that `internal_from_bytes` parsed them into (`Heightmaps`, `block_ticks`,
+/// `fluid_ticks`, `block_entities`). Either way the writer owns them, so they must
+/// never be sourced from [`ChunkData::retained_nbt`].
+///
+/// Keep in sync with the `root_compound.put_*` calls in `internal_to_bytes`;
+/// `writer_emits_exactly_the_written_root_keys` fails on drift.
+const WRITTEN_ROOT_KEYS: &[&str] = &[
+    "DataVersion",
+    "xPos",
+    "yPos",
+    "zPos",
+    "Status",
+    "Heightmaps",
+    "sections",
+    "block_ticks",
+    "fluid_ticks",
+    "block_entities",
+    "isLightOn",
+    "InhabitedTime",
+];
+
+/// Root keys we neither write nor carry over, because writing them back would be worse
+/// than losing them.
+///
+/// The rule: retain keys that *describe* what is already in the chunk, drop keys that
+/// record *work still to be done*. We have no code for any key below, so we can never
+/// clear one once it has been applied — we would re-assert the same directive on every
+/// save, against blocks that have since changed.
+///
+/// - `entities`: entities live in the separate `entities/` region folder, so a retained
+///   copy would be a second, never-updated set of the same mobs.
+/// - `PostProcessing`, `below_zero_retrogen`, `UpgradeData`: work records.
+/// - `carving_mask`: generation-stage scratch state. Unreachable in practice, since we
+///   only retain from chunks loaded at `Status: full`, but listed so the rule stays legible.
+///
+/// How these are classified is reasoning about vanilla rather than something validated
+/// against a real region file. What is verified is that we have no code for any of them.
+const NEVER_RETAINED_ROOT_KEYS: &[&str] = &[
+    "entities",
+    "PostProcessing",
+    "below_zero_retrogen",
+    "UpgradeData",
+    "carving_mask",
+];
+
+fn is_owned_root_key(key: &str) -> bool {
+    WRITTEN_ROOT_KEYS.contains(&key) || NEVER_RETAINED_ROOT_KEYS.contains(&key)
+}
+
+/// Clones the root tags we do not model out of a freshly parsed chunk, so they can be
+/// written back untouched instead of dropped.
+fn retain_foreign_root_tags(root: &NbtCompound) -> NbtCompound {
+    root.child_tags
+        .iter()
+        .filter(|&(key, _)| !is_owned_root_key(key))
+        .map(|(key, tag)| (key.clone(), tag.clone()))
+        .collect()
+}
+
+/// Writes retained tags back onto a root compound.
+///
+/// Must be called *after* every `root_compound.put_*` in `internal_to_bytes`:
+/// [`NbtCompound::put`] is insert-if-absent, so merging last makes it structurally
+/// impossible for a stale disk value to shadow live chunk state. A bug in the filter can
+/// then only ever drop a foreign tag, never corrupt an owned one.
+///
+/// Deliberately not `Extend`: `NbtCompound` has two `Extend` impls that disagree about
+/// overwriting, and the call site cannot show which one is selected.
+fn merge_foreign_root_tags(root: &mut NbtCompound, retained: &NbtCompound) {
+    for (key, tag) in &retained.child_tags {
+        root.put(key, tag.clone());
+    }
+}
+
 impl ChunkData {
     #[allow(clippy::too_many_lines)]
     pub fn internal_from_bytes(
@@ -367,6 +445,19 @@ impl ChunkData {
             _ => ChunkStatus::Empty,
         };
 
+        // Only a chunk loaded at `full` is guaranteed to be written back over the same
+        // terrain. Anything below `full` goes straight back into the generation pipeline
+        // through `ProtoChunk::from_chunk_data`, which restores blocks and heightmaps but
+        // leaves `structure_starts` empty and `carving_mask` fresh, so the chunk is
+        // finished *without* the structures the retained metadata describes. An
+        // unrecognised `Status` lands here too, via the fall-through above — precisely
+        // the case where we must not vouch for anything.
+        let retained_nbt = if status == ChunkStatus::Full {
+            retain_foreign_root_tags(&root_tag)
+        } else {
+            NbtCompound::new()
+        };
+
         Ok(Self {
             section,
             heightmap: std::sync::Mutex::new(heightmaps),
@@ -382,6 +473,7 @@ impl ChunkData {
             status,
             blending_data: None,
             inhabited_time: AtomicU64::new(root_tag.get_long("InhabitedTime").unwrap_or(0) as u64),
+            retained_nbt,
         })
     }
 
@@ -529,6 +621,18 @@ impl ChunkData {
         root_compound.put_list("block_entities", block_entities_list);
 
         root_compound.put_bool("isLightOn", is_light_correct);
+
+        // The live value, never a retained one — this is incremented every tick in
+        // `World::tick`. Before this it was parsed on load and then never written, so the
+        // first save zeroed whatever had accumulated.
+        root_compound.put_long(
+            "InhabitedTime",
+            self.inhabited_time.load(Ordering::Relaxed) as i64,
+        );
+
+        // Last. See `merge_foreign_root_tags` — `put` is insert-if-absent, so an owned key
+        // can never be shadowed by a stale value off disk.
+        merge_foreign_root_tags(&mut root_compound, &self.retained_nbt);
 
         let mut result = Vec::new();
         pumpkin_nbt::serializer::to_bytes(&root_compound, &mut result)
@@ -757,4 +861,290 @@ struct EntityNbt {
     data_version: i32,
     position: [i32; 2],
     entities: Vec<NbtCompound>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NEVER_RETAINED_ROOT_KEYS, WORLD_DATA_VERSION, WRITTEN_ROOT_KEYS};
+    use crate::chunk::ChunkData;
+    use pumpkin_nbt::compound::NbtCompound;
+    use pumpkin_nbt::tag::NbtTag;
+    use pumpkin_util::math::vector2::Vector2;
+    use std::sync::atomic::Ordering;
+
+    /// The smallest root compound `internal_from_bytes` accepts. An empty `sections` list
+    /// is valid: `max_y_section` starts at `min_y_section`, so the section count is 1.
+    fn minimal_root(status: &str) -> NbtCompound {
+        let mut root = NbtCompound::new();
+        root.put_int("DataVersion", WORLD_DATA_VERSION);
+        root.put_int("xPos", 0);
+        root.put_int("zPos", 0);
+        root.put_int("yPos", -4);
+        root.put_string("Status", status.to_string());
+        root.put_list("sections", Vec::new());
+        root
+    }
+
+    fn encode(root: &NbtCompound) -> Vec<u8> {
+        let mut buf = Vec::new();
+        pumpkin_nbt::serializer::to_bytes(root, &mut buf).expect("serialize fixture");
+        buf
+    }
+
+    fn decode_root(bytes: &[u8]) -> NbtCompound {
+        let mut cursor = std::io::Cursor::new(bytes);
+        let mut reader = pumpkin_nbt::deserializer::NbtReadHelperJava::new(&mut cursor);
+        pumpkin_nbt::Nbt::read(&mut reader)
+            .expect("reparse written chunk")
+            .root_tag
+    }
+
+    fn parse(root: &NbtCompound) -> ChunkData {
+        ChunkData::internal_from_bytes(&encode(root), Vector2::new(0, 0)).expect("parse fixture")
+    }
+
+    fn round_trip(root: &NbtCompound) -> NbtCompound {
+        decode_root(&parse(root).internal_to_bytes().expect("serialize chunk"))
+    }
+
+    fn sorted_keys(root: &NbtCompound) -> Vec<&str> {
+        let mut keys: Vec<&str> = root.child_tags.keys().map(AsRef::as_ref).collect();
+        keys.sort_unstable();
+        keys
+    }
+
+    #[test]
+    fn foreign_root_tags_survive_a_disk_round_trip() {
+        let mut fixture = minimal_root("minecraft:full");
+
+        let mut structures = NbtCompound::new();
+        structures.put_compound("starts", NbtCompound::new());
+        structures.put_compound("References", NbtCompound::new());
+        fixture.put_compound("structures", structures);
+        fixture.put("LastUpdate", NbtTag::Long(1_287_805));
+        fixture.put_compound("blending_data", NbtCompound::new());
+        // A tag no version of this server knows about, to pin the future-proofing claim:
+        // an unrecognised key survives with no code change. The list of empty lists is the
+        // load-bearing shape here, being the only nested empty sequence.
+        fixture.put_list(
+            "some_future_mojang_tag",
+            (0..24).map(|_| NbtTag::List(Vec::new())).collect(),
+        );
+
+        let out = round_trip(&fixture);
+
+        for key in [
+            "structures",
+            "LastUpdate",
+            "blending_data",
+            "some_future_mojang_tag",
+        ] {
+            assert_eq!(
+                out.get(key),
+                fixture.get(key),
+                "foreign root tag `{key}` was not preserved across a save"
+            );
+        }
+    }
+
+    #[test]
+    fn work_directive_root_tags_are_never_retained() {
+        let mut fixture = minimal_root("minecraft:full");
+        // Spelled out rather than iterated from NEVER_RETAINED_ROOT_KEYS, so that deleting
+        // a key from that constant also has to fail here.
+        fixture.put_list("entities", vec![NbtTag::Compound(NbtCompound::new())]);
+        fixture.put_list("PostProcessing", Vec::new());
+        fixture.put_compound("below_zero_retrogen", NbtCompound::new());
+        fixture.put_compound("UpgradeData", NbtCompound::new());
+        fixture.put("carving_mask", NbtTag::LongArray(vec![1, 2, 3]));
+
+        let out = round_trip(&fixture);
+
+        // `entities` is excluded because entities live in the separate `entities/` region
+        // folder; a retained copy would be a second, never-updated set of the same mobs.
+        // The rest record work still to be done, which we have no way to perform or clear.
+        for key in [
+            "entities",
+            "PostProcessing",
+            "below_zero_retrogen",
+            "UpgradeData",
+            "carving_mask",
+        ] {
+            assert!(!out.has(key), "`{key}` should never be written back");
+        }
+    }
+
+    #[test]
+    fn owned_root_keys_are_rewritten_from_the_live_chunk() {
+        let mut fixture = minimal_root("minecraft:full");
+        fixture.put_int("DataVersion", 1234);
+
+        let out = round_trip(&fixture);
+
+        // Regression test for the insert-if-absent `put`: if `merge_foreign_root_tags` ever
+        // moves above the owned puts, `DataVersion` comes back as 1234 and this fails.
+        assert_eq!(out.get_int("DataVersion"), Some(WORLD_DATA_VERSION));
+        assert_eq!(out.get_string("Status"), Some("minecraft:full"));
+        assert_eq!(out.get_int("xPos"), Some(0));
+        assert_eq!(out.get_int("zPos"), Some(0));
+        assert_eq!(out.get_int("yPos"), Some(-4));
+    }
+
+    #[test]
+    fn heightmaps_round_trip_verbatim_through_the_typed_field() {
+        let mut heightmaps = NbtCompound::new();
+        heightmaps.put("WORLD_SURFACE", NbtTag::LongArray(vec![7; 37]));
+        let mut fixture = minimal_root("minecraft:full");
+        fixture.put_compound("Heightmaps", heightmaps);
+
+        let out = round_trip(&fixture);
+
+        // Heightmaps are parsed into `ChunkHeightmaps` and re-emitted from it; nothing
+        // recomputes them on the load path. So they are owned by the writer but not
+        // *derived* by it, and they never route through `retained_nbt`.
+        let written = out.get_compound("Heightmaps").expect("Heightmaps written");
+        assert_eq!(
+            written.get_long_array("WORLD_SURFACE"),
+            Some(&[7i64; 37][..])
+        );
+    }
+
+    #[test]
+    fn inhabited_time_round_trips_through_disk() {
+        let mut fixture = minimal_root("minecraft:full");
+        fixture.put_long("InhabitedTime", 123_456);
+
+        assert_eq!(
+            parse(&fixture).inhabited_time.load(Ordering::Relaxed),
+            123_456
+        );
+        // Before this fix the key was parsed and never written, so the first save zeroed
+        // whatever had accumulated.
+        assert_eq!(
+            round_trip(&fixture).get_long("InhabitedTime"),
+            Some(123_456)
+        );
+    }
+
+    #[test]
+    fn inhabited_time_is_written_from_the_live_value() {
+        let mut fixture = minimal_root("minecraft:full");
+        fixture.put_long("InhabitedTime", 100);
+
+        let chunk = parse(&fixture);
+        chunk.inhabited_time.store(500, Ordering::Relaxed);
+        let out = decode_root(&chunk.internal_to_bytes().expect("serialize chunk"));
+
+        assert_eq!(out.get_long("InhabitedTime"), Some(500));
+    }
+
+    #[test]
+    fn writer_emits_exactly_the_written_root_keys() {
+        let out = round_trip(&minimal_root("minecraft:full"));
+
+        let mut expected: Vec<&str> = WRITTEN_ROOT_KEYS.to_vec();
+        expected.sort_unstable();
+        assert_eq!(sorted_keys(&out), expected);
+
+        // Cross-check against a literal list. Without this, a change that stops writing a
+        // key *and* drops it from the constant would pass the assertion above, and that key
+        // would silently start being echoed back off disk instead.
+        assert_eq!(
+            expected,
+            [
+                "DataVersion",
+                "Heightmaps",
+                "InhabitedTime",
+                "Status",
+                "block_entities",
+                "block_ticks",
+                "fluid_ticks",
+                "isLightOn",
+                "sections",
+                "xPos",
+                "yPos",
+                "zPos",
+            ]
+        );
+    }
+
+    #[test]
+    fn chunks_below_full_status_retain_nothing() {
+        let mut fixture = minimal_root("minecraft:features");
+        fixture.put_compound("structures", NbtCompound::new());
+        fixture.put("LastUpdate", NbtTag::Long(1));
+
+        // A chunk below `full` goes back through the generation pipeline, which finishes it
+        // without the structures this metadata describes. Losing the tags is what we already
+        // did; writing them back beside contradicting terrain would be new damage.
+        assert!(parse(&fixture).retained_nbt.is_empty());
+        let out = round_trip(&fixture);
+        assert!(!out.has("structures"));
+        assert!(!out.has("LastUpdate"));
+    }
+
+    #[test]
+    fn unrecognized_status_retains_nothing() {
+        let mut fixture = minimal_root("minecraft:some_future_step");
+        fixture.put_compound("structures", NbtCompound::new());
+
+        // An unknown status falls through to `ChunkStatus::Empty`, so the terrain is
+        // regenerated from scratch — the worst case for vouching for stale metadata.
+        assert!(parse(&fixture).retained_nbt.is_empty());
+    }
+
+    #[test]
+    fn retained_tags_survive_the_proto_chunk_round_trip() {
+        use crate::ProtoChunk;
+        use crate::chunk_system::chunk_state::Chunk;
+        use crate::generation::get_world_gen;
+        use pumpkin_config::lighting::LightingEngineConfig;
+        use pumpkin_data::dimension::Dimension;
+        use pumpkin_util::world_seed::Seed;
+
+        // Flat, so there is no noise-router setup cost.
+        let world_gen = get_world_gen(
+            Seed(0),
+            Dimension::OVERWORLD,
+            true,
+            Vec::new(),
+            String::new(),
+        );
+
+        // A chunk we generated ourselves pays nothing for any of this.
+        assert!(ProtoChunk::new(0, 0, &world_gen).retained_nbt.is_empty());
+
+        let mut fixture = minimal_root("minecraft:full");
+        fixture.put_compound("structures", NbtCompound::new());
+        fixture.put_long("InhabitedTime", 777);
+
+        // The level -> proto -> level trip a full chunk makes when it is downgraded for
+        // relighting. Without the carry on `ProtoChunk`, both assertions below fail and the
+        // fix is silently vacuous on this path.
+        let mut chunk = Chunk::Proto(Box::new(ProtoChunk::from_chunk_data(
+            &parse(&fixture),
+            &world_gen,
+        )));
+        chunk.upgrade_to_level_chunk(&Dimension::OVERWORLD, &LightingEngineConfig::Default);
+        let Chunk::Level(rebuilt) = chunk else {
+            panic!("upgrade_to_level_chunk did not produce a level chunk");
+        };
+
+        let out = decode_root(&rebuilt.internal_to_bytes().expect("serialize chunk"));
+        assert_eq!(out.get("structures"), fixture.get("structures"));
+        assert_eq!(out.get_long("InhabitedTime"), Some(777));
+        // Deliberately asserts nothing about section counts: #2551 changes
+        // `ProtoChunk::new`'s height source, which changes them.
+    }
+
+    #[test]
+    fn owned_keys_are_disjoint_from_never_retained_keys() {
+        for key in NEVER_RETAINED_ROOT_KEYS {
+            assert!(
+                !WRITTEN_ROOT_KEYS.contains(key),
+                "`{key}` is both written and never-retained; the writer would emit it \
+                 while the filter claims we drop it"
+            );
+        }
+    }
 }

--- a/pumpkin-world/src/chunk/format/mod.rs
+++ b/pumpkin-world/src/chunk/format/mod.rs
@@ -21,6 +21,7 @@ use crate::{
         format::anvil::{SingleChunkDataSerializer, WORLD_DATA_VERSION},
         io::{Dirtiable, file_manager::PathFromLevelFolder},
     },
+    chunk_system::chunk_state::StagedChunkEnum,
     generation::section_coords,
     level::LevelFolder,
     tick::{ScheduledTick, TickPriority, scheduler::ChunkTickScheduler},
@@ -188,8 +189,13 @@ const WRITTEN_ROOT_KEYS: &[&str] = &[
 /// - `entities`: entities live in the separate `entities/` region folder, so a retained
 ///   copy would be a second, never-updated set of the same mobs.
 /// - `PostProcessing`, `below_zero_retrogen`, `UpgradeData`: work records.
-/// - `carving_mask`: generation-stage scratch state. Unreachable in practice, since we
-///   only retain from chunks loaded at `Status: full`, but listed so the rule stays legible.
+/// - `carving_mask`: generation-stage scratch state.
+/// - `Lights`: vanilla's per-section list of light sources still to be processed,
+///   written for chunks below `light` status. Retaining it would put a work record on a
+///   chunk we go on to stamp `Status: minecraft:full`.
+///
+/// `carving_mask` and `Lights` only became reachable when the retention cutoff moved from
+/// `full` down to `features`; both belong to chunks caught mid-generation.
 ///
 /// How these are classified is reasoning about vanilla rather than something validated
 /// against a real region file. What is verified is that we have no code for any of them.
@@ -199,6 +205,7 @@ const NEVER_RETAINED_ROOT_KEYS: &[&str] = &[
     "below_zero_retrogen",
     "UpgradeData",
     "carving_mask",
+    "Lights",
 ];
 
 fn is_owned_root_key(key: &str) -> bool {
@@ -445,14 +452,26 @@ impl ChunkData {
             _ => ChunkStatus::Empty,
         };
 
-        // Only a chunk loaded at `full` is guaranteed to be written back over the same
-        // terrain. Anything below `full` goes straight back into the generation pipeline
-        // through `ProtoChunk::from_chunk_data`, which restores blocks and heightmaps but
-        // leaves `structure_starts` empty and `carving_mask` fresh, so the chunk is
-        // finished *without* the structures the retained metadata describes. An
-        // unrecognised `Status` lands here too, via the fall-through above — precisely
-        // the case where we must not vouch for anything.
-        let retained_nbt = if status == ChunkStatus::Full {
+        // Retain only from a chunk that will be written back over the same terrain the
+        // metadata describes.
+        //
+        // A chunk below `features` goes back into the generation pipeline through
+        // `ProtoChunk::from_chunk_data`, which restores blocks and heightmaps but leaves
+        // `structure_starts` empty and `carving_mask` fresh, so it is finished *without*
+        // the structures the retained metadata claims are there. An unrecognised `Status`
+        // falls through to `Empty` above and lands here too — precisely the case where we
+        // must not vouch for anything.
+        //
+        // At or above `features` that cannot happen: the features/structures step never
+        // re-runs for such a chunk. `drop_satisfied_tasks` deletes every task at or below
+        // the loaded stage, `Cache::advance` early-returns for a stage already reached,
+        // and the dispatch loop drops queued nodes for reached stages. `structure_starts`
+        // is only ever filled by `set_structure_starts`/`set_structure_references`, whose
+        // tasks are dropped for anything loaded at or above `StructureReferences`.
+        //
+        // So `features` is the boundary, not `full` — gating on `full` made this a no-op
+        // for exactly the chunks #2626 reported, which sit at `initialize_light`.
+        let retained_nbt = if StagedChunkEnum::from(status) >= StagedChunkEnum::Features {
             retain_foreign_root_tags(&root_tag)
         } else {
             NbtCompound::new()
@@ -957,6 +976,10 @@ mod tests {
         fixture.put_compound("below_zero_retrogen", NbtCompound::new());
         fixture.put_compound("UpgradeData", NbtCompound::new());
         fixture.put("carving_mask", NbtTag::LongArray(vec![1, 2, 3]));
+        fixture.put_list(
+            "Lights",
+            (0..24).map(|_| NbtTag::List(Vec::new())).collect(),
+        );
 
         let out = round_trip(&fixture);
 
@@ -969,7 +992,28 @@ mod tests {
             "below_zero_retrogen",
             "UpgradeData",
             "carving_mask",
+            "Lights",
         ] {
+            assert!(!out.has(key), "`{key}` should never be written back");
+        }
+    }
+
+    #[test]
+    fn work_directive_root_tags_are_never_retained_below_full_either() {
+        // The exclusions have to hold at the bottom of the retention range too, which is
+        // where a half-generated vanilla chunk actually carries them. `carving_mask` and
+        // `Lights` are unreachable at `full` and reachable here.
+        let mut fixture = minimal_root("minecraft:initialize_light");
+        fixture.put("carving_mask", NbtTag::LongArray(vec![1, 2, 3]));
+        fixture.put_list(
+            "Lights",
+            (0..24).map(|_| NbtTag::List(Vec::new())).collect(),
+        );
+        fixture.put_list("PostProcessing", Vec::new());
+
+        let out = round_trip(&fixture);
+
+        for key in ["carving_mask", "Lights", "PostProcessing"] {
             assert!(!out.has(key), "`{key}` should never be written back");
         }
     }
@@ -1069,18 +1113,45 @@ mod tests {
     }
 
     #[test]
-    fn chunks_below_full_status_retain_nothing() {
-        let mut fixture = minimal_root("minecraft:features");
+    fn chunks_below_the_features_stage_retain_nothing() {
+        let mut fixture = minimal_root("minecraft:carvers");
         fixture.put_compound("structures", NbtCompound::new());
         fixture.put("LastUpdate", NbtTag::Long(1));
 
-        // A chunk below `full` goes back through the generation pipeline, which finishes it
-        // without the structures this metadata describes. Losing the tags is what we already
-        // did; writing them back beside contradicting terrain would be new damage.
+        // A chunk below `features` still has its features/structures step ahead of it, so
+        // it is finished without the structures this metadata describes. Losing the tags is
+        // what we already did; writing them back beside contradicting terrain would be new
+        // damage.
         assert!(parse(&fixture).retained_nbt.is_empty());
         let out = round_trip(&fixture);
         assert!(!out.has("structures"));
         assert!(!out.has("LastUpdate"));
+    }
+
+    #[test]
+    fn chunks_from_the_features_stage_up_retain_their_metadata() {
+        // The statuses a half-generated vanilla world actually contains, including the
+        // `initialize_light` of #2626's reported chunk. Gating on `full` meant every one of
+        // these was still stripped on save.
+        for status in [
+            "minecraft:features",
+            "minecraft:initialize_light",
+            "minecraft:light",
+            "minecraft:spawn",
+            "minecraft:full",
+        ] {
+            let mut fixture = minimal_root(status);
+            fixture.put_compound("structures", NbtCompound::new());
+            fixture.put("LastUpdate", NbtTag::Long(1));
+
+            assert!(
+                !parse(&fixture).retained_nbt.is_empty(),
+                "`{status}` should retain foreign tags"
+            );
+            let out = round_trip(&fixture);
+            assert!(out.has("structures"), "`{status}` dropped `structures`");
+            assert!(out.has("LastUpdate"), "`{status}` dropped `LastUpdate`");
+        }
     }
 
     #[test]

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -83,6 +83,13 @@ pub struct ChunkData {
     pub blending_data: Option<crate::generation::blender::blending_data::BlendingData>,
     pub dirty: AtomicBool,
     pub inhabited_time: AtomicU64,
+    /// Root NBT tags read off disk that we do not model, kept verbatim so saving a
+    /// chunk does not strip them.
+    ///
+    /// Populated only for chunks loaded at `Status: full`; empty for generated chunks
+    /// and for anything that re-enters the generation pipeline. Immutable after
+    /// construction, hence no lock. See `format::retain_foreign_root_tags`.
+    pub retained_nbt: NbtCompound,
 }
 
 pub struct ChunkEntityData {

--- a/pumpkin-world/src/chunk_system/chunk_state.rs
+++ b/pumpkin-world/src/chunk_system/chunk_state.rs
@@ -6,6 +6,7 @@ use crate::generation::biome_coords;
 use crate::tick::scheduler::ChunkTickScheduler;
 use pumpkin_config::lighting::LightingEngineConfig;
 use pumpkin_data::dimension::Dimension;
+use pumpkin_nbt::compound::NbtCompound;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64};
@@ -278,6 +279,7 @@ impl Chunk {
                 blending_data: None,
                 dirty: AtomicBool::new(false),
                 inhabited_time: AtomicU64::new(0),
+                retained_nbt: NbtCompound::new(),
             })),
         ) {
             Self::Proto(proto) => proto,
@@ -323,7 +325,8 @@ impl Chunk {
             pending_block_entities: Mutex::new(pending_block_entities),
             status: proto_chunk.stage.into(),
             blending_data: proto_chunk.blending_data,
-            inhabited_time: AtomicU64::new(0),
+            inhabited_time: AtomicU64::new(proto_chunk.inhabited_time),
+            retained_nbt: proto_chunk.retained_nbt,
         };
 
         *self = Self::Level(Arc::new(chunk));

--- a/pumpkin-world/src/generation/proto_chunk.rs
+++ b/pumpkin-world/src/generation/proto_chunk.rs
@@ -145,6 +145,14 @@ pub struct ProtoChunk {
     pub blending_data: Option<crate::generation::blender::blending_data::BlendingData>,
     pub pending_block_entities: Vec<NbtCompound>,
     pub fluid_ticks: Vec<ScheduledTick<&'static Fluid>>,
+    /// Carried through the level -> proto -> level round trip performed when a full chunk
+    /// is downgraded for relighting; see [`ChunkData::retained_nbt`]. Empty for every
+    /// chunk loaded below `Status: full`, because capture is gated on `full`, so this can
+    /// never re-attach metadata to terrain the generation pipeline rebuilt.
+    pub retained_nbt: NbtCompound,
+    /// Ditto. Without this the relight downgrade resets a loaded chunk's inhabited time
+    /// to zero when the level chunk is rebuilt.
+    pub inhabited_time: u64,
 }
 
 pub struct TerrainCache {
@@ -230,6 +238,8 @@ impl ProtoChunk {
             blending_data: None,
             pending_block_entities: Vec::new(),
             fluid_ticks: Vec::new(),
+            retained_nbt: NbtCompound::new(),
+            inhabited_time: 0,
         }
     }
 
@@ -244,6 +254,12 @@ impl ProtoChunk {
         proto_chunk
             .blending_data
             .clone_from(&chunk_data.blending_data);
+        proto_chunk
+            .retained_nbt
+            .clone_from(&chunk_data.retained_nbt);
+        proto_chunk.inhabited_time = chunk_data
+            .inhabited_time
+            .load(std::sync::atomic::Ordering::Relaxed);
 
         let section_data = &chunk_data.section;
         let heightmap_data = chunk_data.heightmap.lock().unwrap();


### PR DESCRIPTION
Part of #2626 — see "What this does not fix" below, which is most of the reported symptom.

## What changed

`ChunkData::internal_to_bytes` builds a fresh root compound and writes eleven keys. Every other root tag on the parsed chunk died with the local `let root_tag = nbt.root_tag;` binding, so saving a chunk stripped it. This PR addresses two separate losses in that function.

**`InhabitedTime` was parsed on load and never written back.** It is not foreign metadata — it is our own live field. `World::tick` increments it every tick for every chunk in a player's active set, and `MobSpawnEquipment` reads it for regional difficulty (`local_scale += chunk_inhabited_time / 3_600_000`). It was read at load, incremented in memory, and then silently dropped on save, so **the first save zeroed whatever had accumulated** and local difficulty could never rise above whatever was already on disk. It is now a twelfth written key, sourced from the live atomic rather than from the retained map, so a stale disk value cannot shadow it.

**Root tags we do not model are now preserved.** `structures`, `LastUpdate`, `blending_data` and anything a future version adds are cloned off the parsed root into a new `ChunkData::retained_nbt` and merged back at the end of the writer.

Merging last is load-bearing: `NbtCompound::put` is insert-if-absent, so a bug in the filter can only ever drop a foreign tag, never corrupt an owned one. There is a test pinning that ordering.

## Retention is gated at `features`, not `full`

An earlier revision of this PR gated retention on `Status: full`. That was wrong, and it made the whole change a no-op for the chunks actually reported — #2626's diff is of a chunk at `minecraft:initialize_light`. Thanks to @Sawlyer for catching it.

The cutoff is now `StagedChunkEnum::from(status) >= StagedChunkEnum::Features`.

Below `features`, the original reasoning stands: the chunk re-enters generation through `ProtoChunk::from_chunk_data`, which restores blocks and heightmaps but leaves `structure_starts` empty and `carving_mask` fresh, so it is finished *without* the structures the retained metadata describes. Writing that metadata back beside contradicting terrain would convert an honest data loss into a chunk that lies about its own contents. An unrecognised `Status` falls through to `ChunkStatus::Empty` and lands here too.

At or above `features` that cannot happen — the features/structures step never re-runs for such a chunk, three times over:

- `drop_satisfied_tasks` deletes every task at or below the loaded stage on IO completion
- `Cache::advance` early-returns when the centre chunk has already reached the requested stage
- the scheduler's dispatch loop drops queued nodes for already-reached stages

and `structure_starts` is only ever populated by `set_structure_starts`/`set_structure_references`, whose tasks are dropped for anything loaded at or above `StructureReferences`.

Widening the cutoff makes two keys reachable that could not appear under a `full`-only gate: `carving_mask` and `Lights`, both of which belong to chunks caught mid-generation. `Lights` — vanilla's per-section list of light sources still to be processed — was in neither the written nor the never-retained list, because it was previously unreachable. It is now excluded, since retaining it would write a work record onto a chunk we go on to stamp `Status: minecraft:full`.

**Keys that record work still to be done are never retained**, as opposed to keys that describe what is already present. `PostProcessing`, `below_zero_retrogen`, `UpgradeData`, `carving_mask` and `Lights` are instructions to re-run work on load. We have no code for any of them, so we can neither perform nor clear them — retaining one would re-assert the same directive on every save, against blocks that have since changed. Root `entities` is excluded separately because entities live in the `entities/` region folder, so a retained copy would be a second, never-updated set of the same mobs.

How those keys are classified is reasoning about vanilla, not something validated against a real region file — there is no `.mca` fixture in the workspace. The doc comment says so. **If you have a vanilla world and think I have misclassified a key, please say so.**

## What this does not fix

**Block entities, and block and fluid ticks, are still lost on the same chunks.** This is the headline symptom of #2626 — the emptied chests — and it is a different bug in a different place, so this PR does not close the issue.

`block_entities` is a *modeled* field, so it never routes through `retained_nbt` by design. It dies in `ProtoChunk::from_chunk_data`, which never copies `chunk_data.pending_block_entities`; `upgrade_to_level_chunk` then rebuilds the saved chunk from the empty vector `ProtoChunk::new` installed. `fluid_ticks` goes the same way, and `block_ticks` worse — `ProtoChunk` has no such field at all, so the rebuild hardcodes `ChunkTickScheduler::default()`.

Two things make that worse than the tag loss fixed here: it needs no player interaction, since Proto chunks skip the `is_dirty()` check that Level chunks get on the save path; and it is not limited to below-full chunks, since `needs_relighting` sends `full` chunks with `isLightOn: false` through the same `from_chunk_data`. Sent separately.

Note this is distinct from #2452, which persists *live* block entities out of `World::block_entities`. That one covers entities a player has touched; this one covers entities that were on disk and never made it back out. #2626 needs both.

## Known limitations

- Chunks below `features` still lose foreign root tags, deliberately, as above.
- Nested tags inside *owned* keys are still dropped — notably the `OCEAN_FLOOR` heightmap, since `ChunkHeightmaps` models three of vanilla's four. Root-level retention does not reach it. This is not a fully lossless round trip.
- An `initialize_light` chunk is written back as `Status: minecraft:light` with `isLightOn: true`, because `ChunkStatus::InitializeLight | Light` both map to `StagedChunkEnum::Lighting` and the Lighting task is then dropped as satisfied. So light initialization never actually runs for it. Pre-existing, orthogonal to this PR, and worth its own issue.

## Impact

- Vanilla-authored `structures` / `LastUpdate` and any unrecognised root tag now survive a save on any chunk at or above `features`, which is the population a half-generated imported world mostly consists of.
- `InhabitedTime` now persists, on every world including ones we generated ourselves. This is a behaviour change: regional difficulty will now actually accumulate across restarts rather than resetting.
- No new locks, no new allocations for generated chunks (`retained_nbt` is empty by construction and costs an empty `HashMap`). For a loaded chunk the retained subset is cloned once per save.

## Changes since first review

- Gate moved from `full` to `features`; `chunks_below_full_status_retain_nothing` replaced by a pair of tests covering both sides of the new boundary, including `initialize_light`.
- `Lights` added to the never-retained set, with coverage at both ends of the retention range.
- The `perf(world)` commit that released the section, heightmap and light guards early has been **dropped from this PR**. Its "no behaviour change" claim was false: `block_ticks`/`fluid_ticks` are read after the drops, and the section read guard was an incidental barrier against a concurrent `set_block_no_heightmap_update` plus its `schedule_tick`. It will be resent on its own with the tick queues snapshotted above the drops. (Block entities were never affected — they are snapshotted under their own mutex before any of the four guards are taken.)
- The `DataVersion` mismatch is fixed in #2640 rather than here, since that is the PR that makes our chunks readable by vanilla at all and therefore makes the stamp matter.
