### PR TITLE
fix(entity): use 0.8x width for suffocation box to match vanilla

### DIFF
--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -1579,7 +1579,14 @@ impl Entity {
         let max = aabb.max_block_pos();
 
         let eye_height = self.get_eye_height();
+        let eye_width = f64::from(self.width()) * 0.8;
         let mut eye_level_box = aabb;
+        let shrink_x = (aabb.max.x - aabb.min.x - eye_width) / 2.0;
+        let shrink_z = (aabb.max.z - aabb.min.z - eye_width) / 2.0;
+        eye_level_box.min.x += shrink_x;
+        eye_level_box.max.x -= shrink_x;
+        eye_level_box.min.z += shrink_z;
+        eye_level_box.max.z -= shrink_z;
         eye_level_box.min.y += eye_height;
         eye_level_box.max.y = eye_level_box.min.y;
 


### PR DESCRIPTION
## Description

Fixes #2897

The suffocation check in `tick_block_collisions` builds the eye-level box from the entity's full AABB (full `width`). When a player stands/walks directly against a wall, the box edge lands exactly on the wall face, so the float32 precision error (~4.6e-6) makes `intersects` return `true` and the player takes suffocation damage. This reproduces on Bedrock (which sends exact coordinates) but not on Java.

Vanilla Java's `Entity.isInWall()` uses `AABB.ofSize(eyePos, width*0.8, 1e-6, width*0.8)` — a box 0.8× the entity width. With that box, the edge stays 0.06 away from the wall when hugging it, so it is immune to small float errors.

This PR shrinks the eye-level box to `width * 0.8` in X/Z, matching vanilla behavior.

## Testing

- Server: Pumpkin `0.1.0-dev+26.2-26.40`, Bedrock Edition (Protocol 2168)
- Client: Bedrock Edition
- Steps: walk straight against the side of a block / brush along it diagonally
- Before: player takes suffocation damage (1 HP per tick)
- After: no suffocation damage in the same scenario
- Confirmed the issue does not reproduce on Java Edition
