### PR TITLE
perf: write nbt byte arrays in bulk

### DIFF
--- a/crates/pumpkin-nbt/src/tag.rs
+++ b/crates/pumpkin-nbt/src/tag.rs
@@ -141,9 +141,11 @@ impl NbtTag {
                 }
 
                 w.write_i32(len as i32)?;
-                for int in byte_array {
-                    w.write_i8(int)?;
-                }
+                // SAFETY: `i8` and `u8` have identical layouts, and the slice is only read.
+                let bytes = unsafe {
+                    std::slice::from_raw_parts(byte_array.as_ptr().cast::<u8>(), byte_array.len())
+                };
+                w.write_slice(bytes)?;
             }
             Self::String(string) => {
                 w.write_string(&string)?;

--- a/pumpkin-nbt/src/tag.rs
+++ b/pumpkin-nbt/src/tag.rs
@@ -139,9 +139,11 @@ impl NbtTag {
                 }
 
                 w.write_i32(len as i32)?;
-                for int in byte_array {
-                    w.write_i8(int)?;
-                }
+                // SAFETY: `i8` and `u8` have identical layouts, and the slice is only read.
+                let bytes = unsafe {
+                    std::slice::from_raw_parts(byte_array.as_ptr().cast::<u8>(), byte_array.len())
+                };
+                w.write_slice(bytes)?;
             }
             Self::String(string) => {
                 w.write_string(&string)?;


### PR DESCRIPTION
## Description

Replaces per-byte nbt serialization with a single bulk write. This preserves the encoded output and applies to both Java and Bedrock nbt

## Testing

Benchmarks for a 64 KiB byte array:

Java: 19.32 µs ->3.01 µs
Bedrock: 18.77 µs -> 2.97 µs