### PR TITLE
fix(net): drop Java connections that go silent before login finishes

### DIFF
--- a/crates/pumpkin/src/net/java/pending.rs
+++ b/crates/pumpkin/src/net/java/pending.rs
@@ -41,6 +41,16 @@ use super::JavaClient;
 
 const BRAND_CHANNEL_PREFIX: &str = "minecraft:brand";
 
+/// How long a connection may stay silent before login finishes.
+///
+/// Once a player is in game, [`JavaClient::progress_player_packets`] keeps the
+/// connection honest with keep-alives. Nothing plays that role beforehand, and
+/// accepted sockets have no TCP keep-alive either, so a peer that stops talking
+/// without closing would otherwise hold its descriptor for the lifetime of the
+/// server. The timer covers silence rather than the whole handshake: it is reset
+/// on every packet, so a slow but progressing login is never cut off.
+const HANDSHAKE_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 pub struct PendingConnection {
     pub id: u64,
     pub address: SocketAddr,
@@ -116,6 +126,14 @@ impl PendingConnection {
         let packet_result = tokio::select! {
             () = close_token.cancelled() => {
                 debug!("Canceling pending connection packet processing");
+                return None;
+            },
+            () = tokio::time::sleep(HANDSHAKE_IDLE_TIMEOUT) => {
+                debug!(
+                    "Client {} sent nothing for {}s before finishing login, dropping it",
+                    self.id,
+                    HANDSHAKE_IDLE_TIMEOUT.as_secs()
+                );
                 return None;
             },
             res = self.network_reader.get_raw_packet() => res,


### PR DESCRIPTION
Closes #2627.

## What was changed

`PendingConnection::get_packet` gives up after 30s of silence, so a connection that stops sending before login finishes is dropped instead of waited on forever. The timer covers silence and is reset on every packet, not a deadline on the whole handshake.

## Why

Nothing bounds the handshake/status/login phase today. `progress_player_packets` keeps play-state connections honest with keep-alives, but there is no equivalent before that, and accepted sockets only get `set_nodelay` — no TCP keep-alive. A peer that goes away without closing holds its descriptor until the process exits, which is the monotonic growth in #2627.

Measured on `a2b92e6d`, sampling the server's descriptor count with `lsof`:

| | before | after |
| --- | --- | --- |
| 100 connections that connect and never send, held open 45s | +100, unchanged for the whole window | back to baseline at t+30s |
| 100 status pings, closed normally | +0 | +0 |

The client held every socket open the whole time, so the descriptors released after the change were released by the server, not by the client hanging up.

## Impact

Java connections only. A slow login is unaffected: a status exchange that idles 20s before the handshake and another 20s before the request returns the same 10352-byte response it does on `master`.

`cargo test` 598 passed, `cargo clippy --all-targets` and `cargo fmt --check` clean.

## Known issues or limitations

The timeout is a constant rather than a config option. Bedrock connections take a different path and are untouched.

---

Used AI assistance to navigate the codebase. The change and the measurements above were done by hand.
