### PR TITLE
fix: deal starvation damage on Peaceful when health is high

### DIFF
--- a/pumpkin/src/entity/hunger.rs
+++ b/pumpkin/src/entity/hunger.rs
@@ -79,8 +79,7 @@ impl HungerManager {
             if timer >= 80 {
                 timer = 0;
                 let should_starve = match difficulty {
-                    Difficulty::Peaceful => false,
-                    Difficulty::Easy => health > 10.0,
+                    Difficulty::Peaceful | Difficulty::Easy => health > 10.0,
                     Difficulty::Normal => health > 1.0,
                     Difficulty::Hard => true,
                 };


### PR DESCRIPTION
HungerManager::tick hardcoded should_starve to false on Peaceful. Vanilla FoodData's starvation check is a single boolean expression, health > 10.0F || difficulty == HARD || (health > 1.0F && difficulty == NORMAL), which for Peaceful reduces to health > 10.0F, not an unconditional false. Exhaustion cannot normally drop hunger to zero on Peaceful, but a food level forced to zero by NBT or command should still starve down to 10 health as vanilla does.

Test plan:
- cargo test -p pumpkin --lib: 167 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets: clean
- cargo fmt --all -- --check: clean