### PR TITLE
feat(pumpkin): add /perf command

### DIFF
--- a/crates/pumpkin/src/command/commands/mod.rs
+++ b/crates/pumpkin/src/command/commands/mod.rs
@@ -45,6 +45,7 @@ mod op;
 mod pardon;
 mod pardonip;
 mod particle;
+mod perf;
 mod place;
 mod playsound;
 mod plugin;
@@ -188,6 +189,7 @@ pub async fn default_dispatcher(
     help::register(&mut dispatcher, registry);
     kill::register(&mut dispatcher, registry);
     op::register(&mut dispatcher, registry);
+    perf::register(&mut dispatcher, registry);
     place::register(&mut dispatcher, registry);
     random::register(&mut dispatcher, registry);
     list::register(&mut dispatcher, registry);

--- a/crates/pumpkin/src/command/commands/mod.rs
+++ b/crates/pumpkin/src/command/commands/mod.rs
@@ -48,6 +48,7 @@ mod op;
 mod pardon;
 mod pardonip;
 mod particle;
+mod perf;
 mod place;
 mod playsound;
 mod plugin;
@@ -190,6 +191,7 @@ pub fn default_dispatcher(
     help::register(&mut dispatcher, registry);
     kill::register(&mut dispatcher, registry);
     op::register(&mut dispatcher, registry);
+    perf::register(&mut dispatcher, registry);
     place::register(&mut dispatcher, registry);
     random::register(&mut dispatcher, registry);
     list::register(&mut dispatcher, registry);

--- a/crates/pumpkin/src/command/commands/perf.rs
+++ b/crates/pumpkin/src/command/commands/perf.rs
@@ -1,0 +1,137 @@
+use std::sync::atomic::Ordering;
+
+use pumpkin_data::translation;
+use pumpkin_util::PermissionLvl;
+use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
+use pumpkin_util::text::TextComponent;
+
+use crate::command::CommandSender;
+use crate::command::argument_builder::{ArgumentBuilder, command, literal};
+use crate::command::context::command_context::CommandContext;
+use crate::command::context::command_source::CommandSource;
+use crate::command::errors::error_types::CommandErrorType;
+use crate::command::node::dispatcher::CommandDispatcher;
+use crate::command::node::{CommandExecutor, CommandExecutorResult};
+use crate::server::perf_profiler::{
+    PERF_PROFILE_DURATION, PerfProfileResult, StartPerfError, StopPerfError,
+};
+
+const DESCRIPTION: &str = "Captures info and metrics about the game for 10 seconds.";
+const PERMISSION: &str = "minecraft:command.perf";
+
+// Bedrock has no `/perf` command, so both editions use the Java keys.
+const ALREADY_RUNNING_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMANDS_PERF_ALREADYRUNNING,
+    translation::java::COMMANDS_PERF_ALREADYRUNNING,
+);
+
+const NOT_RUNNING_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMANDS_PERF_NOTRUNNING,
+    translation::java::COMMANDS_PERF_NOTRUNNING,
+);
+
+async fn send_stopped_feedback(source: &CommandSource, result: PerfProfileResult) {
+    let seconds = result.duration.as_secs_f64();
+    let tps = result.ticks_per_second();
+    let feedback = if matches!(source.output, CommandSender::Player(_)) {
+        TextComponent::translate_cross(
+            translation::java::COMMANDS_PERF_STOPPED,
+            translation::java::COMMANDS_PERF_STOPPED,
+            [
+                TextComponent::text(format!("{seconds:.2}")),
+                TextComponent::text(result.ticks.to_string()),
+                TextComponent::text(format!("{tps:.2}")),
+            ],
+        )
+    } else {
+        // Non-player command sources cannot resolve translation placeholders
+        // server-side, so they receive an already-rendered message.
+        TextComponent::text(format!(
+            "Stopped performance profiling after {seconds:.2} seconds and {} ticks ({tps:.2} ticks per second)",
+            result.ticks
+        ))
+    };
+    source.send_feedback(feedback, true).await;
+}
+
+struct PerfStartExecutor;
+
+impl CommandExecutor for PerfStartExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let server = context.server();
+            let current_tick = server.tick_count.load(Ordering::Relaxed);
+            let generation = server.perf_profiler.start(current_tick).map_err(
+                |StartPerfError::AlreadyRunning| {
+                    ALREADY_RUNNING_ERROR_TYPE.create_without_context()
+                },
+            )?;
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_PERF_STARTED,
+                        translation::java::COMMANDS_PERF_STARTED,
+                        [],
+                    ),
+                    false,
+                )
+                .await;
+
+            // Vanilla profiling runs end on their own after 10 seconds unless
+            // `/perf stop` ends them early.
+            let server = server.clone();
+            let source = context.source.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(PERF_PROFILE_DURATION).await;
+                let current_tick = server.tick_count.load(Ordering::Relaxed);
+                if let Some(result) = server
+                    .perf_profiler
+                    .stop_if_generation(generation, current_tick)
+                {
+                    send_stopped_feedback(&source, result).await;
+                }
+            });
+
+            Ok(0)
+        })
+    }
+}
+
+struct PerfStopExecutor;
+
+impl CommandExecutor for PerfStopExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let server = context.server();
+            let current_tick = server.tick_count.load(Ordering::Relaxed);
+            let result =
+                server
+                    .perf_profiler
+                    .stop(current_tick)
+                    .map_err(|StopPerfError::NotRunning| {
+                        NOT_RUNNING_ERROR_TYPE.create_without_context()
+                    })?;
+
+            send_stopped_feedback(&context.source, result).await;
+
+            Ok(0)
+        })
+    }
+}
+
+pub fn register(dispatcher: &mut CommandDispatcher, registry: &PermissionRegistry) {
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION,
+        DESCRIPTION,
+        PermissionDefault::Op(PermissionLvl::Four),
+    ));
+
+    dispatcher.register(
+        command("perf", DESCRIPTION)
+            .requires(PERMISSION)
+            .then(literal("start").executes(PerfStartExecutor))
+            .then(literal("stop").executes(PerfStopExecutor)),
+    );
+}

