### PR TITLE
fix(rcon): make max_connections actually limit connections

### DIFF
--- a/crates/pumpkin/src/net/rcon/mod.rs
+++ b/crates/pumpkin/src/net/rcon/mod.rs
@@ -1,4 +1,7 @@
-use std::{net::SocketAddr, sync::atomic::Ordering};
+use std::{
+    net::SocketAddr,
+    sync::atomic::{AtomicU32, Ordering},
+};
 
 use packet::{ClientboundPacket, Packet, PacketError, ServerboundPacket};
 use pumpkin_config::RCONConfig;
@@ -35,7 +38,10 @@ impl RCONServer {
 
         let password = Arc::new(config.password.clone());
 
-        let mut connections = 0;
+        // Shared with the connection tasks: each one lives past the loop
+        // iteration that accepted it, so the count has to come back down when
+        // the task ends rather than when it is spawned.
+        let connections = Arc::new(AtomicU32::new(0));
         while !SHOULD_STOP.load(Ordering::Relaxed) {
             let await_new_client = || async {
                 let t1 = listener.accept();
@@ -52,18 +58,25 @@ impl RCONServer {
                 break;
             };
 
-            if config.max_connections != 0 && connections >= config.max_connections {
+            if config.max_connections != 0
+                && connections.load(Ordering::Relaxed) >= config.max_connections
+            {
+                // RCON has no "server busy" reply, so refusing means hanging up.
+                debug!("refused RCON connection from {address}: at max_connections");
                 continue;
             }
 
-            connections += 1;
+            connections.fetch_add(1, Ordering::Relaxed);
             let mut client = RCONClient::new(connection, address);
 
             let password = password.clone();
             let server = server.clone();
-            tokio::spawn(async move { while !client.handle(&server, &password).await {} });
-            debug!("closed RCON connection");
-            connections -= 1;
+            let connections = connections.clone();
+            tokio::spawn(async move {
+                while !client.handle(&server, &password).await {}
+                connections.fetch_sub(1, Ordering::Relaxed);
+                debug!("closed RCON connection");
+            });
         }
     }
 }


### PR DESCRIPTION
## What was changed

`max_connections` is now tracked in an `AtomicU32` shared with the connection tasks, decremented when a task ends instead of one line after the spawn.

## Why

The counter went up and back down inside the same loop iteration, while the connection was handled in a detached `tokio::spawn`. It therefore read zero on every pass and the limit never applied. `RCONConfig` defaults to `max_connections: 10` and documents it as "the maximum number of concurrent RCON connections allowed", so every server has a cap that does nothing.

With `max_connections = 2` and five clients authenticating:

| | before | after |
| --- | --- | --- |
| authenticated | 5 | 2 |
| still usable afterwards | 5 | 2 |

Opening two more once those are closed succeeds, so the count comes back down rather than latching.

## Impact

Servers that set `max_connections` get it enforced; a refused connection is hung up on, since RCON has no "busy" reply. `0` still means unlimited. `closed RCON connection` now logs on close rather than on spawn.

`cargo test` 599 passed, `cargo clippy --all-targets` and `cargo fmt --check` clean.

## Known issues or limitations

The check and the increment are not one atomic step, which is fine while a single accept loop owns them, but would need revisiting if RCON ever accepts from more than one task.

---

Used AI assistance to navigate the codebase. The change and the measurements above were done by hand.
