### PR TITLE
fix(block): notify neighbors when a block is removed by a neighbor update

### DIFF
--- a/crates/pumpkin/src/block/blocks/doors.rs
+++ b/crates/pumpkin/src/block/blocks/doors.rs
@@ -181,7 +181,11 @@ impl BlockBehaviour for DoorBlock {
     }
 
     fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
-        can_place_at(args.block_accessor, args.position)
+        has_support(args.block_accessor, args.position)
+            && args
+                .block_accessor
+                .get_block_state(&args.position.up())
+                .replaceable()
     }
 
     fn placed<'a>(&'a self, args: PlacedArgs<'a>) -> BlockFuture<'a, ()> {
@@ -303,7 +307,7 @@ impl BlockBehaviour for DoorBlock {
             {
                 if lv == DoubleBlockHalf::Lower
                     && args.direction == BlockDirection::Down
-                    && !can_place_at(args.world, args.position)
+                    && !has_support(args.world, args.position)
                 {
                     return BlockStateId::AIR;
                 }
@@ -350,9 +354,8 @@ impl BlockBehaviour for DoorBlock {
     }
 }
 
-fn can_place_at(world: &dyn BlockAccessor, block_pos: &BlockPos) -> bool {
-    world.get_block_state(&block_pos.up()).replaceable()
-        && world
-            .get_block_state(&block_pos.down())
-            .is_side_solid(BlockDirection::Up)
+fn has_support(world: &dyn BlockAccessor, block_pos: &BlockPos) -> bool {
+    world
+        .get_block_state(&block_pos.down())
+        .is_side_solid(BlockDirection::Up)
 }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -5142,7 +5142,8 @@ impl World {
 
         if new_state_id != block_state_id {
             if is_air(new_state_id) {
-                self.break_block(block_pos, None, flags).await;
+                self.break_block(block_pos, None, flags | BlockFlags::NOTIFY_ALL)
+                    .await;
             } else {
                 self.set_block_state(block_pos, new_state_id, flags).await;
             }


### PR DESCRIPTION
Fixes #2837

When a block is destroyed as a result of a neighbor update (the second half of a door, a torch losing its support, ...), `replace_with_state_for_neighbor_update` passed the incoming flags straight to `break_block`. Those flags come from `set_block_state`, which already stripped `NOTIFY_NEIGHBORS` before running the neighbor pass, so the removal itself never notified anything around it.

Vanilla does the opposite here: `Block.replace` calls `World.breakBlock`, which always sets the new state with `NOTIFY_ALL`. Only the `setBlockState` branch keeps the reduced flags.

The visible effect underwater: breaking the lower half of a door removes the upper half, but nothing around the upper half is updated, so the water next to it never schedules a fluid tick. The column above only advances a single layer and then stops.

Also fixed the door support check. `can_place_at` required the block above to be replaceable, which is a placement-time condition - for an already placed door the block above is its own upper half, so the check could never pass. It is now split: placement keeps both conditions, while `get_state_for_neighbor_update` only asks whether the block below can still support the door.
