### PR TITLE
Fix persistent mobs counting toward spawn caps

### DIFF
--- a/crates/pumpkin/src/entity/mob/mod.rs
+++ b/crates/pumpkin/src/entity/mob/mod.rs
@@ -496,6 +496,23 @@ pub trait Mob: EntityBase + Send + Sync {
 
     fn get_mob_entity(&self) -> &MobEntity;
 
+    /// Vanilla `Mob.setPersistenceRequired`.
+    fn set_persistence_required(&self) {
+        self.get_entity().persistence_required.store(true, Relaxed);
+    }
+
+    /// Vanilla `Mob.isPersistenceRequired`.
+    fn is_persistence_required(&self) -> bool {
+        self.get_entity().persistence_required.load(Relaxed)
+    }
+
+    /// Vanilla `Mob.requiresCustomPersistence` for passengers and leashes.
+    fn requires_custom_persistence_cached(&self) -> bool {
+        let entity = self.get_entity();
+        entity.vehicle_persistence_required.load(Relaxed)
+            || entity.leash_persistence_required.load(Relaxed)
+    }
+
     fn get_job_site(&self) -> Option<BlockPos> {
         None
     }

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -848,6 +848,13 @@ pub struct Entity {
     pub vehicle: Mutex<Option<Arc<dyn EntityBase>>>,
     /// The entity this entity is attached/leashed to (if any)
     pub leashed_to: Mutex<Option<Arc<dyn EntityBase>>>,
+    /// Vanilla `Mob.persistenceRequired`, shared by all mob implementations.
+    pub persistence_required: AtomicBool,
+    /// Cached vanilla `Mob.requiresCustomPersistence` state for vehicle and
+    /// leash relationships. The sources stay separate so one ending cannot
+    /// clear the other.
+    pub vehicle_persistence_required: AtomicBool,
+    pub leash_persistence_required: AtomicBool,
     /// Cooldown before entity can mount again after dismounting
     pub riding_cooldown: AtomicI32,
     /// The age of the entity in ticks. Negative values indicate a baby.
@@ -994,6 +1001,9 @@ impl Entity {
             passengers: Mutex::new(Vec::new()),
             vehicle: Mutex::new(None),
             leashed_to: Mutex::new(None),
+            persistence_required: AtomicBool::new(false),
+            vehicle_persistence_required: AtomicBool::new(false),
+            leash_persistence_required: AtomicBool::new(false),
 
             riding_cooldown: AtomicI32::new(0),
             age: AtomicI32::new(0),
@@ -3190,6 +3200,7 @@ impl Entity {
     pub async fn leash_to(&self, holder: Arc<dyn EntityBase>) {
         let holder_entity = holder.get_entity();
         *self.leashed_to.lock().await = Some(holder.clone());
+        self.leash_persistence_required.store(true, Relaxed);
 
         let je_packet = pumpkin_protocol::java::client::play::CSetEntityLink::new(
             self.entity_id,
@@ -3215,11 +3226,12 @@ impl Entity {
         );
     }
 
-    pub async fn unleash(&self) {
+    pub async fn unleash(&self) -> bool {
         let old_holder = self.leashed_to.lock().await.take();
         if old_holder.is_none() {
-            return;
+            return false;
         }
+        self.leash_persistence_required.store(false, Relaxed);
 
         let je_packet =
             pumpkin_protocol::java::client::play::CSetEntityLink::new(self.entity_id, -1);
@@ -3239,13 +3251,49 @@ impl Entity {
             &je_packet,
             &be_packet,
         );
+        true
+    }
+
+    pub async fn unleash_if_holder(&self, holder_uuid: Uuid) -> bool {
+        let removed = {
+            let mut leash = self.leashed_to.lock().await;
+            if leash
+                .as_ref()
+                .is_some_and(|holder| holder.get_entity().entity_uuid == holder_uuid)
+            {
+                leash.take();
+                self.leash_persistence_required.store(false, Relaxed);
+                true
+            } else {
+                false
+            }
+        };
+        if !removed {
+            return false;
+        }
+
+        let je_packet =
+            pumpkin_protocol::java::client::play::CSetEntityLink::new(self.entity_id, -1);
+        let be_packet = pumpkin_protocol::bedrock::client::CSetActorLink {
+            link: pumpkin_protocol::bedrock::client::common::EntityLink {
+                ridden_unique_id: pumpkin_protocol::codec::var_long::VarLong(self.entity_id as i64),
+                rider_unique_id: pumpkin_protocol::codec::var_long::VarLong(-1),
+                link_type: 0,
+                immediate: true,
+                rider_initiated: false,
+                vehicle_angular_velocity: 0.0,
+            },
+        };
+        self.world.load().broadcast_to_chunk_editioned_sync(
+            self.chunk_pos.load(),
+            &je_packet,
+            &be_packet,
+        );
+        true
     }
 
     pub async fn tick_leash(&self) {
-        let holder = {
-            let guard = self.leashed_to.lock().await;
-            guard.clone()
-        };
+        let holder = self.leashed_to.lock().await.clone();
 
         if let Some(holder) = holder {
             let holder_entity = holder.get_entity();
@@ -3263,13 +3311,18 @@ impl Entity {
 
             if distance > Self::LEASH_SNAP_DISTANCE {
                 // Too far: snap/break leash and drop lead item
-                self.unleash().await;
-                let lead_item =
-                    pumpkin_data::item_stack::ItemStack::new(1, &pumpkin_data::item::Item::LEAD);
-                self.world
-                    .load()
-                    .drop_stack(&self.block_pos.load(), lead_item)
-                    .await;
+                if self.unleash_if_holder(holder_entity.entity_uuid).await
+                    && self.world.load().level_info.load().game_rules.entity_drops
+                {
+                    let lead_item = pumpkin_data::item_stack::ItemStack::new(
+                        1,
+                        &pumpkin_data::item::Item::LEAD,
+                    );
+                    self.world
+                        .load()
+                        .drop_stack(&self.block_pos.load(), lead_item)
+                        .await;
+                }
             } else if distance > Self::LEASH_ELASTIC_DISTANCE {
                 // Elastic pull force towards leash holder
                 let dir = (holder_pos - self_pos).normalize();
@@ -3322,10 +3375,23 @@ impl Entity {
         }
 
         let passenger_entity = passenger.get_entity();
-        *passenger_entity.vehicle.lock().await = Some(vehicle);
+        passenger_entity
+            .vehicle_persistence_required
+            .store(true, Relaxed);
+        let previous_vehicle = passenger_entity.vehicle.lock().await.replace(vehicle);
+        if let Some(previous_vehicle) = previous_vehicle {
+            let mut previous_passengers = previous_vehicle.get_entity().passengers.lock().await;
+            previous_passengers
+                .retain(|entry| entry.get_entity().entity_uuid != passenger_entity.entity_uuid);
+        }
 
         let mut passengers = self.passengers.lock().await;
-        passengers.push(passenger);
+        if !passengers
+            .iter()
+            .any(|entry| entry.get_entity().entity_uuid == passenger_entity.entity_uuid)
+        {
+            passengers.push(passenger);
+        }
 
         let passenger_ids: Vec<VarInt> = passengers
             .iter()
@@ -3347,7 +3413,11 @@ impl Entity {
             .position(|passenger| passenger.get_entity().entity_id == passenger_id)
         {
             let passenger = passengers.remove(index);
-            *passenger.get_entity().vehicle.lock().await = None;
+            let passenger_entity = passenger.get_entity();
+            *passenger_entity.vehicle.lock().await = None;
+            passenger_entity
+                .vehicle_persistence_required
+                .store(false, Relaxed);
         }
 
         let passenger_ids: Vec<VarInt> = passengers
@@ -3391,7 +3461,11 @@ impl Entity {
             .position(|p| p.get_entity().entity_id == passenger_id)
         {
             let passenger = passengers.remove(idx);
-            *passenger.get_entity().vehicle.lock().await = None;
+            let passenger_entity = passenger.get_entity();
+            *passenger_entity.vehicle.lock().await = None;
+            passenger_entity
+                .vehicle_persistence_required
+                .store(false, Relaxed);
             Some(passenger)
         } else {
             None
@@ -3710,6 +3784,12 @@ impl NBTStorage for Entity {
                 "id",
                 format!("minecraft:{}", self.entity_type.resource_name),
             );
+            if self.entity_type.mob {
+                nbt.put_bool(
+                    "PersistenceRequired",
+                    self.persistence_required.load(Relaxed),
+                );
+            }
             nbt.put_uuid("UUID", self.entity_uuid);
             nbt.put(
                 "Pos",
@@ -3802,6 +3882,12 @@ impl NBTStorage for Entity {
                 .store(nbt.get_bool("OnGround").unwrap_or(false), Relaxed);
             self.invulnerable
                 .store(nbt.get_bool("Invulnerable").unwrap_or(false), Relaxed);
+            if self.entity_type.mob {
+                self.persistence_required.store(
+                    nbt.get_bool("PersistenceRequired").unwrap_or(false),
+                    Relaxed,
+                );
+            }
             self.portal_cooldown
                 .store(nbt.get_int("PortalCooldown").unwrap_or(0) as u32, Relaxed);
             self.has_visual_fire

--- a/crates/pumpkin/src/item/items/name_tag.rs
+++ b/crates/pumpkin/src/item/items/name_tag.rs
@@ -28,8 +28,10 @@ impl ItemBehaviour for NameTagItem {
             if entity.entity_type.saveable
                 && let Some(name) = item.get_data_component::<CustomNameImpl>()
             {
-                // TODO
                 entity.set_custom_name(name.name.clone());
+                if let Some(mob) = entity.get_mob() {
+                    mob.set_persistence_required();
+                }
                 item.decrement_unless_creative(player.gamemode.load(), 1);
             }
         })

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -4490,17 +4490,16 @@ impl World {
             if other_entity.entity_uuid == holder_uuid {
                 continue;
             }
-            if other_entity.unleash_if_holder(holder_uuid).await {
-                if !other_entity.is_removed()
-                    && self
-                        .entities
-                        .load()
-                        .iter()
-                        .any(|entity| entity.get_entity().entity_uuid == other_entity.entity_uuid)
-                {
-                    self.spawn_state.load().remove_entity(self, other.as_ref());
-                    self.spawn_state.load().add_entity(self, other.as_ref());
-                }
+            if other_entity.unleash_if_holder(holder_uuid).await
+                && !other_entity.is_removed()
+                && self
+                    .entities
+                    .load()
+                    .iter()
+                    .any(|entity| entity.get_entity().entity_uuid == other_entity.entity_uuid)
+            {
+                self.spawn_state.load().remove_entity(self, other.as_ref());
+                self.spawn_state.load().add_entity(self, other.as_ref());
             }
         }
     }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1922,7 +1922,9 @@ impl World {
             is_thundering,
         );
         for entity in entities {
-            self.spawn_entity(entity).await;
+            if !self.spawn_entity(entity.clone()).await {
+                spawn_state.remove_entity(self, entity.as_ref());
+            }
         }
     }
 
@@ -4430,6 +4432,8 @@ impl World {
             let uuid = player.gameprofile.id;
             let entity_id = player.entity_id();
 
+            self.clear_leashes_to(uuid).await;
+
             let bedrock_remove_player = CPlayerList {
                 action: CPlayerList::ACTION_REMOVE,
                 entries: vec![PlayerListEntry {
@@ -4480,6 +4484,27 @@ impl World {
         removed_player
     }
 
+    async fn clear_leashes_to(&self, holder_uuid: Uuid) {
+        for other in self.entities.load().iter() {
+            let other_entity = other.get_entity();
+            if other_entity.entity_uuid == holder_uuid {
+                continue;
+            }
+            if other_entity.unleash_if_holder(holder_uuid).await {
+                if !other_entity.is_removed()
+                    && self
+                        .entities
+                        .load()
+                        .iter()
+                        .any(|entity| entity.get_entity().entity_uuid == other_entity.entity_uuid)
+                {
+                    self.spawn_state.load().remove_entity(self, other.as_ref());
+                    self.spawn_state.load().add_entity(self, other.as_ref());
+                }
+            }
+        }
+    }
+
     pub fn spawn_entity_non_save(&self, entity: &Arc<dyn EntityBase>) {
         let _base_entity = entity.get_entity();
         self.broadcast_entity_spawn(entity);
@@ -4492,7 +4517,7 @@ impl World {
         });
     }
 
-    pub async fn spawn_entity(self: &Arc<Self>, entity: Arc<dyn EntityBase>) {
+    pub async fn spawn_entity(self: &Arc<Self>, entity: Arc<dyn EntityBase>) -> bool {
         let mut event = crate::plugin::api::events::entity::entity_spawn::EntitySpawnEvent::new(
             entity.get_entity().entity_id,
             entity.get_entity().entity_type.id.to_string(),
@@ -4503,12 +4528,12 @@ impl World {
             server.plugin_manager.fire(&server, &mut event).await;
         }
         if event.cancelled {
-            return;
+            return false;
         }
 
         self.broadcast_entity_spawn(&entity);
         entity.init_data_tracker().await;
-        self.add_entity_silent(entity).await;
+        self.add_entity_silent(entity).await
     }
 
     pub fn broadcast_entity_spawn(&self, entity: &Arc<dyn EntityBase>) {
@@ -4527,7 +4552,7 @@ impl World {
     }
 
     #[allow(clippy::unused_async)]
-    pub async fn add_entity_silent(&self, entity: Arc<dyn EntityBase>) {
+    pub async fn add_entity_silent(&self, entity: Arc<dyn EntityBase>) -> bool {
         let base_entity = entity.get_entity();
 
         // Guard against duplicate entities with the same UUID.
@@ -4539,7 +4564,7 @@ impl World {
             .iter()
             .any(|e| e.get_entity().entity_uuid == base_entity.entity_uuid);
         if already_exists {
-            return;
+            return false;
         }
 
         // The entity stays live-only: it is written to its chunk's saved data on
@@ -4552,6 +4577,7 @@ impl World {
             new_entities.push(entity.clone());
             new_entities
         });
+        true
     }
 
     #[allow(clippy::unused_async)]
@@ -4565,6 +4591,35 @@ impl World {
             return;
         }
         base_entity.removed.store(true, Ordering::Release);
+
+        // Detach relationships before removing the entity. Vanilla does not
+        // leave passengers or leashes pointing at a discarded entity.
+        let vehicle = base_entity.vehicle.lock().await.take();
+        if let Some(vehicle) = vehicle {
+            let mut passengers = vehicle.get_entity().passengers.lock().await;
+            passengers
+                .retain(|passenger| passenger.get_entity().entity_uuid != base_entity.entity_uuid);
+            base_entity
+                .vehicle_persistence_required
+                .store(false, Relaxed);
+        }
+        self.clear_leashes_to(base_entity.entity_uuid).await;
+        let passengers = base_entity
+            .passengers
+            .lock()
+            .await
+            .drain(..)
+            .collect::<Vec<_>>();
+        for passenger in passengers {
+            let passenger_entity = passenger.get_entity();
+            *passenger_entity.vehicle.lock().await = None;
+            passenger_entity
+                .vehicle_persistence_required
+                .store(false, Relaxed);
+        }
+        if base_entity.leashed_to.lock().await.take().is_some() {
+            base_entity.leash_persistence_required.store(false, Relaxed);
+        }
 
         self.spawn_state.load().remove_entity(self, entity);
         self.entities.rcu(|current_entities| {
@@ -4589,26 +4644,17 @@ impl World {
         if chunks_set.is_empty() {
             return;
         }
-        let mut entities_to_remove = Vec::new();
-
-        self.entities.rcu(|current_entities| {
-            let mut new_entities = (**current_entities).clone();
-            new_entities.retain(|entity| {
-                let base_entity = entity.get_entity();
-                let pos = base_entity.chunk_pos.load();
-                if chunks_set.contains(&pos) {
-                    entities_to_remove.push(entity.clone());
-                    false
-                } else {
-                    true
-                }
-            });
-            new_entities
-        });
+        let entities_to_remove: Vec<_> = self
+            .entities
+            .load()
+            .iter()
+            .filter(|entity| chunks_set.contains(&entity.get_entity().chunk_pos.load()))
+            .cloned()
+            .collect();
 
         for entity in entities_to_remove {
             self.save_entity(&entity).await;
-            self.spawn_state.load().remove_entity(self, entity.as_ref());
+            self.remove_entity(entity.as_ref()).await;
         }
 
         for chunk_pos in &chunks_set {

--- a/crates/pumpkin/src/world/natural_spawner.rs
+++ b/crates/pumpkin/src/world/natural_spawner.rs
@@ -286,6 +286,7 @@ impl fmt::Debug for SpawnState {
             .field("mob_category_counts", &self.mob_category_counts)
             .field("spawn_potential", &self.spawn_potential)
             .field("local_mob_cap_calculator", &self.local_mob_cap_calculator)
+            .field("counted_entities", &self.counted_entities)
             .field("last_checked", &self.last_checked)
             .finish()
     }
@@ -344,10 +345,10 @@ impl SpawnState {
 
     pub fn remove_entity(&self, world: &World, entity: &dyn EntityBase) {
         let base_entity = entity.get_entity();
-        if !self
+        if self
             .counted_entities
             .remove(&base_entity.entity_uuid)
-            .is_some()
+            .is_none()
         {
             return;
         }

--- a/crates/pumpkin/src/world/natural_spawner.rs
+++ b/crates/pumpkin/src/world/natural_spawner.rs
@@ -28,7 +28,20 @@ use uuid::Uuid;
 
 const MAGIC_NUMBER: i32 = 17 * 17;
 
-use dashmap::DashMap;
+fn counts_for_spawn_caps(entity: &dyn EntityBase) -> bool {
+    let base_entity = entity.get_entity();
+    if base_entity.entity_type.category == &MobCategory::MISC {
+        return false;
+    }
+
+    let Some(mob) = entity.get_mob() else {
+        return true;
+    };
+
+    !mob.is_persistence_required() && !mob.requires_custom_persistence_cached()
+}
+
+use dashmap::{DashMap, DashSet};
 use std::sync::atomic::{AtomicI32, Ordering::Relaxed};
 
 pub struct MobCounts([AtomicI32; 8]);
@@ -248,6 +261,7 @@ pub struct SpawnState {
     pub mob_category_counts: MobCounts,
     spawn_potential: PotentialCalculator,
     local_mob_cap_calculator: LocalMobCapCalculator,
+    counted_entities: DashSet<Uuid>,
     // unmodifiable_mob_category_counts: MobCounts, seems only for debug
     last_checked: AtomicCell<Option<(BlockPos, &'static EntityType, f64)>>,
 }
@@ -259,6 +273,7 @@ impl Clone for SpawnState {
             mob_category_counts: self.mob_category_counts.clone(),
             spawn_potential: self.spawn_potential.clone(),
             local_mob_cap_calculator: self.local_mob_cap_calculator.clone(),
+            counted_entities: self.counted_entities.clone(),
             last_checked: AtomicCell::new(self.last_checked.load()),
         }
     }
@@ -284,6 +299,7 @@ impl SpawnState {
             mob_category_counts: MobCounts::default(),
             spawn_potential: PotentialCalculator::default(),
             local_mob_cap_calculator: LocalMobCapCalculator::default(),
+            counted_entities: DashSet::new(),
             last_checked: AtomicCell::new(None),
         }
     }
@@ -293,11 +309,24 @@ impl SpawnState {
     }
 
     pub fn add_entity(&self, world: &World, entity: &dyn EntityBase) {
-        let base_entity = entity.get_entity();
-        let entity_type = base_entity.entity_type;
-        if !entity_type.mob || entity_type.category == &MobCategory::MISC {
+        if entity.get_entity().is_removed() {
             return;
         }
+        if !counts_for_spawn_caps(entity) {
+            return;
+        }
+        let base_entity = entity.get_entity();
+        if !world
+            .active_chunks
+            .load()
+            .contains(&base_entity.chunk_pos.load())
+        {
+            return;
+        }
+        if !self.counted_entities.insert(base_entity.entity_uuid) {
+            return;
+        }
+        let entity_type = base_entity.entity_type;
         let entity_pos = base_entity.block_pos.load();
         let biome = base_entity.current_biome.load();
         if let Some(cost) = biome.spawn_costs.get(entity_type.resource_name) {
@@ -309,16 +338,20 @@ impl SpawnState {
                 world,
                 entity_type.category,
             );
-            self.mob_category_counts.add(entity_type.category);
         }
+        self.mob_category_counts.add(entity_type.category);
     }
 
     pub fn remove_entity(&self, world: &World, entity: &dyn EntityBase) {
         let base_entity = entity.get_entity();
-        let entity_type = base_entity.entity_type;
-        if !entity_type.mob || entity_type.category == &MobCategory::MISC {
+        if !self
+            .counted_entities
+            .remove(&base_entity.entity_uuid)
+            .is_some()
+        {
             return;
         }
+        let entity_type = base_entity.entity_type;
         let entity_pos = base_entity.block_pos.load();
         let biome = base_entity.current_biome.load();
         if let Some(cost) = biome.spawn_costs.get(entity_type.resource_name) {
@@ -330,8 +363,8 @@ impl SpawnState {
                 world,
                 entity_type.category,
             );
-            self.mob_category_counts.remove(entity_type.category);
         }
+        self.mob_category_counts.remove(entity_type.category);
     }
 
     pub fn new(
@@ -342,18 +375,19 @@ impl SpawnState {
         let potential = PotentialCalculator::default();
         let local_mob_cap = LocalMobCapCalculator::default();
         let counter = MobCounts::default();
+        let counted_entities = DashSet::new();
         let active_chunks = world.active_chunks.load();
         for entity in entities.load().iter() {
-            let entity = entity.get_entity();
-            let entity_type = entity.entity_type;
-            if !entity_type.mob || entity_type.category == &MobCategory::MISC {
-                // TODO (mob.isPersistenceRequired() || mob.requiresCustomPersistence())
+            if !counts_for_spawn_caps(entity.as_ref()) {
                 continue;
             }
+            let entity = entity.get_entity();
+            let entity_type = entity.entity_type;
             let chunk_pos = entity.chunk_pos.load();
             if !active_chunks.contains(&chunk_pos) {
                 continue;
             }
+            counted_entities.insert(entity.entity_uuid);
             let entity_pos = entity.block_pos.load();
             let biome = entity.current_biome.load();
             if let Some(cost) = biome.spawn_costs.get(entity_type.resource_name) {
@@ -369,6 +403,7 @@ impl SpawnState {
             mob_category_counts: counter,
             spawn_potential: potential,
             local_mob_cap_calculator: local_mob_cap,
+            counted_entities,
             last_checked: AtomicCell::new(None),
         }
     }
@@ -415,6 +450,7 @@ impl SpawnState {
         &self,
         entity_type: &'static EntityType,
         pos: &BlockPos,
+        entity_uuid: Uuid,
         world: &Arc<World>,
     ) {
         let charge = if let Some((l_pos, l_type, l_charge)) = self.last_checked.load()
@@ -435,6 +471,9 @@ impl SpawnState {
                 .map_or(0., |cost| cost.charge)
         });
 
+        if !self.counted_entities.insert(entity_uuid) {
+            return;
+        }
         self.spawn_potential.add_charge(pos, charge);
         self.mob_category_counts.add(entity_type.category);
         self.local_mob_cap_calculator.add_mob(
@@ -719,10 +758,11 @@ pub fn spawn_category_for_position(
             entity
                 .get_entity()
                 .set_rotation(rng().random::<f32>() * 360., 0.);
+            let entity_uuid = entity.get_entity().entity_uuid;
 
             spawn_cluster_size += 1;
             batch_buffer.push(entity);
-            spawn_state.after_spawn(entity_type, &new_pos, world);
+            spawn_state.after_spawn(entity_type, &new_pos, entity_uuid, world);
             if spawn_cluster_size >= entity_type.limit_per_chunk {
                 break 'group_loop;
             }


### PR DESCRIPTION
Keep persistent mobs, passengers, and leashed mobs out of natural spawn cap accounting like vanilla. Also preserve PersistenceRequired through NBT and clean up mount and leash state when entities are removed.