### PR TITLE
feat(plugin): native cdylib plugin loading via native-wit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1623,7 +1623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2391,7 +2391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2775,6 +2775,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-wit-bindgen"
+version = "0.1.0"
+source = "git+https://github.com/BjornTheProgrammer/native-wit#06916dce4aea1eff45af833cd604d0ba53544fb4"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.119",
+ "wit-bindgen-core",
+ "wit-parser 0.258.0",
+]
+
+[[package]]
+name = "native-wit-wasmtime"
+version = "0.1.0"
+source = "git+https://github.com/BjornTheProgrammer/native-wit#06916dce4aea1eff45af833cd604d0ba53544fb4"
+dependencies = [
+ "anyhow",
+ "libloading",
+ "native-wit-wasmtime-macro",
+ "tokio",
+ "wasmtime",
+]
+
+[[package]]
+name = "native-wit-wasmtime-macro"
+version = "0.1.0"
+source = "git+https://github.com/BjornTheProgrammer/native-wit#06916dce4aea1eff45af833cd604d0ba53544fb4"
+dependencies = [
+ "anyhow",
+ "native-wit-bindgen",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wit-parser 0.258.0",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,7 +2887,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3394,7 +3433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3475,7 +3514,7 @@ dependencies = [
  "hyper",
  "image",
  "indexmap",
- "libloading",
+ "native-wit-wasmtime",
  "notify",
  "num-bigint 0.5.1",
  "ordered-float",
@@ -3807,7 +3846,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3820,7 +3859,7 @@ dependencies = [
  "libc",
  "log",
  "socket2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4465,7 +4504,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4534,7 +4573,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5062,7 +5101,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6110,7 +6149,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6436,8 +6475,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "wit-bindgen"
 version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e473fd0095479f9689ac7d2a52c427cc96bb2b973ace50238dfcc1ab1cd52d93"
+source = "git+https://github.com/BjornTheProgrammer/wit-bindgen?branch=wit-native#850e186d95c6b58ee8046017952c9258caa93dbf"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
@@ -6445,8 +6483,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87445680dfe6d6b5369e884bd63c03a3335268e855365b2fc3f7bcdce96a630e"
+source = "git+https://github.com/BjornTheProgrammer/wit-bindgen?branch=wit-native#850e186d95c6b58ee8046017952c9258caa93dbf"
 dependencies = [
  "anyhow",
  "heck",
@@ -6456,8 +6493,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f2fe494de0d898216caf0fd0ae76af75753fcb3ff4f465b46131537cf24cf8"
+source = "git+https://github.com/BjornTheProgrammer/wit-bindgen?branch=wit-native#850e186d95c6b58ee8046017952c9258caa93dbf"
 dependencies = [
  "anyhow",
  "heck",
@@ -6472,8 +6508,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59283a01aec94f60f92ada22ffe182a5cea8acfce43be3be688de8d52df55312"
+source = "git+https://github.com/BjornTheProgrammer/wit-bindgen?branch=wit-native#850e186d95c6b58ee8046017952c9258caa93dbf"
 dependencies = [
  "anyhow",
  "prettyplease",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1615,15 +1615,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1632,38 +1632,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1916,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2531,6 +2531,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-wit-bindgen"
+version = "0.1.0"
+source = "git+https://github.com/BjornTheProgrammer/native-wit#5bdc51ba9a2727eb6a98e981b7a7ba99474d64e2"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.119",
+ "wit-bindgen-core",
+ "wit-parser 0.254.0",
+]
+
+[[package]]
+name = "native-wit-wasmtime"
+version = "0.1.0"
+source = "git+https://github.com/BjornTheProgrammer/native-wit#5bdc51ba9a2727eb6a98e981b7a7ba99474d64e2"
+dependencies = [
+ "anyhow",
+ "libloading",
+ "native-wit-wasmtime-macro",
+ "tokio",
+ "wasmtime",
+]
+
+[[package]]
+name = "native-wit-wasmtime-macro"
+version = "0.1.0"
+source = "git+https://github.com/BjornTheProgrammer/native-wit#5bdc51ba9a2727eb6a98e981b7a7ba99474d64e2"
+dependencies = [
+ "anyhow",
+ "native-wit-bindgen",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wit-parser 0.254.0",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -2857,9 +2896,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2867,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2877,9 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2890,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -3275,7 +3314,7 @@ dependencies = [
  "hyper",
  "image",
  "indexmap",
- "libloading",
+ "native-wit-wasmtime",
  "notify",
  "num-bigint 0.5.1",
  "ordered-float",
@@ -3918,9 +3957,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5961,8 +6000,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 [[package]]
 name = "wit-bindgen"
 version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a301904d6657d6364c758d869e5389d05d393b16d5b65db60b4f03cbe71bb80d"
+source = "git+https://github.com/BjornTheProgrammer/wit-bindgen?branch=wit-native#22aa9868aa29c1b3c5314ad5d795f0a78b635d00"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
@@ -5970,8 +6008,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48521bb96e56cbb9e031ad306c80dc20e89e69e49ada02781ee06f60fbcb545f"
+source = "git+https://github.com/BjornTheProgrammer/wit-bindgen?branch=wit-native#22aa9868aa29c1b3c5314ad5d795f0a78b635d00"
 dependencies = [
  "anyhow",
  "heck",
@@ -5981,8 +6018,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df3fe9b9a0066f82fd0c2f07f79d0ffc0f85c53fa5f998516d8722712479042"
+source = "git+https://github.com/BjornTheProgrammer/wit-bindgen?branch=wit-native#22aa9868aa29c1b3c5314ad5d795f0a78b635d00"
 dependencies = [
  "anyhow",
  "heck",
@@ -5997,8 +6033,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d689c4bc9d6af067c651cfba444766343c9a4bdef15fad1e2efab95c0c277af0"
+source = "git+https://github.com/BjornTheProgrammer/wit-bindgen?branch=wit-native#22aa9868aa29c1b3c5314ad5d795f0a78b635d00"
 dependencies = [
  "anyhow",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ pumpkin-plugin-utils = { path = "crates/pumpkin-plugin-utils", default-features 
 pumpkin-protocol = { path = "crates/pumpkin-protocol", default-features = false }
 pumpkin-util = { path = "crates/pumpkin-util", default-features = false }
 pumpkin-world = { path = "crates/pumpkin-world", default-features = false }
+native-wit-wasmtime = { git = "https://github.com/BjornTheProgrammer/native-wit", default-features = false }
 quote = { version = "1.0", default-features = false, features = ["proc-macro"] }
 rand = { version = "0.10.2", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 rsa = { version = "=0.10.0-rc.18", default-features = false, features = ["std", "encoding"] }
@@ -223,9 +224,9 @@ wasmtime-wasi-http = { version = "48.0", default-features = false, features = ["
 # needed for interacting with wasmtime-wasi-http - keep in sync
 hyper = { version = "^1.11", default-features = false }
 axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio"] }
-webrtc = { version = "0.20.3" }
 async-trait = "0.1"
-wit-bindgen = { version = "0.61", default-features = false, features = ["macros"] }
+webrtc = { version = "0.20.3" }
+wit-bindgen = { git = "https://github.com/BjornTheProgrammer/wit-bindgen", branch = "wit-native", default-features = false, features = ["macros"] }
 
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 tracing-serde-structured = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ pumpkin-nbt = { path = "crates/pumpkin-nbt", default-features = false }
 pumpkin-protocol = { path = "crates/pumpkin-protocol", default-features = false }
 pumpkin-util = { path = "crates/pumpkin-util", default-features = false }
 pumpkin-world = { path = "crates/pumpkin-world", default-features = false }
+native-wit-wasmtime = { git = "https://github.com/BjornTheProgrammer/native-wit", default-features = false }
 quote = { version = "1.0", default-features = false, features = ["proc-macro"] }
 rand = { version = "0.10.2", default-features = false, features = ["std", "std_rng", "thread_rng"] }
 rsa = { version = "=0.10.0-rc.18", default-features = false, features = ["std", "encoding"] }
@@ -219,7 +220,7 @@ wasmtime-wasi-http = { version = "47.0", default-features = false, features = ["
 hyper = { version = "^1.11", default-features = false }
 axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio"] }
 webrtc = { version = "0.17.0", default-features = false }
-wit-bindgen = { version = "0.60", default-features = false, features = ["macros"] }
+wit-bindgen = { git = "https://github.com/BjornTheProgrammer/wit-bindgen", branch = "wit-native", default-features = false, features = ["macros"] }
 
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 tracing-serde-structured = { version = "0.4", default-features = false }

--- a/crates/pumpkin-plugin-api/src/lib.rs
+++ b/crates/pumpkin-plugin-api/src/lib.rs
@@ -481,7 +481,14 @@ static mut PLUGIN: Option<Box<dyn Plugin>> = None;
 #[macro_export]
 macro_rules! register_plugin {
     ($plugin_type:ty) => {
+        #[cfg(target_arch = "wasm32")]
         #[unsafe(export_name = "init-plugin")]
+        pub extern "C" fn __init_plugin() {
+            $crate::register_plugin(|| Box::new(<$plugin_type as $crate::Plugin>::new()));
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        #[unsafe(export_name = "init_plugin")]
         pub extern "C" fn __init_plugin() {
             $crate::register_plugin(|| Box::new(<$plugin_type as $crate::Plugin>::new()));
         }

--- a/crates/pumpkin-plugin-api/src/lib.rs
+++ b/crates/pumpkin-plugin-api/src/lib.rs
@@ -122,7 +122,8 @@ mod wit {
         skip: ["init-plugin"],
         path: "../pumpkin-plugin-wit/v0.1",
         world: "plugin",
-        enable_method_chaining: true
+        enable_method_chaining: true,
+        link_native_symbols: true,
     });
 
     use super::Component;
@@ -346,7 +347,14 @@ static mut PLUGIN: Option<Box<dyn Plugin>> = None;
 #[macro_export]
 macro_rules! register_plugin {
     ($plugin_type:ty) => {
+        #[cfg(target_arch = "wasm32")]
         #[unsafe(export_name = "init-plugin")]
+        pub extern "C" fn __init_plugin() {
+            $crate::register_plugin(|| Box::new(<$plugin_type as $crate::Plugin>::new()));
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        #[unsafe(export_name = "init_plugin")]
         pub extern "C" fn __init_plugin() {
             $crate::register_plugin(|| Box::new(<$plugin_type as $crate::Plugin>::new()));
         }

--- a/crates/pumpkin/Cargo.toml
+++ b/crates/pumpkin/Cargo.toml
@@ -93,7 +93,7 @@ tracing-subscriber.workspace = true
 time = { workspace = true, features = ["parsing", "macros", "local-offset"] }
 
 # plugins
-libloading.workspace = true
+native-wit-wasmtime.workspace = true
 rustc-hash.workspace = true
 
 # Task handling

--- a/crates/pumpkin/src/plugin/loader/native.rs
+++ b/crates/pumpkin/src/plugin/loader/native.rs
@@ -1,16 +1,19 @@
-use std::{
-    any::Any,
-    sync::{Arc, LazyLock},
-};
+use std::{any::Any, sync::Arc, sync::LazyLock};
 
-use libloading::Library;
+use tokio::sync::Mutex;
+use wasmtime::{Engine, Store};
 
 use crate::plugin::{
-    PLUGIN_API_VERSION,
-    loader::{PluginLoadFuture, PluginUnloadFuture},
+    PluginMetadata,
+    loader::{
+        PluginLoadFuture, PluginUnloadFuture,
+        wasm::wasm_host::{PluginInstance, WasmPlugin, state::PluginHostState, wit::v0_1::native},
+    },
 };
 
-use super::{LoaderError, Path, Plugin, PluginLoader, PluginMetadata};
+use super::{LoaderError, Path, Plugin, PluginLoader};
+
+static STORE_ENGINE: LazyLock<Engine> = LazyLock::new(Engine::default);
 
 pub struct NativePluginLoader;
 
@@ -19,49 +22,52 @@ impl PluginLoader for NativePluginLoader {
         Box::pin(async {
             let path = path.to_owned();
 
-            // SAFETY: Loading dynamic library from path configured by server administrator.
-            let library = unsafe { Library::new(&path) }
-                .map_err(|e| LoaderError::LibraryLoad(e.to_string()))?;
+            let plugin = native::AnyPlugin::Native(
+                // SAFETY: `Plugin::new` dlopen's `path` and looks up the symbols the
+                // `plugin` WIT world defines. Loading a shared library runs its
+                // initializers, so the caller vouches for the file being a trusted
+                // cdylib built against this WIT world; every symbol lookup inside is
+                // checked and reported as an error rather than assumed to exist.
+                unsafe { native::Plugin::new(&path) }
+                    .map_err(|e| LoaderError::LibraryLoad(e.to_string()))?,
+            );
 
-            // Ensure this plugin was built against a compatible Pumpkin plugin API version
-            // SAFETY: `PUMPKIN_API_VERSION` is an exported `u32` constant symbol created by `#[plugin_impl]`.
-            let plugin_api_version = unsafe {
-                match library.get::<*const u32>(b"PUMPKIN_API_VERSION") {
-                    Ok(symbol) => **symbol,
-                    Err(_) => return Err(LoaderError::ApiVersionMissing),
-                }
+            let mut store = Store::new(&STORE_ENGINE, PluginHostState::new());
+
+            plugin
+                .call_init_plugin(&mut store)
+                .await
+                .map_err(|e| LoaderError::InitializationFailed(e.to_string()))?;
+
+            let metadata = plugin
+                .call_get_metadata(&mut store)
+                .await
+                .map_err(|e| LoaderError::InitializationFailed(e.to_string()))?;
+
+            let metadata = PluginMetadata {
+                name: metadata.name,
+                version: metadata.version,
+                authors: metadata.authors,
+                description: metadata.description,
+                dependencies: metadata.dependencies,
+                permissions: metadata.permissions,
             };
 
-            if plugin_api_version != PLUGIN_API_VERSION {
-                return Err(LoaderError::ApiVersionMismatch {
-                    plugin_version: plugin_api_version,
-                    server_version: PLUGIN_API_VERSION,
-                });
-            }
+            store
+                .data_mut()
+                .permissions
+                .clone_from(&metadata.permissions);
 
-            // 2. Extract Metadata (METADATA)
-            // `#[plugin_impl]` exports this as a `LazyLock`, since `PluginMetadata`
-            // owns its strings and can't be built in a const.
-            // SAFETY: `METADATA` is an exported `LazyLock<PluginMetadata>` symbol created by `#[plugin_impl]`.
-            let metadata = unsafe {
-                let metadata = library
-                    .get::<*const LazyLock<PluginMetadata>>(b"METADATA")
-                    .map_err(|_| LoaderError::MetadataMissing)?;
-                (**metadata).clone()
-            };
-
-            // 3. Extract Plugin Factory (plugin)
-            // SAFETY: `plugin` is an exported constructor function symbol with signature `fn() -> Box<dyn Plugin>` created by `#[plugin_impl]`.
-            let plugin_factory = unsafe {
-                library
-                    .get::<fn() -> Box<dyn Plugin>>(b"plugin")
-                    .map_err(|_| LoaderError::EntrypointMissing)?
-            };
+            let plugin = Arc::new(WasmPlugin {
+                plugin_instance: PluginInstance::V0_1(plugin),
+                store: Mutex::new(store),
+            });
+            plugin.store.lock().await.data_mut().plugin = Some(Arc::downgrade(&plugin));
 
             Ok((
-                Arc::from(plugin_factory()),
+                plugin as Arc<dyn Plugin>,
                 metadata,
-                Box::new(library) as Box<dyn Any + Send + Sync>,
+                Box::new(()) as Box<dyn Any + Send + Sync>,
             ))
         })
     }
@@ -78,14 +84,8 @@ impl PluginLoader for NativePluginLoader {
         }
     }
 
-    fn unload(&self, data: Box<dyn Any + Send + Sync>) -> PluginUnloadFuture<'_> {
-        Box::pin(async {
-            data.downcast::<Library>()
-                .map_or(Err(LoaderError::InvalidLoaderData), |library| {
-                    drop(library);
-                    Ok(())
-                })
-        })
+    fn unload(&self, _data: Box<dyn Any + Send + Sync>) -> PluginUnloadFuture<'_> {
+        Box::pin(async { Ok(()) })
     }
 
     /// Windows specific issue: Windows locks DLLs, so we must indicate they cannot be unloaded.

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
@@ -115,7 +115,7 @@ pub struct PluginRuntime {
 }
 
 pub enum PluginInstance {
-    V0_1(wit::v0_1::Plugin),
+    V0_1(wit::v0_1::native::AnyPlugin),
 }
 
 pub struct WasmPlugin {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
@@ -48,7 +48,7 @@ pub struct PluginRuntime {
 }
 
 pub enum PluginInstance {
-    V0_1(wit::v0_1::Plugin),
+    V0_1(wit::v0_1::native::AnyPlugin),
 }
 
 pub struct WasmPlugin {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/mod.rs
@@ -609,6 +609,9 @@ impl pumpkin::plugin::command::HostCommandNode for PluginHostState {
                     WasmCommandNode::Argument(argument(name, StringArgumentType::GreedyPhrase))
                 }
             },
+            ArgumentType::Message => {
+                WasmCommandNode::Argument(argument(name, StringArgumentType::GreedyPhrase))
+            }
             ArgumentType::Entities => {
                 WasmCommandNode::Argument(argument(name, EntityArgumentType::Entities))
             }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/mod.rs
@@ -578,6 +578,7 @@ impl pumpkin::plugin::command::HostCommandNode for PluginHostState {
                 StringType::SingleWord | StringType::Quotable => argument(name, SimpleArgConsumer),
                 StringType::Greedy => argument(name, MsgArgConsumer),
             },
+            ArgumentType::Message => argument(name, MsgArgConsumer),
             ArgumentType::Entities => argument(name, EntitiesArgumentConsumer),
             ArgumentType::Entity => argument(name, EntityArgumentConsumer),
             ArgumentType::Players | ArgumentType::GameProfile => {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
@@ -73,6 +73,14 @@ bindgen!({
     exports: { default: async | trappable},
 });
 
+pub mod native {
+    native_wit_wasmtime::bindgen!({
+        path: "../pumpkin-plugin-wit/v0.1",
+        world: "plugin",
+        trappable: true,
+    });
+}
+
 impl pumpkin::plugin::java_packets::Host for PluginHostState {}
 impl pumpkin::plugin::bedrock_packets::Host for PluginHostState {}
 impl pumpkin::plugin::data_components::Host for PluginHostState {}
@@ -137,7 +145,7 @@ pub async fn init_plugin(
 
     Ok((
         WasmPlugin {
-            plugin_instance: PluginInstance::V0_1(plugin),
+            plugin_instance: PluginInstance::V0_1(native::AnyPlugin::Wasm(plugin)),
             store: Mutex::new(store),
         },
         metadata,

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
@@ -41,6 +41,14 @@ bindgen!({
     exports: { default: async | trappable},
 });
 
+pub mod native {
+    native_wit_wasmtime::bindgen!({
+        path: "../pumpkin-plugin-wit/v0.1",
+        world: "plugin",
+        trappable: true,
+    });
+}
+
 impl pumpkin::plugin::java_packets::Host for PluginHostState {}
 impl pumpkin::plugin::bedrock_packets::Host for PluginHostState {}
 impl pumpkin::plugin::data_components::Host for PluginHostState {}
@@ -95,7 +103,7 @@ pub async fn init_plugin(
 
     Ok((
         WasmPlugin {
-            plugin_instance: PluginInstance::V0_1(plugin),
+            plugin_instance: PluginInstance::V0_1(native::AnyPlugin::Wasm(plugin)),
             store: Mutex::new(store),
         },
         metadata,


### PR DESCRIPTION
## Description

Adds the ability to compile native plugins using the wit api. Currently here for the purposes of exploring this approach. No where near ready for review.

You can try this out by using any plugin and just compile it to a native target. Copy the resultling `.so`, `.dll`, or `.dylib` target into the `plugins` directory. It should just work then.

You can see the native-wit repo [here](https://github.com/BjornTheProgrammer/native-wit). Some of it was AI generated, so I need to do more work to review the entire codebase again before merging.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
