### PR TITLE
Enable spider wall climbing

### DIFF
--- a/pumpkin-codegen/src/tracked_data.rs
+++ b/pumpkin-codegen/src/tracked_data.rs
@@ -43,6 +43,12 @@ pub(crate) fn build() -> TokenStream {
         if let Some(id) = wolf_variant_id {
             parsed.insert("WOLF_VARIANT_ID".to_owned(), id);
         }
+        if matches!(
+            ver,
+            JavaMinecraftVersion::V_26_1 | JavaMinecraftVersion::V_26_2
+        ) {
+            parsed.insert("SPIDER_FLAGS".to_owned(), 16);
+        }
 
         versions.insert(ver, parsed);
     }

--- a/pumpkin-data/src/generated/tracked_data.rs
+++ b/pumpkin-data/src/generated/tracked_data.rs
@@ -3153,8 +3153,8 @@ impl TrackedData {
         v1_21_7: 255u8,
         v1_21_9: 16u8,
         v1_21_11: 16u8,
-        v26_1: 255u8,
-        v26_2: 255u8,
+        v26_1: 16u8,
+        v26_2: 16u8,
     };
     pub const SPIKES_RETRACTED: TrackedId = TrackedId {
         v1_21: 16u8,

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -1054,6 +1054,25 @@ impl LivingEntity {
     }
 
     fn check_climbing(&self) {
+        if let Some(climbing) = spider_climbing_state(
+            self.entity.entity_type,
+            self.entity.horizontal_collision.load(SeqCst),
+        ) {
+            let was_climbing = self.climbing.swap(climbing, Relaxed);
+
+            if climbing != was_climbing {
+                self.entity.send_meta_data(
+                    &[Metadata::new(
+                        TrackedData::SPIDER_FLAGS,
+                        MetaDataType::BYTE,
+                        u8::from(climbing),
+                    )],
+                    None,
+                );
+            }
+            return;
+        }
+
         // If spectator: return false
 
         // TODO
@@ -2830,6 +2849,17 @@ impl EntityBase for LivingEntity {
     }
 }
 
+const fn spider_climbing_state(
+    entity_type: &EntityType,
+    horizontal_collision: bool,
+) -> Option<bool> {
+    if entity_type.id == EntityType::SPIDER.id || entity_type.id == EntityType::CAVE_SPIDER.id {
+        Some(horizontal_collision)
+    } else {
+        None
+    }
+}
+
 /// Returns `true` if `damage_type` is in `#minecraft:bypasses_armor` (1.21.11).
 /// These sources bypass armor entirely (fall, drown, freeze, etc.).
 pub(crate) const fn bypasses_armor_durability(damage_type: &DamageType) -> bool {
@@ -2884,6 +2914,22 @@ pub(crate) const fn bypasses_armor_durability(damage_type: &DamageType) -> bool 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn spiders_climb_only_during_horizontal_collisions() {
+        assert_eq!(spider_climbing_state(&EntityType::SPIDER, true), Some(true));
+        assert_eq!(
+            spider_climbing_state(&EntityType::SPIDER, false),
+            Some(false)
+        );
+        assert_eq!(
+            spider_climbing_state(&EntityType::CAVE_SPIDER, true),
+            Some(true)
+        );
+        assert_eq!(spider_climbing_state(&EntityType::ZOMBIE, true), None);
+        assert_eq!(TrackedData::SPIDER_FLAGS.v26_1, 16);
+        assert_eq!(TrackedData::SPIDER_FLAGS.v26_2, 16);
+    }
 
     // ── bypasses_armor_durability ─────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- update spider and cave-spider climbing state from horizontal collisions
- synchronize the climbing state for current protocol versions
- preserve the existing climbing movement behavior

## Validation
- `cargo fmt -p pumpkin`
- focused spider climbing regression
- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets`
- `cargo test -p pumpkin --lib` (190 passed)
- codegen tests
- focused test on current upstream
- `git diff --check`