### PR TITLE
fix(block): damage shears when carving pumpkins

### DIFF
--- a/pumpkin/src/block/blocks/pumpkin.rs
+++ b/pumpkin/src/block/blocks/pumpkin.rs
@@ -47,7 +47,9 @@ impl crate::block::BlockBehaviour for PumpkinBlock {
                 ItemStack::new(4, &Item::PUMPKIN_SEEDS),
             ));
             args.world.spawn_entity(item_entity).await;
-            // TODO: Deduct 1 durability from held shears (skip in Creative mode).
+            args.player
+                .damage_item_in_slot(args.equipment_slot, 1)
+                .await;
             BlockActionResult::Consume
         })
     }

--- a/pumpkin/src/block/mod.rs
+++ b/pumpkin/src/block/mod.rs
@@ -22,6 +22,7 @@ use crate::entity::EntityBase;
 use crate::server::Server;
 use pumpkin_data::BlockDirection;
 use pumpkin_data::block_rotation::{Mirror, Rotation};
+use pumpkin_data::data_component_impl::EquipmentSlot;
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_protocol::java::server::play::SUseItemOn;
 use pumpkin_util::math::boundingbox::BoundingBox;
@@ -247,6 +248,7 @@ pub struct UseWithItemArgs<'a> {
     pub player: &'a Arc<Player>,
     pub hit: &'a BlockHitResult<'a>,
     pub item_stack: &'a Arc<Mutex<ItemStack>>,
+    pub equipment_slot: &'a EquipmentSlot,
 }
 
 pub struct BlockHitResult<'a> {

--- a/pumpkin/src/block/registry.rs
+++ b/pumpkin/src/block/registry.rs
@@ -145,6 +145,7 @@ use crate::server::Server;
 use crate::world::World;
 use pumpkin_data::BlockStateId;
 use pumpkin_data::block_rotation::{Mirror, Rotation};
+use pumpkin_data::data_component_impl::EquipmentSlot;
 use pumpkin_data::fluid::Fluid;
 use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
@@ -782,6 +783,7 @@ impl BlockRegistry {
         position: &BlockPos,
         hit: &BlockHitResult<'_>,
         item_stack: &Arc<Mutex<ItemStack>>,
+        equipment_slot: &EquipmentSlot,
         server: &Server,
         world: &Arc<World>,
     ) -> BlockActionResult {
@@ -796,6 +798,7 @@ impl BlockRegistry {
                     player,
                     hit,
                     item_stack,
+                    equipment_slot,
                 })
                 .await;
         }

--- a/pumpkin/src/net/bedrock/play.rs
+++ b/pumpkin/src/net/bedrock/play.rs
@@ -670,6 +670,7 @@ impl BedrockClient {
                                 cursor_pos: &data.click_position,
                             },
                             &held_item,
+                            &EquipmentSlot::MAIN_HAND,
                             &server,
                             &world,
                         )

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -2249,6 +2249,11 @@ impl JavaClient {
         } else {
             off_hand_item
         };
+        let equipment_slot = if matches!(hand, Hand::Left) {
+            EquipmentSlot::MAIN_HAND
+        } else {
+            EquipmentSlot::OFF_HAND
+        };
 
         let item_id = item.lock().await.item.id;
         player
@@ -2290,6 +2295,7 @@ impl JavaClient {
                     &cursor_pos,
                     &face,
                     &item,
+                    &equipment_slot,
                     &world,
                     block,
                     server,
@@ -2375,6 +2381,7 @@ impl JavaClient {
         cursor_pos: &Vector3<f32>,
         face: &BlockDirection,
         held_item: &Arc<Mutex<ItemStack>>,
+        equipment_slot: &EquipmentSlot,
         world: &Arc<World>,
         block: &Block,
         server: &Arc<Server>,
@@ -2387,6 +2394,7 @@ impl JavaClient {
                 position,
                 &BlockHitResult { face, cursor_pos },
                 held_item,
+                equipment_slot,
                 server,
                 world,
             )


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

Fixes shears not getting damaged when carving pumpkins

Now shears gets damaged when carving pumpkins as per the vanilla logic.

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] Manually tested shears when carving pumpkins.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
