### PR TITLE
fix(world): do not tick entities while their chunk is not loaded

### DIFF
--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -974,6 +974,7 @@ impl World {
         let entity_count = entities_to_tick.len();
         let server_for_entities = server.clone();
         let active_chunks = self.active_chunks.load();
+        let level_for_entities = self.level.clone();
 
         let entity_future = async move {
             let t = tokio::time::Instant::now();
@@ -991,6 +992,14 @@ impl World {
                     get_section_cord(entity_pos.z.floor() as i32),
                 );
                 if !active_chunks.contains(&entity_chunk) {
+                    continue;
+                }
+
+                // A chunk stays active while it is still being generated. Mobs spawned by the
+                // generator are added to the world before their chunk is published, and every
+                // block read in a missing chunk reports air, so ticking them here would let
+                // them fall through the terrain that is about to appear.
+                if !level_for_entities.is_chunk_loaded(&entity_chunk) {
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #2834

The spawn placement itself is fine. I generated the reported chunk (seed 1787870112421306378, chunk -4/-4) and walked every column: the frozen ocean has ice at y=62 and air at y=63, and all 256 columns pass the `ON_GROUND` spawn check at y=63, on top of the ice. So the bears are placed on the ice and end up in the water afterwards.

What happens is:

1. `ProtoChunk::spawn_mobs` runs inside the generation task and calls `spawn_entity_non_save`, which puts the mob into `World::entities` right away.
2. The chunk only reaches `level.loaded_chunks` later, when the scheduler receives the finished generation result.
3. Entity ticking only asks whether the chunk is in `active_chunks`, which is purely distance based, so the mob starts ticking while its chunk is still missing.
4. Every block lookup in a missing chunk returns air (`get_block_state_id` falls back to air), so the mob has nothing to stand on and falls until the chunk shows up.

On land the fall is short and mostly unnoticeable, which matches "most spawn correctly". Over a frozen ocean the bear falls off the ice into the water column below and stays trapped under the ice sheet.

Entities in unloaded chunks are now skipped, which is also what vanilla does - entity ticking is driven by chunks that have reached ticking status.

I could not test this in game; the analysis is from the code path plus the generated chunk dump above.
