### PR TITLE
fix(protocol): send block change acknowledgements every tick

### DIFF
--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -2097,6 +2097,10 @@ impl Player {
 
     #[expect(clippy::too_many_lines)]
     pub async fn tick(self: &Arc<Self>, server: &Server) {
+        if let ClientPlatform::Java(client) = self.client.as_ref() {
+            client.acknowledge_block_changes().await;
+        }
+
         if let Some(camera_id) = self.camera_target_id.load() {
             if camera_id == self.entity_id() {
                 self.camera_target_id.store(None);

--- a/crates/pumpkin/src/net/java/mod.rs
+++ b/crates/pumpkin/src/net/java/mod.rs
@@ -110,6 +110,7 @@ pub struct JavaClient {
     pub last_keep_alive_time: AtomicCell<Instant>,
 
     pub packet_sequence: AtomicI32,
+    pub pending_packet_sequence: AtomicI32,
 }
 
 pub enum OutgoingPacketType {
@@ -120,6 +121,18 @@ pub enum OutgoingPacketType {
 struct OutgoingPacket {
     data: Bytes,
     completion: Option<oneshot::Sender<()>>,
+}
+
+fn finish_packet_sequence(pending: &AtomicI32, ready: &AtomicI32) {
+    let sequence = pending.swap(-1, Ordering::Relaxed);
+    if sequence >= 0 {
+        ready.fetch_max(sequence, Ordering::Relaxed);
+    }
+}
+
+fn take_packet_sequence(ready: &AtomicI32) -> Option<i32> {
+    let sequence = ready.swap(-1, Ordering::Relaxed);
+    (sequence >= 0).then_some(sequence)
 }
 
 impl OutgoingPacket {
@@ -170,6 +183,7 @@ impl JavaClient {
             keep_alive_id: AtomicCell::new(0),
             last_keep_alive_time: AtomicCell::new(Instant::now()),
             packet_sequence: AtomicI32::new(-1),
+            pending_packet_sequence: AtomicI32::new(-1),
         }
     }
 
@@ -214,12 +228,6 @@ impl JavaClient {
                     let packet = pumpkin_protocol::java::client::play::CKeepAlive::new(keep_alive_id);
                     self.enqueue_packet(&packet).await;
 
-                    let seq = self.packet_sequence.swap(-1, Ordering::Relaxed);
-                    if seq != -1 {
-                        self
-                            .send_packet_now(&CAcknowledgeBlockChange::new(seq.into()))
-                            .await;
-                    }
                 }
 
                 // INCOMING PACKETS
@@ -249,9 +257,21 @@ impl JavaClient {
                             );
                         }
                     }
+                    self.finish_packet_processing();
                 }
             }
         }
+    }
+
+    pub async fn acknowledge_block_changes(&self) {
+        if let Some(sequence) = take_packet_sequence(&self.packet_sequence) {
+            self.send_packet_now(&CAcknowledgeBlockChange::new(sequence.into()))
+                .await;
+        }
+    }
+
+    fn finish_packet_processing(&self) {
+        finish_packet_sequence(&self.pending_packet_sequence, &self.packet_sequence);
     }
 
     pub async fn await_tasks(&self) {
@@ -1000,5 +1020,25 @@ impl JavaClient {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{finish_packet_sequence, take_packet_sequence};
+    use std::sync::atomic::{AtomicI32, Ordering};
+
+    #[test]
+    fn block_change_sequence_is_ready_only_after_packet_processing() {
+        let pending = AtomicI32::new(-1);
+        let ready = AtomicI32::new(-1);
+
+        pending.fetch_max(4, Ordering::Relaxed);
+        pending.fetch_max(2, Ordering::Relaxed);
+        assert_eq!(take_packet_sequence(&ready), None);
+
+        finish_packet_sequence(&pending, &ready);
+        assert_eq!(take_packet_sequence(&ready), Some(4));
+        assert_eq!(take_packet_sequence(&ready), None);
     }
 }

--- a/crates/pumpkin/src/net/java/play.rs
+++ b/crates/pumpkin/src/net/java/play.rs
@@ -2205,10 +2205,8 @@ impl JavaClient {
         if sequence < 0 {
             error!("Expected packet sequence >= 0");
         }
-        self.packet_sequence.store(
-            self.packet_sequence.load(Ordering::Relaxed).max(sequence),
-            Ordering::Relaxed,
-        );
+        self.pending_packet_sequence
+            .fetch_max(sequence, Ordering::Relaxed);
     }
 
     async fn sync_block_state_to_client(&self, world: &World, position: BlockPos) {


### PR DESCRIPTION
## Description

Pumpkin was only sending block change acknowledgements alongside the keep-alive packet, which is sent every 15 seconds.

These acknowledgements tell the client that the server has finished processing an interaction. While waiting for one, block state changes could appear several seconds late or multiple changes could appear at once. This affected any interaction that changes a block state, including crops growing from bonemeal and rails
  connecting to each other.

I moved block change acknowledgements to the regular player tick, matching the official server. Since Pumpkin processes packets asynchronously, the sequence is kept pending until its packet handler finishes. The next player tick then acknowledges the highest completed sequence.

## Testing

I tested bonemealing farmland crops and confirmed that they grow immediately instead of updating several seconds later. I also tested placing rails next to each other and confirmed that they connect immediately.