### PR TITLE
Add option to disable plugin signature verification

### DIFF
--- a/crates/pumpkin-config/src/plugins.rs
+++ b/crates/pumpkin-config/src/plugins.rs
@@ -45,6 +45,8 @@ pub struct PluginsConfig {
     /// MY_API_KEY = "secret_key"
     /// ```
     pub overrides: HashMap<String, PluginOverride>,
+    /// Whether Pumpkin should verify WASM plugin signatures before loading.
+    pub verify_signatures: bool,
 }
 
 impl Default for PluginsConfig {
@@ -60,6 +62,7 @@ impl Default for PluginsConfig {
             loopback_only: false,
             max_memory_mb: None,
             overrides: HashMap::new(),
+            verify_signatures: true,
         }
     }
 }
@@ -117,6 +120,7 @@ mod tests {
         assert!(!config.loopback_only);
         assert_eq!(config.max_memory_mb, None);
         assert!(config.overrides.is_empty());
+        assert!(config.verify_signatures);
     }
 
     #[test]
@@ -131,6 +135,7 @@ mod tests {
             inherit_env = true
             loopback_only = true
             max_memory_mb = 256
+            verify_signatures = false
 
             [overrides.my_plugin]
             enabled = false
@@ -154,6 +159,7 @@ mod tests {
         assert!(config.inherit_env);
         assert!(config.loopback_only);
         assert_eq!(config.max_memory_mb, Some(256));
+        assert!(!config.verify_signatures);
 
         let override_cfg = config.overrides.get("my_plugin").unwrap();
         assert!(!override_cfg.enabled);

--- a/crates/pumpkin/src/plugin/loader/wasm/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/mod.rs
@@ -46,14 +46,24 @@ impl Plugin for WasmPlugin {
     }
 }
 
-pub struct WasmPluginLoader;
+pub struct WasmPluginLoader {
+    verify_signatures: bool,
+}
+
+impl WasmPluginLoader {
+    #[must_use]
+    pub const fn new(verify_signatures: bool) -> Self {
+        Self { verify_signatures }
+    }
+}
+
 impl PluginLoader for WasmPluginLoader {
     fn load<'a>(&'a self, path: &'a Path) -> PluginLoadFuture<'a> {
         Box::pin(async {
             let path = path.to_owned();
 
             let runtime = PluginRuntime::new(&path)?;
-            let (plugin, metadata) = runtime.init_plugin(&path).await?;
+            let (plugin, metadata) = runtime.init_plugin(&path, self.verify_signatures).await?;
 
             Ok((
                 plugin as Arc<dyn Plugin>,

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
@@ -89,29 +89,36 @@ impl PluginRuntime {
     pub async fn init_plugin<P: AsRef<Path>>(
         &self,
         path: P,
+        verify_signatures: bool,
     ) -> Result<(Arc<WasmPlugin>, PluginMetadata), PluginInitError> {
         let wasm_bytes = std::fs::read(&path).map_err(PluginInitError::FileReadFailed)?;
-
-        let verification =
-            signature::verify_wasm_plugin(&wasm_bytes, &path.as_ref().to_string_lossy());
-        let marketplace_metadata = if verification.is_signed && verification.is_valid {
-            verification.metadata.map(|m| {
-                wit::v0_1::pumpkin::plugin::context::MarketplaceMetadata {
-                    marketplace_url: m.marketplace_url,
-                    plugin_id: m.plugin_id,
-                    plugin_name: m.plugin_name,
-                    version: m.version,
-                    dev_id: m.dev_id,
-                    dev_name: m.dev_name,
-                    is_paid: m.is_paid,
-                    user_id: m.user_id,
-                    license_key: m.license_key,
-                    issued_at: m.issued_at,
+        let marketplace_metadata = maybe_verify_wasm_plugin(
+            &wasm_bytes,
+            &path.as_ref().to_string_lossy(),
+            verify_signatures,
+            |bytes, path_str| {
+                let verification = signature::verify_wasm_plugin(bytes, path_str);
+                if verification.is_signed && verification.is_valid {
+                    verification.metadata.map(|m| {
+                        wit::v0_1::pumpkin::plugin::context::MarketplaceMetadata {
+                            marketplace_url: m.marketplace_url,
+                            plugin_id: m.plugin_id,
+                            plugin_name: m.plugin_name,
+                            version: m.version,
+                            dev_id: m.dev_id,
+                            dev_name: m.dev_name,
+                            is_paid: m.is_paid,
+                            user_id: m.user_id,
+                            license_key: m.license_key,
+                            issued_at: m.issued_at,
+                        }
+                    })
+                } else {
+                    None
                 }
-            })
-        } else {
-            None
-        };
+            },
+        )
+        .flatten();
 
         let wasm_bytes = signature::strip_pumpkin_sections(&wasm_bytes).unwrap_or(wasm_bytes);
 
@@ -137,6 +144,18 @@ impl PluginRuntime {
         };
         Ok((wasm_plugin, metadata))
     }
+}
+
+fn maybe_verify_wasm_plugin<T, F>(
+    wasm_bytes: &[u8],
+    path_str: &str,
+    verify_signatures: bool,
+    verify: F,
+) -> Option<T>
+where
+    F: FnOnce(&[u8], &str) -> T,
+{
+    verify_signatures.then(|| verify(wasm_bytes, path_str))
 }
 
 fn setup_linker(engine: &Engine) -> wasmtime::Result<Linker<PluginHostState>> {

--- a/crates/pumpkin/src/plugin/mod.rs
+++ b/crates/pumpkin/src/plugin/mod.rs
@@ -214,19 +214,19 @@ pub enum ManagerError {
 
 impl Default for PluginManager {
     fn default() -> Self {
-        Self::new()
+        Self::new(true)
     }
 }
 
 impl PluginManager {
     /// Create a new plugin manager with default loaders
     #[must_use]
-    pub fn new() -> Self {
+    pub fn new(verify_plugin_signatures: bool) -> Self {
         Self {
             plugins: RwLock::new(Vec::new()),
             loaders: RwLock::new(vec![
                 Arc::new(NativePluginLoader),
-                Arc::new(WasmPluginLoader),
+                Arc::new(WasmPluginLoader::new(verify_plugin_signatures)),
             ]),
             handlers: Arc::new(ArcSwap::from_pointee(HashMap::new())),
             unloaded_files: RwLock::new(HashSet::new()),

--- a/crates/pumpkin/src/server/mod.rs
+++ b/crates/pumpkin/src/server/mod.rs
@@ -254,11 +254,18 @@ impl Server {
                 .collect::<Vec<_>>()
         );
 
+        let verify_plugin_signatures = advanced_config.plugins.verify_signatures;
+        if !verify_plugin_signatures {
+            warn!(
+                "Plugin signature verification is disabled. Only do this if you fully trust your plugins and their sources, because unsigned or tampered WASM plugins will be loaded without verification."
+            );
+        }
+
         let server = Self {
             basic_config,
             advanced_config,
             data: vanilla_data,
-            plugin_manager: Arc::new(PluginManager::new()),
+            plugin_manager: Arc::new(PluginManager::new(verify_plugin_signatures)),
             permission_manager,
             container_id: 0.into(),
             recipe_manager: Arc::new(recipe::RecipeManager::new()),


### PR DESCRIPTION
This PR adds a configuration option to disable plugin signature verification.

I want to optimise my startup times as much as possible, and currently the request takes a few seconds, and is done per plugin. I'm planning on only running proprietary plugins so I won't actually need/use plugin signature verification unless there will one day be an option to verify it against a self generated key.

On my M5 16GB running in Docker, with 2 proprietary WASM plugins, this makes about ~5 seconds difference.

If wanted I could open another PR after this to make sure the key gets cached instead of retrieved for each plugin.