--- a/crates/pumpkin/src/command/commands/perf.rs
+++ b/crates/pumpkin/src/command/commands/perf.rs
@@ -1,0 +1,137 @@
+use std::sync::atomic::Ordering;
+
+use pumpkin_data::translation;
+use pumpkin_util::PermissionLvl;
+use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
+use pumpkin_util::text::TextComponent;
+
+use crate::command::CommandSender;
+use crate::command::argument_builder::{ArgumentBuilder, command, literal};
+use crate::command::context::command_context::CommandContext;
+use crate::command::context::command_source::CommandSource;
+use crate::command::errors::error_types::CommandErrorType;
+use crate::command::node::dispatcher::CommandDispatcher;
+use crate::command::node::{CommandExecutor, CommandExecutorResult};
+use crate::server::perf_profiler::{
+    PERF_PROFILE_DURATION, PerfProfileResult, StartPerfError, StopPerfError,
+};
+
+const DESCRIPTION: &str = "Captures info and metrics about the game for 10 seconds.";
+const PERMISSION: &str = "minecraft:command.perf";
+
+// Bedrock has no `/perf` command, so both editions use the Java keys.
+const ALREADY_RUNNING_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMANDS_PERF_ALREADYRUNNING,
+    translation::java::COMMANDS_PERF_ALREADYRUNNING,
+);
+
+const NOT_RUNNING_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMANDS_PERF_NOTRUNNING,
+    translation::java::COMMANDS_PERF_NOTRUNNING,
+);
+
+async fn send_stopped_feedback(source: &CommandSource, result: PerfProfileResult) {
+    let seconds = result.duration.as_secs_f64();
+    let tps = result.ticks_per_second();
+    let feedback = if matches!(source.output, CommandSender::Player(_)) {
+        TextComponent::translate_cross(
+            translation::java::COMMANDS_PERF_STOPPED,
+            translation::java::COMMANDS_PERF_STOPPED,
+            [
+                TextComponent::text(format!("{seconds:.2}")),
+                TextComponent::text(result.ticks.to_string()),
+                TextComponent::text(format!("{tps:.2}")),
+            ],
+        )
+    } else {
+        // Non-player command sources cannot resolve translation placeholders
+        // server-side, so they receive an already-rendered message.
+        TextComponent::text(format!(
+            "Stopped performance profiling after {seconds:.2} seconds and {} ticks ({tps:.2} ticks per second)",
+            result.ticks
+        ))
+    };
+    source.send_feedback(feedback, true).await;
+}
+
+struct PerfStartExecutor;
+
+impl CommandExecutor for PerfStartExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let server = context.server();
+            let current_tick = server.tick_count.load(Ordering::Relaxed);
+            let generation = server.perf_profiler.start(current_tick).map_err(
+                |StartPerfError::AlreadyRunning| {
+                    ALREADY_RUNNING_ERROR_TYPE.create_without_context()
+                },
+            )?;
+
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_PERF_STARTED,
+                        translation::java::COMMANDS_PERF_STARTED,
+                        [],
+                    ),
+                    false,
+                )
+                .await;
+
+            // Vanilla profiling runs end on their own after 10 seconds unless
+            // `/perf stop` ends them early.
+            let server = server.clone();
+            let source = context.source.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(PERF_PROFILE_DURATION).await;
+                let current_tick = server.tick_count.load(Ordering::Relaxed);
+                if let Some(result) = server
+                    .perf_profiler
+                    .stop_if_generation(generation, current_tick)
+                {
+                    send_stopped_feedback(&source, result).await;
+                }
+            });
+
+            Ok(0)
+        })
+    }
+}
+
+struct PerfStopExecutor;
+
+impl CommandExecutor for PerfStopExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let server = context.server();
+            let current_tick = server.tick_count.load(Ordering::Relaxed);
+            let result =
+                server
+                    .perf_profiler
+                    .stop(current_tick)
+                    .map_err(|StopPerfError::NotRunning| {
+                        NOT_RUNNING_ERROR_TYPE.create_without_context()
+                    })?;
+
+            send_stopped_feedback(&context.source, result).await;
+
+            Ok(0)
+        })
+    }
+}
+
+pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION,
+        DESCRIPTION,
+        PermissionDefault::Op(PermissionLvl::Four),
+    ));
+
+    dispatcher.register(
+        command("perf", DESCRIPTION)
+            .requires(PERMISSION)
+            .then(literal("start").executes(PerfStartExecutor))
+            .then(literal("stop").executes(PerfStopExecutor)),
+    );
+}

