### PR TITLE
fix(config): accept operator permission level 1

### DIFF
--- a/crates/pumpkin-util/src/permission.rs
+++ b/crates/pumpkin-util/src/permission.rs
@@ -452,30 +452,3 @@ impl<'de> Deserialize<'de> for PermissionLvl {
         }
     }
 }
-
-#[cfg(test)]
-mod test {
-    use crate::permission::PermissionLvl;
-
-    #[test]
-    fn serde_round_trip() {
-        for lvl in [
-            PermissionLvl::Zero,
-            PermissionLvl::One,
-            PermissionLvl::Two,
-            PermissionLvl::Three,
-            PermissionLvl::Four,
-        ] {
-            let serialized = serde_json::to_string(&lvl).expect("Should have serialized");
-            assert_eq!(
-                serde_json::from_str::<PermissionLvl>(&serialized).expect("Should have parsed"),
-                lvl
-            );
-        }
-    }
-
-    #[test]
-    fn deserialize_rejects_unknown_level() {
-        assert!(serde_json::from_str::<PermissionLvl>("5").is_err());
-    }
-}

--- a/crates/pumpkin-util/src/permission.rs
+++ b/crates/pumpkin-util/src/permission.rs
@@ -442,6 +442,7 @@ impl<'de> Deserialize<'de> for PermissionLvl {
         let value = u8::deserialize(deserializer)?;
         match value {
             0 => Ok(Self::Zero),
+            1 => Ok(Self::One),
             2 => Ok(Self::Two),
             3 => Ok(Self::Three),
             4 => Ok(Self::Four),
@@ -449,5 +450,32 @@ impl<'de> Deserialize<'de> for PermissionLvl {
                 "Invalid value for OpLevel: {value}"
             ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::permission::PermissionLvl;
+
+    #[test]
+    fn serde_round_trip() {
+        for lvl in [
+            PermissionLvl::Zero,
+            PermissionLvl::One,
+            PermissionLvl::Two,
+            PermissionLvl::Three,
+            PermissionLvl::Four,
+        ] {
+            let serialized = serde_json::to_string(&lvl).expect("Should have serialized");
+            assert_eq!(
+                serde_json::from_str::<PermissionLvl>(&serialized).expect("Should have parsed"),
+                lvl
+            );
+        }
+    }
+
+    #[test]
+    fn deserialize_rejects_unknown_level() {
+        assert!(serde_json::from_str::<PermissionLvl>("5").is_err());
     }
 }

--- a/pumpkin-util/src/permission.rs
+++ b/pumpkin-util/src/permission.rs
@@ -368,6 +368,7 @@ impl<'de> Deserialize<'de> for PermissionLvl {
         let value = u8::deserialize(deserializer)?;
         match value {
             0 => Ok(Self::Zero),
+            1 => Ok(Self::One),
             2 => Ok(Self::Two),
             3 => Ok(Self::Three),
             4 => Ok(Self::Four),
@@ -375,5 +376,32 @@ impl<'de> Deserialize<'de> for PermissionLvl {
                 "Invalid value for OpLevel: {value}"
             ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::permission::PermissionLvl;
+
+    #[test]
+    fn serde_round_trip() {
+        for lvl in [
+            PermissionLvl::Zero,
+            PermissionLvl::One,
+            PermissionLvl::Two,
+            PermissionLvl::Three,
+            PermissionLvl::Four,
+        ] {
+            let serialized = serde_json::to_string(&lvl).expect("Should have serialized");
+            assert_eq!(
+                serde_json::from_str::<PermissionLvl>(&serialized).expect("Should have parsed"),
+                lvl
+            );
+        }
+    }
+
+    #[test]
+    fn deserialize_rejects_unknown_level() {
+        assert!(serde_json::from_str::<PermissionLvl>("5").is_err());
     }
 }

--- a/pumpkin-util/src/permission.rs
+++ b/pumpkin-util/src/permission.rs
@@ -378,30 +378,3 @@ impl<'de> Deserialize<'de> for PermissionLvl {
         }
     }
 }
-
-#[cfg(test)]
-mod test {
-    use crate::permission::PermissionLvl;
-
-    #[test]
-    fn serde_round_trip() {
-        for lvl in [
-            PermissionLvl::Zero,
-            PermissionLvl::One,
-            PermissionLvl::Two,
-            PermissionLvl::Three,
-            PermissionLvl::Four,
-        ] {
-            let serialized = serde_json::to_string(&lvl).expect("Should have serialized");
-            assert_eq!(
-                serde_json::from_str::<PermissionLvl>(&serialized).expect("Should have parsed"),
-                lvl
-            );
-        }
-    }
-
-    #[test]
-    fn deserialize_rejects_unknown_level() {
-        assert!(serde_json::from_str::<PermissionLvl>("5").is_err());
-    }
-}


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description

`PermissionLvl::One` cannot be deserialized, so any server whose operator permission level is 1 refuses to start.

| Input | Expected | Actual on `master` |
|---|---|---|
| `op_permission_level = 1` in `pumpkin.toml` | server starts, `/op` grants moderator | panic in `BasicConfiguration::load` (`pumpkin-config/src/lib.rs:315`, "Failed to convert merged config"), exit 1 |
| `[commands] default_op_level = 1` in `pumpkin.toml` | server starts, non-ops default to moderator | same panic, same location, exit 1 |
| `data/ops.json` entry with `"level": 1` | operator loaded at level 1 | panic in `LoadJSONConfiguration::load` (`pumpkin/src/data/mod.rs:60`), exit 1 |
| `serde_json::from_str::<PermissionLvl>(&to_string(PermissionLvl::One))` | `Ok(One)` | `Err("Invalid value for OpLevel: 1")` |

Levels 0, 2, 3 and 4 are unaffected.

**Cause.** The hand-written `Deserialize` impl in `pumpkin-util/src/permission.rs` has match arms for `0`, `2`, `3` and `4`, and no arm for `1`; the value falls through to the catch-all error. `PermissionLvl::One = 1` is a real variant of the enum, documented "Moderator. Can bypass spawn protection.", and the `Serialize` impl 20 lines above writes it as `*self as u8` → `1`. The type therefore does not round-trip through its own serde impls. The arm has been absent since #348 introduced the enum; every later touch of the file was cosmetic.

**Why it matters.** `op_permission_level` and `[commands] default_op_level` are Pumpkin's own config keys, and `PermissionLvl::One` is a documented variant of the type they deserialize into — "Moderator. Can bypass spawn protection.". Setting either key to that documented value kills the server at startup, and it does so silently: `PumpkinConfig::load` runs before `init_logger` in `main`, so nothing at all reaches stdout or stderr. The operator sees exit code 1, an empty console, and a file under `crash-reports/`:

```
Message: Failed to convert merged config: Error { message: "Invalid value for OpLevel: 1", ... }
Panic Location: pumpkin-config/src/lib.rs:315:14
```

The `data/ops.json` path is reachable by hand-editing the file. `/op` cannot currently produce it, because `/op` grants `op_permission_level` and that key cannot itself hold 1 — the config bug is what keeps the data bug unwritable today. Its panic message also misdirects: "Just delete the old data config and restart", i.e. delete your operator list.

**Fix.** Add the missing `1 => Ok(Self::One),` arm, in numeric order. Out-of-range values still hit the same error as before; nothing else in the file changed.

## Testing

Checked against a debug build of the server on `1.95.0-aarch64-apple-darwin`, branched from `938a6272`, in both directions.

Without the arm (i.e. `master`), a `pumpkin.toml` containing only

```toml
[commands]
default_op_level = 1
```

exits 1 with stdout and stderr both empty, leaving the crash report quoted above. With the arm, the same config reaches "Server is now running". `op_permission_level = 1` and a `data/ops.json` entry with `"level": 1` behave the same way in both directions.

At the serde level, `serde_json::from_str::<PermissionLvl>("1")` gives `Err("Invalid value for OpLevel: 1")` without the arm and `Ok(One)` with it; `5` is still rejected either way, so the accepted range is not widened.

Full gates on the current branch:

| Gate | Result |
|---|---|
| `cargo test --workspace` | 461 passed, 0 failed, 5 ignored — identical to the `master` baseline at `938a6272` |
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets --all-features` | 0 warnings, 0 errors |

An alternative fix would be to drop the hand-written impls in favour of `serde_repr` (already a workspace dependency), which makes this class of omission impossible. I kept the change to one line since that is a larger refactor of a public type and a new dependency edge for `pumpkin-util` — happy to switch if you'd prefer it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric permission value `1` is now correctly recognized as permission level One during deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->