### PR TITLE
fix: Bedrock NetherNet ICE connectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3241,6 +3241,7 @@ dependencies = [
 name = "pumpkin"
 version = "0.1.0-dev+26.2-26.40"
 dependencies = [
+ "aes 0.9.1",
  "arc-swap",
  "axum",
  "base64 0.23.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,7 +3243,6 @@ version = "0.1.0-dev+26.2-26.40"
 dependencies = [
  "aes 0.9.1",
  "arc-swap",
- "async-trait",
  "axum",
  "base64 0.23.1",
  "bitflags 2.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,6 +3243,7 @@ version = "0.1.0-dev+26.2-26.40"
 dependencies = [
  "aes 0.9.1",
  "arc-swap",
+ "async-trait",
  "axum",
  "base64 0.23.1",
  "bitflags 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ strip = false
 
 
 [workspace.dependencies]
+async-trait = "0.1"
 serde_json5 = "0.2.1"
 tokio = { version = "1.53", default-features = false }
 syn = { version = "3.0", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "clone-impls", "derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,6 @@ strip = false
 
 
 [workspace.dependencies]
-async-trait = "0.1"
 serde_json5 = "0.2.1"
 tokio = { version = "1.53", default-features = false }
 syn = { version = "3.0", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "clone-impls", "derive"] }

--- a/crates/pumpkin-config/src/networking/bedrock.rs
+++ b/crates/pumpkin-config/src/networking/bedrock.rs
@@ -1,6 +1,6 @@
 use crate::CompressionConfig;
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroU8;
 use std::path::PathBuf;
 
@@ -24,11 +24,15 @@ pub struct BedrockAuthenticationConfig {
 pub struct NetherNetConfig {
     /// Whether clients may connect using `NetherNet`.
     pub enabled: bool,
-    /// HTTP signaling address. WebRTC uses separately allocated UDP ports for game traffic.
+    /// HTTP signaling address.
     pub address: SocketAddr,
+    /// UDP address shared by all WebRTC game sessions.
+    pub ice_address: SocketAddr,
+    /// Optional public IP advertised when the ICE address is behind NAT.
+    pub external_ip: Option<IpAddr>,
     /// PKCS#8 P-384 identity key retained across restarts for Trust On First Use.
     pub identity_key: PathBuf,
-    /// Optional STUN server URLs used to gather a public ICE candidate behind NAT.
+    /// Optional ICE server URLs. Use `external_ip` for NAT with the single-port UDP mux.
     pub stun_servers: Vec<String>,
 }
 
@@ -37,9 +41,14 @@ impl Default for NetherNetConfig {
         let address = "0.0.0.0:19132"
             .parse()
             .unwrap_or_else(|_| std::net::SocketAddr::from(([0, 0, 0, 0], 19132)));
+        let ice_address = "0.0.0.0:19134"
+            .parse()
+            .unwrap_or_else(|_| std::net::SocketAddr::from(([0, 0, 0, 0], 19134)));
         Self {
             enabled: true,
             address,
+            ice_address,
+            external_ip: None,
             identity_key: "nethernet-key.der".into(),
             stun_servers: Vec::new(),
         }

--- a/crates/pumpkin-config/src/networking/bedrock.rs
+++ b/crates/pumpkin-config/src/networking/bedrock.rs
@@ -24,10 +24,8 @@ pub struct BedrockAuthenticationConfig {
 pub struct NetherNetConfig {
     /// Whether clients may connect using `NetherNet`.
     pub enabled: bool,
-    /// HTTP signaling address.
+    /// TCP signaling and shared UDP status/ICE address.
     pub address: SocketAddr,
-    /// UDP address shared by all WebRTC game sessions.
-    pub ice_address: SocketAddr,
     /// Optional public IP advertised when the ICE address is behind NAT.
     pub external_ip: Option<IpAddr>,
     /// PKCS#8 P-384 identity key retained across restarts for Trust On First Use.
@@ -41,13 +39,9 @@ impl Default for NetherNetConfig {
         let address = "0.0.0.0:19132"
             .parse()
             .unwrap_or_else(|_| std::net::SocketAddr::from(([0, 0, 0, 0], 19132)));
-        let ice_address = "0.0.0.0:19134"
-            .parse()
-            .unwrap_or_else(|_| std::net::SocketAddr::from(([0, 0, 0, 0], 19134)));
         Self {
             enabled: true,
             address,
-            ice_address,
             external_ip: None,
             identity_key: "nethernet-key.der".into(),
             stun_servers: Vec::new(),

--- a/crates/pumpkin/Cargo.toml
+++ b/crates/pumpkin/Cargo.toml
@@ -17,7 +17,6 @@ LegalCopyright = "Copyright © 2026 Aleksander Medvedev"
 doctest = false
 
 [dependencies]
-async-trait.workspace = true
 # pumpkin
 arc-swap.workspace = true
 rayon.workspace = true

--- a/crates/pumpkin/Cargo.toml
+++ b/crates/pumpkin/Cargo.toml
@@ -65,6 +65,7 @@ num-bigint.workspace = true
 rustyline.workspace = true
 
 # encryption
+aes.workspace = true
 rsa.workspace = true
 
 # verification & WASM parsing

--- a/crates/pumpkin/Cargo.toml
+++ b/crates/pumpkin/Cargo.toml
@@ -17,6 +17,7 @@ LegalCopyright = "Copyright © 2026 Aleksander Medvedev"
 doctest = false
 
 [dependencies]
+async-trait.workspace = true
 # pumpkin
 arc-swap.workspace = true
 rayon.workspace = true

--- a/crates/pumpkin/src/lib.rs
+++ b/crates/pumpkin/src/lib.rs
@@ -11,7 +11,7 @@ use crate::data::VanillaData;
 use crate::logging::{GzipRollingLogger, PumpkinCommandCompleter, ReadlineLogWrapper};
 use crate::net::bedrock::{
     BedrockClient,
-    nethernet::{NetherNetListener, load_or_create_identity_key},
+    nethernet::{NetherNetListener, discovery::NetherNetDiscovery, load_or_create_identity_key},
     status::StatusResponder,
 };
 use crate::net::java::JavaClient;
@@ -217,6 +217,7 @@ pub struct PumpkinServer {
     pub server: Arc<Server>,
     pub tcp_listener: Option<TcpListener>,
     pub bedrock_status: Option<StatusResponder>,
+    pub nethernet_discovery: Option<NetherNetDiscovery>,
     pub nethernet_listener: Option<NetherNetListener>,
 }
 
@@ -307,11 +308,29 @@ impl PumpkinServer {
 
         let nethernet_listener = Self::bind_nethernet(&server).await;
         let bedrock_status = Self::bind_bedrock_status(&server, nethernet_listener.is_some()).await;
+        let nethernet_discovery = if nethernet_listener.is_some() {
+            let discovery = NetherNetDiscovery::bind(
+                server.advanced_config.networking.bedrock.nethernet.address,
+                server.server_guid,
+            )
+            .await
+            .expect("Failed to bind NetherNet LAN discovery");
+            info!(
+                "Bedrock NetherNet LAN discovery is listening on {}",
+                discovery
+                    .local_addr()
+                    .expect("NetherNet discovery socket should have a local address")
+            );
+            Some(discovery)
+        } else {
+            None
+        };
 
         Self {
             server,
             tcp_listener,
             bedrock_status,
+            nethernet_discovery,
             nethernet_listener,
         }
     }
@@ -343,6 +362,7 @@ impl PumpkinServer {
             config.nethernet.ice_address,
             config.nethernet.external_ip,
             identity_key,
+            config.online_mode,
             oidc_verifier,
             config.nethernet.stun_servers.clone(),
         )
@@ -499,6 +519,8 @@ impl PumpkinServer {
         tasks: &Arc<TaskTracker>,
         bedrock_clients: &Arc<Mutex<HashMap<SocketAddr, Arc<BedrockClient>>>>,
     ) -> bool {
+        let mut discovery_buf = vec![0; u16::MAX as usize].into_boxed_slice();
+
         select! {
             // Branch for TCP connections (Java Edition)
             tcp_result = resolve_some(self.tcp_listener.as_ref(), tokio::net::TcpListener::accept) => {
@@ -579,6 +601,18 @@ impl PumpkinServer {
             ) => {
                 if let Err(error) = status_result {
                     debug!("Bedrock status packet failed: {error}");
+                }
+            },
+
+            // NetherNet-native LAN discovery for clients joining the discovered server entry.
+            discovery_result = resolve_some(
+                self.nethernet_discovery.as_ref().zip(self.nethernet_listener.as_ref()),
+                |(discovery, listener): (&NetherNetDiscovery, &NetherNetListener)| {
+                    discovery.receive(&self.server, listener, &mut discovery_buf)
+                },
+            ) => {
+                if let Err(error) = discovery_result {
+                    debug!("NetherNet discovery packet failed: {error}");
                 }
             },
 

--- a/crates/pumpkin/src/lib.rs
+++ b/crates/pumpkin/src/lib.rs
@@ -340,6 +340,8 @@ impl PumpkinServer {
         };
         match NetherNetListener::bind(
             config.nethernet.address,
+            config.nethernet.ice_address,
+            config.nethernet.external_ip,
             identity_key,
             oidc_verifier,
             config.nethernet.stun_servers.clone(),

--- a/crates/pumpkin/src/lib.rs
+++ b/crates/pumpkin/src/lib.rs
@@ -12,7 +12,7 @@ use crate::logging::{GzipRollingLogger, PumpkinCommandCompleter, ReadlineLogWrap
 use crate::net::bedrock::{
     BedrockClient,
     nethernet::{NetherNetListener, discovery::NetherNetDiscovery, load_or_create_identity_key},
-    status::StatusResponder,
+    status::{IceSocket, StatusResponder},
 };
 use crate::net::java::JavaClient;
 use crate::net::java::pending::PendingConnection;
@@ -306,8 +306,8 @@ impl PumpkinServer {
             });
         };
 
-        let nethernet_listener = Self::bind_nethernet(&server).await;
-        let bedrock_status = Self::bind_bedrock_status(&server, nethernet_listener.is_some()).await;
+        let (bedrock_status, ice_socket) = Self::bind_bedrock_status(&server).await;
+        let nethernet_listener = Self::bind_nethernet(&server, ice_socket).await;
         let nethernet_discovery = if nethernet_listener.is_some() {
             let discovery = NetherNetDiscovery::bind(
                 server.advanced_config.networking.bedrock.nethernet.address,
@@ -335,11 +335,18 @@ impl PumpkinServer {
         }
     }
 
-    async fn bind_nethernet(server: &Arc<Server>) -> Option<NetherNetListener> {
+    async fn bind_nethernet(
+        server: &Arc<Server>,
+        ice_socket: Option<IceSocket>,
+    ) -> Option<NetherNetListener> {
         let config = &server.advanced_config.networking.bedrock;
         if !config.enabled || !config.nethernet.enabled {
             return None;
         }
+        let Some(ice_socket) = ice_socket else {
+            error!("Bedrock UDP should be bound before NetherNet");
+            return None;
+        };
         let identity_key = match load_or_create_identity_key(&config.nethernet.identity_key) {
             Ok(key) => key,
             Err(err) => {
@@ -359,7 +366,7 @@ impl PumpkinServer {
         };
         match NetherNetListener::bind(
             config.nethernet.address,
-            config.nethernet.ice_address,
+            ice_socket,
             config.nethernet.external_ip,
             identity_key,
             config.online_mode,
@@ -376,25 +383,25 @@ impl PumpkinServer {
         }
     }
 
-    async fn bind_bedrock_status(server: &Server, enabled: bool) -> Option<StatusResponder> {
-        if !enabled {
-            return None;
+    async fn bind_bedrock_status(server: &Server) -> (Option<StatusResponder>, Option<IceSocket>) {
+        let config = &server.advanced_config.networking.bedrock;
+        if !config.enabled || !config.nethernet.enabled {
+            return (None, None);
         }
-        let responder = match StatusResponder::bind(
-            server.advanced_config.networking.bedrock.nethernet.address,
-        )
-        .await
-        {
-            Ok(r) => r,
-            Err(err) => {
-                error!("Failed to bind Bedrock server-list status: {err}");
-                return None;
+        match StatusResponder::bind(config.nethernet.address).await {
+            Ok((responder, ice_socket)) => {
+                if let Ok((ipv4, ipv6)) = responder.local_addrs() {
+                    info!(
+                        "Bedrock server-list status is listening on {ipv4} (IPv4) and {ipv6} (IPv6)"
+                    );
+                }
+                (Some(responder), Some(ice_socket))
             }
-        };
-        if let Ok((ipv4, ipv6)) = responder.local_addrs() {
-            info!("Bedrock server-list status is listening on {ipv4} (IPv4) and {ipv6} (IPv6)");
+            Err(err) => {
+                error!("Failed to bind Bedrock UDP status/ICE endpoint: {err}");
+                (None, None)
+            }
         }
-        Some(responder)
     }
 
     pub async fn init_plugins(&self) -> std::time::Duration {

--- a/crates/pumpkin/src/lib.rs
+++ b/crates/pumpkin/src/lib.rs
@@ -11,7 +11,7 @@ use crate::data::VanillaData;
 use crate::logging::{GzipRollingLogger, PumpkinCommandCompleter, ReadlineLogWrapper};
 use crate::net::bedrock::{
     BedrockClient,
-    nethernet::{NetherNetListener, discovery::NetherNetDiscovery, load_or_create_identity_key},
+    nethernet::{NetherNetListener, load_or_create_identity_key},
     status::{IceSocket, StatusResponder},
 };
 use crate::net::java::JavaClient;
@@ -217,7 +217,6 @@ pub struct PumpkinServer {
     pub server: Arc<Server>,
     pub tcp_listener: Option<TcpListener>,
     pub bedrock_status: Option<StatusResponder>,
-    pub nethernet_discovery: Option<NetherNetDiscovery>,
     pub nethernet_listener: Option<NetherNetListener>,
 }
 
@@ -308,29 +307,11 @@ impl PumpkinServer {
 
         let (bedrock_status, ice_socket) = Self::bind_bedrock_status(&server).await;
         let nethernet_listener = Self::bind_nethernet(&server, ice_socket).await;
-        let nethernet_discovery = if nethernet_listener.is_some() {
-            let discovery = NetherNetDiscovery::bind(
-                server.advanced_config.networking.bedrock.nethernet.address,
-                server.server_guid,
-            )
-            .await
-            .expect("Failed to bind NetherNet LAN discovery");
-            info!(
-                "Bedrock NetherNet LAN discovery is listening on {}",
-                discovery
-                    .local_addr()
-                    .expect("NetherNet discovery socket should have a local address")
-            );
-            Some(discovery)
-        } else {
-            None
-        };
 
         Self {
             server,
             tcp_listener,
             bedrock_status,
-            nethernet_discovery,
             nethernet_listener,
         }
     }
@@ -526,8 +507,6 @@ impl PumpkinServer {
         tasks: &Arc<TaskTracker>,
         bedrock_clients: &Arc<Mutex<HashMap<SocketAddr, Arc<BedrockClient>>>>,
     ) -> bool {
-        let mut discovery_buf = vec![0; u16::MAX as usize].into_boxed_slice();
-
         select! {
             // Branch for TCP connections (Java Edition)
             tcp_result = resolve_some(self.tcp_listener.as_ref(), tokio::net::TcpListener::accept) => {
@@ -608,18 +587,6 @@ impl PumpkinServer {
             ) => {
                 if let Err(error) = status_result {
                     debug!("Bedrock status packet failed: {error}");
-                }
-            },
-
-            // NetherNet-native LAN discovery for clients joining the discovered server entry.
-            discovery_result = resolve_some(
-                self.nethernet_discovery.as_ref().zip(self.nethernet_listener.as_ref()),
-                |(discovery, listener): (&NetherNetDiscovery, &NetherNetListener)| {
-                    discovery.receive(&self.server, listener, &mut discovery_buf)
-                },
-            ) => {
-                if let Err(error) = discovery_result {
-                    debug!("NetherNet discovery packet failed: {error}");
                 }
             },
 

--- a/crates/pumpkin/src/net/bedrock/login.rs
+++ b/crates/pumpkin/src/net/bedrock/login.rs
@@ -186,7 +186,10 @@ impl BedrockClient {
 
         let login_public_key = pumpkin_util::jwt::extract_cpk_from_token(&auth_payload.token)
             .map_err(LoginError::ChainValidationFailed)?;
-        if self.nethernet_public_key() != &login_public_key {
+        if self
+            .nethernet_public_key()
+            .is_some_and(|public_key| public_key != &login_public_key)
+        {
             return Err(LoginError::ChainValidationFailed(
                 AuthError::PublicKeyBuild(
                     "NetherNet and Bedrock login identities do not match".into(),

--- a/crates/pumpkin/src/net/bedrock/mod.rs
+++ b/crates/pumpkin/src/net/bedrock/mod.rs
@@ -240,7 +240,7 @@ impl BedrockClient {
         }
     }
 
-    pub fn nethernet_public_key(&self) -> &pumpkin_util::p384::PublicKey {
+    pub fn nethernet_public_key(&self) -> Option<&pumpkin_util::p384::PublicKey> {
         self.session.client_public_key()
     }
 

--- a/crates/pumpkin/src/net/bedrock/nethernet.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet.rs
@@ -34,7 +34,7 @@ use tokio::{
     sync::{Mutex, RwLock, mpsc},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 use webrtc::{
     api::{API, APIBuilder, media_engine::MediaEngine, setting_engine::SettingEngine},
     data_channel::{RTCDataChannel, data_channel_message::DataChannelMessage},
@@ -43,6 +43,7 @@ use webrtc::{
         udp_mux::{UDPMuxDefault, UDPMuxParams},
         udp_network::UDPNetwork,
     },
+    ice_transport::ice_candidate::RTCIceCandidateInit,
     ice_transport::{ice_candidate_type::RTCIceCandidateType, ice_server::RTCIceServer},
     peer_connection::{
         RTCPeerConnection, configuration::RTCConfiguration,
@@ -52,6 +53,8 @@ use webrtc::{
 };
 
 use crate::STOP_INTERRUPT;
+
+pub mod discovery;
 
 const RELIABLE_CHANNEL: &str = "ReliableDataChannel";
 const UNRELIABLE_CHANNEL: &str = "UnreliableDataChannel";
@@ -66,6 +69,7 @@ type IncomingSession = (Arc<NetherNetSession>, SocketAddr);
 pub struct NetherNetListener {
     incoming: Mutex<mpsc::Receiver<IncomingSession>>,
     local_addr: SocketAddr,
+    state: EndpointState,
 }
 
 #[derive(Clone)]
@@ -73,6 +77,7 @@ struct EndpointState {
     incoming: mpsc::Sender<IncomingSession>,
     api: Arc<API>,
     identity_key: Arc<SigningKey>,
+    require_client_identity: bool,
     oidc_verifier: Option<Arc<(String, Jwks)>>,
     stun_servers: Arc<[String]>,
 }
@@ -83,6 +88,7 @@ impl NetherNetListener {
         ice_address: SocketAddr,
         external_ip: Option<IpAddr>,
         identity_key: Arc<SigningKey>,
+        require_client_identity: bool,
         oidc_verifier: Option<Arc<(String, Jwks)>>,
         stun_servers: Vec<String>,
     ) -> std::io::Result<Self> {
@@ -95,6 +101,7 @@ impl NetherNetListener {
             incoming,
             api: Arc::new(build_api(ice_socket, external_ip)?),
             identity_key,
+            require_client_identity,
             oidc_verifier,
             stun_servers: stun_servers.into(),
         };
@@ -102,7 +109,7 @@ impl NetherNetListener {
             .route("/v1/join", get(ping))
             .route("/v1/join/{network_id}", post(join))
             .layer(DefaultBodyLimit::max(MAX_SDP_SIZE))
-            .with_state(state);
+            .with_state(state.clone());
 
         tokio::spawn(async move {
             let result = axum::serve(
@@ -121,6 +128,7 @@ impl NetherNetListener {
         Ok(Self {
             incoming: Mutex::new(receiver),
             local_addr,
+            state,
         })
     }
 
@@ -227,7 +235,7 @@ async fn join(
         return (StatusCode::BAD_REQUEST, "SDP offer must be UTF-8").into_response();
     };
 
-    match negotiate(&state, address, &offer).await {
+    match negotiate(&state, address, &offer, None).await {
         Ok((answer, _session)) => {
             let mut response = (StatusCode::OK, answer).into_response();
             response
@@ -246,9 +254,14 @@ async fn negotiate(
     state: &EndpointState,
     address: SocketAddr,
     offer: &str,
+    candidates: Option<mpsc::UnboundedReceiver<RTCIceCandidateInit>>,
 ) -> Result<(String, Arc<NetherNetSession>), String> {
-    let (offer, client_public_key) =
-        verify_and_strip_identity(offer, state.oidc_verifier.as_deref())?;
+    trace!("Starting NetherNet negotiation with {address}");
+    let (offer, client_public_key) = authenticate_client_offer(
+        offer,
+        state.require_client_identity,
+        state.oidc_verifier.as_deref(),
+    )?;
 
     let peer = Arc::new(
         state
@@ -277,6 +290,7 @@ async fn negotiate(
     peer.on_data_channel(Box::new(move |channel| {
         let session = session_for_channels.clone();
         Box::pin(async move {
+            trace!(label = channel.label(), "Received NetherNet data channel");
             if let Err(error) = session.attach_channel(channel).await {
                 warn!("Rejected NetherNet data channel: {error}");
                 session.close().await;
@@ -288,6 +302,7 @@ async fn negotiate(
     peer.on_peer_connection_state_change(Box::new(move |connection_state| {
         let session = session_for_state.clone();
         Box::pin(async move {
+            trace!(?connection_state, "NetherNet peer connection state changed");
             if matches!(
                 connection_state,
                 RTCPeerConnectionState::Failed
@@ -303,6 +318,16 @@ async fn negotiate(
     peer.set_remote_description(offer)
         .await
         .map_err(|error| error.to_string())?;
+    if let Some(mut candidates) = candidates {
+        let peer = peer.clone();
+        tokio::spawn(async move {
+            while let Some(candidate) = candidates.recv().await {
+                if let Err(error) = peer.add_ice_candidate(candidate).await {
+                    debug!("Failed to add NetherNet LAN ICE candidate: {error}");
+                }
+            }
+        });
+    }
     let answer = peer
         .create_answer(None)
         .await
@@ -318,10 +343,27 @@ async fn negotiate(
         .local_description()
         .await
         .ok_or_else(|| "WebRTC did not produce a local description".to_string())?;
+    trace!("Completed NetherNet negotiation with {address}");
     Ok((
-        add_server_identity(&answer.sdp, &state.identity_key)?,
+        add_server_identity(
+            &remove_component_two_candidates(&answer.sdp),
+            &state.identity_key,
+        )?,
         session,
     ))
+}
+
+fn remove_component_two_candidates(sdp: &str) -> String {
+    let mut filtered = String::with_capacity(sdp.len());
+    for line in sdp.lines().filter(|line| {
+        line.strip_prefix("a=candidate:")
+            .and_then(|candidate| candidate.split_whitespace().nth(1))
+            != Some("2")
+    }) {
+        filtered.push_str(line);
+        filtered.push_str("\r\n");
+    }
+    filtered
 }
 
 /// A WebRTC connection carrying complete Bedrock batch packets.
@@ -336,7 +378,7 @@ pub struct NetherNetSession {
     open_channels: AtomicU8,
     accepted: AtomicBool,
     closed: CancellationToken,
-    client_public_key: PublicKey,
+    client_public_key: Option<PublicKey>,
     address: SocketAddr,
     incoming: mpsc::Sender<IncomingSession>,
 }
@@ -344,7 +386,7 @@ pub struct NetherNetSession {
 impl NetherNetSession {
     fn new(
         peer: Arc<RTCPeerConnection>,
-        client_public_key: PublicKey,
+        client_public_key: Option<PublicKey>,
         address: SocketAddr,
         incoming: mpsc::Sender<IncomingSession>,
     ) -> Self {
@@ -518,8 +560,8 @@ impl NetherNetSession {
         Ok(())
     }
 
-    pub const fn client_public_key(&self) -> &PublicKey {
-        &self.client_public_key
+    pub const fn client_public_key(&self) -> Option<&PublicKey> {
+        self.client_public_key.as_ref()
     }
 
     pub fn is_closed(&self) -> bool {
@@ -616,6 +658,21 @@ fn verify_and_strip_identity(
         .join("\r\n");
     stripped.push_str("\r\n");
     Ok((stripped, public_key))
+}
+
+fn authenticate_client_offer(
+    offer: &str,
+    require_identity: bool,
+    oidc_verifier: Option<&(String, Jwks)>,
+) -> Result<(String, Option<PublicKey>), String> {
+    if offer.lines().any(|line| line.starts_with("a=identity:")) {
+        let (offer, public_key) = verify_and_strip_identity(offer, oidc_verifier)?;
+        return Ok((offer, Some(public_key)));
+    }
+    if require_identity {
+        return Err("SDP offer is missing its identity assertion".to_string());
+    }
+    Ok((offer.to_owned(), None))
 }
 
 fn validate_token_expiration(token: &str) -> Result<(), String> {
@@ -808,6 +865,15 @@ mod tests {
     }
 
     #[test]
+    fn data_channel_sdp_only_advertises_component_one() {
+        let sdp = "v=0\r\na=candidate:1 1 udp 1 192.0.2.1 19134 typ host\r\na=candidate:1 2 udp 1 192.0.2.1 19134 typ host\r\na=end-of-candidates\r\n";
+        assert_eq!(
+            remove_component_two_candidates(sdp),
+            "v=0\r\na=candidate:1 1 udp 1 192.0.2.1 19134 typ host\r\na=end-of-candidates\r\n"
+        );
+    }
+
+    #[test]
     fn configured_oidc_validation_rejects_untrusted_identity_tokens() {
         let key = SigningKey::from_slice(&[7; 48]).unwrap();
         let sdp = "v=0\r\nt=0 0\r\nm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\na=fingerprint:sha-256 AA:BB\r\n";
@@ -844,6 +910,23 @@ mod tests {
             verify_and_strip_identity(&offer, Some(&verifier)).unwrap_err(),
             "invalid identity provider"
         );
+    }
+
+    #[test]
+    fn offline_mode_accepts_an_offer_without_identity() {
+        let offer = "v=0\r\nt=0 0\r\nm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n";
+        let (offer, public_key) = authenticate_client_offer(offer, false, None).unwrap();
+        assert_eq!(
+            offer,
+            "v=0\r\nt=0 0\r\nm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n"
+        );
+        assert!(public_key.is_none());
+    }
+
+    #[test]
+    fn online_mode_rejects_an_offer_without_identity() {
+        let error = authenticate_client_offer("v=0\r\n", true, None).unwrap_err();
+        assert_eq!(error, "SDP offer is missing its identity assertion");
     }
 
     #[tokio::test]
@@ -902,11 +985,12 @@ mod tests {
             incoming,
             api: Arc::new(build_api(ice_socket, None).unwrap()),
             identity_key: server_key.clone(),
+            require_client_identity: true,
             oidc_verifier: None,
             stun_servers: Arc::from([]),
         };
         let (answer, server_session) =
-            negotiate(&state, "127.0.0.1:19132".parse().unwrap(), &offer)
+            negotiate(&state, "127.0.0.1:19132".parse().unwrap(), &offer, None)
                 .await
                 .unwrap();
         let (answer, public_key) = verify_and_strip_identity(&answer, None).unwrap();

--- a/crates/pumpkin/src/net/bedrock/nethernet.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet.rs
@@ -30,7 +30,7 @@ use pumpkin_util::p384::{
 };
 use serde_json::{Value, json};
 use tokio::{
-    net::{TcpListener, UdpSocket},
+    net::TcpListener,
     sync::{Mutex, RwLock, mpsc},
 };
 use tokio_util::sync::CancellationToken;
@@ -53,6 +53,7 @@ use webrtc::{
 };
 
 use crate::STOP_INTERRUPT;
+use crate::net::bedrock::status::IceSocket;
 
 pub mod discovery;
 
@@ -85,7 +86,7 @@ struct EndpointState {
 impl NetherNetListener {
     pub async fn bind(
         address: SocketAddr,
-        ice_address: SocketAddr,
+        ice_socket: IceSocket,
         external_ip: Option<IpAddr>,
         identity_key: Arc<SigningKey>,
         require_client_identity: bool,
@@ -94,7 +95,6 @@ impl NetherNetListener {
     ) -> std::io::Result<Self> {
         let listener = TcpListener::bind(address).await?;
         let local_addr = listener.local_addr()?;
-        let ice_socket = UdpSocket::bind(ice_address).await?;
         let ice_local_addr = ice_socket.local_addr()?;
         let (incoming, receiver) = mpsc::channel(128);
         let state = EndpointState {
@@ -141,8 +141,13 @@ impl NetherNetListener {
     }
 }
 
-fn build_api(ice_socket: UdpSocket, external_ip: Option<IpAddr>) -> std::io::Result<API> {
-    let ice_ip = ice_socket.local_addr()?.ip();
+fn build_api<C>(ice_socket: C, external_ip: Option<IpAddr>) -> std::io::Result<API>
+where
+    C: webrtc::util::Conn + Send + Sync + 'static,
+{
+    let ice_ip = webrtc::util::Conn::local_addr(&ice_socket)
+        .map_err(|error| std::io::Error::other(error.to_string()))?
+        .ip();
     if external_ip.is_some_and(|external_ip| external_ip.is_ipv4() != ice_ip.is_ipv4()) {
         return Err(std::io::Error::new(
             ErrorKind::InvalidInput,
@@ -818,6 +823,7 @@ fn unix_time() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::net::UdpSocket;
     use webrtc::data_channel::data_channel_init::RTCDataChannelInit;
 
     #[test]

--- a/crates/pumpkin/src/net/bedrock/nethernet.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet.rs
@@ -1,10 +1,10 @@
 use std::{
     fs::OpenOptions,
     io::{ErrorKind, Write},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     path::Path as FsPath,
     sync::{
-        Arc,
+        Arc, OnceLock,
         atomic::{AtomicBool, AtomicU8, Ordering},
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -30,15 +30,20 @@ use pumpkin_util::p384::{
 };
 use serde_json::{Value, json};
 use tokio::{
-    net::TcpListener,
+    net::{TcpListener, UdpSocket},
     sync::{Mutex, RwLock, mpsc},
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use webrtc::{
-    api::{APIBuilder, media_engine::MediaEngine},
+    api::{API, APIBuilder, media_engine::MediaEngine, setting_engine::SettingEngine},
     data_channel::{RTCDataChannel, data_channel_message::DataChannelMessage},
-    ice_transport::ice_server::RTCIceServer,
+    ice::{
+        network_type::NetworkType,
+        udp_mux::{UDPMuxDefault, UDPMuxParams},
+        udp_network::UDPNetwork,
+    },
+    ice_transport::{ice_candidate_type::RTCIceCandidateType, ice_server::RTCIceServer},
     peer_connection::{
         RTCPeerConnection, configuration::RTCConfiguration,
         peer_connection_state::RTCPeerConnectionState,
@@ -66,6 +71,7 @@ pub struct NetherNetListener {
 #[derive(Clone)]
 struct EndpointState {
     incoming: mpsc::Sender<IncomingSession>,
+    api: Arc<API>,
     identity_key: Arc<SigningKey>,
     oidc_verifier: Option<Arc<(String, Jwks)>>,
     stun_servers: Arc<[String]>,
@@ -74,15 +80,20 @@ struct EndpointState {
 impl NetherNetListener {
     pub async fn bind(
         address: SocketAddr,
+        ice_address: SocketAddr,
+        external_ip: Option<IpAddr>,
         identity_key: Arc<SigningKey>,
         oidc_verifier: Option<Arc<(String, Jwks)>>,
         stun_servers: Vec<String>,
     ) -> std::io::Result<Self> {
         let listener = TcpListener::bind(address).await?;
         let local_addr = listener.local_addr()?;
+        let ice_socket = UdpSocket::bind(ice_address).await?;
+        let ice_local_addr = ice_socket.local_addr()?;
         let (incoming, receiver) = mpsc::channel(128);
         let state = EndpointState {
             incoming,
+            api: Arc::new(build_api(ice_socket, external_ip)?),
             identity_key,
             oidc_verifier,
             stun_servers: stun_servers.into(),
@@ -106,6 +117,7 @@ impl NetherNetListener {
         });
 
         info!("Bedrock NetherNet signaling is listening on {local_addr}");
+        info!("Bedrock NetherNet ICE is listening on {ice_local_addr}");
         Ok(Self {
             incoming: Mutex::new(receiver),
             local_addr,
@@ -119,6 +131,39 @@ impl NetherNetListener {
     pub const fn local_addr(&self) -> SocketAddr {
         self.local_addr
     }
+}
+
+fn build_api(ice_socket: UdpSocket, external_ip: Option<IpAddr>) -> std::io::Result<API> {
+    let ice_ip = ice_socket.local_addr()?.ip();
+    if external_ip.is_some_and(|external_ip| external_ip.is_ipv4() != ice_ip.is_ipv4()) {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            "NetherNet external IP and ICE address must use the same address family",
+        ));
+    }
+    let mut media_engine = MediaEngine::default();
+    media_engine
+        .register_default_codecs()
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+
+    let udp_mux = UDPMuxDefault::new(UDPMuxParams::new(ice_socket));
+    let mut setting_engine = SettingEngine::default();
+    setting_engine.set_udp_network(UDPNetwork::Muxed(udp_mux));
+    setting_engine.set_network_types(vec![if ice_ip.is_ipv4() {
+        NetworkType::Udp4
+    } else {
+        NetworkType::Udp6
+    }]);
+    if let Some(external_ip) = external_ip {
+        let selected_ip = OnceLock::new();
+        setting_engine.set_ip_filter(Box::new(move |ip| selected_ip.get_or_init(|| ip) == &ip));
+        setting_engine.set_nat_1to1_ips(vec![external_ip.to_string()], RTCIceCandidateType::Host);
+    }
+
+    Ok(APIBuilder::new()
+        .with_media_engine(media_engine)
+        .with_setting_engine(setting_engine)
+        .build())
 }
 
 pub fn load_or_create_identity_key(path: &FsPath) -> std::io::Result<Arc<SigningKey>> {
@@ -205,24 +250,21 @@ async fn negotiate(
     let (offer, client_public_key) =
         verify_and_strip_identity(offer, state.oidc_verifier.as_deref())?;
 
-    let mut media_engine = MediaEngine::default();
-    media_engine
-        .register_default_codecs()
-        .map_err(|error| error.to_string())?;
-    let api = APIBuilder::new().with_media_engine(media_engine).build();
     let peer = Arc::new(
-        api.new_peer_connection(RTCConfiguration {
-            ice_servers: (!state.stun_servers.is_empty())
-                .then(|| RTCIceServer {
-                    urls: state.stun_servers.to_vec(),
-                    ..Default::default()
-                })
-                .into_iter()
-                .collect(),
-            ..Default::default()
-        })
-        .await
-        .map_err(|error| error.to_string())?,
+        state
+            .api
+            .new_peer_connection(RTCConfiguration {
+                ice_servers: (!state.stun_servers.is_empty())
+                    .then(|| RTCIceServer {
+                        urls: state.stun_servers.to_vec(),
+                        ..Default::default()
+                    })
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| error.to_string())?,
     );
     let session = Arc::new(NetherNetSession::new(
         peer.clone(),
@@ -854,8 +896,11 @@ mod tests {
 
         let (incoming, mut receiver) = mpsc::channel(1);
         let server_key = Arc::new(SigningKey::from_slice(&[9; 48]).unwrap());
+        let ice_socket = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        let ice_port = ice_socket.local_addr().unwrap().port();
         let state = EndpointState {
             incoming,
+            api: Arc::new(build_api(ice_socket, None).unwrap()),
             identity_key: server_key.clone(),
             oidc_verifier: None,
             stun_servers: Arc::from([]),
@@ -866,6 +911,7 @@ mod tests {
                 .unwrap();
         let (answer, public_key) = verify_and_strip_identity(&answer, None).unwrap();
         assert_eq!(public_key, PublicKey::from(server_key.verifying_key()));
+        assert!(answer.contains(&format!(" {ice_port} typ host")));
         client
             .set_remote_description(RTCSessionDescription::answer(answer).unwrap())
             .await

--- a/crates/pumpkin/src/net/bedrock/nethernet.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet.rs
@@ -223,25 +223,30 @@ pub fn load_or_create_identity_key(path: &FsPath) -> std::io::Result<Arc<Signing
     }
 }
 
-async fn ping() -> StatusCode {
+async fn ping(ConnectInfo(address): ConnectInfo<SocketAddr>) -> StatusCode {
+    trace!(%address, "Accepted NetherNet capability probe");
     StatusCode::OK
 }
 
 async fn join(
     State(state): State<EndpointState>,
     ConnectInfo(address): ConnectInfo<SocketAddr>,
-    Path(_network_id): Path<String>,
+    Path(network_id): Path<String>,
     offer: Bytes,
 ) -> Response {
+    trace!(%address, %network_id, length = offer.len(), "Received NetherNet SDP offer");
     if offer.is_empty() {
+        debug!(%address, %network_id, "Rejected empty NetherNet SDP offer");
         return (StatusCode::BAD_REQUEST, "Missing SDP offer").into_response();
     }
     let Ok(offer) = String::from_utf8(offer.to_vec()) else {
+        debug!(%address, %network_id, "Rejected non-UTF-8 NetherNet SDP offer");
         return (StatusCode::BAD_REQUEST, "SDP offer must be UTF-8").into_response();
     };
 
     match negotiate(&state, address, &offer, None).await {
         Ok((answer, _session)) => {
+            trace!(%address, %network_id, length = answer.len(), "Returning NetherNet SDP answer");
             let mut response = (StatusCode::OK, answer).into_response();
             response
                 .headers_mut()
@@ -261,7 +266,8 @@ async fn negotiate(
     offer: &str,
     candidates: Option<mpsc::UnboundedReceiver<RTCIceCandidateInit>>,
 ) -> Result<(String, Arc<NetherNetSession>), String> {
-    trace!("Starting NetherNet negotiation with {address}");
+    let signaling = if candidates.is_some() { "LAN" } else { "HTTP" };
+    trace!(%address, signaling, "Starting NetherNet negotiation");
     let (offer, client_public_key) = authenticate_client_offer(
         offer,
         state.require_client_identity,
@@ -269,6 +275,8 @@ async fn negotiate(
     )?;
     trace!(
         %address,
+        signaling,
+        authenticated = client_public_key.is_some(),
         candidates = ?candidate_summary(&offer),
         "Received NetherNet ICE candidates"
     );
@@ -295,45 +303,13 @@ async fn negotiate(
         address,
         state.incoming.clone(),
     ));
-
-    let session_for_channels = session.clone();
-    peer.on_data_channel(Box::new(move |channel| {
-        let session = session_for_channels.clone();
-        Box::pin(async move {
-            trace!(label = channel.label(), "Received NetherNet data channel");
-            if let Err(error) = session.attach_channel(channel).await {
-                warn!("Rejected NetherNet data channel: {error}");
-                session.close().await;
-            }
-        })
-    }));
-
-    let session_for_state = session.clone();
-    peer.on_peer_connection_state_change(Box::new(move |connection_state| {
-        let session = session_for_state.clone();
-        Box::pin(async move {
-            trace!(?connection_state, "NetherNet peer connection state changed");
-            if matches!(
-                connection_state,
-                RTCPeerConnectionState::Failed
-                    | RTCPeerConnectionState::Disconnected
-                    | RTCPeerConnectionState::Closed
-            ) {
-                session.mark_closed();
-            }
-        })
-    }));
-
-    peer.on_ice_connection_state_change(Box::new(move |connection_state| {
-        Box::pin(async move {
-            trace!(?connection_state, %address, "NetherNet ICE connection state changed");
-        })
-    }));
+    register_peer_callbacks(&peer, &session, address);
 
     let offer = RTCSessionDescription::offer(offer).map_err(|error| error.to_string())?;
     peer.set_remote_description(offer)
         .await
         .map_err(|error| error.to_string())?;
+    trace!(%address, signaling, "Applied NetherNet remote description");
     if let Some(mut candidates) = candidates {
         let peer = peer.clone();
         tokio::spawn(async move {
@@ -352,6 +328,7 @@ async fn negotiate(
     peer.set_local_description(answer)
         .await
         .map_err(|error| error.to_string())?;
+    trace!(%address, signaling, "Gathering NetherNet ICE candidates");
     tokio::time::timeout(Duration::from_secs(10), gathering_complete.recv())
         .await
         .map_err(|_| "Timed out gathering ICE candidates".to_string())?;
@@ -359,19 +336,62 @@ async fn negotiate(
         .local_description()
         .await
         .ok_or_else(|| "WebRTC did not produce a local description".to_string())?;
+    let answer = remove_component_two_candidates(&answer.sdp);
     trace!(
         %address,
-        candidates = ?candidate_summary(&answer.sdp),
+        signaling,
+        candidates = ?candidate_summary(&answer),
         "Gathered NetherNet ICE candidates"
     );
-    trace!("Completed NetherNet negotiation with {address}");
-    Ok((
-        add_server_identity(
-            &remove_component_two_candidates(&answer.sdp),
-            &state.identity_key,
-        )?,
-        session,
-    ))
+    trace!(%address, signaling, "Completed NetherNet negotiation");
+    Ok((add_server_identity(&answer, &state.identity_key)?, session))
+}
+
+fn register_peer_callbacks(
+    peer: &RTCPeerConnection,
+    session: &Arc<NetherNetSession>,
+    address: SocketAddr,
+) {
+    let session_for_channels = session.clone();
+    peer.on_data_channel(Box::new(move |channel| {
+        let session = session_for_channels.clone();
+        Box::pin(async move {
+            trace!(
+                %address,
+                label = channel.label(),
+                ordered = channel.ordered(),
+                negotiated = channel.negotiated(),
+                max_retransmits = ?channel.max_retransmits(),
+                "Received NetherNet data channel"
+            );
+            if let Err(error) = session.attach_channel(channel).await {
+                warn!("Rejected NetherNet data channel: {error}");
+                session.close().await;
+            }
+        })
+    }));
+
+    let session_for_state = session.clone();
+    peer.on_peer_connection_state_change(Box::new(move |connection_state| {
+        let session = session_for_state.clone();
+        Box::pin(async move {
+            trace!(?connection_state, %address, "NetherNet peer connection state changed");
+            if matches!(
+                connection_state,
+                RTCPeerConnectionState::Failed
+                    | RTCPeerConnectionState::Disconnected
+                    | RTCPeerConnectionState::Closed
+            ) {
+                session.mark_closed();
+            }
+        })
+    }));
+
+    peer.on_ice_connection_state_change(Box::new(move |connection_state| {
+        Box::pin(async move {
+            trace!(?connection_state, %address, "NetherNet ICE connection state changed");
+        })
+    }));
 }
 
 fn candidate_summary(sdp: &str) -> Vec<String> {
@@ -502,6 +522,12 @@ impl NetherNetSession {
 
     async fn channel_opened(self: &Arc<Self>, bit: u8) {
         let open = self.open_channels.fetch_or(bit, Ordering::AcqRel) | bit;
+        trace!(
+            address = %self.address,
+            channel = if bit == 1 { "reliable" } else { "unreliable" },
+            both_open = open == 3,
+            "NetherNet data channel opened"
+        );
         if open == 3 && !self.accepted.swap(true, Ordering::AcqRel) {
             debug!(
                 "Accepted Bedrock NetherNet connection from {}",
@@ -615,7 +641,10 @@ impl NetherNetSession {
     }
 
     fn mark_closed(&self) {
-        self.closed.cancel();
+        if !self.closed.is_cancelled() {
+            trace!(address = %self.address, "NetherNet session closed");
+            self.closed.cancel();
+        }
     }
 
     #[allow(clippy::unused_async)]

--- a/crates/pumpkin/src/net/bedrock/nethernet.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet.rs
@@ -267,6 +267,11 @@ async fn negotiate(
         state.require_client_identity,
         state.oidc_verifier.as_deref(),
     )?;
+    trace!(
+        %address,
+        candidates = ?candidate_summary(&offer),
+        "Received NetherNet ICE candidates"
+    );
 
     let peer = Arc::new(
         state
@@ -319,6 +324,12 @@ async fn negotiate(
         })
     }));
 
+    peer.on_ice_connection_state_change(Box::new(move |connection_state| {
+        Box::pin(async move {
+            trace!(?connection_state, %address, "NetherNet ICE connection state changed");
+        })
+    }));
+
     let offer = RTCSessionDescription::offer(offer).map_err(|error| error.to_string())?;
     peer.set_remote_description(offer)
         .await
@@ -348,6 +359,11 @@ async fn negotiate(
         .local_description()
         .await
         .ok_or_else(|| "WebRTC did not produce a local description".to_string())?;
+    trace!(
+        %address,
+        candidates = ?candidate_summary(&answer.sdp),
+        "Gathered NetherNet ICE candidates"
+    );
     trace!("Completed NetherNet negotiation with {address}");
     Ok((
         add_server_identity(
@@ -356,6 +372,31 @@ async fn negotiate(
         )?,
         session,
     ))
+}
+
+fn candidate_summary(sdp: &str) -> Vec<String> {
+    sdp.lines()
+        .filter_map(|line| line.strip_prefix("a=candidate:"))
+        .map(|candidate| {
+            let fields = candidate.split_whitespace().collect::<Vec<_>>();
+            match fields.as_slice() {
+                [
+                    foundation,
+                    component,
+                    protocol,
+                    _,
+                    address,
+                    port,
+                    "typ",
+                    kind,
+                    ..,
+                ] => {
+                    format!("{foundation}/{component} {protocol} {address}:{port} {kind}")
+                }
+                _ => "malformed candidate".to_owned(),
+            }
+        })
+        .collect()
 }
 
 fn remove_component_two_candidates(sdp: &str) -> String {
@@ -877,6 +918,13 @@ mod tests {
             remove_component_two_candidates(sdp),
             "v=0\r\na=candidate:1 1 udp 1 192.0.2.1 19134 typ host\r\na=end-of-candidates\r\n"
         );
+    }
+
+    #[test]
+    fn summarizes_candidates_without_credentials() {
+        let sdp = "a=ice-ufrag:secret\r\na=ice-pwd:also-secret\r\n\
+                   a=candidate:123 1 udp 2130706431 192.0.2.1 19132 typ host\r\n";
+        assert_eq!(candidate_summary(sdp), ["123/1 udp 192.0.2.1:19132 host"]);
     }
 
     #[test]

--- a/crates/pumpkin/src/net/bedrock/nethernet.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet.rs
@@ -37,7 +37,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 use webrtc::{
     api::{API, APIBuilder, media_engine::MediaEngine, setting_engine::SettingEngine},
-    data_channel::{RTCDataChannel, data_channel_message::DataChannelMessage},
+    data_channel::RTCDataChannel,
     ice::{
         network_type::NetworkType,
         udp_mux::{UDPMuxDefault, UDPMuxParams},
@@ -62,6 +62,9 @@ const UNRELIABLE_CHANNEL: &str = "UnreliableDataChannel";
 // NetherNet splits encoded packets that exceed 10,000 bytes into application-level
 // segments. Larger SCTP messages are rejected by some Bedrock clients.
 const MAX_FRAGMENT_SIZE: usize = 10_000;
+// Bedrock may send its login batch as one maximum-sized NetherNet segment. This
+// exceeds webrtc-rs's 65,535-byte callback buffer when the skin data is large.
+const MAX_INBOUND_MESSAGE_SIZE: usize = 262_144;
 const MAX_SDP_SIZE: usize = 1 << 20;
 
 type IncomingSession = (Arc<NetherNetSession>, SocketAddr);
@@ -161,6 +164,7 @@ where
 
     let udp_mux = UDPMuxDefault::new(UDPMuxParams::new(ice_socket));
     let mut setting_engine = SettingEngine::default();
+    setting_engine.detach_data_channels();
     setting_engine.set_udp_network(UDPNetwork::Muxed(udp_mux));
     setting_engine.set_network_types(vec![if ice_ip.is_ipv4() {
         NetworkType::Udp4
@@ -498,23 +502,46 @@ impl NetherNetSession {
         };
 
         let session = self.clone();
-        channel.on_message(Box::new(move |message: DataChannelMessage| {
-            let session = session.clone();
-            Box::pin(async move {
-                if let Err(error) = session.receive_segment(bit, message.data).await {
-                    warn!(
-                        "Invalid NetherNet message from {}: {error}",
-                        session.address
-                    );
-                    session.close().await;
-                }
-            })
-        }));
-
-        let session = self.clone();
+        let channel_for_open = channel.clone();
         channel.on_open(Box::new(move || {
             Box::pin(async move {
+                let detached = match channel_for_open.detach().await {
+                    Ok(channel) => channel,
+                    Err(error) => {
+                        warn!(%error, address = %session.address, "Failed to detach NetherNet data channel");
+                        session.close().await;
+                        return;
+                    }
+                };
                 session.channel_opened(bit).await;
+                tokio::spawn(async move {
+                    let mut buffer = vec![0; MAX_INBOUND_MESSAGE_SIZE];
+                    loop {
+                        match detached.read_data_channel(&mut buffer).await {
+                            Ok((0, _)) => break,
+                            Ok((length, _)) => {
+                                if let Err(error) = session
+                                    .receive_segment(
+                                        bit,
+                                        Bytes::copy_from_slice(&buffer[..length]),
+                                    )
+                                    .await
+                                {
+                                    warn!(
+                                        "Invalid NetherNet message from {}: {error}",
+                                        session.address
+                                    );
+                                    break;
+                                }
+                            }
+                            Err(error) => {
+                                warn!(%error, address = %session.address, "Failed to read NetherNet data channel");
+                                break;
+                            }
+                        }
+                    }
+                    session.close().await;
+                });
             })
         }));
         Ok(())
@@ -894,7 +921,10 @@ fn unix_time() -> i64 {
 mod tests {
     use super::*;
     use tokio::net::UdpSocket;
-    use webrtc::data_channel::data_channel_init::RTCDataChannelInit;
+    use webrtc::{
+        api::setting_engine::SctpMaxMessageSize,
+        data_channel::data_channel_init::RTCDataChannelInit,
+    };
 
     #[test]
     fn fragments_round_trip() {
@@ -1012,14 +1042,37 @@ mod tests {
         assert_eq!(error, "SDP offer is missing its identity assertion");
     }
 
+    async fn receive_packet(session: &NetherNetSession) -> Bytes {
+        tokio::time::timeout(Duration::from_secs(5), session.recv())
+            .await
+            .unwrap()
+            .unwrap()
+    }
+
+    async fn receive_bytes(receiver: &mut mpsc::Receiver<Bytes>) -> Bytes {
+        tokio::time::timeout(Duration::from_secs(5), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap()
+    }
+
+    fn test_client_api() -> API {
+        let mut media_engine = MediaEngine::default();
+        media_engine.register_default_codecs().unwrap();
+        let mut setting_engine = SettingEngine::default();
+        setting_engine.set_sctp_max_message_size_can_send(SctpMaxMessageSize::Unbounded);
+        APIBuilder::new()
+            .with_media_engine(media_engine)
+            .with_setting_engine(setting_engine)
+            .build()
+    }
+
     #[tokio::test]
     async fn negotiates_channels_and_receives_a_packet() {
         let _ = tracing_subscriber::fmt().with_test_writer().try_init();
-        let mut media_engine = MediaEngine::default();
-        media_engine.register_default_codecs().unwrap();
-        let api = APIBuilder::new().with_media_engine(media_engine).build();
         let client = Arc::new(
-            api.new_peer_connection(RTCConfiguration::default())
+            test_client_api()
+                .new_peer_connection(RTCConfiguration::default())
                 .await
                 .unwrap(),
         );
@@ -1051,7 +1104,6 @@ mod tests {
                 let _ = sender.send(message.data).await;
             })
         }));
-
         let offer = client.create_offer(None).await.unwrap();
         let mut gathering_complete = client.gathering_complete_promise().await;
         client.set_local_description(offer).await.unwrap();
@@ -1059,7 +1111,6 @@ mod tests {
         let offer = client.local_description().await.unwrap();
         let client_key = SigningKey::from_slice(&[8; 48]).unwrap();
         let offer = add_server_identity(&offer.sdp, &client_key).unwrap();
-
         let (incoming, mut receiver) = mpsc::channel(1);
         let server_key = Arc::new(SigningKey::from_slice(&[9; 48]).unwrap());
         let ice_socket = UdpSocket::bind("0.0.0.0:0").await.unwrap();
@@ -1079,11 +1130,14 @@ mod tests {
         let (answer, public_key) = verify_and_strip_identity(&answer, None).unwrap();
         assert_eq!(public_key, PublicKey::from(server_key.verifying_key()));
         assert!(answer.contains(&format!(" {ice_port} typ host")));
+        let answer = answer.replace(
+            "a=sctp-port:5000\r\n",
+            "a=sctp-port:5000\r\na=max-message-size:262144\r\n",
+        );
         client
             .set_remote_description(RTCSessionDescription::answer(answer).unwrap())
             .await
             .unwrap();
-
         let Ok(Some((session, _))) =
             tokio::time::timeout(Duration::from_secs(5), receiver.recv()).await
         else {
@@ -1097,21 +1151,21 @@ mod tests {
             .send(&Bytes::from_static(b"\0hello"))
             .await
             .unwrap();
-        let packet = tokio::time::timeout(Duration::from_secs(5), session.recv())
-            .await
-            .unwrap()
-            .unwrap();
+        let packet = receive_packet(&session).await;
         assert_eq!(packet, b"hello".as_slice());
+        let large_packet = vec![42; 100_000];
+        let mut segment = Vec::with_capacity(large_packet.len() + 1);
+        segment.push(0);
+        segment.extend_from_slice(&large_packet);
+        reliable.send(&Bytes::from(segment)).await.unwrap();
+        let packet = receive_packet(&session).await;
+        assert_eq!(packet, large_packet);
         session
             .send_unreliable(Bytes::from_static(b"world"))
             .await
             .unwrap();
-        let packet = tokio::time::timeout(Duration::from_secs(5), unreliable_receiver.recv())
-            .await
-            .unwrap()
-            .unwrap();
+        let packet = receive_bytes(&mut unreliable_receiver).await;
         assert_eq!(packet, b"\0world".as_slice());
-
         session.close().await;
         client.close().await.unwrap();
     }

--- a/crates/pumpkin/src/net/bedrock/nethernet/discovery.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet/discovery.rs
@@ -121,6 +121,16 @@ impl NetherNetDiscovery {
             server.advanced_config.networking.bedrock.online_mode,
         )?;
         self.socket.send_to(&response, address).await?;
+        trace!(
+            %address,
+            network_id = self.network_id,
+            advertisement_id = format_args!("{:016x}", self.advertisement_id),
+            version = SERVER_DATA_VERSION,
+            players,
+            max_players = server.advanced_config.networking.bedrock.max_players,
+            online_mode = server.advanced_config.networking.bedrock.online_mode,
+            "Sent NetherNet LAN discovery response"
+        );
         Ok(())
     }
 
@@ -138,15 +148,18 @@ impl NetherNetDiscovery {
         let (Some(signal_type), Some(connection_id), Some(data)) =
             (parts.next(), parts.next(), parts.next())
         else {
+            trace!(%address, sender_id, "Ignored empty or malformed NetherNet LAN signal");
             return;
         };
         let Ok(connection_id) = connection_id.parse::<u64>() else {
+            trace!(%address, sender_id, "Ignored NetherNet LAN signal with invalid connection ID");
             return;
         };
         let key = (sender_id, connection_id);
 
         match signal_type {
             "CONNECTREQUEST" => {
+                trace!(%address, sender_id, connection_id, "Accepted NetherNet LAN connection request");
                 let (candidate_sender, candidate_receiver) = mpsc::unbounded_channel();
                 self.candidates.lock().await.insert(key, candidate_sender);
 
@@ -170,6 +183,8 @@ impl NetherNetDiscovery {
                         Ok(response) => {
                             if let Err(error) = socket.send_to(&response, address).await {
                                 warn!("Failed to send NetherNet LAN signal to {address}: {error}");
+                            } else {
+                                trace!(%address, sender_id, connection_id, "Sent NetherNet LAN connection response");
                             }
                         }
                         Err(error) => warn!("Failed to encode NetherNet LAN signal: {error}"),
@@ -186,6 +201,9 @@ impl NetherNetDiscovery {
                     });
                 if let Some(sender) = self.candidates.lock().await.get(&key) {
                     let _ = sender.send(candidate);
+                    trace!(%address, sender_id, connection_id, "Forwarded NetherNet LAN ICE candidate");
+                } else {
+                    trace!(%address, sender_id, connection_id, "Ignored NetherNet LAN ICE candidate for unknown connection");
                 }
             }
             signal_type => debug!("Ignoring NetherNet LAN signal {signal_type}"),

--- a/crates/pumpkin/src/net/bedrock/nethernet/discovery.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet/discovery.rs
@@ -362,9 +362,7 @@ fn push_string(buffer: &mut Vec<u8>, value: &str) -> Result<(), Error> {
 fn encrypt(data: &mut [u8]) {
     let (blocks, remainder) = Block::slice_as_chunks_mut(data);
     debug_assert!(remainder.is_empty());
-    Aes256::new_from_slice(KEY.as_slice())
-        .expect("AES-256 key has the correct length")
-        .encrypt_blocks(blocks);
+    Aes256::new((&*KEY).into()).encrypt_blocks(blocks);
 }
 
 fn decrypt(data: &mut [u8]) -> Option<()> {
@@ -372,9 +370,7 @@ fn decrypt(data: &mut [u8]) -> Option<()> {
     if !remainder.is_empty() {
         return None;
     }
-    Aes256::new_from_slice(KEY.as_slice())
-        .ok()?
-        .decrypt_blocks(blocks);
+    Aes256::new((&*KEY).into()).decrypt_blocks(blocks);
     Some(())
 }
 

--- a/crates/pumpkin/src/net/bedrock/nethernet/discovery.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet/discovery.rs
@@ -1,0 +1,430 @@
+use std::{
+    collections::HashMap,
+    io::{Error, ErrorKind},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
+
+use aes::{
+    Aes256, Block,
+    cipher::{BlockCipherDecrypt, BlockCipherEncrypt, KeyInit},
+};
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+use tokio::{
+    net::UdpSocket,
+    sync::{Mutex, mpsc},
+};
+use tracing::{debug, trace, warn};
+use webrtc::ice_transport::ice_candidate::RTCIceCandidateInit;
+
+use super::{NetherNetListener, negotiate};
+use crate::server::Server;
+
+const DISCOVERY_PORT: u16 = 7551;
+const CHECKSUM_SIZE: usize = 32;
+const HEADER_SIZE: usize = 18;
+const REQUEST_PACKET: u16 = 0;
+const RESPONSE_PACKET: u16 = 1;
+const MESSAGE_PACKET: u16 = 2;
+const SERVER_DATA_VERSION: u8 = 6;
+
+type ConnectionKey = (u64, u64);
+
+static KEY: LazyLock<[u8; 32]> =
+    LazyLock::new(|| Sha256::digest(0xdeadbeefu64.to_le_bytes()).into());
+
+pub struct NetherNetDiscovery {
+    socket: Arc<UdpSocket>,
+    network_id: u64,
+    advertisement_id: u64,
+    candidates: Arc<Mutex<HashMap<ConnectionKey, mpsc::UnboundedSender<RTCIceCandidateInit>>>>,
+}
+
+impl NetherNetDiscovery {
+    pub async fn bind(address: SocketAddr, network_id: u64) -> Result<Self, Error> {
+        let ip = match address.ip() {
+            IpAddr::V4(ip) => ip,
+            IpAddr::V6(_) => Ipv4Addr::UNSPECIFIED,
+        };
+        let socket = UdpSocket::bind((ip, DISCOVERY_PORT)).await?;
+        Ok(Self {
+            socket: Arc::new(socket),
+            network_id,
+            advertisement_id: rand::random(),
+            candidates: Arc::default(),
+        })
+    }
+
+    pub async fn receive(
+        &self,
+        server: &Server,
+        listener: &NetherNetListener,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        let (length, address) = self.socket.recv_from(buffer).await?;
+        match decode_packet(&buffer[..length]) {
+            Some(Packet::Request) => {
+                trace!("Received NetherNet LAN discovery request from {address}");
+                self.advertise(server, address).await?;
+            }
+            Some(Packet::Message {
+                sender_id,
+                recipient_id,
+                data,
+            }) if recipient_id == self.network_id => {
+                trace!(
+                    sender_id,
+                    recipient_id,
+                    signal = data
+                        .split_once(' ')
+                        .map_or(data.as_str(), |(signal, _)| signal),
+                    "Received NetherNet LAN signal from {address}"
+                );
+                self.handle_signal(listener, address, sender_id, data).await;
+            }
+            Some(Packet::Message {
+                sender_id,
+                recipient_id,
+                ..
+            }) => trace!(
+                sender_id,
+                recipient_id,
+                expected_recipient_id = self.network_id,
+                "Ignored NetherNet LAN signal for another server"
+            ),
+            None => trace!("Ignored invalid {length}-byte NetherNet LAN packet from {address}"),
+        }
+        Ok(())
+    }
+
+    async fn advertise(&self, server: &Server, address: SocketAddr) -> Result<(), Error> {
+        let players = server
+            .get_status()
+            .lock()
+            .await
+            .status_response
+            .players
+            .as_ref()
+            .map_or(0, |players| players.online);
+        let game_mode = server.defaultgamemode.lock().await.gamemode as u8;
+        let response = encode_response(
+            self.network_id,
+            self.advertisement_id,
+            &server.advanced_config.networking.bedrock.motd,
+            &server.basic_config.default_level_name,
+            game_mode,
+            players,
+            server.advanced_config.networking.bedrock.max_players,
+            server.basic_config.hardcore,
+            server.advanced_config.networking.bedrock.online_mode,
+        )?;
+        self.socket.send_to(&response, address).await?;
+        Ok(())
+    }
+
+    async fn handle_signal(
+        &self,
+        listener: &NetherNetListener,
+        address: SocketAddr,
+        sender_id: u64,
+        data: String,
+    ) {
+        if data == "Ping" {
+            return;
+        }
+        let mut parts = data.splitn(3, ' ');
+        let (Some(signal_type), Some(connection_id), Some(data)) =
+            (parts.next(), parts.next(), parts.next())
+        else {
+            return;
+        };
+        let Ok(connection_id) = connection_id.parse::<u64>() else {
+            return;
+        };
+        let key = (sender_id, connection_id);
+
+        match signal_type {
+            "CONNECTREQUEST" => {
+                let (candidate_sender, candidate_receiver) = mpsc::unbounded_channel();
+                self.candidates.lock().await.insert(key, candidate_sender);
+
+                let state = listener.state.clone();
+                let socket = self.socket.clone();
+                let candidates = self.candidates.clone();
+                let offer = data.to_owned();
+                let network_id = self.network_id;
+                tokio::spawn(async move {
+                    let signal =
+                        match negotiate(&state, address, &offer, Some(candidate_receiver)).await {
+                            Ok((answer, _session)) => {
+                                format!("CONNECTRESPONSE {connection_id} {answer}")
+                            }
+                            Err(error) => {
+                                warn!("NetherNet LAN negotiation with {address} failed: {error}");
+                                format!("CONNECTERROR {connection_id} 11")
+                            }
+                        };
+                    match encode_message(network_id, sender_id, &signal) {
+                        Ok(response) => {
+                            if let Err(error) = socket.send_to(&response, address).await {
+                                warn!("Failed to send NetherNet LAN signal to {address}: {error}");
+                            }
+                        }
+                        Err(error) => warn!("Failed to encode NetherNet LAN signal: {error}"),
+                    }
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                    candidates.lock().await.remove(&key);
+                });
+            }
+            "CANDIDATEADD" => {
+                let candidate =
+                    serde_json::from_str(data).unwrap_or_else(|_| RTCIceCandidateInit {
+                        candidate: data.to_owned(),
+                        ..Default::default()
+                    });
+                if let Some(sender) = self.candidates.lock().await.get(&key) {
+                    let _ = sender.send(candidate);
+                }
+            }
+            signal_type => debug!("Ignoring NetherNet LAN signal {signal_type}"),
+        }
+    }
+
+    pub fn local_addr(&self) -> Result<SocketAddr, Error> {
+        self.socket.local_addr()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Packet {
+    Request,
+    Message {
+        sender_id: u64,
+        recipient_id: u64,
+        data: String,
+    },
+}
+
+fn decode_packet(data: &[u8]) -> Option<Packet> {
+    let encrypted = data.get(CHECKSUM_SIZE..)?;
+    if encrypted.is_empty() || !encrypted.len().is_multiple_of(16) {
+        return None;
+    }
+
+    let mut payload = encrypted.to_vec();
+    decrypt(&mut payload)?;
+    let padding = usize::from(*payload.last()?);
+    if padding == 0
+        || padding > 16
+        || payload.len() < padding
+        || payload[payload.len() - padding..]
+            .iter()
+            .any(|byte| usize::from(*byte) != padding)
+    {
+        return None;
+    }
+    payload.truncate(payload.len() - padding);
+
+    let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(KEY.as_slice()).ok()?;
+    mac.update(&payload);
+    mac.verify_slice(data.get(..CHECKSUM_SIZE)?).ok()?;
+
+    let declared_length = usize::from(u16::from_le_bytes(payload.get(..2)?.try_into().ok()?));
+    if ![payload.len(), payload.len() - 2].contains(&declared_length)
+        || payload.get(12..20)? != [0; 8]
+    {
+        return None;
+    }
+    let packet_id = u16::from_le_bytes(payload.get(2..4)?.try_into().ok()?);
+    let sender_id = u64::from_le_bytes(payload.get(4..12)?.try_into().ok()?);
+    let body = payload.get(20..)?;
+    match packet_id {
+        REQUEST_PACKET if body.is_empty() => Some(Packet::Request),
+        MESSAGE_PACKET => {
+            let recipient_id = u64::from_le_bytes(body.get(..8)?.try_into().ok()?);
+            let length = u32::from_le_bytes(body.get(8..12)?.try_into().ok()?) as usize;
+            let data = body.get(12..12usize.checked_add(length)?)?;
+            if body.len() != 12 + length {
+                return None;
+            }
+            Some(Packet::Message {
+                sender_id,
+                recipient_id,
+                data: String::from_utf8(data.to_vec()).ok()?,
+            })
+        }
+        _ => None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_response(
+    network_id: u64,
+    advertisement_id: u64,
+    server_name: &str,
+    level_name: &str,
+    game_mode: u8,
+    player_count: u32,
+    max_player_count: u32,
+    hardcore: bool,
+    online_mode: bool,
+) -> Result<Vec<u8>, Error> {
+    let mut server_data = vec![SERVER_DATA_VERSION];
+    push_string(&mut server_data, server_name)?;
+    push_string(&mut server_data, level_name)?;
+    server_data.push(game_mode << 1);
+    server_data.extend_from_slice(
+        &i32::try_from(player_count)
+            .unwrap_or(i32::MAX)
+            .to_le_bytes(),
+    );
+    server_data.extend_from_slice(
+        &i32::try_from(max_player_count)
+            .unwrap_or(i32::MAX)
+            .to_le_bytes(),
+    );
+    server_data.extend_from_slice(&[0, u8::from(hardcore), 0, u8::from(!online_mode)]);
+    push_string(&mut server_data, &format!("{advertisement_id:016x}"))?;
+    server_data.extend_from_slice(&[2 << 1, 4 << 1]);
+
+    let application_data = hex::encode(server_data);
+    let application_length = u32::try_from(application_data.len())
+        .map_err(|_| Error::new(ErrorKind::InvalidInput, "NetherNet MOTD is too long"))?;
+    let mut body = Vec::with_capacity(size_of::<u32>() + application_data.len());
+    body.extend_from_slice(&application_length.to_le_bytes());
+    body.extend_from_slice(application_data.as_bytes());
+    encode_packet(RESPONSE_PACKET, network_id, &body)
+}
+
+fn encode_message(network_id: u64, recipient_id: u64, data: &str) -> Result<Vec<u8>, Error> {
+    let length = u32::try_from(data.len())
+        .map_err(|_| Error::new(ErrorKind::InvalidInput, "NetherNet signal is too long"))?;
+    let mut body = Vec::with_capacity(size_of::<u64>() + size_of::<u32>() + data.len());
+    body.extend_from_slice(&recipient_id.to_le_bytes());
+    body.extend_from_slice(&length.to_le_bytes());
+    body.extend_from_slice(data.as_bytes());
+    encode_packet(MESSAGE_PACKET, network_id, &body)
+}
+
+fn encode_packet(packet_id: u16, network_id: u64, body: &[u8]) -> Result<Vec<u8>, Error> {
+    let packet_length = u16::try_from(size_of::<u16>() + HEADER_SIZE + body.len())
+        .map_err(|_| Error::new(ErrorKind::InvalidInput, "NetherNet packet is too long"))?;
+    let mut payload = Vec::with_capacity(usize::from(packet_length) + 16);
+    payload.extend_from_slice(&packet_length.to_le_bytes());
+    payload.extend_from_slice(&packet_id.to_le_bytes());
+    payload.extend_from_slice(&network_id.to_le_bytes());
+    payload.extend_from_slice(&[0; 8]);
+    payload.extend_from_slice(body);
+
+    let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(KEY.as_slice())
+        .map_err(|_| Error::other("invalid NetherNet discovery key"))?;
+    mac.update(&payload);
+    let checksum = mac.finalize().into_bytes();
+
+    let padding = 16 - payload.len() % 16;
+    payload.resize(payload.len() + padding, padding as u8);
+    encrypt(&mut payload);
+
+    let mut response = Vec::with_capacity(CHECKSUM_SIZE + payload.len());
+    response.extend_from_slice(&checksum);
+    response.extend_from_slice(&payload);
+    Ok(response)
+}
+
+fn push_string(buffer: &mut Vec<u8>, value: &str) -> Result<(), Error> {
+    let length = u8::try_from(value.len())
+        .map_err(|_| Error::new(ErrorKind::InvalidInput, "NetherNet MOTD field is too long"))?;
+    buffer.push(length);
+    buffer.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn encrypt(data: &mut [u8]) {
+    let (blocks, remainder) = Block::slice_as_chunks_mut(data);
+    debug_assert!(remainder.is_empty());
+    Aes256::new_from_slice(KEY.as_slice())
+        .expect("AES-256 key has the correct length")
+        .encrypt_blocks(blocks);
+}
+
+fn decrypt(data: &mut [u8]) -> Option<()> {
+    let (blocks, remainder) = Block::slice_as_chunks_mut(data);
+    if !remainder.is_empty() {
+        return None;
+    }
+    Aes256::new_from_slice(KEY.as_slice())
+        .ok()?
+        .decrypt_blocks(blocks);
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_reference_discovery_request() {
+        let request = hex::decode(
+            "b3eca3eb83a6fcb079faf2eae2bf8abbaadb5906bc42bd63a0056274a26e013f\
+             6b9027ddcd144fe3ada066f65b76e8faff0f8709e13bf6858e2051c321db615e",
+        )
+        .unwrap();
+        assert_eq!(decode_packet(&request), Some(Packet::Request));
+    }
+
+    #[test]
+    fn decodes_current_discovery_request() {
+        let request = hex::decode(
+            "ba539dab685df1c59ba406ec900f48e8249d28821c6e7149309d3fc289002201\
+             ee5a9a7b4fec49402ac54510cb744a96ff0f8709e13bf6858e2051c321db615e",
+        )
+        .unwrap();
+        assert_eq!(decode_packet(&request), Some(Packet::Request));
+    }
+
+    #[test]
+    fn encodes_current_server_data() {
+        let response = encode_response(
+            99,
+            0x9bb64bcf14727bdb,
+            "Dedicated Server",
+            "Creative level",
+            1,
+            0,
+            10,
+            false,
+            false,
+        )
+        .unwrap();
+        let mut payload = response[CHECKSUM_SIZE..].to_vec();
+        decrypt(&mut payload).unwrap();
+        let padding = usize::from(*payload.last().unwrap());
+        payload.truncate(payload.len() - padding);
+        assert_eq!(
+            usize::from(u16::from_le_bytes(payload[..2].try_into().unwrap())),
+            payload.len()
+        );
+        let application_length = u32::from_le_bytes(payload[20..24].try_into().unwrap()) as usize;
+        let server_data = hex::decode(&payload[24..24 + application_length]).unwrap();
+        assert_eq!(
+            hex::encode(server_data),
+            "0610446564696361746564205365727665720e4372656174697665206c6576656c\
+             02000000000a0000000000000110396262363462636631343732376264620408"
+        );
+    }
+
+    #[test]
+    fn message_packet_roundtrip() {
+        let message = encode_message(99, 42, "CONNECTREQUEST 7 offer").unwrap();
+        assert_eq!(
+            decode_packet(&message),
+            Some(Packet::Message {
+                sender_id: 99,
+                recipient_id: 42,
+                data: "CONNECTREQUEST 7 offer".to_owned(),
+            })
+        );
+    }
+}

--- a/crates/pumpkin/src/net/bedrock/status.rs
+++ b/crates/pumpkin/src/net/bedrock/status.rs
@@ -1,8 +1,11 @@
 use std::{
-    io::{Cursor, Error},
+    io::{Cursor, Error, ErrorKind},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
 };
 
+use async_trait::async_trait;
+use bytes::Bytes;
 use pumpkin_protocol::{
     BClientPacket,
     bedrock::status::{
@@ -13,31 +16,52 @@ use pumpkin_protocol::{
     serial::PacketRead,
 };
 use pumpkin_world::{CURRENT_BEDROCK_MC_PROTOCOL, CURRENT_BEDROCK_MC_VERSION};
-use tokio::net::UdpSocket;
+use tokio::{
+    net::UdpSocket,
+    sync::{Mutex, mpsc},
+};
+use tracing::trace;
+use webrtc::util::{Conn, Error as WebRtcError};
 
 use crate::server::Server;
 
 pub struct StatusResponder {
-    ipv4: UdpSocket,
+    ipv4: Arc<UdpSocket>,
     ipv6: UdpSocket,
     ipv4_port: u16,
     ipv6_port: u16,
+    ice_packets: mpsc::Sender<(Bytes, SocketAddr)>,
+}
+
+/// The WebRTC side of the UDP socket shared with Bedrock server-list status.
+pub struct IceSocket {
+    socket: Arc<UdpSocket>,
+    packets: Mutex<mpsc::Receiver<(Bytes, SocketAddr)>>,
 }
 
 impl StatusResponder {
-    pub async fn bind(address: SocketAddr) -> Result<Self, Error> {
+    pub async fn bind(address: SocketAddr) -> Result<(Self, IceSocket), Error> {
         let ipv4_ip = match address.ip() {
             IpAddr::V4(ip) => ip,
             IpAddr::V6(_) => Ipv4Addr::UNSPECIFIED,
         };
         let ipv4_port = address.port();
         let ipv6_port = ipv4_port.saturating_add(1);
-        Ok(Self {
-            ipv4: UdpSocket::bind((ipv4_ip, ipv4_port)).await?,
-            ipv6: UdpSocket::bind((Ipv6Addr::UNSPECIFIED, ipv6_port)).await?,
-            ipv4_port,
-            ipv6_port,
-        })
+        let ipv4 = Arc::new(UdpSocket::bind((ipv4_ip, ipv4_port)).await?);
+        let (ice_packets, packets) = mpsc::channel(1024);
+        Ok((
+            Self {
+                ipv4: ipv4.clone(),
+                ipv6: UdpSocket::bind((Ipv6Addr::UNSPECIFIED, ipv6_port)).await?,
+                ipv4_port,
+                ipv6_port,
+                ice_packets,
+            },
+            IceSocket {
+                socket: ipv4,
+                packets: Mutex::new(packets),
+            },
+        ))
     }
 
     pub fn local_addrs(&self) -> Result<(SocketAddr, SocketAddr), Error> {
@@ -45,12 +69,20 @@ impl StatusResponder {
     }
 
     pub async fn receive(&self, server: &Server) -> Result<(), Error> {
-        let mut ipv4_buffer = [0; 64];
+        let mut ipv4_buffer = [0; 2048];
         let mut ipv6_buffer = [0; 64];
         tokio::select! {
             result = self.ipv4.recv_from(&mut ipv4_buffer) => {
                 let (length, client) = result?;
-                self.respond(server, &self.ipv4, &ipv4_buffer[..length], client).await
+                let packet = &ipv4_buffer[..length];
+                if is_status_packet(packet) {
+                    self.respond(server, &self.ipv4, packet, client).await
+                } else {
+                    if self.ice_packets.try_send((Bytes::copy_from_slice(packet), client)).is_err() {
+                        trace!(%client, "Dropped Bedrock ICE datagram because its queue is unavailable");
+                    }
+                    Ok(())
+                }
             }
             result = self.ipv6.recv_from(&mut ipv6_buffer) => {
                 let (length, client) = result?;
@@ -79,6 +111,74 @@ impl StatusResponder {
             self.ipv6_port,
         )
         .await
+    }
+}
+
+fn is_status_packet(packet: &[u8]) -> bool {
+    matches!(packet.first(), Some(&id) if id == SUnconnectedPing::PACKET_ID as u8
+        || id == SUnconnectedPingOpenConnections::PACKET_ID as u8)
+        && packet.get(9..25) == Some(OFFLINE_MESSAGE_MAGIC.as_slice())
+}
+
+impl IceSocket {
+    pub fn local_addr(&self) -> Result<SocketAddr, Error> {
+        self.socket.local_addr()
+    }
+}
+
+#[async_trait]
+impl Conn for IceSocket {
+    async fn connect(&self, _address: SocketAddr) -> Result<(), WebRtcError> {
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "the shared Bedrock UDP socket cannot be connected",
+        )
+        .into())
+    }
+
+    async fn recv(&self, buffer: &mut [u8]) -> Result<usize, WebRtcError> {
+        self.recv_from(buffer).await.map(|(length, _)| length)
+    }
+
+    async fn recv_from(&self, buffer: &mut [u8]) -> Result<(usize, SocketAddr), WebRtcError> {
+        let (packet, address) = self
+            .packets
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or_else(|| Error::new(ErrorKind::BrokenPipe, "Bedrock UDP socket closed"))?;
+        let length = buffer.len().min(packet.len());
+        buffer[..length].copy_from_slice(&packet[..length]);
+        Ok((length, address))
+    }
+
+    async fn send(&self, _buffer: &[u8]) -> Result<usize, WebRtcError> {
+        Err(Error::new(
+            ErrorKind::NotConnected,
+            "the shared Bedrock UDP socket has no default peer",
+        )
+        .into())
+    }
+
+    async fn send_to(&self, buffer: &[u8], target: SocketAddr) -> Result<usize, WebRtcError> {
+        Ok(self.socket.send_to(buffer, target).await?)
+    }
+
+    fn local_addr(&self) -> Result<SocketAddr, WebRtcError> {
+        Ok(self.socket.local_addr()?)
+    }
+
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        None
+    }
+
+    async fn close(&self) -> Result<(), WebRtcError> {
+        Ok(())
+    }
+
+    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
+        self
     }
 }
 
@@ -133,4 +233,49 @@ pub async fn handle_packet(
     pong.write_packet(&mut response)?;
     socket.send_to(&response, client).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distinguishes_raknet_status_from_stun() {
+        let mut ping = [0; 33];
+        ping[0] = SUnconnectedPing::PACKET_ID as u8;
+        ping[9..25].copy_from_slice(&OFFLINE_MESSAGE_MAGIC);
+        assert!(is_status_packet(&ping));
+
+        let mut stun_success = [0; 32];
+        stun_success[..2].copy_from_slice(&[0x01, 0x01]);
+        assert!(!is_status_packet(&stun_success));
+    }
+
+    #[tokio::test]
+    async fn ice_socket_uses_the_shared_udp_port() {
+        let server = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+        let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let (sender, receiver) = mpsc::channel(1);
+        let ice = IceSocket {
+            socket: server.clone(),
+            packets: Mutex::new(receiver),
+        };
+        sender
+            .send((Bytes::from_static(b"request"), client.local_addr().unwrap()))
+            .await
+            .unwrap();
+
+        let mut request = [0; 16];
+        let (length, address) = Conn::recv_from(&ice, &mut request).await.unwrap();
+        assert_eq!(&request[..length], b"request");
+        assert_eq!(address, client.local_addr().unwrap());
+
+        Conn::send_to(&ice, b"response", client.local_addr().unwrap())
+            .await
+            .unwrap();
+        let mut response = [0; 16];
+        let (length, address) = client.recv_from(&mut response).await.unwrap();
+        assert_eq!(&response[..length], b"response");
+        assert_eq!(address, server.local_addr().unwrap());
+    }
 }

--- a/crates/pumpkin/src/net/bedrock/status.rs
+++ b/crates/pumpkin/src/net/bedrock/status.rs
@@ -20,7 +20,7 @@ use tokio::{
     net::UdpSocket,
     sync::{Mutex, mpsc},
 };
-use tracing::trace;
+use tracing::{trace, warn};
 use webrtc::util::{Conn, Error as WebRtcError};
 
 use crate::server::Server;
@@ -76,6 +76,7 @@ impl StatusResponder {
                 let (length, client) = result?;
                 let packet = &ipv4_buffer[..length];
                 if is_status_packet(packet) {
+                    trace!(%client, length, "Received Bedrock server-list status ping");
                     self.respond(server, &self.ipv4, packet, client).await
                 } else {
                     trace!(
@@ -92,6 +93,7 @@ impl StatusResponder {
             }
             result = self.ipv6.recv_from(&mut ipv6_buffer) => {
                 let (length, client) = result?;
+                trace!(%client, length, "Received Bedrock IPv6 server-list status packet");
                 self.respond(server, &self.ipv6, &ipv6_buffer[..length], client).await
             }
         }
@@ -178,13 +180,26 @@ impl Conn for IceSocket {
     }
 
     async fn send_to(&self, buffer: &[u8], target: SocketAddr) -> Result<usize, WebRtcError> {
-        trace!(
-            %target,
-            length = buffer.len(),
-            kind = ice_packet_kind(buffer),
-            "Sending Bedrock ICE datagram"
-        );
-        Ok(self.socket.send_to(buffer, target).await?)
+        match self.socket.send_to(buffer, target).await {
+            Ok(length) => {
+                trace!(
+                    %target,
+                    length,
+                    kind = ice_packet_kind(buffer),
+                    "Sent Bedrock ICE datagram"
+                );
+                Ok(length)
+            }
+            Err(error) => {
+                warn!(
+                    %target,
+                    kind = ice_packet_kind(buffer),
+                    %error,
+                    "Failed to send Bedrock ICE datagram"
+                );
+                Err(error.into())
+            }
+        }
     }
 
     fn local_addr(&self) -> Result<SocketAddr, WebRtcError> {
@@ -254,6 +269,14 @@ pub async fn handle_packet(
     let mut response = vec![CUnconnectedPong::PACKET_ID as u8];
     pong.write_packet(&mut response)?;
     socket.send_to(&response, client).await?;
+    trace!(
+        %client,
+        players,
+        max_players = server.advanced_config.networking.bedrock.max_players,
+        protocol = CURRENT_BEDROCK_MC_PROTOCOL,
+        response_length = response.len(),
+        "Sent Bedrock server-list status pong"
+    );
     Ok(())
 }
 

--- a/crates/pumpkin/src/net/bedrock/status.rs
+++ b/crates/pumpkin/src/net/bedrock/status.rs
@@ -1,10 +1,11 @@
 use std::{
+    future::Future,
     io::{Cursor, Error, ErrorKind},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    pin::Pin,
     sync::Arc,
 };
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use pumpkin_protocol::{
     BClientPacket,
@@ -24,6 +25,10 @@ use tracing::{trace, warn};
 use webrtc::util::{Conn, Error as WebRtcError};
 
 use crate::server::Server;
+
+// `webrtc::util::Conn` uses `async-trait`. Spell out its object-safe future ABI so
+// Pumpkin does not need a direct dependency on the proc macro.
+type ConnFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, WebRtcError>> + Send + 'a>>;
 
 pub struct StatusResponder {
     ipv4: Arc<UdpSocket>,
@@ -144,62 +149,97 @@ impl IceSocket {
     }
 }
 
-#[async_trait]
 impl Conn for IceSocket {
-    async fn connect(&self, _address: SocketAddr) -> Result<(), WebRtcError> {
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "the shared Bedrock UDP socket cannot be connected",
-        )
-        .into())
+    fn connect<'a, 'async_trait>(&'a self, _address: SocketAddr) -> ConnFuture<'async_trait, ()>
+    where
+        'a: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async {
+            Err(Error::new(
+                ErrorKind::Unsupported,
+                "the shared Bedrock UDP socket cannot be connected",
+            )
+            .into())
+        })
     }
 
-    async fn recv(&self, buffer: &mut [u8]) -> Result<usize, WebRtcError> {
-        self.recv_from(buffer).await.map(|(length, _)| length)
+    fn recv<'a, 'b, 'async_trait>(&'a self, buffer: &'b mut [u8]) -> ConnFuture<'async_trait, usize>
+    where
+        'a: 'async_trait,
+        'b: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move { self.recv_from(buffer).await.map(|(length, _)| length) })
     }
 
-    async fn recv_from(&self, buffer: &mut [u8]) -> Result<(usize, SocketAddr), WebRtcError> {
-        let (packet, address) = self
-            .packets
-            .lock()
-            .await
-            .recv()
-            .await
-            .ok_or_else(|| Error::new(ErrorKind::BrokenPipe, "Bedrock UDP socket closed"))?;
-        let length = buffer.len().min(packet.len());
-        buffer[..length].copy_from_slice(&packet[..length]);
-        Ok((length, address))
+    fn recv_from<'a, 'b, 'async_trait>(
+        &'a self,
+        buffer: &'b mut [u8],
+    ) -> ConnFuture<'async_trait, (usize, SocketAddr)>
+    where
+        'a: 'async_trait,
+        'b: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move {
+            let (packet, address) =
+                self.packets.lock().await.recv().await.ok_or_else(|| {
+                    Error::new(ErrorKind::BrokenPipe, "Bedrock UDP socket closed")
+                })?;
+            let length = buffer.len().min(packet.len());
+            buffer[..length].copy_from_slice(&packet[..length]);
+            Ok((length, address))
+        })
     }
 
-    async fn send(&self, _buffer: &[u8]) -> Result<usize, WebRtcError> {
-        Err(Error::new(
-            ErrorKind::NotConnected,
-            "the shared Bedrock UDP socket has no default peer",
-        )
-        .into())
+    fn send<'a, 'b, 'async_trait>(&'a self, _buffer: &'b [u8]) -> ConnFuture<'async_trait, usize>
+    where
+        'a: 'async_trait,
+        'b: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async {
+            Err(Error::new(
+                ErrorKind::NotConnected,
+                "the shared Bedrock UDP socket has no default peer",
+            )
+            .into())
+        })
     }
 
-    async fn send_to(&self, buffer: &[u8], target: SocketAddr) -> Result<usize, WebRtcError> {
-        match self.socket.send_to(buffer, target).await {
-            Ok(length) => {
-                trace!(
-                    %target,
-                    length,
-                    kind = ice_packet_kind(buffer),
-                    "Sent Bedrock ICE datagram"
-                );
-                Ok(length)
+    fn send_to<'a, 'b, 'async_trait>(
+        &'a self,
+        buffer: &'b [u8],
+        target: SocketAddr,
+    ) -> ConnFuture<'async_trait, usize>
+    where
+        'a: 'async_trait,
+        'b: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move {
+            match self.socket.send_to(buffer, target).await {
+                Ok(length) => {
+                    trace!(
+                        %target,
+                        length,
+                        kind = ice_packet_kind(buffer),
+                        "Sent Bedrock ICE datagram"
+                    );
+                    Ok(length)
+                }
+                Err(error) => {
+                    warn!(
+                        %target,
+                        kind = ice_packet_kind(buffer),
+                        %error,
+                        "Failed to send Bedrock ICE datagram"
+                    );
+                    Err(error.into())
+                }
             }
-            Err(error) => {
-                warn!(
-                    %target,
-                    kind = ice_packet_kind(buffer),
-                    %error,
-                    "Failed to send Bedrock ICE datagram"
-                );
-                Err(error.into())
-            }
-        }
+        })
     }
 
     fn local_addr(&self) -> Result<SocketAddr, WebRtcError> {
@@ -210,8 +250,12 @@ impl Conn for IceSocket {
         None
     }
 
-    async fn close(&self) -> Result<(), WebRtcError> {
-        Ok(())
+    fn close<'a, 'async_trait>(&'a self) -> ConnFuture<'async_trait, ()>
+    where
+        'a: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async { Ok(()) })
     }
 
     fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {

--- a/crates/pumpkin/src/net/bedrock/status.rs
+++ b/crates/pumpkin/src/net/bedrock/status.rs
@@ -178,6 +178,12 @@ impl Conn for IceSocket {
     }
 
     async fn send_to(&self, buffer: &[u8], target: SocketAddr) -> Result<usize, WebRtcError> {
+        trace!(
+            %target,
+            length = buffer.len(),
+            kind = ice_packet_kind(buffer),
+            "Sending Bedrock ICE datagram"
+        );
         Ok(self.socket.send_to(buffer, target).await?)
     }
 

--- a/crates/pumpkin/src/net/bedrock/status.rs
+++ b/crates/pumpkin/src/net/bedrock/status.rs
@@ -78,6 +78,12 @@ impl StatusResponder {
                 if is_status_packet(packet) {
                     self.respond(server, &self.ipv4, packet, client).await
                 } else {
+                    trace!(
+                        %client,
+                        length,
+                        kind = ice_packet_kind(packet),
+                        "Received Bedrock ICE datagram"
+                    );
                     if self.ice_packets.try_send((Bytes::copy_from_slice(packet), client)).is_err() {
                         trace!(%client, "Dropped Bedrock ICE datagram because its queue is unavailable");
                     }
@@ -118,6 +124,16 @@ fn is_status_packet(packet: &[u8]) -> bool {
     matches!(packet.first(), Some(&id) if id == SUnconnectedPing::PACKET_ID as u8
         || id == SUnconnectedPingOpenConnections::PACKET_ID as u8)
         && packet.get(9..25) == Some(OFFLINE_MESSAGE_MAGIC.as_slice())
+}
+
+fn ice_packet_kind(packet: &[u8]) -> &'static str {
+    if packet.len() >= 20 && packet.get(4..8) == Some(&[0x21, 0x12, 0xa4, 0x42]) {
+        "STUN"
+    } else if matches!(packet.first(), Some(20..=63)) {
+        "DTLS"
+    } else {
+        "unknown"
+    }
 }
 
 impl IceSocket {
@@ -248,7 +264,9 @@ mod tests {
 
         let mut stun_success = [0; 32];
         stun_success[..2].copy_from_slice(&[0x01, 0x01]);
+        stun_success[4..8].copy_from_slice(&[0x21, 0x12, 0xa4, 0x42]);
         assert!(!is_status_packet(&stun_success));
+        assert_eq!(ice_packet_kind(&stun_success), "STUN");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description
Fixes NetherNet connections failing after signaling because WebRTC advertised a separate ICE port that could be blocked or unreachable. Built on top of https://github.com/Pumpkin-MC/Pumpkin/pull/2821

## What
- Uses UDP `19132` for both Bedrock server-list status and NetherNet ICE traffic.
- Removes the separate UDP `19134` ICE listener and configuration.
- Keeps NetherNet HTTP signaling on TCP `19132`.
- Routes RakNet status packets to the MOTD responder and WebRTC/STUN packets to the ICE transport.
- Preserves support for public servers using a configured external IP.
- Reduces the required firewall and port-forwarding configuration to TCP and UDP `19132`.

## How
- Shares the Bedrock UDP socket between the status responder and WebRTC’s UDP multiplexer.
- Identifies RakNet status requests using both their packet ID and offline-message magic, preventing STUN packets from being misclassified.
- Forwards all other UDP datagrams through a bounded channel implementing WebRTC’s connection interface.
- Keeps socket ownership centralized so the status responder and ICE transport do not compete to bind the same port.

## Testing
- `cargo test -p pumpkin nethernet --lib`
- `cargo test -p pumpkin bedrock::status --lib`
- `cargo test -p pumpkin-config --lib`
- `cargo check -p pumpkin`
- `cargo clippy -p pumpkin --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Waiting for QuantumSegfault to test. If Quantum says it doesnt work, this PR can be disregarded.
