### PR TITLE
Match vanilla attribute ranges

### DIFF
--- a/crates/pumpkin-data/src/generated/attributes.rs
+++ b/crates/pumpkin-data/src/generated/attributes.rs
@@ -4,6 +4,8 @@ use std::hash::Hash;
 pub struct Attributes {
     pub id: u8,
     pub default_value: f64,
+    pub min_value: f64,
+    pub max_value: f64,
     pub name: &'static str,
 }
 impl PartialEq for Attributes {
@@ -21,201 +23,281 @@ impl Attributes {
     pub const AIR_DRAG_MODIFIER: Self = Self {
         id: 0,
         default_value: 1f64,
+        min_value: 0f64,
+        max_value: 2048f64,
         name: "minecraft:air_drag_modifier",
     };
     pub const ARMOR: Self = Self {
         id: 1,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 30f64,
         name: "minecraft:armor",
     };
     pub const ARMOR_TOUGHNESS: Self = Self {
         id: 2,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 20f64,
         name: "minecraft:armor_toughness",
     };
     pub const ATTACK_DAMAGE: Self = Self {
         id: 3,
         default_value: 2f64,
+        min_value: 0f64,
+        max_value: 2048f64,
         name: "minecraft:attack_damage",
     };
     pub const ATTACK_KNOCKBACK: Self = Self {
         id: 4,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 5f64,
         name: "minecraft:attack_knockback",
     };
     pub const ATTACK_SPEED: Self = Self {
         id: 5,
         default_value: 4f64,
+        min_value: 0f64,
+        max_value: 1024f64,
         name: "minecraft:attack_speed",
     };
     pub const BELOW_NAME_DISTANCE: Self = Self {
         id: 6,
         default_value: 10f64,
+        min_value: 0f64,
+        max_value: 512f64,
         name: "minecraft:below_name_distance",
     };
     pub const BLOCK_BREAK_SPEED: Self = Self {
         id: 7,
         default_value: 1f64,
+        min_value: 0f64,
+        max_value: 1024f64,
         name: "minecraft:block_break_speed",
     };
     pub const BLOCK_INTERACTION_RANGE: Self = Self {
         id: 8,
         default_value: 4.5f64,
+        min_value: 0f64,
+        max_value: 64f64,
         name: "minecraft:block_interaction_range",
     };
     pub const BOUNCINESS: Self = Self {
         id: 9,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 1f64,
         name: "minecraft:bounciness",
     };
     pub const BURNING_TIME: Self = Self {
         id: 10,
         default_value: 1f64,
+        min_value: 0f64,
+        max_value: 1024f64,
         name: "minecraft:burning_time",
     };
     pub const CAMERA_DISTANCE: Self = Self {
         id: 11,
         default_value: 4f64,
+        min_value: 0f64,
+        max_value: 32f64,
         name: "minecraft:camera_distance",
     };
     pub const EXPLOSION_KNOCKBACK_RESISTANCE: Self = Self {
         id: 12,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 1f64,
         name: "minecraft:explosion_knockback_resistance",
     };
     pub const ENTITY_INTERACTION_RANGE: Self = Self {
         id: 13,
         default_value: 3f64,
+        min_value: 0f64,
+        max_value: 64f64,
         name: "minecraft:entity_interaction_range",
     };
     pub const FALL_DAMAGE_MULTIPLIER: Self = Self {
         id: 14,
         default_value: 1f64,
+        min_value: 0f64,
+        max_value: 100f64,
         name: "minecraft:fall_damage_multiplier",
     };
     pub const FLYING_SPEED: Self = Self {
         id: 15,
         default_value: 0.4f64,
+        min_value: 0f64,
+        max_value: 1024f64,
         name: "minecraft:flying_speed",
     };
     pub const FOLLOW_RANGE: Self = Self {
         id: 16,
         default_value: 32f64,
+        min_value: 0f64,
+        max_value: 2048f64,
         name: "minecraft:follow_range",
     };
     pub const FRICTION_MODIFIER: Self = Self {
         id: 17,
         default_value: 1f64,
+        min_value: 0f64,
+        max_value: 2048f64,
         name: "minecraft:friction_modifier",
     };
     pub const GRAVITY: Self = Self {
         id: 18,
         default_value: 0.08f64,
+        min_value: -1f64,
+        max_value: 1f64,
         name: "minecraft:gravity",
     };
     pub const JUMP_STRENGTH: Self = Self {
         id: 19,
         default_value: 0.41999998688697815f64,
+        min_value: 0f64,
+        max_value: 32f64,
         name: "minecraft:jump_strength",
     };
     pub const KNOCKBACK_RESISTANCE: Self = Self {
         id: 20,
         default_value: 0f64,
+        min_value: -2f64,
+        max_value: 1f64,
         name: "minecraft:knockback_resistance",
     };
     pub const LUCK: Self = Self {
         id: 21,
         default_value: 0f64,
+        min_value: -1024f64,
+        max_value: 1024f64,
         name: "minecraft:luck",
     };
     pub const MAX_ABSORPTION: Self = Self {
         id: 22,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 2048f64,
         name: "minecraft:max_absorption",
     };
     pub const MAX_HEALTH: Self = Self {
         id: 23,
         default_value: 20f64,
+        min_value: 1f64,
+        max_value: 1024f64,
         name: "minecraft:max_health",
     };
     pub const MINING_EFFICIENCY: Self = Self {
         id: 24,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 1024f64,
         name: "minecraft:mining_efficiency",
     };
     pub const MOVEMENT_EFFICIENCY: Self = Self {
         id: 25,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 1f64,
         name: "minecraft:movement_efficiency",
     };
     pub const MOVEMENT_SPEED: Self = Self {
         id: 26,
         default_value: 0.7f64,
+        min_value: 0f64,
+        max_value: 1024f64,
         name: "minecraft:movement_speed",
     };
     pub const NAME_TAG_DISTANCE: Self = Self {
         id: 27,
         default_value: 64f64,
+        min_value: 0f64,
+        max_value: 512f64,
         name: "minecraft:name_tag_distance",
     };
     pub const OXYGEN_BONUS: Self = Self {
         id: 28,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 1024f64,
         name: "minecraft:oxygen_bonus",
     };
     pub const SAFE_FALL_DISTANCE: Self = Self {
         id: 29,
         default_value: 3f64,
+        min_value: -1024f64,
+        max_value: 1024f64,
         name: "minecraft:safe_fall_distance",
     };
     pub const SCALE: Self = Self {
         id: 30,
         default_value: 1f64,
+        min_value: 0.0625f64,
+        max_value: 16f64,
         name: "minecraft:scale",
     };
     pub const SNEAKING_SPEED: Self = Self {
         id: 31,
         default_value: 0.3f64,
+        min_value: 0f64,
+        max_value: 1f64,
         name: "minecraft:sneaking_speed",
     };
     pub const SPAWN_REINFORCEMENTS: Self = Self {
         id: 32,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 1f64,
         name: "minecraft:spawn_reinforcements",
     };
     pub const STEP_HEIGHT: Self = Self {
         id: 33,
         default_value: 0.6f64,
+        min_value: 0f64,
+        max_value: 10f64,
         name: "minecraft:step_height",
     };
     pub const SUBMERGED_MINING_SPEED: Self = Self {
         id: 34,
         default_value: 0.2f64,
+        min_value: 0f64,
+        max_value: 20f64,
         name: "minecraft:submerged_mining_speed",
     };
     pub const SWEEPING_DAMAGE_RATIO: Self = Self {
         id: 35,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 1f64,
         name: "minecraft:sweeping_damage_ratio",
     };
     pub const TEMPT_RANGE: Self = Self {
         id: 36,
         default_value: 10f64,
+        min_value: 0f64,
+        max_value: 2048f64,
         name: "minecraft:tempt_range",
     };
     pub const WATER_MOVEMENT_EFFICIENCY: Self = Self {
         id: 37,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 1f64,
         name: "minecraft:water_movement_efficiency",
     };
     pub const WAYPOINT_TRANSMIT_RANGE: Self = Self {
         id: 38,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 60000000f64,
         name: "minecraft:waypoint_transmit_range",
     };
     pub const WAYPOINT_RECEIVE_RANGE: Self = Self {
         id: 39,
         default_value: 0f64,
+        min_value: 0f64,
+        max_value: 60000000f64,
         name: "minecraft:waypoint_receive_range",
     };
     pub const ALL: &'static [Self] = &[

--- a/crates/pumpkin/src/entity/ai/goal/track_target.rs
+++ b/crates/pumpkin/src/entity/ai/goal/track_target.rs
@@ -22,7 +22,6 @@ pub struct TrackTargetGoal {
     target_predicate: TargetPredicate,
 }
 
-#[expect(dead_code)]
 impl TrackTargetGoal {
     #[must_use]
     pub fn new(check_visibility: bool, check_can_navigate: bool) -> Self {

--- a/crates/pumpkin/src/entity/attributes.rs
+++ b/crates/pumpkin/src/entity/attributes.rs
@@ -33,7 +33,7 @@ pub struct AttributeInstance {
 
 impl AttributeInstance {
     #[must_use]
-    pub fn new(base_value: f64, min_value: f64, max_value: f64) -> Self {
+    pub const fn new(base_value: f64, min_value: f64, max_value: f64) -> Self {
         Self {
             base_value,
             min_value,

--- a/crates/pumpkin/src/entity/attributes.rs
+++ b/crates/pumpkin/src/entity/attributes.rs
@@ -24,6 +24,8 @@ pub struct Modifier {
 #[derive(Debug)]
 pub struct AttributeInstance {
     pub base_value: f64,
+    pub min_value: f64,
+    pub max_value: f64,
     pub modifiers: Vec<Modifier>,
     pub cached_value: AtomicU64,
     pub dirty: AtomicBool,
@@ -31,12 +33,14 @@ pub struct AttributeInstance {
 
 impl AttributeInstance {
     #[must_use]
-    pub const fn new(base_value: f64) -> Self {
+    pub fn new(base_value: f64, min_value: f64, max_value: f64) -> Self {
         Self {
             base_value,
+            min_value,
+            max_value,
             modifiers: Vec::new(),
             cached_value: AtomicU64::new(base_value.to_bits()),
-            dirty: AtomicBool::new(false),
+            dirty: AtomicBool::new(true),
         }
     }
 
@@ -48,23 +52,27 @@ impl AttributeInstance {
         let mut value = self.base_value;
 
         let mut add_sum = 0.0;
-        let mut mul_base = 0.0;
         let mut mul_total = 1.0;
         for m in &self.modifiers {
             match m.operation {
                 ModifierOperation::Add => add_sum += m.amount,
-                ModifierOperation::MultiplyBase => mul_base += m.amount,
+                ModifierOperation::MultiplyBase => {}
                 ModifierOperation::MultiplyTotal => mul_total *= 1.0 + m.amount,
             }
         }
 
         value += add_sum;
-        value *= 1.0 + mul_base;
+        let base = value;
+        for modifier in self
+            .modifiers
+            .iter()
+            .filter(|modifier| matches!(modifier.operation, ModifierOperation::MultiplyBase))
+        {
+            value += base * modifier.amount;
+        }
         value *= mul_total;
 
-        if value.is_nan() || value.is_infinite() {
-            value = self.base_value;
-        }
+        value = sanitize_value(value, self.min_value, self.max_value);
 
         self.cached_value.store(value.to_bits(), Ordering::Relaxed);
         self.dirty.store(false, Ordering::Relaxed);
@@ -184,10 +192,54 @@ impl Clone for AttributeInstance {
     fn clone(&self) -> Self {
         Self {
             base_value: self.base_value,
+            min_value: self.min_value,
+            max_value: self.max_value,
             modifiers: self.modifiers.clone(),
             cached_value: AtomicU64::new(self.cached_value.load(Ordering::Relaxed)),
             dirty: AtomicBool::new(self.dirty.load(Ordering::Relaxed)),
         }
+    }
+}
+
+pub(crate) const fn sanitize_value(value: f64, min_value: f64, max_value: f64) -> f64 {
+    if value.is_nan() {
+        min_value
+    } else {
+        value.clamp(min_value, max_value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AttributeInstance, Modifier, ModifierOperation};
+
+    #[test]
+    fn ranged_values_match_vanilla_sanitization() {
+        let mut instance = AttributeInstance::new(100.0, 0.0, 30.0);
+        assert_eq!(instance.base_value, 100.0);
+        assert_eq!(instance.value(), 30.0);
+
+        instance.add_or_replace_modifier(Modifier {
+            id: "over-max".to_string(),
+            amount: 100.0,
+            operation: ModifierOperation::Add,
+        });
+        assert_eq!(instance.value(), 30.0);
+
+        let nan = AttributeInstance::new(f64::NAN, 0.0, 30.0);
+        assert!(nan.base_value.is_nan());
+        assert_eq!(nan.value(), 0.0);
+
+        let negative = AttributeInstance::new(-1.0, -2.0, 1.0);
+        assert_eq!(negative.value(), -1.0);
+
+        let mut non_finite = AttributeInstance::new(f64::INFINITY, 0.0, 30.0);
+        non_finite.add_or_replace_modifier(Modifier {
+            id: "zero-multiplier".to_string(),
+            amount: 0.0,
+            operation: ModifierOperation::MultiplyBase,
+        });
+        assert_eq!(non_finite.value(), 0.0);
     }
 }
 

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -156,7 +156,10 @@ impl LivingEntity {
                     if attr.id == Attributes::MAX_HEALTH.id {
                         max_health = *base as f32;
                     }
-                    m.insert(attr.id, AttributeInstance::new(*base));
+                    m.insert(
+                        attr.id,
+                        AttributeInstance::new(*base, attr.min_value, attr.max_value),
+                    );
                 }
                 std::sync::RwLock::new(m)
             },
@@ -499,7 +502,7 @@ impl LivingEntity {
                     },
                     |a| a.1,
                 );
-            AttributeInstance::new(base)
+            AttributeInstance::new(base, attribute.min_value, attribute.max_value)
         });
 
         f(inst);
@@ -548,7 +551,7 @@ impl LivingEntity {
             inst.base_value = new_base;
             inst.dirty.store(true, Ordering::Relaxed);
         } else {
-            let ai = AttributeInstance::new(new_base);
+            let ai = AttributeInstance::new(new_base, attribute.min_value, attribute.max_value);
             ai.dirty.store(true, Ordering::Relaxed);
             map.insert(attribute.id, ai);
         }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1064,7 +1064,6 @@ impl World {
         self.play_sound_expect(player, sound, category, &new_vec);
     }
 
-    #[expect(clippy::too_many_lines)]
     pub async fn tick(self: &Arc<Self>, server: Arc<Server>) {
         let start = tokio::time::Instant::now();
 
@@ -1402,7 +1401,6 @@ impl World {
         }
     }
 
-    #[expect(clippy::too_many_lines)]
     pub async fn tick_chunks(self: &Arc<Self>) {
         let active_chunks = self.active_chunks.load();
         let tick_data = self.level.get_tick_data(&active_chunks);
@@ -2814,7 +2812,6 @@ impl World {
         }
     }
 
-    #[expect(clippy::too_many_lines)]
     pub async fn spawn_java_player(
         &self,
         base_config: &BasicConfiguration,
@@ -4677,7 +4674,6 @@ impl World {
     }
 
     /// Sets a block and returns the old block id
-    #[expect(clippy::too_many_lines)]
     pub async fn set_block_state(
         self: &Arc<Self>,
         position: &BlockPos,

--- a/tools/pumpkin-codegen/src/attributes.rs
+++ b/tools/pumpkin-codegen/src/attributes.rs
@@ -15,6 +15,53 @@ struct Attributes {
     default_value: f64,
 }
 
+/// The bounds are the values registered by vanilla's `RangedAttribute` entries
+/// in `net.minecraft.world.entity.ai.attributes.Attributes`.
+fn range(name: &str) -> (f64, f64) {
+    match name {
+        "air_drag_modifier" => (0.0, 2048.0),
+        "armor" => (0.0, 30.0),
+        "armor_toughness" => (0.0, 20.0),
+        "attack_damage" => (0.0, 2048.0),
+        "attack_knockback" => (0.0, 5.0),
+        "attack_speed" => (0.0, 1024.0),
+        "below_name_distance" => (0.0, 512.0),
+        "block_break_speed" => (0.0, 1024.0),
+        "block_interaction_range" => (0.0, 64.0),
+        "bounciness" => (0.0, 1.0),
+        "burning_time" => (0.0, 1024.0),
+        "camera_distance" => (0.0, 32.0),
+        "explosion_knockback_resistance" => (0.0, 1.0),
+        "entity_interaction_range" => (0.0, 64.0),
+        "fall_damage_multiplier" => (0.0, 100.0),
+        "flying_speed" => (0.0, 1024.0),
+        "follow_range" => (0.0, 2048.0),
+        "friction_modifier" => (0.0, 2048.0),
+        "gravity" => (-1.0, 1.0),
+        "jump_strength" => (0.0, 32.0),
+        "knockback_resistance" => (-2.0, 1.0),
+        "luck" => (-1024.0, 1024.0),
+        "max_absorption" => (0.0, 2048.0),
+        "max_health" => (1.0, 1024.0),
+        "mining_efficiency" => (0.0, 1024.0),
+        "movement_efficiency" => (0.0, 1.0),
+        "movement_speed" => (0.0, 1024.0),
+        "name_tag_distance" => (0.0, 512.0),
+        "oxygen_bonus" => (0.0, 1024.0),
+        "safe_fall_distance" => (-1024.0, 1024.0),
+        "scale" => (0.0625, 16.0),
+        "sneaking_speed" => (0.0, 1.0),
+        "spawn_reinforcements" => (0.0, 1.0),
+        "step_height" => (0.0, 10.0),
+        "submerged_mining_speed" => (0.0, 20.0),
+        "sweeping_damage_ratio" => (0.0, 1.0),
+        "tempt_range" => (0.0, 2048.0),
+        "water_movement_efficiency" => (0.0, 1.0),
+        "waypoint_transmit_range" | "waypoint_receive_range" => (0.0, 60_000_000.0),
+        other => panic!("Missing vanilla range for attribute {other}"),
+    }
+}
+
 /// Generates the `TokenStream` for the `Attributes` struct and its associated constants.
 pub fn build() -> TokenStream {
     let attributes: BTreeMap<String, Attributes> =
@@ -33,12 +80,15 @@ pub fn build() -> TokenStream {
 
         let id_lit = LitInt::new(&raw_value.id.to_string(), Span::call_site());
         let default_value_lit = raw_value.default_value;
+        let (min_value, max_value) = range(&raw_name);
         let name_str = format!("minecraft:{raw_name}");
 
         constant_defs.push(quote!(
             pub const #constant_ident: Self = Self {
                 id: #id_lit,
                 default_value: #default_value_lit,
+                min_value: #min_value,
+                max_value: #max_value,
                 name: #name_str,
             };
         ));
@@ -51,6 +101,8 @@ pub fn build() -> TokenStream {
         pub struct Attributes {
             pub id: u8,
             pub default_value: f64,
+            pub min_value: f64,
+            pub max_value: f64,
             pub name: &'static str,
         }
         impl PartialEq for Attributes {


### PR DESCRIPTION
Match vanilla attribute bounds and modifier calculation when computing effective values.

Validated with formatting, focused regression coverage, and the full PumpkinPie library suite.