### PR TITLE
fix: make chickens glide (#2753)

### DIFF
--- a/pumpkin/src/entity/passive/chicken.rs
+++ b/pumpkin/src/entity/passive/chicken.rs
@@ -174,9 +174,16 @@ impl Mob for ChickenEntity {
             if self.mob_entity.living_entity.dead.load(Relaxed) {
                 return;
             }
+            let entity = &self.mob_entity.living_entity.entity;
+            let current_velocity = entity.velocity.load();
+            let on_ground = entity.on_ground.load(Ordering::Relaxed);
+
+            // TODO: move velocity logic to physics tick when implemented
+            if (!on_ground) && current_velocity.y < 0.0 {
+                entity.set_velocity(current_velocity.multiply(1.0, 0.6, 1.0));
+            }
             if self.egg_lay_time.fetch_sub(1, Ordering::Relaxed) <= 1 {
                 let next_time = rand::rng().random_range(6000..12000);
-                let entity = &self.mob_entity.living_entity.entity;
                 let world = entity.world.load_full();
                 let pos = entity.block_pos.load();
                 world.drop_stack(&pos, ItemStack::new(1, &Item::EGG)).await;


### PR DESCRIPTION
## Description
This makes the chickens y velocity be smaller when not on ground

## What was changed?
The y velocity was multiplied by 0.6 following the same pattern from vanilla java code:
`net/minecraft/entity/passive/ChickenEntity.java`
```java
Vec3d lv = this.getVelocity();
      if (!this.isOnGround() && lv.y < 0.0) {
         this.setVelocity(lv.multiply(1.0, 0.6, 1.0));
      }
```
## Why were these changes necessary?
The current behaviour is different from vanilla

## What is the impact of this change?
Now the chickens float normally

## Are there any known issues or limitations?
the original java implementation used tickMovement, but current Mob trait does not have that field and implementing it would require a major refactor

## Testing
I tested it in java edition 1.26.2, and it worked normally

https://youtu.be/RbL4Oc-Wtt8



Fixes: #2753 
