### PR TITLE
fix(protocol): reject infinite player positions

### DIFF
--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -84,6 +84,12 @@ use tokio::sync::Mutex;
 /// Vanilla: 2 minutes
 const CHAT_MESSAGE_MAX_AGE: i64 = 1000 * 60 * 2;
 
+// Vanilla: `ServerGamePacketListenerImpl::handleMovePlayer` rejects every non-finite
+// position component before clamping it to the world border.
+const fn has_finite_position(position: Vector3<f64>) -> bool {
+    position.x.is_finite() && position.y.is_finite() && position.z.is_finite()
+}
+
 #[derive(Debug, Error)]
 pub enum BlockPlacingError {
     BlockOutOfReach,
@@ -330,7 +336,7 @@ impl JavaClient {
         }
         // y = feet Y
         let position = packet.position;
-        if position.x.is_nan() || position.y.is_nan() || position.z.is_nan() {
+        if !has_finite_position(position) {
             self.kick(TextComponent::translate_cross(
                 translation::java::MULTIPLAYER_DISCONNECT_INVALID_PLAYER_MOVEMENT,
                 translation::java::MULTIPLAYER_DISCONNECT_INVALID_PLAYER_MOVEMENT,
@@ -463,12 +469,7 @@ impl JavaClient {
         }
         // y = feet Y
         let position = packet.position;
-        if !position.x.is_finite()
-            || !position.y.is_finite()
-            || !position.z.is_finite()
-            || !packet.yaw.is_finite()
-            || !packet.pitch.is_finite()
-        {
+        if !has_finite_position(position) || !packet.yaw.is_finite() || !packet.pitch.is_finite() {
             self.kick(TextComponent::translate_cross(
                 translation::java::MULTIPLAYER_DISCONNECT_INVALID_PLAYER_MOVEMENT,
                 translation::java::MULTIPLAYER_DISCONNECT_INVALID_PLAYER_MOVEMENT,
@@ -2970,5 +2971,24 @@ impl JavaClient {
                 .subscribed_debug_sample
                 .store(true, Ordering::Relaxed);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pumpkin_util::math::vector3::Vector3;
+
+    use super::has_finite_position;
+
+    #[test]
+    fn movement_position_rejects_non_finite_components() {
+        assert!(has_finite_position(Vector3::new(0.0, -64.0, 0.0)));
+        assert!(!has_finite_position(Vector3::new(f64::NAN, 0.0, 0.0)));
+        assert!(!has_finite_position(Vector3::new(f64::INFINITY, 0.0, 0.0)));
+        assert!(!has_finite_position(Vector3::new(
+            0.0,
+            f64::NEG_INFINITY,
+            0.0
+        )));
     }
 }


### PR DESCRIPTION
## Summary

- reject positive and negative infinity in position-only movement packets
- share the finite-coordinate rule with position-and-rotation packets
- add regression coverage for NaN and both infinities

## Vanilla 26.2 reference

`ServerGamePacketListenerImpl.handleMovePlayer` calls `containsInvalidValues` before
clamping coordinates and disconnects when any position component is non-finite.

## Verification

- `cargo test -p pumpkin movement_position_rejects_non_finite_components --lib`
- `cargo fmt -p pumpkin --check`
- `git diff --check origin/master...HEAD`
