### PR TITLE
fix(combat): include melee source positions

### DIFF
--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -280,7 +280,7 @@ impl MobEntity {
                 target,
                 attack_damage,
                 DamageType::MOB_ATTACK,
-                None,
+                Some(caller.get_entity().pos.load()),
                 Some(caller),
                 Some(caller),
             )

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1048,7 +1048,7 @@ impl Player {
                 } else {
                     DamageType::PLAYER_ATTACK
                 },
-                None,
+                Some(self.living_entity.entity.pos.load()),
                 Some(self),
                 Some(self),
             )
@@ -1141,7 +1141,7 @@ impl Player {
                                     other_victim.as_ref(),
                                     sweep_damage,
                                     DamageType::PLAYER_ATTACK,
-                                    None,
+                                    Some(self.living_entity.entity.pos.load()),
                                     Some(self),
                                     Some(self),
                                 )


### PR DESCRIPTION
## Summary

- include attacker position in player primary melee damage
- include attacker position in sweep damage
- include attacker position in mob melee damage

## Vanilla 26.2 reference

`LivingEntity.applyItemBlocking` uses `DamageSource.getSourcePosition` to compare the
incoming damage direction with the defender's view direction. Pumpkin already has this
shield-facing branch, but melee callers passed no source position, bypassing it.

## Verification

- compiled through focused Pumpkin tests
- `cargo fmt -p pumpkin --check`
- `git diff --check origin/master...HEAD`
