### PR TITLE
Add FoodLevelChangeEvent

### DIFF
--- a/crates/pumpkin/src/block/blocks/cake.rs
+++ b/crates/pumpkin/src/block/blocks/cake.rs
@@ -40,11 +40,20 @@ impl CakeBlock {
                 if hunger_level >= 20 {
                     return BlockActionResult::Pass;
                 }
-                player.hunger_manager.level.store(20.min(hunger_level + 2));
-                player
-                    .hunger_manager
-                    .saturation
-                    .store(player.hunger_manager.saturation.load() + 0.4);
+                let Some(new_level) =
+                    crate::entity::hunger::HungerManager::fire_food_level_change_event(
+                        player,
+                        20.min(hunger_level + 2),
+                        Some("minecraft:cake".to_string()),
+                    )
+                    .await
+                else {
+                    return BlockActionResult::Pass;
+                };
+                player.hunger_manager.level.store(new_level);
+                player.hunger_manager.saturation.store(
+                    (player.hunger_manager.saturation.load() + 0.4).min(f32::from(new_level)),
+                );
                 player.send_health().await;
             }
             GameMode::Creative | GameMode::Spectator => {}

--- a/crates/pumpkin/src/entity/hunger.rs
+++ b/crates/pumpkin/src/entity/hunger.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::{NBTStorage, NBTStorageInit, player::Player};
 use crate::entity::NbtFuture;
+use crate::plugin::api::events::entity::food_level_change::FoodLevelChangeEvent;
 use crossbeam::atomic::AtomicCell;
 use pumpkin_data::damage::DamageType;
 use pumpkin_nbt::compound::NbtCompound;
