### PR TITLE
fix: restore redstone tick ordering and inflight scheduling visibility (fixes #2699) 🤖🤖🤖

### DIFF
--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -954,4 +954,12 @@ impl Level {
         })
         .unwrap_or(false)
     }
+
+    pub fn clear_block_tick_inflight(&self, active_chunks: &FxHashSet<Vector2<i32>>) {
+        for pos in active_chunks {
+            if let Some(chunk) = self.loaded_chunks.get(pos) {
+                chunk.block_ticks.clear_inflight();
+            }
+        }
+    }
 }

--- a/pumpkin-world/src/tick/scheduler.rs
+++ b/pumpkin-world/src/tick/scheduler.rs
@@ -16,6 +16,7 @@ pub struct ChunkTickScheduler<T> {
 struct ChunkTickSchedulerInner<T> {
     tick_queue: [Vec<OrderedTick<T>>; MAX_TICK_DELAY],
     queued_ticks: FxHashSet<(BlockPos, T)>,
+    inflight_ticks: FxHashSet<(BlockPos, T)>,
 }
 
 impl<'a, T: std::hash::Hash + Eq> ChunkTickScheduler<&'a T> {
@@ -40,9 +41,9 @@ impl<'a, T: std::hash::Hash + Eq> ChunkTickScheduler<&'a T> {
                 inner
                     .queued_ticks
                     .remove(&(next_tick.position, next_tick.value));
-            }
-            if inner.queued_ticks.is_empty() {
-                *inner_guard = None;
+                inner
+                    .inflight_ticks
+                    .insert((next_tick.position, next_tick.value));
             }
         }
         res
@@ -57,6 +58,7 @@ impl<'a, T: std::hash::Hash + Eq> ChunkTickScheduler<&'a T> {
             Box::new(ChunkTickSchedulerInner {
                 tick_queue: std::array::from_fn(|_| Vec::new()),
                 queued_ticks: FxHashSet::default(),
+                inflight_ticks: FxHashSet::default(),
             })
         });
 
@@ -78,7 +80,10 @@ impl<'a, T: std::hash::Hash + Eq> ChunkTickScheduler<&'a T> {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .as_ref()
-            .is_some_and(|inner| inner.queued_ticks.contains(&(pos, value)))
+            .is_some_and(|inner| {
+                inner.queued_ticks.contains(&(pos, value))
+                    || inner.inflight_ticks.contains(&(pos, value))
+            })
     }
 
     pub fn has_ticks(&self) -> bool {
@@ -86,7 +91,20 @@ impl<'a, T: std::hash::Hash + Eq> ChunkTickScheduler<&'a T> {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .as_ref()
-            .is_some_and(|inner| !inner.queued_ticks.is_empty())
+            .is_some_and(|inner| !inner.queued_ticks.is_empty() || !inner.inflight_ticks.is_empty())
+    }
+
+    pub fn clear_inflight(&self) {
+        let mut inner_guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(inner) = inner_guard.as_mut() {
+            inner.inflight_ticks.clear();
+            if inner.queued_ticks.is_empty() && inner.inflight_ticks.is_empty() {
+                *inner_guard = None;
+            }
+        }
     }
 
     #[must_use]
@@ -132,6 +150,7 @@ impl<'a, T: std::hash::Hash + Eq + 'static> FromIterator<ScheduledTick<&'a T>>
                 Box::new(ChunkTickSchedulerInner {
                     tick_queue: std::array::from_fn(|_| Vec::new()),
                     queued_ticks: FxHashSet::default(),
+                    inflight_ticks: FxHashSet::default(),
                 })
             });
             inner.queued_ticks.reserve(lower);
