### PR TITLE
fix(protocol): actually write the resource-pack prompt message

### DIFF
--- a/pumpkin-protocol/src/java/client/config/add_resource_pack.rs
+++ b/pumpkin-protocol/src/java/client/config/add_resource_pack.rs
@@ -46,9 +46,9 @@ impl ClientPacket for CConfigAddResourcePack<'_> {
         write.write_string(self.url)?;
         write.write_string(self.hash)?;
         write.write_bool(self.forced)?;
-        if let Some(_prompt) = &self.prompt_message {
+        if let Some(prompt) = &self.prompt_message {
             write.write_bool(true)?;
-            // TODO
+            write.write_slice(&prompt.encode())?;
         } else {
             write.write_bool(false)?;
         }


### PR DESCRIPTION
CConfigAddResourcePack::write_packet_data had a TODO where, if prompt_message was Some, it wrote the has-prompt boolean flag as true but then wrote zero bytes for the actual NBT-encoded text component.

This desyncs the packet stream for any server config with a non-empty prompt_message, since login.rs only passes Some(...) for that field when the configured string is non-empty, so the bad branch is reachable in normal use, not dead code.

Fix encodes the component the same way every other packet in this codebase already does (TextComponent::encode()), matching the pattern in e.g. actionbar.rs.

Verified with cargo check / cargo fmt --check / cargo clippy --all-targets -D warnings, all clean.