### PR TITLE
fix: correct lava slope-find distance

### DIFF
--- a/pumpkin/src/block/fluid/lava.rs
+++ b/pumpkin/src/block/fluid/lava.rs
@@ -294,9 +294,9 @@ impl FlowingFluid for FlowingLava {
     fn get_max_flow_distance(&self, world: &World) -> i32 {
         // Ultrawarm logic
         if world.dimension == Dimension::THE_NETHER {
-            5
+            4
         } else {
-            3
+            2
         }
     }
 


### PR DESCRIPTION
get_max_flow_distance feeds the fluid pathfinder's slope_find_distance, the search radius used to pick a downhill flow direction. It returned 5 (Nether) and 3 (overworld), one more than vanilla LavaFluid.getSlopeFindDistance's 4 and 2. Water's equivalent constant (4) already matches vanilla, confirming only lava's was off by one in both branches.

Test plan:
- cargo test -p pumpkin --lib: 167 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets: clean
- cargo fmt --all -- --check: clean