### PR TITLE
Match mob targeting behavior

### DIFF
--- a/crates/pumpkin/src/entity/ai/goal/active_target.rs
+++ b/crates/pumpkin/src/entity/ai/goal/active_target.rs
@@ -18,7 +18,8 @@ pub struct ActiveTargetGoal {
     track_target_goal: TrackTargetGoal,
     target: Option<Arc<dyn EntityBase>>,
     reciprocal_chance: i32,
-    target_type: &'static EntityType,
+    target_type: Option<&'static EntityType>,
+    target_types: Option<&'static [&'static EntityType]>,
     target_predicate: TargetPredicate,
 }
 
@@ -60,7 +61,18 @@ impl ActiveTargetGoal {
         target_type: &'static EntityType,
         check_visibility: bool,
     ) -> Box<Self> {
+        Self::with_default_and_memory(mob, target_type, check_visibility, 60)
+    }
+
+    #[must_use]
+    pub fn with_default_and_memory(
+        mob: &MobEntity,
+        target_type: &'static EntityType,
+        check_visibility: bool,
+        unseen_memory_ticks: i32,
+    ) -> Box<Self> {
         let track_target_goal = TrackTargetGoal::with_default(check_visibility);
+        let track_target_goal = track_target_goal.set_unseen_memory_ticks(unseen_memory_ticks);
         let mut target_predicate = TargetPredicate::create_attackable();
         target_predicate.base_max_distance = mob
             .living_entity
@@ -70,7 +82,41 @@ impl ActiveTargetGoal {
             track_target_goal,
             target: None,
             reciprocal_chance: to_goal_ticks(DEFAULT_RECIPROCAL_CHANCE),
-            target_type,
+            target_type: Some(target_type),
+            target_types: None,
+            target_predicate,
+        })
+    }
+
+    #[must_use]
+    pub fn with_default_types(
+        mob: &MobEntity,
+        target_types: &'static [&'static EntityType],
+        check_visibility: bool,
+    ) -> Box<Self> {
+        Self::with_default_types_and_memory(mob, target_types, check_visibility, 60)
+    }
+
+    #[must_use]
+    pub fn with_default_types_and_memory(
+        mob: &MobEntity,
+        target_types: &'static [&'static EntityType],
+        check_visibility: bool,
+        unseen_memory_ticks: i32,
+    ) -> Box<Self> {
+        let track_target_goal = TrackTargetGoal::with_default(check_visibility);
+        let track_target_goal = track_target_goal.set_unseen_memory_ticks(unseen_memory_ticks);
+        let mut target_predicate = TargetPredicate::create_attackable();
+        target_predicate.base_max_distance = mob
+            .living_entity
+            .get_attribute_value(&Attributes::FOLLOW_RANGE);
+
+        Box::new(Self {
+            track_target_goal,
+            target: None,
+            reciprocal_chance: to_goal_ticks(DEFAULT_RECIPROCAL_CHANCE),
+            target_type: None,
+            target_types: Some(target_types),
             target_predicate,
         })
     }
