### PR TITLE
fix(player): change MAIN_ARM_ID metadata to ARM type for 1.21.11

### DIFF
--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -3896,9 +3896,10 @@ impl Player {
                     MetaDataType::BYTE,
                     config.skin_parts,
                 ),
+                // 1.21.11
                 Metadata::new(
                     TrackedData::MAIN_ARM_ID,
-                    MetaDataType::BYTE,
+                    MetaDataType::ARM,
                     config.main_hand as u8,
                 ),
             ],


### PR DESCRIPTION
Fix for https://github.com/Pumpkin-MC/Pumpkin/issues/2870 where you can't join from 1.21.11 because MAIN_ARM_ID send wrong data type