### PR TITLE
fix(crafting): preserve transmute input components

### DIFF
--- a/pumpkin-inventory/src/crafting/crafting_screen_handler.rs
+++ b/pumpkin-inventory/src/crafting/crafting_screen_handler.rs
@@ -29,6 +29,8 @@ use crate::screen_handler::{
 };
 use crate::slot::{BoxFuture, NormalSlot, Slot};
 
+use pumpkin_data::data_component::DataComponent;
+use pumpkin_data::data_component_impl::DataComponentImpl;
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::recipes::{CraftingRecipeTypes, RECIPES_CRAFTING};
 use pumpkin_data::screen::WindowType;
@@ -54,6 +56,27 @@ pub struct ResultSlot {
 pub struct RecipeResult {
     pub item_id: String,
     pub count: u8,
+    /// Components copied from a transmuted input, matching vanilla's
+    /// `TransmuteRecipe::createWithOriginalComponents`.
+    pub component_patch: Vec<(DataComponent, Option<Box<dyn DataComponentImpl>>)>,
+}
+
+impl RecipeResult {
+    fn new(item_id: String, count: u8) -> Self {
+        Self {
+            item_id,
+            count,
+            component_patch: Vec::new(),
+        }
+    }
+
+    fn transmuted(item_id: String, count: u8, input: &ItemStack) -> Self {
+        Self {
+            item_id,
+            count,
+            component_patch: input.patch.clone(),
+        }
+    }
 }
 
 /// Checks if a recipe pattern is symmetrical horizontally.
@@ -165,10 +188,7 @@ async fn recipe_matches(
                 }
             }
 
-            matched.then_some(RecipeResult {
-                item_id: result.id.to_string(),
-                count: result.count,
-            })
+            matched.then(|| RecipeResult::new(result.id.to_string(), result.count))
         }
         GenericRecipe::Vanilla(CraftingRecipeTypes::CraftingShapeless {
             ingredients,
@@ -193,10 +213,7 @@ async fn recipe_matches(
                 }
                 return None;
             }
-            Some(RecipeResult {
-                item_id: result.id.to_string(),
-                count: result.count,
-            })
+            Some(RecipeResult::new(result.id.to_string(), result.count))
         }
         GenericRecipe::Vanilla(CraftingRecipeTypes::CraftingTransmute {
             input,
@@ -204,23 +221,42 @@ async fn recipe_matches(
             result,
             ..
         }) => {
+            // Vanilla `TransmuteRecipe::matches` requires one input and one
+            // material stack. If an item matches both ingredients, it is the
+            // input, matching vanilla's input-first classification.
             if count != 2 {
                 return None;
             }
+            let mut input_count = 0;
+            let mut material_count = 0;
+            let mut input_stack = None;
             'item_stack: for i in 0..inventory.size() {
                 let slot = inventory.get_stack(i).await;
                 let slot = slot.lock().await;
                 if slot.is_empty() {
                     continue 'item_stack;
                 }
-                if !material.match_item(slot.item) && !input.match_item(slot.item) {
+
+                if input.match_item(slot.item) {
+                    input_count += 1;
+                    input_stack = Some(slot.clone());
+                } else if material.match_item(slot.item) {
+                    material_count += 1;
+                } else {
                     return None;
                 }
             }
-            Some(RecipeResult {
-                item_id: result.id.to_string(),
-                count: result.count,
-            })
+            if input_count != 1 || material_count != 1 {
+                return None;
+            }
+
+            Some(RecipeResult::transmuted(
+                result.id.to_string(),
+                result.count,
+                input_stack
+                    .as_ref()
+                    .expect("matched transmute recipe has an input"),
+            ))
         }
         GenericRecipe::Vanilla(CraftingRecipeTypes::CraftingDecoratedPot { .. }) => {
             if count != 4 || inventory.get_width() != 3 || inventory.get_height() != 3 {
@@ -237,10 +273,7 @@ async fn recipe_matches(
                     return None;
                 }
             }
-            Some(RecipeResult {
-                item_id: "minecraft:decorated_pot".to_string(),
-                count: 1,
-            })
+            Some(RecipeResult::new("minecraft:decorated_pot".to_string(), 1))
         }
         GenericRecipe::Dynamic(OwnedCraftingRecipe::Shaped {
             pattern,
@@ -286,10 +319,7 @@ async fn recipe_matches(
                     }
                 }
             }
-            matched.then_some(RecipeResult {
-                item_id: result.item_id.clone(),
-                count: result.count,
-            })
+            matched.then(|| RecipeResult::new(result.item_id.clone(), result.count))
         }
         GenericRecipe::Dynamic(OwnedCraftingRecipe::Shapeless {
             ingredients,
@@ -314,10 +344,7 @@ async fn recipe_matches(
                 }
                 return None;
             }
-            Some(RecipeResult {
-                item_id: result.item_id.clone(),
-                count: result.count,
-            })
+            Some(RecipeResult::new(result.item_id.clone(), result.count))
         }
         _ => None,
     }
