### PR TITLE
feat(mob): add generic item-pickup framework to the Mob trait

### DIFF
--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -115,6 +115,11 @@ impl ItemEntity {
         &self.entity
     }
 
+    /// Vanilla `ItemEntity.hasPickUpDelay`.
+    pub fn has_pickup_delay(&self) -> bool {
+        self.pickup_delay.load(Ordering::Relaxed) > 0
+    }
+
     async fn can_merge(&self) -> bool {
         if self.never_pickup.load(Ordering::Relaxed) || self.entity.removed.load(Ordering::Relaxed)
         {

--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -550,6 +550,64 @@ pub trait Mob: EntityBase + Send + Sync {
         0
     }
 
+    /// Vanilla `Mob.aiStep`'s pickup-loot loop: scans nearby dropped items within pickup
+    /// reach and offers each one to `on_item_pickup` if it passes `wants_to_pick_up_item`
+    /// and the item entity's own pickup-delay gate. Gated on `can_pick_up_loot` and the
+    /// `mobGriefing` gamerule.
+    fn mob_try_pick_up_items(&self) -> EntityBaseFuture<'_, ()> {
+        Box::pin(async move {
+            if !self.can_pick_up_loot() {
+                return;
+            }
+
+            let mob_entity = self.get_mob_entity();
+            let entity = &mob_entity.living_entity.entity;
+            if !entity.is_alive() {
+                return;
+            }
+
+            let world = entity.world.load();
+            if !world.level_info.load().game_rules.mob_griefing {
+                return;
+            }
+
+            let reach = entity.bounding_box.load().expand(1.0, 0.0, 1.0);
+            for candidate in world.get_entities_at_box(&reach) {
+                let Some(item_entity) = candidate.clone().get_item_entity() else {
+                    continue;
+                };
+
+                if !item_entity.get_entity().is_alive() || item_entity.has_pickup_delay() {
+                    continue;
+                }
+
+                let stack_snapshot = { item_entity.get_item_stack().lock().await.clone() };
+                if stack_snapshot.is_empty() || !self.wants_to_pick_up_item(&stack_snapshot) {
+                    continue;
+                }
+
+                let taken = self
+                    .on_item_pickup(&stack_snapshot)
+                    .min(stack_snapshot.item_count);
+                if taken == 0 {
+                    continue;
+                }
+
+                let is_empty = {
+                    let mut stack = item_entity.get_item_stack().lock().await;
+                    stack.decrement(taken);
+                    stack.is_empty()
+                };
+
+                if is_empty {
+                    item_entity.get_entity().remove().await;
+                } else {
+                    item_entity.init_data_tracker().await;
+                }
+            }
+        })
+    }
+
     fn get_owner_uuid(&self) -> Option<Uuid> {
         None
     }
@@ -639,6 +697,7 @@ impl<T: Mob + Send + 'static> EntityBase for T {
             }
 
             self.mob_tick(caller).await;
+            self.mob_try_pick_up_items().await;
 
             let age = mob_entity.living_entity.entity.age.load(Relaxed);
             let entity_id = mob_entity.living_entity.entity.entity_id;

--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -528,6 +528,28 @@ pub trait Mob: EntityBase + Send + Sync {
         Box::pin(async {})
     }
 
+    /// Vanilla `Mob.wantsToPickUp` default: delegates to `canHoldItem`, which defaults to
+    /// `true`. Whether picking up is ever attempted at all is gated separately by
+    /// `can_pick_up_loot`.
+    fn wants_to_pick_up_item(&self, _stack: &ItemStack) -> bool {
+        true
+    }
+
+    /// Vanilla `Mob.canPickUpLoot`: whether this mob is allowed to pick up dropped items at
+    /// all. Backed by the mob's `CanPickUpLoot` tracked-data flag, which defaults to `false`
+    /// and is set at spawn time for a few mob types (see `equipment.rs`).
+    fn can_pick_up_loot(&self) -> bool {
+        self.get_mob_entity().can_pick_up_loot()
+    }
+
+    /// Vanilla `Mob.onItemPickup`/`equipItemIfPossible`: called once a candidate item stack
+    /// has passed `wants_to_pick_up_item`, to actually take it. Returns the number of items
+    /// taken from the stack; the caller only shrinks/removes the `ItemEntity` by that count.
+    /// Default takes nothing, so no `ItemEntity` is ever touched unless a mob overrides this.
+    fn on_item_pickup(&self, _stack: &ItemStack) -> u8 {
+        0
+    }
+
     fn get_owner_uuid(&self) -> Option<Uuid> {
         None
     }


### PR DESCRIPTION
Groundwork for mob item pickup, mirroring vanilla `Mob.wantsToPickUp` /
`Mob.canPickUpLoot` / `Mob.onItemPickup` / `Mob.aiStep`'s pickup-loot loop. Two commits,
landed together since the second is unusable without the first:

- Adds `wants_to_pick_up_item`, `can_pick_up_loot`, and `on_item_pickup` to the `Mob`
  trait. `can_pick_up_loot` delegates to the existing per-instance `CanPickUpLoot` flag
  (already populated at spawn for some mob types in `equipment.rs`, but currently unread
  anywhere). `on_item_pickup` returns the count actually taken so callers only mutate an
  `ItemEntity` when a mob overrides it.
- Wires the generic scan: each tick, if `can_pick_up_loot()` and the `mobGriefing`
  gamerule are both true, scan `ItemEntity`s within pickup reach (bounding box expanded 1
  block horizontally, matching vanilla's `Vec3i(1, 0, 1)`), skip any still on their pickup
  delay, and offer eligible stacks to `on_item_pickup`. Only shrinks or removes the
  `ItemEntity` when the mob actually takes a nonzero count. Adds
  `ItemEntity::has_pickup_delay`, a thin public getter mirroring
  `ItemEntity.hasPickUpDelay`, so the scan doesn't need private field access.

No mob currently overrides `wants_to_pick_up_item` or `on_item_pickup`, so this is a
no-op for every mob today -- including zombie/husk/zombie_villager/drowned/skeleton/
stray/bogged, which already roll `CanPickUpLoot=true` at spawn per `equipment.rs`.
Whichever follow-up adds the first real `on_item_pickup` override will also be the first
to make those mobs actually pick things up. Flagging this explicitly since the diff has
no observable gameplay effect on its own -- it's infrastructure, not a fix.

## Test plan
- [x] `cargo fmt --all`
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace --lib` passing