### PR TITLE
Add API to get world spawn location

### DIFF
--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
@@ -68,7 +68,7 @@ use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::world::{
     BlockPos as WitBlockPos, BlockState as WitBlockState, BlockStateInfo as WitBlockStateInfo,
     BoundingBox as WitBoundingBox, Chunk as WitChunk,
     NoteblockInstrument as WitNoteblockInstrument, PistonBehavior as WitPistonBehavior,
-    WorldBorder as WitWorldBorder,
+    WorldBorder as WitWorldBorder, WorldSpawnLocation as WitWorldSpawnLocation,
 };
 use crate::plugin::loader::wasm::wasm_host::{
     state::{
@@ -510,6 +510,22 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
             .dimension
             .minecraft_name
             .to_string())
+    }
+
+    async fn get_spawn_location(
+        &mut self,
+        world: Resource<World>,
+    ) -> wasmtime::Result<WitWorldSpawnLocation> {
+        let (pos, yaw, pitch) = self.get_world_res(&world)?.provider.get_spawn_location();
+        Ok(WitWorldSpawnLocation {
+            pos: WitBlockPos {
+                x: pos.0.x,
+                y: pos.0.y,
+                z: pos.0.z,
+            },
+            yaw,
+            pitch,
+        })
     }
 
     async fn get_top_block_y(

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -447,6 +447,17 @@ impl World {
             .unwrap_or("world")
     }
 
+    /// Returns the configured shared world spawn block position and rotation.
+    #[must_use]
+    pub fn get_spawn_location(&self) -> (BlockPos, f32, f32) {
+        let level_info = self.level_info.load();
+        (
+            BlockPos::new(level_info.spawn_x, level_info.spawn_y, level_info.spawn_z),
+            level_info.spawn_yaw,
+            level_info.spawn_pitch,
+        )
+    }
+
     pub async fn shutdown(&self) {
         for entity in self.entities.load().iter() {
             self.save_entity(entity).await;


### PR DESCRIPTION
For my hub plugin I want to TP players to spawn on join, but there is currently no way to get the world spawn location.

Depends on https://github.com/Pumpkin-MC/pumpkin-plugin-wit/pull/35