### PR TITLE
fix(worldgen): skip jigsaw blocks whose final state is a structure void

### DIFF
--- a/crates/pumpkin-world/src/generation/structure/template/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/template/mod.rs
@@ -86,10 +86,8 @@ pub fn place_template(
     for block in &template.blocks {
         let palette_entry = &template.palette[block.state as usize];
 
-        // Structure blocks are data markers and structure void preserves the existing block.
-        if palette_entry.name == "minecraft:structure_void"
-            || palette_entry.name == "minecraft:structure_block"
-        {
+        // Structure blocks are data markers.
+        if palette_entry.name == "minecraft:structure_block" {
             continue;
         }
 
@@ -105,6 +103,12 @@ pub fn place_template(
                 .unwrap_or("minecraft:air");
             placed_entry = PaletteEntry::from_string(final_state);
             block_entity_nbt = None;
+        }
+
+        // Structure void preserves the existing block, both from the palette itself and from a
+        // jigsaw final state.
+        if placed_entry.name == "minecraft:structure_void" {
+            continue;
         }
 
         // Resolve block state with rotation applied to directional properties
@@ -311,5 +315,61 @@ pub(crate) fn get_block_entity_id(block_name: &str) -> Option<&'static str> {
         | "minecraft:warped_sign" => Some("minecraft:sign"),
         "minecraft:hanging_sign" => Some("minecraft:hanging_sign"),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pumpkin_data::Block;
+
+    struct CollectingPlacer(Vec<BlockStateId>);
+
+    impl BlockPlacer for CollectingPlacer {
+        fn get_block_state(&self, _pos: &Vector3<i32>) -> BlockStateId {
+            Block::AIR.default_state.id
+        }
+
+        fn set_block_state(&mut self, _pos: &Vector3<i32>, state: &BlockState) {
+            self.0.push(state.id);
+        }
+
+        fn add_block_entity(&mut self, _nbt: NbtCompound) {}
+    }
+
+    #[test]
+    fn structure_void_is_never_placed() {
+        let mut placed_templates = 0;
+
+        for name in all_template_names() {
+            let Some(template) = get_template(name) else {
+                continue;
+            };
+
+            let mut placer = CollectingPlacer(Vec::new());
+            place_template(
+                &mut placer,
+                &template,
+                Vector3::new(0, 0, 0),
+                (0, 0),
+                Rotation::None,
+                false,
+                false,
+                &[],
+                None,
+            );
+
+            for state_id in &placer.0 {
+                assert_ne!(
+                    state_id.to_block_id(),
+                    Block::STRUCTURE_VOID.id,
+                    "{name} placed a structure void"
+                );
+            }
+
+            placed_templates += 1;
+        }
+
+        assert!(placed_templates > 0);
     }
 }

--- a/crates/pumpkin/src/block/entities/jigsaw_block.rs
+++ b/crates/pumpkin/src/block/entities/jigsaw_block.rs
@@ -144,6 +144,9 @@ impl JigsawBlockEntity {
                             pumpkin_world::generation::structure::template::PaletteEntry::from_string(
                                 final_state_str,
                             );
+                            if entry.name == "minecraft:structure_void" {
+                                continue;
+                            }
                             let final_state =
                             pumpkin_world::generation::structure::template::BlockStateResolver::resolve(
                                 &entry,


### PR DESCRIPTION
Fixes #2836

`place_template` filtered structure voids by looking at the raw palette entry, but a jigsaw block is only turned into its `final_state` a few lines later. Village templates use `"final_state": "minecraft:structure_void"` on most of their jigsaw blocks - 1124 of them across the embedded village templates - which means those positions were resolved to a real structure void state and written into the world.

The void check now runs on the entry that is actually placed, so it covers both a structure void coming from the palette and one coming from a jigsaw final state. The same substitution in the jigsaw block entity (used by `/place jigsaw` and the jigsaw block generate button) got the same check.

Added a test that runs every embedded template through `place_template` and asserts no structure void ends up at the placer. It fails on master and passes with this change.
