### PR TITLE
fix(inventory): decode block-placement and swing hands via from_packet_id

### DIFF
--- a/crates/pumpkin/src/net/java/play.rs
+++ b/crates/pumpkin/src/net/java/play.rs
@@ -1352,7 +1352,7 @@ impl JavaClient {
         swing_arm: SSwingArm,
     ) {
         player.update_last_action_time();
-        let Ok(hand) = Hand::try_from(swing_arm.hand.0) else {
+        let Ok(hand) = Hand::from_packet_id(swing_arm.hand.0) else {
             self.kick(TextComponent::text("Invalid hand")).await;
             return;
         };
@@ -2282,7 +2282,7 @@ impl JavaClient {
             return Err(BlockPlacingError::InvalidBlockFace);
         };
 
-        let Ok(hand) = Hand::try_from(use_item_on.hand.0) else {
+        let Ok(hand) = Hand::from_packet_id(use_item_on.hand.0) else {
             return Err(BlockPlacingError::InvalidHand);
         };
 
@@ -2297,11 +2297,8 @@ impl JavaClient {
         let held_item_empty = held_item.is_empty();
         let off_hand_item_empty = off_hand_item.is_empty();
 
-        let item_id = if matches!(hand, Hand::Left) {
-            held_item.item.id
-        } else {
-            off_hand_item.item.id
-        };
+        let mut item = inventory.get_stack_in_hand(hand).await;
+        let item_id = item.item.id;
         player
             .increment_stat(StatisticCategory::Used, item_id as i32, 1)
             .await;
@@ -2331,12 +2328,7 @@ impl JavaClient {
             }
         }}
 
-        let mut item = if matches!(hand, Hand::Left) {
-            held_item
-        } else {
-            off_hand_item
-        };
-        let equipment_slot = if matches!(hand, Hand::Left) {
+        let equipment_slot = if matches!(hand, Hand::Right) {
             EquipmentSlot::MAIN_HAND
         } else {
             EquipmentSlot::OFF_HAND
@@ -2369,7 +2361,7 @@ impl JavaClient {
             }
         }
 
-        let slot_index = if matches!(hand, Hand::Left) {
+        let slot_index = if matches!(hand, Hand::Right) {
             inventory.get_selected_slot() as usize
         } else {
             PlayerInventory::OFF_HAND_SLOT


### PR DESCRIPTION
## Summary

Fixes the "infinite items / duplication into the off-hand" bug reported in #2831, #2862 and #2875.

When placing a block (or swinging), the packet's `hand` field was decoded with `Hand::try_from`, which maps `0 -> Hand::Left`. That conversion is meant for the client's **dominant-hand setting** (`0 = left hand`). But the packet field uses `0 = main hand`, so a main-hand placement produced `Hand::Left` — which means **off-hand** in the inventory API.

Result: the decremented stack was written back to the **off-hand** instead of the main hand. The main-hand slot was never actually decremented on the server, so:
- blocks only "consumed" once visually, then stayed at the same count (infinite blocks),
- a copy of the stack appeared in the off-hand (duplication),
- swing animation fired on the wrong arm.

## Changes

- Use `Hand::from_packet_id` (added in #2857) for the block-placement (`use_item_on`) and swing (`swing_arm`) packet handlers.
- Read the in-hand item via `inventory.get_stack_in_hand(hand)` and flip the main-hand checks from `Hand::Left` to `Hand::Right`, matching the existing `use_item` handler.

## Testing

Verified with a live client on a fresh world: placing sand, dirt and logs decrements the stack on every placement and no longer duplicates into the off-hand. `cargo check -p pumpkin` passes.
