### PR TITLE
fix(bedrock): persist and restore player positions after reconnecting

### DIFF
--- a/crates/pumpkin/src/server/mod.rs
+++ b/crates/pumpkin/src/server/mod.rs
@@ -535,6 +535,9 @@ impl Server {
 
         if let Some(mut nbt_data) = nbt {
             player.read_nbt(&mut nbt_data).await;
+            // The data file itself proves this is a returning player. Older Bedrock
+            // sessions could persist HasPlayedBefore as false and mask a valid Pos.
+            player.has_played_before.store(true, Ordering::Relaxed);
         }
 
         // Wrap in Arc after data is loaded

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1945,6 +1945,12 @@ impl World {
             (position, level_info.spawn_yaw, level_info.spawn_pitch)
         };
 
+        // Keep the server-side transform aligned with the StartGame position. In
+        // particular, this ensures an early disconnect persists the real spawn.
+        player.living_entity.entity.set_pos(position);
+        player.living_entity.entity.set_rotation(yaw, pitch);
+        player.living_entity.entity.last_pos.store(position);
+
         // Todo make the data less spread
         let level_settings = LevelSettings {
             seed: self.level.seed.0,
@@ -2635,6 +2641,8 @@ impl World {
 
             client.send_game_packet(&ex_be_mob_equipment).await;
         }
+
+        player.has_played_before.store(true, Ordering::Relaxed);
 
         // 3. Trigger Join Event and Broadcast Join Message
         let msg_comp = TextComponent::translate_cross(

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -2035,7 +2035,12 @@ impl World {
                 entity_id: VarLong(runtime_id as _),
                 runtime_entity_id: VarULong(runtime_id),
                 player_gamemode: player.gamemode.load(),
-                position: Vector3::new(position.x as f32, position.y as f32, position.z as f32),
+                // Bedrock represents the local player at eye height; Pumpkin stores feet position.
+                position: Vector3::new(
+                    position.x as f32,
+                    position.y as f32 + player.get_entity().entity_type.eye_height,
+                    position.z as f32,
+                ),
                 pitch,
                 yaw,
                 level_settings,


### PR DESCRIPTION
## Description
Fixes Bedrock players spawning at the wrong location when reconnecting. Pretty sure this was a regression.

## What
- Restores returning Bedrock players at their saved position instead of the world spawn.
- Preserves the selected spawn position if a player disconnects early during login.
- Prevents Bedrock players from initially appearing partially inside the ground.
- Restores the player’s saved rotation alongside their position.
- Handles older player files where `HasPlayedBefore` was incorrectly saved as false.

## How
- Treats the presence of saved player NBT as proof that the player has previously joined.
- Synchronizes the server-side position, rotation, and previous position with the transform selected during login.
- Keeps Pumpkin’s internal position at feet level while applying Bedrock’s required eye-height offset to the `StartGame` packet.
- Marks the player as having joined successfully once world initialization completes.

## Testing
- `cargo check -p pumpkin`
- `cargo clippy -p pumpkin --all-targets -- -D warnings`
- `cargo fmt --all -- --check`.
- Join and move away from spawn, disconnect, and reconnect.
- Confirm the saved position and rotation are restored.
- Restart the server and confirm the position remains persistent.