### PR TITLE
chore(fuzzer): drop unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,11 +3511,8 @@ dependencies = [
 name = "pumpkin-fuzzer"
 version = "0.1.0-dev+26.2-26.40"
 dependencies = [
- "bytes",
  "clap",
  "colored",
- "pumpkin-protocol",
- "pumpkin-util",
  "rand 0.9.5",
  "tokio",
 ]

--- a/tools/pumpkin-fuzzer/Cargo.toml
+++ b/tools/pumpkin-fuzzer/Cargo.toml
@@ -6,12 +6,9 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-pumpkin-protocol.workspace = true
-pumpkin-util.workspace = true
 tokio = { workspace = true, features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 colored.workspace = true
-bytes.workspace = true
 rand = "0.9"
 
 [lints.clippy]


### PR DESCRIPTION
`pumpkin-fuzzer` declares `bytes`, `pumpkin-protocol` and `pumpkin-util`, but the crate uses none of them — its only imports are `clap`, `colored`, `rand`, `std` and `tokio`. The `bytes` matches in the source are the `bytes_sent` counter and `to_be_bytes()` calls, not the crate.

This fails the `Detect unused dependencies` job, which currently makes the Cargo workflow red on master (a2b92e6) and on every pull request whose CI has run since. Because that job runs first, the build and lint jobs are skipped, so PRs cannot go green at all.

Verified with `cargo machete` (clean afterwards) and `cargo check -p pumpkin-fuzzer`.