### PR TITLE
fix: size Nether chunk generation storage to its real height

### DIFF
--- a/pumpkin-world/src/generation/proto_chunk.rs
+++ b/pumpkin-world/src/generation/proto_chunk.rs
@@ -180,7 +180,7 @@ impl ProtoChunk {
     #[must_use]
     pub fn new(x: i32, z: i32, generator: &super::generator::WorldGenerator) -> Self {
         let dimension = generator.dimension();
-        let height = dimension.logical_height as u16;
+        let height = dimension.height as u16;
         let section_count = (height as usize) / 16;
 
         let default_block = match generator {

--- a/pumpkin-world/src/generation/structure/mod.rs
+++ b/pumpkin-world/src/generation/structure/mod.rs
@@ -149,9 +149,8 @@ pub fn try_generate_structure(
 
     if let Some(pos) = structure_pos {
         // Get the biome at the structure's starting position.
-        // Clamp biome Y to the chunk's valid range — structure start_pos.y may exceed
-        // the chunk's logical height (e.g. nether fossils use full height 256 but
-        // ProtoChunk only covers logical_height 128).
+        // Clamp biome Y to the chunk's valid range in case a structure's start_pos.y
+        // falls outside this chunk's stored biome section range.
         let biome_y = biome_coords::from_block(pos.start_pos.0.y);
         let biome_height = (chunk.height() >> 2) as i32;
         let biome_bottom = biome_coords::from_block(chunk.bottom_y() as i32);


### PR DESCRIPTION
Fixes #2560.

ProtoChunk::new allocated flat_block_map, flat_biome_map, and light section counts using dimension.logical_height, but Chunk::upgrade_to_level_chunk sizes the destination chunk's block sections using dimension.height. For every other dimension these two fields are equal, so the mismatch was invisible. The Nether is the only dimension where they diverge (height=256, logical_height=128), because logical_height is vanilla's portal/compass scaling concept, not a storage bound.

A Nether ProtoChunk's 128-tall array does not cover the full 256-tall column upgrade_to_level_chunk expects, which panics with an index-out-of-bounds a full row past the array's end once generation reaches y>=128. This is the crash in issue #2560, reported when a player teleports through a nether portal. The attached crash log's flat_block_map length is 32768 = 256*128 exactly, matching this mismatch precisely:

index out of bounds: the len is 32768 but the index is 32768
Panic Location: pumpkin-world/src/generation/proto_chunk.rs:450:9

Fix: use dimension.height in ProtoChunk::new, matching every other call site in this crate (CarvingContext, biome-map sizing) and every other dimension's already-equal height/logical_height fields. Also updates a comment in structure/mod.rs that described this exact gap as a known, only partially worked-around issue.

Test plan:
- cargo test -p pumpkin-world --lib: 104 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin-world --all-targets: clean
- cargo fmt --all -- --check: clean