### PR TITLE
fix(combat): include melee source positions

### DIFF
--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -280,7 +280,7 @@ impl MobEntity {
                 target,
                 attack_damage,
                 DamageType::MOB_ATTACK,
-                None,
+                Some(caller.get_entity().pos.load()),
                 Some(caller),
                 Some(caller),
             )

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1048,7 +1048,7 @@ impl Player {
                 } else {
                     DamageType::PLAYER_ATTACK
                 },
-                None,
+                Some(self.living_entity.entity.pos.load()),
                 Some(self),
                 Some(self),
             )
@@ -1141,7 +1141,7 @@ impl Player {
                                     other_victim.as_ref(),
                                     sweep_damage,
                                     DamageType::PLAYER_ATTACK,
-                                    None,
+                                    Some(self.living_entity.entity.pos.load()),
                                     Some(self),
                                     Some(self),
                                 )


### PR DESCRIPTION
Player, sweep, and mob melee passed no attacker position, so shields never blocked ordinary melee; the existing source position is now supplied. Reopened after branch deletion (was #2681).