### PR TITLE
feat(plugin): add bulk world editing ops to the world API

### DIFF
--- a/crates/pumpkin-plugin-api/src/lib.rs
+++ b/crates/pumpkin-plugin-api/src/lib.rs
@@ -88,6 +88,8 @@ pub mod forms;
 pub mod permissions;
 /// Custom recipe registration and builder utilities.
 pub mod recipe;
+/// Ergonomic helpers for the bulk region block operations on the world.
+pub mod region;
 /// Scheduler utilities.
 pub mod scheduler;
 /// Scoreboard team management and builder utilities.
@@ -135,6 +137,7 @@ pub use recipe::{
     CookingRecipeBuilder, Ingredient, RecipeCategory, RecipeError, RecipeManager,
     RegistrableRecipe, ShapedRecipeBuilder, ShapelessRecipeBuilder,
 };
+pub use region::{Region, WorldExt};
 pub use screens_wit::Screen;
 pub use statistics_wit::{CustomStatistic, StatisticCategory};
 pub use team::{PlayerTeamExt, ScoreboardTeamExt, Team, TeamSettingsBuilder};

--- a/crates/pumpkin-plugin-api/src/region.rs
+++ b/crates/pumpkin-plugin-api/src/region.rs
@@ -1,0 +1,287 @@
+//! Ergonomic helpers for the bulk region block operations on the world.
+//!
+//! [`World::get_region`](crate::world::World) and
+//! [`World::set_region`](crate::world::World) work with a flat array of
+//! block-state ids. [`Region`] wraps that array together with the region's
+//! bounds so plugins can read and write blocks by coordinate instead of
+//! computing flat indices by hand, and [`WorldExt`] bridges the two.
+
+use crate::wit::pumpkin::plugin::common::BlockPos;
+use crate::wit::pumpkin::plugin::world::{BlockFlags, World};
+
+/// Returns the corner-wise minimum and maximum of two positions, so callers can
+/// pass the two corners of a region in any order.
+fn normalize(a: BlockPos, b: BlockPos) -> (BlockPos, BlockPos) {
+    (
+        BlockPos {
+            x: a.x.min(b.x),
+            y: a.y.min(b.y),
+            z: a.z.min(b.z),
+        },
+        BlockPos {
+            x: a.x.max(b.x),
+            y: a.y.max(b.y),
+            z: a.z.max(b.z),
+        },
+    )
+}
+
+/// Inclusive length along one axis. `hi` is assumed `>= lo` (true after
+/// [`normalize`]); the widening avoids overflow on large spans.
+fn span(lo: i32, hi: i32) -> u32 {
+    ((i64::from(hi) - i64::from(lo)) + 1) as u32
+}
+
+/// A cuboid of block-state ids, addressable by coordinate.
+///
+/// The states are stored in the same order the host uses: `x` outermost, then
+/// `z`, then `y` innermost. Read one with [`WorldExt::read_region`], modify it
+/// with [`Region::set`], and write it back with [`WorldExt::write_region`].
+pub struct Region {
+    min: BlockPos,
+    max: BlockPos,
+    states: Vec<u16>,
+}
+
+impl Region {
+    /// Creates a region covering the cuboid between `a` and `b` (inclusive, in
+    /// any corner order) with every block set to `state`.
+    #[must_use]
+    pub fn filled(a: BlockPos, b: BlockPos, state: u16) -> Self {
+        let (min, max) = normalize(a, b);
+        let len = Self::volume(min, max);
+        Self {
+            min,
+            max,
+            states: vec![state; len],
+        }
+    }
+
+    /// Wraps a flat `states` array that was read for the cuboid between `a` and
+    /// `b`. Returns `None` if `states` is not exactly one entry per block.
+    #[must_use]
+    pub fn from_states(a: BlockPos, b: BlockPos, states: Vec<u16>) -> Option<Self> {
+        let (min, max) = normalize(a, b);
+        if states.len() != Self::volume(min, max) {
+            return None;
+        }
+        Some(Self { min, max, states })
+    }
+
+    fn volume(min: BlockPos, max: BlockPos) -> usize {
+        (u64::from(span(min.x, max.x))
+            * u64::from(span(min.y, max.y))
+            * u64::from(span(min.z, max.z))) as usize
+    }
+
+    /// The minimum (corner) position of the region.
+    #[must_use]
+    pub const fn min(&self) -> BlockPos {
+        self.min
+    }
+
+    /// The maximum (corner) position of the region.
+    #[must_use]
+    pub const fn max(&self) -> BlockPos {
+        self.max
+    }
+
+    /// The size of the region along x, y and z.
+    #[must_use]
+    pub fn dimensions(&self) -> (u32, u32, u32) {
+        (
+            span(self.min.x, self.max.x),
+            span(self.min.y, self.max.y),
+            span(self.min.z, self.max.z),
+        )
+    }
+
+    /// The flat index for an absolute position, if it lies in the region.
+    ///
+    /// This must match the host's `x` then `z` then `y` iteration order.
+    fn index(&self, pos: BlockPos) -> Option<usize> {
+        if pos.x < self.min.x
+            || pos.x > self.max.x
+            || pos.y < self.min.y
+            || pos.y > self.max.y
+            || pos.z < self.min.z
+            || pos.z > self.max.z
+        {
+            return None;
+        }
+        let (_, sy, sz) = self.dimensions();
+        let x_off = u64::from((pos.x - self.min.x) as u32);
+        let y_off = u64::from((pos.y - self.min.y) as u32);
+        let z_off = u64::from((pos.z - self.min.z) as u32);
+        Some(((x_off * u64::from(sz) + z_off) * u64::from(sy) + y_off) as usize)
+    }
+
+    /// Absolute position for an offset from the minimum corner, if in range.
+    fn offset(&self, dx: u32, dy: u32, dz: u32) -> Option<BlockPos> {
+        let (sx, sy, sz) = self.dimensions();
+        if dx >= sx || dy >= sy || dz >= sz {
+            return None;
+        }
+        Some(BlockPos {
+            x: self.min.x + dx as i32,
+            y: self.min.y + dy as i32,
+            z: self.min.z + dz as i32,
+        })
+    }
+
+    /// The block-state id at an absolute position, if inside the region.
+    #[must_use]
+    pub fn get(&self, pos: BlockPos) -> Option<u16> {
+        self.index(pos).map(|i| self.states[i])
+    }
+
+    /// The block-state id at an offset from the region's minimum corner.
+    #[must_use]
+    pub fn get_relative(&self, dx: u32, dy: u32, dz: u32) -> Option<u16> {
+        self.get(self.offset(dx, dy, dz)?)
+    }
+
+    /// Sets the block-state id at an absolute position. Returns `false` if the
+    /// position lies outside the region.
+    pub fn set(&mut self, pos: BlockPos, state: u16) -> bool {
+        match self.index(pos) {
+            Some(i) => {
+                self.states[i] = state;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Sets the block-state id at an offset from the minimum corner. Returns
+    /// `false` if the offset lies outside the region.
+    pub fn set_relative(&mut self, dx: u32, dy: u32, dz: u32, state: u16) -> bool {
+        match self.offset(dx, dy, dz) {
+            Some(pos) => self.set(pos, state),
+            None => false,
+        }
+    }
+
+    /// Iterates over every `(position, state)` in the region, in the host's
+    /// `x` then `z` then `y` order.
+    pub fn iter(&self) -> impl Iterator<Item = (BlockPos, u16)> + '_ {
+        let (_, sy, sz) = self.dimensions();
+        let plane = u64::from(sy) * u64::from(sz);
+        self.states.iter().enumerate().map(move |(i, &state)| {
+            let i = i as u64;
+            let x_off = i / plane;
+            let rem = i % plane;
+            let z_off = rem / u64::from(sy);
+            let y_off = rem % u64::from(sy);
+            let pos = BlockPos {
+                x: self.min.x + x_off as i32,
+                y: self.min.y + y_off as i32,
+                z: self.min.z + z_off as i32,
+            };
+            (pos, state)
+        })
+    }
+
+    /// Consumes the region, returning its flat states array in the order
+    /// [`World::set_region`](crate::world::World) expects.
+    #[must_use]
+    pub fn into_states(self) -> Vec<u16> {
+        self.states
+    }
+}
+
+/// Region-oriented convenience methods on [`World`].
+pub trait WorldExt {
+    /// Reads the cuboid between `a` and `b` (inclusive) into a [`Region`].
+    ///
+    /// # Errors
+    /// Returns the host error string if the region is too large or the read
+    /// otherwise fails.
+    fn read_region(&self, a: BlockPos, b: BlockPos) -> Result<Region, String>;
+
+    /// Writes a [`Region`] back into the world with the given update flags,
+    /// returning the number of blocks that actually changed.
+    ///
+    /// # Errors
+    /// Returns the host error string if the write fails.
+    fn write_region(&self, region: &Region, flags: BlockFlags) -> Result<u32, String>;
+}
+
+impl WorldExt for World {
+    fn read_region(&self, a: BlockPos, b: BlockPos) -> Result<Region, String> {
+        let states = self.get_region(a, b)?;
+        Region::from_states(a, b, states)
+            .ok_or_else(|| "get-region returned an unexpected number of states".to_string())
+    }
+
+    fn write_region(&self, region: &Region, flags: BlockFlags) -> Result<u32, String> {
+        self.set_region(region.min, region.max, &region.states, flags)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const fn pos(x: i32, y: i32, z: i32) -> BlockPos {
+        BlockPos { x, y, z }
+    }
+
+    #[test]
+    fn index_matches_host_x_then_z_then_y_order() {
+        // sx=2, sy=3, sz=4 -> 24 blocks; each cell holds its own flat index.
+        let region = Region::from_states(pos(0, 0, 0), pos(1, 2, 3), (0..24).collect()).unwrap();
+        assert_eq!(region.dimensions(), (2, 3, 4));
+
+        let (_, sy, sz) = region.dimensions();
+        for x in 0..2 {
+            for z in 0..4 {
+                for y in 0..3 {
+                    let expected = (x * sz + z) * sy + y;
+                    assert_eq!(
+                        region.get(pos(x as i32, y as i32, z as i32)),
+                        Some(expected as u16)
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn wrong_state_count_is_rejected() {
+        assert!(Region::from_states(pos(0, 0, 0), pos(1, 1, 1), vec![0; 7]).is_none());
+        assert!(Region::from_states(pos(0, 0, 0), pos(1, 1, 1), vec![0; 8]).is_some());
+    }
+
+    #[test]
+    fn set_and_relative_addressing_roundtrip() {
+        let mut region = Region::filled(pos(10, 64, -5), pos(12, 66, -3), 0);
+        assert!(region.set(pos(11, 65, -4), 42));
+        assert_eq!(region.get(pos(11, 65, -4)), Some(42));
+        // Relative (1,1,1) from min (10,64,-5) is the same block.
+        assert_eq!(region.get_relative(1, 1, 1), Some(42));
+        // Out of bounds is rejected, not panicking.
+        assert!(!region.set(pos(100, 0, 0), 1));
+        assert!(region.get(pos(100, 0, 0)).is_none());
+        assert!(!region.set_relative(9, 0, 0, 1));
+    }
+
+    #[test]
+    fn iter_yields_positions_in_host_order() {
+        let region = Region::filled(pos(0, 0, 0), pos(1, 1, 1), 7);
+        let coords: Vec<_> = region.iter().map(|(p, _)| (p.x, p.y, p.z)).collect();
+        assert_eq!(
+            coords,
+            vec![
+                (0, 0, 0),
+                (0, 1, 0),
+                (0, 0, 1),
+                (0, 1, 1),
+                (1, 0, 0),
+                (1, 1, 0),
+                (1, 0, 1),
+                (1, 1, 1),
+            ]
+        );
+    }
+}

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
@@ -66,7 +66,7 @@ use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::game_rul
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::world::{
     BlockDirection as WitBlockDirection, BlockEntity, BlockEntityType, BlockFlags as WitBlockFlags,
     BlockPos as WitBlockPos, BlockState as WitBlockState, BlockStateInfo as WitBlockStateInfo,
-    BoundingBox as WitBoundingBox, Chunk as WitChunk,
+    BlockUpdate as WitBlockUpdate, BoundingBox as WitBoundingBox, Chunk as WitChunk,
     NoteblockInstrument as WitNoteblockInstrument, PistonBehavior as WitPistonBehavior,
     WorldBorder as WitWorldBorder,
 };
@@ -332,6 +332,105 @@ impl pumpkin::plugin::world::Host for PluginHostState {
         Ok(result.ok())
     }
 }
+
+/// The largest number of blocks a single bulk world operation may touch.
+///
+/// This is a memory-safety limit, not a game-mechanics one. A `get-region`
+/// result is a `list<u16>`, so 2 bytes per block; the value here (2^21) caps
+/// that copy into the plugin's memory at 4 MiB, and bounds how much work a
+/// single call can ask for. It is far larger than vanilla's `/fill` limit;
+/// larger jobs should be split across several calls.
+const MAX_BULK_BLOCKS: u64 = 2_097_152;
+
+/// How many blocks a bulk operation processes before yielding back to the async
+/// runtime, so a large operation cannot starve the server tick.
+///
+/// This trades tick responsiveness against throughput: yielding too often adds
+/// overhead a capable server does not need, while yielding too rarely can stall
+/// a tick. 32768 keeps the pause between yields well under a tick's budget even
+/// on modest hardware while staying cheap. A future improvement could make this
+/// server-configurable.
+const BULK_YIELD_INTERVAL: u64 = 32_768;
+
+/// Converts the plugin-facing block update flags into the server's internal
+/// flags.
+fn to_internal_flags(update_flags: WitBlockFlags) -> BlockFlags {
+    let mut internal_flags = BlockFlags::empty();
+    if update_flags.contains(WitBlockFlags::NOTIFY_NEIGHBORS) {
+        internal_flags |= BlockFlags::NOTIFY_NEIGHBORS;
+    }
+    if update_flags.contains(WitBlockFlags::NOTIFY_LISTENERS) {
+        internal_flags |= BlockFlags::NOTIFY_LISTENERS;
+    }
+    if update_flags.contains(WitBlockFlags::FORCE_STATE) {
+        internal_flags |= BlockFlags::FORCE_STATE;
+    }
+    if update_flags.contains(WitBlockFlags::SKIP_DROPS) {
+        internal_flags |= BlockFlags::SKIP_DROPS;
+    }
+    if update_flags.contains(WitBlockFlags::MOVED) {
+        internal_flags |= BlockFlags::MOVED;
+    }
+    if update_flags.contains(WitBlockFlags::SKIP_REDSTONE_WIRE_STATE_REPLACEMENT) {
+        internal_flags |= BlockFlags::SKIP_REDSTONE_WIRE_STATE_REPLACEMENT;
+    }
+    if update_flags.contains(WitBlockFlags::SKIP_BLOCK_ENTITY_REPLACED_CALLBACK) {
+        internal_flags |= BlockFlags::SKIP_BLOCK_ENTITY_REPLACED_CALLBACK;
+    }
+    if update_flags.contains(WitBlockFlags::SKIP_BLOCK_ADDED_CALLBACK) {
+        internal_flags |= BlockFlags::SKIP_BLOCK_ADDED_CALLBACK;
+    }
+    internal_flags
+}
+
+/// Returns the corner-wise minimum and maximum of two positions, so callers can
+/// pass the two corners of a region in any order.
+fn normalized_bounds(a: (i32, i32, i32), b: (i32, i32, i32)) -> ((i32, i32, i32), (i32, i32, i32)) {
+    (
+        (a.0.min(b.0), a.1.min(b.1), a.2.min(b.2)),
+        (a.0.max(b.0), a.1.max(b.1), a.2.max(b.2)),
+    )
+}
+
+/// Returns the number of blocks in the inclusive cuboid between `min` and
+/// `max`, saturating instead of overflowing for absurdly large regions.
+fn region_volume(min: (i32, i32, i32), max: (i32, i32, i32)) -> u64 {
+    // Widen to i64 before subtracting so an extreme span (for example
+    // `i32::MAX - i32::MIN`) cannot overflow.
+    let span = |lo: i32, hi: i32| (i64::from(hi) - i64::from(lo)).unsigned_abs() + 1;
+    span(min.0, max.0)
+        .saturating_mul(span(min.1, max.1))
+        .saturating_mul(span(min.2, max.2))
+}
+
+/// Yields every position in the inclusive cuboid between `min` and `max`,
+/// ordered by x, then z, then y.
+///
+/// `get-region` and `set-region` both iterate through this, which is what
+/// guarantees a snapshot read back with `get-region` lines up with the blocks
+/// `set-region` writes.
+fn region_positions(
+    min: (i32, i32, i32),
+    max: (i32, i32, i32),
+) -> impl Iterator<Item = (i32, i32, i32)> {
+    // The captured tuples are `Copy`, so each nested closure gets its own copy.
+    (min.0..=max.0).flat_map(move |x| {
+        (min.2..=max.2).flat_map(move |z| (min.1..=max.1).map(move |y| (x, y, z)))
+    })
+}
+
+/// Returns an error if a bulk operation would touch more than the allowed
+/// number of blocks.
+fn check_bulk_volume(volume: u64) -> Result<(), String> {
+    if volume > MAX_BULK_BLOCKS {
+        Err(format!(
+            "bulk world operation covers {volume} blocks, which is over the limit of {MAX_BULK_BLOCKS}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 impl pumpkin::plugin::particles::Host for PluginHostState {}
 impl pumpkin::plugin::sounds::Host for PluginHostState {}
 
@@ -451,31 +550,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         let world_ref = self.get_world_res(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
 
-        let mut internal_flags = BlockFlags::empty();
-        if update_flags.contains(WitBlockFlags::NOTIFY_NEIGHBORS) {
-            internal_flags |= BlockFlags::NOTIFY_NEIGHBORS;
-        }
-        if update_flags.contains(WitBlockFlags::NOTIFY_LISTENERS) {
-            internal_flags |= BlockFlags::NOTIFY_LISTENERS;
-        }
-        if update_flags.contains(WitBlockFlags::FORCE_STATE) {
-            internal_flags |= BlockFlags::FORCE_STATE;
-        }
-        if update_flags.contains(WitBlockFlags::SKIP_DROPS) {
-            internal_flags |= BlockFlags::SKIP_DROPS;
-        }
-        if update_flags.contains(WitBlockFlags::MOVED) {
-            internal_flags |= BlockFlags::MOVED;
-        }
-        if update_flags.contains(WitBlockFlags::SKIP_REDSTONE_WIRE_STATE_REPLACEMENT) {
-            internal_flags |= BlockFlags::SKIP_REDSTONE_WIRE_STATE_REPLACEMENT;
-        }
-        if update_flags.contains(WitBlockFlags::SKIP_BLOCK_ENTITY_REPLACED_CALLBACK) {
-            internal_flags |= BlockFlags::SKIP_BLOCK_ENTITY_REPLACED_CALLBACK;
-        }
-        if update_flags.contains(WitBlockFlags::SKIP_BLOCK_ADDED_CALLBACK) {
-            internal_flags |= BlockFlags::SKIP_BLOCK_ADDED_CALLBACK;
-        }
+        let internal_flags = to_internal_flags(update_flags);
         let Some(state) = BlockStateId::new(state) else {
             return Err(wasmtime::Error::msg("Invalid BlockStateId"));
         };
@@ -485,6 +560,163 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
             .set_block_state(&internal_pos, state, internal_flags)
             .await;
         Ok(())
+    }
+
+    async fn fill_blocks(
+        &mut self,
+        world: Resource<World>,
+        start: WitBlockPos,
+        end: WitBlockPos,
+        state: u16,
+        update_flags: WitBlockFlags,
+    ) -> wasmtime::Result<Result<u32, String>> {
+        // Take an owned handle to the world so the loop below does not hold a
+        // borrow of `self` across the many await points.
+        let world = self.get_world_res(&world)?.provider.clone();
+
+        let Some(state) = BlockStateId::new(state) else {
+            return Ok(Err("invalid block state id".to_string()));
+        };
+
+        let (min, max) = normalized_bounds((start.x, start.y, start.z), (end.x, end.y, end.z));
+        if let Err(error) = check_bulk_volume(region_volume(min, max)) {
+            return Ok(Err(error));
+        }
+
+        let flags = to_internal_flags(update_flags);
+        let mut changed = 0u32;
+        // Iterating x, then z, then y keeps consecutive writes within the same
+        // chunk column as much as possible.
+        for (processed, (x, y, z)) in region_positions(min, max).enumerate() {
+            let pos = BlockPos::new(x, y, z);
+            let replaced = world.set_block_state(&pos, state, flags).await;
+            if replaced != state {
+                changed += 1;
+            }
+            if (processed as u64 + 1).is_multiple_of(BULK_YIELD_INTERVAL) {
+                tokio::task::yield_now().await;
+            }
+        }
+
+        Ok(Ok(changed))
+    }
+
+    async fn get_region(
+        &mut self,
+        world: Resource<World>,
+        start: WitBlockPos,
+        end: WitBlockPos,
+    ) -> wasmtime::Result<Result<Vec<u16>, String>> {
+        let world = self.get_world_res(&world)?.provider.clone();
+
+        let (min, max) = normalized_bounds((start.x, start.y, start.z), (end.x, end.y, end.z));
+        let volume = region_volume(min, max);
+        if let Err(error) = check_bulk_volume(volume) {
+            return Ok(Err(error));
+        }
+
+        let mut states = Vec::with_capacity(usize::try_from(volume).unwrap_or(0));
+        for (processed, (x, y, z)) in region_positions(min, max).enumerate() {
+            let pos = BlockPos::new(x, y, z);
+            states.push(world.get_block_state_id(&pos).as_u16());
+            if (processed as u64 + 1).is_multiple_of(BULK_YIELD_INTERVAL) {
+                tokio::task::yield_now().await;
+            }
+        }
+
+        Ok(Ok(states))
+    }
+
+    async fn set_region(
+        &mut self,
+        world: Resource<World>,
+        start: WitBlockPos,
+        end: WitBlockPos,
+        states: Vec<u16>,
+        update_flags: WitBlockFlags,
+    ) -> wasmtime::Result<Result<u32, String>> {
+        let world = self.get_world_res(&world)?.provider.clone();
+
+        let (min, max) = normalized_bounds((start.x, start.y, start.z), (end.x, end.y, end.z));
+        let volume = region_volume(min, max);
+        if let Err(error) = check_bulk_volume(volume) {
+            return Ok(Err(error));
+        }
+
+        if states.len() as u64 != volume {
+            return Ok(Err(format!(
+                "set-region expected {volume} block states for the region but got {}",
+                states.len()
+            )));
+        }
+
+        // Validate every state id before changing anything, so an invalid entry
+        // cannot leave the region half-updated.
+        let mut validated = Vec::with_capacity(states.len());
+        for state in states {
+            let Some(state) = BlockStateId::new(state) else {
+                return Ok(Err(format!("invalid block state id {state}")));
+            };
+            validated.push(state);
+        }
+
+        let flags = to_internal_flags(update_flags);
+        let mut changed = 0u32;
+        // Shares `region_positions` with `get_region`, so the states line up with
+        // the same blocks a snapshot was read from.
+        for (index, (x, y, z)) in region_positions(min, max).enumerate() {
+            let pos = BlockPos::new(x, y, z);
+            let state = validated[index];
+            let replaced = world.set_block_state(&pos, state, flags).await;
+            if replaced != state {
+                changed += 1;
+            }
+            if (index as u64 + 1).is_multiple_of(BULK_YIELD_INTERVAL) {
+                tokio::task::yield_now().await;
+            }
+        }
+
+        Ok(Ok(changed))
+    }
+
+    async fn set_blocks(
+        &mut self,
+        world: Resource<World>,
+        blocks: Vec<WitBlockUpdate>,
+        update_flags: WitBlockFlags,
+    ) -> wasmtime::Result<Result<u32, String>> {
+        let world = self.get_world_res(&world)?.provider.clone();
+
+        if let Err(error) = check_bulk_volume(blocks.len() as u64) {
+            return Ok(Err(error));
+        }
+
+        // Validate every state id before changing anything, so an invalid entry
+        // cannot leave the world half-updated.
+        let mut updates = Vec::with_capacity(blocks.len());
+        for block in blocks {
+            let Some(state) = BlockStateId::new(block.state) else {
+                return Ok(Err(format!(
+                    "invalid block state id {} at ({}, {}, {})",
+                    block.state, block.pos.x, block.pos.y, block.pos.z
+                )));
+            };
+            updates.push((BlockPos::new(block.pos.x, block.pos.y, block.pos.z), state));
+        }
+
+        let flags = to_internal_flags(update_flags);
+        let mut changed = 0u32;
+        for (index, (pos, state)) in updates.into_iter().enumerate() {
+            let replaced = world.set_block_state(&pos, state, flags).await;
+            if replaced != state {
+                changed += 1;
+            }
+            if (index as u64 + 1).is_multiple_of(BULK_YIELD_INTERVAL) {
+                tokio::task::yield_now().await;
+            }
+        }
+
+        Ok(Ok(changed))
     }
 
     async fn get_time_of_day(&mut self, world: Resource<World>) -> wasmtime::Result<u64> {
@@ -1754,5 +1986,74 @@ impl pumpkin_world::generation::generator::CustomChunkGenerator for WasmChunkGen
         let chunk = cache.chunks[mid].get_proto_chunk_mut();
         self.invoke_phase(pumpkin::plugin::world::GenerationPhase::Features, chunk);
         chunk.stage = pumpkin_world::chunk_system::StagedChunkEnum::Features;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{
+        MAX_BULK_BLOCKS, check_bulk_volume, normalized_bounds, region_positions, region_volume,
+    };
+
+    #[test]
+    fn bounds_are_normalized_regardless_of_corner_order() {
+        let (min, max) = normalized_bounds((5, 10, 5), (0, 2, 8));
+        assert_eq!(min, (0, 2, 5));
+        assert_eq!(max, (5, 10, 8));
+    }
+
+    #[test]
+    fn volume_counts_inclusive_blocks() {
+        assert_eq!(region_volume((7, 7, 7), (7, 7, 7)), 1);
+        assert_eq!(region_volume((0, 0, 0), (2, 2, 2)), 27);
+        assert_eq!(region_volume((0, 2, 5), (5, 10, 8)), 6 * 9 * 4);
+    }
+
+    #[test]
+    fn extreme_spans_saturate_instead_of_overflowing() {
+        // Would overflow if computed with i32 subtraction or non-saturating
+        // multiplication; must simply come back very large and be rejected.
+        let volume = region_volume(
+            (i32::MIN, i32::MIN, i32::MIN),
+            (i32::MAX, i32::MAX, i32::MAX),
+        );
+        assert!(volume >= MAX_BULK_BLOCKS);
+        assert!(check_bulk_volume(volume).is_err());
+    }
+
+    #[test]
+    fn region_positions_are_x_then_z_then_y_and_cover_the_volume() {
+        let (min, max) = ((0, 0, 0), (1, 1, 1));
+        let positions: Vec<_> = region_positions(min, max).collect();
+
+        // Count matches the volume, and the order is x (outer), z (middle),
+        // y (inner) so it round-trips with a get-region snapshot.
+        assert_eq!(positions.len() as u64, region_volume(min, max));
+        assert_eq!(
+            positions,
+            vec![
+                (0, 0, 0),
+                (0, 1, 0),
+                (0, 0, 1),
+                (0, 1, 1),
+                (1, 0, 0),
+                (1, 1, 0),
+                (1, 0, 1),
+                (1, 1, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn region_positions_handle_a_single_block() {
+        let positions: Vec<_> = region_positions((4, 5, 6), (4, 5, 6)).collect();
+        assert_eq!(positions, vec![(4, 5, 6)]);
+    }
+
+    #[test]
+    fn volume_limit_is_inclusive() {
+        assert!(check_bulk_volume(MAX_BULK_BLOCKS).is_ok());
+        assert!(check_bulk_volume(MAX_BULK_BLOCKS + 1).is_err());
+        assert!(check_bulk_volume(1).is_ok());
     }
 }


### PR DESCRIPTION
## Description

Adds bulk block editing to the plugin world API so plugins can read and write regions of blocks in a single call instead of one block at a time. New functions on the world resource:

- fill-blocks: set every block in a cuboid to one state.
- get-blocks: read the state ids of a cuboid, ordered by x, then z, then y.
- set-region: write a flat array of state ids back into a cuboid, in the same order as get-blocks, so a snapshot read with get-blocks round-trips through set-region.
- set-blocks: set many blocks from an explicit list of position and state pairs.

Each operation is capped at 2097152 blocks, yields to the async runtime every few thousand blocks so a large call cannot starve the server tick, and validates every block state before changing anything so an invalid entry cannot leave a region half updated.

This depends on the WIT interface change in Pumpkin-MC/pumpkin-plugin-wit#31. The submodule pointer here targets that branch, so this is a draft until the WIT PR merges and the pointer can move to the merged commit.

Further work (block-entity handling, entities, biomes, rotate and flip, chunk-section performance) is tracked in #2810.

## Testing

cargo fmt --all --check, cargo clippy --all-targets --all-features, typos, and cargo test --workspace all pass. New unit tests cover the region iteration order, inclusive volume counting, saturating behaviour on extreme spans, and the block limit.
