### PR TITLE
fix(block): wire real rotate/mirror overrides for redstone wire, stairs, and structure placement

### DIFF
--- a/pumpkin-world/src/generation/structure/template/template_piece.rs
+++ b/pumpkin-world/src/generation/structure/template/template_piece.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use pumpkin_data::{Mirror, Rotation};
+use pumpkin_data::{Block, Mirror, Rotation};
 use pumpkin_util::{
     math::{block_box::BlockBox, vector3::Vector3},
     random::RandomGenerator,
@@ -120,7 +120,12 @@ impl TemplatePiece {
     }
 
     /// Places all blocks from the template into the chunk.
-    fn place_blocks(&self, chunk: &mut ProtoChunk, chunk_box: &BlockBox) {
+    fn place_blocks(
+        &self,
+        chunk: &mut ProtoChunk,
+        block_registry: &dyn WorldPortalExt,
+        chunk_box: &BlockBox,
+    ) {
         let box_limit = self.piece.bounding_box;
 
         for block in &self.template.blocks {
@@ -131,13 +136,22 @@ impl TemplatePiece {
                 continue;
             }
 
-            // Resolve the block state with rotation/mirror
-            let Some(state) =
-                BlockStateResolver::resolve(palette_entry, self.rotation, self.mirror)
-            else {
+            // Resolve the untransformed block state, then apply rotation/mirror through the
+            // block registry so per-block BlockBehaviour overrides (e.g. redstone wire, stairs)
+            // run the same transform as every other placement path.
+            let Some(base_state) = BlockStateResolver::resolve_simple(palette_entry) else {
                 debug!("Failed to resolve block: {}", palette_entry.name);
                 continue;
             };
+
+            let resolved_block = Block::from_state_id(base_state.id);
+            let mut state = base_state;
+            if self.mirror != Mirror::None {
+                state = block_registry.mirror(resolved_block, state.id, self.mirror);
+            }
+            if self.rotation != Rotation::None {
+                state = block_registry.rotate(resolved_block, state.id, self.rotation);
+            }
 
             // Transform position to world coordinates
             let world_pos = self.transform_pos(block.pos);
@@ -198,12 +212,12 @@ impl StructurePieceBase for TemplatePiece {
     fn place(
         &mut self,
         chunk: &mut ProtoChunk,
-        _block_registry: &dyn WorldPortalExt,
+        block_registry: &dyn WorldPortalExt,
         _random: &mut RandomGenerator,
         _seed: i64,
         chunk_box: &BlockBox,
     ) {
-        self.place_blocks(chunk, chunk_box);
+        self.place_blocks(chunk, block_registry, chunk_box);
     }
 
     fn get_structure_piece(&self) -> &StructurePiece {

--- a/pumpkin/src/block/blocks/redstone/redstone_wire.rs
+++ b/pumpkin/src/block/blocks/redstone/redstone_wire.rs
@@ -5,7 +5,7 @@ use pumpkin_data::block_properties::{
     BlockProperties, EastRedstone, HorizontalFacing, NorthRedstone, ObserverLikeProperties,
     RedstoneWireLikeProperties, RepeaterLikeProperties, SouthRedstone, WestRedstone,
 };
-use pumpkin_data::{Block, BlockDirection, BlockState, HorizontalFacingExt};
+use pumpkin_data::{Block, BlockDirection, BlockState, HorizontalFacingExt, Mirror, Rotation};
 use pumpkin_macros::pumpkin_block;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::world::{BlockAccessor, BlockFlags};
@@ -235,6 +235,68 @@ impl BlockBehaviour for RedstoneWireBlock {
         Box::pin(async move {
             update_wire_neighbors(args.world, args.position).await;
         })
+    }
+
+    fn mirror(&self, block: &Block, state_id: BlockStateId, mirror: Mirror) -> &'static BlockState {
+        let wire = RedstoneWireProperties::from_state_id(state_id, block);
+        BlockState::from_id(mirror_wire(wire, mirror).to_state_id(block))
+    }
+
+    fn rotate(
+        &self,
+        block: &Block,
+        state_id: BlockStateId,
+        rotation: Rotation,
+    ) -> &'static BlockState {
+        let wire = RedstoneWireProperties::from_state_id(state_id, block);
+        BlockState::from_id(rotate_wire(wire, rotation).to_state_id(block))
+    }
+}
+
+/// Permutes the four connection sides for a mirror transform. The `RedstoneSide` value at
+/// each direction is untouched, only which direction key holds which value changes.
+fn mirror_wire(wire: RedstoneWireProperties, mirror: Mirror) -> RedstoneWireProperties {
+    match mirror {
+        Mirror::LeftRight => RedstoneWireProperties {
+            north: wire.south.to_wire_connection().to_north(),
+            south: wire.north.to_wire_connection().to_south(),
+            ..wire
+        },
+        Mirror::FrontBack => RedstoneWireProperties {
+            east: wire.west.to_wire_connection().to_east(),
+            west: wire.east.to_wire_connection().to_west(),
+            ..wire
+        },
+        Mirror::None => wire,
+    }
+}
+
+/// Permutes the four connection sides for a rotation transform, matching vanilla
+/// `RedStoneWireBlock.rotate`.
+fn rotate_wire(wire: RedstoneWireProperties, rotation: Rotation) -> RedstoneWireProperties {
+    match rotation {
+        Rotation::Clockwise90 => RedstoneWireProperties {
+            north: wire.west.to_wire_connection().to_north(),
+            east: wire.north.to_wire_connection().to_east(),
+            south: wire.east.to_wire_connection().to_south(),
+            west: wire.south.to_wire_connection().to_west(),
+            power: wire.power,
+        },
+        Rotation::Rotate180 => RedstoneWireProperties {
+            north: wire.south.to_wire_connection().to_north(),
+            east: wire.west.to_wire_connection().to_east(),
+            south: wire.north.to_wire_connection().to_south(),
+            west: wire.east.to_wire_connection().to_west(),
+            power: wire.power,
+        },
+        Rotation::CounterClockwise90 => RedstoneWireProperties {
+            north: wire.east.to_wire_connection().to_north(),
+            east: wire.south.to_wire_connection().to_east(),
+            south: wire.west.to_wire_connection().to_south(),
+            west: wire.north.to_wire_connection().to_west(),
+            power: wire.power,
+        },
+        Rotation::None => wire,
     }
 }
 
@@ -560,4 +622,160 @@ async fn calculate_power(world: &World, pos: &BlockPos) -> u8 {
     }
 
     block_power.max(wire_power.saturating_sub(1))
+}
+
+#[cfg(test)]
+mod rotate_mirror_tests {
+    use super::*;
+
+    const fn wire(
+        north: NorthRedstone,
+        south: SouthRedstone,
+        east: EastRedstone,
+        west: WestRedstone,
+    ) -> RedstoneWireProperties {
+        RedstoneWireProperties {
+            north,
+            south,
+            east,
+            west,
+            power: 0,
+        }
+    }
+
+    #[test]
+    fn rotate_none_is_identity() {
+        let w = wire(
+            NorthRedstone::Side,
+            SouthRedstone::None,
+            EastRedstone::Up,
+            WestRedstone::None,
+        );
+        assert_eq!(rotate_wire(w, Rotation::None), w);
+    }
+
+    #[test]
+    fn rotate_clockwise_90_permutes_sides() {
+        let w = wire(
+            NorthRedstone::Side,
+            SouthRedstone::None,
+            EastRedstone::Up,
+            WestRedstone::None,
+        );
+        let rotated = rotate_wire(w, Rotation::Clockwise90);
+        assert_eq!(
+            rotated.north,
+            WestRedstone::None.to_wire_connection().to_north()
+        );
+        assert_eq!(
+            rotated.east,
+            NorthRedstone::Side.to_wire_connection().to_east()
+        );
+        assert_eq!(
+            rotated.south,
+            EastRedstone::Up.to_wire_connection().to_south()
+        );
+        assert_eq!(
+            rotated.west,
+            SouthRedstone::None.to_wire_connection().to_west()
+        );
+    }
+
+    #[test]
+    fn rotate_counter_clockwise_90_is_inverse_of_clockwise_90() {
+        let w = wire(
+            NorthRedstone::Side,
+            SouthRedstone::Up,
+            EastRedstone::None,
+            WestRedstone::Side,
+        );
+        let round_tripped = rotate_wire(
+            rotate_wire(w, Rotation::Clockwise90),
+            Rotation::CounterClockwise90,
+        );
+        assert_eq!(round_tripped, w);
+    }
+
+    #[test]
+    fn rotate_180_twice_is_identity() {
+        let w = wire(
+            NorthRedstone::Side,
+            SouthRedstone::Up,
+            EastRedstone::None,
+            WestRedstone::Side,
+        );
+        let twice = rotate_wire(rotate_wire(w, Rotation::Rotate180), Rotation::Rotate180);
+        assert_eq!(twice, w);
+    }
+
+    #[test]
+    fn mirror_none_is_identity() {
+        let w = wire(
+            NorthRedstone::Side,
+            SouthRedstone::None,
+            EastRedstone::Up,
+            WestRedstone::None,
+        );
+        assert_eq!(mirror_wire(w, Mirror::None), w);
+    }
+
+    #[test]
+    fn mirror_left_right_swaps_north_south_only() {
+        let w = wire(
+            NorthRedstone::Side,
+            SouthRedstone::None,
+            EastRedstone::Up,
+            WestRedstone::None,
+        );
+        let mirrored = mirror_wire(w, Mirror::LeftRight);
+        assert_eq!(
+            mirrored.north,
+            SouthRedstone::None.to_wire_connection().to_north()
+        );
+        assert_eq!(
+            mirrored.south,
+            NorthRedstone::Side.to_wire_connection().to_south()
+        );
+        assert_eq!(mirrored.east, w.east);
+        assert_eq!(mirrored.west, w.west);
+    }
+
+    #[test]
+    fn mirror_front_back_swaps_east_west_only() {
+        let w = wire(
+            NorthRedstone::Side,
+            SouthRedstone::None,
+            EastRedstone::Up,
+            WestRedstone::None,
+        );
+        let mirrored = mirror_wire(w, Mirror::FrontBack);
+        assert_eq!(
+            mirrored.east,
+            WestRedstone::None.to_wire_connection().to_east()
+        );
+        assert_eq!(
+            mirrored.west,
+            EastRedstone::Up.to_wire_connection().to_west()
+        );
+        assert_eq!(mirrored.north, w.north);
+        assert_eq!(mirrored.south, w.south);
+    }
+
+    #[test]
+    fn mirror_applied_twice_is_identity() {
+        let w = wire(
+            NorthRedstone::Side,
+            SouthRedstone::Up,
+            EastRedstone::None,
+            WestRedstone::Side,
+        );
+        assert_eq!(
+            mirror_wire(mirror_wire(w, Mirror::LeftRight), Mirror::LeftRight),
+            w
+        );
+        assert_eq!(
+            mirror_wire(mirror_wire(w, Mirror::FrontBack), Mirror::FrontBack),
+            w
+        );
+    }
 }

--- a/pumpkin/src/block/blocks/stairs.rs
+++ b/pumpkin/src/block/blocks/stairs.rs
@@ -3,7 +3,6 @@ use pumpkin_data::BlockStateId;
 use pumpkin_data::block_properties::BlockProperties;
 use pumpkin_data::block_properties::Half;
 use pumpkin_data::block_properties::HorizontalAxis;
-use pumpkin_data::block_properties::HorizontalAxis;
 use pumpkin_data::block_properties::HorizontalFacing;
 use pumpkin_data::block_properties::StairsShape;
 use pumpkin_data::tag::Taggable;

--- a/pumpkin/src/block/blocks/stairs.rs
+++ b/pumpkin/src/block/blocks/stairs.rs
@@ -2,10 +2,12 @@ use crate::entity::EntityBase;
 use pumpkin_data::BlockStateId;
 use pumpkin_data::block_properties::BlockProperties;
 use pumpkin_data::block_properties::Half;
+use pumpkin_data::block_properties::HorizontalAxis;
+use pumpkin_data::block_properties::HorizontalAxis;
 use pumpkin_data::block_properties::HorizontalFacing;
 use pumpkin_data::block_properties::StairsShape;
 use pumpkin_data::tag::Taggable;
-use pumpkin_data::{BlockDirection, tag};
+use pumpkin_data::{Block, BlockDirection, BlockState, Mirror, Rotation, tag};
 use pumpkin_macros::pumpkin_block_from_tag;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::world::BlockFlags;
@@ -75,6 +77,69 @@ impl BlockBehaviour for StairBlock {
             }
         })
     }
