### PR TITLE
feat(plugin): add status effect methods to the entity API

### DIFF
--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -732,6 +732,12 @@ impl LivingEntity {
         effects.get(&effect).cloned()
     }
 
+    /// Returns every status effect currently applied to this entity.
+    pub async fn get_active_effects(&self) -> Vec<Effect> {
+        let effects = self.active_effects.lock().await;
+        effects.values().cloned().collect()
+    }
+
     pub fn is_in_fall_damage_resetting(&self) -> (bool, &Block) {
         let block_pos = self.entity.block_pos.load();
         let block = self.entity.world.load().get_block(&block_pos);

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -4238,8 +4238,7 @@ impl Player {
     }
 
     pub async fn get_active_effects(&self) -> Vec<Effect> {
-        let effects = self.living_entity.active_effects.lock().await;
-        effects.values().cloned().collect()
+        self.living_entity.get_active_effects().await
     }
 
     pub async fn send_active_effects(&self) {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
@@ -13,6 +13,7 @@ use crate::plugin::loader::wasm::wasm_host::{
         common::{EntityPose, Position},
         entity::Host,
         entity_types,
+        status_effect::{StatusEffectInstance, StatusEffectType},
         text::TextComponent,
         uuid::Uuid,
         world::{
@@ -982,6 +983,115 @@ impl HostEntity for PluginHostState {
             },
             face: to_wasm_block_direction(face),
         }))
+    }
+
+    async fn add_effect(
+        &mut self,
+        entity: Resource<Entity>,
+        effect: StatusEffectInstance,
+    ) -> wasmtime::Result<()> {
+        let entity = entity_from_resource(self, &entity)?;
+        let Some(living) = entity.get_living_entity() else {
+            return Ok(());
+        };
+        let effect_type = super::status_effect::from_wasm_status_effect_type(effect.effect_type);
+        if let Some(status_effect) =
+            pumpkin_data::effect::StatusEffect::from_name(effect_type.to_name())
+        {
+            let effect_obj = pumpkin_data::potion::Effect {
+                effect_type: status_effect,
+                duration: effect.duration as i32,
+                amplifier: effect.amplifier,
+                ambient: effect.ambient,
+                show_particles: effect.show_particles,
+                show_icon: effect.show_icon,
+                blend: false,
+            };
+            living.add_effect(effect_obj).await;
+        }
+        Ok(())
+    }
+
+    async fn remove_effect(
+        &mut self,
+        entity: Resource<Entity>,
+        effect: StatusEffectType,
+    ) -> wasmtime::Result<()> {
+        let entity = entity_from_resource(self, &entity)?;
+        let Some(living) = entity.get_living_entity() else {
+            return Ok(());
+        };
+        let effect_type = super::status_effect::from_wasm_status_effect_type(effect);
+        if let Some(status_effect) =
+            pumpkin_data::effect::StatusEffect::from_name(effect_type.to_name())
+        {
+            living.remove_effect(status_effect).await;
+        }
+        Ok(())
+    }
+
+    async fn clear_effects(&mut self, entity: Resource<Entity>) -> wasmtime::Result<()> {
+        let entity = entity_from_resource(self, &entity)?;
+        if let Some(living) = entity.get_living_entity() {
+            living.reset_effects_and_attributes().await;
+        }
+        Ok(())
+    }
+
+    async fn has_effect(
+        &mut self,
+        entity: Resource<Entity>,
+        effect: StatusEffectType,
+    ) -> wasmtime::Result<bool> {
+        let entity = entity_from_resource(self, &entity)?;
+        let Some(living) = entity.get_living_entity() else {
+            return Ok(false);
+        };
+        let effect_type = super::status_effect::from_wasm_status_effect_type(effect);
+        if let Some(status_effect) =
+            pumpkin_data::effect::StatusEffect::from_name(effect_type.to_name())
+        {
+            Ok(living.has_effect(status_effect).await)
+        } else {
+            Ok(false)
+        }
+    }
+
+    async fn get_effect(
+        &mut self,
+        entity: Resource<Entity>,
+        effect: StatusEffectType,
+    ) -> wasmtime::Result<Option<StatusEffectInstance>> {
+        let entity = entity_from_resource(self, &entity)?;
+        let Some(living) = entity.get_living_entity() else {
+            return Ok(None);
+        };
+        let effect_type = super::status_effect::from_wasm_status_effect_type(effect);
+        if let Some(status_effect) =
+            pumpkin_data::effect::StatusEffect::from_name(effect_type.to_name())
+            && let Some(eff) = living.get_effect(status_effect).await
+        {
+            return Ok(super::status_effect::to_wasm_status_effect_instance(&eff));
+        }
+        Ok(None)
+    }
+
+    async fn get_active_effects(
+        &mut self,
+        entity: Resource<Entity>,
+    ) -> wasmtime::Result<Vec<StatusEffectInstance>> {
+        let entity = entity_from_resource(self, &entity)?;
+        let Some(living) = entity.get_living_entity() else {
+            return Ok(Vec::new());
+        };
+        let effects = living.get_active_effects().await;
+        let mut list = Vec::with_capacity(effects.len());
+        for eff in &effects {
+            if let Some(instance) = super::status_effect::to_wasm_status_effect_instance(eff) {
+                list.push(instance);
+            }
+        }
+        Ok(list)
     }
 
     async fn drop(&mut self, rep: Resource<Entity>) -> wasmtime::Result<()> {


### PR DESCRIPTION
## Description

Adds status effect methods to the plugin entity API so plugins can apply and query potion effects on any living entity, not only players. New methods on the entity resource:

- add-effect
- remove-effect
- clear-effects
- has-effect
- get-effect
- get-active-effects

These mirror the methods the player resource already has. Internally they surface the existing living entity effect system, so effects apply, sync to clients, and persist across reload exactly as they already do for players. Calling them on an entity that cannot hold effects, such as a dropped item or a projectile, is a no-op, matching how the existing mob-only entity methods handle non-matching entities.

The only supporting change is a small get-active-effects accessor moved onto the living entity, which the player method now delegates to, removing a duplicate.

This depends on the WIT interface change in Pumpkin-MC/pumpkin-plugin-wit#32. The submodule pointer here targets that branch, so this is a draft until the WIT PR merges and the pointer can move to the merged commit.

## Testing

cargo fmt --all --check, cargo clippy --all-targets --all-features, typos, and cargo test --workspace all pass. The methods are thin pass-throughs to already-tested living entity methods, the same pattern as the existing player effect bindings, so no new unit tests are added.
