### PR TITLE
fix(command): send success message after teleport

### DIFF
--- a/crates/pumpkin/src/command/commands/teleport.rs
+++ b/crates/pumpkin/src/command/commands/teleport.rs
@@ -64,8 +64,8 @@ fn resolve_sender_world(
         .expect("Server should have at least one world")
 }
 
-async fn success_key_and_arg<'a>(
-    targets: &'a [Arc<dyn EntityBase>],
+async fn success_key_and_arg(
+    targets: &[Arc<dyn EntityBase>],
     single_key: &'static str,
     multiple_key: &'static str,
 ) -> (&'static str, TextComponent) {

--- a/crates/pumpkin/src/command/commands/teleport.rs
+++ b/crates/pumpkin/src/command/commands/teleport.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pumpkin_data::translation;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
@@ -62,12 +64,24 @@ fn resolve_sender_world(
         .expect("Server should have at least one world")
 }
 
+async fn success_key_and_arg<'a>(
+    targets: &'a [Arc<dyn EntityBase>],
+    single_key: &'static str,
+    multiple_key: &'static str,
+) -> (&'static str, TextComponent) {
+    if targets.len() == 1 {
+        (single_key, targets[0].get_display_name().await)
+    } else {
+        (multiple_key, TextComponent::text(targets.len().to_string()))
+    }
+}
+
 struct EntitiesToEntityExecutor;
 
 impl CommandExecutor for EntitiesToEntityExecutor {
     fn execute<'a>(
         &'a self,
-        _sender: &'a CommandSender,
+        sender: &'a CommandSender,
         _server: &'a crate::server::Server,
         args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
@@ -93,6 +107,20 @@ impl CommandExecutor for EntitiesToEntityExecutor {
                     .teleport(pos, Some(yaw), Some(pitch), world.clone())
                     .await;
             }
+
+            let (key, target_arg) = success_key_and_arg(
+                targets,
+                translation::java::COMMANDS_TELEPORT_SUCCESS_ENTITY_SINGLE,
+                translation::java::COMMANDS_TELEPORT_SUCCESS_ENTITY_MULTIPLE,
+            )
+            .await;
+            sender
+                .send_message(TextComponent::translate_cross(
+                    key,
+                    key,
+                    [target_arg, destination.get_display_name().await],
+                ))
+                .await;
 
             Ok(targets.len() as i32)
         })
@@ -129,6 +157,25 @@ impl CommandExecutor for EntitiesToPosFacingPosExecutor {
                     .teleport(pos, Some(yaw), Some(pitch), world.clone())
                     .await;
             }
+
+            let (key, target_arg) = success_key_and_arg(
+                targets,
+                translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_SINGLE,
+                translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_MULTIPLE,
+            )
+            .await;
+            sender
+                .send_message(TextComponent::translate_cross(
+                    key,
+                    key,
+                    [
+                        target_arg,
+                        TextComponent::text(pos.x.to_string()),
+                        TextComponent::text(pos.y.to_string()),
+                        TextComponent::text(pos.z.to_string()),
+                    ],
+                ))
+                .await;
 
             Ok(targets.len() as i32)
         })
@@ -167,6 +214,25 @@ impl CommandExecutor for EntitiesToPosFacingEntityExecutor {
                     .await;
             }
 
+            let (key, target_arg) = success_key_and_arg(
+                targets,
+                translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_SINGLE,
+                translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_MULTIPLE,
+            )
+            .await;
+            sender
+                .send_message(TextComponent::translate_cross(
+                    key,
+                    key,
+                    [
+                        target_arg,
+                        TextComponent::text(pos.x.to_string()),
+                        TextComponent::text(pos.y.to_string()),
+                        TextComponent::text(pos.z.to_string()),
+                    ],
+                ))
+                .await;
+
             Ok(targets.len() as i32)
         })
     }
@@ -204,6 +270,25 @@ impl CommandExecutor for EntitiesToPosWithRotationExecutor {
                     .await;
             }
 
+            let (key, target_arg) = success_key_and_arg(
+                targets,
+                translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_SINGLE,
+                translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_MULTIPLE,
+            )
+            .await;
+            sender
+                .send_message(TextComponent::translate_cross(
+                    key,
+                    key,
+                    [
+                        target_arg,
+                        TextComponent::text(pos.x.to_string()),
+                        TextComponent::text(pos.y.to_string()),
+                        TextComponent::text(pos.z.to_string()),
+                    ],
+                ))
+                .await;
+
             Ok(targets.len() as i32)
         })
     }
@@ -239,6 +324,25 @@ impl CommandExecutor for EntitiesToPosExecutor {
                     .await;
             }
 
+            let (key, target_arg) = success_key_and_arg(
+                targets,
+                translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_SINGLE,
+                translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_MULTIPLE,
+            )
+            .await;
+            sender
+                .send_message(TextComponent::translate_cross(
+                    key,
+                    key,
+                    [
+                        target_arg,
+                        TextComponent::text(pos.x.to_string()),
+                        TextComponent::text(pos.y.to_string()),
+                        TextComponent::text(pos.z.to_string()),
+                    ],
+                ))
+                .await;
+
             Ok(targets.len() as i32)
         })
     }
