### PR TITLE
fix(item): require a non-empty charged list to fire a crossbow

### DIFF
--- a/crates/pumpkin/src/item/items/crossbow.rs
+++ b/crates/pumpkin/src/item/items/crossbow.rs
@@ -36,9 +36,12 @@ impl ItemBehaviour for CrossbowItem {
             let held = inventory.held_item();
             let stack = held.lock().await.clone();
 
+            // Every crossbow carries a ChargedProjectiles component by default, so its mere
+            // presence does not mean the crossbow is loaded. Vanilla checks the list is also
+            // non-empty (CrossbowItem.java:68).
             if stack
                 .get_data_component::<ChargedProjectilesImpl>()
-                .is_some()
+                .is_some_and(|charged| !charged.projectiles.is_empty())
             {
                 Self::fire_projectiles(player, &held).await;
                 return;


### PR DESCRIPTION
## Summary

A freshly crafted crossbow cannot be used at all. `normal_use` treats a crossbow as loaded
whenever the `ChargedProjectiles` component is *present*, but `Item::CROSSBOW` ships that
component by default with an empty projectile list, so the check is true for every crossbow.

The first right-click therefore takes the fire branch, `fire_projectiles` iterates an empty
list and does nothing, and charging never begins. The crossbow stays unusable until some
other path happens to write a non-empty patch onto the stack.

This changes the check to require the list be present *and* non-empty, matching vanilla.

Vanilla evidence: `net.minecraft.world.item.CrossbowItem#use` (26.2):

```java
ChargedProjectiles chargedProjectiles = itemStack.get(DataComponents.CHARGED_PROJECTILES);
if (chargedProjectiles != null && !chargedProjectiles.isEmpty()) {
    this.performShooting(...);
    return InteractionResult.CONSUME;
}
```

The default component is visible in `crates/pumpkin-data/src/generated/item.rs`, in the
`CROSSBOW` component table: `ChargedProjectilesImpl { projectiles: Vec::new() }`.

## Scope

One-line behavioural change plus a comment. `.is_some()` becomes
`.is_some_and(|charged| !charged.projectiles.is_empty())`.

A genuinely charged crossbow still has a non-empty list and fires exactly as before, so this
cannot regress a working charged-crossbow path; it only stops the empty/default case from
short-circuiting into a no-op fire. No other call site reads `ChargedProjectilesImpl` in
`crates/pumpkin/src`.

The rest of the charge cycle was checked against `CrossbowItem.java` while here and is
already correct: quick-charge timing via `EnchantmentEffect::CrossbowChargeTime`, multishot
count and spread, the charged state persisting on the item, firing clearing the patch, and
the loaded projectile identity (arrow vs firework rocket) being preserved.

## Test plan

- `cargo fmt --all`
- `RUSTFLAGS="-D warnings" cargo clippy -p pumpkin --all-targets`