@@ -408,7 +435,7 @@ impl ResultSlot {
                 .unwrap_or(&matched.item_id);
             let item = pumpkin_data::item::Item::from_registry_key(key)
                 .unwrap_or(&pumpkin_data::item::Item::AIR);
-            ItemStack::new(matched.count, item)
+            ItemStack::new_with_component(matched.count, item, matched.component_patch)
         } else {
             ItemStack::EMPTY.clone()
         };
@@ -668,3 +695,118 @@ impl ScreenHandler for CraftingTableScreenHandler {
 }
 
 impl CraftingScreenHandler<CraftingInventory> for CraftingTableScreenHandler {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crafting::crafting_inventory::CraftingInventory;
+    use pumpkin_data::item::Item;
+    use pumpkin_data::recipes::{RecipeCategoryTypes, RecipeIngredientTypes, RecipeResultStruct};
+
+    fn transmute_recipe() -> CraftingRecipeTypes {
+        CraftingRecipeTypes::CraftingTransmute {
+            category: RecipeCategoryTypes::Misc,
+            group: None,
+            input: RecipeIngredientTypes::Simple("minecraft:shulker_box"),
+            material: RecipeIngredientTypes::Simple("minecraft:black_dye"),
+            result: RecipeResultStruct {
+                id: "minecraft:black_shulker_box",
+                count: 1,
+            },
+        }
+    }
+
+    async fn match_transmute(
+        recipe: &CraftingRecipeTypes,
+        stacks: Vec<ItemStack>,
+    ) -> Option<RecipeResult> {
+        let inventory = CraftingInventory::new(3, 3);
+        for (slot, stack) in stacks.into_iter().enumerate() {
+            inventory.set_stack(slot, stack).await;
+        }
+
+        recipe_matches(GenericRecipe::Vanilla(recipe), 1, 2, 0, 0, 2, &inventory).await
+    }
+
+    #[tokio::test]
+    async fn transmute_requires_one_input_and_one_material() {
+        let recipe = transmute_recipe();
+        assert!(
+            match_transmute(
+                &recipe,
+                vec![
+                    ItemStack::new(1, &Item::SHULKER_BOX),
+                    ItemStack::new(1, &Item::BLACK_DYE),
+                ],
+            )
+            .await
+            .is_some()
+        );
+        assert!(
+            match_transmute(
+                &recipe,
+                vec![
+                    ItemStack::new(1, &Item::BLACK_DYE),
+                    ItemStack::new(1, &Item::BLACK_DYE),
+                ],
+            )
+            .await
+            .is_none()
+        );
+        assert!(
+            match_transmute(
+                &recipe,
+                vec![
+                    ItemStack::new(1, &Item::SHULKER_BOX),
+                    ItemStack::new(1, &Item::SHULKER_BOX),
+                ],
+            )
+            .await
+            .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn transmute_classifies_an_overlapping_ingredient_as_input() {
+        let recipe = CraftingRecipeTypes::CraftingTransmute {
+            category: RecipeCategoryTypes::Misc,
+            group: None,
+            input: RecipeIngredientTypes::Simple("minecraft:black_dye"),
+            material: RecipeIngredientTypes::Simple("minecraft:black_dye"),
+            result: RecipeResultStruct {
+                id: "minecraft:black_shulker_box",
+                count: 1,
+            },
+        };
+
+        // Both stacks are classified as inputs, leaving no material stack.
+        assert!(
+            match_transmute(
+                &recipe,
+                vec![
+                    ItemStack::new(1, &Item::BLACK_DYE),
+                    ItemStack::new(1, &Item::BLACK_DYE),
+                ],
+            )
+            .await
+            .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn transmute_preserves_the_input_component_patch() {
+        let mut input = ItemStack::new(1, &Item::SHULKER_BOX);
+        input.set_damage(26);
+        let recipe = transmute_recipe();
+        let result = match_transmute(&recipe, vec![input, ItemStack::new(1, &Item::BLACK_DYE)])
+            .await
+            .expect("transmute recipe should match");
+        let output = ItemStack::new_with_component(
+            result.count,
+            &Item::BLACK_SHULKER_BOX,
+            result.component_patch,
+        );
+
+        assert_eq!(output.get_damage(), 26);
+    }
+}


### PR DESCRIPTION
## Summary

- require exactly one transmute input and one material
- use vanilla's input-first classification when ingredient predicates overlap
- copy the matched input's component patch to the transformed output
- add focused matcher and component-preservation tests

## Vanilla 26.2 reference

`TransmuteRecipe.matches` requires one input and one material, classifying the input
first. `computeResult` calls `createWithOriginalComponents(target, input)`, applying the
input stack's data-component patch to the transformed item.

## Verification

- focused transmute tests (3 passed)
- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin-inventory --all-targets`
- `cargo fmt -p pumpkin-inventory --check`
- `git diff --check origin/master...HEAD`