@@ -273,6 +377,17 @@ impl CommandExecutor for SelfToEntityExecutor {
                     player
                         .clone()
                         .teleport(pos, Some(yaw), Some(pitch), world)
+                        .await;
+
+                    sender
+                        .send_message(TextComponent::translate_cross(
+                            translation::java::COMMANDS_TELEPORT_SUCCESS_ENTITY_SINGLE,
+                            translation::java::COMMANDS_TELEPORT_SUCCESS_ENTITY_SINGLE,
+                            [
+                                player.get_display_name().await,
+                                destination.get_display_name().await,
+                            ],
+                        ))
                         .await;
 
                     Ok(1)
@@ -311,6 +426,19 @@ impl CommandExecutor for SelfToPosExecutor {
                     player
                         .clone()
                         .teleport(pos, Some(yaw), Some(pitch), player.world().clone())
+                        .await;
+
+                    sender
+                        .send_message(TextComponent::translate_cross(
+                            translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_SINGLE,
+                            translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_SINGLE,
+                            [
+                                player.get_display_name().await,
+                                TextComponent::text(pos.x.to_string()),
+                                TextComponent::text(pos.y.to_string()),
+                                TextComponent::text(pos.z.to_string()),
+                            ],
+                        ))
                         .await;
 
                     Ok(1)

--- a/crates/pumpkin/src/command/commands/teleport.rs
+++ b/crates/pumpkin/src/command/commands/teleport.rs
@@ -117,7 +117,7 @@ impl CommandExecutor for EntitiesToEntityExecutor {
             sender
                 .send_message(TextComponent::translate_cross(
                     key,
-                    key,
+                    translation::bedrock::COMMANDS_TP_SUCCESSVICTIM,
                     [target_arg, destination.get_display_name().await],
                 ))
                 .await;
@@ -167,7 +167,7 @@ impl CommandExecutor for EntitiesToPosFacingPosExecutor {
             sender
                 .send_message(TextComponent::translate_cross(
                     key,
-                    key,
+                    translation::bedrock::COMMANDS_TP_SUCCESS_COORDINATES,
                     [
                         target_arg,
                         TextComponent::text(pos.x.to_string()),
@@ -223,7 +223,7 @@ impl CommandExecutor for EntitiesToPosFacingEntityExecutor {
             sender
                 .send_message(TextComponent::translate_cross(
                     key,
-                    key,
+                    translation::bedrock::COMMANDS_TP_SUCCESS_COORDINATES,
                     [
                         target_arg,
                         TextComponent::text(pos.x.to_string()),
@@ -279,7 +279,7 @@ impl CommandExecutor for EntitiesToPosWithRotationExecutor {
             sender
                 .send_message(TextComponent::translate_cross(
                     key,
-                    key,
+                    translation::bedrock::COMMANDS_TP_SUCCESS_COORDINATES,
                     [
                         target_arg,
                         TextComponent::text(pos.x.to_string()),
@@ -333,7 +333,7 @@ impl CommandExecutor for EntitiesToPosExecutor {
             sender
                 .send_message(TextComponent::translate_cross(
                     key,
-                    key,
+                    translation::bedrock::COMMANDS_TP_SUCCESS_COORDINATES,
                     [
                         target_arg,
                         TextComponent::text(pos.x.to_string()),
@@ -382,7 +382,7 @@ impl CommandExecutor for SelfToEntityExecutor {
                     sender
                         .send_message(TextComponent::translate_cross(
                             translation::java::COMMANDS_TELEPORT_SUCCESS_ENTITY_SINGLE,
-                            translation::java::COMMANDS_TELEPORT_SUCCESS_ENTITY_SINGLE,
+                            translation::bedrock::COMMANDS_TP_SUCCESSVICTIM,
                             [
                                 player.get_display_name().await,
                                 destination.get_display_name().await,
@@ -431,7 +431,7 @@ impl CommandExecutor for SelfToPosExecutor {
                     sender
                         .send_message(TextComponent::translate_cross(
                             translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_SINGLE,
-                            translation::java::COMMANDS_TELEPORT_SUCCESS_LOCATION_SINGLE,
+                            translation::bedrock::COMMANDS_TP_SUCCESS_COORDINATES,
                             [
                                 player.get_display_name().await,
                                 TextComponent::text(pos.x.to_string()),


### PR DESCRIPTION
## Description

Fixes #2920

After running a `/tp` command, the player was teleported but no feedback was shown in chat. This PR adds a success message to all seven executors in `crates/pumpkin/src/command/commands/teleport.rs`, using the already-existing translation keys:

- `commands.teleport.success.entity.single` / `.multiple`
- `commands.teleport.success.location.single` / `.multiple`

Affected executors: `SelfToPosExecutor`, `SelfToEntityExecutor`, `EntitiesToPosExecutor`, `EntitiesToPosWithRotationExecutor`, `EntitiesToPosFacingPosExecutor`, `EntitiesToPosFacingEntityExecutor`, `EntitiesToEntityExecutor`.

## Testing

- `cargo check -p pumpkin` passes.
- Tested on a live server (Java, 26.2): all `/tp` variants now show the success message in chat.

![tp success message](https://raw.githubusercontent.com/2982136527/mc-images/main/tp-success-message.png)
