### PR TITLE
fix(redstone): prevent panic when querying strong power from above

### DIFF
--- a/pumpkin/src/block/blocks/redstone/redstone_wire.rs
+++ b/pumpkin/src/block/blocks/redstone/redstone_wire.rs
@@ -215,13 +215,7 @@ impl BlockBehaviour for RedstoneWireBlock {
     ) -> BlockFuture<'a, u8> {
         Box::pin(async move {
             let wire = RedstoneWireProperties::from_state_id(args.state.id, args.block);
-            if args.direction == BlockDirection::Up
-                || wire.is_side_connected(args.direction.opposite().to_horizontal_facing().unwrap())
-            {
-                wire.power
-            } else {
-                0
-            }
+            strong_power_toward(wire, args.direction)
         })
     }
 
@@ -235,6 +229,24 @@ impl BlockBehaviour for RedstoneWireBlock {
         Box::pin(async move {
             update_wire_neighbors(args.world, args.position).await;
         })
+    }
+}
+
+/// Strong power the wire emits to the block that queried it, where `direction`
+/// points from the querying block toward the wire.
+///
+/// `to_horizontal_facing` returns `None` for the vertical directions, so the
+/// result has to be matched instead of unwrapped: a block sitting directly above
+/// the wire queries it with `BlockDirection::Down`, whose opposite is
+/// `BlockDirection::Up`.
+fn strong_power_toward(wire: RedstoneWireProperties, direction: BlockDirection) -> u8 {
+    if direction == BlockDirection::Up {
+        return wire.power;
+    }
+
+    match direction.opposite().to_horizontal_facing() {
+        Some(facing) if wire.is_side_connected(facing) => wire.power,
+        _ => 0,
     }
 }
 
@@ -560,4 +572,49 @@ async fn calculate_power(world: &World, pos: &BlockPos) -> u8 {
     }
 
     block_power.max(wire_power.saturating_sub(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn powered_wire(power: u8) -> RedstoneWireProperties {
+        let mut wire = RedstoneWireProperties::default(&Block::REDSTONE_WIRE);
+        wire.power = power;
+        wire.north = NorthRedstone::None;
+        wire.south = SouthRedstone::None;
+        wire.east = EastRedstone::None;
+        wire.west = WestRedstone::None;
+        wire
+    }
+
+    #[test]
+    fn queried_from_above_yields_no_strong_power() {
+        // A block directly above the wire queries it with `Down`, and the
+        // opposite of `Down` is `Up`, which has no horizontal facing. Matching
+        // that `None` is what keeps the query from panicking.
+        assert_eq!(
+            strong_power_toward(powered_wire(15), BlockDirection::Down),
+            0
+        );
+    }
+
+    #[test]
+    fn queried_from_below_yields_full_strong_power() {
+        assert_eq!(
+            strong_power_toward(powered_wire(15), BlockDirection::Up),
+            15
+        );
+    }
+
+    #[test]
+    fn horizontal_strong_power_follows_connections() {
+        let mut wire = powered_wire(15);
+        wire.north = NorthRedstone::Side;
+
+        // Queried from the south: the opposite side is north, which is connected.
+        assert_eq!(strong_power_toward(wire, BlockDirection::South), 15);
+        // Queried from the east: the opposite side is west, which is not.
+        assert_eq!(strong_power_toward(wire, BlockDirection::East), 0);
+    }
 }


### PR DESCRIPTION
Relates to #2734. Deliberately **not** using a closing keyword: this fixes one of the two
panicking call sites, and #2739 fixes the other. #2734 is only fully resolved once both land.

## Description

`RedstoneWireBlock::get_strong_redstone_power` calls:

```rust
args.direction.opposite().to_horizontal_facing().unwrap()
```

`to_horizontal_facing()` returns `None` for the vertical directions. When the querying block
sits directly above the wire, `args.direction` is `Down`, its opposite is `Up`, and the
`unwrap()` panics, taking down the Tokio worker and the server with it.

The path is reachable without involving weak power at all:

```
get_max_strong_power(pos, dust_power = true)          redstone/mod.rs:102
  -> iterates BlockDirection::all(), which includes Down
  -> get_strong_power(..., side = Down, dust_power = true)   redstone/mod.rs:157
     -> the `!dust_power && block == REDSTONE_WIRE` guard at :165 does NOT fire
     -> get_strong_redstone_power(..., Down)                 redstone/mod.rs:170
        -> Down.opposite() == Up -> to_horizontal_facing() == None -> unwrap() panics
```

So any solid block with redstone dust directly beneath it panics the server as soon as
something asks that block for its power — a note block, repeater, door, or piston next to it
is enough.

### Relationship to #2739

#2739 fixes the byte-identical `unwrap()` in the sibling function
`get_weak_redstone_power` (line 203) and closes #2734. That patch is correct, but it does not
touch `get_strong_redstone_power` (line 219), and the trace above shows that site is reached
independently through `get_max_strong_power`. If #2739 merges alone, #2734 gets closed while
this crash is still live.

These two PRs are complementary, not competing. This one deliberately leaves
`get_weak_redstone_power` untouched so it cannot conflict with #2739 — the diffs are in
different hunks and can merge in either order.

### The change

The condition moves into a free function, `strong_power_toward`, which matches the `Option`
instead of unwrapping it. Extracting it also makes the vertical cases reachable from unit
tests — the trait method itself needs a live `&World`, so it cannot be tested directly.

Behaviour is otherwise unchanged:

| Query direction | Before | After |
| --- | --- | --- |
| `Up` | `wire.power` | `wire.power` |
| Horizontal | depends on connected side | depends on connected side |
| `Down` | **panic** | `0` |

## Testing

Reproduced against a real client (Java, offline mode) on an unpatched build: place redstone
dust, put a solid block directly on top of it, then place a note block beside that solid
block. The server dies immediately:

```
====== Pumpkin Crash Report ======
Message: called `Option::unwrap()` on a `None` value
Panic Location: pumpkin\src\block\blocks\redstone\redstone_wire.rs:219:92

--- Panicking Thread ---
Name: tokio-rt-worker
```

Note the line number: **219**, `get_strong_redstone_power` — not the 203 site that #2739
addresses. The identical setup on a patched build does not crash and redstone behaves
normally.

Three unit tests cover the vertical and horizontal cases. They were verified to fail against
the original code before being committed — reinstating the `unwrap()` makes
`queried_from_above_yields_no_strong_power` panic at the unwrap, while the other two continue
to pass, confirming the fix does not change the non-panicking behaviour.

```bash
cargo fmt --check
RUSTFLAGS='-Dwarnings' cargo clippy --all-targets --all-features
RUSTFLAGS='-Dwarnings' cargo clippy --release --all-targets --all-features
cargo test --workspace   # 484 passed, 0 failed
```

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
