### PR TITLE
fix: sync item motion at vanilla's velocity-delta threshold

### DIFF
--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -378,7 +378,7 @@ impl ItemEntity {
         let velocity_dirty = entity.velocity_dirty.swap(false, Ordering::SeqCst)
             || entity.touching_water.load(Ordering::SeqCst)
             || entity.touching_lava.load(Ordering::SeqCst)
-            || entity.velocity.load().sub(&original_velo).length_squared() > 0.1;
+            || entity.velocity.load().sub(&original_velo).length_squared() > 0.01;
 
         if velocity_dirty {
             entity.send_pos_rot();


### PR DESCRIPTION
sync_motion_if_dirty compared this-tick velocity against the pre-gravity value with a squared-length threshold of 0.1, ten times looser than vanilla ItemEntity.tick's 0.01 (needsSync = delta.lengthSqr() > 0.01). Thrown and flowing items suppressed position/velocity packets vanilla would send, producing visible client-side stutter.

Test plan:
- cargo test -p pumpkin --lib: 167 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets: clean
- cargo fmt --all -- --check: clean