### PR TITLE
Add centralized unix timestamp functions

### DIFF
--- a/pumpkin-util/src/jwt/mod.rs
+++ b/pumpkin-util/src/jwt/mod.rs
@@ -4,6 +4,7 @@
 //! sent by a Minecraft: Bedrock Edition client. It handles cryptographic signature
 //! verification, public key extraction, and decoding of player data.
 
+use crate::duration_since_epoch;
 use base64::{Engine as _, engine::general_purpose};
 use ecdsa::Signature;
 use p384::PublicKey;
@@ -453,10 +454,7 @@ fn verify_oidc_claims(payload: &Value, expected_issuer: Option<&str>) -> Result<
         .get("exp")
         .and_then(Value::as_u64)
         .ok_or_else(|| AuthError::PublicKeyBuild("OIDC payload missing exp".into()))?;
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let now = duration_since_epoch().as_secs();
     if now > exp {
         return Err(AuthError::PublicKeyBuild("OIDC token expired".into()));
     }

--- a/pumpkin-util/src/jwt/mod.rs
+++ b/pumpkin-util/src/jwt/mod.rs
@@ -4,7 +4,7 @@
 //! sent by a Minecraft: Bedrock Edition client. It handles cryptographic signature
 //! verification, public key extraction, and decoding of player data.
 
-use crate::duration_since_epoch;
+use crate::unix_timestamp_secs;
 use base64::{Engine as _, engine::general_purpose};
 use ecdsa::Signature;
 use p384::PublicKey;
@@ -454,8 +454,7 @@ fn verify_oidc_claims(payload: &Value, expected_issuer: Option<&str>) -> Result<
         .get("exp")
         .and_then(Value::as_u64)
         .ok_or_else(|| AuthError::PublicKeyBuild("OIDC payload missing exp".into()))?;
-    let now = duration_since_epoch().as_secs();
-    if now > exp {
+    if unix_timestamp_secs() > exp {
         return Err(AuthError::PublicKeyBuild("OIDC token expired".into()));
     }
 

--- a/pumpkin-util/src/lib.rs
+++ b/pumpkin-util/src/lib.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::ops::{Index, IndexMut};
+use std::{
+    ops::{Index, IndexMut},
+    time::{Duration, UNIX_EPOCH},
+};
 
 pub use p384;
 pub use serde_json;
@@ -285,4 +288,10 @@ impl TryFrom<i32> for Hand {
             _ => Err(InvalidHand),
         }
     }
+}
+
+#[inline]
+#[must_use]
+pub fn duration_since_epoch() -> Duration {
+    UNIX_EPOCH.elapsed().expect("Time went backwards")
 }

--- a/pumpkin-util/src/lib.rs
+++ b/pumpkin-util/src/lib.rs
@@ -290,8 +290,59 @@ impl TryFrom<i32> for Hand {
     }
 }
 
+/// Returns elapsed time since `UNIX_EPOCH`.
+///
+/// # Panics
+///
+/// Panics if the system clock moved to before the Unix Epoch.
 #[inline]
 #[must_use]
 pub fn duration_since_epoch() -> Duration {
-    UNIX_EPOCH.elapsed().expect("Time went backwards")
+    UNIX_EPOCH
+        .elapsed()
+        .expect("System Clock set to before UNIX EPOCH")
+}
+
+/// Returns seconds since `UNIX_EPOCH`.
+///
+/// # Panics
+///
+/// Panics if the system clock moved to before the Unix Epoch.
+#[inline]
+#[must_use]
+pub fn unix_timestamp_secs() -> u64 {
+    duration_since_epoch().as_secs()
+}
+
+/// Returns milliseconds since `UNIX_EPOCH`.
+///
+/// # Panics
+///
+/// Panics if the system clock moved to before the Unix Epoch.
+#[inline]
+#[must_use]
+pub fn unix_timestamp_millis() -> u128 {
+    duration_since_epoch().as_millis()
+}
+
+/// Returns microseconds since `UNIX_EPOCH`.
+///
+/// # Panics
+///
+/// Panics if the system clock moved to before the Unix Epoch.
+#[inline]
+#[must_use]
+pub fn unix_timestamp_micros() -> u128 {
+    duration_since_epoch().as_micros()
+}
+
+/// Returns nanoseconds since `UNIX_EPOCH`.
+///
+/// # Panics
+///
+/// Panics if the system clock moved to before the Unix Epoch.
+#[inline]
+#[must_use]
+pub fn unix_timestamp_nanos() -> u128 {
+    duration_since_epoch().as_nanos()
 }

