### PR TITLE
fix(entity): stop panicking in on_death when the entity left the world

### DIFF
--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1326,14 +1326,12 @@ impl LivingEntity {
 
     pub async fn on_death(
         &self,
+        dyn_self: &dyn EntityBase,
         damage_type: DamageType,
         source: Option<&dyn EntityBase>,
         cause: Option<&dyn EntityBase>,
     ) {
         let world = self.entity.world.load();
-        let dyn_self = world
-            .get_entity_by_id(self.entity.entity_id)
-            .expect("Entity not found in world");
         if self
             .dead
             .compare_exchange(false, true, Relaxed, Relaxed)
@@ -1343,7 +1341,7 @@ impl LivingEntity {
             self.jumping.store(false, Relaxed);
 
             // Statistics updates
-            self.update_death_stats(&*dyn_self, cause).await;
+            self.update_death_stats(dyn_self, cause).await;
 
             // Plays the death sound
             world.send_entity_status(&self.entity, EntityStatus::Death);
@@ -1411,7 +1409,7 @@ impl LivingEntity {
             self.drop_equipment(looting_level).await;
 
             // Broadcast death message if it's a player and the gamerule is enabled
-            self.broadcast_death_message(&*dyn_self, damage_type, source, cause)
+            self.broadcast_death_message(dyn_self, damage_type, source, cause)
                 .await;
 
             self.reset_effects_and_attributes().await;
@@ -2515,7 +2513,7 @@ impl EntityBase for LivingEntity {
             if clamped_health <= 0.0
                 && (bypasses_cooldown_protection || !self.try_use_death_protector(caller).await)
             {
-                self.on_death(damage_type, source, cause).await;
+                self.on_death(caller, damage_type, source, cause).await;
             }
 
             // Armor durability is based on incoming raw damage, not post-absorption remaining.


### PR DESCRIPTION
## Description

`LivingEntity::on_death` re-derived its own `&dyn EntityBase` by looking itself up in the
world's entity list, and unwrapped the result:

```rust
let dyn_self = world
    .get_entity_by_id(self.entity.entity_id)
    .expect("Entity not found in world");
```

That list is mutated concurrently with entity ticking. `World::tick` snapshots
`self.entities` and spawns one task per entity, each holding its own `Arc<dyn EntityBase>`,
so a tick keeps running after the entity has been dropped from the list. Meanwhile
`chunker::update_position` calls `World::remove_entities_in_chunks` from the player's packet
task whenever the player's watched chunks change. A player moving fast enough crosses many
chunk borders per movement packet, so entities are removed in batches while their ticks are
still in flight. Any of them that dies in that window reaches `on_death`, the lookup returns
`None`, and the panic hook takes the whole server down.

Nothing in `on_death` needs world registration. `dyn_self` is only used for
`update_death_stats`, `get_experience_reward` and `broadcast_death_message`, which need the
outermost trait-object view of the dying entity — and the damage call chain already carries
exactly that as `caller`. `on_death` now takes it as a parameter instead of consulting the
registry.

Death handling, loot, experience and death messages are unchanged, and the O(n) lookup on
every death is gone. The other `get_entity_by_id` call sites in this file (poison, wither,
instant damage) already treated a missing entity as `None`; this was the only `expect`.

`on_death` is `pub` and gains a parameter, so out-of-tree callers would need updating. Every
in-tree call site is covered.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets --all-features`, `cargo test --workspace`
and `cargo test --doc` pass.

No unit test: constructing a `LivingEntity` needs a live `World` (`Entity::world` is an
`ArcSwap<World>`, which needs a `Level`, a `LevelInfo` and a `Weak<Server>`), and the crate
has no scaffolding for that. The trigger is a tick/packet-task race that cannot be driven
deterministically. Instead I audited every `damage_with_context` and `damage` call site in
the workspace to confirm `caller` is always the victim's outermost `&dyn EntityBase`.

Fixes #2153