### PR TITLE
Fix lightning rod placement orientation

### DIFF
--- a/crates/pumpkin/src/block/blocks/redstone/lightning_rod.rs
+++ b/crates/pumpkin/src/block/blocks/redstone/lightning_rod.rs
@@ -5,8 +5,8 @@ use crate::block::{
     OnScheduledTickArgs,
 };
 use crate::world::World;
-use pumpkin_data::block_properties::{BlockProperties, Facing, LightningRodLikeProperties};
-use pumpkin_data::{BlockDirection, BlockStateId, FacingExt};
+use pumpkin_data::block_properties::{BlockProperties, LightningRodLikeProperties};
+use pumpkin_data::{BlockStateId, FacingExt};
 use pumpkin_macros::pumpkin_block;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::tick::TickPriority;
@@ -47,16 +47,8 @@ impl LightningRodBlock {
 impl BlockBehaviour for LightningRodBlock {
     fn on_place<'a>(&'a self, args: OnPlaceArgs<'a>) -> BlockFuture<'a, BlockStateId> {
         Box::pin(async move {
-            let facing = match args.direction {
-                BlockDirection::North => Facing::North,
-                BlockDirection::South => Facing::South,
-                BlockDirection::East => Facing::East,
-                BlockDirection::West => Facing::West,
-                BlockDirection::Up => Facing::Up,
-                BlockDirection::Down => Facing::Down,
-            };
             let mut props = LightningRodLikeProperties::default(args.block);
-            props.facing = facing;
+            props.facing = args.direction.to_facing().opposite();
             props.to_state_id(args.block)
         })
     }


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description
### What was changed?
The orientation of placed lightning rods was reversed.
### Why were these changes necessary?
Lightning rods were previously placed facing into the block they were placed against, this is not vanilla behaviour.
### What is the impact of this change?
Lightning rods now face out from the block they are placed against.
It party fixes #2745
### Are there any known issues or limitations?
Waxed and oxidized lightning rods still do not work, they are always placed facing up.
## Testing
cargo clippy --all-targets
typos
cargo test