### PR TITLE
fix(item): bundle interactions and content handling

### DIFF
--- a/pumpkin-codegen/src/item.rs
+++ b/pumpkin-codegen/src/item.rs
@@ -736,7 +736,7 @@ impl ToTokens for ItemComponents {
             tokens.extend(quote! { (BucketEntityData, &BucketEntityDataImpl), });
         }
         if self.bundle_contents.is_some() {
-            tokens.extend(quote! { (BundleContents, &BundleContentsImpl { items: Vec::new() }), });
+            tokens.extend(quote! { (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }), });
         }
         if self.charged_projectiles.is_some() {
             tokens.extend(quote! { (ChargedProjectiles, &ChargedProjectilesImpl { projectiles: Vec::new() }), });

--- a/pumpkin-data/src/data_component_impl/utility.rs
+++ b/pumpkin-data/src/data_component_impl/utility.rs
@@ -211,6 +211,16 @@ impl BundleContentsImpl {
     }
 }
 impl DataComponentImpl for BundleContentsImpl {
+    fn write_data(&self) -> NbtTag {
+        let mut items = Vec::new();
+        for item in &self.items {
+            let mut compound = NbtCompound::new();
+            item.write_item_stack(&mut compound);
+            items.push(NbtTag::Compound(compound));
+        }
+        NbtTag::List(items)
+    }
+
     default_impl!(BundleContents);
 }
 

--- a/pumpkin-data/src/data_component_impl/utility.rs
+++ b/pumpkin-data/src/data_component_impl/utility.rs
@@ -145,22 +145,30 @@ impl BundleContentsImpl {
             return false;
         }
         let weight_per_item = (64 / stack.get_max_stack_size() as u32).max(1);
-        let mut inserted_anything = false;
-        while stack.item_count > 0 && self.get_weight() + weight_per_item <= 64 {
-            if let Some(top) = self.items.first_mut()
-                && crate::item_stack::ItemStack::are_items_and_components_equal(top, stack)
-                && top.item_count < top.get_max_stack_size()
-            {
-                top.item_count += 1;
-                stack.item_count -= 1;
-                inserted_anything = true;
-                continue;
-            }
-            self.items.insert(0, stack.copy_with_count(1));
-            stack.item_count -= 1;
-            inserted_anything = true;
+        let available = 64u32.saturating_sub(self.get_weight()) / weight_per_item;
+        let amount_to_add = stack.item_count.min(available as u8);
+        if amount_to_add == 0 {
+            return false;
         }
-        inserted_anything
+
+        let matching_index = if stack.is_stackable() {
+            self.items
+                .iter()
+                .position(|item| item.are_items_and_components_equal(stack))
+        } else {
+            None
+        };
+
+        if let Some(index) = matching_index {
+            let mut merged_stack = self.items.remove(index);
+            merged_stack.increment(amount_to_add);
+            stack.decrement(amount_to_add);
+            self.items.insert(0, merged_stack);
+        } else {
+            self.items.insert(0, stack.split(amount_to_add));
+        }
+
+        true
     }
     pub fn toggle_selected_item(&mut self, selected_item_index: i32) {
         self.selected_item_index = if self.selected_item_index != selected_item_index
@@ -246,6 +254,26 @@ mod bundle_tests {
         };
 
         assert_eq!(contents, selected_contents);
+    }
+
+    #[test]
+    fn insertion_merges_matching_stack_and_moves_it_to_front() {
+        let mut contents = BundleContentsImpl {
+            items: vec![
+                ItemStack::new(2, &Item::DIAMOND),
+                ItemStack::new(3, &Item::APPLE),
+            ],
+            selected_item_index: -1,
+        };
+        let mut apples = ItemStack::new(4, &Item::APPLE);
+
+        assert!(contents.try_insert(&mut apples));
+
+        assert!(apples.is_empty());
+        assert_eq!(contents.items.len(), 2);
+        assert_eq!(contents.items[0].item.id, Item::APPLE.id);
+        assert_eq!(contents.items[0].item_count, 7);
+        assert_eq!(contents.items[1].item.id, Item::DIAMOND.id);
     }
 }
 

