### PR TITLE
fix: persist air supply across relog

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -4268,6 +4268,15 @@ impl NBTStorage for Player {
             // Store food level, saturation, exhaustion, and tick timer
             self.hunger_manager.write_nbt(nbt).await;
 
+            nbt.put_int(
+                "AirSupply",
+                self.breath_manager.air_supply.load(Ordering::Relaxed),
+            );
+            nbt.put_int(
+                "DrowningTick",
+                self.breath_manager.drowning_tick.load(Ordering::Relaxed),
+            );
+
             nbt.put_string(
                 "Dimension",
                 self.world().dimension.minecraft_name.to_string(),
@@ -4319,6 +4328,15 @@ impl NBTStorage for Player {
             );
 
             self.hunger_manager.read_nbt(nbt).await;
+
+            if let Some(air) = nbt.get_int("AirSupply") {
+                self.breath_manager.air_supply.store(air, Ordering::Relaxed);
+            }
+            if let Some(tick) = nbt.get_int("DrowningTick") {
+                self.breath_manager
+                    .drowning_tick
+                    .store(tick, Ordering::Relaxed);
+            }
 
             // Load any saved spawnpoint data (SpawnX/SpawnY/SpawnZ, SpawnDimension, SpawnForced)
             if let (Some(x), Some(y), Some(z)) = (

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -3145,6 +3145,7 @@ impl World {
             .await;
 
         player.send_active_effects().await;
+        player.breath_manager.send_air_supply(player);
         self.send_player_equipment(player).await;
 
         if let crate::net::ClientPlatform::Java(java_client) = player.client.as_ref()


### PR DESCRIPTION
Air was not saved to NBT, causing it to reset to full on every login. This allowed players to exploit drowning by relogging to restore lost air bubbles.

(PR superseeded in other PR this one I screwed up my git so)