### PR TITLE
fix(plugin): apply WASM sent packet payloads

### DIFF
--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -2385,18 +2385,26 @@ impl Player {
         false
     }
 
-    pub async fn fire_packet_sent_no_obj(self: &Arc<Self>, packet_id: i32, payload: Bytes) -> bool {
-        let server = self.world().server.upgrade();
-        if let Some(server) = server {
-            // This is a dummy object to satisfy the non-optional requirement in WIT
-            // In the future we should make all packets 'static or have a way to represent raw packets in WIT
-            struct RawPacket;
-            let mut event =
-                PacketSentEvent::new(self.clone(), packet_id, payload, Arc::new(RawPacket));
+    pub(crate) async fn fire_packet_sent_event_no_obj(
+        self: &Arc<Self>,
+        packet_id: i32,
+        payload: Bytes,
+    ) -> PacketSentEvent {
+        // This is a dummy object to satisfy the non-optional requirement in WIT
+        // In the future we should make all packets 'static or have a way to represent raw packets in WIT
+        struct RawPacket;
+
+        let mut event = PacketSentEvent::new(self.clone(), packet_id, payload, Arc::new(RawPacket));
+        if let Some(server) = self.world().server.upgrade() {
             server.plugin_manager.fire(&server, &mut event).await;
-            return event.cancelled;
         }
-        false
+        event
+    }
+
+    pub async fn fire_packet_sent_no_obj(self: &Arc<Self>, packet_id: i32, payload: Bytes) -> bool {
+        self.fire_packet_sent_event_no_obj(packet_id, payload)
+            .await
+            .cancelled
     }
 
     pub const fn entity_id(&self) -> i32 {

--- a/crates/pumpkin/src/net/bedrock/mod.rs
+++ b/crates/pumpkin/src/net/bedrock/mod.rs
@@ -368,14 +368,14 @@ impl BedrockClient {
             Ok(()) => {
                 let payload = Bytes::from(packet_buf);
                 let player = self.player.load_full();
-                let cancelled = if let Some(player) = player.as_ref() {
-                    player
-                        .fire_packet_sent_no_obj(P::PACKET_ID, payload.clone())
-                        .await
+                if let Some(player) = player.as_ref() {
+                    let event = player
+                        .fire_packet_sent_event_no_obj(P::PACKET_ID, payload)
+                        .await;
+                    if !event.cancelled {
+                        self.enqueue_packet_data(event.payload).await;
+                    }
                 } else {
-                    false
-                };
-                if !cancelled {
                     self.enqueue_packet_data(payload).await;
                 }
             }
@@ -493,16 +493,17 @@ impl BedrockClient {
             Ok(()) => {
                 let payload = Bytes::from(packet_buf);
                 let player = self.player.load_full();
-                let cancelled = if let Some(player) = player.as_ref() {
-                    player
-                        .fire_packet_sent_no_obj(P::PACKET_ID, payload.clone())
-                        .await
+                let payload = if let Some(player) = player.as_ref() {
+                    let event = player
+                        .fire_packet_sent_event_no_obj(P::PACKET_ID, payload)
+                        .await;
+                    if event.cancelled {
+                        return;
+                    }
+                    event.payload
                 } else {
-                    false
+                    payload
                 };
-                if cancelled {
-                    return;
-                }
                 let (tx, rx) = oneshot::channel();
                 if let Err(err) = self
                     .outgoing_packet_priority_send

--- a/crates/pumpkin/src/net/java/mod.rs
+++ b/crates/pumpkin/src/net/java/mod.rs
@@ -323,14 +323,14 @@ impl JavaClient {
         let payload = Bytes::from(buf);
 
         let player = self.player.load_full();
-        let cancelled = if let Some(player) = player.as_ref() {
-            player
-                .fire_packet_sent_no_obj(P::to_id(self.version.load()), payload.clone())
-                .await
+        if let Some(player) = player.as_ref() {
+            let event = player
+                .fire_packet_sent_event_no_obj(P::to_id(self.version.load()), payload)
+                .await;
+            if !event.cancelled {
+                self.enqueue_packet_data(event.payload).await;
+            }
         } else {
-            false
-        };
-        if !cancelled {
             self.enqueue_packet_data(payload).await;
         }
     }
@@ -450,15 +450,14 @@ impl JavaClient {
         let payload = Bytes::from(packet_buf);
 
         let player = self.player.load_full();
-        let cancelled = if let Some(player) = player.as_ref() {
-            player
-                .fire_packet_sent_no_obj(P::to_id(self.version.load()), payload.clone())
-                .await
+        if let Some(player) = player.as_ref() {
+            let event = player
+                .fire_packet_sent_event_no_obj(P::to_id(self.version.load()), payload)
+                .await;
+            if !event.cancelled {
+                self.send_packet_now_data(event.payload).await;
+            }
         } else {
-            false
-        };
-
-        if !cancelled {
             self.send_packet_now_data(payload).await;
         }
     }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/server.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/server.rs
@@ -98,6 +98,12 @@ impl ToFromWasmEvent for PacketSentEvent {
         })
     }
 
+    fn apply_wasm_event(&mut self, event: Event, _state: &mut PluginHostState) {
+        if let Event::PacketSentEvent(data) = event {
+            self.payload = data.raw_payload.into();
+            self.cancelled = data.cancelled;
+        }
+    }
     fn from_wasm_event(event: Event, _state: &mut PluginHostState) -> Self {
         match event {
             Event::PacketSentEvent(_) => {


### PR DESCRIPTION
## Description

Apply raw payload changes returned by blocking WASM packet sent handlers.

Outgoing Java and Bedrock packet paths now queue the payload returned by `PacketSentEvent` instead of always sending the originally serialized bytes. The existing public cancellation helper remains unchanged.

No WIT changes. `packet-id` remains metadata in this change; raw payload replacement uses the existing serialized clientbound payload.