### PR TITLE
fix: let primed TNT take explosion knockback

### DIFF
--- a/pumpkin/src/entity/tnt.rs
+++ b/pumpkin/src/entity/tnt.rs
@@ -122,8 +122,4 @@ impl EntityBase for TNTEntity {
     fn cast_any(&self) -> &dyn std::any::Any {
         self
     }
-
-    fn is_immune_to_explosion(&self) -> bool {
-        true
-    }
 }


### PR DESCRIPTION
TNTEntity overrode is_immune_to_explosion to return true, so the explosion entity loop skipped primed TNT entirely, giving them neither damage nor knockback. In vanilla, PrimedTnt does not override Entity.ignoreExplosion (base returns false), so an explosion pushes primed TNT like any other entity. ServerExplosion.hurtEntities even selects the knockback origin with 'entity instanceof PrimedTnt ? position() : getEyePosition()', which Pumpkin already mirrors in Explosion::damage_entities but could never reach because the immunity check short-circuited first.

Fix: remove the override so primed TNT inherits the default false, restoring explosion-driven TNT momentum (cannons, flying machines, chain detonations).

Test plan:
- cargo test -p pumpkin --lib: 167 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets: clean
- cargo fmt --all -- --check: clean