### PR TITLE
fix(block): a batch of vanilla-parity block behaviour fixes

### DIFF
--- a/pumpkin/src/block/blocks/farmland.rs
+++ b/pumpkin/src/block/blocks/farmland.rs
@@ -114,8 +114,8 @@ impl BlockBehaviour for FarmlandBlock {
 }
 
 fn can_place_at(world: &dyn BlockAccessor, block_pos: &BlockPos) -> bool {
-    let state = world.get_block_state(&block_pos.up());
-    !state.is_solid() // TODO: add fence gate block
+    let (block, state) = world.get_block_and_state(&block_pos.up());
+    !state.is_solid() || block.has_tag(&tag::Block::MINECRAFT_MAINTAINS_FARMLAND)
 }
 
 fn is_water_nearby(world: &Arc<World>, block_pos: &BlockPos) -> bool {

--- a/pumpkin/src/block/blocks/plant/lily_pad.rs
+++ b/pumpkin/src/block/blocks/plant/lily_pad.rs
@@ -14,13 +14,11 @@ pub struct LilyPadBlock;
 impl BlockBehaviour for LilyPadBlock {
     fn on_entity_collision<'a>(&'a self, args: OnEntityCollisionArgs<'a>) -> BlockFuture<'a, ()> {
         Box::pin(async move {
-            // Proberbly not the best solution, but works
             if args
                 .entity
                 .get_entity()
                 .entity_type
-                .resource_name
-                .ends_with("_boat")
+                .has_tag(&tag::EntityType::C_BOATS)
             {
                 args.world
                     .break_block(args.position, None, BlockFlags::empty())

--- a/pumpkin/src/block/blocks/plant/sea_pickles.rs
+++ b/pumpkin/src/block/blocks/plant/sea_pickles.rs
@@ -22,6 +22,25 @@ type SeaPickleProperties = pumpkin_data::block_properties::SeaPickleLikeProperti
 #[pumpkin_block("minecraft:sea_pickle")]
 pub struct SeaPickleBlock;
 
+/// `SeaPickleBlock.performBonemeal`'s diamond-shaped z-span/z-offset progression across
+/// its 5 x-iterations: widest (5) at the middle iteration, narrowing to 1 at the edges.
+fn diamond_z_spans_and_offsets() -> [(i32, i32); 5] {
+    let mut z_span = 1;
+    let mut removed_z = 0;
+    let mut spans = [(0, 0); 5];
+    for (count, slot) in spans.iter_mut().enumerate() {
+        *slot = (z_span, removed_z);
+        if count < 2 {
+            z_span += 2;
+            removed_z += 1;
+        } else {
+            z_span -= 2;
+            removed_z -= 1;
+        }
+    }
+    spans
+}
+
 impl BlockBehaviour for SeaPickleBlock {
     fn use_with_item<'a>(
         &'a self,
@@ -45,17 +64,13 @@ impl BlockBehaviour for SeaPickleBlock {
             //1:1 vanilla algorithm
             //TODO use pumpkin random
 
-            //let mut j = 1;
-            let mut count = 0;
             let base_x = args.position.0.x - 2;
-            let mut removed_z = 0;
-            for added_x in 0..5 {
-                for added_z in 0..1 {
+            for (added_x, (z_span, removed_z)) in diamond_z_spans_and_offsets().iter().enumerate() {
+                for added_z in 0..*z_span {
                     let temp_y = 2 + args.position.0.y - 1;
                     for y in (temp_y - 2)..temp_y {
-                        //let mut lv2: BlockState;
                         let lv = BlockPos::new(
-                            base_x + added_x,
+                            base_x + added_x as i32,
                             y,
                             args.position.0.z - removed_z + added_z,
                         );
@@ -81,14 +96,6 @@ impl BlockBehaviour for SeaPickleBlock {
                             .await;
                     }
                 }
-                if count < 2 {
-                    //j += 2;
-                    removed_z += 1;
-                } else {
-                    //j -= 2;
-                    removed_z -= 1;
-                }
-                count += 1;
             }
             let mut sea_pickle_prop = SeaPickleProperties::default(args.block);
             sea_pickle_prop.pickles = 4;
@@ -149,3 +156,26 @@ impl BlockBehaviour for SeaPickleBlock {
 }
 
 impl PlantBlockBase for SeaPickleBlock {}
+
+#[cfg(test)]
+mod tests {
+    use super::diamond_z_spans_and_offsets;
+
+    #[test]
+    fn diamond_z_span_widens_then_narrows() {
+        let spans: Vec<i32> = diamond_z_spans_and_offsets()
+            .iter()
+            .map(|(span, _)| *span)
+            .collect();
+        assert_eq!(spans, vec![1, 3, 5, 3, 1]);
+    }
+
+    #[test]
+    fn diamond_z_offset_rises_then_falls() {
+        let offsets: Vec<i32> = diamond_z_spans_and_offsets()
+            .iter()
+            .map(|(_, offset)| *offset)
+            .collect();
+        assert_eq!(offsets, vec![0, 1, 2, 1, 0]);
+    }
+}

--- a/pumpkin/src/block/blocks/redstone/bell.rs
+++ b/pumpkin/src/block/blocks/redstone/bell.rs
@@ -37,8 +37,8 @@ fn ring_bell(position: BlockPos, world: &Arc<World>, hit_direction: Option<Horiz
         Sound::BlockBellUse,
         SoundCategory::Blocks,
         &position.to_centered_f64(),
-        1.0,
         2.0,
+        1.0,
     );
 
     //TODO Emit game event: BLOCK_CHANGE -> Send block update Packet

--- a/pumpkin/src/block/blocks/redstone/copper_bulb.rs
+++ b/pumpkin/src/block/blocks/redstone/copper_bulb.rs
@@ -1,5 +1,8 @@
 use crate::block::blocks::redstone::block_receives_redstone_power;
-use crate::block::{BlockBehaviour, BlockFuture, BlockMetadata, OnNeighborUpdateArgs, OnPlaceArgs};
+use crate::block::{
+    BlockBehaviour, BlockFuture, BlockMetadata, GetComparatorOutputArgs, OnNeighborUpdateArgs,
+    OnPlaceArgs,
+};
 use pumpkin_data::BlockId;
 use pumpkin_data::BlockStateId;
 use pumpkin_data::block_properties::BlockProperties;
@@ -71,6 +74,16 @@ impl BlockBehaviour for CopperBulbBlock {
                     )
                     .await;
             }
+        })
+    }
+
+    fn get_comparator_output<'a>(
+        &'a self,
+        args: GetComparatorOutputArgs<'a>,
+    ) -> BlockFuture<'a, Option<u8>> {
+        Box::pin(async move {
+            let props = CopperBulbLikeProperties::from_state_id(args.state.id, args.block);
+            Some(if props.lit { 15 } else { 0 })
         })
     }
 }

--- a/pumpkin/src/block/blocks/redstone/pressure_plate/weighted.rs
+++ b/pumpkin/src/block/blocks/redstone/pressure_plate/weighted.rs
@@ -111,12 +111,7 @@ impl PressurePlate for WeightedPressurePlateBlock {
         };
         let aabb = detection_box_at(pos);
         let len = world.get_entities_at_box(&aabb).len() + world.get_players_at_box(&aabb).len();
-        let len = len.min(weight);
-        if len > 0 {
-            let f = (weight.min(len) / weight) as f32;
-            return (f * 15.0).ceil() as u8;
-        }
-        0
+        Self::signal_for_count(weight, len)
     }
 
     fn set_redstone_output(&self, block: &Block, state: &BlockState, output: u8) -> BlockStateId {
@@ -127,5 +122,41 @@ impl PressurePlate for WeightedPressurePlateBlock {
 
     fn tick_rate(&self) -> u8 {
         10
+    }
+}
+
+impl WeightedPressurePlateBlock {
+    fn signal_for_count(weight: usize, count: usize) -> u8 {
+        let count = count.min(weight);
+        if count > 0 {
+            let f = count as f32 / weight as f32;
+            return (f * 15.0).ceil() as u8;
+        }
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WeightedPressurePlateBlock;
+
+    #[test]
+    fn fractional_load_produces_graded_nonzero_signal() {
+        // 50 entities on an Iron (heavy) plate with maxWeight 150 should give a
+        // partial, nonzero signal rather than truncating to 0 like integer
+        // division did before the fix.
+        let signal = WeightedPressurePlateBlock::signal_for_count(150, 50);
+        assert_eq!(signal, 5);
+        assert_ne!(signal, 0);
+    }
+
+    #[test]
+    fn zero_entities_produce_zero_signal() {
+        assert_eq!(WeightedPressurePlateBlock::signal_for_count(150, 0), 0);
+    }
+
+    #[test]
+    fn full_weight_produces_max_signal() {
+        assert_eq!(WeightedPressurePlateBlock::signal_for_count(150, 150), 15);
     }
 }

--- a/pumpkin/src/block/blocks/redstone/repeater.rs
+++ b/pumpkin/src/block/blocks/redstone/repeater.rs
@@ -114,6 +114,10 @@ impl BlockBehaviour for RepeaterBlock {
 
     fn normal_use<'a>(&'a self, args: NormalUseArgs<'a>) -> BlockFuture<'a, BlockActionResult> {
         Box::pin(async move {
+            if !args.player.abilities.lock().await.allow_modify_world {
+                return BlockActionResult::Pass;
+            }
+
             let state = args.world.get_block_state(args.position);
             let props = RepeaterProperties::from_state_id(state.id, args.block);
             self.on_use(props, args.world, *args.position, args.block)

--- a/pumpkin/src/block/blocks/redstone/sculk_sensor.rs
+++ b/pumpkin/src/block/blocks/redstone/sculk_sensor.rs
@@ -9,7 +9,7 @@ use pumpkin_data::block_properties::{
     BlockProperties, CalibratedSculkSensorLikeProperties, SculkSensorLikeProperties,
     SculkSensorPhase,
 };
-use pumpkin_data::{Block, BlockId, BlockStateId};
+use pumpkin_data::{Block, BlockId, BlockStateId, HorizontalFacingExt};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::tick::TickPriority;
 use pumpkin_world::world::BlockFlags;
@@ -46,7 +46,8 @@ impl SculkSensorBlock {
                     .set_block_state(pos, props.to_state_id(block), BlockFlags::NOTIFY_ALL)
                     .await;
                 world.update_neighbors(pos, None).await;
-                world.schedule_block_tick(block, *pos, 30, TickPriority::Normal);
+                // CalibratedSculkSensorBlock overrides getActiveTicks() to 10.
+                world.schedule_block_tick(block, *pos, 10, TickPriority::Normal);
             }
         }
     }
@@ -88,7 +89,9 @@ impl BlockBehaviour for SculkSensorBlock {
             } else if args.block.id == BlockId::CALIBRATED_SCULK_SENSOR {
                 let props =
                     CalibratedSculkSensorLikeProperties::from_state_id(args.state.id, args.block);
-                if props.sculk_sensor_phase == SculkSensorPhase::Active {
+                if props.sculk_sensor_phase == SculkSensorPhase::Active
+                    && args.direction != props.facing.to_block_direction()
+                {
                     props.power
                 } else {
                     0

--- a/pumpkin/src/block/blocks/signs.rs
+++ b/pumpkin/src/block/blocks/signs.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::Ordering;
 
 use crate::block::entities::hanging_sign::HangingSignBlockEntity;
 use crate::block::entities::sign::SignBlockEntity;
+use crate::command::CommandSender;
 use pumpkin_data::Block;
 use pumpkin_data::BlockDirection;
 use pumpkin_data::BlockId;
@@ -439,6 +440,43 @@ impl BlockBehaviour for SignBlock {
             let Some(sign_entity) = block_entity.as_any().downcast_ref::<SignBlockEntity>() else {
                 return BlockActionResult::Pass;
             };
+
+            // Vanilla executeClickCommandsIfPresent: run any RunCommand click event on the
+            // side of the sign the player is actually facing.
+            let mut executed_command = false;
+            if let Some(server) = args.world.server.upgrade() {
+                let is_facing_front =
+                    is_facing_front_text(args.world, args.position, args.block, args.player);
+                let text = if is_facing_front {
+                    &sign_entity.front_text
+                } else {
+                    &sign_entity.back_text
+                };
+                let lines = text.messages.lock().unwrap().clone();
+                for line in &lines {
+                    let Ok(component) =
+                        serde_json::from_str::<pumpkin_util::text::TextComponent>(line)
+                    else {
+                        continue;
+                    };
+                    let Some(pumpkin_util::text::click::ClickEvent::RunCommand { command }) =
+                        &component.0.style.click_event
+                    else {
+                        continue;
+                    };
+                    let source = CommandSender::Dummy.into_source(&server).await;
+                    server
+                        .command_dispatcher
+                        .read()
+                        .await
+                        .handle_command(&source, command)
+                        .await;
+                    executed_command = true;
+                }
+            }
+            if executed_command {
+                return BlockActionResult::SuccessServer;
+            }
 
             if sign_entity.is_waxed.load(Ordering::Relaxed) {
                 args.world.play_block_sound(

--- a/pumpkin/src/block/blocks/sponge.rs
+++ b/pumpkin/src/block/blocks/sponge.rs
@@ -4,10 +4,12 @@ use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 
 use crate::block::{BlockBehaviour, BlockFuture, OnNeighborUpdateArgs, PlacedArgs};
+use crate::item::items::bucket::{is_waterlogged, set_waterlogged};
 use pumpkin_data::dimension::Dimension;
 use pumpkin_data::particle::Particle;
 use pumpkin_data::sound::{Sound, SoundCategory};
-use pumpkin_data::{Block, BlockStateId};
+use pumpkin_data::tag::Taggable;
+use pumpkin_data::{Block, BlockStateId, tag};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::world::BlockFlags;
 
@@ -53,11 +55,13 @@ impl SpongeBlock {
                 }
 
                 visited.insert(next_pos);
-                let (block, _state) = world.get_block_and_state(&next_pos);
 
-                // Only add to queue if it's water.
-                // This prevents "jumping" through air or solid blocks.
-                if block.id == Block::WATER.id {
+                // Only add to queue if its fluid state is water. This also catches
+                // waterlogged blocks, unlike a direct block-id comparison.
+                if world
+                    .get_fluid(&next_pos)
+                    .has_tag(&tag::Fluid::MINECRAFT_WATER)
+                {
                     water_blocks.push(next_pos);
                     queue.push_back(next_pos);
                 }
@@ -68,8 +72,14 @@ impl SpongeBlock {
             false
         } else {
             for water_pos in &water_blocks {
+                let (block, state) = world.get_block_and_state_id(water_pos);
+                let new_state = if is_waterlogged(block, state) {
+                    set_waterlogged(block, state, false)
+                } else {
+                    BlockStateId::AIR
+                };
                 world
-                    .set_block_state(water_pos, BlockStateId::AIR, BlockFlags::NOTIFY_ALL)
+                    .set_block_state(water_pos, new_state, BlockFlags::NOTIFY_ALL)
                     .await;
             }
             world
@@ -97,10 +107,10 @@ impl BlockBehaviour for SpongeBlock {
 
     fn on_neighbor_update<'a>(&'a self, args: OnNeighborUpdateArgs<'a>) -> BlockFuture<'a, ()> {
         Box::pin(async move {
-            // If a neighboring block changed and it's water, attempt to absorb.
-            if args.source_block.id == Block::WATER.id {
-                Self::absorb_water(args.world, args.position).await;
-            }
+            // Vanilla's `neighborChanged` always retries the absorb BFS, since it's the
+            // traversal itself (now fluid-tag based) that determines whether there's
+            // water nearby, not the identity of whatever neighbor changed.
+            Self::absorb_water(args.world, args.position).await;
         })
     }
 }

--- a/pumpkin/src/block/blocks/stonecutter.rs
+++ b/pumpkin/src/block/blocks/stonecutter.rs
@@ -1,6 +1,8 @@
 use crate::block::registry::BlockActionResult;
-use crate::block::{BlockBehaviour, BlockFuture, NormalUseArgs};
+use crate::block::{BlockBehaviour, BlockFuture, NormalUseArgs, OnPlaceArgs};
 
+use pumpkin_data::BlockStateId;
+use pumpkin_data::block_properties::{BlockProperties, WallTorchLikeProperties};
 use pumpkin_data::translation;
 use pumpkin_inventory::player::player_inventory::PlayerInventory;
 use pumpkin_inventory::screen_handler::{
@@ -17,6 +19,19 @@ use pumpkin_inventory::stonecutter_screen_handler::StonecutterScreenHandler;
 pub struct StonecutterBlock;
 
 impl BlockBehaviour for StonecutterBlock {
+    fn on_place<'a>(&'a self, args: OnPlaceArgs<'a>) -> BlockFuture<'a, BlockStateId> {
+        Box::pin(async move {
+            let mut props = WallTorchLikeProperties::default(args.block);
+            props.facing = args
+                .player
+                .living_entity
+                .entity
+                .get_horizontal_facing()
+                .opposite();
+            props.to_state_id(args.block)
+        })
+    }
+
     fn normal_use<'a>(&'a self, args: NormalUseArgs<'a>) -> BlockFuture<'a, BlockActionResult> {
         Box::pin(async move {
             args.player

--- a/pumpkin/src/block/entities/bell.rs
+++ b/pumpkin/src/block/entities/bell.rs
@@ -3,11 +3,16 @@ use crate::world::World;
 use crossbeam::atomic::AtomicCell;
 use pumpkin_data::block_properties::HorizontalFacing;
 use pumpkin_data::sound::{Sound, SoundCategory};
+use pumpkin_data::tag;
+use pumpkin_data::tag::Taggable;
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::math::position::BlockPos;
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
+
+// BellBlockEntity.HEAR_BELL_RADIUS (BellBlockEntity.java).
+const HEAR_BELL_RADIUS: f64 = 32.0;
 
 pub struct BellBlockEntity {
     pub position: BlockPos,
@@ -39,10 +44,19 @@ impl BellBlockEntity {
             self.ringing.store(true);
         }
     }
-    pub const fn raiders_hear_bell(&self) -> bool {
-        //TODO
-
-        false
+    /// `BellBlockEntity.areRaidersNearby`: whether a living raider is within
+    /// `HEAR_BELL_RADIUS` of the bell.
+    pub fn raiders_hear_bell(&self, world: &World) -> bool {
+        world
+            .get_nearby_entities(self.position.to_centered_f64(), HEAR_BELL_RADIUS)
+            .values()
+            .any(|entity| {
+                entity.get_entity().is_alive()
+                    && entity
+                        .get_entity()
+                        .entity_type
+                        .has_tag(&tag::EntityType::MINECRAFT_RAIDERS)
+            })
     }
 }
 
@@ -72,7 +86,7 @@ impl BlockEntity for BellBlockEntity {
             }
             if self.ring_ticks.load() >= 5
                 && self.resonate_time.load() == 0
-                && self.raiders_hear_bell()
+                && self.raiders_hear_bell(world)
             {
                 self.resonating.store(true);
                 world.play_sound_fine(

--- a/pumpkin/src/item/items/bucket.rs
+++ b/pumpkin/src/item/items/bucket.rs
@@ -68,7 +68,7 @@ fn get_start_and_end_pos(player: &Player) -> (Vector3<f64>, Vector3<f64>) {
     (start_pos, end_pos)
 }
 
-fn waterlogged_check(block: &Block, state: BlockStateId) -> Option<bool> {
+pub(crate) fn waterlogged_check(block: &Block, state: BlockStateId) -> Option<bool> {
     block.properties(state).and_then(|properties| {
         properties
             .to_props()
@@ -78,11 +78,15 @@ fn waterlogged_check(block: &Block, state: BlockStateId) -> Option<bool> {
     })
 }
 
-fn is_waterlogged(block: &Block, state: BlockStateId) -> bool {
+pub(crate) fn is_waterlogged(block: &Block, state: BlockStateId) -> bool {
     waterlogged_check(block, state).unwrap_or(false)
 }
 
-fn set_waterlogged(block: &Block, state: BlockStateId, waterlogged: bool) -> BlockStateId {
+pub(crate) fn set_waterlogged(
+    block: &Block,
+    state: BlockStateId,
+    waterlogged: bool,
+) -> BlockStateId {
     let original_props = &block.properties(state).unwrap().to_props();
     let waterlogged = waterlogged.to_string();
     let props: Vec<(&str, &str)> = original_props


### PR DESCRIPTION
Eleven independent block behaviour fixes, each checked against the decompiled 26.2
source named in its commit message. Grouped only because they are all single-block
behaviour corrections; happy to split further if maintainers prefer.

- Sea pickle: the bonemeal spread loop ran one z-iteration per x-iteration instead of
  vanilla's diamond-shaped z-span progression (1, 3, 5, 3, 1 across the five
  x-iterations), so bonemealing only ever seeded a thin line of candidates instead of an
  area.
- Lily pad: `on_entity_collision` matched entity types by resource-name suffix
  `_boat`, missing `bamboo_raft`/`bamboo_chest_raft` since vanilla's `AbstractBoat`
  covers rafts too. Switched to the `c:boats` entity tag, which lists all boat and raft
  variants.
- Weighted pressure plate: `calculate_redstone_output` divided the entity count by
  `maxWeight` as integers before casting to `f32`, so any partial load below the full
  weight truncated to 0 instead of a graded signal, unlike vanilla's
  `Mth.ceil((float)Math.min(maxWeight,count)/maxWeight * 15.0F)`.
- Repeater: `normal_use` cycled the delay unconditionally; vanilla's `useWithoutItem`
  only does this when the player's abilities allow modifying the world, returning PASS
  otherwise.
- Sponge: `absorb_water`/`on_neighbor_update` compared `block.id` against `Block::WATER`
  directly, so the breadth-first search never matched waterlogged blocks (fences, slabs,
  etc.) or picked up their water, unlike vanilla's `SpongeBlock` which checks the fluid
  state via `FluidTags.WATER`. Switches the traversal to the water fluid tag; draining a
  waterlogged block now clears its waterlogged property instead of replacing the block
  with air. Kelp/seagrass/tall_seagrass removal during this BFS is a known separate gap,
  not folded into this fix.
- Bell: `BellBlock.java` plays the ring sound at volume 2.0, pitch 1.0 -- these were
  swapped. `raiders_hear_bell` was also a hardcoded `false` stub; implemented against the
  existing raid/entity-tag infrastructure (`areRaidersNearby` checks for a living entity
  tagged `minecraft:raiders` within the 32-block `HEAR_BELL_RADIUS`).
- Stonecutter: never overrode `on_place`, so it always faced north regardless of the
  placing player. Vanilla's `getStateForPlacement` sets `FACING` to the opposite of the
  player's horizontal direction.
- Copper bulb: comparator output (15 when lit, 0 otherwise) was entirely missing.
- Farmland: `can_place_at` checked `c:fence_gates` instead of vanilla's
  `minecraft:maintains_farmland` tag (`FarmlandBlock.shouldMaintainFarmland`), which also
  covers crops, torchflower, pitcher_crop, wheat and moving_piston. The generated tag
  already exists in `pumpkin-data` with the correct contents, so this is a direct swap.
- Calibrated sculk sensor: `getSignal` excludes the sensor's own `FACING` direction from
  its weak redstone power, and its active-ticks delay is 10 rather than the shared 30
  used by the plain sculk sensor. Neither was ported.
- Sign: `normal_use` ran any `RunCommand` click event found on either `front_text` or
  `back_text` unconditionally. Vanilla's `useWithoutItem` computes `isFrontText` once and
  only executes click-commands attached to that side.

Deliberately absent from this branch: sapling growth light-gating, campfire cooking
decay, mob spawner offset/range/NBT fixes, target block power-reset-on-placement, and
calibrated sculk sensor's `last_vibration_frequency` bookkeeping. Each depends on
infrastructure from a separate, unrelated commit not included here; folding them in
would violate one-fix-per-PR, so they're left for a follow-up once their prerequisite
lands.

## Test plan
- [x] `cargo fmt --all`
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace --lib` passing