### PR TITLE
fix: save block entities before their chunk is dropped

### DIFF
--- a/crates/pumpkin/src/block/entities/mod.rs
+++ b/crates/pumpkin/src/block/entities/mod.rs
@@ -433,3 +433,40 @@ pub fn create_block_entity(
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::{BlockEntity, block_entity_from_nbt, furnace::FurnaceBlockEntity};
+    use pumpkin_data::{item::Item, item_stack::ItemStack};
+    use pumpkin_nbt::compound::NbtCompound;
+    use pumpkin_util::math::position::BlockPos;
+    use pumpkin_world::inventory::Inventory;
+    use std::sync::Arc;
+
+    /// A loaded block entity is serialized back into its chunk with
+    /// `write_internal`, so whatever it holds has to survive that round trip or
+    /// it is gone the next time the chunk is read.
+    #[tokio::test]
+    async fn furnace_contents_survive_a_chunk_round_trip() {
+        let position = BlockPos::new(0, 100, 0);
+        let furnace = Arc::new(FurnaceBlockEntity::new(position));
+        furnace
+            .set_stack(0, ItemStack::new(5, &Item::DIAMOND))
+            .await;
+
+        let mut nbt = NbtCompound::new();
+        furnace.write_internal(&mut nbt).await;
+
+        let inventory = block_entity_from_nbt(&nbt).and_then(BlockEntity::get_inventory);
+        assert!(
+            inventory.is_some(),
+            "furnace should be readable back from its own NBT"
+        );
+
+        if let Some(inventory) = inventory {
+            let stack = inventory.get_stack(0).await;
+            assert_eq!(stack.get_item().id, Item::DIAMOND.id);
+            assert_eq!(stack.item_count, 5);
+        }
+    }
+}

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -382,6 +382,15 @@ impl World {
             self.save_entity(entity).await;
         }
 
+        let chunks: Vec<Vector2<i32>> = self
+            .block_entities
+            .iter()
+            .map(|chunk_block_entities| *chunk_block_entities.key())
+            .collect();
+        for chunk_pos in chunks {
+            self.save_block_entities(&chunk_pos).await;
+        }
+
         // Save portal POI to disk
         let save_result = self.portal_poi.lock().await.save_all();
         if let Err(e) = save_result {
@@ -403,6 +412,27 @@ impl World {
         let chunk = self.level.get_entity_chunk(current_chunk).await;
         chunk.data.lock().await.push(nbt);
         chunk.mark_dirty(true);
+    }
+
+    /// Serializes the live block entities of a chunk back into that chunk's block
+    /// entity data. The live map is the source of truth while a chunk is loaded -
+    /// `get_block_entity` takes the saved NBT out of the chunk when it wakes an
+    /// entity up - so this has to run before the chunk is dropped, or everything
+    /// the entity did since it was loaded is lost.
+    async fn save_block_entities(&self, chunk_pos: &Vector2<i32>) {
+        let Some(block_entities) = self
+            .block_entities
+            .get(chunk_pos)
+            .map(|chunk_block_entities| chunk_block_entities.values().cloned().collect::<Vec<_>>())
+        else {
+            return;
+        };
+
+        for block_entity in block_entities {
+            let mut nbt = NbtCompound::new();
+            block_entity.write_internal(&mut nbt).await;
+            self.add_block_entity_nbt(block_entity.get_position(), &nbt);
+        }
     }
 
     /// Sends an entity status update to all players tracking the specified entity.
@@ -4314,6 +4344,7 @@ impl World {
         }
 
         for chunk_pos in &chunks_set {
+            self.save_block_entities(chunk_pos).await;
             self.block_entities.remove(chunk_pos);
         }
     }


### PR DESCRIPTION
Fixes #2771.

`World::get_block_entity` takes the block entity's NBT *out* of the chunk (`pending_block_entities.remove`) when it wakes the entity up, so from that moment the live `World::block_entities` map is the only copy of its state. Nothing ever writes that copy back: when the chunk stops being watched, `remove_entities_in_chunks` just drops the map, and the chunk is then saved without the entity's data. Anything the entity did while it was loaded is gone - for a furnace that means the items, the burn timers and the recipes used for XP.

This mirrors what already happens for regular entities: `remove_entities_in_chunks` calls `save_entity` before dropping them, and `World::shutdown` saves them all. Block entities were missing the equivalent step, so this adds `save_block_entities`, which serializes each live block entity of a chunk with `write_internal` (the same NBT `from_nbt` reads back) and puts it into the chunk's block entity data. It runs in both places:

- `remove_entities_in_chunks`, before the chunk's entry is dropped - this covers a player walking away and the periodic `clean_memory` pass
- `World::shutdown`, for chunks that are still loaded when the server stops

`write_internal` is async and takes the lock properly, so unlike `chunk_data_nbt` it can't silently skip an inventory it failed to `try_read`.

Also adds a test that a furnace holding an item survives the `write_internal` -> `block_entity_from_nbt` round trip, which is the payload the flush relies on.

Verified with `cargo test -p pumpkin`, `cargo clippy -p pumpkin --all-targets` and `cargo fmt`. I could not drive this end to end from the console: chunks only load around players, `forceload` marks a chunk active without requesting a load, and there's no `data get block` yet, so `setblock` at an unwatched position just answers "That position is not loaded". Testing with a real client would be welcome.
