### PR TITLE
fix: don't block the async runtime when reading inventories

### DIFF
--- a/crates/pumpkin-world/src/inventory/simple_inventory.rs
+++ b/crates/pumpkin-world/src/inventory/simple_inventory.rs
@@ -5,6 +5,7 @@ use tokio::sync::RwLock;
 
 pub struct SimpleInventory {
     pub stacks: RwLock<Vec<ItemStack>>,
+    size: usize,
 }
 
 impl SimpleInventory {
@@ -12,6 +13,7 @@ impl SimpleInventory {
     pub fn new(size: usize) -> Self {
         Self {
             stacks: RwLock::new(vec![ItemStack::EMPTY.clone(); size]),
+            size,
         }
     }
 }
@@ -27,7 +29,7 @@ impl Clearable for SimpleInventory {
 
 impl Inventory for SimpleInventory {
     fn size(&self) -> usize {
-        self.stacks.blocking_read().len()
+        self.size
     }
 
     fn is_empty(&self) -> InventoryFuture<'_, bool> {

--- a/crates/pumpkin/src/block/entities/brewing_stand.rs
+++ b/crates/pumpkin/src/block/entities/brewing_stand.rs
@@ -18,7 +18,7 @@ use pumpkin_data::tag::{self, Taggable};
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
-use pumpkin_world::inventory::{Inventory, sync_write_items_to_nbt};
+use pumpkin_world::inventory::{Inventory, sync_read_items_from_nbt, sync_write_items_to_nbt};
 use tokio::sync::RwLock;
 
 pub struct BrewingStandBlockEntity {
@@ -332,7 +332,7 @@ impl crate::block::entities::BlockEntity for BrewingStandBlockEntity {
     where
         Self: Sized,
     {
-        let entity = Self::new(position);
+        let mut entity = Self::new(position);
 
         // Load brew time / fuel if present in NBT
         if let Some(bt) = nbt.get_int("BrewTime") {
@@ -343,28 +343,28 @@ impl crate::block::entities::BlockEntity for BrewingStandBlockEntity {
         }
 
         // Load inventory items from NBT
-        entity.read_data(nbt, &mut *futures::executor::block_on(entity.items.write()));
+        let items = entity.items.get_mut();
+        sync_read_items_from_nbt(nbt, items);
 
-        let items_guard = futures::executor::block_on(entity.items.read());
         // If there's an ingredient in slot 3, remember its base item for matching
-        if !items_guard[3].is_empty() {
-            *entity
-                .ingredient_item
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                Some(items_guard[3].get_item());
-        }
+        let ingredient_item = (!items[3].is_empty()).then(|| items[3].get_item());
 
         // Recompute last_potion_count so visuals are correct after load
         let mut current: [bool; 3] = [false; 3];
-        for (i, slot) in items_guard.iter().take(3).enumerate() {
+        for (i, slot) in items.iter().take(3).enumerate() {
             current[i] = !slot.is_empty()
                 && (slot
                     .get_data_component::<pumpkin_data::data_component_impl::PotionContentsImpl>()
                     .is_some()
                     || slot.get_item().id == pumpkin_data::item::Item::GLASS_BOTTLE.id);
         }
-        drop(items_guard);
+
+        if let Some(item) = ingredient_item {
+            *entity
+                .ingredient_item
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(item);
+        }
 
         *entity
             .last_potion_count


### PR DESCRIPTION
Follow-up to #2827.

The crashes in that issue came from `blocking_write()` calls inside `from_nbt`, which panic with *"Cannot block the current thread from within a runtime"* whenever a chunk with a chest/barrel/dispenser got ticked. Those particular calls are already gone on master (49360e5 replaced them with `get_mut()`), but the same pattern is still alive in two places, so the crash can still be hit:

**`SimpleInventory::size()`** used `stacks.blocking_read()`. `size()` is a sync trait method and it is called from `ScreenHandler` while building slots, so it always runs on a tokio worker - opening an anvil, a stonecutter, an enchanting table or a villager trade panics the server the same way. The vector length never changes after construction, so the size is now just stored as a field, matching how every other inventory implements `size()` (a constant).

**`BrewingStandBlockEntity::from_nbt()`** still went through `futures::executor::block_on` to grab the item lock. It doesn't panic, but it parks a runtime worker thread while loading a chunk for no reason. The entity is still owned locally at that point, so `get_mut()` works there, same as barrel/dispenser/chest.

No behavior change beyond not blocking - loading and saving still read the exact same NBT.

Verified with `cargo check` and `cargo clippy` on `pumpkin` and `pumpkin-world`.

One thing I left alone: `chunk_data_nbt()` in several block entities still uses `futures::executor::block_on(self.items.read())`. It only takes `&self`, so `get_mut()` isn't an option, and making it async would ripple into `add_block_entity`/`update_block_entity` and their callers. Worth a separate PR.
