### PR TITLE
 fix(death):  Fixed some behavior in player death

### DIFF
--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1376,8 +1376,8 @@ impl LivingEntity {
                         format!("death.attack.{}.player", damage_type.message_id)
                     };
                     TextComponent::translate_cross(
-                        key.clone(),    // Java
-                        key.clone(),    // Bedrock
+                        key.clone(), // Java
+                        key.clone(), // Bedrock
                         [
                             dyn_self.get_display_name().await,
                             cause.get_display_name().await,

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1369,9 +1369,15 @@ impl LivingEntity {
                 if let Some(cause) = cause
                     && source.is_some()
                 {
+                    // XXX: Java and bedrock are using same key
+                    let key = if damage_type.message_id == "player" {
+                        translation::java::DEATH_ATTACK_PLAYER.to_string()
+                    } else {
+                        format!("death.attack.{}.player", damage_type.message_id)
+                    };
                     TextComponent::translate_cross(
-                        format!("death.attack.{}.player", damage_type.message_id),
-                        format!("death.attack.{}.player", damage_type.message_id),
+                        key.clone(),    // Java
+                        key.clone(),    // Bedrock
                         [
                             dyn_self.get_display_name().await,
                             cause.get_display_name().await,

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -3677,7 +3677,7 @@ impl World {
                     ),
                     spawn_yaw,
                     spawn_pitch,
-                    self.dimension.clone(),
+                    Dimension::OVERWORLD,
                 )
             };
 


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description
Fixes #1583.

Now when you died in other dimentions, if no anchor or bed helps you reset your spawn point, it will forcely teleport you back to the `minecraft:overworld` instead of using the dimension where you died.

Simultaneously, this PR fixes that a player killed another player, the death message doesn't show correctly.

## Testing
 - [x] `cargo clippy --all-targets` 
 - [x] `cargo test`
 - [x] `cargo fmt --check`
 - [x] In-game test   