### PR TITLE
fix: correct ridden-minecart on-rail friction

### DIFF
--- a/pumpkin/src/entity/vehicle/minecart.rs
+++ b/pumpkin/src/entity/vehicle/minecart.rs
@@ -356,7 +356,7 @@ impl EntityBase for MinecartEntity {
                     let passengers = self.vehicle.entity.passengers.lock().await;
                     let has_passengers = !passengers.is_empty();
                     drop(passengers);
-                    friction = if has_passengers { 0.99 } else { 0.96 };
+                    friction = if has_passengers { 0.997 } else { 0.96 };
                 } else {
                     let below_block_pos = BlockPos(Vector3::new(
                         block_pos.0.x,


### PR DESCRIPTION
The ridden on-rail slowdown factor was 0.99 instead of vanilla's 0.997 (OldMinecartBehavior.getSlowdownFactor, used since MINECART_IMPROVEMENTS is off by default in 26.2). The unridden branch (0.96) already matched vanilla exactly, isolating this to the ridden case: a ridden minecart lost velocity roughly 3x faster per tick than vanilla, capping travel distance well short.

Test plan:
- cargo test -p pumpkin --lib: 167 passed
- RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets: clean
- cargo fmt --all -- --check: clean