### PR TITLE
fix(inventory): merge picked up items into a filled off-hand 🤖🤖🤖

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,6 +3524,7 @@ dependencies = [
 name = "pumpkin-inventory"
 version = "0.1.0-dev+26.2-26.40"
 dependencies = [
+ "futures",
  "pumpkin-data",
  "pumpkin-protocol",
  "pumpkin-util",

--- a/crates/pumpkin-inventory/Cargo.toml
+++ b/crates/pumpkin-inventory/Cargo.toml
@@ -27,5 +27,8 @@ tracing.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+futures.workspace = true
+
 [lints]
 workspace = true

--- a/crates/pumpkin-inventory/src/player/player_inventory.rs
+++ b/crates/pumpkin-inventory/src/player/player_inventory.rs
@@ -188,15 +188,7 @@ impl PlayerInventory {
     /// Returns the number of items that couldn't fit.
     async fn add_stack_to_slot(&self, slot: usize, stack: ItemStack) -> usize {
         if slot >= Self::MAIN_SIZE {
-            if let Some(slot_type) = self.equipment_slots.get(&slot) {
-                let mut equipment = self.entity_equipment.lock().await;
-                let current = equipment.get(slot_type);
-                if current.is_empty() {
-                    equipment.put(slot_type, stack);
-                    return 0;
-                }
-            }
-            return stack.item_count as usize;
+            return self.add_stack_to_equipment_slot(slot, stack).await;
         }
 
         let mut inv = self.main_inventory.write().await;
@@ -215,6 +207,39 @@ impl PlayerInventory {
             self_stack.increment(count_min);
         }
         stack_count as usize
+    }
+
+    /// Adds a stack to an equipment slot (armor or off-hand).
+    ///
+    /// Mirrors [`Self::add_stack_to_slot`]: an empty slot takes the whole stack,
+    /// and a slot already holding a compatible stack is topped up.
+    ///
+    /// Returns the number of items that couldn't fit.
+    async fn add_stack_to_equipment_slot(&self, slot: usize, stack: ItemStack) -> usize {
+        let Some(slot_type) = self.equipment_slots.get(&slot) else {
+            return stack.item_count as usize;
+        };
+
+        let mut equipment = self.entity_equipment.lock().await;
+        let mut current = equipment.get(slot_type);
+
+        if current.is_empty() {
+            equipment.put(slot_type, stack);
+            return 0;
+        }
+
+        // Same predicate `get_occupied_slot_with_room_for_stack` used to pick this
+        // slot, so a slot it deemed stackable is never rejected here.
+        if !Self::can_stack_add_more(&current, &stack) {
+            return stack.item_count as usize;
+        }
+
+        let count_left = current.get_max_stack_size() - current.item_count;
+        let count_min = stack.item_count.min(count_left);
+        current.increment(count_min);
+        equipment.put(slot_type, current);
+
+        (stack.item_count - count_min) as usize
     }
 
     /// Finds an empty slot in the inventory.
@@ -526,5 +551,98 @@ impl PlayerInventory {
     /// Gets the currently selected hotbar slot index.
     pub fn get_selected_slot(&self) -> u8 {
         self.selected_slot.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::build_equipment_slots;
+    use futures::executor::block_on;
+
+    fn empty_inventory() -> (PlayerInventory, Arc<Mutex<EntityEquipment>>) {
+        let equipment = Arc::new(Mutex::new(EntityEquipment::new()));
+        let inventory = PlayerInventory::new(equipment.clone(), Arc::new(build_equipment_slots()));
+        (inventory, equipment)
+    }
+
+    fn off_hand(equipment: &Arc<Mutex<EntityEquipment>>) -> ItemStack {
+        block_on(equipment.lock()).get(&EquipmentSlot::OFF_HAND)
+    }
+
+    fn set_off_hand(equipment: &Arc<Mutex<EntityEquipment>>, stack: ItemStack) {
+        block_on(equipment.lock()).put(&EquipmentSlot::OFF_HAND, stack);
+    }
+
+    /// A partially filled off-hand used to block every pickup: the slot was picked as
+    /// the destination and then refused, with no fallback to the main inventory.
+    #[test]
+    fn picks_up_into_a_partially_filled_off_hand() {
+        let (inventory, equipment) = empty_inventory();
+        set_off_hand(&equipment, ItemStack::new(1, &Item::TORCH));
+
+        let mut picked_up = ItemStack::new(1, &Item::TORCH);
+        assert!(block_on(inventory.insert_stack_anywhere(&mut picked_up)));
+
+        assert!(picked_up.is_empty(), "the whole stack should be taken");
+        assert_eq!(
+            off_hand(&equipment).item_count,
+            2,
+            "off-hand should stack up"
+        );
+    }
+
+    #[test]
+    fn picks_up_into_an_empty_off_hand_inventory() {
+        let (inventory, _equipment) = empty_inventory();
+
+        let mut picked_up = ItemStack::new(1, &Item::TORCH);
+        assert!(block_on(inventory.insert_stack_anywhere(&mut picked_up)));
+        assert!(picked_up.is_empty());
+    }
+
+    /// A different item in the off-hand must not interfere with the pickup.
+    #[test]
+    fn off_hand_holding_another_item_does_not_block_pickup() {
+        let (inventory, equipment) = empty_inventory();
+        set_off_hand(&equipment, ItemStack::new(1, &Item::TORCH));
+
+        let mut picked_up = ItemStack::new(1, &Item::STONE);
+        assert!(block_on(inventory.insert_stack_anywhere(&mut picked_up)));
+
+        assert!(picked_up.is_empty());
+        assert_eq!(off_hand(&equipment).item_count, 1, "off-hand is untouched");
+    }
+
+    /// A full off-hand is never chosen as a destination, so the stack lands in the
+    /// main inventory instead.
+    #[test]
+    fn full_off_hand_falls_back_to_the_main_inventory() {
+        let (inventory, equipment) = empty_inventory();
+        let max = ItemStack::new(1, &Item::TORCH).get_max_stack_size();
+        set_off_hand(&equipment, ItemStack::new(max, &Item::TORCH));
+
+        let mut picked_up = ItemStack::new(1, &Item::TORCH);
+        assert!(block_on(inventory.insert_stack_anywhere(&mut picked_up)));
+
+        assert!(picked_up.is_empty());
+        assert_eq!(off_hand(&equipment).item_count, max, "off-hand stays full");
+    }
+
+    /// Only what fits goes into the off-hand; the rest must not be silently dropped.
+    #[test]
+    fn overflow_beyond_the_off_hand_is_kept() {
+        let (inventory, equipment) = empty_inventory();
+        let max = ItemStack::new(1, &Item::TORCH).get_max_stack_size();
+        set_off_hand(&equipment, ItemStack::new(max - 1, &Item::TORCH));
+
+        let mut picked_up = ItemStack::new(5, &Item::TORCH);
+        assert!(block_on(inventory.insert_stack_anywhere(&mut picked_up)));
+
+        assert_eq!(off_hand(&equipment).item_count, max, "off-hand tops up");
+        assert!(
+            picked_up.is_empty(),
+            "the remaining 4 belong in the main inventory, not lost"
+        );
     }
 }


### PR DESCRIPTION
## What was changed?

`add_stack_to_slot` now merges into an occupied equipment slot instead of
refusing it. The equipment branch moved into `add_stack_to_equipment_slot`,
which mirrors the main-inventory path below it and reuses `can_stack_add_more`.

## Why were these changes necessary?

`get_occupied_slot_with_room_for_stack` offers `OFF_HAND_SLOT` as a destination
whenever the off-hand holds a stackable item with room left. `add_stack_to_slot`
only ever handled an **empty** equipment slot: for an occupied one it returned
the whole stack as "did not fit". Because a slot *had* been found, `add_stack`
never fell back to `get_empty_slot`, so nothing was inserted anywhere.

`insert_stack_anywhere` then reported failure and
`ItemEntity::on_player_collision` skipped the pickup entirely.

The predicate that *picks* the slot and the code that *fills* it disagreed;
this PR makes them the same predicate.

## What is the impact of this change?

**Only the item type held in the off-hand is affected.** Holding a partially
stacked torch there made torches on the ground unpickable, while every other
item kept being picked up normally. The main inventory could be completely
empty and the torch would still be refused.

This is not torch-specific: it applies to whichever stackable item the off-hand
happens to hold. Vanilla merges into the off-hand normally, so this was a
divergence.

Reproduced on `a2b92e6d`, on a real server:

| Off-hand | Item on ground | Before | After |
|---|---|---|---|
| empty | torch | picked up | picked up |
| 1 torch | **torch** | **never picked up** | **picked up, off-hand goes to 2** |
| 1 torch | stone | picked up | picked up |
| 64 torches (full) | torch | picked up | picked up |

Row 3 is the one that scopes the bug: a *different* item is unaffected, because
`can_stack_add_more` requires matching items before the off-hand is even
considered.

Row 4 is what pinned the cause down: a **full** off-hand also works, because
the same predicate then rejects it and the slot is never chosen. Only a
partially filled one gets chosen and then refused — which is why the bug looks
intermittent.

Worth noting for anyone who could not reproduce it: it also disappears when the
same item is in the main hand as well, since the selected slot is tested first.

## Tests

Adds the first tests for `pumpkin-inventory`, covering the empty, partial,
mismatched, full and overflow cases. The partial and overflow tests fail without
the change, and the other three keep passing, so they are genuine regression
tests rather than decoration.

`cargo test -p pumpkin-inventory` and `cargo clippy -p pumpkin-inventory
--all-targets` are both clean. `futures` was added as a dev-dependency for
`block_on`, matching how the rest of the codebase drives futures from sync code.

## Known limitations

Deliberately scoped to the pickup path. Two nearby issues are left alone:

- `get_occupied_slot_with_room_for_stack` takes `main_inventory.read()` then
  `entity_equipment.lock()`, while `swap_item` takes them in the opposite order.
- `offer_or_drop_stack` has the same missing-merge assumption.

Happy to address either here or separately, whichever you prefer.

Fixes #2833
