### PR TITLE
refactor(plugin): move NBT types to a dedicated nbt interface

### DIFF
--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/item_stack.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/item_stack.rs
@@ -4,6 +4,8 @@ use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::enchantm
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::item_stack::{
     DataComponentValue as WitDataComponentValue, EnchantmentValue as WitEnchantmentValue,
     Host as ItemStackInterfaceHost, HostItemStack, ItemStack as ItemStackHandle,
+};
+use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::nbt::{
     NbtEntry as WitNbtEntry, NbtTag as WitNbtTag, NbtTree as WitNbtTree,
 };
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::text::TextComponent as WitTextComponent;

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
@@ -47,6 +47,7 @@ impl pumpkin::plugin::data_components::Host for PluginHostState {}
 impl pumpkin::plugin::enchantments::Host for PluginHostState {}
 impl pumpkin::plugin::biomes::Host for PluginHostState {}
 impl pumpkin::plugin::attributes::Host for PluginHostState {}
+impl pumpkin::plugin::nbt::Host for PluginHostState {}
 
 pub fn add_to_linker(linker: &mut Linker<PluginHostState>) -> wasmtime::Result<()> {
     Plugin::add_to_linker::<_, HasSelf<_>>(linker, |state: &mut PluginHostState| state)?;


### PR DESCRIPTION
## Description

Moves the shared NBT types (nbt-tree, nbt-tag, nbt-entry) out of the item-stack WIT interface into a dedicated nbt interface, and bumps the plugin-wit submodule to that change. See Pumpkin-MC/pumpkin-plugin-wit#33.

These types are generic, not item specific. Giving them their own interface fixes the dependency direction and lets other interfaces reuse structured NBT rather than depending on item-stack for it. The immediate motivation is upcoming per-entity custom data.

Host changes are minimal and mechanical:

- item_stack.rs imports the NBT types from the nbt module instead of the item_stack module.
- An empty Host impl is added for the new nbt interface, matching how the other types-only interfaces (enchantments, data-components, biomes) are wired.

No behaviour changes. The type representation is unchanged, and the component model matches types by shape, so this does not affect the ABI.

This depends on the WIT change above, so it is a draft until that merges and the submodule pointer can move to the merged commit.

## Testing

cargo fmt --all --check, cargo clippy --all-targets --all-features, typos, and cargo test --workspace all pass.