--- a/pumpkin-util/src/random/mod.rs
+++ b/pumpkin-util/src/random/mod.rs
@@ -1,12 +1,8 @@
-use std::{
-    sync::atomic::{AtomicU64, Ordering},
-    time,
-};
-
+use std::sync::atomic::{AtomicU64, Ordering};
 use enum_dispatch::enum_dispatch;
 use legacy_rand::{LegacyRand, LegacySplitter};
 use xoroshiro128::{Xoroshiro, XoroshiroSplitter};
-
+use crate::duration_since_epoch;
 mod gaussian;
 pub mod legacy_rand;
 pub mod xoroshiro128;
@@ -34,10 +30,7 @@ pub fn get_seed() -> u64 {
         })
         .unwrap();
 
-    let nanos = time::SystemTime::now()
-        .duration_since(time::SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
+    let nanos = duration_since_epoch().as_nanos();
 
     let nano_upper = (nanos >> 8) as u64;
     let nano_lower = nanos as u64;

--- a/pumpkin-util/src/random/mod.rs
+++ b/pumpkin-util/src/random/mod.rs
@@ -1,8 +1,8 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use crate::unix_timestamp_nanos;
 use enum_dispatch::enum_dispatch;
 use legacy_rand::{LegacyRand, LegacySplitter};
+use std::sync::atomic::{AtomicU64, Ordering};
 use xoroshiro128::{Xoroshiro, XoroshiroSplitter};
-use crate::duration_since_epoch;
 mod gaussian;
 pub mod legacy_rand;
 pub mod xoroshiro128;
@@ -30,7 +30,7 @@ pub fn get_seed() -> u64 {
         })
         .unwrap();
 
-    let nanos = duration_since_epoch().as_nanos();
+    let nanos = unix_timestamp_nanos();
 
     let nano_upper = (nanos >> 8) as u64;
     let nano_lower = nanos as u64;

--- a/pumpkin-world/src/chunk/format/anvil.rs
+++ b/pumpkin-world/src/chunk/format/anvil.rs
@@ -3,20 +3,18 @@ use flate2::read::{GzDecoder, GzEncoder, ZlibDecoder, ZlibEncoder};
 use itertools::Itertools;
 use lz4_java_wrc::Context;
 use pumpkin_config::chunk::AnvilChunkConfig;
