### PR TITLE
fix: Bedrock dropped item synchronization

### DIFF
--- a/crates/pumpkin/src/entity/item.rs
+++ b/crates/pumpkin/src/entity/item.rs
@@ -11,7 +11,7 @@ use pumpkin_protocol::bedrock::network_item::ItemStackWrapper;
 use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_protocol::codec::var_long::VarLong;
 use pumpkin_protocol::codec::var_ulong::VarULong;
-use pumpkin_protocol::java::client::play::Metadata;
+use pumpkin_protocol::java::client::play::{CSetEntityMetadata, Metadata};
 use pumpkin_util::math::atomic_f32::AtomicF32;
 use pumpkin_util::math::vector3::Vector3;
 use std::sync::atomic::Ordering::{AcqRel, Relaxed};
@@ -38,6 +38,8 @@ pub struct ItemEntity {
     never_despawn: AtomicBool,
     never_pickup: AtomicBool,
 }
+
+const ITEM_UPDATE_INTERVAL: u32 = 20;
 
 impl ItemEntity {
     pub fn new(entity: Entity, item_stack: ItemStack) -> Self {
@@ -379,9 +381,19 @@ impl ItemEntity {
             || entity.touching_water.load(Ordering::SeqCst)
             || entity.touching_lava.load(Ordering::SeqCst)
             || entity.velocity.load().sub(&original_velo).length_squared() > 0.1;
+        let moved = entity.pos.load() != entity.last_sent_pos.load();
+        let position_dirty = moved
+            && self
+                .item_age
+                .load(Ordering::Relaxed)
+                .is_multiple_of(ITEM_UPDATE_INTERVAL);
 
-        if velocity_dirty {
+        if position_dirty || velocity_dirty {
             entity.send_pos_rot();
+        } else if moved {
+            entity.send_bedrock_pos();
+        }
+        if velocity_dirty {
             entity.send_velocity();
         }
     }
@@ -621,6 +633,33 @@ impl EntityBase for ItemEntity {
                 from_fishing: false,
             };
             client.send_game_packet(&packet).await;
+        })
+    }
+
+    fn send_java_spawn_packet<'a>(
+        &'a self,
+        client: &'a crate::net::java::JavaClient,
+    ) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            client
+                .enqueue_packet(&self.entity.create_spawn_packet())
+                .await;
+
+            let metadata = Metadata::new(
+                TrackedData::ITEM,
+                MetaDataType::ITEM_STACK,
+                ItemStackSerializer::from(self.item_stack.lock().await.clone()),
+            );
+            let mut data = Vec::new();
+            if metadata.write(&mut data, &client.version.load()).is_ok() {
+                data.push(255);
+                client
+                    .enqueue_packet(&CSetEntityMetadata::new(
+                        self.entity.entity_id.into(),
+                        data.into(),
+                    ))
+                    .await;
+            }
         })
     }
 }

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     entity::item::ItemEntity,
-    net::{ClientPlatform, bedrock::BedrockClient},
+    net::{ClientPlatform, bedrock::BedrockClient, java::JavaClient},
     server::Server,
     world::{
         World,
@@ -296,6 +296,14 @@ pub trait EntityBase: Send + Sync + NBTStorage + std::any::Any {
                 Vec::new(),
             );
             client.send_game_packet(&packet).await;
+        })
+    }
+
+    fn send_java_spawn_packet<'a>(&'a self, client: &'a JavaClient) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            client
+                .enqueue_packet(&self.get_entity().create_spawn_packet())
+                .await;
         })
     }
 
@@ -1775,6 +1783,36 @@ impl Entity {
             }
         }
         self.send_head_rot(yaw);
