### PR TITLE
fix(entity): let explosions push TNT

### DIFF
--- a/crates/pumpkin/src/entity/tnt.rs
+++ b/crates/pumpkin/src/entity/tnt.rs
@@ -41,13 +41,17 @@ impl EntityBase for TNTEntity {
     ) -> EntityBaseFuture<'a, ()> {
         Box::pin(async move {
             let entity = &self.entity;
-            let original_velo = entity.velocity.load();
 
-            let mut velo = original_velo;
+            let mut velo = entity.velocity.load();
             velo.y -= self.get_gravity();
 
             entity.move_entity(caller, velo).await;
             entity.tick_block_collisions(caller, server).await;
+
+            // Read back what actually happened instead of reusing the pre-move
+            // value: `move_entity` clamps on collision, and an explosion may have
+            // pushed us while we were awaiting above
+            let velo = entity.velocity.load();
             if entity.on_ground.load(Ordering::Relaxed) {
                 entity.velocity.store(velo.multiply(0.7, -0.5, 0.7));
             } else {
@@ -121,9 +125,5 @@ impl EntityBase for TNTEntity {
 
     fn cast_any(&self) -> &dyn std::any::Any {
         self
-    }
-
-    fn is_immune_to_explosion(&self) -> bool {
-        true
     }
 }


### PR DESCRIPTION
## Description

The problem is TNT was immune to explosions. `damage_entities` throws out immune entities right at the top, before it gets anywhere near the knockback, so a chained TNT never got pushed. Vanilla TNT isn't immune, so the override is gone.

`tick` was also grabbing the velocity before it moved and writing that old value back at the end, so any push that came in while it was moving got wiped. It reads the velocity again after `move_entity` now, like vanilla does.

### Before
<img width="520" height="252" alt="before" src="https://github.com/user-attachments/assets/bddb4b51-bdd7-4063-b928-5cb3ec29027b" />



### After

<img width="520" height="252" alt="after" src="https://github.com/user-attachments/assets/b811d6cb-0286-4ac1-8ead-ee4296a29cde" />
