### PR TITLE
feat: let experience orbs follow nearby players

### DIFF
--- a/pumpkin/src/entity/experience_orb.rs
+++ b/pumpkin/src/entity/experience_orb.rs
@@ -82,6 +82,21 @@ impl EntityBase for ExperienceOrbEntity {
 
             let mut velo = original_velo;
 
+            let world = entity.world.load();
+            if let Some(player) = world.get_closest_player(entity.pos.load(), 8.0)
+                && !player.is_spectator()
+            {
+                let player_entity = player.get_entity();
+                let target = player_entity.pos.load()
+                    + Vector3::new(0.0, player_entity.get_eye_height() / 2.0, 0.0);
+                let delta = target - entity.pos.load();
+                let distance = delta.length();
+                if distance > 1.0e-4 {
+                    let power = (1.0 - distance / 8.0).max(0.0);
+                    velo += delta.normalize() * (power * power * 0.1);
+                }
+            }
+
             let no_clip = !self
                 .entity
                 .world


### PR DESCRIPTION
ExperienceOrbEntity::tick had no equivalent of vanilla's followNearbyPlayer: orbs only moved under gravity and could only be collected by literal bounding-box contact.

Port the vanilla algorithm each tick: find the closest non-spectator player within 8 blocks (ExperienceOrb.java's search radius), aim at their eye height halved above their feet as vanilla's getY() + eyeHeight / 2.0 does, and add an ease-in velocity of normalize(delta) * (1 - dist / 8)^2 * 0.1 toward them.

This uses a fresh closest-player lookup each tick rather than vanilla's cached followingPlayer field (re-searched only when the cached player goes out of range or becomes a spectator); the two are behaviorally equivalent since the lookup already selects the nearest candidate.

Test plan:
- cargo test -p pumpkin --lib: 167 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets: clean
- cargo fmt --all -- --check: clean