### PR TITLE
feat: implement core wolf, cat, and parrot taming

### DIFF
--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -77,6 +77,7 @@ pub struct MobEntity {
     pub love_ticks: AtomicI32,
     pub breeding_cooldown: AtomicI32,
     pub breeder: AtomicCell<Option<Uuid>>,
+    pub owner: AtomicCell<Option<Uuid>>,
     mob_flags: AtomicU8,
     last_sent_yaw: AtomicU8,
     last_sent_pitch: AtomicU8,
@@ -114,6 +115,7 @@ impl MobEntity {
             love_ticks: AtomicI32::new(0),
             breeding_cooldown: AtomicI32::new(0),
             breeder: AtomicCell::new(None),
+            owner: AtomicCell::new(None),
             mob_flags: AtomicU8::new(0),
             last_sent_yaw: AtomicU8::new(0),
             last_sent_pitch: AtomicU8::new(0),
@@ -197,6 +199,14 @@ impl MobEntity {
 
     pub fn reset_love_ticks(&self) {
         self.love_ticks.store(0, Relaxed);
+    }
+
+    pub fn is_tamed(&self) -> bool {
+        self.owner.load().is_some()
+    }
+
+    pub fn set_owner(&self, owner: Uuid) {
+        self.owner.store(Some(owner));
     }
 
     pub fn is_breeding_ready(&self) -> bool {
@@ -529,7 +539,7 @@ pub trait Mob: EntityBase + Send + Sync {
     }
 
     fn get_owner_uuid(&self) -> Option<Uuid> {
-        None
+        self.get_mob_entity().owner.load()
     }
 
     fn is_sitting(&self) -> bool {

--- a/pumpkin/src/entity/passive/cat.rs
+++ b/pumpkin/src/entity/passive/cat.rs
@@ -5,11 +5,15 @@ use std::sync::{
 
 use pumpkin_data::entity::EntityType;
 use pumpkin_data::item::Item;
+use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::meta_data_type::MetaDataType;
+use pumpkin_data::particle::Particle;
 use pumpkin_data::tracked_data::TrackedData;
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::java::client::play::Metadata;
+use pumpkin_util::math::vector3::Vector3;
+use rand::RngExt;
 
 use crate::entity::{
     Entity, EntityBase, EntityBaseFuture, NBTStorage, NbtFuture,
@@ -19,6 +23,7 @@ use crate::entity::{
         tempt::TemptGoal, wander_around::WanderAroundGoal,
     },
     mob::{Mob, MobEntity},
+    player::Player,
 };
 
 const TEMPT_ITEMS: &[&Item] = &[&Item::COD, &Item::SALMON];
@@ -113,6 +118,34 @@ impl NBTStorage for CatEntity {
 impl Mob for CatEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
+    }
+
+    fn mob_interact<'a>(
+        &'a self,
+        player: &'a Arc<Player>,
+        item_stack: &'a mut ItemStack,
+    ) -> EntityBaseFuture<'a, bool> {
+        Box::pin(async move {
+            let is_food = TEMPT_ITEMS.iter().any(|i| i.id == item_stack.item.id);
+            if self.mob_entity.is_tamed() || !is_food {
+                return false;
+            }
+
+            item_stack.decrement_unless_creative(player.gamemode.load(), 1);
+
+            let entity = &self.mob_entity.living_entity.entity;
+            let world = entity.world.load();
+            let pos = entity.pos.load() + Vector3::new(0.0, f64::from(entity.height()), 0.0);
+
+            if self.get_random().random_range(0..3) == 0 {
+                self.mob_entity.set_owner(player.gameprofile.id);
+                world.spawn_particle(pos, Vector3::new(0.5, 0.5, 0.5), 1.0, 7, Particle::Heart);
+            } else {
+                world.spawn_particle(pos, Vector3::new(0.5, 0.5, 0.5), 1.0, 7, Particle::Smoke);
+            }
+
+            true
+        })
     }
 
     fn mob_set_variant_name(&self, name: &str) {

--- a/pumpkin/src/entity/passive/parrot.rs
+++ b/pumpkin/src/entity/passive/parrot.rs
@@ -1,14 +1,26 @@
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
+use std::sync::Weak;
 
+use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::item_stack::ItemStack;
+use pumpkin_data::particle::Particle;
+use pumpkin_data::potion::Effect;
+use pumpkin_data::{
+    effect::StatusEffect,
+    tag::{self, Taggable},
+};
+use pumpkin_util::math::vector3::Vector3;
+use rand::RngExt;
 
 use crate::entity::{
-    Entity, NBTStorage,
+    Entity, EntityBase, EntityBaseFuture, NBTStorage,
     ai::goal::{
         look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal, swim::SwimGoal,
         wander_around::WanderAroundGoal,
     },
     mob::{Mob, MobEntity},
+    player::Player,
 };
 
 /// Represents a Parrot, a passive flying mob that can mimic nearby mob sounds.
@@ -49,5 +61,60 @@ impl NBTStorage for ParrotEntity {}
 impl Mob for ParrotEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
+    }
+
+    fn mob_interact<'a>(
+        &'a self,
+        player: &'a Arc<Player>,
+        item_stack: &'a mut ItemStack,
+    ) -> EntityBaseFuture<'a, bool> {
+        Box::pin(async move {
+            let entity = &self.mob_entity.living_entity.entity;
+
+            if !self.mob_entity.is_tamed()
+                && item_stack.item.has_tag(&tag::Item::MINECRAFT_PARROT_FOOD)
+            {
+                item_stack.decrement_unless_creative(player.gamemode.load(), 1);
+
+                let world = entity.world.load();
+                let pos = entity.pos.load() + Vector3::new(0.0, f64::from(entity.height()), 0.0);
+
+                if self.get_random().random_range(0..10) == 0 {
+                    self.mob_entity.set_owner(player.gameprofile.id);
+                    world.spawn_particle(pos, Vector3::new(0.5, 0.5, 0.5), 1.0, 7, Particle::Heart);
+                } else {
+                    world.spawn_particle(pos, Vector3::new(0.5, 0.5, 0.5), 1.0, 7, Particle::Smoke);
+                }
+
+                return true;
+            }
+
+            if item_stack
+                .item
+                .has_tag(&tag::Item::MINECRAFT_PARROT_POISONOUS_FOOD)
+            {
+                item_stack.decrement_unless_creative(player.gamemode.load(), 1);
+
+                if let Some(living) = self.get_living_entity() {
+                    living
+                        .add_effect(Effect {
+                            effect_type: &StatusEffect::POISON,
+                            duration: 900,
+                            amplifier: 0,
+                            ambient: false,
+                            show_particles: true,
+                            show_icon: true,
+                            blend: false,
+                        })
+                        .await;
+                }
+                self.damage(player.as_ref(), f32::MAX, DamageType::PLAYER_ATTACK)
+                    .await;
+
+                return true;
+            }
+
+            false
+        })
     }
 }

--- a/pumpkin/src/entity/passive/wolf.rs
+++ b/pumpkin/src/entity/passive/wolf.rs
@@ -5,11 +5,15 @@ use std::sync::{
 
 use pumpkin_data::entity::EntityType;
 use pumpkin_data::item::Item;
+use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::meta_data_type::MetaDataType;
+use pumpkin_data::particle::Particle;
 use pumpkin_data::tracked_data::TrackedData;
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::java::client::play::Metadata;
+use pumpkin_util::math::vector3::Vector3;
+use rand::RngExt;
 
 use crate::entity::{
     Entity, EntityBase, EntityBaseFuture, NBTStorage, NbtFuture,
@@ -19,6 +23,7 @@ use crate::entity::{
         look_at_entity::LookAtEntityGoal, swim::SwimGoal, wander_around::WanderAroundGoal,
     },
     mob::{Mob, MobEntity},
+    player::Player,
 };
 
 pub struct WolfEntity {
@@ -109,6 +114,36 @@ impl Mob for WolfEntity {
         &self.mob_entity
     }
 
+    fn mob_interact<'a>(
+        &'a self,
+        player: &'a Arc<Player>,
+        item_stack: &'a mut ItemStack,
+    ) -> EntityBaseFuture<'a, bool> {
+        Box::pin(async move {
+            if self.mob_entity.is_tamed() || item_stack.item.id != Item::BONE.id {
+                return false;
+            }
+
+            item_stack.decrement_unless_creative(player.gamemode.load(), 1);
+
+            let entity = &self.mob_entity.living_entity.entity;
+            let world = entity.world.load();
+            let pos = entity.pos.load() + Vector3::new(0.0, f64::from(entity.height()), 0.0);
+
+            if self.get_random().random_range(0..3) == 0 {
+                self.mob_entity.set_owner(player.gameprofile.id);
+                self.mob_entity
+                    .living_entity
+                    .set_health(self.mob_entity.living_entity.get_max_health());
+                world.spawn_particle(pos, Vector3::new(0.5, 0.5, 0.5), 1.0, 7, Particle::Heart);
+            } else {
+                world.spawn_particle(pos, Vector3::new(0.5, 0.5, 0.5), 1.0, 7, Particle::Smoke);
+            }
+
+            true
+        })
+    }
+
     fn mob_set_variant_name(&self, name: &str) {
         let variant = match name.strip_prefix("minecraft:").unwrap_or(name) {
             "ashen" => 0,
@@ -140,7 +175,7 @@ impl Mob for WolfEntity {
             }
             entity.send_meta_data(
                 &[Metadata::new(
-                    TrackedData::WOLF_VARIANT_ID,
+                    TrackedData::VARIANT,
                     MetaDataType::WOLF_VARIANT,
                     VarInt(self.variant.load(Ordering::Relaxed) as i32),
                 )],

--- a/pumpkin/src/entity/passive/wolf.rs
+++ b/pumpkin/src/entity/passive/wolf.rs
@@ -175,7 +175,7 @@ impl Mob for WolfEntity {
             }
             entity.send_meta_data(
                 &[Metadata::new(
-                    TrackedData::VARIANT,
+                    TrackedData::WOLF_VARIANT_ID,
                     MetaDataType::WOLF_VARIANT,
                     VarInt(self.variant.load(Ordering::Relaxed) as i32),
                 )],


### PR DESCRIPTION
Fixes #2535 (taming does nothing) and #2534 (parrots can not eat cookies).

Wolf, cat, and parrot never overrode Mob::mob_interact, so right-clicking them with their tame food (bones, cod/salmon, seeds) fell through to the default stub and did nothing: no ownership, no particles, no consumption. Every other tameable/breedable passive mob (pig, cow, sheep, ...) already implements this override; wolf/cat/parrot were the only ones missing it.

Add an owner: AtomicCell<Option<Uuid>> field to MobEntity alongside the existing love/breeding fields, with is_tamed/set_owner helpers, and make the Mob trait's get_owner_uuid default read it instead of always returning None. Each of the three species now consumes its food and rolls vanilla's tame chance (TamableAnimal/Wolf/Cat.tryToTame: 1-in-3; Parrot.mobInteract: 1-in-10), setting the owner and spawning vanilla's 7-particle heart burst on success or smoke on failure. Parrots additionally special-case ItemTags.PARROT_POISONOUS_FOOD (cookie): apply Poison for 900 ticks and deal lethal player-attack damage, matching Parrot.mobInteract exactly.

Deliberately out of scope for this change, to keep it minimal: sitting AI, follow-owner goal, wolf collar dye/body armor, and cat gift-item trust mechanics. Owner is not yet NBT-persisted, matching the existing precedent for MobEntity::breeder, which is also runtime-only.

Test plan:
- cargo test -p pumpkin --lib: 167 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets: clean
- cargo fmt --all -- --check: clean