### PR TITLE
fix: stop stdin console task from busy-looping on EOF

### DIFF
--- a/crates/pumpkin/src/lib.rs
+++ b/crates/pumpkin/src/lib.rs
@@ -703,6 +703,9 @@ fn setup_stdin_console(server: Arc<Server>) {
                         )
                         .await;
                 }
+            } else {
+                info!("Console input closed (EOF), stopping command reader");
+                break;
             }
         }
     });


### PR DESCRIPTION
## Description

Fixes #2863.

When the server starts with stdin not a TTY (systemd `StandardInput=null`, Docker,
`nohup … </dev/null`, or a closed pipe), the stdin reader thread hits EOF and exits,
dropping the only sender and closing the mpsc channel. The receiver task then spins
forever: `rx.recv().await` returns `None` immediately, the `if let Some` branch is
skipped, and the `while` loop re-polls at 100% of one core — with zero players
connected. One `tokio-rt-worker` spins in pure user space, no syscalls.

This adds an `else { break; }` so the loop exits once the channel is closed, instead
of re-polling.

## Testing

Idle CPU drops from ~160–180% to ~2%. Verified on a J1900 board (measured 181% → 0.9%,
all worker threads sleeping) and locally. Console commands still work when stdin
delivers input (tested by piping `help`).
