### PR TITLE
plugin-api: Improve `PluginInitError` messages

### DIFF
--- a/pumpkin/src/plugin/cache.rs
+++ b/pumpkin/src/plugin/cache.rs
@@ -30,14 +30,19 @@ impl PermissionCache {
 }
 
 pub async fn calculate_hash(path: &Path) -> tokio::io::Result<String> {
+    let bytes = fs::read(path).await?;
+    Ok(calculate_hash_for_bytes(&bytes))
+}
+
+#[must_use]
+pub fn calculate_hash_for_bytes(bytes: &[u8]) -> String {
     use std::fmt::Write;
 
-    let bytes = fs::read(path).await?;
     let mut hasher = Sha256::new();
-    hasher.update(&bytes);
+    hasher.update(bytes);
     let result = hasher.finalize();
-    Ok(result.iter().fold(String::new(), |mut output, b| {
+    result.iter().fold(String::new(), |mut output, b| {
         let _ = write!(output, "{b:02x}");
         output
-    }))
+    })
 }

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
@@ -5,7 +5,8 @@ use wasmtime::{Cache, CacheConfig, Engine, Store, component::Component, componen
 use wasmtime_wasi::{DirPerms, FilePerms, WasiCtxBuilder, sockets::SocketAddrUse};
 
 use crate::plugin::{
-    Context, PluginMetadata, loader::wasm::wasm_host::state::PluginHostState, permissions,
+    Context, PluginMetadata, cache::calculate_hash_for_bytes,
+    loader::wasm::wasm_host::state::PluginHostState, permissions,
 };
 
 pub mod args;
@@ -15,16 +16,26 @@ pub mod wit;
 
 #[derive(Error, Debug)]
 pub enum PluginInitError {
-    #[error("Engine creation failed")]
+    #[error("Engine creation failed: {0}")]
     EngineCreationFailed(wasmtime::Error),
-    #[error("Failed to setup linker")]
+    #[error("Failed to setup linker: {0}")]
     LinkerSetupFailed(wasmtime::Error),
-    #[error("plugin API version mismatch")]
-    ApiVersionMismatch,
-    #[error("failed to read plugin bytes")]
-    FailedToReadPluginBytes(#[from] std::io::Error),
-    #[error("plugin failed to load with error: {0}")]
-    PluginFailedToLoad(#[from] wasmtime::Error),
+    #[error("Plugin is built against a different API version: {0}")]
+    ApiVersionMismatch(wasmtime::Error),
+    #[error("Failed to read plugin file: {0}")]
+    FileReadFailed(std::io::Error),
+    #[error("Failed to load plugin as component: {0}")]
+    ComponentNewFailed(wasmtime::Error),
+    #[error("Failed to create cache data for plugin: {0}")]
+    ComponentCacheSerializeFailed(wasmtime::Error),
+    #[error("Failed to write cache file for plugin: {0}")]
+    ComponentCacheWriteFailed(std::io::Error),
+    #[error("Failed to instantiate plugin: {0}")]
+    InstantiationFailed(wasmtime::Error),
+    #[error("Calling `init_plugin` failed: {0}")]
+    CallInitPluginFailed(wasmtime::Error),
+    #[error("Calling `get_metadata` failed: {0}")]
+    CallGetMetadataFailed(wasmtime::Error),
 }
 
 pub struct PluginRuntime {
@@ -75,18 +86,20 @@ impl PluginRuntime {
         &self,
         path: P,
     ) -> Result<(Arc<WasmPlugin>, PluginMetadata), PluginInitError> {
-        let wasm_bytes = std::fs::read(&path)?;
+        let wasm_bytes = std::fs::read(&path).map_err(PluginInitError::FileReadFailed)?;
 
-        let component = load_component(&self.engine, &wasm_bytes, path.as_ref(), &self.cache_dir)?;
+        let component = load_component(&self.engine, &wasm_bytes, &self.cache_dir)?;
 
-        let instance_pre = self.linker.instantiate_pre(&component)?;
+        let instance_pre = self
+            .linker
+            .instantiate_pre(&component)
+            .map_err(PluginInitError::ApiVersionMismatch)?;
 
         let (wasm_plugin, metadata) = {
-            if let Ok(plugin_pre) = wit::v0_1::prepare_plugin(&instance_pre) {
-                wit::v0_1::init_plugin(&self.engine, plugin_pre).await?
-            } else {
-                return Err(PluginInitError::ApiVersionMismatch);
-            }
+            let plugin_pre = wit::v0_1::prepare_plugin(&instance_pre)
+                .map_err(PluginInitError::ApiVersionMismatch)?;
+
+            wit::v0_1::init_plugin(&self.engine, plugin_pre).await?
         };
 
         let wasm_plugin = Arc::new(wasm_plugin);
@@ -103,29 +116,13 @@ fn setup_linker(engine: &Engine) -> wasmtime::Result<Linker<PluginHostState>> {
     Ok(linker)
 }
 
-fn cache_key(wasm_path: &Path) -> Result<String, std::io::Error> {
-    let metadata = fs::metadata(wasm_path)?;
-    let file_name = wasm_path.file_stem().unwrap().to_string_lossy();
-    let len = metadata.len();
-    let modified = metadata
-        .modified()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-
-    Ok(format!(
-        "{file_name}-{len}-{modified}-{}.cwasm",
-        env!("CARGO_PKG_VERSION"),
-    ))
-}
-
 fn load_component(
     engine: &Engine,
     wasm_bytes: &[u8],
-    wasm_path: &Path,
     cache_dir: &Path,
 ) -> Result<Component, PluginInitError> {
-    let cache_name = cache_key(wasm_path)?;
+    let hash = calculate_hash_for_bytes(wasm_bytes);
+    let cache_name = format!("{hash}-{}.cwasm", env!("CARGO_PKG_VERSION"));
     let cache_path = cache_dir.join(cache_name);
 
     if cache_path.exists() {
@@ -137,8 +134,15 @@ fn load_component(
         }
     }
 
-    let component = Component::new(engine, wasm_bytes)?;
-    fs::write(&cache_path, component.serialize()?)?;
+    let component =
+        Component::new(engine, wasm_bytes).map_err(PluginInitError::ComponentNewFailed)?;
+    fs::write(
+        &cache_path,
+        component
+            .serialize()
+            .map_err(PluginInitError::ComponentCacheSerializeFailed)?,
+    )
+    .map_err(PluginInitError::ComponentCacheWriteFailed)?;
     Ok(component)
 }
 

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
@@ -1,6 +1,8 @@
 use crate::plugin::{
     PluginMetadata,
-    loader::wasm::wasm_host::{PluginInstance, WasmPlugin, state::PluginHostState},
+    loader::wasm::wasm_host::{
+        PluginInitError, PluginInstance, WasmPlugin, state::PluginHostState,
+    },
 };
 use tokio::sync::Mutex;
 use wasmtime::component::{HasSelf, InstancePre, Linker, bindgen};
@@ -57,16 +59,23 @@ pub fn prepare_plugin(
 pub async fn init_plugin(
     engine: &Engine,
     plugin_pre: PluginPre<PluginHostState>,
-) -> wasmtime::Result<(WasmPlugin, PluginMetadata)> {
+) -> Result<(WasmPlugin, PluginMetadata), PluginInitError> {
     let mut store = Store::new(engine, PluginHostState::new());
-    let plugin = plugin_pre.instantiate_async(&mut store).await?;
+    let plugin = plugin_pre
+        .instantiate_async(&mut store)
+        .await
+        .map_err(PluginInitError::InstantiationFailed)?;
 
-    plugin.call_init_plugin(&mut store).await?;
+    plugin
+        .call_init_plugin(&mut store)
+        .await
+        .map_err(PluginInitError::CallInitPluginFailed)?;
 
     let metadata = plugin
         .pumpkin_plugin_metadata()
         .call_get_metadata(&mut store)
-        .await?;
+        .await
+        .map_err(PluginInitError::CallGetMetadataFailed)?;
 
     let metadata = PluginMetadata {
         name: metadata.name,


### PR DESCRIPTION
Modifies Wasm plugin initialization so `PluginInitError` provides more context in error messages. Most notably, the error recieved when a plugin/component's requested `import` don't match what Pumpkin provides (the most frequent kind of breakage) is now actually tracked as a `ApiVersionMismatch`. Previously only `export` mismatches were obviously so.

Before:
```
Failed to load plugin from "./plugins/pumpkin_fly_plugin.wasm": Wasm plugin initialization error: plugin failed to load with error: component imports instance `pumpkin:plugin/command@0.1.0`, but a matching implementation was not found in the linker
```

After:
```
Failed to load plugin from "./plugins/pumpkin_fly_plugin.wasm": Wasm plugin initialization error: Plugin is built against a different API version: component imports instance `pumpkin:plugin/command@0.1.0`, but a matching implementation was not found in the linker
```

As part of the rework, `.cwasm` cache filenames now use the hash of the original wasm (same as the permission system), rather than a combination file name, length, and timestamp. This was done mainly to reduce the amount of error cases.

-----------

Error messages were tested for
- `ApiVersionMismatch` for import mismatches
- `FileReadFailed` when file is present, but read permission is denied
- `ComponentCacheWriteFailed` when the `plugins/cache` directory can't be written to.
- `CallInitPluginFailed` for traps during `init_plugin`
- `CallGetMetadataFailed` for traps during `get_metadata`


The rest, e.g. `LinkerSetupFailed` aren't all easy to reproduce, and remain untested, but there's no reason why they shouldn't work.