### PR TITLE
fix: scoreboard.dat saving/loading, working render types, criteria, operations, improved API, etc.

### DIFF
--- a/pumpkin-codegen/src/scoreboard_slot.rs
+++ b/pumpkin-codegen/src/scoreboard_slot.rs
@@ -14,6 +14,7 @@ pub fn build() -> TokenStream {
     let variants = array_to_tokenstream(&sound_categories);
 
     quote! {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         pub enum ScoreboardDisplaySlot {
             #variants
         }

--- a/pumpkin-data/src/generated/scoreboard_slot.rs
+++ b/pumpkin-data/src/generated/scoreboard_slot.rs
@@ -1,4 +1,5 @@
 /* This file is generated. Do not edit manually. */
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ScoreboardDisplaySlot {
     List,
     Sidebar,

--- a/pumpkin-protocol/src/java/client/play/update_objectives.rs
+++ b/pumpkin-protocol/src/java/client/play/update_objectives.rs
@@ -47,21 +47,7 @@ impl ClientPacket for CUpdateObjectives {
         if self.mode == 0 || self.mode == 2 {
             write.write_slice(&self.display_name.encode())?;
             write.write_var_int(&self.render_type)?;
-            write.write_option(&self.number_format, |p, v| {
-                match v {
-                    NumberFormat::Blank => p.write_var_int(&VarInt(0)),
-                    NumberFormat::Styled(style) => {
-                        p.write_var_int(&VarInt(1))?;
-                        // TODO
-                        pumpkin_nbt::serializer::to_bytes_unnamed(style, p)
-                            .map_err(|err| WritingError::Serde(err.to_string()))
-                    }
-                    NumberFormat::Fixed(text_component) => {
-                        p.write_var_int(&VarInt(2))?;
-                        p.write_slice(&text_component.encode())
-                    }
-                }
-            })
+            write.write_option(&self.number_format, |w, n| n.write(w))
         } else {
             Ok(())
         }

--- a/pumpkin-protocol/src/lib.rs
+++ b/pumpkin-protocol/src/lib.rs
@@ -14,6 +14,7 @@ use pumpkin_util::{
     version::JavaMinecraftVersion,
 };
 use ser::{ReadingError, WritingError};
+use serde::{Deserialize, Serialize};
 
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
@@ -382,7 +383,7 @@ impl KnownPack<'_> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub enum NumberFormat {
     /// Show nothing.
     Blank,
@@ -393,13 +394,16 @@ pub enum NumberFormat {
 }
 
 impl NumberFormat {
-    pub fn write(&self, write: &mut impl ser::NetworkWriteExt) -> Result<(), ser::WritingError> {
+    pub fn write(
+        &self,
+        write: &mut (impl ser::NetworkWriteExt + std::io::Write),
+    ) -> Result<(), ser::WritingError> {
         match self {
             Self::Blank => write.write_var_int(&0.into()),
-            Self::Styled(_style) => {
+            Self::Styled(style) => {
                 write.write_var_int(&1.into())?;
-                // TODO: Style write
-                Ok(())
+                pumpkin_nbt::serializer::to_bytes_unnamed(style, write)
+                    .map_err(|err| ser::WritingError::Serde(err.to_string()))
             }
             Self::Fixed(text) => {
                 write.write_var_int(&2.into())?;

--- a/pumpkin-world/src/world_info/anvil.rs
+++ b/pumpkin-world/src/world_info/anvil.rs
@@ -13,10 +13,10 @@ use crate::world_info::{
     MAXIMUM_SUPPORTED_LEVEL_VERSION, MAXIMUM_SUPPORTED_WORLD_DATA_VERSION,
     MINIMUM_SUPPORTED_LEVEL_VERSION, MINIMUM_SUPPORTED_WORLD_DATA_VERSION,
     data_files::{
-        minecraft_data_dir, read_game_rules, read_wandering_trader, read_weather,
+        minecraft_data_dir, read_game_rules, read_scoreboard, read_wandering_trader, read_weather,
         read_world_clocks, read_world_gen_settings, write_custom_boss_events_stub,
-        write_game_rules, write_scheduled_events_stub, write_wandering_trader, write_weather,
-        write_world_clocks, write_world_gen_settings,
+        write_game_rules, write_scheduled_events_stub, write_scoreboard, write_wandering_trader,
+        write_weather, write_world_clocks, write_world_gen_settings,
     },
 };
 
@@ -131,6 +131,9 @@ impl WorldInfoReader for AnvilLevelInfo {
             info.data.clear_weather_time = weather.clear_weather_time;
         }
 
+        // scoreboard.dat
+        info.data.scoreboard_data = read_scoreboard(level_folder);
+
         // (wandering_trader.dat is not part of LevelData; stored separately when needed)
 
         Ok(info.data)
@@ -199,6 +202,11 @@ impl WorldInfoWriter for AnvilLevelInfo {
             error!("Failed to write weather.dat: {e}");
         }
 
+        // scoreboard.dat
+        if let Err(e) = write_scoreboard(level_folder, &info.scoreboard_data) {
+            error!("Failed to write scoreboard.dat: {e}");
+        }
+
         // wandering_trader.dat (stub / load-save)
         let mut wandering_trader = read_wandering_trader(level_folder);
         wandering_trader.data_version = data_version;
@@ -247,6 +255,7 @@ mod test {
     };
 
     use super::{AnvilLevelInfo, LEVEL_DAT_FILE_NAME, LevelDat, WorldInfoReader, WorldInfoWriter};
+    use crate::world_info::data_files::ScoreboardData;
 
     #[test]
     fn preserve_level_dat_seed() {
@@ -323,6 +332,7 @@ mod test {
             world_gen_settings: WorldGenSettings::new(Seed(1)),
             last_played: 1733847709327,
             level_name: "New World".to_string(),
+            scoreboard_data: ScoreboardData::default(),
             spawn_x: 160,
             spawn_y: 70,
             spawn_z: 160,

--- a/pumpkin-world/src/world_info/data_files.rs
+++ b/pumpkin-world/src/world_info/data_files.rs
@@ -415,3 +415,92 @@ pub fn write_scheduled_events_stub(
     pumpkin_nbt::nbt_compress::write_gzip_compound_tag(root, file)
         .map_err(|e| WorldInfoError::SerializationError(e.to_string()))
 }
+
+/// Serializable scoreboard data for `data/minecraft/scoreboard.dat`.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct ScoreboardData {
+    #[serde(rename = "objectives", default)]
+    pub objectives: Vec<SerializableObjective>,
+    #[serde(rename = "scores", default)]
+    pub scores: Vec<SerializableScore>,
+    #[serde(rename = "teams", default)]
+    pub teams: Vec<SerializableTeam>,
+    /// Display slot bindings: slot name (e.g. "list", "sidebar") -> objective name
+    #[serde(rename = "displaySlots", default)]
+    pub display_slots: std::collections::HashMap<String, String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct SerializableObjective {
+    #[serde(rename = "name")]
+    pub name: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    #[serde(rename = "renderType")]
+    pub render_type: String,
+    #[serde(rename = "criteriaName")]
+    pub criteria_name: String,
+    /// Whether the score's display name is auto-updated when the score changes.
+    #[serde(rename = "displayAutoUpdate", default)]
+    pub display_auto_update: bool,
+    /// Optional number format for all scores in this objective (JSON-encoded).
+    #[serde(rename = "format", default, skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct SerializableScore {
+    #[serde(rename = "entityName")]
+    pub entity_name: String,
+    #[serde(rename = "objectiveName")]
+    pub objective_name: String,
+    #[serde(rename = "value")]
+    pub value: i32,
+    #[serde(rename = "locked", default)]
+    pub locked: bool,
+    /// Optional per-score display name (`TextComponent` JSON).
+    #[serde(rename = "display", default, skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
+    /// Optional per-score number format override (JSON-encoded).
+    #[serde(rename = "format", default, skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct SerializableTeam {
+    #[serde(rename = "name")]
+    pub name: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    #[serde(rename = "players", default)]
+    pub players: Vec<String>,
+}
+
+pub fn read_scoreboard(level_folder: &Path) -> ScoreboardData {
+    let path = minecraft_data_dir(level_folder).join("scoreboard.dat");
+    if !path.exists() {
+        return ScoreboardData::default();
+    }
+    match File::open(&path) {
+        Ok(f) => match from_gzip_bytes::<DataFileRoot<ScoreboardData>, _>(f) {
+            Ok(root) => root.data,
+            Err(e) => {
+                warn!("Failed to deserialize scoreboard.dat, using defaults: {e}");
+                ScoreboardData::default()
+            }
+        },
+        Err(e) => {
+            warn!("Failed to open scoreboard.dat, using defaults: {e}");
+            ScoreboardData::default()
+        }
+    }
+}
+
+pub fn write_scoreboard(level_folder: &Path, data: &ScoreboardData) -> Result<(), WorldInfoError> {
+    let dir = ensure_minecraft_data_dir(level_folder)?;
+    let path = dir.join("scoreboard.dat");
+    let file = File::create(&path)?;
+    let root = DataFileRoot { data: data.clone() };
+    to_gzip_bytes(&root, BufWriter::new(file))
+        .map_err(|e| WorldInfoError::SerializationError(e.to_string()))
+}

--- a/pumpkin-world/src/world_info/mod.rs
+++ b/pumpkin-world/src/world_info/mod.rs
@@ -96,6 +96,10 @@ pub struct LevelData {
     /// Persisted to `data/minecraft/weather.dat`.
     #[serde(rename = "clearWeatherTime", skip_serializing, default)]
     pub clear_weather_time: i32,
+
+    /// Scoreboard data persisted to `data/minecraft/scoreboard.dat`.
+    #[serde(skip_serializing, default)]
+    pub scoreboard_data: data_files::ScoreboardData,
 }
 
 const DEFAULT_BORDER_DAMAGE_PER_BLOCK: f64 = 0.2;
@@ -353,6 +357,7 @@ impl LevelData {
             world_gen_settings: WorldGenSettings::new(seed),
             day_time: 0,
             clear_weather_time: -1,
+            scoreboard_data: data_files::ScoreboardData::default(),
         }
     }
 

--- a/pumpkin/src/command/argument_types/display_slot.rs
+++ b/pumpkin/src/command/argument_types/display_slot.rs
@@ -1,0 +1,105 @@
+use crate::command::{
+    argument_types::argument_type::{ArgumentType, JavaClientArgumentType},
+    context::command_context::CommandContext,
+    errors::command_syntax_error::CommandSyntaxError,
+    errors::error_types::CommandErrorType,
+    string_reader::StringReader,
+    suggestion::suggestions::{Suggestions, SuggestionsBuilder},
+};
+use pumpkin_data::scoreboard::ScoreboardDisplaySlot;
+use pumpkin_util::text::TextComponent;
+use std::pin::Pin;
+
+pub const UNKNOWN_DISPLAY_SLOT_ERROR_TYPE: CommandErrorType<1> = CommandErrorType::new(
+    pumpkin_data::translation::java::ARGUMENT_SCOREBOARDDISPLAYSLOT_INVALID,
+    pumpkin_data::translation::java::ARGUMENT_SCOREBOARDDISPLAYSLOT_INVALID,
+);
+
+pub struct ScoreboardDisplaySlotArgumentType;
+
+impl ArgumentType for ScoreboardDisplaySlotArgumentType {
+    type Item = ScoreboardDisplaySlot;
+
+    fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
+        let start = reader.cursor();
+        reader.read_unquoted_string();
+        let name = &reader.string()[start..reader.cursor()];
+
+        match name {
+            "list" => Ok(ScoreboardDisplaySlot::List),
+            "sidebar" => Ok(ScoreboardDisplaySlot::Sidebar),
+            "belowName" | "below_name" => Ok(ScoreboardDisplaySlot::BelowName),
+            "sidebar.team.black" => Ok(ScoreboardDisplaySlot::TeamBlack),
+            "sidebar.team.dark_blue" => Ok(ScoreboardDisplaySlot::TeamDarkBlue),
+            "sidebar.team.dark_green" => Ok(ScoreboardDisplaySlot::TeamDarkGreen),
+            "sidebar.team.dark_aqua" => Ok(ScoreboardDisplaySlot::TeamDarkAqua),
+            "sidebar.team.dark_red" => Ok(ScoreboardDisplaySlot::TeamDarkRed),
+            "sidebar.team.dark_purple" => Ok(ScoreboardDisplaySlot::TeamDarkPurple),
+            "sidebar.team.gold" => Ok(ScoreboardDisplaySlot::TeamGold),
+            "sidebar.team.gray" => Ok(ScoreboardDisplaySlot::TeamGray),
+            "sidebar.team.dark_gray" => Ok(ScoreboardDisplaySlot::TeamDarkGray),
+            "sidebar.team.blue" => Ok(ScoreboardDisplaySlot::TeamBlue),
+            "sidebar.team.green" => Ok(ScoreboardDisplaySlot::TeamGreen),
+            "sidebar.team.aqua" => Ok(ScoreboardDisplaySlot::TeamAqua),
+            "sidebar.team.red" => Ok(ScoreboardDisplaySlot::TeamRed),
+            "sidebar.team.light_purple" => Ok(ScoreboardDisplaySlot::TeamLightPurple),
+            "sidebar.team.yellow" => Ok(ScoreboardDisplaySlot::TeamYellow),
+            "sidebar.team.white" => Ok(ScoreboardDisplaySlot::TeamWhite),
+            _ => Err(UNKNOWN_DISPLAY_SLOT_ERROR_TYPE
+                .create(reader, TextComponent::text(name.to_string()))),
+        }
+    }
+
+    fn client_side_parser(&'_ self) -> JavaClientArgumentType {
+        JavaClientArgumentType::ScoreboardSlot
+    }
+
+    fn list_suggestions<'a>(
+        &'a self,
+        _context: &'a CommandContext,
+        builder: SuggestionsBuilder,
+    ) -> Pin<Box<dyn Future<Output = Suggestions> + Send + 'a>> {
+        Box::pin(async move {
+            builder
+                .filter_and_suggest(&[
+                    "list",
+                    "sidebar",
+                    "belowName",
+                    "sidebar.team.black",
+                    "sidebar.team.dark_blue",
+                    "sidebar.team.dark_green",
+                    "sidebar.team.dark_aqua",
+                    "sidebar.team.dark_red",
+                    "sidebar.team.dark_purple",
+                    "sidebar.team.gold",
+                    "sidebar.team.gray",
+                    "sidebar.team.dark_gray",
+                    "sidebar.team.blue",
+                    "sidebar.team.green",
+                    "sidebar.team.aqua",
+                    "sidebar.team.red",
+                    "sidebar.team.light_purple",
+                    "sidebar.team.yellow",
+                    "sidebar.team.white",
+                ])
+                .build()
+        })
+    }
+
+    fn examples(&self) -> Vec<String> {
+        examples!("list", "sidebar", "belowName")
+    }
+}
+
+impl ScoreboardDisplaySlotArgumentType {
+    /// Returns a [`CommandContext`]'s parsed `ScoreboardDisplaySlot` argument.
+    pub fn get(
+        context: &crate::command::context::command_context::CommandContext,
+        name: &str,
+    ) -> Result<
+        ScoreboardDisplaySlot,
+        crate::command::errors::command_syntax_error::CommandSyntaxError,
+    > {
+        Ok(*context.get_argument::<ScoreboardDisplaySlot>(name)?)
+    }
+}

--- a/pumpkin/src/command/argument_types/mod.rs
+++ b/pumpkin/src/command/argument_types/mod.rs
@@ -222,6 +222,7 @@ pub mod block;
 pub mod coordinates;
 pub mod core;
 pub mod dialog;
+pub mod display_slot;
 pub mod entity;
 pub mod entity_anchor;
 pub mod entity_selector;

--- a/pumpkin/src/command/commands/scoreboard.rs
+++ b/pumpkin/src/command/commands/scoreboard.rs
@@ -1,5 +1,7 @@
 use crate::command::argument_builder::{ArgumentBuilder, argument, command, literal};
+use crate::command::argument_types::core::integer::IntegerArgumentType;
 use crate::command::argument_types::core::string::StringArgumentType;
+use crate::command::argument_types::display_slot::ScoreboardDisplaySlotArgumentType;
 use crate::command::argument_types::entity::EntityArgumentType;
 use crate::command::argument_types::objective::ObjectiveArgumentType;
 use crate::command::context::command_context::CommandContext;
@@ -7,12 +9,15 @@ use crate::command::errors::error_types::CommandErrorType;
 use crate::command::node::dispatcher::CommandDispatcher;
 use crate::command::node::{CommandExecutor, CommandExecutorResult};
 use crate::world::scoreboard::{ScoreboardObjective, ScoreboardScore};
+use pumpkin_data::scoreboard::ScoreboardDisplaySlot;
 use pumpkin_data::translation;
+use pumpkin_protocol::NumberFormat;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::java::client::play::RenderType;
 use pumpkin_util::PermissionLvl;
 use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
 use pumpkin_util::text::TextComponent;
+use std::sync::Arc;
 
 const DESCRIPTION: &str = "Manages scoreboard objectives and players.";
 const PERMISSION: &str = "minecraft:command.scoreboard";
@@ -21,11 +26,22 @@ const ARG_OBJECTIVE: &str = "objective";
 const ARG_CRITERION: &str = "criterion";
 const ARG_DISPLAY_NAME: &str = "display_name";
 const ARG_TARGETS: &str = "targets";
+const ARG_SCORE: &str = "score";
+const ARG_TARGET: &str = "target";
+const ARG_SLOT: &str = "slot";
 
 const DUPLICATE_OBJECTIVE_ERROR: CommandErrorType<0> = CommandErrorType::new(
     translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_ADD_DUPLICATE,
     translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_ADD_DUPLICATE,
 );
+
+const INVALID_CRITERION_ERROR: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_ADD_DUPLICATE, // Approximate error, no exact key
+    translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_ADD_DUPLICATE,
+);
+
+const STYLE_PARSE_ERROR: crate::command::errors::error_types::LiteralCommandErrorType =
+    crate::command::errors::error_types::LiteralCommandErrorType::new("Invalid style format");
 
 const INVALID_ENABLE_ERROR: CommandErrorType<0> = CommandErrorType::new(
     translation::java::COMMANDS_SCOREBOARD_PLAYERS_ENABLE_INVALID,
@@ -37,8 +53,34 @@ const FAILED_ENABLE_ERROR: CommandErrorType<0> = CommandErrorType::new(
     translation::java::COMMANDS_SCOREBOARD_PLAYERS_ENABLE_FAILED,
 );
 
+const DISPLAY_SLOT_ALREADY_EMPTY_ERROR: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_DISPLAY_ALREADYEMPTY,
+    translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_DISPLAY_ALREADYEMPTY,
+);
+
+const DISPLAY_SLOT_ALREADY_SET_ERROR: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_DISPLAY_ALREADYSET,
+    translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_DISPLAY_ALREADYSET,
+);
+
+const NO_VALUE_ERROR: CommandErrorType<2> = CommandErrorType::new(
+    translation::java::COMMANDS_SCOREBOARD_PLAYERS_GET_NULL,
+    translation::java::COMMANDS_SCOREBOARD_PLAYERS_GET_NULL,
+);
+
+const OBJECTIVE_NOT_FOUND_ERROR: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::ARGUMENTS_OBJECTIVE_NOTFOUND,
+    translation::java::ARGUMENTS_OBJECTIVE_NOTFOUND,
+);
+
 struct ObjectivesAddExecutor {
     has_display_name: bool,
+}
+
+fn obj_name<'a>(
+    context: &'a CommandContext,
+) -> Result<&'a str, crate::command::errors::command_syntax_error::CommandSyntaxError> {
+    ObjectiveArgumentType::get(context, ARG_OBJECTIVE)
 }
 
 impl CommandExecutor for ObjectivesAddExecutor {
@@ -53,6 +95,10 @@ impl CommandExecutor for ObjectivesAddExecutor {
                 TextComponent::text(objective_name.to_string())
             };
 
+            if !crate::world::scoreboard::is_valid_criterion(criterion) {
+                return Err(INVALID_CRITERION_ERROR.create_without_context());
+            }
+
             let world = context.world();
             let mut scoreboard = world.scoreboard.lock().await;
 
@@ -60,18 +106,17 @@ impl CommandExecutor for ObjectivesAddExecutor {
                 return Err(DUPLICATE_OBJECTIVE_ERROR.create_without_context());
             }
 
-            let obj_name_static = Box::leak(objective_name.to_string().into_boxed_str());
-            let criterion_static = Box::leak(criterion.to_string().into_boxed_str());
-
+            let render_type =
+                crate::world::scoreboard::default_render_type_for_criterion(criterion);
             let new_objective = ScoreboardObjective::new(
-                obj_name_static,
+                Arc::from(objective_name),
                 display_name.clone(),
-                RenderType::Integer,
+                render_type,
                 None,
-                criterion_static,
+                Arc::from(criterion),
             );
 
-            scoreboard.add_objective(world, new_objective).await;
+            scoreboard.add_objective(world, new_objective);
 
             context
                 .source
@@ -104,9 +149,9 @@ impl CommandExecutor for PlayersEnableExecutor {
             let objective = scoreboard
                 .get_objectives()
                 .get(objective_name)
-                .ok_or_else(|| INVALID_ENABLE_ERROR.create_without_context())?;
+                .ok_or_else(|| OBJECTIVE_NOT_FOUND_ERROR.create_without_context())?;
 
-            if objective.criterion != "trigger" {
+            if &*objective.criterion != "trigger" {
                 return Err(INVALID_ENABLE_ERROR.create_without_context());
             }
 
@@ -128,8 +173,8 @@ impl CommandExecutor for PlayersEnableExecutor {
                     let number_format = current_score.and_then(|s| s.number_format.clone());
 
                     let updated_score = ScoreboardScore {
-                        entity_name: Box::leak(player_name.clone().into_boxed_str()),
-                        objective_name: Box::leak(objective_name.to_string().into_boxed_str()),
+                        entity_name: Arc::from(player_name.as_str()),
+                        objective_name: Arc::from(objective_name),
                         value: VarInt(value),
                         display_name,
                         number_format,
@@ -172,6 +217,1428 @@ impl CommandExecutor for PlayersEnableExecutor {
     }
 }
 
+struct ObjectivesListExecutor;
+
+impl CommandExecutor for ObjectivesListExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let scoreboard = context.world().scoreboard.lock().await;
+            let objectives: Vec<&str> = scoreboard
+                .get_objectives()
+                .keys()
+                .map(String::as_str)
+                .collect();
+
+            if objectives.is_empty() {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_LIST_EMPTY,
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_LIST_EMPTY,
+                            [],
+                        ),
+                        false,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_LIST_SUCCESS,
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_LIST_SUCCESS,
+                            [
+                                TextComponent::text(objectives.len().to_string()),
+                                TextComponent::text(objectives.join(", ")),
+                            ],
+                        ),
+                        false,
+                    )
+                    .await;
+            }
+
+            Ok(objectives.len() as i32)
+        })
+    }
+}
+
+struct ObjectivesRemoveExecutor;
+
+impl CommandExecutor for ObjectivesRemoveExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let objective_name = obj_name(context)?;
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.get_objectives().contains_key(objective_name) {
+                return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+            }
+
+            scoreboard.remove_objective(world, objective_name);
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_REMOVE_SUCCESS,
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_REMOVE_SUCCESS,
+                        [TextComponent::text(objective_name.to_string())],
+                    ),
+                    true,
+                )
+                .await;
+
+            Ok(0)
+        })
+    }
+}
+
+struct ModifyDisplayNameExecutor;
+
+impl CommandExecutor for ModifyDisplayNameExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let objective_name = obj_name(context)?;
+            let new_display = TextComponent::text(
+                StringArgumentType::get(context, ARG_DISPLAY_NAME)?.to_string(),
+            );
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            let Some(objective) = scoreboard.get_objective(objective_name) else {
+                return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+            };
+            let render_type = objective.render_type;
+            let number_format = objective.number_format.clone();
+            let old_display = objective.display_name.clone();
+            let _ = objective;
+
+            if old_display == new_display {
+                return Ok(0);
+            }
+
+            scoreboard.modify_objective(
+                world,
+                objective_name,
+                new_display.clone(),
+                render_type,
+                number_format,
+            );
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_DISPLAYNAME,
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_DISPLAYNAME,
+                        [TextComponent::text(objective_name.to_string()), new_display],
+                    ),
+                    true,
+                )
+                .await;
+
+            Ok(0)
+        })
+    }
+}
+
+struct ModifyRenderTypeExecutor {
+    render_type: RenderType,
+}
+
+impl CommandExecutor for ModifyRenderTypeExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let objective_name = obj_name(context)?;
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            let Some(objective) = scoreboard.get_objective(objective_name) else {
+                return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+            };
+            let display_name = objective.display_name.clone();
+            let render_type = objective.render_type;
+            let number_format = objective.number_format.clone();
+            let _ = objective;
+
+            if render_type as i32 == self.render_type as i32 {
+                return Ok(0);
+            }
+
+            scoreboard.modify_objective(
+                world,
+                objective_name,
+                display_name.clone(),
+                self.render_type,
+                number_format,
+            );
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_RENDERTYPE,
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_RENDERTYPE,
+                        [display_name],
+                    ),
+                    true,
+                )
+                .await;
+
+            Ok(0)
+        })
+    }
+}
+
+struct ObjectivesSetDisplayExecutor;
+
+impl CommandExecutor for ObjectivesSetDisplayExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let slot = ScoreboardDisplaySlotArgumentType::get(context, ARG_SLOT)?;
+            let objective_name: Option<String> =
+                context.get_argument::<String>(ARG_OBJECTIVE).ok().cloned();
+            let slot_name = display_slot_name(slot);
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if let Some(name) = &objective_name {
+                if !scoreboard.get_objectives().contains_key(name) {
+                    return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+                }
+
+                if scoreboard.get_display_objective(&slot) == Some(name.as_str()) {
+                    return Err(DISPLAY_SLOT_ALREADY_SET_ERROR.create_without_context());
+                }
+
+                scoreboard.set_display_objective(world, slot, Some(name));
+
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_DISPLAY_SET,
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_DISPLAY_SET,
+                            [
+                                TextComponent::text(slot_name),
+                                TextComponent::text(name.clone()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                if scoreboard.get_display_objective(&slot).is_none() {
+                    return Err(DISPLAY_SLOT_ALREADY_EMPTY_ERROR.create_without_context());
+                }
+
+                scoreboard.set_display_objective(world, slot, None);
+
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_DISPLAY_CLEARED,
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_DISPLAY_CLEARED,
+                            [TextComponent::text(slot_name)],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(0)
+        })
+    }
+}
+
+struct ObjectivesClearDisplayExecutor;
+
+impl CommandExecutor for ObjectivesClearDisplayExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let slot = ScoreboardDisplaySlotArgumentType::get(context, ARG_SLOT)?;
+            let slot_name = display_slot_name(slot);
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if scoreboard.get_display_objective(&slot).is_none() {
+                return Err(DISPLAY_SLOT_ALREADY_EMPTY_ERROR.create_without_context());
+            }
+
+            scoreboard.set_display_objective(world, slot, None);
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_DISPLAY_CLEARED,
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_DISPLAY_CLEARED,
+                        [TextComponent::text(slot_name)],
+                    ),
+                    true,
+                )
+                .await;
+
+            Ok(0)
+        })
+    }
+}
+
+struct PlayersSetExecutor;
+
+impl CommandExecutor for PlayersSetExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let objective_name = obj_name(context)?;
+            let value = IntegerArgumentType::get(context, ARG_SCORE)?;
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.get_objectives().contains_key(objective_name) {
+                return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+            }
+
+            for player in &targets {
+                let score = ScoreboardScore {
+                    entity_name: Arc::from(player.gameprofile.name.as_str()),
+                    objective_name: Arc::from(objective_name),
+                    value: VarInt(value),
+                    display_name: None,
+                    number_format: None,
+                    locked: false,
+                };
+                scoreboard.update_score(world, score).await;
+            }
+
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_SET_SUCCESS_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_SET_SUCCESS_SINGLE,
+                            [
+                                TextComponent::text(objective_name.to_string()),
+                                TextComponent::text(targets[0].gameprofile.name.clone()),
+                                TextComponent::text(value.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_SET_SUCCESS_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_SET_SUCCESS_MULTIPLE,
+                            [
+                                TextComponent::text(objective_name.to_string()),
+                                TextComponent::text(targets.len().to_string()),
+                                TextComponent::text(value.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(value * targets.len() as i32)
+        })
+    }
+}
+
+struct PlayersGetExecutor;
+
+impl CommandExecutor for PlayersGetExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGET).await?;
+            let objective_name = obj_name(context)?;
+
+            // `players get` with empty targets is a parse error (EntityArgumentType requires at least 1)
+            if targets.is_empty() {
+                return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+            }
+
+            let player = &targets[0];
+            let player_name = &player.gameprofile.name;
+
+            let world = context.world();
+            let scoreboard = world.scoreboard.lock().await;
+
+            let Some(score_info) = scoreboard.get_player_score_info(player_name, objective_name)
+            else {
+                return Err(NO_VALUE_ERROR.create_without_context(
+                    TextComponent::text(objective_name.to_string()),
+                    TextComponent::text(player_name.clone()),
+                ));
+            };
+
+            let value = score_info.value.0;
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_SCOREBOARD_PLAYERS_GET_SUCCESS,
+                        translation::java::COMMANDS_SCOREBOARD_PLAYERS_GET_SUCCESS,
+                        [
+                            TextComponent::text(objective_name.to_string()),
+                            TextComponent::text(player_name.clone()),
+                            TextComponent::text(value.to_string()),
+                        ],
+                    ),
+                    false,
+                )
+                .await;
+
+            Ok(value)
+        })
+    }
+}
+
+struct PlayersAddExecutor;
+
+impl CommandExecutor for PlayersAddExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let objective_name = obj_name(context)?;
+            let add_value = IntegerArgumentType::get(context, ARG_SCORE)?;
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            let objective = scoreboard
+                .get_objectives()
+                .get(objective_name)
+                .ok_or_else(|| OBJECTIVE_NOT_FOUND_ERROR.create_without_context())?;
+            let obj_display = objective.display_name.clone();
+            let _ = objective;
+
+            let mut result = 0;
+            for player in &targets {
+                let player_name = &player.gameprofile.name;
+                let existing = scoreboard.get_player_score_info(player_name, objective_name);
+                let current = existing.map_or(0, |s| s.value.0);
+                let new_value = current + add_value;
+
+                let score = ScoreboardScore {
+                    entity_name: Arc::from(player_name.as_str()),
+                    objective_name: Arc::from(objective_name),
+                    value: VarInt(new_value),
+                    display_name: existing.and_then(|s| s.display_name.clone()),
+                    number_format: existing.and_then(|s| s.number_format.clone()),
+                    locked: existing.is_none_or(|s| s.locked),
+                };
+                scoreboard.update_score(world, score).await;
+                result += new_value;
+            }
+
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_ADD_SUCCESS_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_ADD_SUCCESS_SINGLE,
+                            [
+                                TextComponent::text(add_value.to_string()),
+                                obj_display,
+                                TextComponent::text(targets[0].gameprofile.name.clone()),
+                                TextComponent::text(result.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_ADD_SUCCESS_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_ADD_SUCCESS_MULTIPLE,
+                            [
+                                TextComponent::text(add_value.to_string()),
+                                obj_display,
+                                TextComponent::text(targets.len().to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(result)
+        })
+    }
+}
+
+struct PlayersRemoveExecutor;
+
+impl CommandExecutor for PlayersRemoveExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let objective_name = obj_name(context)?;
+            let remove_value = IntegerArgumentType::get(context, ARG_SCORE)?;
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            let objective = scoreboard
+                .get_objectives()
+                .get(objective_name)
+                .ok_or_else(|| OBJECTIVE_NOT_FOUND_ERROR.create_without_context())?;
+            let obj_display = objective.display_name.clone();
+            let _ = objective;
+
+            let mut result = 0;
+            for player in &targets {
+                let player_name = &player.gameprofile.name;
+                let existing = scoreboard.get_player_score_info(player_name, objective_name);
+                let current = existing.map_or(0, |s| s.value.0);
+                let new_value = current - remove_value;
+
+                let score = ScoreboardScore {
+                    entity_name: Arc::from(player_name.as_str()),
+                    objective_name: Arc::from(objective_name),
+                    value: VarInt(new_value),
+                    display_name: existing.and_then(|s| s.display_name.clone()),
+                    number_format: existing.and_then(|s| s.number_format.clone()),
+                    locked: existing.is_none_or(|s| s.locked),
+                };
+                scoreboard.update_score(world, score).await;
+                result += new_value;
+            }
+
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_REMOVE_SUCCESS_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_REMOVE_SUCCESS_SINGLE,
+                            [
+                                TextComponent::text(remove_value.to_string()),
+                                obj_display,
+                                TextComponent::text(targets[0].gameprofile.name.clone()),
+                                TextComponent::text(result.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_REMOVE_SUCCESS_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_REMOVE_SUCCESS_MULTIPLE,
+                            [
+                                TextComponent::text(remove_value.to_string()),
+                                obj_display,
+                                TextComponent::text(targets.len().to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(result)
+        })
+    }
+}
+
+struct PlayersResetAllExecutor;
+
+impl CommandExecutor for PlayersResetAllExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            for player in &targets {
+                scoreboard.reset_all_player_scores(world, &player.gameprofile.name);
+            }
+
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_RESET_ALL_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_RESET_ALL_SINGLE,
+                            [TextComponent::text(targets[0].gameprofile.name.clone())],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_RESET_ALL_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_RESET_ALL_MULTIPLE,
+                            [TextComponent::text(targets.len().to_string())],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(targets.len() as i32)
+        })
+    }
+}
+
+struct PlayersResetSingleExecutor;
+
+impl CommandExecutor for PlayersResetSingleExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let objective_name = obj_name(context)?;
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            for player in &targets {
+                scoreboard.reset_single_player_score(
+                    world,
+                    &player.gameprofile.name,
+                    objective_name,
+                );
+            }
+
+            let obj_display = TextComponent::text(objective_name.to_string());
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_RESET_SPECIFIC_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_RESET_SPECIFIC_SINGLE,
+                            [
+                                obj_display,
+                                TextComponent::text(targets[0].gameprofile.name.clone()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_RESET_SPECIFIC_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_RESET_SPECIFIC_MULTIPLE,
+                            [obj_display, TextComponent::text(targets.len().to_string())],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(targets.len() as i32)
+        })
+    }
+}
+
+struct PlayersListExecutor;
+
+impl CommandExecutor for PlayersListExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let scoreboard = context.world().scoreboard.lock().await;
+            let tracked = scoreboard.get_tracked_players();
+
+            if tracked.is_empty() {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_LIST_EMPTY,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_LIST_EMPTY,
+                            [],
+                        ),
+                        false,
+                    )
+                    .await;
+            } else {
+                let names = tracked.clone();
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_LIST_SUCCESS,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_LIST_SUCCESS,
+                            [
+                                TextComponent::text(names.len().to_string()),
+                                TextComponent::text(names.join(", ")),
+                            ],
+                        ),
+                        false,
+                    )
+                    .await;
+            }
+
+            Ok(tracked.len() as i32)
+        })
+    }
+}
+
+struct PlayersListTargetExecutor;
+
+impl CommandExecutor for PlayersListTargetExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            if targets.is_empty() {
+                return Err(INVALID_ENABLE_ERROR.create_without_context());
+            }
+            let player_name = &targets[0].gameprofile.name;
+
+            let scoreboard = context.world().scoreboard.lock().await;
+            let scores = scoreboard.list_scores_for_player(player_name);
+
+            if scores.is_empty() {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_LIST_ENTITY_EMPTY,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_LIST_ENTITY_EMPTY,
+                            [TextComponent::text(player_name.clone())],
+                        ),
+                        false,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_LIST_ENTITY_SUCCESS,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_LIST_ENTITY_SUCCESS,
+                            [
+                                TextComponent::text(player_name.clone()),
+                                TextComponent::text(scores.len().to_string()),
+                            ],
+                        ),
+                        false,
+                    )
+                    .await;
+
+                for (obj_name, value) in &scores {
+                    context
+                        .source
+                        .send_feedback(
+                            TextComponent::translate_cross(
+                                translation::java::COMMANDS_SCOREBOARD_PLAYERS_LIST_ENTITY_ENTRY,
+                                translation::java::COMMANDS_SCOREBOARD_PLAYERS_LIST_ENTITY_ENTRY,
+                                [
+                                    TextComponent::text(obj_name.to_string()),
+                                    TextComponent::text(value.to_string()),
+                                ],
+                            ),
+                            false,
+                        )
+                        .await;
+                }
+            }
+
+            Ok(scores.len() as i32)
+        })
+    }
+}
+
+struct PlayersDisplayNameSetExecutor;
+
+impl CommandExecutor for PlayersDisplayNameSetExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let objective_name = obj_name(context)?;
+            let name = TextComponent::text(StringArgumentType::get(context, "name")?.to_string());
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            for player in &targets {
+                scoreboard.set_score_display_name(
+                    world,
+                    &player.gameprofile.name,
+                    objective_name,
+                    Some(name.clone()),
+                );
+            }
+
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NAME_SET_SUCCESS_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NAME_SET_SUCCESS_SINGLE,
+                            [
+                                name,
+                                TextComponent::text(targets[0].gameprofile.name.clone()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NAME_SET_SUCCESS_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NAME_SET_SUCCESS_MULTIPLE,
+                            [
+                                name,
+                                TextComponent::text(targets.len().to_string()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(targets.len() as i32)
+        })
+    }
+}
+
+struct PlayersDisplayNameClearExecutor;
+
+impl CommandExecutor for PlayersDisplayNameClearExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let objective_name = obj_name(context)?;
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            for player in &targets {
+                scoreboard.set_score_display_name(
+                    world,
+                    &player.gameprofile.name,
+                    objective_name,
+                    None,
+                );
+            }
+
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NAME_CLEAR_SUCCESS_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NAME_CLEAR_SUCCESS_SINGLE,
+                            [
+                                TextComponent::text(targets[0].gameprofile.name.clone()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NAME_CLEAR_SUCCESS_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NAME_CLEAR_SUCCESS_MULTIPLE,
+                            [
+                                TextComponent::text(targets.len().to_string()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(targets.len() as i32)
+        })
+    }
+}
+
+const ARG_SOURCE: &str = "source";
+const ARG_SOURCE_OBJECTIVE: &str = "sourceObjective";
+
+fn operation_source_args(
+    executor: impl CommandExecutor + 'static,
+) -> crate::command::argument_builder::RequiredArgumentBuilder {
+    argument(ARG_SOURCE, EntityArgumentType::Players)
+        .then(argument(ARG_SOURCE_OBJECTIVE, ObjectiveArgumentType).executes(executor))
+}
+
+/// Applies an operation to all targets. `op` is `|a, b| -> i32`.
+async fn apply_operation(
+    context: &CommandContext<'_>,
+    op: impl Fn(i32, i32) -> i32 + Send + Sync,
+) -> Result<i32, crate::command::errors::command_syntax_error::CommandSyntaxError> {
+    let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+    let objective_name = obj_name(context)?;
+    let sources = EntityArgumentType::get_players(context, ARG_SOURCE).await?;
+    let source_objective = obj_name(context)?;
+
+    let world = context.world();
+    let mut scoreboard = world.scoreboard.lock().await;
+
+    let mut last_new_value = 0;
+    for target in &targets {
+        let target_name = &target.gameprofile.name;
+        for source in &sources {
+            let source_name = &source.gameprofile.name;
+            let source_value = scoreboard
+                .get_player_score_info(source_name, source_objective)
+                .map_or(0, |s| s.value.0);
+            let current = scoreboard
+                .get_player_score_info(target_name, objective_name)
+                .map_or(0, |s| s.value.0);
+            let new_value = op(current, source_value);
+            last_new_value = new_value;
+
+            let score = ScoreboardScore {
+                entity_name: Arc::from(target_name.as_str()),
+                objective_name: Arc::from(objective_name),
+                value: VarInt(new_value),
+                display_name: None,
+                number_format: None,
+                locked: false,
+            };
+            scoreboard.update_score(world, score).await;
+        }
+    }
+
+    if targets.len() == 1 {
+        context
+            .source
+            .send_feedback(
+                TextComponent::translate_cross(
+                    translation::java::COMMANDS_SCOREBOARD_PLAYERS_OPERATION_SUCCESS_SINGLE,
+                    translation::java::COMMANDS_SCOREBOARD_PLAYERS_OPERATION_SUCCESS_SINGLE,
+                    [
+                        TextComponent::text(objective_name.to_string()),
+                        TextComponent::text(targets[0].gameprofile.name.clone()),
+                        TextComponent::text(last_new_value.to_string()),
+                    ],
+                ),
+                true,
+            )
+            .await;
+    } else {
+        context
+            .source
+            .send_feedback(
+                TextComponent::translate_cross(
+                    translation::java::COMMANDS_SCOREBOARD_PLAYERS_OPERATION_SUCCESS_MULTIPLE,
+                    translation::java::COMMANDS_SCOREBOARD_PLAYERS_OPERATION_SUCCESS_MULTIPLE,
+                    [
+                        TextComponent::text(objective_name.to_string()),
+                        TextComponent::text(targets.len().to_string()),
+                    ],
+                ),
+                true,
+            )
+            .await;
+    }
+
+    Ok(targets.len() as i32)
+}
+
+macro_rules! make_operation_executor {
+    ($name:ident, $op:expr) => {
+        struct $name;
+        impl CommandExecutor for $name {
+            fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+                Box::pin(apply_operation(context, $op))
+            }
+        }
+    };
+}
+
+make_operation_executor!(PlayersOperationAddExecutor, |a, b| a + b);
+make_operation_executor!(PlayersOperationSubExecutor, |a, b| a - b);
+make_operation_executor!(PlayersOperationMulExecutor, |a, b| a * b);
+make_operation_executor!(PlayersOperationDivExecutor, |a, b| if b == 0 {
+    0
+} else {
+    a / b
+});
+make_operation_executor!(PlayersOperationModExecutor, |a, b| if b == 0 {
+    0
+} else {
+    a % b
+});
+make_operation_executor!(PlayersOperationAssignExecutor, |_a, b| b);
+make_operation_executor!(PlayersOperationMinExecutor, Ord::min);
+make_operation_executor!(PlayersOperationMaxExecutor, Ord::max);
+make_operation_executor!(PlayersOperationIfExecutor, |_a, b| b);
+
+struct ModifyObjectiveNumberFormatClearExecutor;
+struct ModifyObjectiveNumberFormatBlankExecutor;
+struct ModifyObjectiveNumberFormatFixedExecutor;
+struct ModifyObjectiveNumberFormatStyledExecutor;
+
+impl CommandExecutor for ModifyObjectiveNumberFormatClearExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let objective_name = obj_name(context)?;
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.set_objective_number_format(world, objective_name, None) {
+                return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+            }
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_OBJECTIVEFORMAT_CLEAR,
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_OBJECTIVEFORMAT_CLEAR,
+                        [TextComponent::text(objective_name.to_string())],
+                    ),
+                    true,
+                )
+                .await;
+
+            Ok(0)
+        })
+    }
+}
+
+impl CommandExecutor for ModifyObjectiveNumberFormatBlankExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let objective_name = obj_name(context)?;
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.set_objective_number_format(
+                world,
+                objective_name,
+                Some(NumberFormat::Blank),
+            ) {
+                return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+            }
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_OBJECTIVEFORMAT_SET,
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_OBJECTIVEFORMAT_SET,
+                        [TextComponent::text(objective_name.to_string())],
+                    ),
+                    true,
+                )
+                .await;
+
+            Ok(0)
+        })
+    }
+}
+
+impl CommandExecutor for ModifyObjectiveNumberFormatFixedExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let objective_name = obj_name(context)?;
+            let contents =
+                TextComponent::text(StringArgumentType::get(context, "contents")?.to_string());
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.set_objective_number_format(
+                world,
+                objective_name,
+                Some(NumberFormat::Fixed(contents)),
+            ) {
+                return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+            }
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_OBJECTIVEFORMAT_SET,
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_OBJECTIVEFORMAT_SET,
+                        [TextComponent::text(objective_name.to_string())],
+                    ),
+                    true,
+                )
+                .await;
+
+            Ok(0)
+        })
+    }
+}
+
+impl CommandExecutor for ModifyObjectiveNumberFormatStyledExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let objective_name = obj_name(context)?;
+            let style_json = StringArgumentType::get(context, "style")?.to_string();
+            let style: pumpkin_util::text::style::Style = serde_json::from_str(&style_json)
+                .map_err(|_| STYLE_PARSE_ERROR.create_without_context())?;
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.set_objective_number_format(
+                world,
+                objective_name,
+                Some(NumberFormat::Styled(style)),
+            ) {
+                return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+            }
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_OBJECTIVEFORMAT_SET,
+                        translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_OBJECTIVEFORMAT_SET,
+                        [TextComponent::text(objective_name.to_string())],
+                    ),
+                    true,
+                )
+                .await;
+
+            Ok(0)
+        })
+    }
+}
+
+struct ModifyDisplayAutoUpdateExecutor;
+
+impl CommandExecutor for ModifyDisplayAutoUpdateExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            use crate::command::argument_types::core::bool::BoolArgumentType;
+
+            let objective_name = obj_name(context)?;
+            let value = BoolArgumentType::get(context, "value")?;
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            if !scoreboard.set_display_auto_update(world, objective_name, value) {
+                return Err(OBJECTIVE_NOT_FOUND_ERROR.create_without_context());
+            }
+
+            if value {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_DISPLAYAUTOUPDATE_ENABLE,
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_DISPLAYAUTOUPDATE_ENABLE,
+                            [
+                                TextComponent::text(objective_name.to_string()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_DISPLAYAUTOUPDATE_DISABLE,
+                            translation::java::COMMANDS_SCOREBOARD_OBJECTIVES_MODIFY_DISPLAYAUTOUPDATE_DISABLE,
+                            [TextComponent::text(objective_name.to_string())],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(0)
+        })
+    }
+}
+
+struct PlayersDisplayNumberFormatClearExecutor;
+struct PlayersDisplayNumberFormatBlankExecutor;
+struct PlayersDisplayNumberFormatFixedExecutor;
+struct PlayersDisplayNumberFormatStyledExecutor;
+
+impl CommandExecutor for PlayersDisplayNumberFormatClearExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let objective_name = obj_name(context)?;
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            for player in &targets {
+                scoreboard.set_score_number_format(
+                    world,
+                    &player.gameprofile.name,
+                    objective_name,
+                    None,
+                );
+            }
+
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_CLEAR_SUCCESS_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_CLEAR_SUCCESS_SINGLE,
+                            [
+                                TextComponent::text(targets[0].gameprofile.name.clone()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_CLEAR_SUCCESS_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_CLEAR_SUCCESS_MULTIPLE,
+                            [
+                                TextComponent::text(targets.len().to_string()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(targets.len() as i32)
+        })
+    }
+}
+
+impl CommandExecutor for PlayersDisplayNumberFormatBlankExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let objective_name = obj_name(context)?;
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            for player in &targets {
+                scoreboard.set_score_number_format(
+                    world,
+                    &player.gameprofile.name,
+                    objective_name,
+                    Some(NumberFormat::Blank),
+                );
+            }
+
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_SINGLE,
+                            [
+                                TextComponent::text(targets[0].gameprofile.name.clone()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_MULTIPLE,
+                            [
+                                TextComponent::text(targets.len().to_string()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(targets.len() as i32)
+        })
+    }
+}
+
+impl CommandExecutor for PlayersDisplayNumberFormatFixedExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let objective_name = obj_name(context)?;
+            let contents =
+                TextComponent::text(StringArgumentType::get(context, "contents")?.to_string());
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            for player in &targets {
+                scoreboard.set_score_number_format(
+                    world,
+                    &player.gameprofile.name,
+                    objective_name,
+                    Some(NumberFormat::Fixed(contents.clone())),
+                );
+            }
+
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_SINGLE,
+                            [
+                                TextComponent::text(targets[0].gameprofile.name.clone()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_MULTIPLE,
+                            [
+                                TextComponent::text(targets.len().to_string()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(targets.len() as i32)
+        })
+    }
+}
+
+impl CommandExecutor for PlayersDisplayNumberFormatStyledExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let targets = EntityArgumentType::get_players(context, ARG_TARGETS).await?;
+            let objective_name = obj_name(context)?;
+            let style_json = StringArgumentType::get(context, "style")?.to_string();
+            let style: pumpkin_util::text::style::Style = serde_json::from_str(&style_json)
+                .map_err(|_| STYLE_PARSE_ERROR.create_without_context())?;
+
+            let world = context.world();
+            let mut scoreboard = world.scoreboard.lock().await;
+
+            for player in &targets {
+                scoreboard.set_score_number_format(
+                    world,
+                    &player.gameprofile.name,
+                    objective_name,
+                    Some(NumberFormat::Styled(style.clone())),
+                );
+            }
+
+            if targets.len() == 1 {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_SINGLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_SINGLE,
+                            [
+                                TextComponent::text(targets[0].gameprofile.name.clone()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            } else {
+                context
+                    .source
+                    .send_feedback(
+                        TextComponent::translate_cross(
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_MULTIPLE,
+                            translation::java::COMMANDS_SCOREBOARD_PLAYERS_DISPLAY_NUMBERFORMAT_SET_SUCCESS_MULTIPLE,
+                            [
+                                TextComponent::text(targets.len().to_string()),
+                                TextComponent::text(objective_name.to_string()),
+                            ],
+                        ),
+                        true,
+                    )
+                    .await;
+            }
+
+            Ok(targets.len() as i32)
+        })
+    }
+}
+
+const fn display_slot_name(slot: ScoreboardDisplaySlot) -> &'static str {
+    match slot {
+        ScoreboardDisplaySlot::List => "list",
+        ScoreboardDisplaySlot::Sidebar => "sidebar",
+        ScoreboardDisplaySlot::BelowName => "below_name",
+        ScoreboardDisplaySlot::TeamBlack => "sidebar.team.black",
+        ScoreboardDisplaySlot::TeamDarkBlue => "sidebar.team.dark_blue",
+        ScoreboardDisplaySlot::TeamDarkGreen => "sidebar.team.dark_green",
+        ScoreboardDisplaySlot::TeamDarkAqua => "sidebar.team.dark_aqua",
+        ScoreboardDisplaySlot::TeamDarkRed => "sidebar.team.dark_red",
+        ScoreboardDisplaySlot::TeamDarkPurple => "sidebar.team.dark_purple",
+        ScoreboardDisplaySlot::TeamGold => "sidebar.team.gold",
+        ScoreboardDisplaySlot::TeamGray => "sidebar.team.gray",
+        ScoreboardDisplaySlot::TeamDarkGray => "sidebar.team.dark_gray",
+        ScoreboardDisplaySlot::TeamBlue => "sidebar.team.blue",
+        ScoreboardDisplaySlot::TeamGreen => "sidebar.team.green",
+        ScoreboardDisplaySlot::TeamAqua => "sidebar.team.aqua",
+        ScoreboardDisplaySlot::TeamRed => "sidebar.team.red",
+        ScoreboardDisplaySlot::TeamLightPurple => "sidebar.team.light_purple",
+        ScoreboardDisplaySlot::TeamYellow => "sidebar.team.yellow",
+        ScoreboardDisplaySlot::TeamWhite => "sidebar.team.white",
+    }
+}
+
+#[allow(clippy::too_many_lines)]
 pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
     registry.register_permission_or_panic(Permission::new(
         PERMISSION,
@@ -183,27 +1650,233 @@ pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionReg
         command("scoreboard", DESCRIPTION)
             .requires(PERMISSION)
             .then(
-                literal("objectives").then(
-                    literal("add").then(
-                        argument(ARG_OBJECTIVE, StringArgumentType::SingleWord).then(
-                            argument(ARG_CRITERION, StringArgumentType::SingleWord)
-                                .executes(ObjectivesAddExecutor {
-                                    has_display_name: false,
-                                })
+                literal("objectives")
+                    .then(
+                        literal("add").then(
+                            argument(ARG_OBJECTIVE, StringArgumentType::SingleWord).then(
+                                argument(ARG_CRITERION, StringArgumentType::SingleWord)
+                                    .executes(ObjectivesAddExecutor {
+                                        has_display_name: false,
+                                    })
+                                    .then(
+                                        argument(
+                                            ARG_DISPLAY_NAME,
+                                            StringArgumentType::GreedyPhrase,
+                                        )
+                                        .executes(
+                                            ObjectivesAddExecutor {
+                                                has_display_name: true,
+                                            },
+                                        ),
+                                    ),
+                            ),
+                        ),
+                    )
+                    .then(literal("list").executes(ObjectivesListExecutor))
+                    .then(
+                        literal("remove").then(
+                            argument(ARG_OBJECTIVE, ObjectiveArgumentType)
+                                .executes(ObjectivesRemoveExecutor),
+                        ),
+                    )
+                    .then(
+                        literal("modify").then(
+                            argument(ARG_OBJECTIVE, ObjectiveArgumentType)
                                 .then(
-                                    argument(ARG_DISPLAY_NAME, StringArgumentType::GreedyPhrase)
-                                        .executes(ObjectivesAddExecutor {
-                                            has_display_name: true,
-                                        }),
+                                    literal("displayname").then(
+                                        argument(
+                                            ARG_DISPLAY_NAME,
+                                            StringArgumentType::GreedyPhrase,
+                                        )
+                                        .executes(ModifyDisplayNameExecutor),
+                                    ),
+                                )
+                                .then(
+                                    literal("rendertype")
+                                        .then(literal("hearts").executes(
+                                            ModifyRenderTypeExecutor {
+                                                render_type: RenderType::Hearts,
+                                            },
+                                        ))
+                                        .then(literal("integer").executes(
+                                            ModifyRenderTypeExecutor {
+                                                render_type: RenderType::Integer,
+                                            },
+                                        )),
+                                )
+                                .then(
+                                    literal("numberformat")
+                                        .executes(ModifyObjectiveNumberFormatClearExecutor)
+                                        .then(literal("blank").executes(
+                                            ModifyObjectiveNumberFormatBlankExecutor,
+                                        ))
+                                        .then(
+                                            literal("fixed").then(
+                                                argument("contents", StringArgumentType::GreedyPhrase)
+                                                    .executes(ModifyObjectiveNumberFormatFixedExecutor),
+                                            ),
+                                        )
+                                        .then(
+                                            literal("styled").then(
+                                                argument("style", StringArgumentType::GreedyPhrase)
+                                                    .executes(ModifyObjectiveNumberFormatStyledExecutor),
+                                            ),
+                                        ),
+                                )
+                                .then(
+                                    literal("displayautoupdate").then(
+                                        argument("value", crate::command::argument_types::core::bool::BoolArgumentType)
+                                            .executes(ModifyDisplayAutoUpdateExecutor),
+                                    ),
+                                ),
+                        ),
+                    )
+                    .then(
+                        literal("setdisplay").then(
+                            argument(ARG_SLOT, ScoreboardDisplaySlotArgumentType)
+                                .executes(ObjectivesClearDisplayExecutor)
+                                .then(
+                                    argument(ARG_OBJECTIVE, ObjectiveArgumentType)
+                                        .executes(ObjectivesSetDisplayExecutor),
                                 ),
                         ),
                     ),
-                ),
             )
-            .then(literal("players").then(literal("enable").then(
-                argument(ARG_TARGETS, EntityArgumentType::Players).then(
-                    argument(ARG_OBJECTIVE, ObjectiveArgumentType).executes(PlayersEnableExecutor),
-                ),
-            ))),
+            .then(
+                literal("players")
+                    .then(
+                        literal("list").executes(PlayersListExecutor).then(
+                            argument(ARG_TARGETS, EntityArgumentType::Players)
+                                .executes(PlayersListTargetExecutor),
+                        ),
+                    )
+                    .then(
+                        literal("set").then(
+                            argument(ARG_TARGETS, EntityArgumentType::Players).then(
+                                argument(ARG_OBJECTIVE, ObjectiveArgumentType).then(
+                                    argument(ARG_SCORE, IntegerArgumentType::any())
+                                        .executes(PlayersSetExecutor),
+                                ),
+                            ),
+                        ),
+                    )
+                    .then(
+                        literal("get").then(
+                            argument(ARG_TARGET, EntityArgumentType::Player).then(
+                                argument(ARG_OBJECTIVE, ObjectiveArgumentType)
+                                    .executes(PlayersGetExecutor),
+                            ),
+                        ),
+                    )
+                    .then(
+                        literal("add").then(
+                            argument(ARG_TARGETS, EntityArgumentType::Players).then(
+                                argument(ARG_OBJECTIVE, ObjectiveArgumentType).then(
+                                    argument(ARG_SCORE, IntegerArgumentType::with_min(0))
+                                        .executes(PlayersAddExecutor),
+                                ),
+                            ),
+                        ),
+                    )
+                    .then(
+                        literal("remove").then(
+                            argument(ARG_TARGETS, EntityArgumentType::Players).then(
+                                argument(ARG_OBJECTIVE, ObjectiveArgumentType).then(
+                                    argument(ARG_SCORE, IntegerArgumentType::with_min(0))
+                                        .executes(PlayersRemoveExecutor),
+                                ),
+                            ),
+                        ),
+                    )
+                    .then(
+                        literal("reset").then(
+                            argument(ARG_TARGETS, EntityArgumentType::Players)
+                                .executes(PlayersResetAllExecutor)
+                                .then(
+                                    argument(ARG_OBJECTIVE, ObjectiveArgumentType)
+                                        .executes(PlayersResetSingleExecutor),
+                                ),
+                        ),
+                    )
+                    .then(
+                        literal("display").then(
+                            literal("name").then(
+                                argument(ARG_TARGETS, EntityArgumentType::Players).then(
+                                    argument(ARG_OBJECTIVE, ObjectiveArgumentType)
+                                        .executes(PlayersDisplayNameClearExecutor)
+                                        .then(
+                                            argument("name", StringArgumentType::GreedyPhrase)
+                                                .executes(PlayersDisplayNameSetExecutor),
+                                        ),
+                                ),
+                            ),
+                        )
+                        .then(
+                            literal("numberformat").then(
+                                argument(ARG_TARGETS, EntityArgumentType::Players).then(
+                                    argument(ARG_OBJECTIVE, ObjectiveArgumentType)
+                                        .executes(PlayersDisplayNumberFormatClearExecutor)
+                                        .then(literal("blank").executes(
+                                            PlayersDisplayNumberFormatBlankExecutor,
+                                        ))
+                                        .then(
+                                            literal("fixed").then(
+                                                argument("contents", StringArgumentType::GreedyPhrase)
+                                                    .executes(PlayersDisplayNumberFormatFixedExecutor),
+                                            ),
+                                        )
+                                        .then(
+                                            literal("styled").then(
+                                                argument("style", StringArgumentType::GreedyPhrase)
+                                                    .executes(PlayersDisplayNumberFormatStyledExecutor),
+                                            ),
+                                        ),
+                                ),
+                            ),
+                        ),
+                    )
+                    .then(
+                        literal("operation").then(
+                            argument(ARG_TARGETS, EntityArgumentType::Players).then(
+                                argument(ARG_OBJECTIVE, ObjectiveArgumentType).then(
+                                    literal("+=")
+                                        .then(operation_source_args(PlayersOperationAddExecutor))
+                                        .then(literal("-=").then(operation_source_args(
+                                            PlayersOperationSubExecutor,
+                                        )))
+                                        .then(literal("*=").then(operation_source_args(
+                                            PlayersOperationMulExecutor,
+                                        )))
+                                        .then(literal("/=").then(operation_source_args(
+                                            PlayersOperationDivExecutor,
+                                        )))
+                                        .then(literal("%=").then(operation_source_args(
+                                            PlayersOperationModExecutor,
+                                        )))
+                                        .then(literal("=").then(operation_source_args(
+                                            PlayersOperationAssignExecutor,
+                                        )))
+                                        .then(literal("<").then(operation_source_args(
+                                            PlayersOperationMinExecutor,
+                                        )))
+                                        .then(literal(">").then(operation_source_args(
+                                            PlayersOperationMaxExecutor,
+                                        )))
+                                        .then(literal("?").then(operation_source_args(
+                                            PlayersOperationIfExecutor,
+                                        ))),
+                                ),
+                            ),
+                        ),
+                    )
+                    .then(
+                        literal("enable").then(
+                            argument(ARG_TARGETS, EntityArgumentType::Players).then(
+                                argument(ARG_OBJECTIVE, ObjectiveArgumentType)
+                                    .executes(PlayersEnableExecutor),
+                            ),
+                        ),
+                    ),
+            ),
     );
 }

--- a/pumpkin/src/command/commands/trigger.rs
+++ b/pumpkin/src/command/commands/trigger.rs
@@ -10,6 +10,7 @@ use pumpkin_data::translation;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
 use pumpkin_util::text::TextComponent;
+use std::sync::Arc;
 
 const DESCRIPTION: &str = "Modifies a trigger scoreboard objective.";
 const PERMISSION: &str = "minecraft:command.trigger";
@@ -44,7 +45,7 @@ impl CommandExecutor for SimpleTriggerExecutor {
                 .get(objective_name)
                 .ok_or_else(|| INVALID_TRIGGER_ERROR.create_without_context())?;
 
-            if objective.criterion != "trigger" {
+            if &*objective.criterion != "trigger" {
                 return Err(INVALID_TRIGGER_ERROR.create_without_context());
             }
 
@@ -69,8 +70,8 @@ impl CommandExecutor for SimpleTriggerExecutor {
             let new_value = current_value + 1;
 
             let updated_score = ScoreboardScore {
-                entity_name: Box::leak(player_name.clone().into_boxed_str()),
-                objective_name: Box::leak(objective_name.to_string().into_boxed_str()),
+                entity_name: Arc::from(player_name.as_str()),
+                objective_name: Arc::from(objective_name),
                 value: VarInt(new_value),
                 display_name: None,
                 number_format: None,
@@ -114,7 +115,7 @@ impl CommandExecutor for AddTriggerExecutor {
                 .get(objective_name)
                 .ok_or_else(|| INVALID_TRIGGER_ERROR.create_without_context())?;
 
-            if objective.criterion != "trigger" {
+            if &*objective.criterion != "trigger" {
                 return Err(INVALID_TRIGGER_ERROR.create_without_context());
             }
 
@@ -139,8 +140,8 @@ impl CommandExecutor for AddTriggerExecutor {
             let new_value = current_value + value;
 
             let updated_score = ScoreboardScore {
-                entity_name: Box::leak(player_name.clone().into_boxed_str()),
-                objective_name: Box::leak(objective_name.to_string().into_boxed_str()),
+                entity_name: Arc::from(player_name.as_str()),
+                objective_name: Arc::from(objective_name),
                 value: VarInt(new_value),
                 display_name: None,
                 number_format: None,
@@ -187,7 +188,7 @@ impl CommandExecutor for SetTriggerExecutor {
                 .get(objective_name)
                 .ok_or_else(|| INVALID_TRIGGER_ERROR.create_without_context())?;
 
-            if objective.criterion != "trigger" {
+            if &*objective.criterion != "trigger" {
                 return Err(INVALID_TRIGGER_ERROR.create_without_context());
             }
 
@@ -204,8 +205,8 @@ impl CommandExecutor for SetTriggerExecutor {
             }
 
             let updated_score = ScoreboardScore {
-                entity_name: Box::leak(player_name.clone().into_boxed_str()),
-                objective_name: Box::leak(objective_name.to_string().into_boxed_str()),
+                entity_name: Arc::from(player_name.as_str()),
+                objective_name: Arc::from(objective_name),
                 value: VarInt(value),
                 display_name: None,
                 number_format: None,

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -471,6 +471,13 @@ pub struct Player {
     pub last_sent_health: AtomicI32,
     pub last_sent_food: AtomicU8,
     pub last_food_saturation: AtomicBool,
+    // Cached values for scoreboard auto-scoring.
+    last_recorded_health_absorption: AtomicCell<f32>,
+    last_recorded_food_level: AtomicI32,
+    last_recorded_air_level: AtomicI32,
+    last_recorded_armor: AtomicI32,
+    last_recorded_experience: AtomicI32,
+    last_recorded_level: AtomicI32,
     /// The player's permission level.
     pub permission_lvl: AtomicCell<PermissionLvl>,
     /// Whether the client has reported that it has loaded.
@@ -706,6 +713,12 @@ impl Player {
             last_sent_health: AtomicI32::new(-1),
             last_sent_food: AtomicU8::new(0),
             last_food_saturation: AtomicBool::new(true),
+            last_recorded_health_absorption: AtomicCell::new(f32::MIN),
+            last_recorded_food_level: AtomicI32::new(i32::MIN),
+            last_recorded_air_level: AtomicI32::new(i32::MIN),
+            last_recorded_armor: AtomicI32::new(i32::MIN),
+            last_recorded_experience: AtomicI32::new(i32::MIN),
+            last_recorded_level: AtomicI32::new(i32::MIN),
             has_played_before: AtomicBool::new(false),
             chat_session: Arc::new(Mutex::new(ChatSession::default())), // Placeholder value until the player actually sets their session id
             signature_cache: Mutex::new(MessageCache::default()),
@@ -2037,6 +2050,8 @@ impl Player {
         // experience handling
         self.tick_experience().await;
         self.tick_health().await;
+        // Update auto-computed scoreboard criteria (health, food, air, armor, xp, level)
+        self.tick_scoreboard_criteria().await;
         self.tick_maps(server).await;
 
         // Timeout/keep alive handling
@@ -2720,6 +2735,75 @@ impl Player {
             self.last_food_saturation
                 .store(saturation == 0.0, Ordering::Relaxed);
             self.send_health().await;
+        }
+    }
+
+    /// Updates all objectives tracking the given criterion with the specified value.
+    async fn update_score_for_criteria(&self, criterion: &str, value: i32) {
+        let world = self.world();
+        let mut scoreboard = world.scoreboard.lock().await;
+        scoreboard
+            .for_all_objectives(&world, criterion, &self.gameprofile.name, value)
+            .await;
+    }
+
+    /// Checks each auto-computed criterion (health, food, air, armor, xp, level)
+    /// and updates the scoreboard when values change.
+    async fn tick_scoreboard_criteria(&self) {
+        if !self.has_client_loaded() {
+            return;
+        }
+
+        let living = &self.living_entity;
+
+        // HEALTH: health + absorption amount, ceiled to int
+        let health_absorption = living.health.load() + living.absorption.load();
+        let last_health_absorption = self.last_recorded_health_absorption.load();
+        if (health_absorption - last_health_absorption).abs() > f32::EPSILON {
+            self.last_recorded_health_absorption
+                .store(health_absorption);
+            self.update_score_for_criteria("health", health_absorption.ceil() as i32)
+                .await;
+        }
+
+        // FOOD: food level
+        let food = self.hunger_manager.level.load() as i32;
+        let last_food = self.last_recorded_food_level.load(Ordering::Relaxed);
+        if food != last_food {
+            self.last_recorded_food_level.store(food, Ordering::Relaxed);
+            self.update_score_for_criteria("food", food).await;
+        }
+
+        // AIR: air supply
+        let air = self.breath_manager.air_supply.load(Ordering::Relaxed);
+        let last_air = self.last_recorded_air_level.load(Ordering::Relaxed);
+        if air != last_air {
+            self.last_recorded_air_level.store(air, Ordering::Relaxed);
+            self.update_score_for_criteria("air", air).await;
+        }
+
+        // ARMOR: armor attribute value
+        let armor = living.get_attribute_value(&Attributes::ARMOR) as i32;
+        let last_armor = self.last_recorded_armor.load(Ordering::Relaxed);
+        if armor != last_armor {
+            self.last_recorded_armor.store(armor, Ordering::Relaxed);
+            self.update_score_for_criteria("armor", armor).await;
+        }
+
+        // XP: total experience points
+        let xp = self.experience_points.load(Ordering::Relaxed);
+        let last_xp = self.last_recorded_experience.load(Ordering::Relaxed);
+        if xp != last_xp {
+            self.last_recorded_experience.store(xp, Ordering::Relaxed);
+            self.update_score_for_criteria("xp", xp).await;
+        }
+
+        // LEVEL: experience level
+        let level = self.experience_level.load(Ordering::Relaxed);
+        let last_level = self.last_recorded_level.load(Ordering::Relaxed);
+        if level != last_level {
+            self.last_recorded_level.store(level, Ordering::Relaxed);
+            self.update_score_for_criteria("level", level).await;
         }
     }
 

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/scoreboard.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/scoreboard.rs
@@ -1,15 +1,19 @@
 use wasmtime::component::Resource;
 
+use std::sync::Arc;
+
 use crate::plugin::loader::wasm::wasm_host::{
     state::{PluginHostState, ScoreboardResource},
     wit::v0_1::pumpkin::{
         self,
         plugin::scoreboard::{
-            self, CollisionRule, DisplaySlot, NametagVisibility, RenderType, TeamSettings,
+            self, CollisionRule, DisplaySlot, NametagVisibility, RenderType as WitRenderType,
+            TeamSettings,
         },
     },
 };
 use crate::world::scoreboard::{ScoreboardObjective, ScoreboardScore, Team};
+use pumpkin_data::scoreboard::ScoreboardDisplaySlot;
 use pumpkin_protocol::codec::var_int::VarInt;
 
 impl PluginHostState {
@@ -21,6 +25,68 @@ impl PluginHostState {
             .get::<ScoreboardResource>(&Resource::new_own(res.rep()))
             .map_err(wasmtime::Error::from)
     }
+
+    const fn to_wit_render_type(
+        rt: pumpkin_protocol::java::client::play::RenderType,
+    ) -> WitRenderType {
+        match rt {
+            pumpkin_protocol::java::client::play::RenderType::Integer => WitRenderType::Integer,
+            pumpkin_protocol::java::client::play::RenderType::Hearts => WitRenderType::Hearts,
+        }
+    }
+
+    const fn to_internal_render_type(
+        rt: WitRenderType,
+    ) -> pumpkin_protocol::java::client::play::RenderType {
+        match rt {
+            WitRenderType::Integer => pumpkin_protocol::java::client::play::RenderType::Integer,
+            WitRenderType::Hearts => pumpkin_protocol::java::client::play::RenderType::Hearts,
+        }
+    }
+
+    const fn to_internal_display_slot(slot: DisplaySlot) -> ScoreboardDisplaySlot {
+        match slot {
+            DisplaySlot::PlayerList => ScoreboardDisplaySlot::List,
+            DisplaySlot::Sidebar => ScoreboardDisplaySlot::Sidebar,
+            DisplaySlot::BelowName => ScoreboardDisplaySlot::BelowName,
+            DisplaySlot::SidebarTeamBlack => ScoreboardDisplaySlot::TeamBlack,
+            DisplaySlot::SidebarTeamDarkBlue => ScoreboardDisplaySlot::TeamDarkBlue,
+            DisplaySlot::SidebarTeamDarkGreen => ScoreboardDisplaySlot::TeamDarkGreen,
+            DisplaySlot::SidebarTeamDarkAqua => ScoreboardDisplaySlot::TeamDarkAqua,
+            DisplaySlot::SidebarTeamDarkRed => ScoreboardDisplaySlot::TeamDarkRed,
+            DisplaySlot::SidebarTeamDarkPurple => ScoreboardDisplaySlot::TeamDarkPurple,
+            DisplaySlot::SidebarTeamGold => ScoreboardDisplaySlot::TeamGold,
+            DisplaySlot::SidebarTeamGray => ScoreboardDisplaySlot::TeamGray,
+            DisplaySlot::SidebarTeamDarkGray => ScoreboardDisplaySlot::TeamDarkGray,
+            DisplaySlot::SidebarTeamBlue => ScoreboardDisplaySlot::TeamBlue,
+            DisplaySlot::SidebarTeamGreen => ScoreboardDisplaySlot::TeamGreen,
+            DisplaySlot::SidebarTeamAqua => ScoreboardDisplaySlot::TeamAqua,
+            DisplaySlot::SidebarTeamRed => ScoreboardDisplaySlot::TeamRed,
+            DisplaySlot::SidebarTeamLightPurple => ScoreboardDisplaySlot::TeamLightPurple,
+            DisplaySlot::SidebarTeamYellow => ScoreboardDisplaySlot::TeamYellow,
+            DisplaySlot::SidebarTeamWhite => ScoreboardDisplaySlot::TeamWhite,
+        }
+    }
+
+    fn to_objective_info(
+        obj: &crate::world::scoreboard::ScoreboardObjective,
+    ) -> scoreboard::ObjectiveInfo {
+        scoreboard::ObjectiveInfo {
+            name: obj.name.to_string(),
+            display_name: obj.display_name.clone().get_text(),
+            criteria_name: obj.criterion.to_string(),
+            render_type: Self::to_wit_render_type(obj.render_type),
+            display_auto_update: obj.display_auto_update,
+        }
+    }
+
+    fn to_team_info(team: &crate::world::scoreboard::Team) -> scoreboard::TeamInfo {
+        scoreboard::TeamInfo {
+            name: team.name.clone(),
+            display_name: team.display_name.clone().get_text(),
+            players: team.players.clone(),
+        }
+    }
 }
 
 impl scoreboard::Host for PluginHostState {}
@@ -31,29 +97,25 @@ impl scoreboard::HostScoreboard for PluginHostState {
         res: Resource<scoreboard::Scoreboard>,
         name: String,
         display_name: Resource<pumpkin::plugin::text::TextComponent>,
-        render_type: RenderType,
+        criteria: String,
+        render_type: WitRenderType,
     ) -> wasmtime::Result<()> {
         let world = self.get_scoreboard_res(&res)?.provider.clone();
         let display_name = self.get_text_provider(&display_name)?;
-
-        let rt = match render_type {
-            RenderType::Integer => pumpkin_protocol::java::client::play::RenderType::Integer,
-            RenderType::Hearts => pumpkin_protocol::java::client::play::RenderType::Hearts,
-        };
+        let rt = Self::to_internal_render_type(render_type);
 
         let objective = ScoreboardObjective::new(
-            Box::leak(name.into_boxed_str()),
+            Arc::from(name.as_str()),
             display_name,
             rt,
             None,
-            "dummy",
+            Arc::from(criteria.as_str()),
         );
         world
             .scoreboard
             .lock()
             .await
-            .add_objective(&world, objective)
-            .await;
+            .add_objective(&world, objective);
         Ok(())
     }
 
@@ -67,9 +129,46 @@ impl scoreboard::HostScoreboard for PluginHostState {
             .scoreboard
             .lock()
             .await
-            .remove_objective(&world, &name)
-            .await;
+            .remove_objective(&world, &name);
         Ok(())
+    }
+
+    async fn get_objective(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+        name: String,
+    ) -> wasmtime::Result<Option<scoreboard::ObjectiveInfo>> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        let sb = world.scoreboard.lock().await;
+        Ok(sb.get_objective(&name).map(Self::to_objective_info))
+    }
+
+    async fn get_objectives(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+    ) -> wasmtime::Result<Vec<scoreboard::ObjectiveInfo>> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        let sb = world.scoreboard.lock().await;
+        Ok(sb
+            .get_objectives()
+            .values()
+            .map(Self::to_objective_info)
+            .collect())
+    }
+
+    async fn get_objectives_by_criteria(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+        criteria: String,
+    ) -> wasmtime::Result<Vec<scoreboard::ObjectiveInfo>> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        let sb = world.scoreboard.lock().await;
+        Ok(sb
+            .get_objectives()
+            .values()
+            .filter(|o| *o.criterion == *criteria)
+            .map(Self::to_objective_info)
+            .collect())
     }
 
     async fn set_display_slot(
@@ -79,62 +178,39 @@ impl scoreboard::HostScoreboard for PluginHostState {
         objective_name: String,
     ) -> wasmtime::Result<()> {
         let world = self.get_scoreboard_res(&res)?.provider.clone();
-        let slot = match slot {
-            DisplaySlot::PlayerList => pumpkin_data::scoreboard::ScoreboardDisplaySlot::List,
-            DisplaySlot::Sidebar => pumpkin_data::scoreboard::ScoreboardDisplaySlot::Sidebar,
-            DisplaySlot::BelowName => pumpkin_data::scoreboard::ScoreboardDisplaySlot::BelowName,
-            DisplaySlot::SidebarTeamBlack => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamBlack
-            }
-            DisplaySlot::SidebarTeamDarkBlue => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamDarkBlue
-            }
-            DisplaySlot::SidebarTeamDarkGreen => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamDarkGreen
-            }
-            DisplaySlot::SidebarTeamDarkAqua => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamDarkAqua
-            }
-            DisplaySlot::SidebarTeamDarkRed => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamDarkRed
-            }
-            DisplaySlot::SidebarTeamDarkPurple => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamDarkPurple
-            }
-            DisplaySlot::SidebarTeamGold => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamGold
-            }
-            DisplaySlot::SidebarTeamGray => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamGray
-            }
-            DisplaySlot::SidebarTeamDarkGray => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamDarkGray
-            }
-            DisplaySlot::SidebarTeamBlue => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamBlue
-            }
-            DisplaySlot::SidebarTeamGreen => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamGreen
-            }
-            DisplaySlot::SidebarTeamAqua => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamAqua
-            }
-            DisplaySlot::SidebarTeamRed => pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamRed,
-            DisplaySlot::SidebarTeamLightPurple => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamLightPurple
-            }
-            DisplaySlot::SidebarTeamYellow => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamYellow
-            }
-            DisplaySlot::SidebarTeamWhite => {
-                pumpkin_data::scoreboard::ScoreboardDisplaySlot::TeamWhite
-            }
-        };
-
-        world.broadcast_packet_all(
-            &pumpkin_protocol::java::client::play::CDisplayObjective::new(slot, objective_name),
+        let internal_slot = Self::to_internal_display_slot(slot);
+        world.scoreboard.lock().await.set_display_objective(
+            &world,
+            internal_slot,
+            Some(&objective_name),
         );
         Ok(())
+    }
+
+    async fn clear_slot(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+        slot: DisplaySlot,
+    ) -> wasmtime::Result<()> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        let internal_slot = Self::to_internal_display_slot(slot);
+        world
+            .scoreboard
+            .lock()
+            .await
+            .set_display_objective(&world, internal_slot, None);
+        Ok(())
+    }
+
+    async fn get_display_slot(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+        slot: DisplaySlot,
+    ) -> wasmtime::Result<Option<String>> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        let internal_slot = Self::to_internal_display_slot(slot);
+        let sb = world.scoreboard.lock().await;
+        Ok(sb.get_display_objective(&internal_slot).map(String::from))
     }
 
     async fn update_score(
@@ -146,8 +222,8 @@ impl scoreboard::HostScoreboard for PluginHostState {
     ) -> wasmtime::Result<()> {
         let world = self.get_scoreboard_res(&res)?.provider.clone();
         let score = ScoreboardScore::new(
-            Box::leak(entity_name.into_boxed_str()),
-            Box::leak(objective_name.into_boxed_str()),
+            Arc::from(entity_name.as_str()),
+            Arc::from(objective_name.as_str()),
             VarInt(value),
             None,
             None,
@@ -175,6 +251,55 @@ impl scoreboard::HostScoreboard for PluginHostState {
             .remove_score(&world, &entity_name, &objective_name)
             .await;
         Ok(())
+    }
+
+    async fn get_scores(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+        entry: String,
+    ) -> wasmtime::Result<Vec<scoreboard::ScoreInfo>> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        let sb = world.scoreboard.lock().await;
+        let raw_scores = sb.list_scores_for_player(&entry);
+        let results: Vec<scoreboard::ScoreInfo> = raw_scores
+            .into_iter()
+            .filter_map(|(obj_name, _)| {
+                let score_info = sb.get_player_score_info(&entry, obj_name)?;
+                Some(scoreboard::ScoreInfo {
+                    objective_name: obj_name.to_string(),
+                    value: score_info.value.0,
+                    locked: score_info.locked,
+                })
+            })
+            .collect();
+        Ok(results)
+    }
+
+    async fn reset_scores(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+        entry: String,
+    ) -> wasmtime::Result<()> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        world
+            .scoreboard
+            .lock()
+            .await
+            .reset_all_player_scores(&world, &entry);
+        Ok(())
+    }
+
+    async fn get_tracked_entries(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+    ) -> wasmtime::Result<Vec<String>> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        let sb = world.scoreboard.lock().await;
+        Ok(sb
+            .get_tracked_players()
+            .into_iter()
+            .map(ToString::to_string)
+            .collect())
     }
 
     async fn create_team(
@@ -209,6 +334,39 @@ impl scoreboard::HostScoreboard for PluginHostState {
         let team = map_team_settings(name, &settings, self)?;
         world.scoreboard.lock().await.update_team(&world, team);
         Ok(())
+    }
+
+    async fn get_team(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+        name: String,
+    ) -> wasmtime::Result<Option<scoreboard::TeamInfo>> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        let sb = world.scoreboard.lock().await;
+        Ok(sb.get_teams().get(&name).map(Self::to_team_info))
+    }
+
+    async fn get_teams(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+    ) -> wasmtime::Result<Vec<scoreboard::TeamInfo>> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        let sb = world.scoreboard.lock().await;
+        Ok(sb.get_teams().values().map(Self::to_team_info).collect())
+    }
+
+    async fn get_entry_team(
+        &mut self,
+        res: Resource<scoreboard::Scoreboard>,
+        entry: String,
+    ) -> wasmtime::Result<Option<String>> {
+        let world = self.get_scoreboard_res(&res)?.provider.clone();
+        let sb = world.scoreboard.lock().await;
+        Ok(sb
+            .get_teams()
+            .values()
+            .find(|t| t.players.contains(&entry))
+            .map(|t| t.name.clone()))
     }
 
     async fn add_player_to_team(

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -13,6 +13,7 @@ use crate::plugin::server::server_broadcast::ServerBroadcastEvent;
 use crate::server::tick_rate_manager::ServerTickRateManager;
 use crate::world::WorldPortal;
 use crate::world::custom_bossbar::CustomBossbars;
+use crate::world::scoreboard::Scoreboard;
 use crate::{
     command::node::dispatcher::CommandDispatcher, entity::player::Player, world::World,
     world::map::MapManager,
@@ -142,6 +143,8 @@ pub struct Server {
     // world stuff which maybe should be put into a struct
     pub level_info: Arc<ArcSwap<LevelData>>,
     world_info_writer: Arc<dyn WorldInfoWriter>,
+    /// Single global scoreboard shared across all dimensions.
+    pub scoreboard: Arc<tokio::sync::Mutex<Scoreboard>>,
 }
 
 impl Server {
@@ -198,6 +201,12 @@ impl Server {
 
         let seed = level_info.world_gen_settings.seed;
         let level_info = Arc::new(ArcSwap::new(Arc::new(level_info)));
+
+        // Create single global scoreboard from saved data
+        let scoreboard_data = level_info.load().scoreboard_data.clone();
+        let mut sb = Scoreboard::default();
+        sb.load_from_data(&scoreboard_data);
+        let scoreboard: Arc<tokio::sync::Mutex<Scoreboard>> = Arc::new(tokio::sync::Mutex::new(sb));
 
         let listing = Mutex::new(CachedStatus::new(
             &basic_config,
@@ -293,6 +302,7 @@ impl Server {
             mojang_public_keys: ArcSwap::from_pointee(Vec::new()),
             world_info_writer: Arc::new(AnvilLevelInfo),
             level_info,
+            scoreboard,
         };
         let server = Arc::new(server);
 
@@ -315,6 +325,7 @@ impl Server {
             let path = world_path.clone();
             let registry = block_registry.clone();
             let l_info = server.level_info.clone(); // Access from struct
+            let sb = server.scoreboard.clone();
             let weak = Arc::downgrade(&server);
             let config = Arc::new(server.advanced_config.world.clone());
             let pool = gen_pool.clone();
@@ -327,7 +338,7 @@ impl Server {
                         .to_pretty_console()
                 );
                 let level = into_level(dim.clone(), &config, path, seed, Some(pool));
-                let world = Arc::new(World::load(level.clone(), l_info, dim, registry, weak));
+                let world = Arc::new(World::load(level.clone(), l_info, sb, dim, registry, weak));
                 let portal: Arc<dyn WorldPortalExt> = Arc::new(WorldPortal(world.clone()));
                 level.world_portal.store(Arc::new(Some(portal)));
                 world
@@ -426,6 +437,7 @@ impl Server {
             let world_path = server.basic_config.get_world_path().join(name_clone);
             let registry = server.block_registry.clone();
             let l_info = server.level_info.clone();
+            let sb = server.scoreboard.clone();
             let weak = Arc::downgrade(&server);
             let config = Arc::new(server.advanced_config.world.clone());
             let seed = server.level_info.load().world_gen_settings.seed;
@@ -438,7 +450,7 @@ impl Server {
                 seed,
                 None,
             );
-            let world: World = World::load(level.clone(), l_info, dimension, registry, weak);
+            let world: World = World::load(level.clone(), l_info, sb, dimension, registry, weak);
             let world = Arc::new(world);
             let portal: Arc<dyn WorldPortalExt> = Arc::new(WorldPortal(world.clone()));
             level.world_portal.store(Arc::new(Some(portal)));
@@ -600,6 +612,16 @@ impl Server {
         for world in self.worlds.load().iter() {
             world.shutdown().await;
         }
+
+        // Save scoreboard into the shared LevelData
+        let sb_data = {
+            let sb = self.scoreboard.lock().await;
+            sb.to_data()
+        };
+        let mut level_data = self.level_info.load().as_ref().clone();
+        level_data.scoreboard_data = sb_data;
+        self.level_info.store(Arc::new(level_data));
+
         let level_data = self.level_info.load();
         // then lets save the world info
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -198,7 +198,8 @@ pub struct World {
     /// This does not include players.
     pub entities: ArcSwap<Vec<Arc<dyn EntityBase>>>,
     /// The world's scoreboard, used for tracking scores, objectives, and display information.
-    pub scoreboard: Mutex<Scoreboard>,
+    /// Shared scoreboard across all dimensions.
+    pub scoreboard: Arc<tokio::sync::Mutex<Scoreboard>>,
     /// The world's worldborder, defining the playable area and controlling its expansion or contraction.
     pub worldborder: Mutex<Worldborder>,
     /// The world's time, including counting ticks for weather, time cycles, and statistics.
@@ -279,6 +280,7 @@ impl World {
     pub fn load(
         level: Arc<Level>,
         level_info: Arc<ArcSwap<LevelData>>,
+        scoreboard: Arc<tokio::sync::Mutex<Scoreboard>>,
         dimension: Dimension,
         block_registry: Arc<BlockRegistry>,
         server: Weak<Server>,
@@ -290,13 +292,14 @@ impl World {
         let portal_poi = portal::PortalPoiStorage::new(level.level_folder.poi_folder.clone());
         let dragon_fight = (dimension.minecraft_name == Dimension::THE_END.minecraft_name)
             .then(|| Mutex::new(dragon_fight::DragonFight::new()));
+
         Self {
             uuid: Uuid::new_v4(),
             level,
             level_info,
             players: ArcSwap::new(Arc::new(Vec::new())),
             entities: ArcSwap::new(Arc::new(Vec::new())),
-            scoreboard: Mutex::new(Scoreboard::default()),
+            scoreboard,
             worldborder: Mutex::new(Worldborder::new(0.0, 0.0, 5.999_996_8E7, 0, 5, 300)),
             level_time: Mutex::new(LevelTime::new()),
             dimension,
@@ -375,6 +378,8 @@ impl World {
         if let Err(e) = save_result {
             error!("Failed to save portal POI: {e}");
         }
+
+        // Scoreboard is global and saved by Server::shutdown() (vanilla: single global scoreboard)
 
         self.level.shutdown().await;
     }
@@ -3166,6 +3171,12 @@ impl World {
         )
         .color_named(NamedColor::Yellow);
         let event = PlayerJoinEvent::new(player.clone(), msg_comp);
+
+        // Send scoreboard state (tracked objectives + display slots + scores) to joining player
+        self.scoreboard
+            .lock()
+            .await
+            .send_state_to_player(player.as_ref());
 
         let event = server.plugin_manager.fire(event).await;
 

--- a/pumpkin/src/world/scoreboard.rs
+++ b/pumpkin/src/world/scoreboard.rs
@@ -1,16 +1,14 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use pumpkin_data::scoreboard::ScoreboardDisplaySlot;
 use pumpkin_protocol::{
     BClientPacket, ClientPacket, NumberFormat,
-    bedrock::client::scoreboard::{
-        CRemoveObjective as BRemoveObjective, CSetDisplayObjective as BSetDisplayObjective,
-        CSetScore as BSetScore, ScoreEntry as BScoreEntry,
-    },
+    bedrock::client::scoreboard::{CSetScore as BSetScore, ScoreEntry as BScoreEntry},
     codec::var_int::VarInt,
     java::client::play::{
-        CDisplayObjective, CSetPlayerTeam, CUpdateObjectives, CUpdateScore, Mode, RenderType,
-        TeamMethod, TeamParameters,
+        CDisplayObjective, CResetScore, CSetPlayerTeam, CUpdateObjectives, CUpdateScore, Mode,
+        RenderType, TeamMethod, TeamParameters,
     },
 };
 use pumpkin_util::text::{TextComponent, color::NamedColor};
@@ -18,21 +16,153 @@ use tracing::warn;
 
 use super::World;
 
+/// Returns `true` if the criterion name is valid (either a known built-in
+/// or matches the `stat.*` or `teamkill.*` / `killedByTeam.*` patterns).
+#[must_use]
+pub fn is_valid_criterion(criterion: &str) -> bool {
+    const BUILT_IN_CRITERIA: &[&str] = &[
+        "dummy",
+        "trigger",
+        "deathCount",
+        "playerKillCount",
+        "totalKillCount",
+        "health",
+        "food",
+        "air",
+        "armor",
+        "xp",
+        "level",
+    ];
+    const TEAM_COLORS: &[&str] = &[
+        "black",
+        "dark_blue",
+        "dark_green",
+        "dark_aqua",
+        "dark_red",
+        "dark_purple",
+        "gold",
+        "gray",
+        "dark_gray",
+        "blue",
+        "green",
+        "aqua",
+        "red",
+        "light_purple",
+        "yellow",
+        "white",
+    ];
+
+    if BUILT_IN_CRITERIA.contains(&criterion) {
+        return true;
+    }
+
+    // Team kill criteria: teamkill.<color> or killedByTeam.<color>
+    for color in TEAM_COLORS {
+        let teamkill_crit = format!("teamkill.{color}");
+        let killed_crit = format!("killedByTeam.{color}");
+        if criterion == teamkill_crit || criterion == killed_crit {
+            return true;
+        }
+    }
+
+    // Stat criteria: stat.<stat_type>.<stat>
+    let parts: Vec<&str> = criterion.split('.').collect();
+    if parts.len() >= 3 && parts[0] == "stat" {
+        return true;
+    }
+
+    false
+}
+
+/// Returns the default [`RenderType`] for a built-in criterion.
+///
+/// Only `"health"` defaults to `Hearts`; all others default to `Integer`.
+#[must_use]
+pub fn default_render_type_for_criterion(criterion: &str) -> RenderType {
+    match criterion {
+        "health" => RenderType::Hearts,
+        _ => RenderType::Integer,
+    }
+}
+
+/// Returns the string name for a display slot.
+/// Used as the NBT key in `scoreboard.dat` (NBT only supports string keys).
+#[must_use]
+pub const fn display_slot_name(slot: ScoreboardDisplaySlot) -> &'static str {
+    match slot {
+        ScoreboardDisplaySlot::List => "list",
+        ScoreboardDisplaySlot::Sidebar => "sidebar",
+        ScoreboardDisplaySlot::BelowName => "below_name",
+        ScoreboardDisplaySlot::TeamBlack => "sidebar.team.black",
+        ScoreboardDisplaySlot::TeamDarkBlue => "sidebar.team.dark_blue",
+        ScoreboardDisplaySlot::TeamDarkGreen => "sidebar.team.dark_green",
+        ScoreboardDisplaySlot::TeamDarkAqua => "sidebar.team.dark_aqua",
+        ScoreboardDisplaySlot::TeamDarkRed => "sidebar.team.dark_red",
+        ScoreboardDisplaySlot::TeamDarkPurple => "sidebar.team.dark_purple",
+        ScoreboardDisplaySlot::TeamGold => "sidebar.team.gold",
+        ScoreboardDisplaySlot::TeamGray => "sidebar.team.gray",
+        ScoreboardDisplaySlot::TeamDarkGray => "sidebar.team.dark_gray",
+        ScoreboardDisplaySlot::TeamBlue => "sidebar.team.blue",
+        ScoreboardDisplaySlot::TeamGreen => "sidebar.team.green",
+        ScoreboardDisplaySlot::TeamAqua => "sidebar.team.aqua",
+        ScoreboardDisplaySlot::TeamRed => "sidebar.team.red",
+        ScoreboardDisplaySlot::TeamLightPurple => "sidebar.team.light_purple",
+        ScoreboardDisplaySlot::TeamYellow => "sidebar.team.yellow",
+        ScoreboardDisplaySlot::TeamWhite => "sidebar.team.white",
+    }
+}
+
+/// Parses a display slot from its string name (inverse of [`display_slot_name`]).
+#[must_use]
+pub fn display_slot_from_name(name: &str) -> Option<ScoreboardDisplaySlot> {
+    match name {
+        "list" => Some(ScoreboardDisplaySlot::List),
+        "sidebar" => Some(ScoreboardDisplaySlot::Sidebar),
+        "below_name" => Some(ScoreboardDisplaySlot::BelowName),
+        "sidebar.team.black" => Some(ScoreboardDisplaySlot::TeamBlack),
+        "sidebar.team.dark_blue" => Some(ScoreboardDisplaySlot::TeamDarkBlue),
+        "sidebar.team.dark_green" => Some(ScoreboardDisplaySlot::TeamDarkGreen),
+        "sidebar.team.dark_aqua" => Some(ScoreboardDisplaySlot::TeamDarkAqua),
+        "sidebar.team.dark_red" => Some(ScoreboardDisplaySlot::TeamDarkRed),
+        "sidebar.team.dark_purple" => Some(ScoreboardDisplaySlot::TeamDarkPurple),
+        "sidebar.team.gold" => Some(ScoreboardDisplaySlot::TeamGold),
+        "sidebar.team.gray" => Some(ScoreboardDisplaySlot::TeamGray),
+        "sidebar.team.dark_gray" => Some(ScoreboardDisplaySlot::TeamDarkGray),
+        "sidebar.team.blue" => Some(ScoreboardDisplaySlot::TeamBlue),
+        "sidebar.team.green" => Some(ScoreboardDisplaySlot::TeamGreen),
+        "sidebar.team.aqua" => Some(ScoreboardDisplaySlot::TeamAqua),
+        "sidebar.team.red" => Some(ScoreboardDisplaySlot::TeamRed),
+        "sidebar.team.light_purple" => Some(ScoreboardDisplaySlot::TeamLightPurple),
+        "sidebar.team.yellow" => Some(ScoreboardDisplaySlot::TeamYellow),
+        "sidebar.team.white" => Some(ScoreboardDisplaySlot::TeamWhite),
+        _ => None,
+    }
+}
+
 #[derive(Default)]
 pub struct Scoreboard {
-    objectives: HashMap<String, ScoreboardObjective<'static>>,
+    objectives: HashMap<String, ScoreboardObjective>,
     teams: HashMap<String, Team>,
-    scores: HashMap<String, HashMap<String, ScoreboardScore<'static>>>,
+    scores: HashMap<String, HashMap<String, ScoreboardScore>>,
+    /// Tracks which objective (by name) is currently displayed in each display slot.
+    /// A `None` value means the slot is empty (no objective displayed).
+    display_objectives: HashMap<ScoreboardDisplaySlot, Option<String>>,
+    /// Only tracked objectives are sent to clients via packets. An objective becomes tracked when it is
+    /// assigned to a display slot. Creating an objective does NOT make it tracked.
+    tracked_objectives: HashSet<String>,
+    /// Reverse index from criterion name -> objective names.
+    /// Enables efficient updates of all objectives tracking a given auto-computed criterion (health, food, etc.).
+    objectives_by_criterion: HashMap<String, Vec<String>>,
 }
 
 impl Scoreboard {
     #[must_use]
-    pub const fn get_objectives(&self) -> &HashMap<String, ScoreboardObjective<'static>> {
+    pub const fn get_objectives(&self) -> &HashMap<String, ScoreboardObjective> {
         &self.objectives
     }
 
     #[must_use]
-    pub const fn get_scores(&self) -> &HashMap<String, HashMap<String, ScoreboardScore<'static>>> {
+    pub const fn get_scores(&self) -> &HashMap<String, HashMap<String, ScoreboardScore>> {
         &self.scores
     }
 
@@ -49,44 +179,165 @@ impl Scoreboard {
         world.broadcast_editioned(je_packet, be_packet).await;
     }
 
-    pub async fn add_objective(&mut self, world: &World, objective: ScoreboardObjective<'static>) {
-        if self.objectives.contains_key(objective.name) {
+    /// Adds an objective to the scoreboard without sending any packets.
+    pub fn add_objective(&mut self, _world: &World, objective: ScoreboardObjective) {
+        if self.objectives.contains_key(&*objective.name) {
             warn!(
                 "Tried to create an objective which already exists: {}",
-                &objective.name
+                &*objective.name
             );
             return;
         }
 
-        let je_update = CUpdateObjectives::new(
-            objective.name.to_string(),
+        let criterion = objective.criterion.to_string();
+        self.objectives_by_criterion
+            .entry(criterion)
+            .or_default()
+            .push(objective.name.to_string());
+        self.objectives
+            .insert(objective.name.to_string(), objective);
+    }
+
+    /// Updates display name, render type, number format, or display auto-update on an existing objective and
+    /// sends the update packet to all players if the objective is tracked.
+    pub fn modify_objective(
+        &mut self,
+        world: &World,
+        objective_name: &str,
+        display_name: TextComponent,
+        render_type: RenderType,
+        number_format: Option<NumberFormat>,
+    ) -> bool {
+        let Some(objective) = self.objectives.get_mut(objective_name) else {
+            return false;
+        };
+        objective.display_name = display_name.clone();
+        objective.render_type = render_type;
+        objective.number_format.clone_from(&number_format);
+
+        // Only send update packet if tracked
+        if self.tracked_objectives.contains(objective_name) {
+            let je_update = CUpdateObjectives::new(
+                objective_name.to_string(),
+                Mode::Update,
+                display_name,
+                render_type,
+                number_format,
+            );
+            world.broadcast_packet_all(&je_update);
+        }
+        true
+    }
+
+    /// Sets the `display_auto_update` flag on an objective. When true, the score's
+    /// display name is automatically updated to the score holder's display name
+    /// whenever the score is modified.
+    pub fn set_display_auto_update(
+        &mut self,
+        world: &World,
+        objective_name: &str,
+        display_auto_update: bool,
+    ) -> bool {
+        let Some(objective) = self.objectives.get_mut(objective_name) else {
+            return false;
+        };
+        if objective.display_auto_update == display_auto_update {
+            return true;
+        }
+        objective.display_auto_update = display_auto_update;
+
+        // Sends update packet for tracked objectives
+        if self.tracked_objectives.contains(objective_name) {
+            let je_update = CUpdateObjectives::new(
+                objective_name.to_string(),
+                Mode::Update,
+                objective.display_name.clone(),
+                objective.render_type,
+                objective.number_format.clone(),
+            );
+            world.broadcast_packet_all(&je_update);
+        }
+        true
+    }
+
+    pub fn set_objective_number_format(
+        &mut self,
+        world: &World,
+        objective_name: &str,
+        number_format: Option<NumberFormat>,
+    ) -> bool {
+        let Some(objective) = self.objectives.get_mut(objective_name) else {
+            return false;
+        };
+        objective.number_format.clone_from(&number_format);
+
+        if self.tracked_objectives.contains(objective_name) {
+            let je_update = CUpdateObjectives::new(
+                objective_name.to_string(),
+                Mode::Update,
+                objective.display_name.clone(),
+                objective.render_type,
+                number_format,
+            );
+            world.broadcast_packet_all(&je_update);
+        }
+        true
+    }
+
+    /// Sends the create-objective packet and all existing scores for this objective to all players.
+    /// Called when an objective is assigned to a display slot for the first time.
+    fn start_tracking_objective(&mut self, world: &World, objective_name: &str) {
+        if self.tracked_objectives.contains(objective_name) {
+            return; // already tracked
+        }
+        let Some(objective) = self.objectives.get(objective_name) else {
+            return;
+        };
+
+        // Send CREATE objective packet
+        let je_create = CUpdateObjectives::new(
+            objective_name.to_string(),
             Mode::Add,
             objective.display_name.clone(),
             objective.render_type,
             objective.number_format.clone(),
         );
+        world.broadcast_packet_all(&je_create);
 
-        let be_update = BSetDisplayObjective {
-            display_slot: "sidebar".to_string(), // Default to sidebar
-            objective_name: objective.name.to_string(),
-            display_name: objective.display_name.clone().get_text(),
-            criteria_name: "dummy".to_string(),
-            sort_order: VarInt(0),
-        };
+        // Send all existing scores for this objective
+        if let Some(objective_scores) = self.scores.get(objective_name) {
+            for score in objective_scores.values() {
+                let je_score = CUpdateScore::new(
+                    score.entity_name.to_string(),
+                    score.objective_name.to_string(),
+                    score.value,
+                    score.display_name.clone(),
+                    score.number_format.clone(),
+                );
+                world.broadcast_packet_all(&je_score);
+            }
+        }
 
-        Self::broadcast_editioned(world, &je_update, &be_update).await;
-
-        let je_display =
-            CDisplayObjective::new(ScoreboardDisplaySlot::Sidebar, objective.name.to_string());
-        // Bedrock's SetDisplayObjective already sets the slot.
-
-        world.broadcast_packet_all(&je_display);
-
-        self.objectives
-            .insert(objective.name.to_string(), objective);
+        self.tracked_objectives.insert(objective_name.to_string());
     }
 
-    pub async fn remove_objective(&mut self, world: &World, name: &str) {
+    /// Sends the remove-objective packet and removes from tracking.
+    fn stop_tracking_objective(&mut self, world: &World, objective_name: &str) {
+        if !self.tracked_objectives.remove(objective_name) {
+            return; // wasn't tracked
+        }
+
+        let je_remove = CUpdateObjectives::new(
+            objective_name.to_string(),
+            Mode::Remove,
+            TextComponent::empty(),
+            RenderType::Integer,
+            None,
+        );
+        world.broadcast_packet_all(&je_remove);
+    }
+
+    pub fn remove_objective(&mut self, world: &World, name: &str) {
         if !self.objectives.contains_key(name) {
             warn!(
                 "Tried to remove an objective which does not exist: {}",
@@ -95,26 +346,476 @@ impl Scoreboard {
             return;
         }
 
-        let je_packet = CUpdateObjectives::new(
-            name.to_string(),
-            Mode::Remove,
-            TextComponent::empty(),
-            RenderType::Integer,
-            None,
-        );
+        // Stop tracking first (sends remove packet, clears display slots)
+        self.stop_tracking_objective(world, name);
 
-        let be_packet = BRemoveObjective {
-            objective_name: name.to_string(),
-        };
+        // When removing an objective, clear any display slots showing it
+        for (slot, displayed) in &self.display_objectives {
+            if displayed.as_deref() == Some(name) {
+                let clear_packet = CDisplayObjective::new(*slot, String::new());
+                world.broadcast_packet_all(&clear_packet);
+            }
+        }
+        self.display_objectives
+            .retain(|_, v| v.as_deref() != Some(name));
 
-        Self::broadcast_editioned(world, &je_packet, &be_packet).await;
+        // Remove from objectives_by_criterion index
+        if let Some(objective) = self.objectives.get(name) {
+            let criterion = &*objective.criterion;
+            if let Some(objectives) = self.objectives_by_criterion.get_mut(criterion) {
+                objectives.retain(|n| n != name);
+                if objectives.is_empty() {
+                    self.objectives_by_criterion.remove(criterion);
+                }
+            }
+        }
 
         self.objectives.remove(name);
         self.scores.remove(name);
     }
 
-    pub async fn update_score(&mut self, world: &World, score: ScoreboardScore<'static>) {
-        if !self.objectives.contains_key(score.objective_name) {
+    /// Sets the objective to display in the given slot, or clears it if `None`.
+    /// Broadcasts the display change to all players.
+    pub fn set_display_objective(
+        &mut self,
+        world: &World,
+        slot: ScoreboardDisplaySlot,
+        objective_name: Option<&str>,
+    ) {
+        let old_objective = self.get_display_objective(&slot).map(ToString::to_string);
+        let score_name = objective_name.unwrap_or("");
+
+        if let Some(name) = objective_name {
+            // If this objective is not yet tracked, start tracking it
+            // (sends create packet + all scores + display packet)
+            if !self.tracked_objectives.contains(name) {
+                self.start_tracking_objective(world, name);
+            }
+        } else if let Some(ref old_name) = old_objective {
+            // Clearing a slot. If the old objective had no other
+            // display slots, it gets untracked (remove packet sent).
+            let has_other_slots = self
+                .display_objectives
+                .iter()
+                .any(|(s, v)| s != &slot && v.as_deref() == Some(old_name.as_str()));
+            if !has_other_slots {
+                self.stop_tracking_objective(world, old_name);
+            }
+        }
+
+        let je_packet = CDisplayObjective::new(slot, score_name.to_string());
+        world.broadcast_packet_all(&je_packet);
+        self.display_objectives
+            .insert(slot, objective_name.map(ToString::to_string));
+    }
+
+    /// Returns the name of the objective currently displayed in the given slot, or `None`.
+    #[must_use]
+    pub fn get_display_objective(&self, slot: &ScoreboardDisplaySlot) -> Option<&str> {
+        self.display_objectives.get(slot).and_then(|v| v.as_deref())
+    }
+
+    #[must_use]
+    pub fn get_objective(&self, name: &str) -> Option<&ScoreboardObjective> {
+        self.objectives.get(name)
+    }
+
+    /// Updates all objectives that use the given criterion with the specified value for the entity.
+    /// Automatically creates score entries if they don't exist.
+    pub async fn for_all_objectives(
+        &mut self,
+        world: &World,
+        criterion: &str,
+        entity_name: &str,
+        value: i32,
+    ) {
+        let Some(objective_names) = self.objectives_by_criterion.get(criterion).cloned() else {
+            return;
+        };
+
+        for objective_name in &objective_names {
+            let score = ScoreboardScore {
+                entity_name: Arc::from(entity_name),
+                objective_name: Arc::from(objective_name.as_str()),
+                value: VarInt(value),
+                display_name: None,
+                number_format: None,
+                locked: false,
+            };
+            self.update_score(world, score).await;
+        }
+    }
+
+    /// Returns whether the given objective is currently tracked (displayed).
+    #[must_use]
+    pub fn is_tracked(&self, objective_name: &str) -> bool {
+        self.tracked_objectives.contains(objective_name)
+    }
+
+    /// Returns all score holders that have at least one score entry.
+    #[must_use]
+    pub fn get_tracked_players(&self) -> Vec<&str> {
+        let mut players: Vec<&str> = self
+            .scores
+            .values()
+            .flat_map(|scores| scores.keys().map(String::as_str))
+            .collect();
+        players.sort_unstable();
+        players.dedup();
+        players
+    }
+
+    /// Resets a single score for a player. Sends a reset-score packet if the
+    /// objective was tracked.
+    pub fn reset_single_player_score(
+        &mut self,
+        world: &World,
+        entity_name: &str,
+        objective_name: &str,
+    ) {
+        let was_removed = self
+            .scores
+            .get_mut(objective_name)
+            .is_some_and(|m| m.remove(entity_name).is_some());
+
+        if was_removed && self.tracked_objectives.contains(objective_name) {
+            let packet =
+                CResetScore::new(entity_name.to_string(), Some(objective_name.to_string()));
+            world.broadcast_packet_all(&packet);
+        }
+    }
+
+    /// Resets all scores for a player across all objectives.
+    pub fn reset_all_player_scores(&mut self, world: &World, entity_name: &str) {
+        let mut any_removed = false;
+        self.scores.retain(|objective_name, scores| {
+            if scores.remove(entity_name).is_some() {
+                any_removed = true;
+                // Only send reset packets for tracked objectives
+                if self.tracked_objectives.contains(objective_name) {
+                    let packet =
+                        CResetScore::new(entity_name.to_string(), Some(objective_name.clone()));
+                    world.broadcast_packet_all(&packet);
+                }
+            }
+            !scores.is_empty()
+        });
+
+        // Send a final reset with null objective if any scores were removed
+        if any_removed {
+            let packet = CResetScore::new(entity_name.to_string(), None);
+            world.broadcast_packet_all(&packet);
+        }
+    }
+
+    #[must_use]
+    pub fn get_player_score_info(
+        &self,
+        entity_name: &str,
+        objective_name: &str,
+    ) -> Option<&ScoreboardScore> {
+        self.scores
+            .get(objective_name)
+            .and_then(|m| m.get(entity_name))
+    }
+
+    pub fn set_score_number_format(
+        &mut self,
+        world: &World,
+        entity_name: &str,
+        objective_name: &str,
+        number_format: Option<NumberFormat>,
+    ) -> bool {
+        let Some(score) = self
+            .scores
+            .get_mut(objective_name)
+            .and_then(|m| m.get_mut(entity_name))
+        else {
+            return false;
+        };
+        score.number_format.clone_from(&number_format);
+        if self.tracked_objectives.contains(objective_name) {
+            let packet = CUpdateScore::new(
+                entity_name.to_string(),
+                objective_name.to_string(),
+                score.value,
+                score.display_name.clone(),
+                number_format,
+            );
+            world.broadcast_packet_all(&packet);
+        }
+        true
+    }
+
+    /// Sets the optional display name for a score entry. Sends packet if tracked.
+    pub fn set_score_display_name(
+        &mut self,
+        world: &World,
+        entity_name: &str,
+        objective_name: &str,
+        display_name: Option<TextComponent>,
+    ) -> bool {
+        let Some(score) = self
+            .scores
+            .get_mut(objective_name)
+            .and_then(|m| m.get_mut(entity_name))
+        else {
+            return false;
+        };
+        score.display_name.clone_from(&display_name);
+        if self.tracked_objectives.contains(objective_name) {
+            let packet = CUpdateScore::new(
+                entity_name.to_string(),
+                objective_name.to_string(),
+                score.value,
+                display_name,
+                score.number_format.clone(),
+            );
+            world.broadcast_packet_all(&packet);
+        }
+        true
+    }
+
+    #[must_use]
+    pub fn list_scores_for_objective(&self, objective_name: &str) -> Vec<&ScoreboardScore> {
+        self.scores
+            .get(objective_name)
+            .map(|m| m.values().collect())
+            .unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn list_scores_for_player(&self, entity_name: &str) -> Vec<(&str, i32)> {
+        let mut result = Vec::new();
+        for (obj_name, scores) in &self.scores {
+            if let Some(score) = scores.get(entity_name) {
+                result.push((obj_name.as_str(), score.value.0));
+            }
+        }
+        result
+    }
+
+    /// Sends the full scoreboard state (all tracked objectives + display slots + scores)
+    /// to a single player. Called when a player joins the world.
+    pub fn send_state_to_player(&self, player: &crate::entity::player::Player) {
+        // Send all tracked objectives (create packet + scores)
+        for objective_name in &self.tracked_objectives {
+            let Some(objective) = self.objectives.get(objective_name.as_str()) else {
+                continue;
+            };
+            let je_create = CUpdateObjectives::new(
+                objective_name.clone(),
+                Mode::Add,
+                objective.display_name.clone(),
+                objective.render_type,
+                objective.number_format.clone(),
+            );
+            // FIXME: using try_enqueue_packet since this is called in spawn context
+            player.client.try_enqueue_packet(&je_create);
+
+            // Send all scores for this objective
+            if let Some(objective_scores) = self.scores.get(objective_name.as_str()) {
+                for score in objective_scores.values() {
+                    let je_score = CUpdateScore::new(
+                        score.entity_name.to_string(),
+                        score.objective_name.to_string(),
+                        score.value,
+                        score.display_name.clone(),
+                        score.number_format.clone(),
+                    );
+                    player.client.try_enqueue_packet(&je_score);
+                }
+            }
+        }
+
+        // Send display slot bindings
+        for (slot, objective_name) in &self.display_objectives {
+            let name = objective_name.as_deref().unwrap_or("");
+            let je_display = CDisplayObjective::new(*slot, name.to_string());
+            player.client.try_enqueue_packet(&je_display);
+        }
+    }
+
+    /// Converts the in-memory scoreboard to a serializable data structure for disk storage.
+    #[must_use]
+    pub fn to_data(&self) -> pumpkin_world::world_info::data_files::ScoreboardData {
+        use pumpkin_protocol::java::client::play::RenderType;
+        use pumpkin_world::world_info::data_files::{
+            SerializableObjective, SerializableScore, SerializableTeam,
+        };
+
+        let objectives = self
+            .objectives
+            .values()
+            .map(|obj| {
+                let display_json = serde_json::to_string(&obj.display_name).unwrap_or_default();
+                SerializableObjective {
+                    name: obj.name.to_string(),
+                    display_name: display_json,
+                    render_type: match obj.render_type {
+                        RenderType::Integer => "integer".to_string(),
+                        RenderType::Hearts => "hearts".to_string(),
+                    },
+                    criteria_name: obj.criterion.to_string(),
+                    display_auto_update: obj.display_auto_update,
+                    number_format: obj
+                        .number_format
+                        .as_ref()
+                        .map(|nf| serde_json::to_string(nf).unwrap_or_default()),
+                }
+            })
+            .collect();
+
+        let mut scores = Vec::new();
+        for (obj_name, obj_scores) in &self.scores {
+            for score in obj_scores.values() {
+                scores.push(SerializableScore {
+                    entity_name: score.entity_name.to_string(),
+                    objective_name: obj_name.clone(),
+                    value: score.value.0,
+                    locked: score.locked,
+                    display: score
+                        .display_name
+                        .as_ref()
+                        .map(|d| serde_json::to_string(d).unwrap_or_default()),
+                    number_format: score
+                        .number_format
+                        .as_ref()
+                        .map(|nf| serde_json::to_string(nf).unwrap_or_default()),
+                });
+            }
+        }
+
+        let teams = self
+            .teams
+            .values()
+            .map(|t| {
+                let display_json = serde_json::to_string(&t.display_name).unwrap_or_default();
+                SerializableTeam {
+                    name: t.name.clone(),
+                    display_name: display_json,
+                    players: t.players.clone(),
+                }
+            })
+            .collect();
+
+        let display_slots = self
+            .display_objectives
+            .iter()
+            .filter_map(|(slot, name)| {
+                name.as_ref()
+                    .map(|n| (display_slot_name(*slot).to_string(), n.clone()))
+            })
+            .collect();
+
+        pumpkin_world::world_info::data_files::ScoreboardData {
+            objectives,
+            scores,
+            teams,
+            display_slots,
+        }
+    }
+
+    /// Populates this scoreboard from serialized data (loaded from disk).
+    pub fn load_from_data(&mut self, data: &pumpkin_world::world_info::data_files::ScoreboardData) {
+        use pumpkin_protocol::java::client::play::RenderType;
+
+        // Clear existing data
+        self.objectives.clear();
+        self.teams.clear();
+        self.scores.clear();
+        self.display_objectives.clear();
+        self.tracked_objectives.clear();
+        self.objectives_by_criterion.clear();
+
+        // Load objectives
+        for obj in &data.objectives {
+            let render_type = if obj.render_type == "hearts" {
+                RenderType::Hearts
+            } else {
+                RenderType::Integer
+            };
+            let display_name = serde_json::from_str(&obj.display_name)
+                .unwrap_or_else(|_| TextComponent::text(obj.display_name.clone()));
+            let number_format = obj
+                .number_format
+                .as_ref()
+                .and_then(|s| serde_json::from_str(s).ok());
+            let mut objective = ScoreboardObjective::new(
+                Arc::from(obj.name.as_str()),
+                display_name,
+                render_type,
+                number_format,
+                Arc::from(obj.criteria_name.as_str()),
+            );
+            objective.display_auto_update = obj.display_auto_update;
+            let criterion = obj.criteria_name.clone();
+            self.objectives_by_criterion
+                .entry(criterion)
+                .or_default()
+                .push(obj.name.clone());
+            self.objectives.insert(obj.name.clone(), objective);
+        }
+
+        // Load scores
+        for score in &data.scores {
+            let display_name = score
+                .display
+                .as_ref()
+                .and_then(|d| serde_json::from_str(d).ok());
+            let number_format = score
+                .number_format
+                .as_ref()
+                .and_then(|s| serde_json::from_str(s).ok());
+            let entry = self.scores.entry(score.objective_name.clone()).or_default();
+            entry.insert(
+                score.entity_name.clone(),
+                ScoreboardScore {
+                    entity_name: Arc::from(score.entity_name.as_str()),
+                    objective_name: Arc::from(score.objective_name.as_str()),
+                    value: VarInt(score.value),
+                    display_name,
+                    number_format,
+                    locked: score.locked,
+                },
+            );
+        }
+
+        // Load teams
+        for team in &data.teams {
+            let display_name = serde_json::from_str(&team.display_name)
+                .unwrap_or_else(|_| TextComponent::text(team.display_name.clone()));
+            self.teams.insert(
+                team.name.clone(),
+                Team {
+                    name: team.name.clone(),
+                    display_name,
+                    options: 0,
+                    nametag_visibility: crate::world::scoreboard::NameTagVisibility::Always,
+                    collision_rule: crate::world::scoreboard::CollisionRule::Always,
+                    color: NamedColor::White,
+                    player_prefix: TextComponent::empty(),
+                    player_suffix: TextComponent::empty(),
+                    players: team.players.clone(),
+                },
+            );
+        }
+
+        // Load display slots (stored as string keys in NBT)
+        for (slot_name, obj_name) in &data.display_slots {
+            if let Some(slot) = display_slot_from_name(slot_name) {
+                self.display_objectives.insert(slot, Some(obj_name.clone()));
+            }
+        }
+
+        // Repopulate tracked_objectives: any objective assigned to a display slot is "tracked"
+        for name in self.display_objectives.values().flatten() {
+            self.tracked_objectives.insert(name.clone());
+        }
+    }
+
+    pub async fn update_score(&mut self, world: &World, mut score: ScoreboardScore) {
+        if !self.objectives.contains_key(&*score.objective_name) {
             warn!(
                 "Tried to place a score into an objective which does not exist: {}",
                 &score.objective_name
@@ -122,27 +823,41 @@ impl Scoreboard {
             return;
         }
 
-        let je_packet = CUpdateScore::new(
-            score.entity_name.to_string(),
-            score.objective_name.to_string(),
-            score.value,
-            score.display_name.clone(),
-            score.number_format.clone(),
-        );
+        // If the objective has this flag set, the score's display name is auto-updated to the score holder's display name.
+        if let Some(objective) = self.objectives.get(&*score.objective_name)
+            && objective.display_auto_update
+        {
+            let entity_display = TextComponent::text(score.entity_name.to_string());
+            let should_update = score.display_name.as_ref() != Some(&entity_display);
+            if should_update {
+                score.display_name = Some(entity_display);
+            }
+        }
 
-        let be_packet = BSetScore {
-            action: VarInt(0), // Change
-            entries: vec![BScoreEntry {
-                scoreboard_id: score.entity_name.as_ptr() as i64, // Hacky ID
-                objective_name: score.objective_name.to_string(),
-                score: score.value,
-                entry_type: VarInt(3), // Fake player/Literal
-                entity_unique_id: 0,
-                custom_name: score.entity_name.to_string(),
-            }],
-        };
+        // Only send packets for tracked objectives
+        if self.tracked_objectives.contains(&*score.objective_name) {
+            let je_packet = CUpdateScore::new(
+                score.entity_name.to_string(),
+                score.objective_name.to_string(),
+                score.value,
+                score.display_name.clone(),
+                score.number_format.clone(),
+            );
 
-        Self::broadcast_editioned(world, &je_packet, &be_packet).await;
+            let be_packet = BSetScore {
+                action: VarInt(0), // Change
+                entries: vec![BScoreEntry {
+                    scoreboard_id: score.entity_name.as_ptr() as i64, // Hacky ID
+                    objective_name: score.objective_name.to_string(),
+                    score: score.value,
+                    entry_type: VarInt(3), // Fake player/Literal
+                    entity_unique_id: 0,
+                    custom_name: score.entity_name.to_string(),
+                }],
+            };
+
+            Self::broadcast_editioned(world, &je_packet, &be_packet).await;
+        }
 
         self.scores
             .entry(score.objective_name.to_string())
@@ -150,23 +865,27 @@ impl Scoreboard {
             .insert(score.entity_name.to_string(), score);
     }
 
+    /// Removes a score. Only sends packet if the objective is tracked.
     pub async fn remove_score(&mut self, world: &World, entity_name: &str, objective_name: &str) {
-        let je_packet =
-            CUpdateScore::new_remove(entity_name.to_string(), objective_name.to_string());
+        // Only send remove packet if objective is tracked
+        if self.tracked_objectives.contains(objective_name) {
+            let je_packet =
+                CUpdateScore::new_remove(entity_name.to_string(), objective_name.to_string());
 
-        let be_packet = BSetScore {
-            action: VarInt(1), // Remove
-            entries: vec![BScoreEntry {
-                scoreboard_id: entity_name.as_ptr() as i64,
-                objective_name: objective_name.to_string(),
-                score: VarInt(0),
-                entry_type: VarInt(3),
-                entity_unique_id: 0,
-                custom_name: entity_name.to_string(),
-            }],
-        };
+            let be_packet = BSetScore {
+                action: VarInt(1), // Remove
+                entries: vec![BScoreEntry {
+                    scoreboard_id: entity_name.as_ptr() as i64,
+                    objective_name: objective_name.to_string(),
+                    score: VarInt(0),
+                    entry_type: VarInt(3),
+                    entity_unique_id: 0,
+                    custom_name: entity_name.to_string(),
+                }],
+            };
 
-        Self::broadcast_editioned(world, &je_packet, &be_packet).await;
+            Self::broadcast_editioned(world, &je_packet, &be_packet).await;
+        }
 
         if let Some(objective_scores) = self.scores.get_mut(objective_name) {
             objective_scores.remove(entity_name);
@@ -291,22 +1010,23 @@ impl Scoreboard {
     }
 }
 
-pub struct ScoreboardObjective<'a> {
-    pub name: &'a str,
+pub struct ScoreboardObjective {
+    pub name: Arc<str>,
     pub display_name: TextComponent,
     pub render_type: RenderType,
     pub number_format: Option<NumberFormat>,
-    pub criterion: &'a str,
+    pub criterion: Arc<str>,
+    pub display_auto_update: bool,
 }
 
-impl<'a> ScoreboardObjective<'a> {
+impl ScoreboardObjective {
     #[must_use]
     pub const fn new(
-        name: &'a str,
+        name: Arc<str>,
         display_name: TextComponent,
         render_type: RenderType,
         number_format: Option<NumberFormat>,
-        criterion: &'a str,
+        criterion: Arc<str>,
     ) -> Self {
         Self {
             name,
@@ -314,24 +1034,25 @@ impl<'a> ScoreboardObjective<'a> {
             render_type,
             number_format,
             criterion,
+            display_auto_update: false,
         }
     }
 }
 
-pub struct ScoreboardScore<'a> {
-    pub entity_name: &'a str,
-    pub objective_name: &'a str,
+pub struct ScoreboardScore {
+    pub entity_name: Arc<str>,
+    pub objective_name: Arc<str>,
     pub value: VarInt,
     pub display_name: Option<TextComponent>,
     pub number_format: Option<NumberFormat>,
     pub locked: bool,
 }
 
-impl<'a> ScoreboardScore<'a> {
+impl ScoreboardScore {
     #[must_use]
     pub const fn new(
-        entity_name: &'a str,
-        objective_name: &'a str,
+        entity_name: Arc<str>,
+        objective_name: Arc<str>,
         value: VarInt,
         display_name: Option<TextComponent>,
         number_format: Option<NumberFormat>,


### PR DESCRIPTION
## Description
Overhauls the scoreboard system to fix long-standing issues and bring it much closer to vanilla parity, plus a greatly expanded scoreboard plugin API.

## Fixes
- [x] Scoreboard persistence (objectives, teams, scores, and display
  slots saved/loaded from `scoreboard.dat`)
- [x] Render types (integer/hearts)
- [x] Criteria (e.g. `dummy`, `health`, `trigger`, custom), not just hardcoded "dummy"
- [x] Display slots (added the missing team-colored sidebar slots and a new `DisplaySlot`
  command argument type)

## Commands
- [x] `/scoreboard` - objectives add/list/remove/modify, players get/set/add/remove/reset, teams create/join/leave/remove, and score operations.
- [x] `/trigger` - works with trigger-criteria objectives, so [future datapacks](https://github.com/Pumpkin-MC/Pumpkin/pull/2642) can use objective-based triggers.

## Plugin API (`scoreboard.wit`)
- [Check out my PR in the `pumpkin-plugin-wit` submodule](https://github.com/Pumpkin-MC/pumpkin-plugin-wit/pull/25) (waiting on this)

## Testing
Example: I got the hearts list display working:
<img width="854" height="480" alt="2026-07-29_17 08 57" src="https://github.com/user-attachments/assets/357bf442-9653-4073-b9c9-9832ba7645f2" />

