### PR TITLE
fix(protocol): canonicalize light update serialization

### DIFF
--- a/pumpkin-protocol/src/java/client/play/chunk_data.rs
+++ b/pumpkin-protocol/src/java/client/play/chunk_data.rs
@@ -1,5 +1,6 @@
 use crate::WritingError;
 use crate::codec::bit_set::BitSet;
+use crate::java::client::play::light_update::light_masks;
 use crate::{ClientPacket, VarInt, ser::NetworkWriteExt};
 use pumpkin_data::block_state_remap::remap_block_state_for_version;
 use pumpkin_data::packet::CURRENT_MC_VERSION;
@@ -232,49 +233,21 @@ impl ClientPacket for CChunkData<'_> {
                 .map_err(|_| WritingError::Message("light_engine lock poisoned".into()))?;
             let num_sections = light_engine.sky_light.len();
 
-            let mut sky_light_empty_mask = 0u64;
-            let mut block_light_empty_mask = 0u64;
-            let mut sky_light_mask = 0u64;
-            let mut block_light_mask = 0u64;
-
-            // Bit 0 represents the section below the world (always empty)
-            sky_light_empty_mask |= 1 << 0;
-            block_light_empty_mask |= 1 << 0;
-
-            // Bits 1..=num_sections represent the actual world sections
-            for section_index in 0..num_sections {
-                let bit_index = section_index + 1; // Offset by 1 for the below-world section
-
-                if let LightContainer::Full(_) = &light_engine.sky_light[section_index] {
-                    sky_light_mask |= 1 << bit_index;
-                } else {
-                    sky_light_empty_mask |= 1 << bit_index;
-                }
-
-                if let LightContainer::Full(_) = &light_engine.block_light[section_index] {
-                    block_light_mask |= 1 << bit_index;
-                } else {
-                    block_light_empty_mask |= 1 << bit_index;
-                }
-            }
-
-            // Bit num_sections+1 represents the section above the world (always empty)
-            sky_light_empty_mask |= 1 << (num_sections + 1);
-            block_light_empty_mask |= 1 << (num_sections + 1);
+            let masks = light_masks(&light_engine);
 
             // Write Sky Light Mask
-            write.write_bitset(&BitSet(Box::new([sky_light_mask as i64])))?;
+            write.write_bitset(&BitSet(Box::new([masks.sky as i64])))?;
             // Write Block Light Mask
-            write.write_bitset(&BitSet(Box::new([block_light_mask as i64])))?;
+            write.write_bitset(&BitSet(Box::new([masks.block as i64])))?;
             // Write Empty Sky Light Mask
-            write.write_bitset(&BitSet(Box::new([sky_light_empty_mask as i64])))?;
+            write.write_bitset(&BitSet(Box::new([masks.empty_sky as i64])))?;
             // Write Empty Block Light Mask
-            write.write_bitset(&BitSet(Box::new([block_light_empty_mask as i64])))?;
+            write.write_bitset(&BitSet(Box::new([masks.empty_block as i64])))?;
 
             let light_data_size: VarInt = VarInt(LightContainer::ARRAY_SIZE as i32);
 
             // Write Sky Light arrays
