### PR TITLE
fix(protocol): accept BungeeCord-forwarded handshake addresses

### DIFF
--- a/pumpkin-protocol/src/java/server/handshake/mod.rs
+++ b/pumpkin-protocol/src/java/server/handshake/mod.rs
@@ -26,7 +26,12 @@ impl<'a> ServerPacket<'a> for SHandShake {
     fn read(read: &mut &'a [u8], _version: &JavaMinecraftVersion) -> Result<Self, ReadingError> {
         Ok(Self {
             protocol_version: read.get_var_int()?,
-            server_address: read.get_str_bounded(255)?,
+            // A vanilla client never sends more than 255 characters here, but
+            // `BungeeCord`-style IP forwarding appends the client's IP, its UUID
+            // and its signed profile properties to this field, which easily
+            // exceeds that. Read it with the same bound `write_string` already
+            // writes it with, as Spigot does.
+            server_address: read.get_str_bounded(i16::MAX as usize)?,
             server_port: read.get_u16_be()?,
             next_state: read
                 .get_var_int()?
@@ -47,5 +52,73 @@ impl ClientPacket for SHandShake {
         write.write_u16_be(self.server_port)?;
         write.write_var_int(&VarInt(self.next_state as i32))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encodes the body of a handshake packet, as a client or a proxy sends it.
+    fn encode_handshake(server_address: &str, next_state: i32) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let protocol_version = JavaMinecraftVersion::V_1_21_11.protocol_version();
+        buf.write_var_int(&VarInt(protocol_version))
+            .expect("write protocol version");
+        // Bound by the input itself so that this helper can also build the
+        // oversized address used by `rejects_oversized_server_address`.
+        buf.write_string_bounded(server_address, server_address.len())
+            .expect("write server address");
+        buf.write_u16_be(25565).expect("write server port");
+        buf.write_var_int(&VarInt(next_state))
+            .expect("write next state");
+        buf
+    }
+
+    /// The address `BungeeCord` sends downstream when `ip_forward` is enabled:
+    /// the host, the client's IP, its UUID and the signed profile properties,
+    /// separated by NUL bytes. `bungeecord_login` in the `pumpkin` crate splits
+    /// this exact value back into those four parts.
+    fn bungeecord_forwarded_address() -> String {
+        let textures = "e".repeat(432);
+        let signature = "s".repeat(684);
+        format!(
+            "mc.example.com\0192.0.2.10\0d8f4a1e0-0f1b-4c3a-9f2e-1a2b3c4d5e6f\0\
+             [{{\"name\":\"textures\",\"value\":\"{textures}\",\"signature\":\"{signature}\"}}]"
+        )
+    }
+
+    #[test]
+    fn reads_bungeecord_forwarded_server_address() {
+        let address = bungeecord_forwarded_address();
+        let buf = encode_handshake(&address, 2);
+
+        let packet = SHandShake::read(&mut &buf[..], &JavaMinecraftVersion::V_1_21_11)
+            .expect("a BungeeCord-forwarded address should be readable");
+
+        assert_eq!(&*packet.server_address, address.as_str());
+        assert_eq!(packet.server_address.split('\0').count(), 4);
+        assert_eq!(packet.next_state, ConnectionState::Login);
+    }
+
+    #[test]
+    fn reads_plain_server_address() {
+        let buf = encode_handshake("localhost", 1);
+
+        let packet = SHandShake::read(&mut &buf[..], &JavaMinecraftVersion::V_1_21_11)
+            .expect("a plain address should be readable");
+
+        assert_eq!(&*packet.server_address, "localhost");
+        assert_eq!(packet.next_state, ConnectionState::Status);
+    }
+
+    #[test]
+    fn rejects_oversized_server_address() {
+        let address = "a".repeat(i16::MAX as usize + 1);
+        let buf = encode_handshake(&address, 2);
+
+        let result = SHandShake::read(&mut &buf[..], &JavaMinecraftVersion::V_1_21_11);
+
+        assert!(matches!(result, Err(ReadingError::TooLarge(_))));
     }
 }

--- a/pumpkin/src/net/proxy/bungeecord.rs
+++ b/pumpkin/src/net/proxy/bungeecord.rs
@@ -71,3 +71,64 @@ pub async fn bungeecord_login(
         },
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pumpkin_protocol::ser::NetworkWriteExt;
+    use pumpkin_protocol::{
+        ServerPacket, codec::var_int::VarInt, java::server::handshake::SHandShake,
+    };
+    use pumpkin_util::version::JavaMinecraftVersion;
+
+    /// Drives the whole path a proxied login takes: the handshake is encoded as
+    /// `BungeeCord` puts it on the wire, decoded by the real packet reader, and
+    /// the address it yields is handed to `bungeecord_login`. This is what fails
+    /// when the reader's bound on `server_address` is too small to hold the
+    /// forwarded profile properties.
+    #[tokio::test]
+    async fn logs_in_from_a_handshake_decoded_off_the_wire() {
+        let textures = "e".repeat(432);
+        let signature = "s".repeat(684);
+        let address = format!(
+            "mc.example.com\0192.0.2.10\0d8f4a1e0-0f1b-4c3a-9f2e-1a2b3c4d5e6f\0\
+             [{{\"name\":\"textures\",\"value\":\"{textures}\",\"signature\":\"{signature}\"}}]"
+        );
+
+        let mut buf = Vec::new();
+        let protocol_version = JavaMinecraftVersion::V_1_21_11.protocol_version();
+        buf.write_var_int(&VarInt(protocol_version))
+            .expect("write protocol version");
+        buf.write_string(&address).expect("write server address");
+        buf.write_u16_be(25565).expect("write server port");
+        buf.write_var_int(&VarInt(2)).expect("write next state");
+
+        let handshake = SHandShake::read(&mut &buf[..], &JavaMinecraftVersion::V_1_21_11)
+            .expect("a handshake sent by BungeeCord should be readable");
+
+        let client_address = Mutex::new(SocketAddr::from(([10, 0, 0, 1], 51234)));
+        let (ip, profile) = bungeecord_login(
+            &client_address,
+            &handshake.server_address,
+            "Steve".to_string(),
+        )
+        .await
+        .expect("the forwarded address should produce a game profile");
+
+        // The forwarded IP and UUID are used, not the proxy's own socket address.
+        assert_eq!(ip, IpAddr::from([192, 0, 2, 10]));
+        assert_eq!(
+            profile.id,
+            "d8f4a1e0-0f1b-4c3a-9f2e-1a2b3c4d5e6f"
+                .parse::<uuid::Uuid>()
+                .expect("valid uuid")
+        );
+
+        // The signed skin survives, so the player keeps their appearance.
+        let properties = profile.properties.load();
+        assert_eq!(properties.len(), 1);
+        assert_eq!(&*properties[0].name, "textures");
+        assert_eq!(&*properties[0].value, textures.as_str());
+        assert_eq!(properties[0].signature.as_deref(), Some(signature.as_str()));
+    }
+}


### PR DESCRIPTION
`SHandShake::read` bounds `server_address` at 255 characters, the limit a vanilla
client observes. `bungeecord_login` expects that same field to carry the host, the
client's IP, its UUID and its signed profile properties separated by NUL bytes —
exactly as its own doc comment says:

```rust
/// It utilizes the `server_address` received in the `SHandShake` packet,
/// which may contain optional data about the client:
///
/// 1. IP address (if `ip_forward` is enabled on the `BungeeCord` server)
/// 2. UUID (if `ip_forward` is enabled on the `BungeeCord` server)
/// 3. Game profile properties (if `ip_forward` and `online_mode` are enabled ...)
```

With `ip_forward` enabled the signed properties alone run well past a thousand
characters, so the read fails before `handle_handshake` ever runs: the connection
state never advances, `server_address` stays empty, and the proxy login path is
unreachable. That is the `too large: string` in the log in #1293 — it is
`ReadingError::TooLarge`'s `Display`.

The same struct already *writes* this field with `write_string`, which bounds it at
`i16::MAX`. The reader was stricter than the writer, and rejected the payload the
proxy layer is written to parse. This reads it with that same bound, as Spigot does.

## Evidence

Two tests, each failing before the change and passing after.

**The reader** — `reads_bungeecord_forwarded_server_address`, in
`pumpkin-protocol`, feeds a handshake carrying a realistic forwarded address:

```
TooLarge("string has too many bytes (1226 > 765)")
```

**The whole path** — `logs_in_from_a_handshake_decoded_off_the_wire`, in `pumpkin`,
encodes a handshake the way BungeeCord puts it on the wire, decodes it with the real
packet reader, and hands the resulting address to `bungeecord_login`, asserting the
forwarded IP, the forwarded UUID and the signed skin all survive. Reverting only the
bound makes it fail inside `SHandShake::read`, so `bungeecord_login` is never
reached at all.

Two more act as controls, and pass either way:

- `reads_plain_server_address` — ordinary hostnames still parse.
- `rejects_oversized_server_address` — 32768 characters is still refused, so the
  bound moved rather than disappeared.

## Notes

- No new DoS surface: `MAX_PACKET_SIZE` (2 MiB) is enforced in the packet decoder
  before the payload reaches `SHandShake::read`, and the wider bound admits at most
  ~98 KB.
- #2559 (BungeeGuard) appends a fifth NUL-delimited token to this same field, and
  its tests build that string in-process rather than reading it off the wire — so it
  needs this fix to work over a real connection.

Closes #1293
