### PR TITLE
Apply cave spider poison on melee hits

### DIFF
--- a/pumpkin/src/entity/ai/goal/melee_attack.rs
+++ b/pumpkin/src/entity/ai/goal/melee_attack.rs
@@ -198,7 +198,7 @@ impl Goal for MeleeAttackGoal {
             {
                 self.cooldown = self.get_max_cooldown();
                 mob.get_mob_entity().living_entity.swing_hand().await;
-                mob.get_mob_entity().try_attack(mob, target.as_ref()).await;
+                mob.try_attack(target.as_ref()).await;
             }
         })
     }

--- a/pumpkin/src/entity/mob/cave_spider.rs
+++ b/pumpkin/src/entity/mob/cave_spider.rs
@@ -1,12 +1,23 @@
 use std::sync::Arc;
 
+use pumpkin_data::{effect::StatusEffect, potion::Effect};
+use pumpkin_util::Difficulty;
+
 use crate::entity::{
-    Entity, NBTStorage,
+    Entity, EntityBase, EntityBaseFuture, NBTStorage,
     mob::{Mob, MobEntity, spider::SpiderEntity},
 };
 
 pub struct CaveSpiderEntity {
     pub spider: Arc<SpiderEntity>,
+}
+
+const fn poison_duration(difficulty: Difficulty) -> Option<i32> {
+    match difficulty {
+        Difficulty::Normal => Some(7 * 20),
+        Difficulty::Hard => Some(15 * 20),
+        Difficulty::Peaceful | Difficulty::Easy => None,
+    }
 }
 
 impl CaveSpiderEntity {
@@ -22,5 +33,39 @@ impl Mob for CaveSpiderEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         self.spider.get_mob_entity()
     }
-    // TODO: Poison effect on attack
+
+    fn on_successful_attack<'a>(&'a self, target: &'a dyn EntityBase) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            let duration =
+                poison_duration(self.get_entity().world.load().level_info.load().difficulty);
+
+            if let (Some(duration), Some(living)) = (duration, target.get_living_entity()) {
+                living
+                    .add_effect(Effect {
+                        effect_type: &StatusEffect::POISON,
+                        duration,
+                        amplifier: 0,
+                        ambient: false,
+                        show_particles: true,
+                        show_icon: true,
+                        blend: false,
+                    })
+                    .await;
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::poison_duration;
+    use pumpkin_util::Difficulty;
+
+    #[test]
+    fn cave_spider_poison_matches_vanilla_difficulty_durations() {
+        assert_eq!(poison_duration(Difficulty::Peaceful), None);
+        assert_eq!(poison_duration(Difficulty::Easy), None);
+        assert_eq!(poison_duration(Difficulty::Normal), Some(140));
+        assert_eq!(poison_duration(Difficulty::Hard), Some(300));
+    }
 }

--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -266,14 +266,21 @@ impl MobEntity {
         true
     }
 
-    pub async fn try_attack(&self, caller: &dyn EntityBase, target: &dyn EntityBase) {
+    pub async fn try_attack(&self, target: &dyn EntityBase) -> bool {
         if self.living_entity.dead.load(Relaxed) {
-            return;
+            return false;
         }
 
         let attack_damage: f32 =
             self.living_entity
                 .get_attribute_value(&Attributes::ATTACK_DAMAGE) as f32;
+
+        let caller = self
+            .living_entity
+            .entity
+            .world
+            .load()
+            .get_entity_by_id(self.living_entity.entity.entity_id);
 
         let damaged = target
             .damage_with_context(
@@ -281,8 +288,8 @@ impl MobEntity {
                 attack_damage,
                 DamageType::MOB_ATTACK,
                 None,
-                Some(caller),
-                Some(caller),
+                caller.as_deref(),
+                caller.as_deref(),
             )
             .await;
 
@@ -294,6 +301,8 @@ impl MobEntity {
                 .last_attack_time
                 .store(self.living_entity.entity.age.load(Relaxed), Relaxed);
         }
+
+        damaged
     }
 
     async fn get_attack_box(&self, attack_range: f64) -> BoundingBox {
@@ -448,6 +457,20 @@ pub trait Mob: EntityBase + Send + Sync {
     }
 
     fn get_mob_entity(&self) -> &MobEntity;
+
+    fn try_attack<'a>(&'a self, target: &'a dyn EntityBase) -> EntityBaseFuture<'a, bool> {
+        Box::pin(async move {
+            let damaged = self.get_mob_entity().try_attack(target).await;
+            if damaged {
+                self.on_successful_attack(target).await;
+            }
+            damaged
+        })
+    }
+
+    fn on_successful_attack<'a>(&'a self, _target: &'a dyn EntityBase) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async {})
+    }
 
     fn get_job_site(&self) -> Option<BlockPos> {
         None

--- a/pumpkin/src/entity/mob/slime.rs
+++ b/pumpkin/src/entity/mob/slime.rs
@@ -323,7 +323,7 @@ impl Mob for SlimeEntity {
         Box::pin(async move {
             if !self.is_tiny() {
                 // dealDamage
-                self.entity.try_attack(self, &**player).await;
+                self.entity.try_attack(&**player).await;
             }
         })
     }


### PR DESCRIPTION
## Summary

- run mob-specific effects only after a successful melee hit
- apply Poison I for 7 seconds on Normal and 15 seconds on Hard
- leave Peaceful and Easy attacks without poison

## Validation

- cave-spider difficulty-duration regression test
- `cargo test -p pumpkin --lib` (168 passed)
- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets`
- `cargo build -p pumpkin`
- `git diff --check`