### PR TITLE
fix(protocol): treat connection resets as closed connections

### DIFF
--- a/crates/pumpkin-protocol/src/bedrock/packet_decoder.rs
+++ b/crates/pumpkin-protocol/src/bedrock/packet_decoder.rs
@@ -166,7 +166,9 @@ impl UDPNetworkDecoder {
         decompressed_reader: &mut Cursor<Vec<u8>>,
     ) -> Result<RawPacket, PacketDecodeError> {
         let packet_len = VarUInt::decode(decompressed_reader).map_err(|err| match err {
-            ReadingError::CleanEOF(_) => PacketDecodeError::ConnectionClosed,
+            ReadingError::CleanEOF(_) | ReadingError::ConnectionClosed(_) => {
+                PacketDecodeError::ConnectionClosed
+            }
             err => PacketDecodeError::MalformedLength(err.to_string()),
         })?;
         let packet_len = packet_len.0 as usize;

--- a/crates/pumpkin-protocol/src/codec/var_int.rs
+++ b/crates/pumpkin-protocol/src/codec/var_int.rs
@@ -73,12 +73,12 @@ impl VarInt {
     pub async fn decode_async(read: &mut (impl AsyncRead + Unpin)) -> Result<Self, ReadingError> {
         let mut val = 0;
         for i in 0..Self::MAX_SIZE.get() {
-            let byte = read.read_u8().await.map_err(|err| {
-                if i == 0 && matches!(err.kind(), ErrorKind::UnexpectedEof) {
-                    ReadingError::CleanEOF("VarInt".to_string())
-                } else {
-                    ReadingError::Incomplete(err.to_string())
-                }
+            let byte = read.read_u8().await.map_err(|err| match err.kind() {
+                ErrorKind::UnexpectedEof if i == 0 => ReadingError::CleanEOF("VarInt".to_string()),
+                ErrorKind::ConnectionReset
+                | ErrorKind::ConnectionAborted
+                | ErrorKind::BrokenPipe => ReadingError::ConnectionClosed(err.to_string()),
+                _ => ReadingError::Incomplete(err.to_string()),
             })?;
             val |= (i32::from(byte) & 0x7F) << (i * 7);
             if byte & 0x80 == 0 {

--- a/crates/pumpkin-protocol/src/codec/var_uint.rs
+++ b/crates/pumpkin-protocol/src/codec/var_uint.rs
@@ -75,12 +75,12 @@ impl VarUInt {
     pub async fn decode_async(read: &mut (impl AsyncRead + Unpin)) -> Result<Self, ReadingError> {
         let mut val = 0;
         for i in 0..Self::MAX_SIZE.get() {
-            let byte = read.read_u8().await.map_err(|err| {
-                if i == 0 && matches!(err.kind(), ErrorKind::UnexpectedEof) {
-                    ReadingError::CleanEOF("VarUInt".to_string())
-                } else {
-                    ReadingError::Incomplete(err.to_string())
-                }
+            let byte = read.read_u8().await.map_err(|err| match err.kind() {
+                ErrorKind::UnexpectedEof if i == 0 => ReadingError::CleanEOF("VarUInt".to_string()),
+                ErrorKind::ConnectionReset
+                | ErrorKind::ConnectionAborted
+                | ErrorKind::BrokenPipe => ReadingError::ConnectionClosed(err.to_string()),
+                _ => ReadingError::Incomplete(err.to_string()),
             })?;
             val |= (u32::from(byte) & 0x7F) << (i * 7);
             if byte & 0x80 == 0 {

--- a/crates/pumpkin-protocol/src/java/packet_decoder.rs
+++ b/crates/pumpkin-protocol/src/java/packet_decoder.rs
@@ -117,7 +117,9 @@ impl<R: AsyncRead + Unpin> TCPNetworkDecoder<R> {
         let packet_len = VarInt::decode_async(reader)
             .await
             .map_err(|err| match err {
-                ReadingError::CleanEOF(_) => PacketDecodeError::ConnectionClosed,
+                ReadingError::CleanEOF(_) | ReadingError::ConnectionClosed(_) => {
+                    PacketDecodeError::ConnectionClosed
+                }
                 err => PacketDecodeError::MalformedLength(err.to_string()),
             })?;
 

--- a/crates/pumpkin-protocol/src/ser/mod.rs
+++ b/crates/pumpkin-protocol/src/ser/mod.rs
@@ -17,6 +17,11 @@ use thiserror::Error;
 pub enum ReadingError {
     #[error("EOF, Tried to read {0} but No bytes left to consume")]
     CleanEOF(String),
+    /// The peer dropped the connection (reset, abort or broken pipe). Distinct from
+    /// [`Self::CleanEOF`] because there is no clean end of stream, and distinct from
+    /// [`Self::Incomplete`] because the data is not malformed — the socket is simply gone.
+    #[error("the connection has closed: {0}")]
+    ConnectionClosed(String),
     #[error("incomplete: {0}")]
     Incomplete(String),
     #[error("too large: {0}")]


### PR DESCRIPTION

`VarInt`/`VarUInt::decode_async` only mapped `UnexpectedEof` at offset 0 to `CleanEOF`.
A client that drops the connection hard — Alt+F4, network loss, a crash — produces
`ConnectionReset` instead, which fell through to `Incomplete` and then to
`PacketDecodeError::MalformedLength`.

That matters because `JavaClient::get_packet_with_reader` deliberately handles
`PacketDecodeError::ConnectionClosed` silently, and a reset never reached that branch.
So an ordinary disconnect took the error path twice over:

```
WARN Failed to decode packet from client 6: malformed packet length VarInt: incomplete: Connection reset by peer (os error 104)
WARN Failed to flush packet batch for client 6: Writing packet failed: Broken pipe (os error 32)
```

The first line reports a protocol violation that did not happen. The second is a
follow-on: because the error was not recognised as a disconnect, `kick()` ran and tried
to write a disconnect packet to a socket that was already gone.

This adds `ReadingError::ConnectionClosed` and maps `ConnectionReset`,
`ConnectionAborted` and `BrokenPipe` onto it in both the Java and Bedrock packet
decoders. `CleanEOF` is kept for the genuine end-of-stream case rather than reused,
since its message ("No bytes left to consume") describes something that did not happen
on a reset.

No behaviour change for well-behaved clients: a clean disconnect still goes through
`CleanEOF`, and genuinely malformed length prefixes still produce `MalformedLength`.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features` with `RUSTFLAGS="-Dwarnings"` — no warnings
- `cargo test` — all existing tests pass
- Manual: killing a connected client hard no longer produces either warning; the
  disconnect is now silent, as it already was for clients that close cleanly.