### PR TITLE
fix(worldgen): square biome parameter distances

### DIFF
--- a/crates/pumpkin-data/src/generated/biome.rs
+++ b/crates/pumpkin-data/src/generated/biome.rs
@@ -9100,13 +9100,14 @@ pub struct ParameterRange {
 }
 impl ParameterRange {
     pub fn calc_distance(&self, noise: i64) -> i64 {
-        if noise > self.max {
+        let distance = if noise > self.max {
             noise - self.max
         } else if noise < self.min {
             self.min - noise
         } else {
             0
-        }
+        };
+        distance * distance
     }
 }
 #[derive(PartialEq)]
@@ -9174,6 +9175,17 @@ impl BiomeTree {
             + params[4].calc_distance(p[4])
             + params[5].calc_distance(p[5])
             + params[6].calc_distance(p[6])
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::ParameterRange;
+    #[test]
+    fn parameter_distance_is_squared_outside_range() {
+        let range = ParameterRange { min: 0, max: 10 };
+        assert_eq!(range.calc_distance(5), 0);
+        assert_eq!(range.calc_distance(13), 9);
+        assert_eq!(range.calc_distance(-3), 9);
     }
 }
 pub const OVERWORLD_BIOME_SOURCE: BiomeTree = BiomeTree::Branch {

--- a/tools/pumpkin-codegen/src/biome.rs
+++ b/tools/pumpkin-codegen/src/biome.rs
@@ -507,13 +507,14 @@ pub fn build() -> TokenStream {
 
         impl ParameterRange {
             pub fn calc_distance(&self, noise: i64) -> i64 {
-                if noise > self.max {
+                let distance = if noise > self.max {
                     noise - self.max
                 } else if noise < self.min {
                     self.min - noise
                 } else {
                     0
-                }
+                };
+                distance * distance
             }
         }
 
@@ -596,6 +597,20 @@ pub fn build() -> TokenStream {
                 params[4].calc_distance(p[4]) +
                 params[5].calc_distance(p[5]) +
                 params[6].calc_distance(p[6])
+            }
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::ParameterRange;
+
+            #[test]
+            fn parameter_distance_is_squared_outside_range() {
+                let range = ParameterRange { min: 0, max: 10 };
+
+                assert_eq!(range.calc_distance(5), 0);
+                assert_eq!(range.calc_distance(13), 9);
+                assert_eq!(range.calc_distance(-3), 9);
             }
         }
 


### PR DESCRIPTION
## Description

Pumpkin's multi-noise biome search calls this a squared-distance search, but each parameter range was returning the raw distance outside the range. Those per-parameter values are then added together, so the search was using a different distance metric from vanilla and could choose the wrong biome near parameter boundaries.

This squares the distance contributed by each parameter before the values are summed. Values inside the range still contribute zero. The checked-in generated biome data is updated together with the code generator.

I found this while comparing fixed-seed world-generation output against vanilla. A wrong biome selection can also affect structure biome checks, even when the structure placement itself is otherwise correct.

The regression test covers a value inside the range and values three units above and below it. The outside values must contribute `9`, not `3`.

## Testing

- `cargo fmt --all -- --check`
- Added `parameter_distance_is_squared_outside_range`
- Full clippy and test coverage will run in GitHub Actions

