### PR TITLE
Persist weather and world clock state

### DIFF
--- a/pumpkin-world/src/world_info/anvil.rs
+++ b/pumpkin-world/src/world_info/anvil.rs
@@ -129,6 +129,10 @@ impl WorldInfoReader for AnvilLevelInfo {
         {
             let weather = read_weather(level_folder);
             info.data.clear_weather_time = weather.clear_weather_time;
+            info.data.rain_time = weather.rain_time;
+            info.data.raining = weather.raining;
+            info.data.thundering = weather.thundering;
+            info.data.thunder_time = weather.thunder_time;
         }
 
         // (wandering_trader.dat is not part of LevelData; stored separately when needed)
@@ -192,9 +196,14 @@ impl WorldInfoWriter for AnvilLevelInfo {
         }
 
         // weather.dat
-        let mut weather = read_weather(level_folder);
-        weather.clear_weather_time = info.clear_weather_time;
-        weather.data_version = data_version;
+        let weather = crate::world_info::data_files::WeatherData {
+            rain_time: info.rain_time,
+            raining: info.raining,
+            thundering: info.thundering,
+            thunder_time: info.thunder_time,
+            clear_weather_time: info.clear_weather_time,
+            data_version,
+        };
         if let Err(e) = write_weather(level_folder, &weather) {
             error!("Failed to write weather.dat: {e}");
         }
@@ -278,6 +287,10 @@ mod test {
             border_warning_blocks: 5.0,
             border_warning_time: 15.0,
             clear_weather_time: 0,
+            rain_time: 0,
+            raining: false,
+            thundering: false,
+            thunder_time: 0,
             data_packs: DataPacks {
                 disabled: vec![
                     "minecart_improvements".to_string(),
@@ -367,8 +380,36 @@ mod test {
         expected.data.world_gen_settings = WorldGenSettings::default();
         expected.data.day_time = 0;
         expected.data.clear_weather_time = 0;
+        expected.data.rain_time = 0;
+        expected.data.raining = false;
+        expected.data.thundering = false;
+        expected.data.thunder_time = 0;
 
         assert_eq!(level_dat_again, expected);
+    }
+
+    #[test]
+    fn preserves_world_clock_and_weather_data() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut data = LevelData::default(Seed(42));
+        data.day_time = 36_001;
+        data.clear_weather_time = 1_200;
+        data.rain_time = 9_001;
+        data.raining = true;
+        data.thundering = true;
+        data.thunder_time = 4_501;
+
+        AnvilLevelInfo
+            .write_world_info(&data, temp_dir.path())
+            .unwrap();
+
+        let loaded = AnvilLevelInfo.read_world_info(temp_dir.path()).unwrap();
+        assert_eq!(loaded.day_time, data.day_time);
+        assert_eq!(loaded.clear_weather_time, data.clear_weather_time);
+        assert_eq!(loaded.rain_time, data.rain_time);
+        assert_eq!(loaded.raining, data.raining);
+        assert_eq!(loaded.thundering, data.thundering);
+        assert_eq!(loaded.thunder_time, data.thunder_time);
     }
 
     #[test]

--- a/pumpkin-world/src/world_info/mod.rs
+++ b/pumpkin-world/src/world_info/mod.rs
@@ -96,6 +96,18 @@ pub struct LevelData {
     /// Persisted to `data/minecraft/weather.dat`.
     #[serde(rename = "clearWeatherTime", skip_serializing, default)]
     pub clear_weather_time: i32,
+
+    #[serde(skip_serializing, default)]
+    pub rain_time: i32,
+
+    #[serde(skip_serializing, default)]
+    pub raining: bool,
+
+    #[serde(skip_serializing, default)]
+    pub thundering: bool,
+
+    #[serde(skip_serializing, default)]
+    pub thunder_time: i32,
 }
 
 const DEFAULT_BORDER_DAMAGE_PER_BLOCK: f64 = 0.2;
@@ -353,6 +365,10 @@ impl LevelData {
             world_gen_settings: WorldGenSettings::new(seed),
             day_time: 0,
             clear_weather_time: -1,
+            rain_time: 0,
+            raining: false,
+            thundering: false,
+            thunder_time: 0,
         }
     }
 

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -599,6 +599,25 @@ impl Server {
         debug!("Done awaiting tasks for server");
 
         info!("Starting worlds");
+        if let Some(overworld) = self
+            .worlds
+            .load()
+            .iter()
+            .find(|world| world.dimension == Dimension::OVERWORLD)
+        {
+            let day_time = overworld.get_time_of_day().await;
+            let weather = overworld.weather.lock().await.clone();
+            self.level_info.rcu(|level_info| {
+                let mut snapshot = (**level_info).clone();
+                snapshot.day_time = day_time;
+                snapshot.clear_weather_time = weather.clear_weather_time;
+                snapshot.rain_time = weather.rain_time;
+                snapshot.raining = weather.raining;
+                snapshot.thundering = weather.thundering;
+                snapshot.thunder_time = weather.thunder_time;
+                snapshot
+            });
+        }
         for world in self.worlds.load().iter() {
             world.shutdown().await;
         }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -284,8 +284,17 @@ impl World {
         block_registry: Arc<BlockRegistry>,
         server: Weak<Server>,
     ) -> Self {
-        // TODO
         let generation_settings = GenerationSettings::from_dimension(&dimension);
+        let persisted_level_info = level_info.load();
+        let level_time = LevelTime::with_time_of_day(persisted_level_info.day_time);
+        let weather = Weather::from_persisted(
+            persisted_level_info.clear_weather_time,
+            persisted_level_info.rain_time,
+            persisted_level_info.raining,
+            persisted_level_info.thunder_time,
+            persisted_level_info.thundering,
+        );
+        drop(persisted_level_info);
 
         // Load portal POI from disk (PoiStorage::new automatically loads from disk if files exist)
         let portal_poi = portal::PortalPoiStorage::new(level.level_folder.poi_folder.clone());
@@ -299,9 +308,9 @@ impl World {
             entities: ArcSwap::new(Arc::new(Vec::new())),
             scoreboard: Mutex::new(Scoreboard::default()),
             worldborder: Mutex::new(Worldborder::new(0.0, 0.0, 5.999_996_8E7, 0, 5, 300)),
-            level_time: Mutex::new(LevelTime::new()),
+            level_time: Mutex::new(level_time),
             dimension,
-            weather: Mutex::new(Weather::new()),
+            weather: Mutex::new(weather),
             block_registry,
             sea_level: generation_settings.sea_level,
             min_y: i32::from(generation_settings.shape.min_y),

--- a/pumpkin/src/world/time.rs
+++ b/pumpkin/src/world/time.rs
@@ -24,6 +24,15 @@ impl LevelTime {
         }
     }
 
+    #[must_use]
+    pub const fn with_time_of_day(time_of_day: i64) -> Self {
+        Self {
+            world_age: 0,
+            time_of_day,
+            rain_time: 0,
+        }
+    }
+
     pub const fn tick_time(&mut self, advance_time: bool, advance_weather: bool) {
         self.world_age += 1;
         if advance_weather {
@@ -74,5 +83,18 @@ impl LevelTime {
     #[must_use]
     pub const fn is_night(&self) -> bool {
         (self.time_of_day % 24000) >= 12000 && (self.time_of_day % 24000) <= 23999
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::LevelTime;
+
+    #[test]
+    fn restores_persisted_time_of_day() {
+        let time = LevelTime::with_time_of_day(36_001);
+
+        assert_eq!(time.time_of_day, 36_001);
+        assert_eq!(time.world_age, 0);
     }
 }

--- a/pumpkin/src/world/weather.rs
+++ b/pumpkin/src/world/weather.rs
@@ -52,6 +52,30 @@ impl Weather {
         }
     }
 
+    #[must_use]
+    pub const fn from_persisted(
+        clear_weather_time: i32,
+        rain_time: i32,
+        raining: bool,
+        thunder_time: i32,
+        thundering: bool,
+    ) -> Self {
+        let rain_level = if raining { 1.0 } else { 0.0 };
+        let thunder_level = if thundering { 1.0 } else { 0.0 };
+        Self {
+            clear_weather_time,
+            raining,
+            rain_time,
+            thundering,
+            thunder_time,
+            rain_level,
+            old_rain_level: rain_level,
+            thunder_level,
+            old_thunder_level: thunder_level,
+            weather_cycle_enabled: true,
+        }
+    }
+
     pub fn set_weather_parameters(
         &mut self,
         world: &World,
@@ -169,5 +193,23 @@ impl Clone for Weather {
             old_thunder_level: self.old_thunder_level,
             weather_cycle_enabled: self.weather_cycle_enabled,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Weather;
+
+    #[test]
+    fn restores_persisted_weather_state() {
+        let weather = Weather::from_persisted(1_200, 9_001, true, 4_501, true);
+
+        assert_eq!(weather.clear_weather_time, 1_200);
+        assert_eq!(weather.rain_time, 9_001);
+        assert!(weather.raining);
+        assert_eq!(weather.thunder_time, 4_501);
+        assert!(weather.thundering);
+        assert_eq!(weather.rain_level, 1.0);
+        assert_eq!(weather.thunder_level, 1.0);
     }
 }


### PR DESCRIPTION
## Summary
- restore saved rain, thunder, timers, and world time during startup
- snapshot current overworld weather and clock state during shutdown
- preserve non-default weather and time values across save/load

## Validation
- `cargo fmt`
- focused weather and clock restoration tests
- focused world-info round-trip test
- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets`
- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin-world --all-targets`
- `git diff --check`