--- a/crates/pumpkin/src/server/mod.rs
+++ b/crates/pumpkin/src/server/mod.rs
@@ -53,6 +53,7 @@ use tokio_util::task::TaskTracker;
 
 mod connection_cache;
 mod key_store;
+pub mod perf_profiler;
 pub mod recipe;
 pub mod scheduler;
 pub mod seasonal_events;
@@ -130,6 +131,8 @@ pub struct Server {
     pub aggregated_tick_times_nanos: AtomicI64,
     /// Total number of ticks processed by the server
     pub tick_count: AtomicI32,
+    /// The metrics recording session driven by `/perf`
+    pub perf_profiler: perf_profiler::PerfProfiler,
     /// Random unique Server ID used by Bedrock Edition
     pub server_guid: u64,
     /// Player idle timeout in minutes (0 = disabled)
@@ -304,6 +307,7 @@ impl Server {
             tick_times_nanos: Mutex::new([0; 100]),
             aggregated_tick_times_nanos: AtomicI64::new(0),
             tick_count: AtomicI32::new(0),
+            perf_profiler: perf_profiler::PerfProfiler::default(),
             tasks: TaskTracker::new(),
             runtime: tokio::runtime::Handle::current(),
             task_scheduler: Arc::new(TaskScheduler::new()),

--- a/crates/pumpkin/src/server/mod.rs
+++ b/crates/pumpkin/src/server/mod.rs
@@ -56,6 +56,7 @@ mod connection_cache;
 pub(crate) mod debug_profiler;
 pub mod enchantment;
 mod key_store;
+pub mod perf_profiler;
 pub mod recipe;
 pub mod scheduler;
 pub mod seasonal_events;
@@ -135,6 +136,8 @@ pub struct Server {
     pub tick_count: AtomicI32,
     /// Owns the server-wide tick profiling session used by `/debug`.
     pub(crate) debug_profiler: debug_profiler::DebugProfiler,
+    /// The metrics recording session driven by `/perf`
+    pub perf_profiler: perf_profiler::PerfProfiler,
     /// Random unique Server ID used by Bedrock Edition
     pub server_guid: u64,
     /// Player idle timeout in minutes (0 = disabled)
@@ -303,6 +306,7 @@ impl Server {
             aggregated_tick_times_nanos: AtomicI64::new(0),
             tick_count: AtomicI32::new(0),
             debug_profiler: debug_profiler::DebugProfiler::new(),
+            perf_profiler: perf_profiler::PerfProfiler::default(),
             tasks: TaskTracker::new(),
             runtime: tokio::runtime::Handle::current(),
             task_scheduler: Arc::new(TaskScheduler::new()),

--- a/crates/pumpkin/src/server/perf_profiler.rs
+++ b/crates/pumpkin/src/server/perf_profiler.rs
@@ -1,0 +1,150 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// How long a `/perf` profiling run lasts unless it is stopped early.
+pub const PERF_PROFILE_DURATION: Duration = Duration::from_secs(10);
+
+struct PerfSession {
+    started_at: Instant,
+    started_tick: i32,
+    generation: u64,
+}
+
+/// Measurements collected by a completed `/perf` profiling run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PerfProfileResult {
+    pub duration: Duration,
+    pub ticks: u32,
+}
+
+impl PerfProfileResult {
+    #[must_use]
+    pub fn ticks_per_second(self) -> f64 {
+        let seconds = self.duration.as_secs_f64();
+        if seconds == 0.0 {
+            return 0.0;
+        }
+
+        f64::from(self.ticks) / seconds
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartPerfError {
+    AlreadyRunning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StopPerfError {
+    NotRunning,
+}
+
+#[derive(Default)]
+struct PerfState {
+    session: Option<PerfSession>,
+    next_generation: u64,
+}
+
+/// Owns the single server-wide metrics recording session used by `/perf`.
+///
+/// Every run gets a generation token so the scheduled auto-stop only ends the
+/// run it was started for and never a newer one.
+#[derive(Default)]
+pub struct PerfProfiler {
+    state: Mutex<PerfState>,
+}
+
+impl PerfProfiler {
+    /// Starts a profiling run, returning its generation token.
+    pub fn start(&self, current_tick: i32) -> Result<u64, StartPerfError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        if state.session.is_some() {
+            return Err(StartPerfError::AlreadyRunning);
+        }
+
+        let generation = state.next_generation;
+        state.next_generation = state.next_generation.wrapping_add(1);
+        state.session = Some(PerfSession {
+            started_at: Instant::now(),
+            started_tick: current_tick,
+            generation,
+        });
+
+        Ok(generation)
+    }
+
+    /// Stops the active profiling run, whichever one it is.
+    pub fn stop(&self, current_tick: i32) -> Result<PerfProfileResult, StopPerfError> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let session = state.session.take().ok_or(StopPerfError::NotRunning)?;
+        Ok(Self::finish(&session, current_tick))
+    }
+
+    /// Stops the profiling run identified by `generation` if it is still the
+    /// active one. Used by the auto-stop task so it never ends a newer run.
+    #[must_use]
+    pub fn stop_if_generation(
+        &self,
+        generation: u64,
+        current_tick: i32,
+    ) -> Option<PerfProfileResult> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        if state
+            .session
+            .as_ref()
+            .is_some_and(|session| session.generation == generation)
+        {
+            let session = state.session.take()?;
+            return Some(Self::finish(&session, current_tick));
+        }
+
+        None
+    }
+
+    fn finish(session: &PerfSession, current_tick: i32) -> PerfProfileResult {
+        PerfProfileResult {
+            duration: session.started_at.elapsed(),
+            ticks: current_tick
+                .wrapping_sub(session.started_tick)
+                .unsigned_abs(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PerfProfiler, StartPerfError, StopPerfError};
+
+    #[test]
+    fn lifecycle_enforces_single_session() {
+        let profiler = PerfProfiler::default();
+        assert_eq!(profiler.stop(0), Err(StopPerfError::NotRunning));
+
+        assert_eq!(profiler.start(100), Ok(0));
+        assert_eq!(profiler.start(100), Err(StartPerfError::AlreadyRunning));
+
+        assert!(profiler.stop(140).is_ok_and(|result| result.ticks == 40));
+        assert_eq!(profiler.stop(140), Err(StopPerfError::NotRunning));
+
+        // The auto-stop of a finished run must not end a newer run.
+        assert_eq!(profiler.start(200), Ok(1));
+        assert!(profiler.stop_if_generation(0, 220).is_none());
+        assert!(
+            profiler
+                .stop_if_generation(1, 220)
+                .is_some_and(|result| result.ticks == 20)
+        );
+    }
+}


### PR DESCRIPTION
Part of #15.

Adds the vanilla `/perf` command (permission level 4).

- `/perf start` begins a metrics recording session. As in Vanilla, the run ends on its own after 10 seconds unless it is stopped early.
- `/perf stop` ends the running session immediately.

Stopping reports the vanilla `commands.perf.stopped` feedback with the elapsed seconds, the number of ticks that passed and the resulting ticks per second. Starting while a run is active gives `commands.perf.alreadyRunning`, and stopping without one gives `commands.perf.notRunning`.

## Implementation notes

- The session lives on `Server` as a small `PerfProfiler` (`server/perf_profiler.rs`) so `/perf start` and `/perf stop` share one server-wide run, matching Vanilla's single-profiler behavior.
- Each run gets a generation token. The scheduled auto-stop only ends the run it was started for, so this sequence behaves correctly: start, stop manually, start again — the first run's timer cannot cut the second run short. There is a unit test covering that.
- Non-player command sources get an already-rendered message instead of the translation, since the console cannot resolve the placeholders server-side.

Vanilla also writes a profiling report to disk (`commands.perf.reportSaved` / `commands.perf.reportFailed`); those keys are left unused for now, as Pumpkin has no report format to write yet.