### PR TITLE
feat(command): implement /return command 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/command/commands/mod.rs
+++ b/crates/pumpkin/src/command/commands/mod.rs
@@ -52,6 +52,7 @@ mod plugins;
 mod pumpkin;
 mod random;
 mod recipe;
+mod r#return;
 mod ride;
 mod rotate;
 mod saveall;
@@ -192,6 +193,7 @@ pub async fn default_dispatcher(
     random::register(&mut dispatcher, registry);
     list::register(&mut dispatcher, registry);
     loot::register(&mut dispatcher, registry);
+    r#return::register(&mut dispatcher, registry);
     seed::register(&mut dispatcher, registry);
     saveall::register(&mut dispatcher, registry);
     saveoff::register(&mut dispatcher, registry);

--- a/crates/pumpkin/src/command/commands/return.rs
+++ b/crates/pumpkin/src/command/commands/return.rs
@@ -1,0 +1,75 @@
+use crate::command::argument_builder::{ArgumentBuilder, argument, command, literal};
+use crate::command::argument_types::core::integer::IntegerArgumentType;
+use crate::command::argument_types::core::string::StringArgumentType;
+use crate::command::context::command_context::CommandContext;
+use crate::command::errors::error_types::CommandErrorType;
+use crate::command::node::dispatcher::CommandDispatcher;
+use crate::command::node::{CommandExecutor, CommandExecutorResult};
+use pumpkin_util::PermissionLvl;
+use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
+
+const DESCRIPTION: &str = "Stops the execution of a function and sets its return value.";
+const PERMISSION: &str = "minecraft:command.return";
+
+const ARG_VALUE: &str = "value";
+const ARG_COMMAND: &str = "command";
+
+static COMMAND_FAILED: CommandErrorType<0> =
+    CommandErrorType::new("command.failed", "command.failed");
+
+struct ReturnValueExecutor;
+
+impl CommandExecutor for ReturnValueExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let value = IntegerArgumentType::get(context, ARG_VALUE)?;
+            Ok(value)
+        })
+    }
+}
+
+struct ReturnFailExecutor;
+
+impl CommandExecutor for ReturnFailExecutor {
+    fn execute<'a>(&'a self, _context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move { Err(COMMAND_FAILED.create_without_context_args_slice(&[])) })
+    }
+}
+
+struct ReturnRunExecutor;
+
+impl CommandExecutor for ReturnRunExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let command_str = StringArgumentType::get(context, ARG_COMMAND)?;
+            let dispatcher = context.server().command_dispatcher.read().await;
+            let result = dispatcher
+                .execute_input(command_str, &context.source)
+                .await?;
+            Ok(result)
+        })
+    }
+}
+
+pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION,
+        DESCRIPTION,
+        PermissionDefault::Op(PermissionLvl::Two),
+    ));
+
+    dispatcher.register(
+        command("return", DESCRIPTION)
+            .requires(PERMISSION)
+            .then(
+                argument(ARG_VALUE, IntegerArgumentType::any()).executes(ReturnValueExecutor),
+            )
+            .then(literal("fail").executes(ReturnFailExecutor))
+            .then(
+                literal("run").then(
+                    argument(ARG_COMMAND, StringArgumentType::GreedyPhrase)
+                        .executes(ReturnRunExecutor),
+                ),
+            ),
+    );
+}


### PR DESCRIPTION
Implements the vanilla `/return` command.

## Changes
- `return <value>` - ends execution with a success and sets the return value to the given integer
- `return fail` - ends execution with a failure and a return value of 0
- `return run <command>` - executes the command and returns its success/result value

Follows the node-based command style (see `seed.rs`), permission level 2 (`minecraft:command.return`), matching vanilla's `LEVEL_GAMEMASTERS` requirement. Reference: `mcsource/net/minecraft/server/commands/ReturnCommand.java`.

## Verification
- `cargo check -p pumpkin --lib` ✅
- `cargo clippy -p pumpkin --lib` ✅
- `cargo test -p pumpkin --lib` ✅ (234 passed)