### PR TITLE
Match natural mob spawn gating

### DIFF
--- a/crates/pumpkin/src/world/natural_spawner.rs
+++ b/crates/pumpkin/src/world/natural_spawner.rs
@@ -653,6 +653,10 @@ pub fn spawn_category_for_position(
     spawn_state: &SpawnState,
     is_thundering: bool,
 ) -> Vec<Arc<dyn EntityBase>> {
+    if world.get_block_state(&pos).is_solid_block() {
+        return Vec::new();
+    }
+
     let mut batch_buffer = vec![];
     let mut spawn_cluster_size = 0;
     let player_positions: Vec<_> = world.players.load().iter().map(|p| p.position()).collect();

--- a/crates/pumpkin/src/world/natural_spawner.rs
+++ b/crates/pumpkin/src/world/natural_spawner.rs
@@ -528,6 +528,10 @@ pub fn spawn_mobs_for_chunk_generation(
     chunk_x: i32,
     chunk_z: i32,
 ) {
+    if !world.level_info.load().game_rules.spawn_mobs {
+        return;
+    }
+
     let mob_settings = &biome.spawners;
     let creatures = &mob_settings.creature;
 


### PR DESCRIPTION
Match vanilla chunk-generation mob-spawn rules and skip redstone-conductor start positions.