### PR TITLE
perf: read nbt byte arrays in bulk

### DIFF
--- a/crates/pumpkin-nbt/src/tag.rs
+++ b/crates/pumpkin-nbt/src/tag.rs
@@ -350,12 +350,7 @@ impl NbtTag {
                 if len > crate::MAX_ARRAY_LENGTH {
                     return Err(Error::LargeLength(len));
                 }
-                let mut byte_array = Vec::with_capacity(len.min(4096));
-                for _ in 0..len {
-                    let byte = reader.get_i8()?;
-                    byte_array.push(byte);
-                }
-                Ok(Self::ByteArray(byte_array.into()))
+                Ok(Self::ByteArray(reader.get_byte_array(len)?.into()))
             }
             STRING_ID => Ok(Self::String(reader.get_string()?.into_owned().into())),
             LIST_ID => {

--- a/pumpkin-nbt/src/tag.rs
+++ b/pumpkin-nbt/src/tag.rs
@@ -299,12 +299,7 @@ impl NbtTag {
                 if len > MAX_ARRAY_LENGTH {
                     return Err(Error::LargeLength(len));
                 }
-                let mut byte_array = Vec::with_capacity(len);
-                for _ in 0..len {
-                    let byte = reader.get_i8()?;
-                    byte_array.push(byte);
-                }
-                Ok(Self::ByteArray(byte_array.into()))
+                Ok(Self::ByteArray(reader.get_byte_array(len)?.into()))
             }
             STRING_ID => Ok(Self::String(reader.get_string()?.into_owned().into())),
             LIST_ID => {


### PR DESCRIPTION
## Description

Reads NBT byte arrays through the bulk reader method instead of decoding each byte individually, which was done previously

## Testing

On the chunk_nbt_deserialization benchmark, time spent decreases from 106.4 µs to 88.3 µs.