### PR TITLE
fix(net): acknowledge block changes after handling each packet

### DIFF
--- a/crates/pumpkin/src/net/java/mod.rs
+++ b/crates/pumpkin/src/net/java/mod.rs
@@ -213,13 +213,6 @@ impl JavaClient {
                     self.last_keep_alive_time.store(Instant::now());
                     let packet = pumpkin_protocol::java::client::play::CKeepAlive::new(keep_alive_id);
                     self.enqueue_packet(&packet).await;
-
-                    let seq = self.packet_sequence.swap(-1, Ordering::Relaxed);
-                    if seq != -1 {
-                        self
-                            .send_packet_now(&CAcknowledgeBlockChange::new(seq.into()))
-                            .await;
-                    }
                 }
 
                 // INCOMING PACKETS
@@ -248,6 +241,15 @@ impl JavaClient {
                                 e
                             );
                         }
+                    }
+
+                    // ServerGamePacketListenerImpl acknowledges the sequence at the end of the
+                    // packet that carried it. Until we do, the client keeps predicting the block
+                    // it interacted with and drops our updates for that position
+                    let seq = self.packet_sequence.swap(-1, Ordering::Relaxed);
+                    if seq != -1 {
+                        self.send_packet_now(&CAcknowledgeBlockChange::new(seq.into()))
+                            .await;
                     }
                 }
             }


### PR DESCRIPTION
## Description

The problem is we only sent the block change confirmation from the keepalive timer, so once every 15s. Until it lands the client keeps showing its own prediction for that block and throws away our updates for that position.

Vanilla sends it at the end of the packet that carried the sequence. Moved it there.

TNT is where you notice it, but it's any interaction where we disagree with the client's guess.

## Testing

Placed TNT, hit it with flint and steel.

### Before
<img width="450" height="218" alt="before" src="https://github.com/user-attachments/assets/0f0dfaad-9b25-4fc7-87c7-e8b87e95735f" />



### After
<img width="450" height="218" alt="after" src="https://github.com/user-attachments/assets/77c3b716-cc8c-4256-9edb-6997334713b7" />

