### PR TITLE
feat(pumpkin): add /reload command

### DIFF
--- a/crates/pumpkin/src/command/commands/mod.rs
+++ b/crates/pumpkin/src/command/commands/mod.rs
@@ -55,6 +55,7 @@ mod plugins;
 mod pumpkin;
 mod random;
 mod recipe;
+mod reload;
 mod ride;
 mod rotate;
 mod saveall;
@@ -187,6 +188,7 @@ pub fn default_dispatcher(
     forceload::register(&mut dispatcher, registry);
     ride::register(&mut dispatcher, registry);
     recipe::register(&mut dispatcher, registry);
+    reload::register(&mut dispatcher, registry);
     help::register(&mut dispatcher, registry);
     kill::register(&mut dispatcher, registry);
     op::register(&mut dispatcher, registry);

--- a/crates/pumpkin/src/command/commands/mod.rs
+++ b/crates/pumpkin/src/command/commands/mod.rs
@@ -52,6 +52,7 @@ mod plugins;
 mod pumpkin;
 mod random;
 mod recipe;
+mod reload;
 mod ride;
 mod rotate;
 mod saveall;
@@ -185,6 +186,7 @@ pub async fn default_dispatcher(
     forceload::register(&mut dispatcher, registry);
     ride::register(&mut dispatcher, registry);
     recipe::register(&mut dispatcher, registry);
+    reload::register(&mut dispatcher, registry);
     help::register(&mut dispatcher, registry);
     kill::register(&mut dispatcher, registry);
     op::register(&mut dispatcher, registry);

--- a/crates/pumpkin/src/command/commands/reload.rs
+++ b/crates/pumpkin/src/command/commands/reload.rs
@@ -1,0 +1,53 @@
+use pumpkin_data::translation;
+use pumpkin_util::PermissionLvl;
+use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
+use pumpkin_util::text::TextComponent;
+
+use crate::command::argument_builder::{ArgumentBuilder, command};
+use crate::command::context::command_context::CommandContext;
+use crate::command::node::dispatcher::CommandDispatcher;
+use crate::command::node::{CommandExecutor, CommandExecutorResult};
+
+const DESCRIPTION: &str = "Reloads the server's datapacks.";
+const PERMISSION: &str = "minecraft:command.reload";
+
+struct ReloadExecutor;
+
+impl CommandExecutor for ReloadExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            // Vanilla announces the reload before doing it, so the feedback
+            // arrives even though reloading takes a moment.
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_RELOAD_SUCCESS,
+                        translation::java::COMMANDS_RELOAD_SUCCESS,
+                        [],
+                    ),
+                    true,
+                )
+                .await;
+
+            let server = context.server();
+            server.reload_datapacks(server).await;
+
+            Ok(0)
+        })
+    }
+}
+
+pub fn register(dispatcher: &mut CommandDispatcher, registry: &PermissionRegistry) {
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION,
+        DESCRIPTION,
+        PermissionDefault::Op(PermissionLvl::Two),
+    ));
+
+    dispatcher.register(
+        command("reload", DESCRIPTION)
+            .requires(PERMISSION)
+            .executes(ReloadExecutor),
+    );
+}

--- a/crates/pumpkin/src/command/commands/reload.rs
+++ b/crates/pumpkin/src/command/commands/reload.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+
+use pumpkin_data::translation;
+use pumpkin_util::PermissionLvl;
+use pumpkin_util::permission::{Permission, PermissionDefault, PermissionRegistry};
+use pumpkin_util::text::TextComponent;
+use tracing::error;
+
+use crate::command::argument_builder::{ArgumentBuilder, command};
+use crate::command::client_suggestions;
+use crate::command::context::command_context::CommandContext;
+use crate::command::errors::error_types::CommandErrorType;
+use crate::command::node::dispatcher::CommandDispatcher;
+use crate::command::node::{CommandExecutor, CommandExecutorResult};
+use crate::net::ClientPlatform;
+use crate::server::Server;
+
+const DESCRIPTION: &str = "Reloads the server's plugins.";
+const PERMISSION: &str = "minecraft:command.reload";
+
+// Bedrock's own reload command is client-side only, so both editions use the Java key.
+const RELOAD_FAILED_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new(
+    translation::java::COMMANDS_RELOAD_FAILURE,
+    translation::java::COMMANDS_RELOAD_FAILURE,
+);
+
+/// Pushes the rebuilt command tree to every online player, so commands that
+/// plugins registered or dropped during the reload show up right away.
+async fn resend_command_tree(server: &Arc<Server>) {
+    let command_dispatcher = server.command_dispatcher.read().await;
+    for player in server.get_all_players() {
+        if let ClientPlatform::Bedrock(_) = player.client.as_ref() {
+            client_suggestions::send_bedrock_commands_packet(&player, server, &command_dispatcher)
+                .await;
+        } else {
+            client_suggestions::send_c_commands_packet(&player, server, &command_dispatcher).await;
+        }
+    }
+}
+
+struct ReloadExecutor;
+
+impl CommandExecutor for ReloadExecutor {
+    fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            context
+                .source
+                .send_feedback(
+                    TextComponent::translate_cross(
+                        translation::java::COMMANDS_RELOAD_SUCCESS,
+                        translation::java::COMMANDS_RELOAD_SUCCESS,
+                        [],
+                    ),
+                    true,
+                )
+                .await;
+
+            let server = context.server();
+
+            // Vanilla keeps the old data when a reload fails. Unloading is the
+            // destructive half, so a failure there is what we report.
+            if let Err(err) = server.plugin_manager.unload_all_plugins().await {
+                error!("Failed to unload plugins during /reload: {err}");
+                resend_command_tree(server).await;
+                return Err(RELOAD_FAILED_ERROR_TYPE.create_without_context());
+            }
+
+            let result = server.plugin_manager.load_plugins(server).await;
+            resend_command_tree(server).await;
+
+            if let Err(err) = result {
+                error!("Failed to load plugins during /reload: {err}");
+                return Err(RELOAD_FAILED_ERROR_TYPE.create_without_context());
+            }
+
+            Ok(0)
+        })
+    }
+}
+
+pub fn register(dispatcher: &mut CommandDispatcher, registry: &mut PermissionRegistry) {
+    registry.register_permission_or_panic(Permission::new(
+        PERMISSION,
+        DESCRIPTION,
+        PermissionDefault::Op(PermissionLvl::Two),
+    ));
+
+    dispatcher.register(
+        command("reload", DESCRIPTION)
+            .requires(PERMISSION)
+            .executes(ReloadExecutor),
+    );
+}


### PR DESCRIPTION
Part of #15.

Adds the vanilla `/reload` command (permission level 2, same as Vanilla).

Vanilla reloads datapacks and then pushes the rebuilt command tree to every player. Pumpkin has no datapack system yet, so the reloadable server data here is its plugins: `/reload` unloads and reloads them, then resends the command tree to all online players so commands that plugins registered or dropped during the reload appear immediately. Once datapack support lands (#2642), reloading those fits into the same command.

Feedback follows Vanilla: `commands.reload.success` ("Reloading!") is sent up front, and `commands.reload.failure` ("Reload failed; keeping old data") is returned if unloading or loading fails — the command tree is resent in that case too, so clients never keep stale entries for plugins that did unload.