### PR TITLE
fix(combat): preserve hurt cooldown damage baseline

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -2370,7 +2370,10 @@ impl EntityBase for LivingEntity {
                 };
 
             // Finalize state
-            self.last_damage_taken.store(amount);
+            // Keep the full post-reduction amount in the same domain used by the
+            // next cooldown comparison. Vanilla stores `damage`, not the incremental
+            // difference applied for this hit.
+            self.last_damage_taken.store(effective_amount);
             let damage_amount = damage_amount.max(0.0);
 
             let config = &world.server.upgrade().unwrap().advanced_config.pvp;


### PR DESCRIPTION
## Summary

- retain the full post-reduction damage as the hurt-cooldown comparison baseline
- keep applying only the incremental difference for a stronger hit during invulnerability
- prevent a later weaker hit from being accepted against an incorrectly reduced baseline

## Vanilla reference

Minecraft 26.2 `LivingEntity.hurtServer` compares the incoming post-blocking damage with `lastHurt`, applies only the difference when appropriate, and stores the full incoming damage back into `lastHurt`.

## Validation

- `cargo test --workspace --no-fail-fast` on the integration branch
- `RUSTFLAGS='-D warnings' cargo clippy -p pumpkin --all-targets` on the integration branch
- `git diff --check`

The isolated current-master worktree reaches unrelated existing WIT binding generation errors before compiling Pumpkin; this one-line behavioral change is already covered by the clean integration-branch build and full workspace suite.
