### PR TITLE
fix(combat): preserve the full hurt-cooldown damage baseline

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -2370,7 +2370,10 @@ impl EntityBase for LivingEntity {
                 };
 
             // Finalize state
-            self.last_damage_taken.store(amount);
+            // Keep the full post-reduction amount in the same domain used by the
+            // next cooldown comparison. Vanilla stores `damage`, not the incremental
+            // difference applied for this hit.
+            self.last_damage_taken.store(effective_amount);
             let damage_amount = damage_amount.max(0.0);
 
             let config = &world.server.upgrade().unwrap().advanced_config.pvp;


### PR DESCRIPTION
A stronger hit within the invulnerability window stored only its incremental damage, then wrongly allowed a later weaker hit; the full post-reduction amount is now retained, matching LivingEntity.hurtServer. Reopened after branch deletion (was #2683).