### PR TITLE
fix(redstone): prevent panic when querying vertical redstone power

### DIFF
--- a/pumpkin/src/block/blocks/redstone/redstone_wire.rs
+++ b/pumpkin/src/block/blocks/redstone/redstone_wire.rs
@@ -199,7 +199,7 @@ impl BlockBehaviour for RedstoneWireBlock {
     ) -> BlockFuture<'a, u8> {
         Box::pin(async move {
             let wire = RedstoneWireProperties::from_state_id(args.state.id, args.block);
-            
+
             if args.direction == BlockDirection::Up {
                 return wire.power;
             }
@@ -213,7 +213,6 @@ impl BlockBehaviour for RedstoneWireBlock {
             0
         })
     }
-    
 
     fn get_strong_redstone_power<'a>(
         &'a self,

--- a/pumpkin/src/block/blocks/redstone/redstone_wire.rs
+++ b/pumpkin/src/block/blocks/redstone/redstone_wire.rs
@@ -199,21 +199,20 @@ impl BlockBehaviour for RedstoneWireBlock {
     ) -> BlockFuture<'a, u8> {
         Box::pin(async move {
             let wire = RedstoneWireProperties::from_state_id(args.state.id, args.block);
-
+            
             if args.direction == BlockDirection::Up {
                 return wire.power;
             }
 
-            if let Some(facing) = args.direction.opposite().to_horizontal_facing() {
-                if wire.is_side_connected(facing) {
-                    return wire.power;
-                }
-            }
+             if let Some(facing) = args.direction.opposite().to_horizontal_facing()
+                 && wire.is_side_connected(facing) {
+                     return wire.power;
+                 }
 
             0
         })
     }
-
+    
     fn get_strong_redstone_power<'a>(
         &'a self,
         args: GetRedstonePowerArgs<'a>,

--- a/pumpkin/src/block/blocks/redstone/redstone_wire.rs
+++ b/pumpkin/src/block/blocks/redstone/redstone_wire.rs
@@ -199,15 +199,21 @@ impl BlockBehaviour for RedstoneWireBlock {
     ) -> BlockFuture<'a, u8> {
         Box::pin(async move {
             let wire = RedstoneWireProperties::from_state_id(args.state.id, args.block);
-            if args.direction == BlockDirection::Up
-                || wire.is_side_connected(args.direction.opposite().to_horizontal_facing().unwrap())
-            {
-                wire.power
-            } else {
-                0
+            
+            if args.direction == BlockDirection::Up {
+                return wire.power;
             }
+
+            if let Some(facing) = args.direction.opposite().to_horizontal_facing() {
+                if wire.is_side_connected(facing) {
+                    return wire.power;
+                }
+            }
+
+            0
         })
     }
+    
 
     fn get_strong_redstone_power<'a>(
         &'a self,

--- a/pumpkin/src/block/blocks/redstone/redstone_wire.rs
+++ b/pumpkin/src/block/blocks/redstone/redstone_wire.rs
@@ -199,20 +199,21 @@ impl BlockBehaviour for RedstoneWireBlock {
     ) -> BlockFuture<'a, u8> {
         Box::pin(async move {
             let wire = RedstoneWireProperties::from_state_id(args.state.id, args.block);
-            
+
             if args.direction == BlockDirection::Up {
                 return wire.power;
             }
 
-             if let Some(facing) = args.direction.opposite().to_horizontal_facing()
-                 && wire.is_side_connected(facing) {
-                     return wire.power;
-                 }
+            if let Some(facing) = args.direction.opposite().to_horizontal_facing()
+                && wire.is_side_connected(facing)
+            {
+                return wire.power;
+            }
 
             0
         })
     }
-    
+
     fn get_strong_redstone_power<'a>(
         &'a self,
         args: GetRedstonePowerArgs<'a>,


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

Fixes #2734

When querying power from a block above the wire, `args.direction` is `BlockDirection::Down`. Calling `.opposite()` results in `BlockDirection::Up`. Because `Up` is vertical, `to_horizontal_facing()` returns `None`. Calling `.unwrap()` on this `None` value caused a panic.

## Description

This PR fixes a crash that would occur if a redstone component was placed above redstone dust. 

The PR specifically changes the `get_weak_redstone_power` function in `redstone_wire.rs`.  I removed the '.unwrap()' in place of a Some() to fix the error. 

## Testing

```bash
cargo fmt --check
cargo test
RUSTFLAGS='-D warnings' cargo clippy -p pumpkin --all-targets
git diff --check
```

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
