### PR TITLE
fix: let baby sheep try to eat grass more often

### DIFF
--- a/pumpkin/src/entity/ai/goal/eat_grass.rs
+++ b/pumpkin/src/entity/ai/goal/eat_grass.rs
@@ -31,11 +31,16 @@ impl EatGrassGoal {
 impl Goal for EatGrassGoal {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async move {
-            if mob.get_random().random_range(0..1000) != 0 {
+            let entity = &mob.get_mob_entity().living_entity.entity;
+            let bound = if entity.age.load(std::sync::atomic::Ordering::Relaxed) < 0 {
+                50
+            } else {
+                1000
+            };
+            if mob.get_random().random_range(0..bound) != 0 {
                 return false;
             }
 
-            let entity = &mob.get_mob_entity().living_entity.entity;
             let block_pos = entity.block_pos.load();
             let world = entity.world.load();
 


### PR DESCRIPTION
EatGrassGoal used a fixed 1/1000 chance per tick regardless of age. Vanilla EatBlockGoal.canUse rolls 1/50 for baby mobs and 1/1000 for adults, so lambs graze roughly twenty times as often as adult sheep.

Test plan:
- cargo test -p pumpkin --lib: 167 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets: clean
- cargo fmt --all -- --check: clean