### PR TITLE
fix: fall back to console logging when the file logger cannot start

### DIFF
--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -60,6 +60,28 @@ pub type LoggerOption = Option<(ReadlineLogWrapper, LevelFilter, LoggingConfig)>
 pub static LOGGER_IMPL: LazyLock<Arc<OnceLock<LoggerOption>>> =
     LazyLock::new(|| Arc::new(OnceLock::new()));
 
+/// Builds the rolling file logger, or `None` if it is disabled or cannot be set up.
+///
+/// This runs before any subscriber is installed, so a panic here would reach the
+/// operator as a bare backtrace with no message. Report the cause on stderr and keep
+/// the console logger instead, which is still enough to run a server.
+#[expect(clippy::print_stderr)]
+fn init_file_logger(level: LevelFilter, file: &str) -> Option<GzipRollingLogger> {
+    if file.is_empty() {
+        return None;
+    }
+
+    match GzipRollingLogger::new(level, file.to_string()) {
+        Ok(file_logger) => Some(file_logger),
+        Err(e) => {
+            eprintln!(
+                "Failed to initialize the file logger 'logs/{file}' ({e}); continuing with console logging only"
+            );
+            None
+        }
+    }
+}
+
 #[expect(clippy::print_stderr)]
 pub fn init_logger(advanced_config: &AdvancedConfiguration) {
     use tracing_subscriber::EnvFilter;
@@ -85,14 +107,7 @@ pub fn init_logger(advanced_config: &AdvancedConfiguration) {
             EnvFilter::new(level_str)
         });
 
-        let file_logger: Option<GzipRollingLogger> = if advanced_config.logging.file.is_empty() {
-            None
-        } else {
-            Some(
-                GzipRollingLogger::new(level, advanced_config.logging.file.clone())
-                    .expect("Failed to initialize file logger."),
-            )
-        };
+        let file_logger = init_file_logger(level, &advanced_config.logging.file);
 
         let (logger, rl): (
             Box<dyn std::io::Write + Send + 'static>,
@@ -186,8 +201,9 @@ pub fn stop_or_exit_server() {
     if SERVER_IS_STOPPING.load(Ordering::Acquire) {
         // Server is already stopping, so we forcefully exit.
         exit(SERVER_EXIT_CODE.load(Ordering::Acquire));
+    } else {
+        stop_server();
     }
-    stop_server();
 }
 
 fn resolve_some<T: Future, D, F: FnOnce(D) -> T>(


### PR DESCRIPTION
Split out of #2612 per review: one fix per PR.

A file logger that failed to initialize (unwritable logs directory, for example) panicked before any subscriber was installed, so the operator got a bare backtrace instead of a message. The failure is now reported on stderr and the server continues with console logging only.