@@ -93,7 +139,7 @@ impl ActiveTargetGoal {
         let mut search_pos = mob.living_entity.entity.pos.load();
         search_pos.y += mob.living_entity.entity.entity_dimension.load().eye_height as f64;
 
-        if self.target_type == &EntityType::PLAYER {
+        if self.target_type == Some(&EntityType::PLAYER) && self.target_types.is_none() {
             let potential_player = world
                 .get_closest_player(search_pos, follow_range)
                 .map(|p: Arc<Player>| p as Arc<dyn EntityBase>);
@@ -109,8 +155,10 @@ impl ActiveTargetGoal {
                 return;
             }
         } else {
-            let potential_entity =
-                world.get_closest_entity(search_pos, follow_range, Some(&[self.target_type]));
+            let target_types = self
+                .target_types
+                .or_else(|| self.target_type.map(std::slice::from_ref));
+            let potential_entity = world.get_closest_entity(search_pos, follow_range, target_types);
 
             if let Some(potential_entity) = potential_entity
                 && let Some(living) = potential_entity.get_living_entity()

--- a/crates/pumpkin/src/entity/ai/goal/active_target.rs
+++ b/crates/pumpkin/src/entity/ai/goal/active_target.rs
@@ -50,7 +50,8 @@ impl ActiveTargetGoal {
             track_target_goal,
             target: None,
             reciprocal_chance: to_goal_ticks(reciprocal_chance),
-            target_type,
+            target_type: Some(target_type),
+            target_types: None,
             target_predicate,
         }
     }
@@ -187,10 +188,13 @@ impl ActiveTargetGoal {
                 return;
             }
         } else {
-            let target_types = self
-                .target_types
-                .or_else(|| self.target_type.map(std::slice::from_ref));
-            let potential_entity = world.get_closest_entity(search_pos, follow_range, target_types);
+            let potential_entity = if let Some(target_types) = self.target_types {
+                world.get_closest_entity(search_pos, follow_range, Some(target_types))
+            } else if let Some(target_type) = self.target_type {
+                world.get_closest_entity(search_pos, follow_range, Some(&[target_type]))
+            } else {
+                None
+            };
 
             if let Some(potential_entity) = potential_entity
                 && let Some(living) = potential_entity.get_living_entity()

--- a/crates/pumpkin/src/entity/ai/goal/active_target.rs
+++ b/crates/pumpkin/src/entity/ai/goal/active_target.rs
@@ -55,6 +55,38 @@ impl ActiveTargetGoal {
         }
     }
 
+    pub fn new_types<F, Fut>(
+        mob: &MobEntity,
+        target_types: &'static [&'static EntityType],
+        reciprocal_chance: i32,
+        check_visibility: bool,
+        check_can_navigate: bool,
+        predicate: Option<F>,
+    ) -> Self
+    where
+        F: Fn(Arc<LivingEntity>, Arc<World>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = bool> + Send + 'static,
+    {
+        let track_target_goal = TrackTargetGoal::new(check_visibility, check_can_navigate);
+        let mut target_predicate = TargetPredicate::create_attackable();
+        target_predicate.base_max_distance = mob
+            .living_entity
+            .get_attribute_value(&Attributes::FOLLOW_RANGE);
+
+        if let Some(predicate) = predicate {
+            target_predicate.set_predicate(predicate);
+        }
+
+        Self {
+            track_target_goal,
+            target: None,
+            reciprocal_chance: to_goal_ticks(reciprocal_chance),
+            target_type: None,
+            target_types: Some(target_types),
+            target_predicate,
+        }
+    }
+
     #[must_use]
     pub fn with_default(
         mob: &MobEntity,

--- a/crates/pumpkin/src/entity/ai/goal/active_target.rs
+++ b/crates/pumpkin/src/entity/ai/goal/active_target.rs
@@ -172,32 +172,47 @@ impl ActiveTargetGoal {
         let mut search_pos = mob.living_entity.entity.pos.load();
         search_pos.y += mob.living_entity.entity.entity_dimension.load().eye_height as f64;
 
-        if self.target_type == Some(&EntityType::PLAYER) && self.target_types.is_none() {
-            let potential_player = world
-                .get_closest_player(search_pos, follow_range)
-                .map(|p: Arc<Player>| p as Arc<dyn EntityBase>);
-
-            if let Some(potential_entity) = potential_player
-                && let Some(living) = potential_entity.get_living_entity()
-                && self
-                    .target_predicate
-                    .test(&world, Some(&mob.living_entity), living)
-                    .await
-            {
-                self.target = Some(potential_entity);
-                return;
-            }
-        } else {
-            let potential_entity = if let Some(target_types) = self.target_types {
-                world.get_closest_entity(search_pos, follow_range, Some(target_types))
+        let mut candidates: Vec<Arc<dyn EntityBase>> =
+            if self.target_type == Some(&EntityType::PLAYER) && self.target_types.is_none() {
+                world
+                    .get_nearby_players(search_pos, follow_range)
+                    .into_iter()
+                    .map(|player: Arc<Player>| player as Arc<dyn EntityBase>)
+                    .collect()
+            } else if let Some(target_types) = self.target_types {
+                world
+                    .get_nearby_entities(search_pos, follow_range)
+                    .into_values()
+                    .filter(|entity| target_types.contains(&entity.get_entity().entity_type))
+                    .collect()
             } else if let Some(target_type) = self.target_type {
-                world.get_closest_entity(search_pos, follow_range, Some(&[target_type]))
+                world
+                    .get_nearby_entities(search_pos, follow_range)
+                    .into_values()
+                    .filter(|entity| entity.get_entity().entity_type == target_type)
+                    .collect()
             } else {
-                None
+                world
+                    .get_nearby_entities(search_pos, follow_range)
+                    .into_values()
+                    .collect()
             };
 
-            if let Some(potential_entity) = potential_entity
-                && let Some(living) = potential_entity.get_living_entity()
+        candidates.sort_by(|a, b| {
+            a.get_entity()
+                .pos
+                .load()
+                .squared_distance_to_vec(&search_pos)
+                .total_cmp(
+                    &b.get_entity()
+                        .pos
+                        .load()
+                        .squared_distance_to_vec(&search_pos),
+                )
+        });
+
+        for potential_entity in candidates {
+            if let Some(living) = potential_entity.get_living_entity()
                 && self
                     .target_predicate
                     .test(&world, Some(&mob.living_entity), living)

--- a/crates/pumpkin/src/entity/ai/goal/avoid_entity.rs
+++ b/crates/pumpkin/src/entity/ai/goal/avoid_entity.rs
@@ -46,7 +46,14 @@ impl AvoidEntityGoal {
 
         if self.flee_type == &EntityType::PLAYER {
             world
-                .get_closest_player(pos, self.flee_distance)
+                .get_closest_player_where(pos, self.flee_distance, |player| {
+                    player.living_entity.is_part_of_game()
+                        && !player.is_creative()
+                        && self
+                            .extra_predicate
+                            .as_ref()
+                            .is_none_or(|p| p(player as &dyn EntityBase))
+                })
                 .map(|p| p as Arc<dyn EntityBase>)
         } else {
             world.get_closest_entity(pos, self.flee_distance, Some(&[self.flee_type]))

--- a/crates/pumpkin/src/entity/ai/goal/avoid_entity.rs
+++ b/crates/pumpkin/src/entity/ai/goal/avoid_entity.rs
@@ -46,14 +46,8 @@ impl AvoidEntityGoal {
 
         if self.flee_type == &EntityType::PLAYER {
             world
-                .get_closest_player_where(pos, self.flee_distance, |player| {
-                    player.living_entity.is_part_of_game()
-                        && !player.is_creative()
-                        && self
-                            .extra_predicate
-                            .as_ref()
-                            .is_none_or(|p| p(player as &dyn EntityBase))
-                })
+                .get_closest_player(pos, self.flee_distance)
+                .filter(|player| player.living_entity.is_part_of_game() && !player.is_creative())
                 .map(|p| p as Arc<dyn EntityBase>)
         } else {
             world.get_closest_entity(pos, self.flee_distance, Some(&[self.flee_type]))

--- a/crates/pumpkin/src/entity/ai/goal/avoid_entity.rs
+++ b/crates/pumpkin/src/entity/ai/goal/avoid_entity.rs
@@ -46,8 +46,16 @@ impl AvoidEntityGoal {
 
         if self.flee_type == &EntityType::PLAYER {
             world
-                .get_closest_player(pos, self.flee_distance)
+                .get_nearby_players(pos, self.flee_distance)
+                .into_iter()
                 .filter(|player| player.living_entity.is_part_of_game() && !player.is_creative())
+                .min_by(|a, b| {
+                    a.get_entity()
+                        .pos
+                        .load()
+                        .squared_distance_to_vec(&pos)
+                        .total_cmp(&b.get_entity().pos.load().squared_distance_to_vec(&pos))
+                })
                 .map(|p| p as Arc<dyn EntityBase>)
         } else {
             world.get_closest_entity(pos, self.flee_distance, Some(&[self.flee_type]))

--- a/crates/pumpkin/src/entity/ai/goal/track_target.rs
+++ b/crates/pumpkin/src/entity/ai/goal/track_target.rs
@@ -22,7 +22,6 @@ pub struct TrackTargetGoal {
     target_predicate: TargetPredicate,
 }
 
-#[expect(dead_code)]
 impl TrackTargetGoal {
     #[must_use]
     pub fn new(check_visibility: bool, check_can_navigate: bool) -> Self {

--- a/crates/pumpkin/src/entity/ai/goal/wander_around.rs
+++ b/crates/pumpkin/src/entity/ai/goal/wander_around.rs
@@ -40,6 +40,10 @@ impl WanderAroundGoal {
 impl Goal for WanderAroundGoal {
     fn can_start<'a>(&'a mut self, mob: &'a dyn Mob) -> GoalFuture<'a, bool> {
         Box::pin(async move {
+            if mob.get_mob_entity().is_schooling_follower() {
+                return false;
+            }
+
             if mob.get_random().random_range(0..self.chance) != 0 {
                 return false;
             }

--- a/crates/pumpkin/src/entity/mob/evoker.rs
+++ b/crates/pumpkin/src/entity/mob/evoker.rs
@@ -14,8 +14,7 @@ use pumpkin_util::math::vector3::Vector3;
 use crate::entity::{
     Entity, EntityBase, EntityBaseFuture, NBTStorage, NbtFuture,
     ai::goal::{
-        Controls, Goal, GoalFuture, active_target::ActiveTargetGoal,
-        avoid_entity::AvoidEntityGoal,
+        Controls, Goal, GoalFuture, active_target::ActiveTargetGoal, avoid_entity::AvoidEntityGoal,
         look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal, swim::SwimGoal,
         wander_around::WanderAroundGoal,
     },

--- a/crates/pumpkin/src/entity/mob/evoker.rs
+++ b/crates/pumpkin/src/entity/mob/evoker.rs
@@ -15,6 +15,7 @@ use crate::entity::{
     Entity, EntityBase, EntityBaseFuture, NBTStorage, NbtFuture,
     ai::goal::{
         Controls, Goal, GoalFuture, active_target::ActiveTargetGoal,
+        avoid_entity::AvoidEntityGoal,
         look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal, swim::SwimGoal,
         wander_around::WanderAroundGoal,
     },
@@ -80,6 +81,14 @@ impl EvokerEntity {
 
             goal_selector.add_goal(0, Box::new(SwimGoal::default()));
             goal_selector.add_goal(1, Box::new(EvokerCastingSpellGoal::new(mob_weak.clone())));
+            goal_selector.add_goal(
+                2,
+                Box::new(AvoidEntityGoal::new(&EntityType::PLAYER, 8.0, 0.6, 1.0)),
+            );
+            goal_selector.add_goal(
+                3,
+                Box::new(AvoidEntityGoal::new(&EntityType::CREAKING, 8.0, 0.6, 1.0)),
+            );
             goal_selector.add_goal(4, Box::new(EvokerSummonSpellGoal::new(mob_weak.clone())));
             goal_selector.add_goal(5, Box::new(EvokerAttackSpellGoal::new(mob_weak.clone())));
             goal_selector.add_goal(6, Box::new(EvokerWololoSpellGoal::new(mob_weak)));

--- a/crates/pumpkin/src/entity/mob/evoker.rs
+++ b/crates/pumpkin/src/entity/mob/evoker.rs
@@ -105,16 +105,26 @@ impl EvokerEntity {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             target_selector.add_goal(
-                1,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::PLAYER, true),
-            );
-            target_selector.add_goal(
                 2,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::VILLAGER, true),
+                ActiveTargetGoal::with_default_and_memory(
+                    &mob_arc.mob_entity,
+                    &EntityType::PLAYER,
+                    true,
+                    300,
+                ),
             );
             target_selector.add_goal(
                 3,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::IRON_GOLEM, true),
+                ActiveTargetGoal::with_default_types_and_memory(
+                    &mob_arc.mob_entity,
+                    &[&EntityType::VILLAGER, &EntityType::WANDERING_TRADER],
+                    false,
+                    300,
+                ),
+            );
+            target_selector.add_goal(
+                3,
+                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::IRON_GOLEM, false),
             );
         };
 

--- a/crates/pumpkin/src/entity/mob/guardian.rs
+++ b/crates/pumpkin/src/entity/mob/guardian.rs
@@ -24,6 +24,7 @@ impl GuardianEntity {
             let mob_arc: Arc<dyn Mob> = mob_arc.clone();
             Arc::downgrade(&mob_arc)
         };
+        let target_weak = mob_weak.clone();
 
         {
             let mut goal_selector = mob_arc
@@ -47,19 +48,35 @@ impl GuardianEntity {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             target_selector.add_goal(
                 1,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::PLAYER, true),
-            );
-            target_selector.add_goal(
-                2,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::SQUID, true),
-            );
-            target_selector.add_goal(
-                2,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::GLOW_SQUID, true),
-            );
-            target_selector.add_goal(
-                3,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::AXOLOTL, true),
+                Box::new(ActiveTargetGoal::new_types(
+                    &mob_arc.mob_entity,
+                    &[
+                        &EntityType::PLAYER,
+                        &EntityType::SQUID,
+                        &EntityType::GLOW_SQUID,
+                        &EntityType::AXOLOTL,
+                    ],
+                    10,
+                    true,
+                    false,
+                    Some(
+                        move |target: Arc<crate::entity::living::LivingEntity>,
+                              _world: Arc<crate::world::World>| {
+                            let target_weak = target_weak.clone();
+                            async move {
+                                let Some(guardian) = target_weak.upgrade() else {
+                                    return false;
+                                };
+                                guardian
+                                    .get_entity()
+                                    .pos
+                                    .load()
+                                    .squared_distance_to_vec(&target.entity.pos.load())
+                                    > 9.0
+                            }
+                        },
+                    ),
+                )),
             );
         };
 

--- a/crates/pumpkin/src/entity/mob/mod.rs
+++ b/crates/pumpkin/src/entity/mob/mod.rs
@@ -26,7 +26,7 @@ use rand::RngExt;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::atomic::{AtomicI32, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU8, Ordering};
 use uuid::Uuid;
 
 pub mod bat;

--- a/crates/pumpkin/src/entity/mob/mod.rs
+++ b/crates/pumpkin/src/entity/mob/mod.rs
@@ -76,6 +76,13 @@ pub struct MobEntity {
     pub position_target_range: AtomicI32,
     pub love_ticks: AtomicI32,
     pub breeding_cooldown: AtomicI32,
+    /// Vanilla `AbstractSchoolingFish.leader != null && leader.isAlive()` state.
+    /// Only schooling-fish goals mutate this flag; other mobs leave it false.
+    pub schooling_follower: AtomicBool,
+    /// Vanilla `Mob.noActionTime`, used by the random despawn check.
+    pub no_action_time: AtomicI32,
+    /// Vanilla `Entity.tickCount`, used by species-specific despawn rules.
+    pub tick_count: AtomicI32,
     pub breeder: AtomicCell<Option<Uuid>>,
     mob_flags: AtomicU8,
     last_sent_yaw: AtomicU8,
@@ -113,6 +120,9 @@ impl MobEntity {
             position_target_range: AtomicI32::new(-1),
             love_ticks: AtomicI32::new(0),
             breeding_cooldown: AtomicI32::new(0),
+            schooling_follower: AtomicBool::new(false),
+            no_action_time: AtomicI32::new(0),
+            tick_count: AtomicI32::new(0),
             breeder: AtomicCell::new(None),
             mob_flags: AtomicU8::new(0),
             last_sent_yaw: AtomicU8::new(0),
@@ -235,6 +245,14 @@ impl MobEntity {
 
     pub fn is_in_love(&self) -> bool {
         self.love_ticks.load(Relaxed) > 0
+    }
+
+    pub fn is_schooling_follower(&self) -> bool {
+        self.schooling_follower.load(Relaxed)
+    }
+
+    pub fn set_schooling_follower(&self, value: bool) {
+        self.schooling_follower.store(value, Relaxed);
     }
 
     pub fn set_love_ticks(&self, ticks: i32, breeder: Option<Uuid>) {

--- a/crates/pumpkin/src/entity/mob/pillager.rs
+++ b/crates/pumpkin/src/entity/mob/pillager.rs
@@ -49,12 +49,16 @@ impl PillagerEntity {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             target_selector.add_goal(
-                1,
+                2,
                 ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::PLAYER, true),
             );
             target_selector.add_goal(
-                2,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::VILLAGER, true),
+                3,
+                ActiveTargetGoal::with_default_types(
+                    &mob_arc.mob_entity,
+                    &[&EntityType::VILLAGER, &EntityType::WANDERING_TRADER],
+                    false,
+                ),
             );
             target_selector.add_goal(
                 3,

--- a/crates/pumpkin/src/entity/mob/ravager.rs
+++ b/crates/pumpkin/src/entity/mob/ravager.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, Weak, atomic::Ordering};
 
 use pumpkin_data::entity::EntityType;
 
@@ -7,7 +7,7 @@ use crate::entity::{
     ai::goal::{
         active_target::ActiveTargetGoal, look_around::RandomLookAroundGoal,
         look_at_entity::LookAtEntityGoal, melee_attack::MeleeAttackGoal, swim::SwimGoal,
-        wander_around::WanderAroundGoal,
+        revenge::RevengeGoal, wander_around::WanderAroundGoal,
     },
     mob::{Mob, MobEntity},
 };
@@ -53,10 +53,30 @@ impl RavagerEntity {
             );
             target_selector.add_goal(
                 2,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::VILLAGER, true),
+                Box::new(RevengeGoal::new(true)),
             );
             target_selector.add_goal(
                 3,
+                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::PLAYER, true),
+            );
+            target_selector.add_goal(
+                4,
+                Box::new(ActiveTargetGoal::new_types(
+                    &mob_arc.mob_entity,
+                    &[&EntityType::VILLAGER, &EntityType::WANDERING_TRADER],
+                    10,
+                    true,
+                    false,
+                    Some(
+                        |target: Arc<crate::entity::living::LivingEntity>,
+                         _world: Arc<crate::world::World>| async move {
+                            target.entity.age.load(Ordering::Relaxed) >= 0
+                        },
+                    ),
+                )),
+            );
+            target_selector.add_goal(
+                4,
                 ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::IRON_GOLEM, true),
             );
         };

--- a/crates/pumpkin/src/entity/mob/ravager.rs
+++ b/crates/pumpkin/src/entity/mob/ravager.rs
@@ -6,8 +6,8 @@ use crate::entity::{
     Entity, NBTStorage,
     ai::goal::{
         active_target::ActiveTargetGoal, look_around::RandomLookAroundGoal,
-        look_at_entity::LookAtEntityGoal, melee_attack::MeleeAttackGoal, swim::SwimGoal,
-        revenge::RevengeGoal, wander_around::WanderAroundGoal,
+        look_at_entity::LookAtEntityGoal, melee_attack::MeleeAttackGoal, revenge::RevengeGoal,
+        swim::SwimGoal, wander_around::WanderAroundGoal,
     },
     mob::{Mob, MobEntity},
 };
@@ -51,10 +51,7 @@ impl RavagerEntity {
                 1,
                 ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::PLAYER, true),
             );
-            target_selector.add_goal(
-                2,
-                Box::new(RevengeGoal::new(true)),
-            );
+            target_selector.add_goal(2, Box::new(RevengeGoal::new(true)));
             target_selector.add_goal(
                 3,
                 ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::PLAYER, true),

--- a/crates/pumpkin/src/entity/mob/ravager.rs
+++ b/crates/pumpkin/src/entity/mob/ravager.rs
@@ -6,8 +6,8 @@ use crate::entity::{
     Entity, NBTStorage,
     ai::goal::{
         active_target::ActiveTargetGoal, look_around::RandomLookAroundGoal,
-        look_at_entity::LookAtEntityGoal, melee_attack::MeleeAttackGoal, revenge::RevengeGoal,
-        swim::SwimGoal, wander_around::WanderAroundGoal,
+        look_at_entity::LookAtEntityGoal, melee_attack::MeleeAttackGoal, swim::SwimGoal,
+        wander_around::WanderAroundGoal,
     },
     mob::{Mob, MobEntity},
 };
@@ -47,11 +47,6 @@ impl RavagerEntity {
                 .target_selector
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            target_selector.add_goal(
-                1,
-                ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::PLAYER, true),
-            );
-            target_selector.add_goal(2, Box::new(RevengeGoal::new(true)));
             target_selector.add_goal(
                 3,
                 ActiveTargetGoal::with_default(&mob_arc.mob_entity, &EntityType::PLAYER, true),


### PR DESCRIPTION
Ports a focused set of vanilla mob AI fixes for Evoker, Ravager, Pillager, Guardian, fish, and creative-player avoidance. It also keeps target selection on the nearest valid entity instead of stopping at the nearest invalid one. Checked with cargo fmt, cargo check -p pumpkin --lib, and git diff --check.