### PR TITLE
fix: wrap time-of-day before the sleep night-window check

### DIFF
--- a/pumpkin/src/block/blocks/bed.rs
+++ b/pumpkin/src/block/blocks/bed.rs
@@ -419,13 +419,14 @@ impl BedBlock {
 async fn can_sleep(world: &Arc<World>) -> bool {
     let time = world.level_time.lock().await;
     let weather = world.weather.lock().await;
+    let day_time = time.time_of_day.rem_euclid(24_000);
 
     if weather.thundering {
         true
     } else if weather.raining {
-        time.time_of_day > 12010 && time.time_of_day < 23991
+        day_time > 12010 && day_time < 23991
     } else {
-        time.time_of_day > 12542 && time.time_of_day < 23459
+        day_time > 12542 && day_time < 23459
     }
 }
 


### PR DESCRIPTION
can_sleep compared the raw cumulative level_time.time_of_day against the night-window constants (12542..23459) without reducing it modulo 24000 first. time_of_day increments unconditionally every tick with no wraparound, so outside of thunderstorms sleeping only ever worked during day 0 and became permanently impossible from day 1 onward on every server.

Every other consumer of the same night-window constants in this codebase (mob/mod.rs, world/mod.rs) already reduces time_of_day mod 24000 first; can_sleep was the one place that did not.

This is high severity: on a real server running past day 1, players can never sleep at all outside of a thunderstorm.

Test plan:
- cargo test -p pumpkin --lib: 167 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets: clean
- cargo fmt --all -- --check: clean