### PR TITLE
fix(bedrock): stop bedrock players from flying after eating

### DIFF
--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -278,12 +278,23 @@ impl LivingEntity {
         self.livings_flags.store(b, Ordering::Relaxed);
 
         let bedrock_meta = (flag == Self::USING_ITEM_FLAG).then(|| {
+            let index =
+                pumpkin_protocol::bedrock::client::set_actor_data::entity_data_flag::USING_ITEM;
+            let mask = 1i64 << index;
+            if value {
+                self.entity.bedrock_flags.fetch_or(mask, Ordering::Relaxed);
+            } else {
+                self.entity
+                    .bedrock_flags
+                    .fetch_and(!mask, Ordering::Relaxed);
+            }
+
             let mut meta = pumpkin_protocol::bedrock::client::set_actor_data::EntityMetadata::new();
-            meta.set_flag(
+            meta.set(
                 pumpkin_protocol::bedrock::client::set_actor_data::entity_data_key::FLAGS,
-                pumpkin_protocol::bedrock::client::set_actor_data::entity_data_flag::USING_ITEM
-                    as u8,
-                value,
+                pumpkin_protocol::bedrock::client::set_actor_data::MetadataValue::Long(
+                    self.entity.bedrock_flags.load(Ordering::Relaxed),
+                ),
             );
             meta
         });


### PR DESCRIPTION
## Description
Fixes Bedrock players gaining underwater bubbles and losing gravity after eating.

## What
- Prevents Bedrock players from floating after consuming food.
- Keeps gravity, breathing, collision, and other entity states intact while using an item.
- Correctly starts and stops the Bedrock eating animation.

## How
- Updates the `USING_ITEM` bit within the player’s existing Bedrock entity flag mask.
- Sends the complete updated flag mask instead of replacing it with partial metadata.
- Keeps the change limited to Bedrock metadata synchronization.

## Testing
- `cargo test -p pumpkin --lib`
- `cargo clippy -p pumpkin --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Verified in survival that eating food no longer displays air bubbles or allows the player to float.