### PR TITLE
fix: correct enchanting table middle-slot level offset

### DIFF
--- a/pumpkin-inventory/src/enchanting/enchanting_screen_handler.rs
+++ b/pumpkin-inventory/src/enchanting/enchanting_screen_handler.rs
@@ -162,7 +162,7 @@ impl EnchantingTableScreenHandler {
 
         match slot {
             0 => (level / 3).max(1),
-            1 => (level * 2 / 3 + 7).max(1),
+            1 => (level * 2 / 3 + 1).max(1),
             2 => level.max(b * 2).max(1),
             _ => 0,
         }


### PR DESCRIPTION
calculate_level_requirement added 7 to the middle slot's level * 2 / 3 term. Vanilla EnchantmentHelper.getEnchantmentCost uses selected * 2 / 3 + 1 for slot 1; the other two slots already matched vanilla exactly. The extra +6 made the middle slot's level requirement six levels harder to reach than vanilla at every bookshelf count.

Test plan:
- cargo test -p pumpkin-inventory --lib: passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin-inventory --all-targets: clean
- cargo fmt --all -- --check: clean