### PR TITLE
refactor(bedrock): Move `CActorEvent` back to `SActorEvent`

### DIFF
--- a/crates/pumpkin-protocol/src/bedrock/client/mod.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/mod.rs
@@ -1,4 +1,3 @@
-pub mod actor_event;
 pub mod add_actor;
 pub mod add_item_actor;
 pub mod add_player;

--- a/crates/pumpkin-protocol/src/bedrock/server/actor_event.rs
+++ b/crates/pumpkin-protocol/src/bedrock/server/actor_event.rs
@@ -8,7 +8,7 @@ use crate::codec::var_int::VarInt;
 
 #[derive(Debug, PacketWrite)]
 #[packet(27)]
-pub struct CActorEvent {
+pub struct SActorEvent {
     pub entity_runtime_id: VarULong,
     pub event_type: ActorEventType,
     pub event_data: VarInt,

--- a/crates/pumpkin-protocol/src/bedrock/server/mod.rs
+++ b/crates/pumpkin-protocol/src/bedrock/server/mod.rs
@@ -1,3 +1,4 @@
+pub mod actor_event;
 pub mod animate;
 pub mod block_pick_request;
 pub mod client_cache_blob_status;

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -6,8 +6,8 @@ use pumpkin_data::tracked_data::{TrackedData, TrackedId};
 use pumpkin_inventory::build_equipment_slots;
 use pumpkin_inventory::player::player_inventory::PlayerInventory;
 use pumpkin_inventory::screen_handler::InventoryPlayer;
-use pumpkin_protocol::bedrock::client::actor_event::{ActorEventType, CActorEvent};
 use pumpkin_protocol::bedrock::client::take_item_actor::CTakeItemActor;
+use pumpkin_protocol::bedrock::server::actor_event::{ActorEventType, SActorEvent};
 use pumpkin_protocol::codec::var_ulong::VarULong;
 use pumpkin_util::GameMode;
 use pumpkin_util::Hand;
@@ -2559,7 +2559,7 @@ impl EntityBase for LivingEntity {
                     (src.z - tgt.z).atan2(src.x - tgt.x).to_degrees() as f32
                         - self.entity.yaw.load()
                 });
-                let hurt_event = CActorEvent {
+                let hurt_event = SActorEvent {
                     entity_runtime_id: VarULong(entity_id as u64),
                     event_type: ActorEventType::Hurt,
                     event_data: VarInt(0),

--- a/crates/pumpkin/src/entity/passive/animal.rs
+++ b/crates/pumpkin/src/entity/passive/animal.rs
@@ -5,7 +5,7 @@ use pumpkin_data::particle::Particle;
 use pumpkin_data::sound::{Sound, SoundCategory};
 
 use crate::entity::{EntityBaseFuture, mob::Mob, player::Player};
-use pumpkin_protocol::bedrock::client::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_util::math::vector3::Vector3;
 
 pub trait Animal: Mob {

--- a/crates/pumpkin/src/entity/passive/cat.rs
+++ b/crates/pumpkin/src/entity/passive/cat.rs
@@ -11,7 +11,7 @@ use pumpkin_data::meta_data_type::MetaDataType;
 use pumpkin_data::tag::{self, Taggable};
 use pumpkin_data::tracked_data::TrackedData;
 use pumpkin_nbt::compound::NbtCompound;
-use pumpkin_protocol::bedrock::client::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::java::client::play::Metadata;
 use rand::RngExt;

--- a/crates/pumpkin/src/entity/passive/ocelot.rs
+++ b/crates/pumpkin/src/entity/passive/ocelot.rs
@@ -10,7 +10,7 @@ use pumpkin_data::meta_data_type::MetaDataType;
 use pumpkin_data::tag::{self, Taggable};
 use pumpkin_data::tracked_data::TrackedData;
 use pumpkin_nbt::compound::NbtCompound;
-use pumpkin_protocol::bedrock::client::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_protocol::java::client::play::Metadata;
 use rand::RngExt;
 

--- a/crates/pumpkin/src/entity/passive/villager/mod.rs
+++ b/crates/pumpkin/src/entity/passive/villager/mod.rs
@@ -18,7 +18,7 @@ use pumpkin_inventory::screen_handler::{
     BoxFuture, InventoryPlayer, ScreenHandlerFactory, SharedScreenHandler,
 };
 use pumpkin_nbt::compound::NbtCompound;
-use pumpkin_protocol::bedrock::client::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::java::client::play::{CMerchantOffers, Metadata};
 use pumpkin_util::math::{boundingbox::BoundingBox, position::BlockPos, vector3::Vector3};

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -222,8 +222,8 @@ use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_nbt::tag::NbtTag;
 use pumpkin_protocol::IdOr;
 use pumpkin_protocol::SoundEvent;
-use pumpkin_protocol::bedrock::client::actor_event::{ActorEventType, CActorEvent};
 use pumpkin_protocol::bedrock::client::container_open::CContainerOpen;
+use pumpkin_protocol::bedrock::server::actor_event::{ActorEventType, SActorEvent};
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_protocol::codec::var_long::VarLong;
 use pumpkin_protocol::codec::var_ulong::VarULong;
@@ -3767,7 +3767,7 @@ impl Player {
         self.client
             .send_packet_now_editioned(
                 &CCombatDeath::new(self.entity_id().into(), &death_msg),
-                &CActorEvent {
+                &SActorEvent {
                     entity_runtime_id: VarULong(self.entity_id() as u64),
                     event_type: ActorEventType::Death,
                     event_data: VarInt(0),

--- a/crates/pumpkin/src/entity/projectile/egg.rs
+++ b/crates/pumpkin/src/entity/projectile/egg.rs
@@ -14,7 +14,7 @@ use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::meta_data_type::MetaDataType;
 use pumpkin_data::tracked_data::TrackedData;
-use pumpkin_protocol::bedrock::client::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_protocol::codec::item_stack_seralizer::ItemStackSerializer;
 use pumpkin_protocol::java::client::play::Metadata;
 use pumpkin_util::math::vector3::Vector3;

--- a/crates/pumpkin/src/entity/projectile/ender_pearl.rs
+++ b/crates/pumpkin/src/entity/projectile/ender_pearl.rs
@@ -13,7 +13,7 @@ use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::{EntityPose, EntityStatus};
 use pumpkin_data::particle::Particle;
 use pumpkin_data::sound::{Sound, SoundCategory};
-use pumpkin_protocol::bedrock::client::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_util::math::vector3::Vector3;
 
 const GRAVITY: f64 = 0.03;

--- a/crates/pumpkin/src/entity/projectile/firework_rocket.rs
+++ b/crates/pumpkin/src/entity/projectile/firework_rocket.rs
@@ -4,7 +4,7 @@ use crate::{
     world::World,
 };
 use pumpkin_data::{entity::EntityStatus, meta_data_type::MetaDataType, tracked_data::TrackedData};
-use pumpkin_protocol::bedrock::client::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_protocol::{codec::optional_int::OptionalInt, java::client::play::Metadata};
 use pumpkin_util::{
     math::vector3::Vector3,

--- a/crates/pumpkin/src/entity/projectile/lingering_potion.rs
+++ b/crates/pumpkin/src/entity/projectile/lingering_potion.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use pumpkin_data::entity::EntityStatus;
 use pumpkin_data::item_stack::ItemStack;
-use pumpkin_protocol::bedrock::client::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_protocol::java::client::play::CWorldEvent;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector2::{Vector2, to_chunk_pos};

--- a/crates/pumpkin/src/entity/projectile/snowball.rs
+++ b/crates/pumpkin/src/entity/projectile/snowball.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::{EntityStatus, EntityType};
-use pumpkin_protocol::bedrock::client::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_util::math::vector3::Vector3;
 
 const GRAVITY: f64 = 0.03;

--- a/crates/pumpkin/src/entity/vehicle/minecart/tnt.rs
+++ b/crates/pumpkin/src/entity/vehicle/minecart/tnt.rs
@@ -5,7 +5,7 @@ use pumpkin_data::entity::EntityStatus;
 use pumpkin_data::particle::Particle;
 use pumpkin_data::sound::{Sound, SoundCategory};
 use pumpkin_nbt::compound::NbtCompound;
-use pumpkin_protocol::bedrock::client::actor_event::ActorEventType;
+use pumpkin_protocol::bedrock::server::actor_event::ActorEventType;
 use pumpkin_util::math::vector3::Vector3;
 use rand::RngExt;
 

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -96,7 +96,6 @@ use pumpkin_protocol::{
     BClientPacket, ClientPacket, IdOr, SoundEvent,
     bedrock::{
         client::{
-            actor_event::{ActorEventType, CActorEvent},
             add_player::CAddPlayer,
             block_event::CBlockEvent as CBedrockBlockEvent,
             common::BuildPlatform,
@@ -108,7 +107,10 @@ use pumpkin_protocol::{
             start_game::{Experiments, GamePublishSetting, LevelSettings},
             update_attributes::{Attribute, CUpdateAttributes},
         },
-        server::text::SText,
+        server::{
+            actor_event::{ActorEventType, SActorEvent},
+            text::SText,
+        },
     },
     codec::{var_int::VarInt, var_long::VarLong, var_uint::VarUInt, var_ulong::VarULong},
     java::{
@@ -494,7 +496,7 @@ impl World {
         let chunk_pos = entity.chunk_pos.load();
         let je_packet = CEntityStatus::new(entity.entity_id, java_status as i8);
         if let Some(be_event) = bedrock_status {
-            let be_packet = CActorEvent {
+            let be_packet = SActorEvent {
                 entity_runtime_id: VarULong(entity.entity_id as u64),
                 event_type: be_event,
                 event_data: VarInt(0),


### PR DESCRIPTION
Moves `CActorEvent` back to `SActorEvent` following the discovery that it is in fact bidirectional (the convention so far is that such packets are marked `S`).

## Testing

These changes are NFC. No testing was done beyond making sure it still compiles.
