### PR TITLE
fix: Bedrock NetherNet offline mode

### DIFF
--- a/crates/pumpkin/src/net/bedrock/nethernet.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet.rs
@@ -538,11 +538,6 @@ fn verify_and_strip_identity(
         .map_err(|error| format!("invalid identity encoding: {error}"))?;
     let identity: Value = serde_json::from_slice(&identity)
         .map_err(|error| format!("invalid identity JSON: {error}"))?;
-    if identity["idp"]["protocol"] != "default"
-        || identity["idp"]["domain"].as_str().is_none_or(str::is_empty)
-    {
-        return Err("invalid identity provider".to_string());
-    }
     let assertion = identity["assertion"]
         .as_str()
         .ok_or_else(|| "identity assertion is missing".to_string())?;
@@ -552,6 +547,11 @@ fn verify_and_strip_identity(
         .as_str()
         .ok_or_else(|| "identity token is missing".to_string())?;
     if let Some((issuer, keys)) = oidc_verifier {
+        if identity["idp"]["protocol"] != "default"
+            || identity["idp"]["domain"].as_str().is_none_or(str::is_empty)
+        {
+            return Err("invalid identity provider".to_string());
+        }
         pumpkin_util::jwt::verify_oidc_token(token, issuer, keys)
             .map_err(|error| format!("invalid GameServerToken: {error}"))?;
     } else {
@@ -762,6 +762,33 @@ mod tests {
             Jwks { keys: Vec::new() },
         );
         assert!(verify_and_strip_identity(&answer, Some(&verifier)).is_err());
+    }
+
+    #[test]
+    fn offline_mode_accepts_an_unverified_identity_provider() {
+        let key = SigningKey::from_slice(&[7; 48]).unwrap();
+        let sdp = "v=0\r\nt=0 0\r\nm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\na=fingerprint:sha-256 AA:BB\r\n";
+        let answer = add_server_identity(sdp, &key).unwrap();
+        let encoded = answer
+            .lines()
+            .find_map(|line| line.strip_prefix("a=identity:"))
+            .unwrap();
+        let mut identity: Value =
+            serde_json::from_slice(&general_purpose::STANDARD.decode(encoded).unwrap()).unwrap();
+        identity["idp"] = json!({"domain": "", "protocol": "offline"});
+        let offline_identity =
+            general_purpose::STANDARD.encode(serde_json::to_vec(&identity).unwrap());
+        let offer = answer.replace(encoded, &offline_identity);
+
+        verify_and_strip_identity(&offer, None).unwrap();
+        let verifier = (
+            "https://issuer.example".to_string(),
+            Jwks { keys: Vec::new() },
+        );
+        assert_eq!(
+            verify_and_strip_identity(&offer, Some(&verifier)).unwrap_err(),
+            "invalid identity provider"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description
Fixes Bedrock NetherNet connections when Pumpkin is running in offline mode.

## What
- Allows offline-mode clients to use unverified identity-provider metadata.
- Keeps token expiration, client public-key, and signed DTLS fingerprint validation enabled.
- Preserves strict identity-provider and OIDC validation in online mode.
- Adds a regression test covering both offline acceptance and online rejection.

## How
Identity-provider validation now runs only when an OIDC verifier is configured. Offline mode skips centralized provider verification while retaining the cryptographic binding between the client identity and its WebRTC connection.

## Testing
- `cargo test -p pumpkin net::bedrock::nethernet::tests --lib`
- `cargo clippy -p pumpkin --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Verified in-game with online_mode = false