+
+    fn mirror(&self, block: &Block, state_id: BlockStateId, mirror: Mirror) -> &'static BlockState {
+        let stair = StairsProperties::from_state_id(state_id, block);
+        BlockState::from_id(mirror_stairs(stair, mirror).to_state_id(block))
+    }
+
+    fn rotate(
+        &self,
+        block: &Block,
+        state_id: BlockStateId,
+        rotation: Rotation,
+    ) -> &'static BlockState {
+        let stair = StairsProperties::from_state_id(state_id, block);
+        BlockState::from_id(rotate_stairs(stair, rotation).to_state_id(block))
+    }
+}
+
+const fn rotate_facing(facing: HorizontalFacing, rotation: Rotation) -> HorizontalFacing {
+    match rotation {
+        Rotation::None => facing,
+        Rotation::Clockwise90 => facing.rotate_clockwise(),
+        Rotation::Rotate180 => facing.opposite(),
+        Rotation::CounterClockwise90 => facing.rotate_counter_clockwise(),
+    }
+}
+
+/// Matches vanilla `StairBlock.rotate`: only the facing changes, the shape is untouched.
+const fn rotate_stairs(mut stair: StairsProperties, rotation: Rotation) -> StairsProperties {
+    stair.facing = rotate_facing(stair.facing, rotation);
+    stair
+}
+
+/// Matches vanilla `StairBlock.mirror`. A mirror only has an effect when the facing's axis
+/// lines up with the mirror axis (`LEFT_RIGHT` mirrors Z-axis facings, `FRONT_BACK` mirrors
+/// X-axis facings) - otherwise it falls through to the block-behaviour default (identity).
+/// When it does apply, the facing is rotated 180 degrees and the inner/outer shape is
+/// swapped left<->right, except that `FRONT_BACK` leaves `INNER_LEFT`/`INNER_RIGHT`/
+/// `STRAIGHT` unchanged - this asymmetry with `LEFT_RIGHT` is intentional, straight from
+/// vanilla source, not a transcription error.
+fn mirror_stairs(mut stair: StairsProperties, mirror: Mirror) -> StairsProperties {
+    match mirror {
+        Mirror::LeftRight if stair.facing.to_axis() == HorizontalAxis::Z => {
+            stair.facing = rotate_facing(stair.facing, Rotation::Rotate180);
+            stair.shape = match stair.shape {
+                StairsShape::OuterLeft => StairsShape::OuterRight,
+                StairsShape::OuterRight => StairsShape::OuterLeft,
+                StairsShape::InnerLeft => StairsShape::InnerRight,
+                StairsShape::InnerRight => StairsShape::InnerLeft,
+                StairsShape::Straight => StairsShape::Straight,
+            };
+            stair
+        }
+        Mirror::FrontBack if stair.facing.to_axis() == HorizontalAxis::X => {
+            stair.facing = rotate_facing(stair.facing, Rotation::Rotate180);
+            stair.shape = match stair.shape {
+                StairsShape::OuterLeft => StairsShape::OuterRight,
+                StairsShape::OuterRight => StairsShape::OuterLeft,
+                other => other,
+            };
+            stair
+        }
+        _ => stair,
+    }
 }
 
 fn compute_stair_shape(
@@ -133,4 +198,133 @@ fn get_stair_properties_if_exists(world: &World, block_pos: &BlockPos) -> Option
     block
         .has_tag(&tag::Block::MINECRAFT_STAIRS)
         .then(|| StairsProperties::from_state_id(block_state, block))
+}
+
+#[cfg(test)]
+mod rotate_mirror_tests {
+    use super::*;
+
+    const fn stair(facing: HorizontalFacing, shape: StairsShape) -> StairsProperties {
+        StairsProperties {
+            facing,
+            half: Half::Bottom,
+            shape,
+            waterlogged: false,
+        }
+    }
+
+    #[test]
+    fn rotate_none_is_identity() {
+        let s = stair(HorizontalFacing::North, StairsShape::OuterLeft);
+        assert_eq!(rotate_stairs(s, Rotation::None), s);
+    }
+
+    #[test]
+    fn rotate_only_changes_facing_never_shape() {
+        for shape in [
+            StairsShape::Straight,
+            StairsShape::InnerLeft,
+            StairsShape::InnerRight,
+            StairsShape::OuterLeft,
+            StairsShape::OuterRight,
+        ] {
+            let s = stair(HorizontalFacing::North, shape);
+            for rotation in [
+                Rotation::Clockwise90,
+                Rotation::Rotate180,
+                Rotation::CounterClockwise90,
+            ] {
+                assert_eq!(rotate_stairs(s, rotation).shape, shape);
+            }
+        }
+    }
+
+    #[test]
+    fn rotate_clockwise_90_cycles_facing() {
+        assert_eq!(
+            rotate_facing(HorizontalFacing::North, Rotation::Clockwise90),
+            HorizontalFacing::East
+        );
+        assert_eq!(
+            rotate_facing(HorizontalFacing::East, Rotation::Clockwise90),
+            HorizontalFacing::South
+        );
+        assert_eq!(
+            rotate_facing(HorizontalFacing::South, Rotation::Clockwise90),
+            HorizontalFacing::West
+        );
+        assert_eq!(
+            rotate_facing(HorizontalFacing::West, Rotation::Clockwise90),
+            HorizontalFacing::North
+        );
+    }
+
+    #[test]
+    fn rotate_180_is_opposite_facing() {
+        assert_eq!(
+            rotate_facing(HorizontalFacing::North, Rotation::Rotate180),
+            HorizontalFacing::South
+        );
+        assert_eq!(
+            rotate_facing(HorizontalFacing::East, Rotation::Rotate180),
+            HorizontalFacing::West
+        );
+    }
+
+    #[test]
+    fn mirror_left_right_applies_when_facing_axis_is_z() {
+        // facing north/south -> axis Z, LEFT_RIGHT applies: 180 facing + shape swap
+        let s = stair(HorizontalFacing::North, StairsShape::OuterLeft);
+        let mirrored = mirror_stairs(s, Mirror::LeftRight);
+        assert_eq!(mirrored.facing, HorizontalFacing::South);
+        assert_eq!(mirrored.shape, StairsShape::OuterRight);
+
+        let s = stair(HorizontalFacing::South, StairsShape::InnerRight);
+        let mirrored = mirror_stairs(s, Mirror::LeftRight);
+        assert_eq!(mirrored.facing, HorizontalFacing::North);
+        assert_eq!(mirrored.shape, StairsShape::InnerLeft);
+    }
+
+    #[test]
+    fn mirror_left_right_is_noop_when_facing_axis_is_x() {
+        // facing east/west -> axis X, LEFT_RIGHT does not apply (falls to identity default)
+        let s = stair(HorizontalFacing::East, StairsShape::OuterLeft);
+        assert_eq!(mirror_stairs(s, Mirror::LeftRight), s);
+    }
+
+    #[test]
+    fn mirror_front_back_applies_when_facing_axis_is_x() {
+        let s = stair(HorizontalFacing::East, StairsShape::OuterLeft);
+        let mirrored = mirror_stairs(s, Mirror::FrontBack);
+        assert_eq!(mirrored.facing, HorizontalFacing::West);
+        assert_eq!(mirrored.shape, StairsShape::OuterRight);
+    }
+
+    #[test]
+    fn mirror_front_back_leaves_inner_shapes_and_straight_unchanged() {
+        // This is the vanilla asymmetry: FRONT_BACK swaps outer left/right but does NOT
+        // swap inner left/right or touch straight, unlike LEFT_RIGHT.
+        for shape in [
+            StairsShape::Straight,
+            StairsShape::InnerLeft,
+            StairsShape::InnerRight,
+        ] {
+            let s = stair(HorizontalFacing::West, shape);
+            let mirrored = mirror_stairs(s, Mirror::FrontBack);
+            assert_eq!(mirrored.shape, shape);
+            assert_eq!(mirrored.facing, HorizontalFacing::East);
+        }
+    }
+
+    #[test]
+    fn mirror_front_back_is_noop_when_facing_axis_is_z() {
+        let s = stair(HorizontalFacing::North, StairsShape::InnerLeft);
+        assert_eq!(mirror_stairs(s, Mirror::FrontBack), s);
+    }
+
+    #[test]
+    fn mirror_none_is_identity() {
+        let s = stair(HorizontalFacing::North, StairsShape::OuterRight);
+        assert_eq!(mirror_stairs(s, Mirror::None), s);
+    }
 }


