### PR TITLE
fix(bedrock): waterlog aquatic blocks

### DIFF
--- a/crates/pumpkin-protocol/src/bedrock/client/level_chunk.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/level_chunk.rs
@@ -3,7 +3,10 @@ use xxhash_rust::xxh64::xxh64;
 
 use pumpkin_macros::packet;
 use pumpkin_nbt::{Nbt, compound::NbtCompound};
-use pumpkin_world::chunk::{ChunkData, palette::NetworkPalette};
+use pumpkin_world::chunk::{
+    ChunkData,
+    palette::{BeNetworkSerialization, NetworkPalette},
+};
 
 use crate::{
     codec::{var_int::VarInt, var_uint::VarUInt},
@@ -11,6 +14,29 @@ use crate::{
 };
 
 const VERSION: u8 = 9;
+
+fn write_block_storage(
+    writer: &mut Vec<u8>,
+    network_repr: BeNetworkSerialization<u16>,
+) -> Result<(), Error> {
+    (network_repr.bits_per_entry << 1 | 1).write(writer)?;
+
+    for data in network_repr.packed_data {
+        data.write(writer)?;
+    }
+
+    match network_repr.palette {
+        NetworkPalette::Single(id) => VarInt(i32::from(id)).write(writer)?,
+        NetworkPalette::Indirect(palette) => {
+            VarInt(palette.len() as i32).write(writer)?;
+            for id in palette {
+                VarInt(i32::from(id)).write(writer)?;
+            }
+        }
+        NetworkPalette::Direct => {}
+    }
+    Ok(())
+}
 
 #[packet(58)]
 pub struct CLevelChunk<'a> {
@@ -69,28 +95,13 @@ impl CLevelChunk<'_> {
             let mut subchunk_buf = Vec::new();
             // Version 9: [version:byte][num_storages:byte][sub_chunk_index:byte]
             let y = (i as i8) + min_y_section;
-            let num_storages = 1;
+            let water_layer = block_palette.convert_be_water_network();
+            let num_storages = if water_layer.is_some() { 2 } else { 1 };
             subchunk_buf.write_all(&[VERSION, num_storages, y as u8])?;
 
-            let network_repr = block_palette.convert_be_network();
-
-            (network_repr.bits_per_entry << 1 | 1).write(&mut subchunk_buf)?;
-
-            for data in network_repr.packed_data {
-                data.write(&mut subchunk_buf)?;
-            }
-
-            match network_repr.palette {
-                NetworkPalette::Single(id) => {
-                    VarInt(i32::from(id)).write(&mut subchunk_buf)?;
-                }
-                NetworkPalette::Indirect(palette) => {
-                    VarInt(palette.len() as i32).write(&mut subchunk_buf)?;
-                    for id in palette {
-                        VarInt(i32::from(id)).write(&mut subchunk_buf)?;
-                    }
-                }
-                NetworkPalette::Direct => (),
+            write_block_storage(&mut subchunk_buf, block_palette.convert_be_network())?;
+            if let Some(water_layer) = water_layer {
+                write_block_storage(&mut subchunk_buf, water_layer)?;
             }
 
             subchunk_bytes_list.push(subchunk_buf);
@@ -186,10 +197,11 @@ impl PacketWrite for CLevelChunk<'_> {
 mod tests {
     use std::io::Cursor;
 
+    use pumpkin_data::{Block, BlockState};
     use pumpkin_nbt::{Nbt, compound::NbtCompound, deserializer::NbtReadHelperBedrock};
     use pumpkin_world::chunk::ChunkData;
 
-    use super::CLevelChunk;
+    use super::{CLevelChunk, VERSION};
     use crate::serial::PacketWrite;
 
     fn read_var_uint(data: &[u8], offset: &mut usize) -> u32 {
@@ -203,6 +215,28 @@ mod tests {
             }
         }
         panic!("VarUInt is too long");
+    }
+
+    fn read_var_int(data: &[u8], offset: &mut usize) -> i32 {
+        let value = read_var_uint(data, offset);
+        ((value >> 1) as i32) ^ -((value & 1) as i32)
+    }
+
+    fn skip_storage(data: &[u8], offset: &mut usize) -> Vec<u32> {
+        let bits_per_entry = data[*offset] >> 1;
+        *offset += 1;
+        if bits_per_entry != 0 {
+            let entries_per_word = 32 / usize::from(bits_per_entry);
+            *offset += 4096usize.div_ceil(entries_per_word) * size_of::<u32>();
+        }
+        let palette_len = if bits_per_entry == 0 {
+            1
+        } else {
+            read_var_int(data, offset) as usize
+        };
+        (0..palette_len)
+            .map(|_| read_var_int(data, offset) as u32)
+            .collect()
     }
 
     fn empty_chunk() -> ChunkData {
@@ -278,5 +312,34 @@ mod tests {
         let parsed = Nbt::read(&mut reader).unwrap();
         assert_eq!(parsed.get_string("id"), Some("Chest"));
         assert_eq!(parsed.get_int("x"), Some(1));
+    }
+
+    #[test]
+    fn aquatic_blocks_use_a_secondary_water_storage() {
+        let chunk = empty_chunk();
+        chunk
+            .section
+            .set_block_absolute_y(0, -64, 0, Block::SEAGRASS.default_state.id);
+
+        let (encoded, _) = CLevelChunk::encode_chunk(&chunk, 0, false, &[]).unwrap();
+        let mut offset = 0;
+        for _ in 0..4 {
+            read_var_uint(&encoded, &mut offset);
+        }
+        offset += 2; // request limit and cache flag
+        read_var_uint(&encoded, &mut offset); // blob count
+        read_var_uint(&encoded, &mut offset); // raw payload length
+
+        assert_eq!(&encoded[offset..offset + 3], &[VERSION, 2, (-4i8) as u8]);
+        offset += 3;
+        skip_storage(&encoded, &mut offset);
+        let water_palette = skip_storage(&encoded, &mut offset);
+        assert_eq!(
+            water_palette,
+            [
+                u32::from(BlockState::to_be_network_id(Block::AIR.default_state.id)),
+                u32::from(BlockState::to_be_network_id(Block::WATER.default_state.id)),
+            ]
+        );
     }
 }

--- a/crates/pumpkin-protocol/src/bedrock/client/update_block.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/update_block.rs
@@ -15,11 +15,16 @@ pub struct CUpdateBlock {
 impl CUpdateBlock {
     #[must_use]
     pub const fn new(position: BlockPos, block_runtime_id: u32) -> Self {
+        Self::with_layer(position, block_runtime_id, 0)
+    }
+
+    #[must_use]
+    pub const fn with_layer(position: BlockPos, block_runtime_id: u32, layer: u32) -> Self {
         Self {
             position,
             block_runtime_id: VarUInt(block_runtime_id),
             flags: VarUInt(0x3), // neighbors | network
-            layer: VarUInt(0),
+            layer: VarUInt(layer),
         }
     }
 }

--- a/crates/pumpkin-world/src/chunk/palette.rs
+++ b/crates/pumpkin-world/src/chunk/palette.rs
@@ -27,6 +27,20 @@ pub fn has_random_ticking_fluid(id: BlockStateId) -> bool {
     Fluid::from_state_id(id).is_some_and(|fluid| Fluid::same_fluid_type(fluid.id, Fluid::LAVA.id))
 }
 
+/// Returns the block state for Bedrock's secondary water storage.
+///
+/// Java stores water inside waterlogged and aquatic block states, while Bedrock stores it in a
+/// separate subchunk layer. Pure fluid blocks stay in the primary layer.
+#[must_use]
+pub fn bedrock_water_state(id: BlockStateId) -> BlockStateId {
+    let state = BlockState::from_id(id);
+    if state.is_waterlogged() || (state.is_liquid() && Fluid::from_state_id(id).is_none()) {
+        pumpkin_data::Block::WATER.default_state.id
+    } else {
+        pumpkin_data::Block::AIR.default_state.id
+    }
+}
+
 #[derive(Clone)]
 pub struct HeterogeneousPaletteData<V: Hash + Eq + Copy, const DIM: usize> {
     storage: PaletteStorage<V, DIM>,
@@ -649,6 +663,65 @@ impl BiomePalette {
 }
 
 impl BlockPalette {
+    /// Builds Bedrock's secondary water storage for blocks whose Java state also contains water.
+    ///
+    /// Bedrock expects mixed secondary storages to use a one-bit, air-first palette. The first
+    /// entry is the default for every position not occupied by water.
+    #[must_use]
+    pub fn convert_be_water_network(&self) -> Option<BeNetworkSerialization<u16>> {
+        let air = pumpkin_data::Block::AIR.default_state.id;
+        let water = pumpkin_data::Block::WATER.default_state.id;
+        match self {
+            Self::Homogeneous(id) => {
+                (bedrock_water_state(*id) != air).then_some(BeNetworkSerialization {
+                    bits_per_entry: 0,
+                    palette: NetworkPalette::Single(BlockState::to_be_network_id(water)),
+                    packed_data: Box::new([]),
+                })
+            }
+            Self::Heterogeneous(data) => {
+                let water_states = data
+                    .palette
+                    .iter()
+                    .map(|&id| bedrock_water_state(id) != air)
+                    .collect::<Vec<_>>();
+                if !water_states.iter().any(|&waterlogged| waterlogged) {
+                    return None;
+                }
+
+                let key_to_index = data
+                    .palette
+                    .iter()
+                    .enumerate()
+                    .map(|(index, &id)| (id, index))
+                    .collect::<HashMap<_, _>>();
+                let mut packed_data = vec![0u32; Self::VOLUME / u32::BITS as usize];
+                let mut output_index = 0;
+                for x in 0..Self::SIZE {
+                    for y in 0..Self::SIZE {
+                        for z in 0..Self::SIZE {
+                            let palette_index = key_to_index[&data.get(x, z, y)];
+                            if water_states[palette_index] {
+                                packed_data[output_index / u32::BITS as usize] |=
+                                    1 << (output_index % u32::BITS as usize);
+                            }
+                            output_index += 1;
+                        }
+                    }
+                }
+
+                Some(BeNetworkSerialization {
+                    bits_per_entry: 1,
+                    palette: NetworkPalette::Indirect(Box::new([
+                        BlockState::to_be_network_id(air),
+                        BlockState::to_be_network_id(water),
+                    ])),
+                    packed_data: packed_data.into_boxed_slice(),
+                })
+            }
+        }
+    }
+
     #[must_use]
     pub fn convert_network(&self) -> NetworkSerialization<u16> {
         match self {
@@ -1005,5 +1078,29 @@ mod tests {
         assert_eq!(network.bits_per_entry, 8);
         assert_eq!(network.packed_data.len(), 1024);
         assert!(matches!(network.palette, NetworkPalette::Indirect(values) if values.len() == 65));
+    }
+
+    #[test]
+    fn bedrock_water_palette_uses_bedrock_block_order() {
+        let mut palette = BlockPalette::default();
+        palette.set(1, 2, 3, Block::SEAGRASS.default_state.id);
+
+        let network = palette.convert_be_water_network().unwrap();
+        let (x, y, z) = (1, 2, 3);
+        let bedrock_index = x * 256 + z * 16 + y;
+
+        assert_eq!(network.bits_per_entry, 1);
+        assert_eq!(
+            network.packed_data[bedrock_index / 32],
+            1 << (bedrock_index % 32)
+        );
+        assert_eq!(
+            network
+                .packed_data
+                .iter()
+                .filter(|&&word| word != 0)
+                .count(),
+            1
+        );
     }
 }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -142,7 +142,9 @@ use pumpkin_util::{
 use pumpkin_world::inventory::Clearable;
 use pumpkin_world::world::{GetBlockError, WorldPortalExt};
 use pumpkin_world::{
-    CURRENT_BEDROCK_MC_VERSION, biome, chunk::io::Dirtiable, inventory::Inventory,
+    CURRENT_BEDROCK_MC_VERSION, biome,
+    chunk::{io::Dirtiable, palette::bedrock_water_state},
+    inventory::Inventory,
 };
 use pumpkin_world::{chunk::ChunkData, world::BlockAccessor};
 use pumpkin_world::{level::Level, tick::TickPriority};
@@ -1387,6 +1389,28 @@ impl World {
                     &CMultiBlockUpdate::new(&updates),
                     recipients_by_version,
                 );
+            }
+
+            let players = self.players.load();
+            let recipients = players.iter().filter(|player| {
+                let center = player.get_entity().chunk_pos.load();
+                let view_distance = get_view_distance(player).get() as i32;
+                is_within_view_distance(chunk_pos, center, view_distance)
+            });
+            for player in recipients {
+                let ClientPlatform::Bedrock(client) = player.client.as_ref() else {
+                    continue;
+                };
+                for (block_pos, block_state_id) in &updates {
+                    let water_state = bedrock_water_state(*block_state_id);
+                    client.try_enqueue_packet(
+                        &pumpkin_protocol::bedrock::client::CUpdateBlock::with_layer(
+                            *block_pos,
+                            u32::from(BlockState::to_be_network_id(water_state)),
+                            1,
+                        ),
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
Fixes waterlogged and aquatic blocks rendering without water for Bedrock players.

## What
- Adds Bedrock’s secondary water storage to chunk data.
- Marks waterlogged blocks and aquatic blocks such as seagrass as containing water.
- Synchronizes the secondary water layer when blocks change.
- Prevents visible air pockets from appearing around underwater vegetation.

## How
- Converts Pumpkin’s Java-style combined block states into Bedrock’s separate block and water layers.
- Encodes secondary water storage only for subchunks that require it.
- Uses Bedrock’s expected X/Z/Y block ordering and compact one-bit air/water palettes.
- Sends layer-1 block updates whenever a changed block gains or loses water.

## Testing
- `cargo test -p pumpkin-world bedrock_water_palette`
- `cargo test -p pumpkin-protocol aquatic_blocks_use_a_secondary_water_storage`
- `cargo check -p pumpkin`
- `cargo clippy -p pumpkin -p pumpkin-world -p pumpkin-protocol --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Verified in-game that seagrass and other aquatic blocks render correctly waterlogged on Bedrock Edition.

- Resolves: https://github.com/Pumpkin-MC/Pumpkin/issues/2867