### PR TITLE
fix: :bug: Fixed that a slime appears after a magma cube died

### DIFF
--- a/crates/pumpkin/src/entity/mob/slime.rs
+++ b/crates/pumpkin/src/entity/mob/slime.rs
@@ -361,7 +361,11 @@ impl Mob for SlimeEntity {
                         pos.y + 0.5,
                         pos.z + zd as f64,
                     );
-                    let new_entity = Entity::new(world.clone(), new_pos, self.entity.living_entity.entity.entity_type);
+                    let new_entity = Entity::new(
+                        world.clone(),
+                        new_pos,
+                        self.entity.living_entity.entity.entity_type,
+                    );
                     let slime_like = Self::new(new_entity);
                     slime_like.set_size(half_size, true);
                     slime_like

--- a/crates/pumpkin/src/entity/mob/slime.rs
+++ b/crates/pumpkin/src/entity/mob/slime.rs
@@ -361,16 +361,16 @@ impl Mob for SlimeEntity {
                         pos.y + 0.5,
                         pos.z + zd as f64,
                     );
-                    let new_entity = Entity::new(world.clone(), new_pos, &EntityType::SLIME);
-                    let slime = Self::new(new_entity);
-                    slime.set_size(half_size, true);
-                    slime
+                    let new_entity = Entity::new(world.clone(), new_pos, self.entity.living_entity.entity.entity_type);
+                    let slime_like = Self::new(new_entity);
+                    slime_like.set_size(half_size, true);
+                    slime_like
                         .entity
                         .living_entity
                         .entity
                         .yaw
                         .store(rand::random_range(0.0..360.0));
-                    world.spawn_entity(slime).await;
+                    world.spawn_entity(slime_like).await;
                 }
             }
         })


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description
In current version, when you beat a magma cube, in expected behavior, another magma cube will be separated. But in current version, a slime appeared, which is very... funny? undescriable.

Consequently, this PR fixed this problem. I am too lazy to open a standalone issue to report this problem, so i created this directly. In this PR-fixed version, at least in my environment, i use sword to beat a magma cube, another magma splited out instead of slime.

## Changes
 - Removed hard-coded new spawn entity type (`EntityType::SLIME`), uses `self.entity.living_entity.entity.entity_type` instead;
 - Updated some variable name to make code much more readable (not so much)

## Testing
 - [x]  `cargo clippy --all-targets` 
 - [x]  `cargo test`
 - [x]  In expected behavior 

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
