### PR TITLE
fix(projectile): attribute trident damage to the trident

### DIFF
--- a/pumpkin/src/entity/projectile/trident.rs
+++ b/pumpkin/src/entity/projectile/trident.rs
@@ -361,7 +361,7 @@ impl EntityBase for TridentEntity {
                     }
 
                     target
-                        .damage(&*target, damage as f32, DamageType::TRIDENT)
+                        .damage(self, damage as f32, DamageType::TRIDENT)
                         .await;
 
                     // Play hit sound


### PR DESCRIPTION
Attribute trident hits to the projectile instead of the victim.