### PR TITLE
fix(item): apply data-driven consumable effects

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -40,6 +40,7 @@ use crossbeam::atomic::AtomicCell;
 use pumpkin_data::attributes::Attributes;
 use pumpkin_data::damage::DeathMessageType;
 use pumpkin_data::data_component_impl::Operation;
+use pumpkin_data::data_component_impl::food::{ConsumableImpl, ConsumeEffect};
 use pumpkin_data::data_component_impl::{
     AttributeModifiersImpl, BlocksAttacksImpl, DeathProtectionImpl, EnchantmentsImpl,
     EquipmentSlot, EquippableImpl, FoodImpl,
@@ -2629,72 +2630,9 @@ impl EntityBase for LivingEntity {
                             .hunger_manager
                             .eat(player, food.nutrition as u8, food.saturation)
                             .await;
-
-                        // Special food effects
-                        if item.item == &Item::GOLDEN_APPLE {
-                            self.add_effect(pumpkin_data::potion::Effect {
-                                effect_type: &pumpkin_data::effect::StatusEffect::REGENERATION,
-                                amplifier: 1,
-                                duration: 100,
-                                ambient: false,
-                                show_particles: true,
-                                show_icon: true,
-                                blend: false,
-                            })
-                            .await;
-                            self.add_effect(pumpkin_data::potion::Effect {
-                                effect_type: &pumpkin_data::effect::StatusEffect::ABSORPTION,
-                                amplifier: 0,
-                                duration: 2400,
-                                ambient: false,
-                                show_particles: true,
-                                show_icon: true,
-                                blend: false,
-                            })
-                            .await;
-                        } else if item.item == &Item::ENCHANTED_GOLDEN_APPLE {
-                            self.add_effect(pumpkin_data::potion::Effect {
-                                effect_type: &pumpkin_data::effect::StatusEffect::REGENERATION,
-                                amplifier: 1,
-                                duration: 400,
-                                ambient: false,
-                                show_particles: true,
-                                show_icon: true,
-                                blend: false,
-                            })
-                            .await;
-                            self.add_effect(pumpkin_data::potion::Effect {
-                                effect_type: &pumpkin_data::effect::StatusEffect::ABSORPTION,
-                                amplifier: 3,
-                                duration: 2400,
-                                ambient: false,
-                                show_particles: true,
-                                show_icon: true,
-                                blend: false,
-                            })
-                            .await;
-                            self.add_effect(pumpkin_data::potion::Effect {
-                                effect_type: &pumpkin_data::effect::StatusEffect::RESISTANCE,
-                                amplifier: 0,
-                                duration: 6000,
-                                ambient: false,
-                                show_particles: true,
-                                show_icon: true,
-                                blend: false,
-                            })
-                            .await;
-                            self.add_effect(pumpkin_data::potion::Effect {
-                                effect_type: &pumpkin_data::effect::StatusEffect::FIRE_RESISTANCE,
-                                amplifier: 0,
-                                duration: 6000,
-                                ambient: false,
-                                show_particles: true,
-                                show_icon: true,
-                                blend: false,
-                            })
-                            .await;
-                        }
                     }
+
+                    self.apply_consumable_effects(item).await;
 
                     // Handle potion consumption
                     if item.get_data_component::<pumpkin_data::data_component_impl::PotionContentsImpl>().is_some() {
@@ -2830,6 +2768,62 @@ impl EntityBase for LivingEntity {
     }
 }
 
+impl LivingEntity {
+    /// Applies data-driven `apply_effects` consume effects after an item completes use.
+    /// Vanilla: `Consumable.onConsume` invokes every configured effect server-side.
+    async fn apply_consumable_effects(&self, item: &ItemStack) {
+        let Some(consumable) = item.get_data_component::<ConsumableImpl>() else {
+            return;
+        };
+
+        for consume_effect in consumable.effects.iter() {
+            let ConsumeEffect::ApplyEffects((effects, probability)) = consume_effect else {
+                continue;
+            };
+            if !consume_effect_probability_applies(*probability, rand::random()) {
+                continue;
+            }
+
+            for effect in effects.iter() {
+                let Some(effect_type) = StatusEffect::from_minecraft_name(&effect.effect_id) else {
+                    continue;
+                };
+                let Ok(amplifier) = u8::try_from(effect.amplifier) else {
+                    continue;
+                };
+
+                self.add_effect(Effect {
+                    effect_type,
+                    duration: effect.duration,
+                    amplifier,
+                    ambient: effect.ambient,
+                    show_particles: effect.show_particles,
+                    show_icon: effect.show_icon,
+                    blend: false,
+                })
+                .await;
+            }
+        }
+    }
+}
+
+/// Mirrors vanilla's strict `random < probability` consume-effect gate.
+const fn consume_effect_probability_applies(probability: f32, random: f32) -> bool {
+    random < probability
+}
+
+#[cfg(test)]
+mod consumable_effect_tests {
+    use super::consume_effect_probability_applies;
+
+    #[test]
+    fn consumable_effect_probability_matches_vanilla_strict_threshold() {
+        assert!(!consume_effect_probability_applies(0.0, 0.0));
+        assert!(consume_effect_probability_applies(1.0, 0.999));
+        assert!(consume_effect_probability_applies(0.5, 0.499));
+        assert!(!consume_effect_probability_applies(0.5, 0.5));
+    }
+}
 /// Returns `true` if `damage_type` is in `#minecraft:bypasses_armor` (1.21.11).
 /// These sources bypass armor entirely (fall, drown, freeze, etc.).
 pub(crate) const fn bypasses_armor_durability(damage_type: &DamageType) -> bool {


### PR DESCRIPTION
Golden-apple effects were hardcoded; consumables now apply their generated component effects with vanilla random<probability semantics, preserving the potion and clear-all paths. Reopened: the branch was deleted and its PR (#2677) auto-closed.