@@ -150,5 +169,86 @@ impl<T> Default for ChunkTickScheduler<T> {
             inner: Mutex::new(None),
             offset: AtomicUsize::new(0),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tick::TickPriority;
+    use pumpkin_util::math::position::BlockPos;
+
+    static VALUE: u8 = 0;
+
+    #[test]
+    fn inflight_tick_still_appears_scheduled() {
+        let scheduler: ChunkTickScheduler<&'static u8> = ChunkTickScheduler::default();
+        let pos = BlockPos::new(0, 0, 0);
+
+        scheduler.schedule_tick(
+            &ScheduledTick {
+                delay: 0,
+                priority: TickPriority::Normal,
+                position: pos,
+                value: &VALUE,
+            },
+            0,
+        );
+
+        assert!(scheduler.is_scheduled(pos, &VALUE));
+
+        let ticks = scheduler.step_tick();
+        assert_eq!(ticks.len(), 1);
+        assert_eq!(ticks[0].position, pos);
+
+        // Tick is in-flight — is_scheduled must still return true
+        assert!(scheduler.is_scheduled(pos, &VALUE));
+
+        // Scheduling a fresh tick for the same position must succeed
+        // while the old one is in-flight
+        scheduler.schedule_tick(
+            &ScheduledTick {
+                delay: 5,
+                priority: TickPriority::Normal,
+                position: pos,
+                value: &VALUE,
+            },
+            1,
+        );
+
+        scheduler.clear_inflight();
+
+        // After clear, in-flight is gone but the fresh queued tick remains
+        assert!(scheduler.is_scheduled(pos, &VALUE));
+        assert!(scheduler.has_ticks());
+
+        // Step again to retrieve the fresh tick
+        for _ in 0..5 {
+            scheduler.step_tick();
+        }
+        let ticks = scheduler.step_tick();
+        assert_eq!(ticks.len(), 1);
+        assert_eq!(ticks[0].position, pos);
+    }
+
+    #[test]
+    fn clear_inflight_drops_inner_when_empty() {
+        let scheduler: ChunkTickScheduler<&'static u8> = ChunkTickScheduler::default();
+        let pos = BlockPos::new(0, 0, 0);
+
+        scheduler.schedule_tick(
+            &ScheduledTick {
+                delay: 0,
+                priority: TickPriority::Normal,
+                position: pos,
+                value: &VALUE,
+            },
+            0,
+        );
+
+        let _ticks = scheduler.step_tick();
+        scheduler.clear_inflight();
+
+        assert!(!scheduler.has_ticks());
     }
 }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1193,26 +1193,29 @@ impl World {
         let active_chunks = self.active_chunks.load();
         let tick_data = self.level.get_tick_data(&active_chunks);
 
-        // ONE JoinSet for all chunk operations
-        let mut chunk_tasks = tokio::task::JoinSet::new();
-
-        // 1. Spawn Block Ticks
-        for scheduled_tick in tick_data.block_ticks {
-            let world = self.clone();
-            let pos = scheduled_tick.position; // Clone for the move closure
-            chunk_tasks.spawn(async move {
-                let block = world.get_block(&pos);
-                if let Some(pumpkin_block) = world.block_registry.get_pumpkin_block(block.id) {
-                    pumpkin_block
-                        .on_scheduled_tick(OnScheduledTickArgs {
-                            world: &world,
-                            block,
-                            position: &pos,
-                        })
-                        .await;
-                }
-            });
+        // Block ticks must execute sequentially and in sorted priority/sub-tick order.
+        // Redstone components (repeaters, observers, torches, wire) depend on strict
+        // update ordering; concurrent execution via JoinSet breaks that contract.
+        for scheduled_tick in &tick_data.block_ticks {
+            let block = self.get_block(&scheduled_tick.position);
+            if let Some(pumpkin_block) = self.block_registry.get_pumpkin_block(block.id) {
+                pumpkin_block
+                    .on_scheduled_tick(OnScheduledTickArgs {
+                        world: self,
+                        block,
+                        position: &scheduled_tick.position,
+                    })
+                    .await;
+            }
         }
+
+        // Mark block ticks as complete so is_block_tick_scheduled returns accurate
+        // results after execution, matching the invariant from PR #861.
+        self.level.clear_block_tick_inflight(&active_chunks);
+
+        // Fluid ticks and random ticks can run concurrently — they don't need strict
+        // ordering guarantees like redstone does.
+        let mut chunk_tasks = tokio::task::JoinSet::new();
 
         // 2. Spawn Fluid Ticks
         for scheduled_tick in tick_data.fluid_ticks {


### PR DESCRIPTION
## Description



Fixes #2699 — redstone state updates could be lost or desynchronized when activated, especially with fast clocks and long redstone lines.



Two regressions were traced to commit `1dbfb75e`:



1. **Block ticks were executed concurrently** — `tick_chunks` spawned every due block tick into a shared `JoinSet`, destroying the priority and sub-tick ordering that redstone components such as repeaters, observers, torches, and wire depend on. This caused clocks, repeater chains, and observer pairs to race and produce incorrect results.



2. **Inflight ticks were invisible to `is_block_tick_scheduled`** — `ChunkTickScheduler::step_tick` removed entries from `queued_ticks` before execution. As a result, redstone torches and repeaters calling `is_block_tick_scheduled` during the same tick received `false`, breaking the deduplication guard introduced in PR #861.



## Changes



* Block ticks now execute sequentially in sorted priority and sub-tick order.

* `ChunkTickScheduler` tracks inflight ticks separately, so `is_scheduled` returns `true` during processing.

* `clear_inflight()` is called after all block ticks complete.

* Added two unit tests verifying inflight visibility and cleanup.



## Testing



* `cargo check` — clean

* `cargo fmt --check` — clean

* `cargo clippy --package pumpkin-world --all-targets` — clean

* Both new scheduler unit tests pass