### PR TITLE
fix(text): flatten hover_event NBT serialization

### DIFF
--- a/crates/pumpkin-util/src/text/mod.rs
+++ b/crates/pumpkin-util/src/text/mod.rs
@@ -238,30 +238,26 @@ impl TextComponentBase {
                 }
                 HoverEvent::ShowItem { id, count } => {
                     hover_tag.put_string("action", "show_item".to_string());
-                    let mut item_tag = pumpkin_nbt::NbtCompound::new();
-                    item_tag.put_string("id", id.to_string());
+                    hover_tag.put_string("id", id.to_string());
                     if let Some(cnt) = count {
-                        item_tag.put_int("count", *cnt);
+                        hover_tag.put_int("count", *cnt);
                     }
-                    hover_tag.put_compound("item", item_tag);
                 }
                 HoverEvent::ShowEntity { id, uuid, name } => {
                     hover_tag.put_string("action", "show_entity".to_string());
-                    let mut entity_tag = pumpkin_nbt::NbtCompound::new();
-                    entity_tag.put_string("id", id.to_string());
-                    entity_tag.put_string("uuid", uuid.to_string());
+                    hover_tag.put_string("id", id.to_string());
+                    hover_tag.put_string("uuid", uuid.to_string());
                     if let Some(n) = name {
                         if n.len() == 1 {
-                            entity_tag.put_compound("name", n[0].to_nbt_compound());
+                            hover_tag.put_compound("name", n[0].to_nbt_compound());
                         } else {
                             let list = n
                                 .iter()
                                 .map(|e| pumpkin_nbt::tag::NbtTag::Compound(e.to_nbt_compound()))
                                 .collect();
-                            entity_tag.put_list("name", list);
+                            hover_tag.put_list("name", list);
                         }
                     }
-                    hover_tag.put_compound("entity", entity_tag);
                 }
             }
             compound.put_compound("hover_event", hover_tag);


### PR DESCRIPTION
`show_entity` and `show_item` wrote their fields into a nested `entity` / `item`
compound when serializing a text component to NBT. Since 1.21.5 the client expects
those fields **directly inside** `hover_event`, so it fails to decode the style, then
the whole component, and drops the connection.

This affects **every player death**, not just `/kill`: `get_display_name()` always
attaches a `show_entity` hover, and that component is carried by the
`player_combat_kill` packet. A vanilla 26.2 client disconnects with:

```
io.netty.handler.codec.DecoderException: Failed to decode packet 'clientbound/minecraft:player_combat_kill'
Caused by: Failed to decode: Failed to parse either. First: Not a string; Second: Not a list:
{translate:"death.attack.genericKill",with:[{...,hover_event:{action:"show_entity",entity:{id:"player",name:{text:"<name>"},uuid:"<uuid>"}},text:"<name>"}]}
```

Note the `entity:{...}` nesting — that is what the client cannot parse.

Two things in the code already pointed at the NBT path being the outlier:

- The serde path for the same enum in `text/hover.rs` serializes both variants **flat**
  via `#[serde(tag = "action")]`, so the two serialization paths disagreed.
- The `click_event` branch directly above in `to_nbt_compound()` had already been
  migrated to the flat 1.21.5 form; `hover_event` was missed.

`show_text` was already correct and is untouched.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features` with `RUSTFLAGS="-Dwarnings"` — no warnings
- `cargo test` — all existing tests pass
- Manual, vanilla 26.2 client against a locally built server: `/kill` now shows the
  death screen and keeps the connection. Before this change the client disconnected
  immediately and wrote the crash report above.