### PR TITLE
fix: don't deadlock when equipping an item from the hand

### DIFF
--- a/crates/pumpkin-util/src/lib.rs
+++ b/crates/pumpkin-util/src/lib.rs
@@ -271,6 +271,21 @@ impl Hand {
     pub const fn all() -> [Self; 2] {
         [Self::Right, Self::Left]
     }
+
+    /// Converts the `hand` field of a play packet, where `0` is the main hand.
+    ///
+    /// This is the opposite of [`TryFrom<i32>`], which reads the dominant hand
+    /// out of the client settings, where `0` is the left hand.
+    ///
+    /// # Errors
+    /// Returns `InvalidHand` if the value is not 0 or 1.
+    pub const fn from_packet_id(value: i32) -> Result<Self, InvalidHand> {
+        match value {
+            0 => Ok(Self::Right),
+            1 => Ok(Self::Left),
+            _ => Err(InvalidHand),
+        }
+    }
 }
 
 /// Error type for invalid hand conversion.

--- a/crates/pumpkin/src/net/java/play.rs
+++ b/crates/pumpkin/src/net/java/play.rs
@@ -2521,17 +2521,13 @@ impl JavaClient {
         player.update_last_action_time();
 
         let inventory = player.inventory();
-        let Ok(hand) = Hand::try_from(use_item.hand.0) else {
+        let Ok(hand) = Hand::from_packet_id(use_item.hand.0) else {
             self.kick(TextComponent::text("InvalidHand")).await;
             return;
         };
         self.update_sequence(player, use_item.sequence.0);
 
-        let mut item_in_hand = if hand == Hand::Left {
-            inventory.held_item().await
-        } else {
-            inventory.off_hand_item().await
-        };
+        let mut item_in_hand = inventory.get_stack_in_hand(hand).await;
 
         let (item_id, _item) = (item_in_hand.item.id, item_in_hand.item);
         player
@@ -2622,27 +2618,27 @@ impl JavaClient {
                     .await;
             }
         }
-        if let Some(equippable) = held.get_data_component::<EquippableImpl>() {
-            let mut equipment_guard = inventory.entity_equipment.lock().await;
-            let current_equipped = equipment_guard.get(equippable.slot);
+        let equipment_slot = held
+            .get_data_component::<EquippableImpl>()
+            .map(|equippable| equippable.slot.clone());
+        if let Some(slot) = equipment_slot {
+            // The equipment lock has to be released before touching the hand again:
+            // the off hand lives in the same map, so holding it here would deadlock.
+            let current_equipped = inventory.entity_equipment.lock().await.get(&slot);
             if current_equipped.are_items_and_components_equal(held) {
                 return;
             }
 
-            player.enqueue_equipment_change(equippable.slot, held).await;
+            player.enqueue_equipment_change(&slot, held).await;
 
-            let equip_item = equipment_guard
-                .equipment
-                .entry(equippable.slot.clone())
-                .or_insert_with(|| ItemStack::EMPTY.clone());
-            if equip_item.is_empty() {
-                *equip_item = held.clone();
+            let equipped = if current_equipped.is_empty() {
+                let equipped = held.clone();
                 held.decrement_unless_creative(player.gamemode.load(), 1);
+                equipped
             } else {
-                let old_held = held.clone();
-                *held = equip_item.clone();
-                *equip_item = old_held;
-            }
+                std::mem::replace(held, current_equipped)
+            };
+            inventory.entity_equipment.lock().await.put(&slot, equipped);
             inventory.set_stack_in_hand(hand, held.clone()).await;
         }
     }


### PR DESCRIPTION
Fixes #2855.

Right-clicking to equip an elytra (or any equippable) froze the whole server. `prepare_hand_item_for_use` held the `entity_equipment` lock while it called `set_stack_in_hand`, and for the off hand that method locks `entity_equipment` again - tokio's mutex isn't reentrant, so the task parked forever holding the lock and every later access to that player's equipment parked behind it.

The reason a *main* hand click ended up on the off hand path is the hand conversion. `Hand::try_from` reads the dominant-hand value from the client settings, where `0` means left; the `hand` field of a play packet uses the opposite convention, where `0` means the main hand. `handle_use_item` used `try_from` on the packet field, so every main hand use was treated as the off hand. It papered over that when reading the item (`hand == Hand::Left` picked the main hand item) but everything downstream - the equipment write-back, the active hand flag - still got the wrong hand.

So this does two things:

- Adds `Hand::from_packet_id`, documents how it differs from the settings conversion, and uses it in `handle_use_item`, which lets the item read go through `get_stack_in_hand` instead of the inverted special case.
- Drops the long-lived equipment guard: the current item is read, the lock is released, and the new item is written back in a second short lock, so nothing else is called while it's held.

`handle_use_item_on` and `handle_swing_arm` convert the same packet field the same wrong way and have their own compensations; they don't deadlock, so I left them out of this fix, but they should get the same treatment.

Verified with `cargo check`, `cargo clippy` and `cargo fmt` on `pumpkin` and `pumpkin-util`. I don't have a Java client here, so the deadlock itself is reasoned from the lock order rather than reproduced - testing an equip from both hands would be welcome.

The creative-flight-while-gliding behaviour also mentioned in the issue is a separate problem and isn't touched here.