-            write.write_var_int(&VarInt(sky_light_mask.count_ones() as i32))?;
+            write.write_var_int(&VarInt(masks.sky.count_ones() as i32))?;
             for section_index in 0..num_sections {
                 if let LightContainer::Full(data) = &light_engine.sky_light[section_index] {
                     write.write_var_int(&light_data_size)?;
@@ -283,7 +256,7 @@ impl ClientPacket for CChunkData<'_> {
             }
 
             // Write Block Light arrays
-            write.write_var_int(&VarInt(block_light_mask.count_ones() as i32))?;
+            write.write_var_int(&VarInt(masks.block.count_ones() as i32))?;
             for section_index in 0..num_sections {
                 if let LightContainer::Full(data) = &light_engine.block_light[section_index] {
                     write.write_var_int(&light_data_size)?;

--- a/pumpkin-protocol/src/java/client/play/light_update.rs
+++ b/pumpkin-protocol/src/java/client/play/light_update.rs
@@ -4,8 +4,8 @@ use crate::{ClientPacket, VarInt, ser::NetworkWriteExt};
 use pumpkin_data::packet::clientbound::PLAY_LIGHT_UPDATE;
 use pumpkin_macros::java_packet;
 use pumpkin_util::version::JavaMinecraftVersion;
-use pumpkin_world::chunk::ChunkData;
 use pumpkin_world::chunk::format::LightContainer;
+use pumpkin_world::chunk::{ChunkData, ChunkLight};
 use std::io::Write;
 
 /// Sent by the server to update light levels (block light and sky light) for a chunk.
@@ -14,6 +14,53 @@ use std::io::Write;
 /// It's used when block placement or removal changes the lighting in a chunk.
 #[java_packet(PLAY_LIGHT_UPDATE)]
 pub struct CLightUpdate<'a>(pub &'a ChunkData);
+
+/// The four masks shared by initial chunk data and incremental light updates.
+///
+/// Minecraft numbers light sections from the padding section below the world, so physical chunk
+/// section zero is bit one and the final above-world padding section is also explicitly empty.
+pub(super) struct LightMasks {
+    pub sky: u64,
+    pub block: u64,
+    pub empty_sky: u64,
+    pub empty_block: u64,
+}
+
+pub(super) fn light_masks(light_engine: &ChunkLight) -> LightMasks {
+    let num_sections = light_engine.sky_light.len();
+    let mut masks = LightMasks {
+        sky: 0,
+        block: 0,
+        empty_sky: 1,
+        empty_block: 1,
+    };
+
+    for section_index in 0..num_sections {
+        let bit_index = section_index + 1;
+        if matches!(
+            light_engine.sky_light[section_index],
+            LightContainer::Full(_)
+        ) {
+            masks.sky |= 1 << bit_index;
+        } else {
+            masks.empty_sky |= 1 << bit_index;
+        }
+
+        if matches!(
+            light_engine.block_light[section_index],
+            LightContainer::Full(_)
+        ) {
+            masks.block |= 1 << bit_index;
+        } else {
+            masks.empty_block |= 1 << bit_index;
+        }
+    }
+
+    let above_world_bit = num_sections + 1;
+    masks.empty_sky |= 1 << above_world_bit;
+    masks.empty_block |= 1 << above_world_bit;
+    masks
+}
 
 impl ClientPacket for CLightUpdate<'_> {
     fn write_packet_data(
@@ -28,76 +75,66 @@ impl ClientPacket for CLightUpdate<'_> {
         // Chunk Z
         write.write_var_int(&VarInt(self.0.z))?;
 
-        // Light masks include sections from -1 (below world) to num_sections (above world)
-        // This means we need to account for 2 extra sections in the bitset
         let light_engine = self
             .0
             .light_engine
             .lock()
             .map_err(|_| WritingError::Message("light_engine lock poisoned".into()))?;
         let num_sections = light_engine.sky_light.len();
-
-        let mut sky_light_empty_mask = 0u64;
-        let mut block_light_empty_mask = 0u64;
-        let mut sky_light_mask = 0u64;
-        let mut block_light_mask = 0u64;
-
-        // Bits 0..num_sections represent the sections including padding
-        for section_index in 0..num_sections {
-            let bit_index = section_index;
-
-            if let LightContainer::Full(_) = &light_engine.sky_light[section_index] {
-                sky_light_mask |= 1 << bit_index;
-            } else {
-                sky_light_empty_mask |= 1 << bit_index;
-            }
-
-            if let LightContainer::Full(_) = &light_engine.block_light[section_index] {
-                block_light_mask |= 1 << bit_index;
-            } else {
-                block_light_empty_mask |= 1 << bit_index;
-            }
-        }
+        let masks = light_masks(&light_engine);
 
         // Write Sky Light Mask
-        write.write_bitset(&BitSet(Box::new([sky_light_mask as i64])))?;
+        write.write_bitset(&BitSet(Box::new([masks.sky as i64])))?;
         // Write Block Light Mask
-        write.write_bitset(&BitSet(Box::new([block_light_mask as i64])))?;
+        write.write_bitset(&BitSet(Box::new([masks.block as i64])))?;
         // Write Empty Sky Light Mask
-        write.write_bitset(&BitSet(Box::new([sky_light_empty_mask as i64])))?;
+        write.write_bitset(&BitSet(Box::new([masks.empty_sky as i64])))?;
         // Write Empty Block Light Mask
-        write.write_bitset(&BitSet(Box::new([block_light_empty_mask as i64])))?;
+        write.write_bitset(&BitSet(Box::new([masks.empty_block as i64])))?;
 
         let light_data_size: VarInt = VarInt(LightContainer::ARRAY_SIZE as i32);
 
         // Write Sky Light arrays
-        write.write_var_int(&VarInt(sky_light_mask.count_ones() as i32))?;
+        write.write_var_int(&VarInt(masks.sky.count_ones() as i32))?;
         for section_index in 0..num_sections {
             if let LightContainer::Full(data) = &light_engine.sky_light[section_index] {
-                // Ensure network nibble ordering matches client expectations
-                // by swapping high/low nibbles per byte.
                 write.write_var_int(&light_data_size)?;
-                let mut swapped = Vec::with_capacity(data.len());
-                for &b in data {
-                    swapped.push(b.rotate_right(4));
-                }
-                write.write_slice(&swapped)?;
+                write.write_slice(data.as_ref())?;
             }
         }
 
         // Write Block Light arrays
-        write.write_var_int(&VarInt(block_light_mask.count_ones() as i32))?;
+        write.write_var_int(&VarInt(masks.block.count_ones() as i32))?;
         for section_index in 0..num_sections {
             if let LightContainer::Full(data) = &light_engine.block_light[section_index] {
                 write.write_var_int(&light_data_size)?;
-                let mut swapped = Vec::with_capacity(data.len());
-                for &b in data {
-                    swapped.push(b.rotate_right(4));
-                }
-                write.write_slice(&swapped)?;
+                write.write_slice(data.as_ref())?;
             }
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pumpkin_world::chunk::format::LightContainer;
+
+    use super::light_masks;
+    use pumpkin_world::chunk::ChunkLight;
+
+    #[test]
+    fn masks_include_padding_and_offset_physical_sections() {
+        let light = ChunkLight {
+            sky_light: [LightContainer::new_filled(15), LightContainer::new_empty(0)].into(),
+            block_light: [LightContainer::new_empty(0), LightContainer::new_filled(1)].into(),
+        };
+
+        let masks = light_masks(&light);
+
+        assert_eq!(masks.sky, 1 << 1);
+        assert_eq!(masks.block, 1 << 2);
+        assert_eq!(masks.empty_sky, (1 << 0) | (1 << 2) | (1 << 3));
+        assert_eq!(masks.empty_block, (1 << 0) | (1 << 1) | (1 << 3));
     }
 }


### PR DESCRIPTION
## Summary

- share one padded-section mask calculation between initial chunks and light updates
- offset physical sections past the below-world padding bit
- mark both below- and above-world padding sections empty
- send nibble arrays without changing their byte ordering

## Vanilla 26.2 reference

`ClientboundLightUpdatePacketData.prepareSectionData` iterates padded light-engine
section indices and appends `DataLayer.copy().getData()` directly. Initial chunk light
and incremental light updates use the same masks and byte representation.

## Verification

- focused light-mask regression test
- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin-protocol --all-targets`
- `cargo fmt -p pumpkin-protocol --check`
- `git diff --check origin/master...HEAD`
