### PR TITLE
Fix Anvil Sound + Add Play Sound Event Method (#2747)

### DIFF
--- a/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
+++ b/pumpkin-inventory/src/anvil/anvil_screen_handler.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use pumpkin_data::{item_stack::ItemStack, screen::WindowType};
+use pumpkin_data::{item_stack::ItemStack, screen::WindowType, world::WorldEvent};
 use pumpkin_world::inventory::Inventory;
 
 use crate::{
@@ -205,6 +205,8 @@ impl ScreenHandler for AnvilScreenHandler {
                             // Consume inputs
                             self.inventory.set_stack(0, ItemStack::EMPTY.clone()).await;
                             self.get_behaviour().slots[0].mark_dirty().await;
+
+                            player.play_sound_event(WorldEvent::SoundAnvilUsed).await;
                         } else {
                             // Cancel click
                             self.send_content_updates().await;

--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -36,6 +36,7 @@ use pumpkin_data::{
     data_component_impl::{EquipmentSlot, EquipmentType, EquippableImpl},
     screen::WindowType,
     statistic::StatisticCategory,
+    world::WorldEvent,
 };
 use pumpkin_protocol::{
     codec::item_stack_seralizer::OptionalItemStackHash,
@@ -189,6 +190,9 @@ pub trait InventoryPlayer: Send + Sync {
 
     /// Awards experience points to the player (used for furnace smelting, etc.)
     fn award_experience(&self, amount: i32) -> PlayerFuture<'_, ()>;
+
+    /// Plays a world event (e.g. anvil used) at the open container position.
+    fn play_sound_event(&self, event: WorldEvent) -> PlayerFuture<'_, ()>;
 
     /// Increments a statistic for the player.
     fn increment_stat(

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -5361,6 +5361,14 @@ impl InventoryPlayer for Player {
         })
     }
 
+    fn play_sound_event(&self, event: pumpkin_data::world::WorldEvent) -> PlayerFuture<'_, ()> {
+        Box::pin(async move {
+            if let Some(pos) = self.open_container_pos.load() {
+                self.world().sync_world_event(event, pos, 0);
+            }
+        })
+    }
+
     fn increment_stat(
         &self,
         category: StatisticCategory,


### PR DESCRIPTION
**Description:**
- I looked at the issues found; Anvil had an issue, looked into it, and saw there was no method calling a play sound effect on use, so I then added a method to player.rs to allow me to play the anvil used sound effect at the player's location, as you couldn't play sounds from it otherwise.  (I try to keep my PRs really simple; that's why I don't send massive long text walls)

**What was changed?**
- I changed `pumpkin-inventory`, where I edited both `anvil_screen_handler.rs` and `screen_handler.rs` to allow me to call and use the new method and also changed 1 file in `pumpkin`, where I edited `player.rs` to add the play sound event for the anvil (and others) to use.

**Why were these changes necessary?** 
- These changes are very much needed, 1 part fixes the issue, and another also adds a reusable method for others that may require this in the future.

**What is the impact of this change?** 
- When using an anvil, it now plays the correct sound instead of nothing. The await may add delay, but it shouldn't add insane delays, if any, which I believe would still be the cost of any other method (unless someone can optimise this for me that I haven't / cannot see).

**Are there any known issues or limitations?** 
- Not that I have seen. I have only tested locally on my end, making sure my changes work; it should play sound for others, but I have not tested that yet.

Fixes: https://github.com/Pumpkin-MC/Pumpkin/issues/2747

cargo test - Passed
cargo clippy --all-targets - Passed
cargo fmt - Ran to make sure the format is correct.