### PR DESCRIPTION
Three commits, one seam: two blocks had no `BlockBehaviour::rotate`/`mirror` override at
all (silently falling through to the no-op identity transform), and the worldgen
structure-piece placer had the plumbing to call per-block overrides but discarded it.

- Redstone wire: no rotate/mirror override existed. Added overrides matching vanilla
  `RedStoneWireBlock`: a four-way permutation of which connection-key
  (north/south/east/west) holds which `RedstoneSide` value; the `RedstoneSide` values
  themselves are never touched. Permutation logic factored into pure functions
  (`rotate_wire`, `mirror_wire`) for unit testing without block-state-table lookups.
- Stairs: same gap. Added overrides matching vanilla `StairBlock`: rotate only changes
  `FACING`, shape is untouched; mirror only has an effect when the facing's axis lines up
  with the mirror axis (`LEFT_RIGHT` mirrors Z-axis facings, `FRONT_BACK` mirrors X-axis
  facings), and when it applies, `FACING` rotates 180 degrees and the inner/outer shape
  swaps left<->right -- except `FRONT_BACK` leaves `INNER_LEFT`/`INNER_RIGHT`/`STRAIGHT`
  unchanged, an intentional asymmetry with `LEFT_RIGHT` straight from vanilla source.
- Worldgen template placer: `TemplatePiece::place_blocks` resolved every palette entry
  through `BlockStateResolver`'s string-keyed property transform, which only handles a
  handful of hardcoded property names and never runs per-block `BlockBehaviour`
  overrides. The generic `StructurePiece::place_block` helper already does this
  correctly, but the `block_registry` parameter needed for it was threaded down to
  `TemplatePiece::place` and then discarded (named `_block_registry`, unused). Wires it
  through `place_blocks` and applies mirror then rotate via the registry, matching the
  hand-coded placer, so per-block overrides (including the two above) actually run during
  structure generation.

## Test plan
- [x] `cargo fmt --all`
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace --lib` passing (new unit tests for rotate_wire/mirror_wire
      and stair rotate/mirror; existing mansion-generation golden tests unaffected)