+    }
+
+    pub fn send_bedrock_pos(&self) {
+        let position = self.pos.load();
+        let chunk_pos = self.chunk_pos.load();
+        let mut flags =
+            MOVE_ACTOR_DELTA_FLAG_HAS_X | MOVE_ACTOR_DELTA_FLAG_HAS_Y | MOVE_ACTOR_DELTA_FLAG_HAS_Z;
+        if self.on_ground.load(Relaxed) {
+            flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
+        }
+        let packet = CMoveActorDelta::new(
+            VarULong(self.entity_id as u64),
+            flags,
+            position.x as f32,
+            position.y as f32,
+            position.z as f32,
+            0,
+            0,
+            0,
+        );
+        let world = self.world.load();
+        for player in world.players.load().iter() {
+            let center = player.get_entity().chunk_pos.load();
+            let view_distance = crate::world::chunker::get_view_distance(player).get() as i32;
+            if is_within_view_distance(chunk_pos, center, view_distance)
+                && let ClientPlatform::Bedrock(client) = player.client.as_ref()
+            {
+                client.try_enqueue_packet(&packet);
+            }
+        }
     }
 
     pub fn update_last_pos(&self) -> Vector3<f64> {

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -129,6 +129,14 @@ pub const DATA_VERSION: i32 = 4903; // 26.2
 /// must apply the same gating.
 pub const MINE_BLOCK_EXHAUSTION: f32 = 0.005; // Vanilla: 0.005F
 
+const fn bedrock_inventory_slot(player_screen_slot: i16) -> Option<u32> {
+    match player_screen_slot {
+        9..=35 => Some(player_screen_slot as u32),
+        36..=44 => Some((player_screen_slot - 36) as u32),
+        _ => None,
+    }
+}
+
 struct HeapNode(i32, Vector2<i32>, Weak<ChunkData>);
 
 impl Eq for HeapNode {}
@@ -5386,13 +5394,18 @@ impl InventoryPlayer for Player {
                     use pumpkin_protocol::codec::var_uint::VarUInt;
 
                     let window_id = packet.window_id.0 as u32;
-                    let slots: Vec<NetworkItemStackDescriptor> = packet
-                        .slot_data
-                        .iter()
-                        .map(|s| NetworkItemStackDescriptor::from(&*s.0))
-                        .collect();
-
                     if window_id == 0 {
+                        // Java's player screen also contains crafting, armor, and off-hand
+                        // slots. Bedrock container 0 contains only the 36-slot player
+                        // inventory in hotbar-first order.
+                        let slots = self
+                            .inventory
+                            .main_inventory
+                            .read()
+                            .await
+                            .iter()
+                            .map(NetworkItemStackDescriptor::from)
+                            .collect();
                         let bedrock_packet = CInventoryContent {
                             container_id: VarUInt(0),
                             slots,
@@ -5425,30 +5438,21 @@ impl InventoryPlayer for Player {
                     use pumpkin_protocol::codec::var_uint::VarUInt;
 
                     let window_id = packet.window_id;
-                    tracing::info!(
-                        "enqueue_slot_packet: window_id={}, slot={}",
-                        window_id,
-                        packet.slot
-                    );
-
                     if window_id == 0 {
-                        tracing::info!(
-                            "enqueue_slot_packet: window_id is 0, sending CInventorySlot to Bedrock client"
-                        );
-                        let slot_idx = packet.slot as usize;
-                        let item_desc = NetworkItemStackDescriptor::from(&*packet.slot_data.0);
-
-                        let bedrock_packet = CInventorySlot {
-                            window_id: VarUInt(0),
-                            inventory_slot: VarUInt(slot_idx as u32),
-                            container_name: Some(FullContainerName {
-                                container_name: ContainerName::Inventory,
-                                dynamic_id: None,
-                            }),
-                            storage: None,
-                            item: item_desc,
-                        };
-                        bedrock.enqueue_packet(&bedrock_packet).await;
+                        if let Some(slot_idx) = bedrock_inventory_slot(packet.slot) {
+                            let item_desc = NetworkItemStackDescriptor::from(&*packet.slot_data.0);
+                            let bedrock_packet = CInventorySlot {
+                                window_id: VarUInt(0),
+                                inventory_slot: VarUInt(slot_idx),
+                                container_name: Some(FullContainerName {
+                                    container_name: ContainerName::Inventory,
+                                    dynamic_id: None,
+                                }),
+                                storage: None,
+                                item: item_desc,
+                            };
+                            bedrock.enqueue_packet(&bedrock_packet).await;
+                        }
                     } else {
                         let slot_idx = packet.slot as usize;
                         let item_desc = NetworkItemStackDescriptor::from(&*packet.slot_data.0);
@@ -5655,5 +5659,20 @@ impl InventoryPlayer for Player {
         Box::pin(async move {
             self.increment_stat(category, stat_id, amount).await;
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bedrock_inventory_slot;
+
+    #[test]
+    fn player_screen_slots_map_to_bedrock_inventory() {
+        assert_eq!(bedrock_inventory_slot(9), Some(9));
+        assert_eq!(bedrock_inventory_slot(35), Some(35));
+        assert_eq!(bedrock_inventory_slot(36), Some(0));
+        assert_eq!(bedrock_inventory_slot(44), Some(8));
+        assert_eq!(bedrock_inventory_slot(8), None);
+        assert_eq!(bedrock_inventory_slot(45), None);
     }
 }

--- a/crates/pumpkin/src/net/mod.rs
+++ b/crates/pumpkin/src/net/mod.rs
@@ -249,6 +249,13 @@ impl ClientPlatform {
         }
     }
 
+    pub async fn enqueue_spawn_packet(&self, entity: &Arc<dyn crate::entity::EntityBase>) {
+        match self {
+            Self::Java(java) => entity.send_java_spawn_packet(java).await,
+            Self::Bedrock(bedrock) => entity.send_bedrock_spawn_packet(bedrock).await,
+        }
+    }
+
     pub async fn send_chunks(&self, chunks: &[SyncChunk]) {
         match self {
             Self::Java(java) => java.send_chunks(chunks).await,

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -3,12 +3,10 @@ use dashmap::DashMap;
 use pumpkin_data::attributes::Attributes;
 use pumpkin_data::chunk::Biome;
 use pumpkin_data::item::{BedrockItem, BedrockItemVersion};
+use pumpkin_protocol::bedrock::client::EntityProperties;
 use pumpkin_protocol::bedrock::client::item_registry::{CItemRegistry, ItemDefinition};
 use pumpkin_protocol::bedrock::client::level_event::{CLevelEvent, LevelEvent};
-use pumpkin_protocol::bedrock::client::{CInventoryContent, EntityProperties};
-use pumpkin_protocol::bedrock::network_item::{
-    ContainerName, FullContainerName, NetworkItemDescriptor, NetworkItemStackDescriptor,
-};
+use pumpkin_protocol::bedrock::network_item::NetworkItemDescriptor;
 use pumpkin_protocol::codec::data_component::data_to_proto_sound;
 use pumpkin_world::generation::proto_chunk::GenerationCache;
 use std::sync::atomic::Ordering::Relaxed;
@@ -2297,23 +2295,8 @@ impl World {
             })
             .await;
 
-        client
-            .send_game_packet(&CInventoryContent {
-                container_id: VarUInt(0), // player inventory,
-                slots: player
-                    .inventory()
-                    .main_inventory
-                    .read()
-                    .await
-                    .iter()
-                    .map(NetworkItemStackDescriptor::from)
-                    .collect(),
-                full_container_name: FullContainerName {
-                    container_name: ContainerName::Inventory,
-                    dynamic_id: None,
-                },
-                storage_item: NetworkItemStackDescriptor::default(),
-            })
+        player
+            .on_screen_handler_opened(player.player_screen_handler.clone())
             .await;
 
         {
@@ -3772,10 +3755,7 @@ impl World {
                         // stale data.
                         base_entity.velocity.store(Vector3::default());
 
-                        player
-                            .client
-                            .enqueue_packet(&base_entity.create_spawn_packet())
-                            .await;
+                        player.client.enqueue_spawn_packet(&entity).await;
                         entities_to_add.push(entity);
                     }
 
@@ -3793,10 +3773,7 @@ impl World {
                     for entity in world.entities.load().iter() {
                         let base_entity = entity.get_entity();
                         if base_entity.chunk_pos.load() == position {
-                            player
-                                .client
-                                .enqueue_packet(&base_entity.create_spawn_packet())
-                                .await;
+                            player.client.enqueue_spawn_packet(entity).await;
                         }
                     }
                 }


### PR DESCRIPTION
## Description
Fixes dropped-item synchronization for Bedrock players, including inventory pickup updates, item movement, and cross-edition visibility.

## What
- Picked-up items now appear in Bedrock inventories instead of disappearing.
- Bedrock inventory slots are mapped correctly between Java’s player screen layout and Bedrock’s 36-slot inventory.
- Dropped items receive smooth position updates on Bedrock and settle on the correct supporting block. (This is in line with bedrock singleplayer behavior)
- Java retains Vanilla’s 20-tick item tracking interval.
- Players joining later receive edition-appropriate entity spawn packets.
- Java players receive the item-stack metadata required to render existing dropped items.

## How
- Connects Bedrock players to Pumpkin’s existing screen-handler synchronization path.
- Sends full Bedrock inventory contents in hotbar-first order and translates incremental player-screen slot updates.
- Sends moving item positions to Bedrock every server tick while preserving Vanilla’s Java tracking cadence.
- Adds edition-aware late entity spawning and includes item metadata after Java item spawns.

## Testing
- `cargo test -p pumpkin --lib`
- `cargo check -p pumpkin`
- `cargo clippy -p pumpkin --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Verified in-game that:
- Bedrock players can drop and recover items without losing them.
- Picked-up items immediately return to the Bedrock inventory.
- Dropped items move smoothly and rest on the correct block.
- Java players joining after an item was dropped can see and collect it.