### PR TITLE
fix(bedrock): one block crawling

### DIFF
--- a/crates/pumpkin/src/net/bedrock/play/player_auth_input.rs
+++ b/crates/pumpkin/src/net/bedrock/play/player_auth_input.rs
@@ -1,5 +1,6 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use pumpkin_data::entity::EntityPose;
 
 impl BedrockClient {
     #[expect(clippy::too_many_lines)]
@@ -160,6 +161,12 @@ impl BedrockClient {
             entity.set_sneaking(true).await;
         } else if input_data.get(InputData::StopSneaking as usize) {
             entity.set_sneaking(false).await;
+        }
+
+        if input_data.get(InputData::StartCrawling as usize) {
+            entity.set_pose(EntityPose::Swimming);
+        } else if input_data.get(InputData::StopCrawling as usize) {
+            player.update_player_pose().await;
         }
 
         if input_data.get(InputData::StartFlying as usize) {


### PR DESCRIPTION
## Description
Fixes Bedrock players automatically entering crawl mode when jumping or crouching toward a one-block gap.

## What
- Prevents Pumpkin’s Java pose fallback from forcing Bedrock players into crawl mode.
- Handles Bedrock’s explicit start and stop crawling inputs.
- Preserves normal intentional crawling.
- Does not change Java Edition pose behavior.

## How
- Tracks `START_CRAWLING` and `STOP_CRAWLING` from Bedrock’s `PlayerAuthInput` packet.
- Uses the Bedrock client’s reported crawling state when selecting its pose.
- Keeps collision-derived standing, crouching, and swimming pose fallback exclusive to Java players.

## Testing
- `cargo test -p pumpkin --lib`
- `cargo clippy -p pumpkin --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Verified in game that jumping or crouching toward a one-block gap no longer forces crawling.
- Verified that normal intentional crawling still works.
- Resolves: https://github.com/Pumpkin-MC/Pumpkin/issues/2898