### PR TITLE
fix(item): consume elytra firework rockets

### DIFF
--- a/pumpkin/src/item/items/firework_rocket.rs
+++ b/pumpkin/src/item/items/firework_rocket.rs
@@ -16,9 +16,24 @@ use pumpkin_util::math::vector3::Vector3;
 
 pub struct FireworkRocketItem;
 
+const fn should_consume_rocket(is_creative: bool) -> bool {
+    !is_creative
+}
+
 impl ItemMetadata for FireworkRocketItem {
     fn ids() -> Box<[u16]> {
         [Item::FIREWORK_ROCKET.id].into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_consume_rocket;
+
+    #[test]
+    fn rockets_are_consumed_outside_creative() {
+        assert!(should_consume_rocket(false));
+        assert!(!should_consume_rocket(true));
     }
 }
 
@@ -64,6 +79,23 @@ impl ItemBehaviour for FireworkRocketItem {
                 );
                 let entity = FireworkRocketEntity::new_shot(entity, player.get_entity());
                 world.spawn_entity(Arc::new(entity)).await;
+
+                // Vanilla `FireworkRocketItem::use` consumes the hand that launched
+                // the attached rocket, except in Creative mode.
+                if should_consume_rocket(player.is_creative()) {
+                    let held_item = player.inventory.held_item();
+                    let mut held_item = held_item.lock().await;
+                    if held_item.item == &Item::FIREWORK_ROCKET {
+                        held_item.decrement(1);
+                    } else {
+                        drop(held_item);
+                        let off_hand_item = player.inventory.off_hand_item().await;
+                        let mut off_hand_item = off_hand_item.lock().await;
+                        if off_hand_item.item == &Item::FIREWORK_ROCKET {
+                            off_hand_item.decrement(1);
+                        }
+                    }
+                }
             }
         })
     }


### PR DESCRIPTION
## Summary

- consume the firework rocket used to boost a fall-flying player
- select the launching main/offhand stack without decrementing an unrelated item
- preserve Creative mode's non-consuming behavior

## Vanilla reference

Minecraft 26.2 `FireworkRocketItem.use` spawns an attached rocket for a fall-flying player and then consumes one item from the used hand unless the player has infinite materials.

## Validation

- focused `item::items::firework_rocket::tests` test passes
- `cargo fmt -p pumpkin -- --check`
- `git diff --check`
- full workspace suite passes on the integration branch
