### PR TITLE
fix(huge_fungus): Fixed the huge fungus generation logic

### DIFF
--- a/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
@@ -252,40 +252,28 @@ impl HugeFungusFeature {
 
                         if bottom {
                             if !inner {
-                                self.generate_hat_drop_block(chunk, random, block_pos, hat_state, place_vines);
+                                self.generate_hat_drop_block(
+                                    chunk,
+                                    random,
+                                    block_pos,
+                                    hat_state,
+                                    place_vines,
+                                );
                             }
                         } else if inner {
                             let vine_prob = if place_vines { 0.1 } else { 0.0 };
                             self.generate_hat_block(
-                                chunk,
-                                random,
-                                block_pos,
-                                hat_state,
-                                0.1,
-                                0.2,
-                                vine_prob,
+                                chunk, random, block_pos, hat_state, 0.1, 0.2, vine_prob,
                             );
                         } else if corner {
                             let vine_prob = if place_vines { 0.083 } else { 0.0 };
                             self.generate_hat_block(
-                                chunk,
-                                random,
-                                block_pos,
-                                hat_state,
-                                0.01,
-                                0.7,
-                                vine_prob,
+                                chunk, random, block_pos, hat_state, 0.01, 0.7, vine_prob,
                             );
                         } else {
                             let vine_prob = if place_vines { 0.07 } else { 0.0 };
                             self.generate_hat_block(
-                                chunk,
-                                random,
-                                block_pos,
-                                hat_state,
-                                5.0e-4,
-                                0.98,
-                                vine_prob,
+                                chunk, random, block_pos, hat_state, 5.0e-4, 0.98, vine_prob,
                             );
                         }
                     }

--- a/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
@@ -1,4 +1,4 @@
-use pumpkin_data::Block;
+use pumpkin_data::{Block, chunk::Biome, tag};
 use pumpkin_util::{math::position::BlockPos, random::RandomGenerator, random::RandomImpl};
 
 use crate::generation::proto_chunk::GenerationCache;
