### PR TITLE
fix(item): keep eyes of ender in creative mode

### DIFF
--- a/crates/pumpkin/src/item/items/ender_eye.rs
+++ b/crates/pumpkin/src/item/items/ender_eye.rs
@@ -72,7 +72,7 @@ impl ItemBehaviour for EnderEyeItem {
                 .set_block_state(&location, new_state_id, BlockFlags::NOTIFY_LISTENERS)
                 .await;
             // Consume one item.
-            item.decrement(1);
+            item.decrement_unless_creative(player.gamemode.load(), 1);
             world.sync_world_event(WorldEvent::EndPortalFrameFill, location, 0);
 
             // Try to complete the portal.
@@ -135,7 +135,7 @@ impl ItemBehaviour for EnderEyeItem {
 
             player.trigger_advancement(crate::entity::player::advancement::trigger::AdvancementTrigger::LaunchedEyeOfEnder).await;
             let mut stack = player.inventory.held_item().await;
-            stack.decrement(1);
+            stack.decrement_unless_creative(player.gamemode.load(), 1);
             player.inventory.set_held_item(stack).await;
         })
     }


### PR DESCRIPTION
Fixes #2835

Throwing an eye of ender decremented the held stack unconditionally, so creative players lost the item. Vanilla uses `decrementUnlessCreative` here.

The same applies to filling an end portal frame: the generic block placement path in `handle_use_item_on` skips the decrement in creative, but an item that consumes itself inside `use_on_block` bypasses that check, and the eye of ender does.

Both now go through the existing `ItemStack::decrement_unless_creative` helper.
