### PR TITLE
fix(entity): clamp the hunger saturation grants instead of wrapping it

### DIFF
--- a/crates/pumpkin/src/entity/hunger.rs
+++ b/crates/pumpkin/src/entity/hunger.rs
@@ -140,7 +140,10 @@ impl HungerManager {
     /// Add hunger manually
     pub fn add_hunger(&self, hunger: u8) {
         let current = self.level.load();
-        self.level.store((current + hunger).min(MAX_FOOD));
+        // Saturating, because the amount comes from an effect amplifier the
+        // player controls and the sum can leave `u8` before it is clamped.
+        self.level
+            .store(current.saturating_add(hunger).min(MAX_FOOD));
     }
 
     /// Add saturation manually
@@ -200,3 +203,45 @@ impl NBTStorage for HungerManager {
 }
 
 impl NBTStorageInit for HungerManager {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `/effect` accepts an amplifier up to 255, and the saturation branch of
+    /// `apply_effect_tick` passes `amplifier + 1` here every tick.
+    const HIGH_AMPLIFIER_HUNGER: u8 = 237;
+
+    #[test]
+    fn add_hunger_clamps_a_large_amount_instead_of_wrapping() {
+        let hunger = HungerManager::default();
+        assert_eq!(hunger.level.load(), MAX_FOOD);
+
+        hunger.add_hunger(HIGH_AMPLIFIER_HUNGER);
+
+        assert_eq!(hunger.level.load(), MAX_FOOD);
+    }
+
+    /// Saturation ticks every tick, so a wrapping add does not just produce one
+    /// wrong value: the bar oscillates between full and nearly empty 20 times a
+    /// second, which is what #2573 reports seeing.
+    #[test]
+    fn repeated_high_amplifier_saturation_keeps_the_bar_full() {
+        let hunger = HungerManager::default();
+
+        for _ in 0..5 {
+            hunger.add_hunger(HIGH_AMPLIFIER_HUNGER);
+            assert_eq!(hunger.level.load(), MAX_FOOD);
+        }
+    }
+
+    #[test]
+    fn add_hunger_still_adds_normally() {
+        let hunger = HungerManager::default();
+        hunger.set_level(7);
+
+        hunger.add_hunger(3);
+
+        assert_eq!(hunger.level.load(), 10);
+    }
+}

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1843,7 +1843,8 @@ impl LivingEntity {
                 && let Some(player) = entity.get_player()
             {
                 // Add hunger and saturation
-                let hunger = amplifier + 1;
+                // `amplifier` reaches 255 through `/effect`, so this must not wrap.
+                let hunger = amplifier.saturating_add(1);
                 player.hunger_manager.add_hunger(hunger);
                 player.hunger_manager.add_saturation(hunger as f32 * 2.0);
             }


### PR DESCRIPTION
`add_hunger` is written to clamp:

```rust
pub fn add_hunger(&self, hunger: u8) {
    let current = self.level.load();
    self.level.store((current + hunger).min(MAX_FOOD));
}
```

but `.min(MAX_FOOD)` runs *after* the `u8` addition, so it cannot protect it.
The saturation branch of `apply_effect_tick` calls this every tick with
`amplifier + 1`, and `/effect` accepts an amplifier of up to 255
(`commands/effect.rs`, `.min(0).max(255) ... as u8`).

`should_apply_effect_tick` returns a bare `true` for `SATURATION`, so the call
happens 20 times a second.

## Why the bar flickers

With a full bar and the amplifier from the report:

| tick | arithmetic | stored level |
|------|-----------|--------------|
| 1 | `20 + 237` = 257, wraps to `1` | **1** |
| 2 | `1 + 237` = 238, clamped | **20** |
| 3 | `20 + 237` = 257, wraps to `1` | **1** |

The bar alternates between full and nearly empty twenty times a second — the
"kept deplenishing and replenishing over and over again" in #2573. The
threshold in the report falls out of the same arithmetic: overflow needs
`current + amplifier + 1 > 255`, which for a full-ish bar starts at an
amplifier around 235-236, and the report says "level 236 or higher".

In debug and test builds this is not a wrong value but a panic:
`attempt to add with overflow`.

## Evidence

`overflow-checks` is not set anywhere in the workspace and there is no
`.cargo/config.toml`, so the test profile keeps Cargo's default of enabled —
and CI runs `cargo nextest run` on that profile. So the two new tests fail the
project's own gate on an unpatched tree:

```
---- entity::hunger::tests::add_hunger_clamps_a_large_amount_instead_of_wrapping ----
thread panicked at pumpkin/src/entity/hunger.rs:143:26:
attempt to add with overflow

---- entity::hunger::tests::repeated_high_amplifier_saturation_keeps_the_bar_full ----
thread panicked at pumpkin/src/entity/hunger.rs:143:26:
attempt to add with overflow

test result: FAILED. 1 passed; 2 failed
```

After the change, all three pass. The third, `add_hunger_still_adds_normally`,
is a control: it passes either way and pins the ordinary case (7 + 3 = 10).

## The change

Both additions saturate. `amplifier + 1` needs it too, since amplifier 255
overflows that on its own before `add_hunger` is even reached. Each result is
still clamped to `MAX_FOOD`, so nothing below the overflow threshold changes,
and this matches vanilla, which does the same arithmetic in `int` and clamps
to 20.

Closes #2573
