### PR TITLE
Fix stale mob navigation paths

### DIFF
--- a/crates/pumpkin/src/entity/ai/goal/avoid_entity.rs
+++ b/crates/pumpkin/src/entity/ai/goal/avoid_entity.rs
@@ -93,9 +93,9 @@ impl AvoidEntityGoal {
             }
 
             let candidate = BlockPos::new(
-                (mob_pos.x + dx) as i32,
-                (mob_pos.y + dy as f64) as i32,
-                (mob_pos.z + dz) as i32,
+                (mob_pos.x + dx).floor() as i32,
+                (mob_pos.y + dy as f64).floor() as i32,
+                (mob_pos.z + dz).floor() as i32,
             );
 
             let block_at = world.get_block_state(&candidate);

--- a/crates/pumpkin/src/entity/ai/pathfinder/mod.rs
+++ b/crates/pumpkin/src/entity/ai/pathfinder/mod.rs
@@ -102,6 +102,9 @@ impl Navigator {
         self.is_idle.store(false, Ordering::Relaxed);
         self.current_goal = Some(goal);
         self.current_path = None;
+        self.ticks_on_current_node = 0;
+        self.last_node_index = 0;
+        self.path_start_pos = None;
     }
 
     pub const fn set_speed(&mut self, speed: f64) {

--- a/crates/pumpkin/src/net/java/play.rs
+++ b/crates/pumpkin/src/net/java/play.rs
@@ -2566,6 +2566,12 @@ impl JavaClient {
         };
         self.update_sequence(player, use_item.sequence.0);
 
+        // Vanilla ServerPlayerGameMode.useItem returns PASS for spectators and does not
+        // dispatch the held item.
+        if player.gamemode.load() == GameMode::Spectator {
+            return;
+        }
+
         let mut item_in_hand = inventory.get_stack_in_hand(hand).await;
 
         let (item_id, _item) = (item_in_hand.item.id, item_in_hand.item);


### PR DESCRIPTION
Clear stale navigation state when vanilla mob goals replace their movement target, and use floor rounding for flee positions.