### PR TITLE
fix(block): use the piston's own block/state for its quasi-power check

### DIFF
--- a/pumpkin/src/block/blocks/piston/piston.rs
+++ b/pumpkin/src/block/blocks/piston/piston.rs
@@ -302,8 +302,11 @@ async fn should_extend(world: &World, block_pos: &BlockPos, piston_dir: BlockDir
         }
         return true;
     }
-    let neighbor_pos = block_pos.offset(BlockDirection::Down.to_offset());
-    let (block, state) = world.get_block_and_state(&neighbor_pos);
+    // Vanilla checks `hasSignal(pos, Direction.DOWN)` here, i.e. whether the piston's own
+    // position is quasi-powered as a solid block by *its own* six neighbours
+    // (PistonBaseBlock#getNeighborSignal, SignalGetter#getSignal). This must use the piston's
+    // own block/state, not the block below it.
+    let (block, state) = world.get_block_and_state(block_pos);
     if is_emitting_redstone_power(block, state, world, block_pos, BlockDirection::Down).await {
         return true;
     }


### PR DESCRIPTION
should_extend's port of hasSignal(pos, Direction.DOWN) (from PistonBaseBlock#getNeighborSignal) read the block/state of the position below the piston instead of the piston's own block/state, while still passing the piston's own position as the query position.

Vanilla evaluates this check against the piston's own block: solidity of the piston's own block is what gates whether getDirectSignalTo(pos) (quasi-connectivity power from the piston's own six neighbours) is considered at all (PistonBaseBlock.java:134-136, SignalGetter.java:61-69). Reading the block below instead meant the piston's own quasi-power check was silently skipped whenever the block underneath happened to be non-solid (air, a slab, glass, etc.), breaking some BUD-switch/piston-door style contraptions that rely on quasi-connectivity.

Fix uses block_pos (the piston's own position) for both the block/state lookup and the power query, matching vanilla exactly.

Not unit-testable without a full World (this function is async fn(world: &World, ...) and needs chunk/registry state), and there's no existing test harness in this area that constructs one. Verified via cargo check / cargo fmt --check / cargo clippy --all-targets -D warnings, all clean.