### PR TITLE
fix: claim both parents' love state atomically before breeding

### DIFF
--- a/pumpkin/src/entity/ai/goal/breed.rs
+++ b/pumpkin/src/entity/ai/goal/breed.rs
@@ -62,6 +62,13 @@ impl BreedGoal {
 
     async fn breed(mob: &dyn Mob, mate: &dyn EntityBase) {
         let mob_entity = mob.get_mob_entity();
+        if !mob_entity.try_claim_love() {
+            return;
+        }
+        if !mate.try_claim_love() {
+            return;
+        }
+
         let entity = mob.get_entity();
         let world = entity.world.load();
 
@@ -87,12 +94,10 @@ impl BreedGoal {
                 .await;
         }
 
-        mob_entity.reset_love_ticks();
         mob_entity
             .breeding_cooldown
             .store(6000, std::sync::atomic::Ordering::Relaxed);
 
-        mate.reset_love();
         mate.set_breeding_cooldown(6000);
 
         let parent_pos = entity.pos.load();

--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -199,6 +199,12 @@ impl MobEntity {
         self.love_ticks.store(0, Relaxed);
     }
 
+    pub fn try_claim_love(&self) -> bool {
+        self.love_ticks
+            .fetch_update(Relaxed, Relaxed, |ticks| (ticks > 0).then_some(0))
+            .is_ok()
+    }
+
     pub fn is_breeding_ready(&self) -> bool {
         self.living_entity.entity.age.load(Relaxed) >= 0
             && self.breeding_cooldown.load(Relaxed) <= 0
@@ -780,6 +786,10 @@ impl<T: Mob + Send + 'static> EntityBase for T {
 
     fn reset_love(&self) {
         self.get_mob_entity().reset_love_ticks();
+    }
+
+    fn try_claim_love(&self) -> bool {
+        self.get_mob_entity().try_claim_love()
     }
 
     fn set_breeding_cooldown(&self, ticks: i32) {

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -590,6 +590,10 @@ pub trait EntityBase: Send + Sync + NBTStorage + std::any::Any {
 
     fn reset_love(&self) {}
 
+    fn try_claim_love(&self) -> bool {
+        false
+    }
+
     fn set_breeding_cooldown(&self, _ticks: i32) {}
 
     fn is_panicking(&self) -> bool {


### PR DESCRIPTION
Fixes #2532.

Entities tick as independent concurrent tokio tasks, so both breeding parents' BreedGoal::tick can reach the timer>=60 && dist_sq<9.0 threshold in the same world tick and each independently call breed(), spawning two children for one breeding event. Vanilla's single-threaded tick gives finalizeSpawnChildFromBreeding implicit mutual exclusion that Pumpkin's concurrent model does not provide, which matches what the issue reports: cows always produce 2 babies, pigs often do.

Fix: add MobEntity::try_claim_love, a real compare-and-swap (AtomicI32::fetch_update from a positive value to 0) exposed through EntityBase so it is callable on a mate reference. breed() now claims both parents atomically before spawning the child; a losing concurrent call sees its own or the mate's claim fail and returns without spawning.

Test plan:
- cargo test -p pumpkin --lib: 167 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets: clean
- cargo fmt --all -- --check: clean