### PR TITLE
fix(bedrock): preserve HAS_GRAVITY when a player uses an item

### DIFF
--- a/pumpkin-protocol/src/bedrock/client/set_actor_data.rs
+++ b/pumpkin-protocol/src/bedrock/client/set_actor_data.rs
@@ -431,3 +431,40 @@ pub mod entity_data_flag {
     pub const ROTATION_LOCKED_TO_VEHICLE: u32 = 126;
     pub const COUNT: u32 = 127;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{EntityMetadata, MetadataValue, entity_data_flag, entity_data_key};
+
+    /// Toggling one flag on top of a seeded `FLAGS` field must keep the other bits.
+    ///
+    /// This guards the Bedrock anti-gravity bug: `FLAGS` is a full bitfield sent
+    /// whole to the client, so a partial update that dropped `HAS_GRAVITY` left
+    /// the player floating. Seeding the field first and then toggling
+    /// `USING_ITEM` must preserve `HAS_GRAVITY`.
+    #[test]
+    fn setting_a_flag_preserves_seeded_bits() {
+        let base = 1i64 << entity_data_flag::HAS_GRAVITY;
+        let mut meta = EntityMetadata::new();
+        meta.set(entity_data_key::FLAGS, MetadataValue::Long(base));
+        meta.set_flag(
+            entity_data_key::FLAGS,
+            entity_data_flag::USING_ITEM as u8,
+            true,
+        );
+
+        let Some(MetadataValue::Long(flags)) = meta.0.get(&entity_data_key::FLAGS) else {
+            panic!("FLAGS field missing after set_flag");
+        };
+        assert_ne!(
+            flags & (1i64 << entity_data_flag::HAS_GRAVITY),
+            0,
+            "HAS_GRAVITY was cleared by a partial flag update"
+        );
+        assert_ne!(
+            flags & (1i64 << entity_data_flag::USING_ITEM),
+            0,
+            "USING_ITEM was not set"
+        );
+    }
+}

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -247,11 +247,25 @@ impl LivingEntity {
         self.livings_flags.store(b, Ordering::Relaxed);
 
         let bedrock_meta = (flag == Self::USING_ITEM_FLAG).then(|| {
-            let mut meta = pumpkin_protocol::bedrock::client::set_actor_data::EntityMetadata::new();
+            use pumpkin_protocol::bedrock::client::set_actor_data::{
+                EntityMetadata, MetadataValue, entity_data_flag, entity_data_key,
+            };
+            let mut meta = EntityMetadata::new();
+            // The Bedrock FLAGS field is a full bitfield: a SetActorData that
+            // carries it replaces the client's entire flag set. Building this
+            // from an empty metadata sent FLAGS with only USING_ITEM, which
+            // cleared HAS_GRAVITY (and HAS_COLLISION, CLIMB, BREATHING) that were
+            // set on spawn, so the moment a player used an item the client
+            // stopped applying gravity and floated. Seed the field with the
+            // entity's accumulated flags before toggling USING_ITEM so gravity
+            // is preserved.
+            meta.set(
+                entity_data_key::FLAGS,
+                MetadataValue::Long(self.entity.bedrock_flags.load(Ordering::Relaxed)),
+            );
             meta.set_flag(
-                pumpkin_protocol::bedrock::client::set_actor_data::entity_data_key::FLAGS,
-                pumpkin_protocol::bedrock::client::set_actor_data::entity_data_flag::USING_ITEM
-                    as u8,
+                entity_data_key::FLAGS,
+                entity_data_flag::USING_ITEM as u8,
                 value,
             );
             meta


### PR DESCRIPTION
Bedrock applies gravity through a per-entity actor flag (HAS_GRAVITY, index 49), not server-side like Java. It is set on spawn, but set_living_flag built its Bedrock SetActorData from an empty EntityMetadata carrying only USING_ITEM. Because the FLAGS field is a full bitfield that replaces the clients whole flag set, using an item wiped HAS_GRAVITY and the client stopped applying gravity, so the player floated (the "anti-grav" bug). The partial update now seeds FLAGS with the entitys accumulated bedrock_flags before toggling USING_ITEM, with a unit test that a seeded flag survives a single-flag update.

Related: #2104 (Bedrock player floating). This addresses the gravity-flag clobber specifically; the swim-state part of that report may be separate.