### PR TITLE
fix(bedrock): restore NetherNet LAN discovery

### DIFF
--- a/crates/pumpkin/src/lib.rs
+++ b/crates/pumpkin/src/lib.rs
@@ -11,7 +11,7 @@ use crate::data::VanillaData;
 use crate::logging::{GzipRollingLogger, PumpkinCommandCompleter, ReadlineLogWrapper};
 use crate::net::bedrock::{
     BedrockClient,
-    nethernet::{NetherNetListener, load_or_create_identity_key},
+    nethernet::{NetherNetListener, discovery::NetherNetDiscovery, load_or_create_identity_key},
     status::{IceSocket, StatusResponder},
 };
 use crate::net::java::JavaClient;
@@ -217,6 +217,7 @@ pub struct PumpkinServer {
     pub server: Arc<Server>,
     pub tcp_listener: Option<TcpListener>,
     pub bedrock_status: Option<StatusResponder>,
+    pub nethernet_discovery: Option<NetherNetDiscovery>,
     pub nethernet_listener: Option<NetherNetListener>,
 }
 
@@ -307,11 +308,33 @@ impl PumpkinServer {
 
         let (bedrock_status, ice_socket) = Self::bind_bedrock_status(&server).await;
         let nethernet_listener = Self::bind_nethernet(&server, ice_socket).await;
+        let nethernet_discovery = if nethernet_listener.is_some() {
+            match NetherNetDiscovery::bind(
+                server.advanced_config.networking.bedrock.nethernet.address,
+                server.server_guid,
+            )
+            .await
+            {
+                Ok(discovery) => {
+                    if let Ok(address) = discovery.local_addr() {
+                        info!("Bedrock NetherNet LAN discovery is listening on {address}");
+                    }
+                    Some(discovery)
+                }
+                Err(error) => {
+                    error!("Failed to bind Bedrock NetherNet LAN discovery: {error}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
         Self {
             server,
             tcp_listener,
             bedrock_status,
+            nethernet_discovery,
             nethernet_listener,
         }
     }
@@ -422,6 +445,7 @@ impl PumpkinServer {
         let tasks = Arc::new(TaskTracker::new());
         let mut master_client_id: u64 = 0;
         let bedrock_clients = Arc::new(Mutex::new(HashMap::new()));
+        let mut discovery_buffer = vec![0; usize::from(u16::MAX)].into_boxed_slice();
 
         self.server
             .plugin_manager
@@ -430,7 +454,12 @@ impl PumpkinServer {
 
         while !SHOULD_STOP.load(Ordering::Relaxed) {
             if !self
-                .unified_listener_task(&mut master_client_id, &tasks, &bedrock_clients)
+                .unified_listener_task(
+                    &mut master_client_id,
+                    &tasks,
+                    &bedrock_clients,
+                    &mut discovery_buffer,
+                )
                 .await
             {
                 break;
@@ -506,6 +535,7 @@ impl PumpkinServer {
         master_client_id_counter: &mut u64,
         tasks: &Arc<TaskTracker>,
         bedrock_clients: &Arc<Mutex<HashMap<SocketAddr, Arc<BedrockClient>>>>,
+        discovery_buffer: &mut [u8],
     ) -> bool {
         select! {
             // Branch for TCP connections (Java Edition)
@@ -587,6 +617,18 @@ impl PumpkinServer {
             ) => {
                 if let Err(error) = status_result {
                     debug!("Bedrock status packet failed: {error}");
+                }
+            },
+
+            // NetherNet-native LAN discovery and connection signaling.
+            discovery_result = resolve_some(
+                self.nethernet_discovery.as_ref().zip(self.nethernet_listener.as_ref()),
+                |(discovery, listener): (&NetherNetDiscovery, &NetherNetListener)| {
+                    discovery.receive(&self.server, listener, discovery_buffer)
+                },
+            ) => {
+                if let Err(error) = discovery_result {
+                    debug!("NetherNet discovery packet failed: {error}");
                 }
             },
 

--- a/crates/pumpkin/src/net/bedrock/nethernet/discovery.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet/discovery.rs
@@ -38,7 +38,6 @@ static KEY: LazyLock<[u8; 32]> =
 pub struct NetherNetDiscovery {
     socket: Arc<UdpSocket>,
     network_id: u64,
-    advertisement_id: u64,
     candidates: Arc<Mutex<HashMap<ConnectionKey, mpsc::UnboundedSender<RTCIceCandidateInit>>>>,
 }
 
@@ -52,7 +51,6 @@ impl NetherNetDiscovery {
         Ok(Self {
             socket: Arc::new(socket),
             network_id,
-            advertisement_id: rand::random(),
             candidates: Arc::default(),
         })
     }
@@ -111,7 +109,6 @@ impl NetherNetDiscovery {
         let game_mode = server.defaultgamemode.lock().await.gamemode as u8;
         let response = encode_response(
             self.network_id,
-            self.advertisement_id,
             &server.advanced_config.networking.bedrock.motd,
             &server.basic_config.default_level_name,
             game_mode,
@@ -124,7 +121,6 @@ impl NetherNetDiscovery {
         trace!(
             %address,
             network_id = self.network_id,
-            advertisement_id = format_args!("{:016x}", self.advertisement_id),
             version = SERVER_DATA_VERSION,
             players,
             max_players = server.advanced_config.networking.bedrock.max_players,
@@ -280,7 +276,6 @@ fn decode_packet(data: &[u8]) -> Option<Packet> {
 #[allow(clippy::too_many_arguments)]
 fn encode_response(
     network_id: u64,
-    advertisement_id: u64,
     server_name: &str,
     level_name: &str,
     game_mode: u8,
@@ -304,7 +299,9 @@ fn encode_response(
             .to_le_bytes(),
     );
     server_data.extend_from_slice(&[0, u8::from(hardcore), 0, u8::from(!online_mode)]);
-    push_string(&mut server_data, &format!("{advertisement_id:016x}"))?;
+    // Bedrock uses this ID both to deduplicate LAN advertisements and as the recipient for
+    // discovery signaling. It must match the network ID in the response packet header.
+    push_string(&mut server_data, &format!("{network_id:016x}"))?;
     server_data.extend_from_slice(&[2 << 1, 4 << 1]);
 
     let application_data = hex::encode(server_data);
@@ -402,7 +399,6 @@ mod tests {
     fn encodes_current_server_data() {
         let response = encode_response(
             99,
-            0x9bb64bcf14727bdb,
             "Dedicated Server",
             "Creative level",
             1,
@@ -425,7 +421,7 @@ mod tests {
         assert_eq!(
             hex::encode(server_data),
             "0610446564696361746564205365727665720e4372656174697665206c6576656c\
-             02000000000a0000000000000110396262363462636631343732376264620408"
+             02000000000a0000000000000110303030303030303030303030303036330408"
         );
     }
 


### PR DESCRIPTION
## Description
Restores NetherNet-native LAN discovery and signaling for Bedrock clients.

## What
- Advertises Pumpkin in Bedrock’s LAN Worlds list through NetherNet discovery.
- Includes the server name, world name, game mode, player counts, online-mode state, and transport information.
- Handles LAN connection requests and ICE candidate signaling.
- Prevents one Pumpkin instance from appearing twice in the LAN Worlds list.
- Fixes LAN connections failing with `Door` while direct-IP connections work.

## How
- Listens for encrypted NetherNet discovery traffic on UDP port `7551`.
- Responds using Bedrock 1.26.40’s discovery packet and server-data formats.
- Routes LAN SDP and ICE signaling through Pumpkin’s existing NetherNet negotiation path.
- Uses Pumpkin’s stable server GUID as both the advertised server identity and NetherNet network ID.
- Ensures RakNet status and NetherNet discovery identify the same server, allowing clients to deduplicate the entries and target the correct signaling recipient.

## Testing
- `cargo test -p pumpkin nethernet::discovery`
- `cargo clippy -p pumpkin --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Verified the encoded discovery request, response, server data, and signaling message round trips.
- Confirmed direct-IP connections remain unaffected.