### PR TITLE
fix(combat): apply vanilla fist damage and attack speed

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -940,7 +940,11 @@ impl Player {
 
         {
             let stack = item_stack.lock().await;
-            if let Some(modifiers) = stack.get_data_component::<AttributeModifiersImpl>() {
+            if stack.is_empty() {
+                // Vanilla fist: base_attack_damage = -1.0, base_attack_speed = -2.4
+                add_damage = -1.0;
+                add_speed = -2.4;
+            } else if let Some(modifiers) = stack.get_data_component::<AttributeModifiersImpl>() {
                 for item_mod in modifiers.attribute_modifiers.iter() {
                     if item_mod.operation == Operation::AddValue {
                         if item_mod.id == "minecraft:base_attack_damage" {
@@ -1007,7 +1011,7 @@ impl Player {
         }
 
         // Modify the added damage based on the multiplier.
-        let mut damage = base_damage + add_damage * damage_multiplier;
+        let mut damage = (base_damage + add_damage) * damage_multiplier;
         damage += extra_ench_damage * attack_cooldown_progress;
 
         if let Some(strength) = self


### PR DESCRIPTION
Fixes fist (empty hand) dealing 2 damage instead of 1. The AIR item has no attribute modifiers, so the attack function used base_damage (2.0) + 0.0 = 2.0. Vanilla applies -1.0 base_attack_damage and -2.4 base_attack_speed for the fist, resulting in 1.0 damage and 1.6 attack speed.

This caused entities like cows (10 HP) to die in 5 hits instead of 10.

Also fixes fist attack speed being 4.0 (creative-mode speed) instead of vanilla 1.6.

Additionally fixes the cooldown scaling formula: `base_damage + add_damage * multiplier` incorrectly kept base_damage un-scaled, so weapon damage was reduced by cooldown but fist damage wasn't. Changed to `(base_damage + add_damage) * multiplier` to match vanilla.