@@ -30,6 +31,26 @@ impl Default for HungerManager {
 }
 
 impl HungerManager {
+    pub(crate) async fn fire_food_level_change_event(
+        player: &Player,
+        food_level: u8,
+        item_name: Option<String>,
+    ) -> Option<u8> {
+        let food_level = food_level.min(MAX_FOOD);
+        let Some(server) = player.world().server.upgrade() else {
+            return Some(food_level);
+        };
+
+        let mut event =
+            FoodLevelChangeEvent::new(player.entity_id(), i32::from(food_level), item_name);
+        server.plugin_manager.fire(&server, &mut event).await;
+        if event.cancelled {
+            return None;
+        }
+
+        Some(event.food_level.clamp(0, i32::from(MAX_FOOD)) as u8)
+    }
+
     pub async fn tick(&self, player: &Arc<Player>) {
         let mut level = self.level.load();
         let mut saturation = self.saturation.load();
@@ -51,7 +72,12 @@ impl HungerManager {
             if saturation > 0.0 {
                 saturation = (saturation - 1.0).max(0.0);
             } else if difficulty != Difficulty::Peaceful {
-                level = level.saturating_sub(1);
+                let target_level = level.saturating_sub(1);
+                if let Some(new_level) =
+                    Self::fire_food_level_change_event(player.as_ref(), target_level, None).await
+                {
+                    level = new_level;
+                }
             }
             needs_sync = true;
         }
@@ -119,8 +145,20 @@ impl HungerManager {
 
         let current_level = self.level.load();
         let current_sat = self.saturation.load();
+        let item_name = player
+            .living_entity
+            .item_in_use
+            .lock()
+            .await
+            .as_ref()
+            .map(|item| format!("minecraft:{}", item.item.registry_key));
 
-        let new_level = (current_level + food).min(MAX_FOOD);
+        let target_level = (current_level + food).min(MAX_FOOD);
+        let Some(new_level) =
+            Self::fire_food_level_change_event(player, target_level, item_name).await
+        else {
+            return;
+        };
 
         let new_sat = (current_sat + added_saturation).min(f32::from(new_level));
 

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1787,8 +1787,22 @@ impl LivingEntity {
             {
                 // Add hunger and saturation
                 let hunger = amplifier + 1;
-                player.hunger_manager.add_hunger(hunger);
-                player.hunger_manager.add_saturation(hunger as f32 * 2.0);
+                let current_level = player.hunger_manager.level.load();
+                if let Some(new_level) =
+                    crate::entity::hunger::HungerManager::fire_food_level_change_event(
+                        player,
+                        current_level.saturating_add(hunger).min(20),
+                        None,
+                    )
+                    .await
+                {
+                    player.hunger_manager.level.store(new_level);
+                    player.hunger_manager.saturation.store(
+                        (player.hunger_manager.saturation.load() + hunger as f32 * 2.0)
+                            .min(f32::from(new_level)),
+                    );
+                    player.send_health().await;
+                }
             }
         }
     }

--- a/crates/pumpkin/src/plugin/api/events/entity/food_level_change.rs
+++ b/crates/pumpkin/src/plugin/api/events/entity/food_level_change.rs
@@ -1,0 +1,27 @@
+use pumpkin_macros::{Event, cancellable};
+
+/// An event that occurs when a player's food level changes.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct FoodLevelChangeEvent {
+    /// The ID of the player entity whose food level is changing.
+    pub entity_id: i32,
+
+    /// The resultant food level that should be applied.
+    pub food_level: i32,
+
+    /// The registry name of the item that triggered the change, if any.
+    pub item_name: Option<String>,
+}
+
+impl FoodLevelChangeEvent {
+    #[must_use]
+    pub const fn new(entity_id: i32, food_level: i32, item_name: Option<String>) -> Self {
+        Self {
+            entity_id,
+            food_level,
+            item_name,
+            cancelled: false,
+        }
+    }
+}

--- a/crates/pumpkin/src/plugin/api/events/entity/mod.rs
+++ b/crates/pumpkin/src/plugin/api/events/entity/mod.rs
@@ -11,6 +11,7 @@ pub mod entity_spawn;
 pub mod entity_tame;
 pub mod entity_target;
 pub mod entity_teleport;
+pub mod food_level_change;
 
 pub use entity_air_change::*;
 pub use entity_breed::*;
@@ -25,3 +26,4 @@ pub use entity_spawn::*;
 pub use entity_tame::*;
 pub use entity_target::*;
 pub use entity_teleport::*;
+pub use food_level_change::*;

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/context.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/context.rs
@@ -253,6 +253,7 @@ async fn register_entity_event(
         entity_death::{EntityDeathEvent, PlayerDeathEvent},
         entity_regain_health::EntityRegainHealthEvent,
         entity_spawn::EntitySpawnEvent,
+        food_level_change::FoodLevelChangeEvent,
     };
 
     match event_type {
@@ -273,6 +274,10 @@ async fn register_entity_event(
         }
         EventType::EntityRegainHealthEvent => {
             register_typed_event::<EntityRegainHealthEvent>(resource, handler, priority, blocking)
+                .await;
+        }
+        EventType::FoodLevelChangeEvent => {
+            register_typed_event::<FoodLevelChangeEvent>(resource, handler, priority, blocking)
                 .await;
         }
         _ => {
@@ -571,7 +576,8 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             | EventType::PlayerDeathEvent
             | EventType::EntitySpawnEvent
             | EventType::EntityCombustEvent
-            | EventType::EntityRegainHealthEvent) => {
+            | EventType::EntityRegainHealthEvent
+            | EventType::FoodLevelChangeEvent) => {
                 register_entity_event(resource, &handler, priority, blocking, event_type).await;
             }
             event_type @ (EventType::BlockRedstoneEvent

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/entity.rs
@@ -5,6 +5,7 @@ use crate::plugin::{
         entity_death::{EntityDeathEvent, PlayerDeathEvent},
         entity_regain_health::EntityRegainHealthEvent,
         entity_spawn::EntitySpawnEvent,
+        food_level_change::FoodLevelChangeEvent,
     },
     loader::wasm::wasm_host::{
         state::PluginHostState,
@@ -15,7 +16,8 @@ use crate::plugin::{
             },
             pumpkin::plugin::event::{
                 EntityCombustEventData, EntityDamageEventData, EntityDeathEventData,
-                EntityRegainHealthEventData, EntitySpawnEventData, Event, PlayerDeathEventData,
+                EntityRegainHealthEventData, EntitySpawnEventData, Event, FoodLevelChangeEventData,
+                PlayerDeathEventData,
             },
         },
     },
@@ -166,6 +168,29 @@ impl ToFromWasmEvent for EntityRegainHealthEvent {
             Event::EntityRegainHealthEvent(data) => Self {
                 entity_id: data.entity_id,
                 amount: data.amount,
+                cancelled: data.cancelled,
+            },
+            _ => panic!("unexpected event type"),
+        }
+    }
+}
+
+impl ToFromWasmEvent for FoodLevelChangeEvent {
+    fn to_wasm_event(&self, _state: &mut PluginHostState) -> Event {
+        Event::FoodLevelChangeEvent(FoodLevelChangeEventData {
+            entity_id: self.entity_id,
+            food_level: self.food_level,
+            item_name: self.item_name.clone(),
+            cancelled: self.cancelled,
+        })
+    }
+
+    fn from_wasm_event(event: Event, _state: &mut PluginHostState) -> Self {
+        match event {
+            Event::FoodLevelChangeEvent(data) => Self {
+                entity_id: data.entity_id,
+                food_level: data.food_level,
+                item_name: data.item_name,
                 cancelled: data.cancelled,
             },
             _ => panic!("unexpected event type"),


### PR DESCRIPTION
For a hub-like plugin I'm working on I want to prevent starvation. This allows you to create a listener to cancel the event

Depends on https://github.com/Pumpkin-MC/pumpkin-plugin-wit/pull/34
If this gets merged the [Tracker](https://github.com/Pumpkin-MC/Pumpkin/issues/1609) can be upated.