--- a/pumpkin-data/src/data_component_impl/utility.rs
+++ b/pumpkin-data/src/data_component_impl/utility.rs
@@ -228,6 +228,7 @@ impl DataComponentImpl for BundleContentsImpl {
 mod bundle_tests {
     use super::{BUNDLE_IN_BUNDLE_WEIGHT, BundleContentsImpl};
     use crate::{item::Item, item_stack::ItemStack};
+    use pumpkin_nbt::compound::NbtCompound;
 
     #[test]
     fn extracts_selected_item_and_clears_selection() {
@@ -301,6 +302,27 @@ mod bundle_tests {
 
         assert!(bundle.is_empty());
         assert_eq!(contents.get_weight(), 8 + BUNDLE_IN_BUNDLE_WEIGHT);
+    }
+
+    #[test]
+    fn bundle_contents_survive_item_stack_nbt_roundtrip() {
+        let mut bundle = ItemStack::new(1, &Item::BUNDLE);
+        bundle
+            .get_data_component_mut::<BundleContentsImpl>()
+            .expect("bundle should have contents")
+            .items
+            .push(ItemStack::new(3, &Item::APPLE));
+
+        let mut nbt = NbtCompound::new();
+        bundle.write_item_stack(&mut nbt);
+        let restored = ItemStack::read_item_stack(&nbt).expect("bundle should deserialize");
+        let contents = restored
+            .get_data_component::<BundleContentsImpl>()
+            .expect("restored bundle should have contents");
+
+        assert_eq!(contents.items.len(), 1);
+        assert_eq!(contents.items[0].item.id, Item::APPLE.id);
+        assert_eq!(contents.items[0].item_count, 3);
     }
 }
 

--- a/pumpkin-data/src/data_component_impl/utility.rs
+++ b/pumpkin-data/src/data_component_impl/utility.rs
@@ -96,6 +96,8 @@ impl DataComponentImpl for ChargedProjectilesImpl {
     default_impl!(ChargedProjectiles);
 }
 
+const BUNDLE_IN_BUNDLE_WEIGHT: u32 = 4;
+
 #[derive(Clone)]
 pub struct BundleContentsImpl {
     pub items: Vec<crate::item_stack::ItemStack>,
@@ -118,6 +120,15 @@ impl std::fmt::Debug for BundleContentsImpl {
     }
 }
 impl BundleContentsImpl {
+    fn get_item_weight(stack: &crate::item_stack::ItemStack) -> u32 {
+        stack
+            .get_data_component::<BundleContentsImpl>()
+            .map_or_else(
+                || (64 / stack.get_max_stack_size() as u32).max(1),
+                |contents| contents.get_weight() + BUNDLE_IN_BUNDLE_WEIGHT,
+            )
+    }
+
     pub fn read_data(tag: &NbtTag) -> Option<Self> {
         let mut items = Vec::new();
         if let NbtTag::List(l) = tag {
@@ -137,14 +148,14 @@ impl BundleContentsImpl {
     pub fn get_weight(&self) -> u32 {
         self.items
             .iter()
-            .map(|item| item.item_count as u32 * (64 / item.get_max_stack_size() as u32).max(1))
+            .map(|item| item.item_count as u32 * Self::get_item_weight(item))
             .sum()
     }
     pub fn try_insert(&mut self, stack: &mut crate::item_stack::ItemStack) -> bool {
-        if stack.is_empty() || stack.get_data_component::<BundleContentsImpl>().is_some() {
+        if stack.is_empty() {
             return false;
         }
-        let weight_per_item = (64 / stack.get_max_stack_size() as u32).max(1);
+        let weight_per_item = Self::get_item_weight(stack);
         let available = 64u32.saturating_sub(self.get_weight()) / weight_per_item;
         let amount_to_add = stack.item_count.min(available as u8);
         if amount_to_add == 0 {
@@ -203,7 +214,7 @@ impl DataComponentImpl for BundleContentsImpl {
 
 #[cfg(test)]
 mod bundle_tests {
-    use super::BundleContentsImpl;
+    use super::{BUNDLE_IN_BUNDLE_WEIGHT, BundleContentsImpl};
     use crate::{item::Item, item_stack::ItemStack};
 
     #[test]
@@ -274,6 +285,38 @@ mod bundle_tests {
         assert_eq!(contents.items[0].item.id, Item::APPLE.id);
         assert_eq!(contents.items[0].item_count, 7);
         assert_eq!(contents.items[1].item.id, Item::DIAMOND.id);
+    }
+
+    #[test]
+    fn inserts_empty_bundle_with_nesting_overhead() {
+        let mut contents = BundleContentsImpl {
+            items: Vec::new(),
+            selected_item_index: -1,
+        };
+        let mut bundle = ItemStack::new(1, &Item::BUNDLE);
+
+        assert!(contents.try_insert(&mut bundle));
+
+        assert!(bundle.is_empty());
+        assert_eq!(contents.get_weight(), BUNDLE_IN_BUNDLE_WEIGHT);
+    }
+
+    #[test]
+    fn nested_bundle_contents_contribute_to_weight() {
+        let mut contents = BundleContentsImpl {
+            items: Vec::new(),
+            selected_item_index: -1,
+        };
+        let mut bundle = ItemStack::new(1, &Item::BUNDLE);
+        bundle
+            .get_data_component_mut::<BundleContentsImpl>()
+            .expect("bundle should have contents")
+            .items
+            .push(ItemStack::new(8, &Item::APPLE));
+
+        assert!(contents.try_insert(&mut bundle));
+
+        assert_eq!(contents.get_weight(), 8 + BUNDLE_IN_BUNDLE_WEIGHT);
     }
 }
 

--- a/pumpkin-data/src/data_component_impl/utility.rs
+++ b/pumpkin-data/src/data_component_impl/utility.rs
@@ -1,6 +1,8 @@
 use crate::data_component_impl::{
     DataComponentImpl, default_impl, get_f32_hash, get_i32_hash, get_str_hash,
 };
+use crate::tag;
+use crate::tag::Taggable;
 use crc_fast::CrcAlgorithm::Crc32Iscsi;
 use crc_fast::Digest;
 use pumpkin_nbt::compound::NbtCompound;
@@ -152,7 +154,7 @@ impl BundleContentsImpl {
             .sum()
     }
     pub fn try_insert(&mut self, stack: &mut crate::item_stack::ItemStack) -> bool {
-        if stack.is_empty() {
+        if stack.is_empty() || stack.item.has_tag(&tag::Item::MINECRAFT_SHULKER_BOXES) {
             return false;
         }
         let weight_per_item = Self::get_item_weight(stack);

--- a/pumpkin-data/src/data_component_impl/utility.rs
+++ b/pumpkin-data/src/data_component_impl/utility.rs
@@ -99,10 +99,16 @@ impl DataComponentImpl for ChargedProjectilesImpl {
 #[derive(Clone)]
 pub struct BundleContentsImpl {
     pub items: Vec<crate::item_stack::ItemStack>,
+    pub selected_item_index: i32,
 }
 impl PartialEq for BundleContentsImpl {
-    fn eq(&self, _other: &Self) -> bool {
-        false
+    fn eq(&self, other: &Self) -> bool {
+        self.items.len() == other.items.len()
+            && self
+                .items
+                .iter()
+                .zip(&other.items)
+                .all(|(item, other)| item.are_equal(other))
     }
 }
 impl Eq for BundleContentsImpl {}
@@ -123,7 +129,10 @@ impl BundleContentsImpl {
                 }
             }
         }
-        Some(Self { items })
+        Some(Self {
+            items,
+            selected_item_index: -1,
+        })
     }
     pub fn get_weight(&self) -> u32 {
         self.items
@@ -153,16 +162,91 @@ impl BundleContentsImpl {
         }
         inserted_anything
     }
+    pub fn toggle_selected_item(&mut self, selected_item_index: i32) {
+        self.selected_item_index = if self.selected_item_index != selected_item_index
+            && selected_item_index >= 0
+            && (selected_item_index as usize) < self.items.len()
+        {
+            selected_item_index
+        } else {
+            -1
+        };
+    }
     pub fn try_extract(&mut self) -> Option<crate::item_stack::ItemStack> {
         if self.items.is_empty() {
             None
         } else {
-            Some(self.items.remove(0))
+            let remove_index = if self.selected_item_index >= 0
+                && (self.selected_item_index as usize) < self.items.len()
+            {
+                self.selected_item_index as usize
+            } else {
+                0
+            };
+            let extracted = self.items.remove(remove_index);
+            self.toggle_selected_item(-1);
+            Some(extracted)
         }
     }
 }
 impl DataComponentImpl for BundleContentsImpl {
     default_impl!(BundleContents);
+}
+
+#[cfg(test)]
+mod bundle_tests {
+    use super::BundleContentsImpl;
+    use crate::{item::Item, item_stack::ItemStack};
+
+    #[test]
+    fn extracts_selected_item_and_clears_selection() {
+        let mut contents = BundleContentsImpl {
+            items: vec![
+                ItemStack::new(1, &Item::STONE),
+                ItemStack::new(1, &Item::APPLE),
+            ],
+            selected_item_index: -1,
+        };
+
+        contents.toggle_selected_item(1);
+        let extracted = contents.try_extract().expect("bundle should not be empty");
+
+        assert_eq!(extracted.item.id, Item::APPLE.id);
+        assert_eq!(contents.items[0].item.id, Item::STONE.id);
+        assert_eq!(contents.selected_item_index, -1);
+    }
+
+    #[test]
+    fn invalid_or_repeated_selection_clears_selection() {
+        let mut contents = BundleContentsImpl {
+            items: vec![ItemStack::new(1, &Item::STONE)],
+            selected_item_index: -1,
+        };
+
+        contents.toggle_selected_item(0);
+        assert_eq!(contents.selected_item_index, 0);
+
+        contents.toggle_selected_item(0);
+        assert_eq!(contents.selected_item_index, -1);
+
+        contents.toggle_selected_item(1);
+        assert_eq!(contents.selected_item_index, -1);
+    }
+
+    #[test]
+    fn equality_ignores_selected_item() {
+        let items = vec![ItemStack::new(1, &Item::STONE)];
+        let contents = BundleContentsImpl {
+            items: items.clone(),
+            selected_item_index: -1,
+        };
+        let selected_contents = BundleContentsImpl {
+            items,
+            selected_item_index: 0,
+        };
+
+        assert_eq!(contents, selected_contents);
+    }
 }
 
 /// The dimension and block position a lodestone compass points to.

--- a/pumpkin-data/src/data_component_impl/utility.rs
+++ b/pumpkin-data/src/data_component_impl/utility.rs
@@ -253,21 +253,6 @@ mod bundle_tests {
     }
 
     #[test]
-    fn equality_ignores_selected_item() {
-        let items = vec![ItemStack::new(1, &Item::STONE)];
-        let contents = BundleContentsImpl {
-            items: items.clone(),
-            selected_item_index: -1,
-        };
-        let selected_contents = BundleContentsImpl {
-            items,
-            selected_item_index: 0,
-        };
-
-        assert_eq!(contents, selected_contents);
-    }
-
-    #[test]
     fn insertion_merges_matching_stack_and_moves_it_to_front() {
         let mut contents = BundleContentsImpl {
             items: vec![
@@ -288,21 +273,7 @@ mod bundle_tests {
     }
 
     #[test]
-    fn inserts_empty_bundle_with_nesting_overhead() {
-        let mut contents = BundleContentsImpl {
-            items: Vec::new(),
-            selected_item_index: -1,
-        };
-        let mut bundle = ItemStack::new(1, &Item::BUNDLE);
-
-        assert!(contents.try_insert(&mut bundle));
-
-        assert!(bundle.is_empty());
-        assert_eq!(contents.get_weight(), BUNDLE_IN_BUNDLE_WEIGHT);
-    }
-
-    #[test]
-    fn nested_bundle_contents_contribute_to_weight() {
+    fn inserts_nested_bundle_with_contents_and_overhead() {
         let mut contents = BundleContentsImpl {
             items: Vec::new(),
             selected_item_index: -1,
@@ -316,6 +287,7 @@ mod bundle_tests {
 
         assert!(contents.try_insert(&mut bundle));
 
+        assert!(bundle.is_empty());
         assert_eq!(contents.get_weight(), 8 + BUNDLE_IN_BUNDLE_WEIGHT);
     }
 }

--- a/pumpkin-data/src/generated/item.rs
+++ b/pumpkin-data/src/generated/item.rs
@@ -3988,7 +3988,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -4941,7 +4941,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -6570,7 +6570,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -7452,7 +7452,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -15144,7 +15144,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -24958,7 +24958,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -25567,7 +25567,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -30648,7 +30648,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -31257,7 +31257,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -32056,7 +32056,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -32900,7 +32900,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -39425,7 +39425,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -42203,7 +42203,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -45691,7 +45691,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -47290,7 +47290,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -61759,7 +61759,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {
@@ -63424,7 +63424,7 @@ impl Item {
                 },
             ),
             (BreakSound, &BreakSoundImpl),
-            (BundleContents, &BundleContentsImpl { items: Vec::new() }),
+            (BundleContents, &BundleContentsImpl { items: Vec::new(), selected_item_index: -1 }),
             (
                 Enchantments,
                 &EnchantmentsImpl {

--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -679,6 +679,30 @@ pub trait ScreenHandler: Send + Sync {
         })
     }
 
+    /// Sets the selected item index for a bundle in a screen handler slot.
+    fn set_selected_bundle_item_index(
+        &self,
+        slot_index: i32,
+        selected_item_index: i32,
+    ) -> ScreenHandlerFuture<'_, ()> {
+        Box::pin(async move {
+            let Ok(slot_index) = usize::try_from(slot_index) else {
+                return;
+            };
+            let Some(slot) = self.get_behaviour().slots.get(slot_index).cloned() else {
+                return;
+            };
+
+            let stack = slot.get_stack().await;
+            let mut stack = stack.lock().await;
+            if let Some(bundle) = stack
+                .get_data_component_mut::<pumpkin_data::data_component_impl::BundleContentsImpl>()
+            {
+                bundle.toggle_selected_item(selected_item_index);
+            }
+        })
+    }
+
     /// Performs a quick move (shift-click) from a slot.
     ///
     /// Must be implemented by concrete screen handlers to define

--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -1060,9 +1060,8 @@ pub trait ScreenHandler: Send + Sync {
                     let slot_stack = slot.get_cloned_stack().await;
                     let mut cursor_stack = self.get_behaviour().cursor_stack.lock().await;
 
-                    if click_type == MouseClick::Right {
-                        let mut intercepted = false;
-
+                    let mut intercepted = false;
+                    if click_type == MouseClick::Left {
                         if !cursor_stack.is_empty() {
                             let stack_guard = slot.get_stack().await;
                             let mut inner_slot_stack = stack_guard.lock().await;
@@ -1083,8 +1082,8 @@ pub trait ScreenHandler: Send + Sync {
                                     intercepted = true;
                                 }
                             }
-
-                        if !intercepted && cursor_stack.is_empty() {
+                    } else {
+                        if cursor_stack.is_empty() {
                             let stack_guard = slot.get_stack().await;
                             let mut inner_slot_stack = stack_guard.lock().await;
                             if let Some(bundle) = inner_slot_stack.get_data_component_mut::<pumpkin_data::data_component_impl::BundleContentsImpl>()
@@ -1097,17 +1096,17 @@ pub trait ScreenHandler: Send + Sync {
                         if !intercepted && slot_stack.is_empty()
                             && let Some(bundle) = cursor_stack.get_data_component_mut::<pumpkin_data::data_component_impl::BundleContentsImpl>()
                                 && let Some(extracted) = bundle.try_extract() {
-                                    slot.set_stack(extracted).await;
-                                    intercepted = true;
-                                }
-
-                        if intercepted {
-                            if cursor_stack.item_count == 0 {
-                                *cursor_stack = ItemStack::EMPTY.clone();
+                                slot.set_stack(extracted).await;
+                                intercepted = true;
                             }
-                            slot.mark_dirty().await;
-                            return;
+                    }
+
+                    if intercepted {
+                        if cursor_stack.item_count == 0 {
+                            *cursor_stack = ItemStack::EMPTY.clone();
                         }
+                        slot.mark_dirty().await;
+                        return;
                     }
 
                     let equipment_slot = cursor_stack

--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -1086,26 +1086,25 @@ pub trait ScreenHandler: Send + Sync {
 
                     let mut intercepted = false;
                     if click_type == MouseClick::Left {
-                        if !cursor_stack.is_empty() {
+                        if !slot_stack.is_empty()
+                            && let Some(bundle) = cursor_stack.get_data_component_mut::<pumpkin_data::data_component_impl::BundleContentsImpl>() {
                             let stack_guard = slot.get_stack().await;
                             let mut inner_slot_stack = stack_guard.lock().await;
-                            if let Some(bundle) = inner_slot_stack.get_data_component_mut::<pumpkin_data::data_component_impl::BundleContentsImpl>()
-                                && bundle.try_insert(&mut cursor_stack) {
-                                    intercepted = true;
-                                }
+                            bundle.try_insert(&mut inner_slot_stack);
+                            if inner_slot_stack.item_count == 0 {
+                                *inner_slot_stack = ItemStack::EMPTY.clone();
+                            }
+                            intercepted = true;
                         }
 
-                        if !intercepted && !slot_stack.is_empty()
-                            && let Some(bundle) = cursor_stack.get_data_component_mut::<pumpkin_data::data_component_impl::BundleContentsImpl>() {
-                                let stack_guard = slot.get_stack().await;
-                                let mut inner_slot_stack = stack_guard.lock().await;
-                                if bundle.try_insert(&mut inner_slot_stack) {
-                                    if inner_slot_stack.item_count == 0 {
-                                        *inner_slot_stack = ItemStack::EMPTY.clone();
-                                    }
-                                    intercepted = true;
-                                }
+                        if !intercepted && !cursor_stack.is_empty() {
+                            let stack_guard = slot.get_stack().await;
+                            let mut inner_slot_stack = stack_guard.lock().await;
+                            if let Some(bundle) = inner_slot_stack.get_data_component_mut::<pumpkin_data::data_component_impl::BundleContentsImpl>() {
+                                bundle.try_insert(&mut cursor_stack);
+                                intercepted = true;
                             }
+                        }
                     } else {
                         if cursor_stack.is_empty() {
                             let stack_guard = slot.get_stack().await;

--- a/pumpkin-protocol/src/codec/data_component.rs
+++ b/pumpkin-protocol/src/codec/data_component.rs
@@ -957,7 +957,10 @@ impl DataComponentCodec<Self> for BundleContentsImpl {
         for _ in 0..len {
             items.push(deserialize_item_stack_template(seq)?);
         }
-        Ok(Self { items })
+        Ok(Self {
+            items,
+            selected_item_index: -1,
+        })
     }
 }
 

--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -508,6 +508,12 @@ impl EntityBase for ItemEntity {
                     .is_ok()
                 {
                     if new <= 0.0 {
+                        let item_id = self.item_stack.lock().await.item.id;
+                        if let Some(server) = self.entity.world.load().server.upgrade()
+                            && let Some(behaviour) = server.item_registry.get_pumpkin_item(item_id)
+                        {
+                            behaviour.on_destroyed(self).await;
+                        }
                         self.entity.remove().await;
                     }
                     return true;

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -2618,8 +2618,21 @@ impl EntityBase for LivingEntity {
             // Current active item
             {
                 let item_in_use = self.item_in_use.lock().await.clone();
+                if let Some(item) = item_in_use.as_ref() {
+                    let ticks_remaining = self.item_use_time.load(Ordering::Relaxed);
+                    if ticks_remaining > 0
+                        && let Some(player) = caller.get_player()
+                    {
+                        server
+                            .item_registry
+                            .on_use_tick(item, player, ticks_remaining)
+                            .await;
+                    }
+                }
+
                 if let Some(item) = item_in_use.as_ref()
-                    && self.item_use_time.fetch_sub(1, Ordering::Relaxed) <= 0
+                    && self.item_use_time.fetch_sub(1, Ordering::Relaxed) <= 1
+                    && item.get_data_component::<ConsumableImpl>().is_some()
                 {
                     // Consume item
                     let mut is_potion = false;
@@ -2724,7 +2737,9 @@ impl EntityBase for LivingEntity {
                                 .await;
                         }
                     }
+                }
 
+                if item_in_use.is_some() && self.item_use_time.load(Ordering::Relaxed) <= 0 {
                     self.clear_active_hand().await;
                 }
             }

--- a/pumpkin/src/item/items/bundle.rs
+++ b/pumpkin/src/item/items/bundle.rs
@@ -4,8 +4,11 @@ use crate::entity::player::Player;
 use crate::item::{ItemBehaviour, ItemMetadata};
 use pumpkin_data::data_component_impl::BundleContentsImpl;
 use pumpkin_data::item::Item;
-use pumpkin_data::sound::Sound;
+use pumpkin_data::item_stack::ItemStack;
+use pumpkin_data::sound::{Sound, SoundCategory};
 use pumpkin_data::tag;
+use pumpkin_inventory::player::player_inventory::PlayerInventory;
+use pumpkin_util::Hand;
 
 pub struct BundleItem;
 
@@ -23,57 +26,117 @@ impl ItemBehaviour for BundleItem {
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
         Box::pin(async move {
             let held_item_ref = player.inventory.held_item();
-            let mut held_item = held_item_ref.lock().await;
-            let mut matched = false;
-            let mut used_slot_index = player.inventory.get_selected_slot() as usize;
-
+            let held_item = held_item_ref.lock().await;
             if !held_item.is_empty() && Self::ids().contains(&held_item.item.id) {
-                matched = true;
-                if let Some(bundle_contents) =
-                    held_item.get_data_component_mut::<BundleContentsImpl>()
-                    && let Some(extracted_stack) = bundle_contents.try_extract()
-                {
-                    let position = player.position();
-                    player.world().play_sound(
-                        Sound::ItemBundleRemoveOne,
-                        pumpkin_data::sound::SoundCategory::Players,
-                        &position,
-                    );
-                    let updated_bundle = held_item.clone();
-                    drop(held_item);
-
-                    player.drop_item(extracted_stack).await;
-                    player.sync_hand_slot(used_slot_index, updated_bundle).await;
-                }
+                let stack = held_item.clone();
+                drop(held_item);
+                player
+                    .living_entity
+                    .set_active_hand(Hand::Right, stack, Self::USE_DURATION)
+                    .await;
+                return;
             }
+            drop(held_item);
 
-            if !matched {
-                let off_hand_item_ref = player.inventory.off_hand_item().await;
-                let mut off_hand_item = off_hand_item_ref.lock().await;
-                if !off_hand_item.is_empty() && Self::ids().contains(&off_hand_item.item.id) {
-                    used_slot_index = 40; // OFF_HAND_SLOT
-                    if let Some(bundle_contents) =
-                        off_hand_item.get_data_component_mut::<BundleContentsImpl>()
-                        && let Some(extracted_stack) = bundle_contents.try_extract()
-                    {
-                        let position = player.position();
-                        player.world().play_sound(
-                            Sound::ItemBundleRemoveOne,
-                            pumpkin_data::sound::SoundCategory::Players,
-                            &position,
-                        );
-                        let updated_bundle = off_hand_item.clone();
-                        drop(off_hand_item);
-
-                        player.drop_item(extracted_stack).await;
-                        player.sync_hand_slot(used_slot_index, updated_bundle).await;
-                    }
-                }
+            let off_hand_item_ref = player.inventory.off_hand_item().await;
+            let off_hand_item = off_hand_item_ref.lock().await;
+            if !off_hand_item.is_empty() && Self::ids().contains(&off_hand_item.item.id) {
+                let stack = off_hand_item.clone();
+                drop(off_hand_item);
+                player
+                    .living_entity
+                    .set_active_hand(Hand::Left, stack, Self::USE_DURATION)
+                    .await;
             }
         })
     }
 
+    fn on_use_tick<'a>(
+        &'a self,
+        _stack: &'a ItemStack,
+        player: &'a Player,
+        ticks_remaining: i32,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            if Self::should_drop_content(ticks_remaining) {
+                Self::drop_content(player).await;
+            }
+        })
+    }
+
+    fn get_use_duration(&self) -> i32 {
+        Self::USE_DURATION
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+impl BundleItem {
+    const USE_DURATION: i32 = 200;
+
+    const fn should_drop_content(ticks_remaining: i32) -> bool {
+        ticks_remaining == Self::USE_DURATION
+            || ticks_remaining < Self::USE_DURATION - 10 && ticks_remaining % 2 == 0
+    }
+
+    async fn drop_content(player: &Player) -> bool {
+        let hand = *player.living_entity.active_hand.lock().await;
+        let (slot_index, bundle_ref) = match hand {
+            Some(Hand::Right) => (
+                player.inventory.get_selected_slot() as usize,
+                player.inventory.held_item(),
+            ),
+            Some(Hand::Left) => (
+                PlayerInventory::OFF_HAND_SLOT,
+                player.inventory.off_hand_item().await,
+            ),
+            None => return false,
+        };
+
+        let mut bundle = bundle_ref.lock().await;
+        if bundle.is_empty() || !Self::ids().contains(&bundle.item.id) {
+            return false;
+        }
+        let Some(bundle_contents) = bundle.get_data_component_mut::<BundleContentsImpl>() else {
+            return false;
+        };
+        let Some(extracted_stack) = bundle_contents.try_extract() else {
+            return false;
+        };
+        let updated_bundle = bundle.clone();
+        drop(bundle);
+
+        let position = player.position();
+        player.world().play_sound(
+            Sound::ItemBundleRemoveOne,
+            SoundCategory::Players,
+            &position,
+        );
+        player.drop_item(extracted_stack).await;
+        player.world().play_sound(
+            Sound::ItemBundleDropContents,
+            SoundCategory::Players,
+            &position,
+        );
+        player.sync_hand_slot(slot_index, updated_bundle).await;
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BundleItem;
+
+    #[test]
+    fn uses_vanilla_drop_timing() {
+        assert!(BundleItem::should_drop_content(200));
+        assert!(!BundleItem::should_drop_content(199));
+        assert!(!BundleItem::should_drop_content(190));
+        assert!(!BundleItem::should_drop_content(189));
+        assert!(BundleItem::should_drop_content(188));
+        assert!(!BundleItem::should_drop_content(187));
+        assert!(BundleItem::should_drop_content(186));
     }
 }

--- a/pumpkin/src/item/items/bundle.rs
+++ b/pumpkin/src/item/items/bundle.rs
@@ -1,8 +1,10 @@
 use std::pin::Pin;
+use std::sync::Arc;
 
-use crate::entity::player::Player;
+use crate::entity::{Entity, item::ItemEntity, player::Player};
 use crate::item::{ItemBehaviour, ItemMetadata};
 use pumpkin_data::data_component_impl::BundleContentsImpl;
+use pumpkin_data::entity::EntityType;
 use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::sound::{Sound, SoundCategory};
@@ -60,6 +62,32 @@ impl ItemBehaviour for BundleItem {
         Box::pin(async move {
             if Self::should_drop_content(ticks_remaining) {
                 Self::drop_content(player).await;
+            }
+        })
+    }
+
+    fn on_destroyed<'a>(
+        &'a self,
+        entity: &'a ItemEntity,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            let contents = {
+                let mut bundle = entity.get_item_stack().lock().await;
+                let Some(contents) = bundle.get_data_component_mut::<BundleContentsImpl>() else {
+                    return;
+                };
+                contents.selected_item_index = -1;
+                std::mem::take(&mut contents.items)
+            };
+
+            let base_entity = entity.get_entity();
+            let world = base_entity.world.load_full();
+            let position = base_entity.pos.load();
+            for stack in contents {
+                let entity = Entity::new(world.clone(), position, &EntityType::ITEM);
+                world
+                    .spawn_entity(Arc::new(ItemEntity::new(entity, stack)))
+                    .await;
             }
         })
     }

--- a/pumpkin/src/item/items/bundle.rs
+++ b/pumpkin/src/item/items/bundle.rs
@@ -1,7 +1,11 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::entity::{Entity, item::ItemEntity, player::Player};
+use crate::entity::{
+    Entity,
+    item::ItemEntity,
+    player::{Player, statistics::StatisticCategory},
+};
 use crate::item::{ItemBehaviour, ItemMetadata};
 use pumpkin_data::data_component_impl::BundleContentsImpl;
 use pumpkin_data::entity::EntityType;
@@ -133,6 +137,7 @@ impl BundleItem {
         let Some(extracted_stack) = bundle_contents.try_extract() else {
             return false;
         };
+        let item_id = bundle.item.id;
         let updated_bundle = bundle.clone();
         drop(bundle);
 
@@ -148,6 +153,9 @@ impl BundleItem {
             SoundCategory::Players,
             &position,
         );
+        player
+            .increment_stat(StatisticCategory::Used, item_id as i32, 1)
+            .await;
         player.sync_hand_slot(slot_index, updated_bundle).await;
         true
     }

--- a/pumpkin/src/item/mod.rs
+++ b/pumpkin/src/item/mod.rs
@@ -60,6 +60,15 @@ pub trait ItemBehaviour: Send + Sync {
         Box::pin(async {})
     }
 
+    fn on_use_tick<'a>(
+        &'a self,
+        _stack: &'a ItemStack,
+        _player: &'a Player,
+        _ticks_remaining: i32,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async {})
+    }
+
     /// Returns the maximum number of ticks this item can be used for.
     /// Return 0 if the item does not have a behaviour-driven use duration.
     fn get_use_duration(&self) -> i32 {

--- a/pumpkin/src/item/mod.rs
+++ b/pumpkin/src/item/mod.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::entity::EntityBase;
+use crate::entity::item::ItemEntity;
 use crate::entity::player::Player;
 use crate::server::Server;
 use pumpkin_data::Block;
@@ -65,6 +66,13 @@ pub trait ItemBehaviour: Send + Sync {
         _stack: &'a ItemStack,
         _player: &'a Player,
         _ticks_remaining: i32,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async {})
+    }
+
+    fn on_destroyed<'a>(
+        &'a self,
+        _entity: &'a ItemEntity,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
         Box::pin(async {})
     }

--- a/pumpkin/src/item/registry.rs
+++ b/pumpkin/src/item/registry.rs
@@ -55,6 +55,12 @@ impl ItemRegistry {
         }
     }
 
+    pub async fn on_use_tick(&self, stack: &ItemStack, player: &Player, ticks_remaining: i32) {
+        if let Some(behaviour) = self.get_pumpkin_item(stack.item.id) {
+            behaviour.on_use_tick(stack, player, ticks_remaining).await;
+        }
+    }
+
     /// Returns the item's use duration in ticks, as defined by its registered behaviour.
     /// Returns `None` if the item has no registered behaviour or its duration is 0.
     #[must_use]

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -2887,6 +2887,13 @@ impl JavaClient {
             "Bundle item selected: Slot ID {}, Selected Item Index {}",
             packet.slot_id.0, selected_item_index
         );
+
+        let screen_handler = player.current_screen_handler.lock().await.clone();
+        screen_handler
+            .lock()
+            .await
+            .set_selected_bundle_item_index(packet.slot_id.0, selected_item_index)
+            .await;
     }
 
     pub async fn handle_teleport_to_entity(


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

Fixes multiple issues with bundles:-

- Left click did not insert items into bundles and right click inserted items instead of extracting them.
- Bundle selection packets and scrolling did not update the selected item.
- Bundle insertion only merged with the first matching internal stack.
- Using a held bundle only dropped one entry and stopped immediately.
- Nested bundles were rejected.
- Shulker boxes could be inserted into bundles.
- Destroying a filled bundle did not spill its contents.
- Bundle use did not play the complete sound sequence or award the item-used statistic.
- Filled bundle contents did not survive item NBT serialization.

Now bundle interactions, content handling, held use, destruction, and serialization work as per the vanilla logic.

also added regression tests:-

- `extracts_selected_item_and_clears_selection`
- `invalid_or_repeated_selection_clears_selection`
- `insertion_merges_matching_stack_and_moves_it_to_front`
- `inserts_nested_bundle_with_contents_and_overhead`
- `uses_vanilla_drop_timing`
- `bundle_contents_survive_item_stack_nbt_roundtrip`

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] Manually tested inserting items into bundles with left click.
- [x] Manually tested extracting items from bundles with right click.
- [x] Manually tested selecting bundle entries by scrolling and extracting the selected entry.
- [x] Manually tested merging items with a matching entry that was not first in the bundle.
- [x] Manually tested progressively dropping bundle contents while holding use.
- [x] Manually tested nested bundle insertion and weight.
- [x] Manually tested rejecting shulker boxes from bundles.
- [x] Manually tested spilling bundle contents when the bundle item entity is destroyed.
- [x] Manually tested bundle removal and drop-content sounds.
- [x] Manually tested the bundle item-used statistic.
- [x] Manually tested bundle contents after saving and loading.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)