-use pumpkin_util::math::vector2::Vector2;
+use pumpkin_util::{duration_since_epoch, math::vector2::Vector2};
 use std::{
     io::{Read, SeekFrom, Write},
     marker::PhantomData,
     path::{Path, PathBuf},
     pin::Pin,
-    time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::{
     io::{AsyncSeekExt, AsyncWrite, AsyncWriteExt, BufWriter},
     sync::Mutex,
 };
 use tracing::{debug, trace};
-
 use crate::chunk::{
     ChunkParsingError, ChunkReadingError, ChunkSerializingError, ChunkWritingError,
     CompressionError,
@@ -613,10 +611,7 @@ impl<S: SingleChunkDataSerializer> ChunkSerializer for AnvilChunkFile<S> {
         chunk: &Self::Data,
         chunk_config: &Self::ChunkConfig,
     ) -> Result<(), ChunkWritingError> {
-        let epoch = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as u32;
+        let epoch = duration_since_epoch().as_secs() as u32;
 
         let index = Self::get_chunk_index(chunk.position().0, chunk.position().1);
         // Default to the compression type read from the file

--- a/pumpkin-world/src/chunk/format/anvil.rs
+++ b/pumpkin-world/src/chunk/format/anvil.rs
@@ -1,9 +1,14 @@
+use crate::chunk::{
+    ChunkParsingError, ChunkReadingError, ChunkSerializingError, ChunkWritingError,
+    CompressionError,
+    io::{ChunkSerializer, Dirtiable, LoadedData},
+};
 use bytes::{Buf, BufMut, Bytes};
 use flate2::read::{GzDecoder, GzEncoder, ZlibDecoder, ZlibEncoder};
 use itertools::Itertools;
 use lz4_java_wrc::Context;
 use pumpkin_config::chunk::AnvilChunkConfig;
-use pumpkin_util::{duration_since_epoch, math::vector2::Vector2};
+use pumpkin_util::{math::vector2::Vector2, unix_timestamp_secs};
 use std::{
     io::{Read, SeekFrom, Write},
     marker::PhantomData,
@@ -15,11 +20,6 @@ use tokio::{
     sync::Mutex,
 };
 use tracing::{debug, trace};
-use crate::chunk::{
-    ChunkParsingError, ChunkReadingError, ChunkSerializingError, ChunkWritingError,
-    CompressionError,
-    io::{ChunkSerializer, Dirtiable, LoadedData},
-};
 
 /// The side size of a region in chunks (one region is 32x32 chunks)
 pub const REGION_SIZE: usize = 32;
@@ -611,7 +611,7 @@ impl<S: SingleChunkDataSerializer> ChunkSerializer for AnvilChunkFile<S> {
         chunk: &Self::Data,
         chunk_config: &Self::ChunkConfig,
     ) -> Result<(), ChunkWritingError> {
-        let epoch = duration_since_epoch().as_secs() as u32;
+        let epoch = unix_timestamp_secs() as u32;
 
         let index = Self::get_chunk_index(chunk.position().0, chunk.position().1);
         // Default to the compression type read from the file

--- a/pumpkin-world/src/chunk/format/linear.rs
+++ b/pumpkin-world/src/chunk/format/linear.rs
@@ -1,20 +1,18 @@
-use std::collections::HashMap;
-use std::io::{ErrorKind, Read};
-use std::marker::PhantomData;
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use crate::chunk::format::anvil::{AnvilChunkFile, SingleChunkDataSerializer};
 use crate::chunk::io::{ChunkSerializer, LoadedData};
 use crate::chunk::{ChunkReadingError, ChunkWritingError};
 use bytes::{Buf, BufMut, Bytes};
+use pumpkin_util::duration_since_epoch;
 use pumpkin_util::math::vector2::Vector2;
 use ruzstd::decoding::StreamingDecoder;
 use ruzstd::encoding::{CompressionLevel, compress_to_vec};
+use std::collections::HashMap;
+use std::io::{ErrorKind, Read};
+use std::marker::PhantomData;
+use std::path::PathBuf;
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tracing::{error, warn};
 use xxhash_rust::xxh64::xxh64;
-
 use super::anvil::CHUNK_COUNT;
 
 /// The signature used as both header and footer.
@@ -568,9 +566,7 @@ impl<S: SingleChunkDataSerializer> ChunkSerializer for LinearV2File<S> {
             .await
             .map_err(|err| ChunkWritingError::ChunkSerializingError(err.to_string()))?;
 
-        self.timestamps[index] = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs());
+        self.timestamps[index] = duration_since_epoch().as_secs();
         self.chunks_data[index] = Some(chunk_raw);
         Ok(())
     }

--- a/pumpkin-world/src/chunk/format/linear.rs
+++ b/pumpkin-world/src/chunk/format/linear.rs
@@ -1,9 +1,10 @@
+use super::anvil::CHUNK_COUNT;
 use crate::chunk::format::anvil::{AnvilChunkFile, SingleChunkDataSerializer};
 use crate::chunk::io::{ChunkSerializer, LoadedData};
 use crate::chunk::{ChunkReadingError, ChunkWritingError};
 use bytes::{Buf, BufMut, Bytes};
-use pumpkin_util::duration_since_epoch;
 use pumpkin_util::math::vector2::Vector2;
+use pumpkin_util::unix_timestamp_secs;
 use ruzstd::decoding::StreamingDecoder;
 use ruzstd::encoding::{CompressionLevel, compress_to_vec};
 use std::collections::HashMap;
@@ -13,7 +14,6 @@ use std::path::PathBuf;
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tracing::{error, warn};
 use xxhash_rust::xxh64::xxh64;
-use super::anvil::CHUNK_COUNT;
 
 /// The signature used as both header and footer.
 /// <https://gist.github.com/Aaron2550/5701519671253d4c6190bde6706f9f98>
@@ -566,7 +566,7 @@ impl<S: SingleChunkDataSerializer> ChunkSerializer for LinearV2File<S> {
             .await
             .map_err(|err| ChunkWritingError::ChunkSerializingError(err.to_string()))?;
 
-        self.timestamps[index] = duration_since_epoch().as_secs();
+        self.timestamps[index] = unix_timestamp_secs();
         self.chunks_data[index] = Some(chunk_raw);
         Ok(())
     }

--- a/pumpkin-world/src/poi/mod.rs
+++ b/pumpkin-world/src/poi/mod.rs
@@ -1,14 +1,14 @@
-use pumpkin_util::duration_since_epoch;
-use std::collections::HashMap;
-use std::io::{Cursor, Read, Write};
-use std::path::{Path, PathBuf};
-use tracing::{info, warn};
 use flate2::Compression;
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
+use pumpkin_util::unix_timestamp_secs;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{Cursor, Read, Write};
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
 
 /// POI type identifier for nether portals
 pub const POI_TYPE_NETHER_PORTAL: &str = "minecraft:nether_portal";
@@ -241,7 +241,7 @@ impl PoiRegion {
         let mut timestamp_table = [0u32; CHUNK_COUNT];
         let mut sector_data: Vec<Vec<u8>> = Vec::new();
 
-        let timestamp = duration_since_epoch().as_secs() as u32;
+        let timestamp = unix_timestamp_secs() as u32;
 
         // Start after header (2 sectors)
         let mut current_sector: u32 = 2;

--- a/pumpkin-world/src/poi/mod.rs
+++ b/pumpkin-world/src/poi/mod.rs
@@ -1,8 +1,8 @@
+use pumpkin_util::duration_since_epoch;
 use std::collections::HashMap;
 use std::io::{Cursor, Read, Write};
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
-
 use flate2::Compression;
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
@@ -241,9 +241,7 @@ impl PoiRegion {
         let mut timestamp_table = [0u32; CHUNK_COUNT];
         let mut sector_data: Vec<Vec<u8>> = Vec::new();
 
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs() as u32);
+        let timestamp = duration_since_epoch().as_secs() as u32;
 
         // Start after header (2 sectors)
         let mut current_sector: u32 = 2;

--- a/pumpkin-world/src/world_info/anvil.rs
+++ b/pumpkin-world/src/world_info/anvil.rs
@@ -1,12 +1,4 @@
-use pumpkin_util::duration_since_epoch;
-use std::{
-    fs::File,
-    io::{Cursor, Read},
-    path::Path,
-};
-use tracing::error;
-use flate2::{Compression, read::GzDecoder, write::GzEncoder};
-use serde::{Deserialize, Serialize};
+use super::{LevelData, WorldInfoError, WorldInfoReader, WorldInfoWriter};
 use crate::world_info::{
     MAXIMUM_SUPPORTED_LEVEL_VERSION, MAXIMUM_SUPPORTED_WORLD_DATA_VERSION,
     MINIMUM_SUPPORTED_LEVEL_VERSION, MINIMUM_SUPPORTED_WORLD_DATA_VERSION,
@@ -17,7 +9,15 @@ use crate::world_info::{
         write_world_clocks, write_world_gen_settings,
     },
 };
-use super::{LevelData, WorldInfoError, WorldInfoReader, WorldInfoWriter};
+use flate2::{Compression, read::GzDecoder, write::GzEncoder};
+use pumpkin_util::unix_timestamp_millis;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::File,
+    io::{Cursor, Read},
+    path::Path,
+};
+use tracing::error;
 
 pub const LEVEL_DAT_FILE_NAME: &str = "level.dat";
 pub const LEVEL_DAT_BACKUP_FILE_NAME: &str = "level.dat_old";
@@ -140,9 +140,8 @@ impl WorldInfoWriter for AnvilLevelInfo {
         info: &LevelData,
         level_folder: &Path,
     ) -> Result<(), WorldInfoError> {
-        let since_the_epoch = duration_since_epoch();
         let mut level_data = info.clone();
-        level_data.last_played = since_the_epoch.as_millis() as i64;
+        level_data.last_played = unix_timestamp_millis() as i64;
         let level = LevelDat { data: level_data };
 
         // ── Write level.dat ───────────────────────────────────────────────────

--- a/pumpkin-world/src/world_info/anvil.rs
+++ b/pumpkin-world/src/world_info/anvil.rs
@@ -1,14 +1,12 @@
+use pumpkin_util::duration_since_epoch;
 use std::{
     fs::File,
     io::{Cursor, Read},
     path::Path,
-    time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::error;
-
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use serde::{Deserialize, Serialize};
-
 use crate::world_info::{
     MAXIMUM_SUPPORTED_LEVEL_VERSION, MAXIMUM_SUPPORTED_WORLD_DATA_VERSION,
     MINIMUM_SUPPORTED_LEVEL_VERSION, MINIMUM_SUPPORTED_WORLD_DATA_VERSION,
@@ -19,7 +17,6 @@ use crate::world_info::{
         write_world_clocks, write_world_gen_settings,
     },
 };
-
 use super::{LevelData, WorldInfoError, WorldInfoReader, WorldInfoWriter};
 
 pub const LEVEL_DAT_FILE_NAME: &str = "level.dat";
@@ -143,10 +140,7 @@ impl WorldInfoWriter for AnvilLevelInfo {
         info: &LevelData,
         level_folder: &Path,
     ) -> Result<(), WorldInfoError> {
-        let start = SystemTime::now();
-        let since_the_epoch = start
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards");
+        let since_the_epoch = duration_since_epoch();
         let mut level_data = info.clone();
         level_data.last_played = since_the_epoch.as_millis() as i64;
         let level = LevelDat { data: level_data };

--- a/pumpkin/src/net/bedrock/connection.rs
+++ b/pumpkin/src/net/bedrock/connection.rs
@@ -1,10 +1,9 @@
-use std::time::UNIX_EPOCH;
-
 use pumpkin_protocol::bedrock::{
     RakReliability,
     client::raknet::connection::CConnectedPong,
     server::raknet::connection::{SConnectedPing, SNewIncomingConnection},
 };
+use pumpkin_util::duration_since_epoch;
 
 use crate::net::bedrock::BedrockClient;
 
@@ -15,10 +14,7 @@ impl BedrockClient {
 
     pub async fn handle_connected_ping(&self, packet: SConnectedPing) {
         self.send_framed_packet(
-            &CConnectedPong::new(
-                packet.time,
-                UNIX_EPOCH.elapsed().unwrap().as_millis() as u64,
-            ),
+            &CConnectedPong::new(packet.time, duration_since_epoch().as_millis() as u64),
             RakReliability::Unreliable,
         )
         .await;

--- a/pumpkin/src/net/bedrock/connection.rs
+++ b/pumpkin/src/net/bedrock/connection.rs
@@ -3,7 +3,7 @@ use pumpkin_protocol::bedrock::{
     client::raknet::connection::CConnectedPong,
     server::raknet::connection::{SConnectedPing, SNewIncomingConnection},
 };
-use pumpkin_util::duration_since_epoch;
+use pumpkin_util::unix_timestamp_millis;
 
 use crate::net::bedrock::BedrockClient;
 
@@ -14,7 +14,7 @@ impl BedrockClient {
 
     pub async fn handle_connected_ping(&self, packet: SConnectedPing) {
         self.send_framed_packet(
-            &CConnectedPong::new(packet.time, duration_since_epoch().as_millis() as u64),
+            &CConnectedPong::new(packet.time, unix_timestamp_millis() as u64),
             RakReliability::Unreliable,
         )
         .await;

--- a/pumpkin/src/net/bedrock/mod.rs
+++ b/pumpkin/src/net/bedrock/mod.rs
@@ -91,7 +91,7 @@ use crate::{
 };
 use arc_swap::ArcSwap;
 use pumpkin_protocol::bedrock::server::login::ClientData;
-use pumpkin_util::{duration_since_epoch, version::BedrockMinecraftVersion};
+use pumpkin_util::{unix_timestamp_millis, version::BedrockMinecraftVersion};
 use pumpkin_world::level::SyncChunk;
 
 pub struct OutgoingPacket {
@@ -1233,7 +1233,7 @@ impl BedrockClient {
                         0,
                         [SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 19132)); 10],
                         request.time,
-                        duration_since_epoch().as_millis() as u64,
+                        unix_timestamp_millis() as u64,
                     ),
                     RakReliability::Unreliable,
                 )

--- a/pumpkin/src/net/bedrock/mod.rs
+++ b/pumpkin/src/net/bedrock/mod.rs
@@ -8,7 +8,6 @@ use std::{
         Arc,
         atomic::{AtomicBool, AtomicU16, AtomicU32, Ordering},
     },
-    time::UNIX_EPOCH,
 };
 
 use tracing::{debug, error, warn};
@@ -92,7 +91,7 @@ use crate::{
 };
 use arc_swap::ArcSwap;
 use pumpkin_protocol::bedrock::server::login::ClientData;
-use pumpkin_util::version::BedrockMinecraftVersion;
+use pumpkin_util::{duration_since_epoch, version::BedrockMinecraftVersion};
 use pumpkin_world::level::SyncChunk;
 
 pub struct OutgoingPacket {
@@ -1234,7 +1233,7 @@ impl BedrockClient {
                         0,
                         [SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 19132)); 10],
                         request.time,
-                        UNIX_EPOCH.elapsed().unwrap().as_millis() as u64,
+                        duration_since_epoch().as_millis() as u64,
                     ),
                     RakReliability::Unreliable,
                 )

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -1,12 +1,12 @@
 use pumpkin_protocol::java::client::play::{
     CAcknowledgeBlockChange, CChunkBatchEnd, CChunkBatchStart, CChunkData, CPlayDisconnect,
 };
+use pumpkin_util::duration_since_epoch;
 use pumpkin_world::level::SyncChunk;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::Instant;
 use std::{io::Write, sync::Arc};
-
 use bytes::Bytes;
 use crossbeam::atomic::AtomicCell;
 use pumpkin_config::networking::compression::CompressionInfo;
@@ -266,9 +266,7 @@ impl JavaClient {
                     }
 
                     // Generate a unique ID (current timestamp in ms)
-                    let keep_alive_id = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
+                    let keep_alive_id = duration_since_epoch()
                         .as_millis() as i64;
 
                     self.keep_alive_id.store(keep_alive_id);

--- a/pumpkin/src/net/java/mod.rs
+++ b/pumpkin/src/net/java/mod.rs
@@ -1,17 +1,11 @@
-use pumpkin_protocol::java::client::play::{
-    CAcknowledgeBlockChange, CChunkBatchEnd, CChunkBatchStart, CChunkData, CPlayDisconnect,
-};
-use pumpkin_util::duration_since_epoch;
-use pumpkin_world::level::SyncChunk;
-use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::time::Instant;
-use std::{io::Write, sync::Arc};
 use bytes::Bytes;
 use crossbeam::atomic::AtomicCell;
 use pumpkin_config::networking::compression::CompressionInfo;
 use pumpkin_data::packet::CURRENT_MC_VERSION;
 use pumpkin_data::translation;
+use pumpkin_protocol::java::client::play::{
+    CAcknowledgeBlockChange, CChunkBatchEnd, CChunkBatchStart, CChunkData, CPlayDisconnect,
+};
 use pumpkin_protocol::java::server::play::{
     SAttack, SBundleItemSelected, SChangeGameMode, SChatCommand, SChatMessage, SChunkBatch,
     SClickSlot, SClientCommand, SClientInformationPlay, SClientTickEnd, SCloseContainer,
@@ -49,7 +43,13 @@ use pumpkin_protocol::{
     ser::{NetworkWriteExt, ReadingError, WritingError},
 };
 use pumpkin_util::text::TextComponent;
+use pumpkin_util::unix_timestamp_millis;
 use pumpkin_util::version::JavaMinecraftVersion;
+use pumpkin_world::level::SyncChunk;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::time::Instant;
+use std::{io::Write, sync::Arc};
 use tokio::{
     io::{BufReader, BufWriter},
     net::{
@@ -266,8 +266,7 @@ impl JavaClient {
                     }
 
                     // Generate a unique ID (current timestamp in ms)
-                    let keep_alive_id = duration_since_epoch()
-                        .as_millis() as i64;
+                    let keep_alive_id = unix_timestamp_millis() as i64;
 
                     self.keep_alive_id.store(keep_alive_id);
                     self.wait_for_keep_alive.store(true, Ordering::Relaxed);

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -1,15 +1,13 @@
 use pumpkin_protocol::bedrock::server::text::SText;
-use pumpkin_util::{Hand, PermissionLvl};
+use pumpkin_util::{Hand, PermissionLvl, duration_since_epoch};
 use rsa::pkcs1v15::{Signature as RsaPkcs1v15Signature, VerifyingKey};
 use rsa::signature::Verifier;
 use sha1::Sha1;
 use std::num::NonZeroU8;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use tracing::{Level, debug, error, info, trace, warn};
-
 use crate::block::BlockHitResult;
 use crate::block::registry::BlockActionResult;
 use crate::block::{self};
@@ -32,7 +30,6 @@ use crate::plugin::player::player_interact_unknown_entity_event::PlayerInteractU
 use crate::plugin::player::player_move::PlayerMoveEvent;
 use crate::plugin::player::player_toggle_flight_event::PlayerToggleFlightEvent;
 use crate::plugin::player::player_toggle_sneak_event::PlayerToggleSneakEvent;
-
 use crate::block::entities::command_block::CommandBlockEntity;
 use crate::block::entities::jigsaw_block::JigsawBlockEntity;
 use crate::block::entities::sign::SignBlockEntity;
@@ -1489,10 +1486,7 @@ impl JavaClient {
                 return Err(ChatError::UnsignedChat); // There is no signature
             }
 
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as i64;
+            let now = duration_since_epoch().as_millis() as i64;
 
             // Verify message timestamp
             if chat_message.timestamp > now || chat_message.timestamp < (now - CHAT_MESSAGE_MAX_AGE)
@@ -1575,10 +1569,7 @@ impl JavaClient {
         session: &SPlayerSession,
     ) -> Result<(), ChatError> {
         // Verify session expiry
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
+        let now = duration_since_epoch().as_millis() as i64;
         if session.expires_at < now {
             return Err(ChatError::InvalidPublicKey);
         }

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -1,14 +1,7 @@
-use pumpkin_protocol::bedrock::server::text::SText;
-use pumpkin_util::{Hand, PermissionLvl, duration_since_epoch};
-use rsa::pkcs1v15::{Signature as RsaPkcs1v15Signature, VerifyingKey};
-use rsa::signature::Verifier;
-use sha1::Sha1;
-use std::num::NonZeroU8;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
-use thiserror::Error;
-use tracing::{Level, debug, error, info, trace, warn};
 use crate::block::BlockHitResult;
+use crate::block::entities::command_block::CommandBlockEntity;
+use crate::block::entities::jigsaw_block::JigsawBlockEntity;
+use crate::block::entities::sign::SignBlockEntity;
 use crate::block::registry::BlockActionResult;
 use crate::block::{self};
 use crate::entity::EntityBase;
@@ -30,9 +23,6 @@ use crate::plugin::player::player_interact_unknown_entity_event::PlayerInteractU
 use crate::plugin::player::player_move::PlayerMoveEvent;
 use crate::plugin::player::player_toggle_flight_event::PlayerToggleFlightEvent;
 use crate::plugin::player::player_toggle_sneak_event::PlayerToggleSneakEvent;
-use crate::block::entities::command_block::CommandBlockEntity;
-use crate::block::entities::jigsaw_block::JigsawBlockEntity;
-use crate::block::entities::sign::SignBlockEntity;
 use crate::plugin::player::player_toggle_sprint_event::PlayerToggleSprintEvent;
 use crate::server::{Server, seasonal_events};
 use crate::world::{World, chunker};
@@ -50,6 +40,7 @@ use pumpkin_inventory::player::player_inventory::PlayerInventory;
 use pumpkin_inventory::screen_handler::{InventoryPlayer, ScreenHandler};
 use pumpkin_macros::send_cancellable;
 use pumpkin_protocol::bedrock::client::CMovePlayer;
+use pumpkin_protocol::bedrock::server::text::SText;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::codec::var_ulong::VarULong;
 use pumpkin_protocol::java::client::play::{
@@ -73,9 +64,18 @@ use pumpkin_protocol::java::server::play::{
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::math::{polynomial_rolling_hash, position::BlockPos, wrap_degrees};
 use pumpkin_util::{GameMode, text::TextComponent};
+use pumpkin_util::{Hand, PermissionLvl, unix_timestamp_millis};
 use pumpkin_world::generation::structure::structures::jigsaw::JigsawJointType;
 use pumpkin_world::world::BlockFlags;
+use rsa::pkcs1v15::{Signature as RsaPkcs1v15Signature, VerifyingKey};
+use rsa::signature::Verifier;
+use sha1::Sha1;
+use std::num::NonZeroU8;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use thiserror::Error;
 use tokio::sync::Mutex;
+use tracing::{Level, debug, error, info, trace, warn};
 
 /// In secure chat mode, Player will be kicked if they send a chat message with a timestamp that is older than this (in ms)
 /// Vanilla: 2 minutes
@@ -1486,7 +1486,7 @@ impl JavaClient {
                 return Err(ChatError::UnsignedChat); // There is no signature
             }
 
-            let now = duration_since_epoch().as_millis() as i64;
+            let now = unix_timestamp_millis() as i64;
 
             // Verify message timestamp
             if chat_message.timestamp > now || chat_message.timestamp < (now - CHAT_MESSAGE_MAX_AGE)
@@ -1569,7 +1569,7 @@ impl JavaClient {
         session: &SPlayerSession,
     ) -> Result<(), ChatError> {
         // Verify session expiry
-        let now = duration_since_epoch().as_millis() as i64;
+        let now = unix_timestamp_millis() as i64;
         if session.expires_at < now {
             return Err(ChatError::InvalidPublicKey);
         }


### PR DESCRIPTION
refactor: add centralized unix timestamp functions

## Description
Adds five helper functions for unix timestamps, one returning a `Duration` and the other 4 for seconds, milliseconds, microseconds, and nanoseconds.
Refactored all relevant call sites to use these functions.
this centralizes the unwrap/expect required for getting the current unix timestamp and ensures a descriptive expect msg.