@@ -16,8 +16,39 @@ impl HugeFungusFeature {
         random: &mut RandomGenerator,
         pos: BlockPos,
     ) -> bool {
+        /* Here we'd like to check something about the
+         * position, like if it's valid for a huge fungus to grow there.
+         */
+        let root_pos = pos;
+
+        // Check: Is this generated in air? (Expected: yes)
+        if !chunk.is_air(&root_pos.0) {
+            return false;
+        }
+
+        // Check: Is the block below a valid ground (nylium or netherrack) (Expected: yes)?
+        let below_state = GenerationCache::get_block_state(chunk, &root_pos.down().0);
+        let is_valid_block = below_state
+            .to_block_id()
+            .has_tag(tag::Block::MINECRAFT_NYLIUM)
+            || below_state.to_block_id().has_tag(tag::Block::C_NETHERRACKS);
+        if !is_valid_block {
+            return false;
+        }
+
+        /* Main generation logic */
         let height = random.next_bounded_i32(4) + 6;
-        let is_warped = random.next_bool();
+        let is_warped = {
+            // Get current biome
+            let biome = chunk.get_biome_for_terrain_gen(pos.0.x, pos.0.y, pos.0.z);
+
+            // And match...
+            match biome {
+                b if b == &Biome::CRIMSON_FOREST => false,
+                b if b == &Biome::WARPED_FOREST => true,
+                _ => return false, // Should not be generated if not in those biome
+            }
+        };
 
         let stem_state = if is_warped {
             Block::WARPED_STEM.default_state

--- a/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
@@ -147,9 +147,10 @@ impl HugeFungusFeature {
     }
 
     /// Check is given position's block in replace list
+    #[allow(clippy::unused_self)]
     fn is_replaceable<T: GenerationCache>(
         &self,
-        chunk: &mut T,
+        chunk: &T,
         pos: &BlockPos,
         check_non_replaceable_plants: bool,
     ) -> bool {
@@ -163,13 +164,15 @@ impl HugeFungusFeature {
         }
 
         if check_non_replaceable_plants {
-            return Self::REPLACEABLE_BLOCKS.contains(&block);
+            return Self::REPLACEABLE_BLOCKS.contains(block);
         }
 
         false
     }
 
     /// Generate the stem of this current fungus.
+    #[allow(clippy::unused_self)]
+    #[allow(clippy::too_many_arguments)]
     fn generate_stem<T: GenerationCache>(
         &self,
         chunk: &mut T,
@@ -180,14 +183,14 @@ impl HugeFungusFeature {
         is_huge: bool,
         planted: bool,
     ) {
-        let stem_radius: i32 = if is_huge { 1 } else { 0 };
+        let stem_radius = i32::from(is_huge);
 
         for dx in -stem_radius..=stem_radius {
             for dz in -stem_radius..=stem_radius {
                 let corner_of_huge_stem =
                     is_huge && dx.abs() == stem_radius && dz.abs() == stem_radius;
                 for dy in 0..total_height {
-                    let block_pos = pos.offset(Vector3::new(dx, dy as i32, dz));
+                    let block_pos = pos.offset(Vector3::new(dx, dy, dz));
                     if self.is_replaceable(chunk, &block_pos, true) {
                         if planted {
                             if !chunk.is_air(&block_pos.down().0) {
@@ -209,6 +212,8 @@ impl HugeFungusFeature {
     }
 
     /// Generate the hat of this current fungus.
+    #[allow(clippy::unused_self)]
+    #[allow(clippy::too_many_arguments)]
     fn generate_hat<T: GenerationCache>(
         &self,
         chunk: &mut T,
@@ -224,14 +229,13 @@ impl HugeFungusFeature {
         let hat_start_y = total_height - hat_height;
 
         for y in hat_start_y..=total_height {
-            let mut r = if y < total_height - random.next_bounded_i32(3) {
+            let mut r = if hat_height > 8 && y < hat_start_y + 4 {
+                3
+            } else if y < total_height - random.next_bounded_i32(3) {
                 2
             } else {
                 1
             };
-            if hat_height > 8 && y < hat_start_y + 4 {
-                r = 3;
-            }
 
             if is_huge {
                 r += 1;
@@ -244,7 +248,7 @@ impl HugeFungusFeature {
                     let inner = !edge_x && !edge_z && y != total_height;
                     let corner = edge_x && edge_z;
                     let bottom = y < hat_start_y + 3;
-                    let block_pos = pos.offset(Vector3::new(x, y as i32, z));
+                    let block_pos = pos.offset(Vector3::new(x, y, z));
                     if self.is_replaceable(chunk, &block_pos, true) {
                         if planted && !chunk.is_air(&block_pos.down().0) {
                             chunk.set_block_state(&block_pos.0, Block::AIR.default_state);
@@ -282,6 +286,8 @@ impl HugeFungusFeature {
         }
     }
 
+    #[allow(clippy::unused_self)]
+    #[allow(clippy::too_many_arguments)]
     fn generate_hat_block<T: GenerationCache>(
         &self,
         chunk: &mut T,
@@ -303,6 +309,7 @@ impl HugeFungusFeature {
         }
     }
 
+    #[allow(clippy::unused_self)]
     fn generate_hat_drop_block<T: GenerationCache>(
         &self,
         chunk: &mut T,
@@ -322,6 +329,7 @@ impl HugeFungusFeature {
         }
     }
 
+    #[allow(clippy::unused_self)]
     fn try_place_weeping_vines<T: GenerationCache>(
         hat_block_pos: BlockPos,
         chunk: &mut T,

--- a/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
@@ -1,17 +1,82 @@
-use pumpkin_data::{Block, chunk::Biome, tag};
-use pumpkin_util::{math::position::BlockPos, random::RandomGenerator, random::RandomImpl};
-
 use crate::generation::proto_chunk::GenerationCache;
+use pumpkin_data::{Block, BlockState, chunk::Biome, tag};
+use pumpkin_util::{
+    math::{position::BlockPos, vector3::Vector3},
+    random::{RandomGenerator, RandomImpl},
+};
 
 pub struct HugeFungusFeature;
 
 impl HugeFungusFeature {
+    /// Replaceable block list
+    const REPLACEABLE_BLOCKS: &[Block] = &[
+        Block::OAK_SAPLING,
+        Block::SPRUCE_SAPLING,
+        Block::BIRCH_SAPLING,
+        Block::JUNGLE_SAPLING,
+        Block::ACACIA_SAPLING,
+        Block::CHERRY_SAPLING,
+        Block::DARK_OAK_SAPLING,
+        Block::PALE_OAK_SAPLING,
+        Block::MANGROVE_PROPAGULE,
+        Block::DANDELION,
+        Block::TORCHFLOWER,
+        Block::POPPY,
+        Block::BLUE_ORCHID,
+        Block::ALLIUM,
+        Block::AZURE_BLUET,
+        Block::RED_TULIP,
+        Block::ORANGE_TULIP,
+        Block::WHITE_TULIP,
+        Block::PINK_TULIP,
+        Block::OXEYE_DAISY,
+        Block::CORNFLOWER,
+        Block::WITHER_ROSE,
+        Block::LILY_OF_THE_VALLEY,
+        Block::BROWN_MUSHROOM,
+        Block::RED_MUSHROOM,
+        Block::WHEAT,
+        Block::SUGAR_CANE,
+        Block::ATTACHED_PUMPKIN_STEM,
+        Block::ATTACHED_MELON_STEM,
+        Block::PUMPKIN_STEM,
+        Block::MELON_STEM,
+        Block::LILY_PAD,
+        Block::NETHER_WART,
+        Block::COCOA,
+        Block::CARROTS,
+        Block::POTATOES,
+        Block::CHORUS_PLANT,
+        Block::CHORUS_FLOWER,
+        Block::TORCHFLOWER_CROP,
+        Block::PITCHER_CROP,
+        Block::BEETROOTS,
+        Block::SWEET_BERRY_BUSH,
+        Block::WARPED_FUNGUS,
+        Block::CRIMSON_FUNGUS,
+        Block::WEEPING_VINES,
+        Block::WEEPING_VINES_PLANT,
+        Block::TWISTING_VINES,
+        Block::TWISTING_VINES_PLANT,
+        Block::CAVE_VINES,
+        Block::CAVE_VINES_PLANT,
+        Block::SPORE_BLOSSOM,
+        Block::AZALEA,
+        Block::FLOWERING_AZALEA,
+        Block::MOSS_CARPET,
+        Block::PINK_PETALS,
+        Block::WILDFLOWERS,
+        Block::BIG_DRIPLEAF,
+        Block::BIG_DRIPLEAF_STEM,
+        Block::SMALL_DRIPLEAF,
+    ];
+
     #[allow(clippy::unused_self)]
     pub fn generate<T: GenerationCache>(
         &self,
         chunk: &mut T,
         _min_y: i8,
-        _height: u16,
+        height: u16,
         _feature: pumpkin_data::placed_feature::PlacedFeature,
         random: &mut RandomGenerator,
         pos: BlockPos,
@@ -19,25 +84,8 @@ impl HugeFungusFeature {
         /* Here we'd like to check something about the
          * position, like if it's valid for a huge fungus to grow there.
          */
-        let root_pos = pos;
 
-        // Check: Is this generated in air? (Expected: yes)
-        if !chunk.is_air(&root_pos.0) {
-            return false;
-        }
-
-        // Check: Is the block below a valid ground (nylium or netherrack) (Expected: yes)?
-        let below_state = GenerationCache::get_block_state(chunk, &root_pos.down().0);
-        let is_valid_block = below_state
-            .to_block_id()
-            .has_tag(tag::Block::MINECRAFT_NYLIUM)
-            || below_state.to_block_id().has_tag(tag::Block::C_NETHERRACKS);
-        if !is_valid_block {
-            return false;
-        }
-
-        /* Main generation logic */
-        let height = random.next_bounded_i32(4) + 6;
+        // Check: Is this generated in a warped/crimson forest? (Expected: yes)
         let is_warped = {
             // Get current biome
             let biome = chunk.get_biome_for_terrain_gen(pos.0.x, pos.0.y, pos.0.z);
@@ -50,6 +98,34 @@ impl HugeFungusFeature {
             }
         };
 
+        // Check: Is the block below a valid ground (nylium or netherrack) (Expected: yes)?
+        let below_state = GenerationCache::get_block_state(chunk, &pos.down().0);
+        let is_valid_block = below_state
+            .to_block_id()
+            .has_tag(tag::Block::MINECRAFT_NYLIUM);
+        if !is_valid_block {
+            return false;
+        }
+
+        /* Main generation logic */
+        // Get the height of the fungus (vanilla range: 4-13 blocks, might double in 1/12 chance)
+        let total_height = {
+            let first_height = random.next_inbetween_i32(4, 13);
+            if random.next_bounded_i32(12) == 0 {
+                first_height * 2
+            } else {
+                first_height
+            }
+        };
+
+        // TODO: In vanilla, it will pass us a config which tells us is this manual or native generation.
+        // TODO: Current it is no, so here we check the height directly.
+        // Check: Is computed height out of given max height?
+        if pos.0.y + total_height + 1 >= height as i32 {
+            return false;
+        }
+
+        // Get the stem and wart block states
         let stem_state = if is_warped {
             Block::WARPED_STEM.default_state
         } else {
@@ -60,28 +136,228 @@ impl HugeFungusFeature {
         } else {
             Block::NETHER_WART_BLOCK.default_state
         };
+        let is_huge = random.next_f32() < 0.06;
 
-        for i in 0..height {
-            let stem_pos = BlockPos::new(pos.0.x, pos.0.y + i, pos.0.z);
-            chunk.set_block_state(&stem_pos.0, stem_state);
+        // Start the main generation logic.
+        chunk.set_block_state(&pos.0, Block::AIR.default_state);
+        self.generate_stem(chunk, pos, stem_state, total_height, random, is_huge, false);
+        self.generate_hat(chunk, pos, wart_state, total_height, random, is_huge, false);
+
+        true
+    }
+
+    /// Check is given position's block in replace list
+    fn is_replaceable<T: GenerationCache>(
+        &self,
+        chunk: &mut T,
+        pos: &BlockPos,
+        check_non_replaceable_plants: bool,
+    ) -> bool {
+        let block_state = GenerationCache::get_block_state(chunk, &pos.0);
+        let block = block_state.to_block();
+
+        // TODO: Attend a field `is_replaceable` to check if the block is replaceable.
+        // In vanilla, only `air` is assigned as replaceable. So here we just check it is air or not.
+        if block.is_air() {
+            return true;
         }
 
-        let cap_y = pos.0.y + height - 2;
-        for dy in 0..=3 {
-            let radius = if dy == 0 || dy == 3 { 1 } else { 2 };
-            for dx in -radius..=radius {
-                for dz in -radius..=radius {
-                    let cap_pos = BlockPos::new(pos.0.x + dx, cap_y + dy, pos.0.z + dz);
-                    let block_state = if (dx == 0 || dz == 0) && dy == 1 && random.next_f32() < 0.3
-                    {
-                        Block::SHROOMLIGHT.default_state
-                    } else {
-                        wart_state
-                    };
-                    chunk.set_block_state(&cap_pos.0, block_state);
+        if check_non_replaceable_plants {
+            return Self::REPLACEABLE_BLOCKS.contains(&block);
+        }
+
+        false
+    }
+
+    /// Generate the stem of this current fungus.
+    fn generate_stem<T: GenerationCache>(
+        &self,
+        chunk: &mut T,
+        pos: BlockPos,
+        stem_state: &BlockState,
+        total_height: i32,
+        random: &mut RandomGenerator,
+        is_huge: bool,
+        planted: bool,
+    ) {
+        let stem_radius: i32 = if is_huge { 1 } else { 0 };
+
+        for dx in -stem_radius..=stem_radius {
+            for dz in -stem_radius..=stem_radius {
+                let corner_of_huge_stem =
+                    is_huge && dx.abs() == stem_radius && dz.abs() == stem_radius;
+                for dy in 0..total_height {
+                    let block_pos = pos.offset(Vector3::new(dx, dy as i32, dz));
+                    if self.is_replaceable(chunk, &block_pos, true) {
+                        if planted {
+                            if !chunk.is_air(&block_pos.down().0) {
+                                chunk.set_block_state(&block_pos.0, Block::AIR.default_state);
+                            }
+
+                            chunk.set_block_state(&block_pos.0, stem_state);
+                        } else if corner_of_huge_stem {
+                            if random.next_f32() < 0.1 {
+                                chunk.set_block_state(&block_pos.0, stem_state);
+                            }
+                        } else {
+                            chunk.set_block_state(&block_pos.0, stem_state);
+                        }
+                    }
                 }
             }
         }
-        true
+    }
+
+    /// Generate the hat of this current fungus.
+    fn generate_hat<T: GenerationCache>(
+        &self,
+        chunk: &mut T,
+        pos: BlockPos,
+        hat_state: &BlockState,
+        total_height: i32,
+        random: &mut RandomGenerator,
+        is_huge: bool,
+        planted: bool,
+    ) {
+        let place_vines = hat_state == Block::NETHER_WART_BLOCK.default_state;
+        let hat_height = (random.next_bounded_i32(1 + total_height / 3) + 5).min(total_height);
+        let hat_start_y = total_height - hat_height;
+
+        for y in hat_start_y..=total_height {
+            let mut r = if y < total_height - random.next_bounded_i32(3) {
+                2
+            } else {
+                1
+            };
+            if hat_height > 8 && y < hat_start_y + 4 {
+                r = 3;
+            }
+
+            if is_huge {
+                r += 1;
+            }
+
+            for x in -r..=r {
+                for z in -r..=r {
+                    let edge_x = x == -r || x == r;
+                    let edge_z = z == -r || z == r;
+                    let inner = !edge_x && !edge_z && y != total_height;
+                    let corner = edge_x && edge_z;
+                    let bottom = y < hat_start_y + 3;
+                    let block_pos = pos.offset(Vector3::new(x, y as i32, z));
+                    if self.is_replaceable(chunk, &block_pos, true) {
+                        if planted && !chunk.is_air(&block_pos.down().0) {
+                            chunk.set_block_state(&block_pos.0, Block::AIR.default_state);
+                        }
+
+                        if bottom {
+                            if !inner {
+                                self.generate_hat_drop_block(chunk, random, block_pos, hat_state, place_vines);
+                            }
+                        } else if inner {
+                            let vine_prob = if place_vines { 0.1 } else { 0.0 };
+                            self.generate_hat_block(
+                                chunk,
+                                random,
+                                block_pos,
+                                hat_state,
+                                0.1,
+                                0.2,
+                                vine_prob,
+                            );
+                        } else if corner {
+                            let vine_prob = if place_vines { 0.083 } else { 0.0 };
+                            self.generate_hat_block(
+                                chunk,
+                                random,
+                                block_pos,
+                                hat_state,
+                                0.01,
+                                0.7,
+                                vine_prob,
+                            );
+                        } else {
+                            let vine_prob = if place_vines { 0.07 } else { 0.0 };
+                            self.generate_hat_block(
+                                chunk,
+                                random,
+                                block_pos,
+                                hat_state,
+                                5.0e-4,
+                                0.98,
+                                vine_prob,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn generate_hat_block<T: GenerationCache>(
+        &self,
+        chunk: &mut T,
+        random: &mut RandomGenerator,
+        pos: BlockPos,
+        hat_state: &BlockState,
+        decor_prob: f32,
+        hat_prob: f32,
+        vine_prob: f32,
+    ) {
+        // Set decor block in chance...
+        if random.next_f32() < decor_prob {
+            chunk.set_block_state(&pos.0, Block::SHROOMLIGHT.default_state);
+        } else if random.next_f32() < hat_prob {
+            chunk.set_block_state(&pos.0, hat_state);
+            if random.next_f32() < vine_prob {
+                Self::try_place_weeping_vines(pos, chunk, random);
+            }
+        }
+    }
+
+    fn generate_hat_drop_block<T: GenerationCache>(
+        &self,
+        chunk: &mut T,
+        random: &mut RandomGenerator,
+        pos: BlockPos,
+        hat_state: &BlockState,
+        place_vines: bool,
+    ) {
+        let block_below = GenerationCache::get_block_state(chunk, &pos.down().0);
+        if block_below == hat_state.id {
+            chunk.set_block_state(&pos.0, hat_state);
+        } else if random.next_f32() < 0.15 {
+            chunk.set_block_state(&pos.0, hat_state);
+            if place_vines && random.next_bounded_i32(11) == 0 {
+                Self::try_place_weeping_vines(pos, chunk, random);
+            }
+        }
+    }
+
+    fn try_place_weeping_vines<T: GenerationCache>(
+        hat_block_pos: BlockPos,
+        chunk: &mut T,
+        random: &mut RandomGenerator,
+    ) {
+        let vine_pos = hat_block_pos.down();
+        if chunk.is_air(&vine_pos.0) {
+            let mut vine_length = random.next_inbetween_i32(1, 5);
+            if random.next_bounded_i32(7) == 0 {
+                vine_length *= 2;
+            }
+
+            // Simplified weeping vine column placement; vanilla uses age 23-25.
+            // We place WEEPING_VINES_PLANT for the stem, and WEEPING_VINES at the tip.
+            for i in 0..vine_length {
+                let current = vine_pos.offset(Vector3::new(0, -i, 0));
+                if i == vine_length - 1 {
+                    // Tip of the vine
+                    chunk.set_block_state(&current.0, Block::WEEPING_VINES.default_state);
+                } else {
+                    // Stem piece
+                    chunk.set_block_state(&current.0, Block::WEEPING_VINES_PLANT.default_state);
+                }
+            }
+        }
     }
 }

--- a/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
@@ -1,5 +1,9 @@
 use crate::generation::proto_chunk::GenerationCache;
-use pumpkin_data::{Block, BlockState, chunk::Biome, tag};
+use pumpkin_data::{
+    Block, BlockState,
+    chunk::Biome,
+    tag::{self, Taggable},
+};
 use pumpkin_util::{
     math::{position::BlockPos, vector3::Vector3},
     random::{RandomGenerator, RandomImpl},
@@ -8,69 +12,6 @@ use pumpkin_util::{
 pub struct HugeFungusFeature;
 
 impl HugeFungusFeature {
-    /// Replaceable block list
-    const REPLACEABLE_BLOCKS: &[Block] = &[
-        Block::OAK_SAPLING,
-        Block::SPRUCE_SAPLING,
-        Block::BIRCH_SAPLING,
-        Block::JUNGLE_SAPLING,
-        Block::ACACIA_SAPLING,
-        Block::CHERRY_SAPLING,
-        Block::DARK_OAK_SAPLING,
-        Block::PALE_OAK_SAPLING,
-        Block::MANGROVE_PROPAGULE,
-        Block::DANDELION,
-        Block::TORCHFLOWER,
-        Block::POPPY,
-        Block::BLUE_ORCHID,
-        Block::ALLIUM,
-        Block::AZURE_BLUET,
-        Block::RED_TULIP,
-        Block::ORANGE_TULIP,
-        Block::WHITE_TULIP,
-        Block::PINK_TULIP,
-        Block::OXEYE_DAISY,
-        Block::CORNFLOWER,
-        Block::WITHER_ROSE,
-        Block::LILY_OF_THE_VALLEY,
-        Block::BROWN_MUSHROOM,
-        Block::RED_MUSHROOM,
-        Block::WHEAT,
-        Block::SUGAR_CANE,
-        Block::ATTACHED_PUMPKIN_STEM,
-        Block::ATTACHED_MELON_STEM,
-        Block::PUMPKIN_STEM,
-        Block::MELON_STEM,
-        Block::LILY_PAD,
-        Block::NETHER_WART,
-        Block::COCOA,
-        Block::CARROTS,
-        Block::POTATOES,
-        Block::CHORUS_PLANT,
-        Block::CHORUS_FLOWER,
-        Block::TORCHFLOWER_CROP,
-        Block::PITCHER_CROP,
-        Block::BEETROOTS,
-        Block::SWEET_BERRY_BUSH,
-        Block::WARPED_FUNGUS,
-        Block::CRIMSON_FUNGUS,
-        Block::WEEPING_VINES,
-        Block::WEEPING_VINES_PLANT,
-        Block::TWISTING_VINES,
-        Block::TWISTING_VINES_PLANT,
-        Block::CAVE_VINES,
-        Block::CAVE_VINES_PLANT,
-        Block::SPORE_BLOSSOM,
-        Block::AZALEA,
-        Block::FLOWERING_AZALEA,
-        Block::MOSS_CARPET,
-        Block::PINK_PETALS,
-        Block::WILDFLOWERS,
-        Block::BIG_DRIPLEAF,
-        Block::BIG_DRIPLEAF_STEM,
-        Block::SMALL_DRIPLEAF,
-    ];
-
     #[allow(clippy::unused_self)]
     pub fn generate<T: GenerationCache>(
         &self,
@@ -81,10 +22,6 @@ impl HugeFungusFeature {
         random: &mut RandomGenerator,
         pos: BlockPos,
     ) -> bool {
-        /* Here we'd like to check something about the
-         * position, like if it's valid for a huge fungus to grow there.
-         */
-
         // Check: Is this generated in a warped/crimson forest? (Expected: yes)
         let is_warped = {
             // Get current biome
@@ -164,7 +101,7 @@ impl HugeFungusFeature {
         }
 
         if check_non_replaceable_plants {
-            return Self::REPLACEABLE_BLOCKS.contains(block);
+            return block.has_tag(&tag::Block::MINECRAFT_REPLACEABLE);
         }
 
         false
@@ -264,21 +201,40 @@ impl HugeFungusFeature {
                                     place_vines,
                                 );
                             }
-                        } else if inner {
-                            let vine_prob = if place_vines { 0.1 } else { 0.0 };
-                            self.generate_hat_block(
-                                chunk, random, block_pos, hat_state, 0.1, 0.2, vine_prob,
-                            );
-                        } else if corner {
-                            let vine_prob = if place_vines { 0.083 } else { 0.0 };
-                            self.generate_hat_block(
-                                chunk, random, block_pos, hat_state, 0.01, 0.7, vine_prob,
-                            );
                         } else {
-                            let vine_prob = if place_vines { 0.07 } else { 0.0 };
-                            self.generate_hat_block(
-                                chunk, random, block_pos, hat_state, 5.0e-4, 0.98, vine_prob,
-                            );
+                            // Basic config
+                            let base = match (inner, corner) {
+                                (true, _) => HatProbConfig {
+                                    decor: 0.1,
+                                    hat: 0.2,
+                                    vine: 0.0,
+                                },
+                                (false, true) => HatProbConfig {
+                                    decor: 0.01,
+                                    hat: 0.7,
+                                    vine: 0.0,
+                                },
+                                (false, false) => HatProbConfig {
+                                    decor: 5.0e-4,
+                                    hat: 0.98,
+                                    vine: 0.0,
+                                },
+                            };
+
+                            let prob_cfg = if place_vines {
+                                match (inner, corner) {
+                                    (true, _) => HatProbConfig { vine: 0.1, ..base },
+                                    (false, true) => HatProbConfig {
+                                        vine: 0.083,
+                                        ..base
+                                    },
+                                    (false, false) => HatProbConfig { vine: 0.07, ..base },
+                                }
+                            } else {
+                                base
+                            };
+
+                            self.generate_hat_block(chunk, random, block_pos, hat_state, prob_cfg);
                         }
                     }
                 }
@@ -294,10 +250,14 @@ impl HugeFungusFeature {
         random: &mut RandomGenerator,
         pos: BlockPos,
         hat_state: &BlockState,
-        decor_prob: f32,
-        hat_prob: f32,
-        vine_prob: f32,
+        prob_config: HatProbConfig,
     ) {
+        let HatProbConfig {
+            decor: decor_prob,
+            hat: hat_prob,
+            vine: vine_prob,
+        } = prob_config;
+
         // Set decor block in chance...
         if random.next_f32() < decor_prob {
             chunk.set_block_state(&pos.0, Block::SHROOMLIGHT.default_state);
@@ -346,6 +306,15 @@ impl HugeFungusFeature {
             // We place WEEPING_VINES_PLANT for the stem, and WEEPING_VINES at the tip.
             for i in 0..vine_length {
                 let current = vine_pos.offset(Vector3::new(0, -i, 0));
+                // Check: Is current block is replaceable
+                if !GenerationCache::get_block_state(chunk, &current.0)
+                    .to_block_id()
+                    .has_tag(tag::Block::MINECRAFT_REPLACEABLE)
+                {
+                    break;
+                }
+
+                // Place the vine block in different positions...
                 if i == vine_length - 1 {
                     // Tip of the vine
                     chunk.set_block_state(&current.0, Block::WEEPING_VINES.default_state);
@@ -356,4 +325,17 @@ impl HugeFungusFeature {
             }
         }
     }
+}
+
+/// Configuration of the probability of the hat.
+#[derive(Debug, Clone, Copy)]
+pub struct HatProbConfig {
+    /// Probability of placing a decor block.
+    pub decor: f32,
+
+    /// Probability of placing a hat block.
+    pub hat: f32,
+
+    /// Probability of placing weeping vines.
+    pub vine: f32,
 }

--- a/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/huge_fungus.rs
@@ -9,6 +9,7 @@ use pumpkin_util::{
     random::{RandomGenerator, RandomImpl},
 };
 
+#[derive(Clone)]
 pub struct HugeFungusFeature;
 
 impl HugeFungusFeature {
@@ -68,17 +69,26 @@ impl HugeFungusFeature {
         } else {
             Block::CRIMSON_STEM.default_state
         };
-        let wart_state = if is_warped {
+        let hat_state = if is_warped {
             Block::WARPED_WART_BLOCK.default_state
         } else {
             Block::NETHER_WART_BLOCK.default_state
         };
         let is_huge = random.next_f32() < 0.06;
 
+        // Pack them into a config struct.
+        let context = HugeFungusContext {
+            hat_state,
+            stem_state,
+            total_height,
+            is_huge,
+            planted: false,
+        };
+
         // Start the main generation logic.
         chunk.set_block_state(&pos.0, Block::AIR.default_state);
-        self.generate_stem(chunk, pos, stem_state, total_height, random, is_huge, false);
-        self.generate_hat(chunk, pos, wart_state, total_height, random, is_huge, false);
+        self.generate_stem(chunk, pos, random, &context);
+        self.generate_hat(chunk, pos, random, &context);
 
         true
     }
@@ -109,39 +119,37 @@ impl HugeFungusFeature {
 
     /// Generate the stem of this current fungus.
     #[allow(clippy::unused_self)]
-    #[allow(clippy::too_many_arguments)]
     fn generate_stem<T: GenerationCache>(
         &self,
         chunk: &mut T,
         pos: BlockPos,
-        stem_state: &BlockState,
-        total_height: i32,
         random: &mut RandomGenerator,
-        is_huge: bool,
-        planted: bool,
+        ctx: &HugeFungusContext,
     ) {
-        let stem_radius = i32::from(is_huge);
+        let stem_radius = i32::from(ctx.is_huge);
 
         for dx in -stem_radius..=stem_radius {
             for dz in -stem_radius..=stem_radius {
                 let corner_of_huge_stem =
-                    is_huge && dx.abs() == stem_radius && dz.abs() == stem_radius;
-                for dy in 0..total_height {
+                    ctx.is_huge && dx.abs() == stem_radius && dz.abs() == stem_radius;
+                for dy in 0..ctx.total_height {
                     let block_pos = pos.offset(Vector3::new(dx, dy, dz));
-                    if self.is_replaceable(chunk, &block_pos, true) {
-                        if planted {
-                            if !chunk.is_air(&block_pos.down().0) {
-                                chunk.set_block_state(&block_pos.0, Block::AIR.default_state);
-                            }
+                    if !self.is_replaceable(chunk, &block_pos, true) {
+                        continue;
+                    }
 
-                            chunk.set_block_state(&block_pos.0, stem_state);
-                        } else if corner_of_huge_stem {
-                            if random.next_f32() < 0.1 {
-                                chunk.set_block_state(&block_pos.0, stem_state);
-                            }
-                        } else {
-                            chunk.set_block_state(&block_pos.0, stem_state);
+                    if ctx.planted {
+                        if !chunk.is_air(&block_pos.down().0) {
+                            chunk.set_block_state(&block_pos.0, Block::AIR.default_state);
                         }
+
+                        chunk.set_block_state(&block_pos.0, ctx.stem_state);
+                    } else if corner_of_huge_stem {
+                        if random.next_f32() < 0.1 {
+                            chunk.set_block_state(&block_pos.0, ctx.stem_state);
+                        }
+                    } else {
+                        chunk.set_block_state(&block_pos.0, ctx.stem_state);
                     }
                 }
             }
@@ -150,92 +158,58 @@ impl HugeFungusFeature {
 
     /// Generate the hat of this current fungus.
     #[allow(clippy::unused_self)]
-    #[allow(clippy::too_many_arguments)]
     fn generate_hat<T: GenerationCache>(
         &self,
         chunk: &mut T,
         pos: BlockPos,
-        hat_state: &BlockState,
-        total_height: i32,
         random: &mut RandomGenerator,
-        is_huge: bool,
-        planted: bool,
+        ctx: &HugeFungusContext,
     ) {
-        let place_vines = hat_state == Block::NETHER_WART_BLOCK.default_state;
-        let hat_height = (random.next_bounded_i32(1 + total_height / 3) + 5).min(total_height);
-        let hat_start_y = total_height - hat_height;
+        let place_vines = ctx.hat_state == Block::NETHER_WART_BLOCK.default_state;
+        let hat_height =
+            (random.next_bounded_i32(1 + ctx.total_height / 3) + 5).min(ctx.total_height);
+        let hat_start_y = ctx.total_height - hat_height;
 
-        for y in hat_start_y..=total_height {
+        for y in hat_start_y..=ctx.total_height {
             let mut r = if hat_height > 8 && y < hat_start_y + 4 {
                 3
-            } else if y < total_height - random.next_bounded_i32(3) {
+            } else if y < ctx.total_height - random.next_bounded_i32(3) {
                 2
             } else {
                 1
             };
 
-            if is_huge {
+            if ctx.is_huge {
                 r += 1;
             }
 
             for x in -r..=r {
                 for z in -r..=r {
-                    let edge_x = x == -r || x == r;
-                    let edge_z = z == -r || z == r;
-                    let inner = !edge_x && !edge_z && y != total_height;
-                    let corner = edge_x && edge_z;
-                    let bottom = y < hat_start_y + 3;
-                    let block_pos = pos.offset(Vector3::new(x, y, z));
-                    if self.is_replaceable(chunk, &block_pos, true) {
-                        if planted && !chunk.is_air(&block_pos.down().0) {
-                            chunk.set_block_state(&block_pos.0, Block::AIR.default_state);
-                        }
+                    let offset = Vector3::new(x, y, z);
+                    let conditions = HatPlaceCond::from_pos(
+                        &offset,
+                        r,
+                        ctx.total_height,
+                        hat_start_y,
+                        place_vines,
+                    );
+                    let block_pos = pos.offset(offset);
 
-                        if bottom {
-                            if !inner {
-                                self.generate_hat_drop_block(
-                                    chunk,
-                                    random,
-                                    block_pos,
-                                    hat_state,
-                                    place_vines,
-                                );
-                            }
-                        } else {
-                            // Basic config
-                            let base = match (inner, corner) {
-                                (true, _) => HatProbConfig {
-                                    decor: 0.1,
-                                    hat: 0.2,
-                                    vine: 0.0,
-                                },
-                                (false, true) => HatProbConfig {
-                                    decor: 0.01,
-                                    hat: 0.7,
-                                    vine: 0.0,
-                                },
-                                (false, false) => HatProbConfig {
-                                    decor: 5.0e-4,
-                                    hat: 0.98,
-                                    vine: 0.0,
-                                },
-                            };
+                    // Check: Is the block replaceable?
+                    if !self.is_replaceable(chunk, &block_pos, true) {
+                        continue;
+                    }
 
-                            let prob_cfg = if place_vines {
-                                match (inner, corner) {
-                                    (true, _) => HatProbConfig { vine: 0.1, ..base },
-                                    (false, true) => HatProbConfig {
-                                        vine: 0.083,
-                                        ..base
-                                    },
-                                    (false, false) => HatProbConfig { vine: 0.07, ..base },
-                                }
-                            } else {
-                                base
-                            };
+                    if ctx.planted && !chunk.is_air(&block_pos.down().0) {
+                        chunk.set_block_state(&block_pos.0, Block::AIR.default_state);
+                    }
 
-                            self.generate_hat_block(chunk, random, block_pos, hat_state, prob_cfg);
-                        }
+                    if conditions.bottom && !conditions.inner {
+                        self.generate_hat_drop_block(chunk, random, block_pos, ctx, place_vines);
+                    } else {
+                        // Basic config
+                        let prob_cfg = HatProbConfig::from_conditions(&conditions);
+                        self.generate_hat_block(chunk, random, block_pos, ctx, prob_cfg);
                     }
                 }
             }
@@ -243,13 +217,12 @@ impl HugeFungusFeature {
     }
 
     #[allow(clippy::unused_self)]
-    #[allow(clippy::too_many_arguments)]
     fn generate_hat_block<T: GenerationCache>(
         &self,
         chunk: &mut T,
         random: &mut RandomGenerator,
         pos: BlockPos,
-        hat_state: &BlockState,
+        ctx: &HugeFungusContext,
         prob_config: HatProbConfig,
     ) {
         let HatProbConfig {
@@ -262,9 +235,9 @@ impl HugeFungusFeature {
         if random.next_f32() < decor_prob {
             chunk.set_block_state(&pos.0, Block::SHROOMLIGHT.default_state);
         } else if random.next_f32() < hat_prob {
-            chunk.set_block_state(&pos.0, hat_state);
+            chunk.set_block_state(&pos.0, ctx.hat_state);
             if random.next_f32() < vine_prob {
-                Self::try_place_weeping_vines(pos, chunk, random);
+                self.try_place_weeping_vines(pos, chunk, random);
             }
         }
     }
@@ -275,22 +248,23 @@ impl HugeFungusFeature {
         chunk: &mut T,
         random: &mut RandomGenerator,
         pos: BlockPos,
-        hat_state: &BlockState,
+        ctx: &HugeFungusContext,
         place_vines: bool,
     ) {
         let block_below = GenerationCache::get_block_state(chunk, &pos.down().0);
-        if block_below == hat_state.id {
-            chunk.set_block_state(&pos.0, hat_state);
+        if block_below == ctx.hat_state.id {
+            chunk.set_block_state(&pos.0, ctx.hat_state);
         } else if random.next_f32() < 0.15 {
-            chunk.set_block_state(&pos.0, hat_state);
+            chunk.set_block_state(&pos.0, ctx.hat_state);
             if place_vines && random.next_bounded_i32(11) == 0 {
-                Self::try_place_weeping_vines(pos, chunk, random);
+                self.try_place_weeping_vines(pos, chunk, random);
             }
         }
     }
 
     #[allow(clippy::unused_self)]
     fn try_place_weeping_vines<T: GenerationCache>(
+        &self,
         hat_block_pos: BlockPos,
         chunk: &mut T,
         random: &mut RandomGenerator,
@@ -327,9 +301,73 @@ impl HugeFungusFeature {
     }
 }
 
+/// Configurations of the huge fungus feature.
+struct HugeFungusContext {
+    /// The block state of the hat.
+    pub hat_state: &'static BlockState,
+
+    /// The block state of the stem.
+    pub stem_state: &'static BlockState,
+
+    /// The total height of the fungus.
+    pub total_height: i32,
+
+    /// Whether is this a huge fungus.
+    pub is_huge: bool,
+
+    /// Whether the hat block is planted by player.
+    pub planted: bool,
+}
+
+/// Conditions of the hat block placement.
+struct HatPlaceCond {
+    /// Whether the hat block is placed in the edge of x-axis.
+    pub edge_x: bool,
+
+    /// Whether the hat block is placed in the edge of z-axis.
+    pub edge_z: bool,
+
+    /// Whether the hat block is placed in the inner corner.
+    pub inner: bool,
+
+    /// Whether the hat block is placed in the corner.
+    pub corner: bool,
+
+    /// Whether is the bottom block.
+    pub bottom: bool,
+
+    /// Whether the hat should place weeping vines.
+    pub place_vines: bool,
+}
+
+impl HatPlaceCond {
+    /// Create this conditions through x, y, z, and radius.
+    pub const fn from_pos(
+        pos: &Vector3<i32>,
+        radius: i32,
+        total_height: i32,
+        hat_start_y: i32,
+        place_vines: bool,
+    ) -> Self {
+        let edge_x = pos.x == -radius || pos.x == radius;
+        let edge_z = pos.z == -radius || pos.z == radius;
+        let inner = !edge_x && !edge_z && pos.y != total_height;
+        let corner = edge_x && edge_z;
+        let bottom = pos.y < hat_start_y + 3;
+        Self {
+            edge_x,
+            edge_z,
+            inner,
+            corner,
+            bottom,
+            place_vines,
+        }
+    }
+}
+
 /// Configuration of the probability of the hat.
 #[derive(Debug, Clone, Copy)]
-pub struct HatProbConfig {
+struct HatProbConfig {
     /// Probability of placing a decor block.
     pub decor: f32,
 
@@ -338,4 +376,75 @@ pub struct HatProbConfig {
 
     /// Probability of placing weeping vines.
     pub vine: f32,
+}
+
+impl HatProbConfig {
+    // Constants (from vanilla source code)
+    /* Inner corner */
+    /// Base probability of placing a decor block in the inner corner.
+    const INNER_DECOR_PROB: f32 = 0.1;
+    /// Base probability of placing a hat block in the inner corner.
+    const INNER_HAT_PROB: f32 = 0.2;
+
+    /* Corner */
+    /// Base probability of placing a decor block in the corner.
+    const CORNER_DECOR_PROB: f32 = 0.01;
+    /// Base probability of placing a hat block in the corner.
+    const CORNER_HAT_PROB: f32 = 0.7;
+
+    /* Outer corner */
+    /// Base probability of placing a decor block in the outer corner.
+    const OUTER_DECOR_PROB: f32 = 5.0e-4;
+    /// Base probability of placing a hat block in the outer corner.
+    const OUTER_HAT_PROB: f32 = 0.98;
+
+    /* Weeping vines */
+    /// Probability of placing weeping vines in generic.
+    const VINE_PROB: f32 = 0.0;
+    /// Probability of placing weeping vines in the inner corner.
+    const INNER_VINE_PROB: f32 = 0.1;
+    /// Probability of placing weeping vines in the corner.
+    const CORNER_VINE_PROB: f32 = 0.083;
+    /// Probability of placing weeping vines in the outer corner.
+    const OUTER_VINE_PROB: f32 = 0.07;
+
+    /// Create this configuration through conditions.
+    pub const fn from_conditions(conditions: &HatPlaceCond) -> Self {
+        let base = match (conditions.inner, conditions.corner) {
+            (true, _) => Self {
+                decor: Self::INNER_DECOR_PROB,
+                hat: Self::INNER_HAT_PROB,
+                vine: Self::VINE_PROB,
+            },
+            (false, true) => Self {
+                decor: Self::CORNER_DECOR_PROB,
+                hat: Self::CORNER_HAT_PROB,
+                vine: Self::VINE_PROB,
+            },
+            (false, false) => Self {
+                decor: Self::OUTER_DECOR_PROB,
+                hat: Self::OUTER_HAT_PROB,
+                vine: Self::VINE_PROB,
+            },
+        };
+
+        if conditions.place_vines {
+            match (conditions.inner, conditions.corner) {
+                (true, _) => Self {
+                    vine: Self::INNER_VINE_PROB,
+                    ..base
+                },
+                (false, true) => Self {
+                    vine: Self::CORNER_VINE_PROB,
+                    ..base
+                },
+                (false, false) => Self {
+                    vine: Self::OUTER_VINE_PROB,
+                    ..base
+                },
+            }
+        } else {
+            base
+        }
+    }
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
As the #2466 describes, the generation of the nether is a bit incorrect. This PR mainly fixed the fungus's generation logic, added some checks to align to vanilla's behavior.

Fixed #2466 

After-fixed screenshots:

<img width="1920" height="1080" alt="2026-07-28_14 32 38" src="https://github.com/user-attachments/assets/1bacc739-cece-4003-aab6-5f0e95ad0513" />
<img width="1920" height="1080" alt="2026-07-28_14 32 36" src="https://github.com/user-attachments/assets/e3854823-d284-4ffa-ab9f-42edd166a2cc" />

### Changes
 - Added biome check instead of random to decide fungus type through biome
 - Added block check to avoid fungus generates on incorrect block
 - Aligned to vanilla generation logic

## Testing
 - `cargo clippy --all-targets` - No warnings
 - `cargo test` - All passed
 - In-game test - In expected behavior (see above)
