### PR TITLE
fix(bedrock): transaction decoding fix

### DIFF
--- a/crates/pumpkin-protocol/src/bedrock/server/inventory_transaction.rs
+++ b/crates/pumpkin-protocol/src/bedrock/server/inventory_transaction.rs
@@ -130,7 +130,7 @@ pub struct UseItemTransactionData {
     pub action_type: VarInt,
     pub trigger_type: u8,
     pub block_position: BlockPos,
-    pub block_face: i32,
+    pub block_face: u8,
     pub hot_bar_slot: VarInt,
     pub item_in_hand: NetworkItemDescriptor,
     pub player_position: Vector3<f32>,
@@ -226,5 +226,60 @@ impl PacketRead for SInventoryTransaction {
             transaction_type,
             transaction_data,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_use_item_transaction_with_empty_hand() {
+        let payload = [
+            0x00, 0x00, 0x01, 0x02, 0x01, 0x00, 0x00, 0x01, 0xec, 0x04, 0x80, 0x01, 0xcb, 0x06,
+            0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x8c, 0xf6, 0x9b, 0x43,
+            0x72, 0x3d, 0x83, 0x42, 0xf3, 0xe1, 0xd1, 0xc3, 0x00, 0x90, 0x61, 0x3f, 0x00, 0x8d,
+            0x26, 0x3f, 0x00, 0x00, 0x80, 0x3f, 0xfd, 0x59, 0x01, 0x00,
+        ];
+        let mut reader = payload.as_slice();
+
+        let packet = SInventoryTransaction::read(&mut reader).unwrap();
+        let TransactionData::UseItem(data) = packet.transaction_data else {
+            panic!("expected use-item transaction");
+        };
+
+        assert_eq!(data.action_type.0, 0);
+        assert_eq!(data.item_in_hand.id.0, 0);
+        assert_eq!(data.block_face, 3);
+        assert!(reader.is_empty());
+    }
+
+    #[test]
+    fn decodes_use_item_transaction_with_crafting_table() {
+        let payload = [
+            0x00, 0x00, 0x01, 0x02, 0x01, 0x01, 0x00, 0x01, 0x01, 0x00, 0x01, 0x00, 0x02, 0x3a,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0xfd, 0x59, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0xa6, 0x05, 0x7e, 0xd9, 0x06, 0x01, 0x04, 0x3a, 0x00, 0x01, 0x00, 0x00, 0x00, 0xfd,
+            0x59, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5f, 0x0f,
+            0xaa, 0x43, 0x72, 0x3d, 0x83, 0x42, 0xb8, 0x39, 0xd5, 0xc3, 0x00, 0x16, 0x15, 0x3f,
+            0x00, 0x00, 0x80, 0x3f, 0x00, 0xc8, 0x81, 0x3e, 0xb6, 0x5e, 0x01, 0x00,
+        ];
+        let mut reader = payload.as_slice();
+        let packet = SInventoryTransaction::read(&mut reader).unwrap();
+        let TransactionData::UseItem(data) = packet.transaction_data else {
+            panic!("expected use-item transaction");
+        };
+
+        assert_eq!(packet.actions.len(), 1);
+        assert_eq!(packet.actions[0].old_item.id.0, 58);
+        assert_eq!(packet.actions[0].new_item.id.0, 0);
+        assert_eq!(data.action_type.0, 0);
+        assert_eq!(data.block_face, 1);
+        assert_eq!(data.hot_bar_slot.0, 2);
+        assert_eq!(data.item_in_hand.id.0, 58);
+        assert_eq!(data.item_in_hand.stack_size, 1);
+        assert_eq!(data.item_in_hand.block_runtime_id.0, 11_517);
+        assert!(reader.is_empty());
     }
 }

--- a/crates/pumpkin/src/net/bedrock/play/inventory_action.rs
+++ b/crates/pumpkin/src/net/bedrock/play/inventory_action.rs
@@ -235,7 +235,7 @@ impl BedrockClient {
                                 pumpkin_protocol::java::server::play::SUseItemOn {
                                     hand: VarInt(0),
                                     position: data.block_position,
-                                    face: VarInt(data.block_face),
+                                    face: VarInt(i32::from(data.block_face)),
                                     cursor_pos: data.click_position,
                                     inside_block: false,
                                     is_against_world_border: false,


### PR DESCRIPTION
## Description
Fixes Bedrock block placement and interaction transactions being decoded incorrectly. I think the regression was introduced with this PR https://github.com/Pumpkin-MC/Pumpkin/pull/2808

## What
- Restores block placement and interaction for Bedrock players.
- Prevents valid transactions from failing with `failed to fill whole buffer`.
- Fixes held items being misread as invalid item IDs such as `1025`.
- Ensures placed blocks are handled server-side and persist correctly.

## How
- Decodes the Bedrock block-face field as its actual one-byte wire value instead of a four-byte integer.
- Keeps subsequent transaction fields correctly aligned.
- Adds regression tests using captured empty-hand and crafting-table placement packets.

## Testing
- `cargo test -p pumpkin-protocol`
- `cargo check -p pumpkin`
- `cargo clippy -p pumpkin -p pumpkin-protocol --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Verified in game that a Bedrock player can place and interact with a newly placed crafting table.