### PR TITLE
fix(world): pick a safe world spawn instead of the origin 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-data/src/generated/biome.rs
+++ b/crates/pumpkin-data/src/generated/biome.rs
@@ -9099,6 +9099,10 @@ pub struct ParameterRange {
     max: i64,
 }
 impl ParameterRange {
+    #[must_use]
+    pub const fn new(min: i64, max: i64) -> Self {
+        Self { min, max }
+    }
     pub fn calc_distance(&self, noise: i64) -> i64 {
         if noise > self.max {
             noise - self.max

--- a/crates/pumpkin-world/src/biome/position_finder.rs
+++ b/crates/pumpkin-world/src/biome/position_finder.rs
@@ -1,5 +1,87 @@
+use std::cell::RefCell;
+
 use pumpkin_data::chunk::ParameterRange;
 use pumpkin_util::math::vector2::Vector2;
+
+use super::multi_noise::to_long;
+use crate::generation::biome_coords;
+use crate::generation::generator::VanillaGenerator;
+use crate::generation::noise::router::multi_noise_sampler::{
+    MultiNoiseSampler, MultiNoiseSamplerBuilderOptions,
+};
+
+/// Climate targets the overworld spawn search aims for.
+///
+/// Two points that differ only in weirdness, both keeping continentalness inland,
+/// which is what steers the spawn away from oceans.
+// OverworldBiomeBuilder.spawnTarget
+#[must_use]
+pub fn overworld_spawn_target() -> [[ParameterRange; 7]; 2] {
+    const FULL_RANGE: (f32, f32) = (-1.0, 1.0);
+    // Climate.Parameter.span(inlandContinentalness, FULL_RANGE) keeps the min of the
+    // first and the max of the second.
+    const INLAND: (f32, f32) = (-0.11, 1.0);
+    const POINT_ZERO: (f32, f32) = (0.0, 0.0);
+
+    let range = |(min, max): (f32, f32)| ParameterRange::new(to_long(min), to_long(max));
+
+    [
+        [
+            range(FULL_RANGE),    // temperature
+            range(FULL_RANGE),    // humidity
+            range(INLAND),        // continentalness
+            range(FULL_RANGE),    // erosion
+            range(POINT_ZERO),    // depth
+            range((-1.0, -0.16)), // weirdness
+            range(POINT_ZERO),    // offset
+        ],
+        [
+            range(FULL_RANGE),
+            range(FULL_RANGE),
+            range(INLAND),
+            range(FULL_RANGE),
+            range(POINT_ZERO),
+            range((0.16, 1.0)),
+            range(POINT_ZERO),
+        ],
+    ]
+}
+
+/// Picks the block position whose climate best matches [`overworld_spawn_target`].
+///
+/// This is the first half of vanilla's initial spawn search: it settles on a region,
+/// not on a standing position. The caller still has to look for solid ground around
+/// the returned position.
+// Climate.Sampler.findSpawnPosition
+#[must_use]
+pub fn find_climate_spawn_position(generator: &VanillaGenerator) -> Vector2<i32> {
+    let options = MultiNoiseSamplerBuilderOptions::new(1, 1, 1);
+    let sampler = RefCell::new(MultiNoiseSampler::generate(
+        &generator.base_router.multi_noise,
+        &options,
+    ));
+
+    let sample = |x: i32, z: i32| {
+        let point = sampler.borrow_mut().sample(
+            biome_coords::from_block(x),
+            0,
+            biome_coords::from_block(z),
+        );
+
+        [
+            point.temperature,
+            point.humidity,
+            point.continentalness,
+            point.erosion,
+            // Vanilla zeroes depth for the spawn search, unlike biome lookups.
+            0,
+            point.weirdness,
+            0,
+        ]
+    };
+
+    FittestPositionFinder::find_best_spawn_position(&overworld_spawn_target(), &sample)
+}
 
 pub struct FittestPositionFinderResult {
     pub location: Vector2<i32>,
@@ -61,7 +143,9 @@ impl FittestPositionFinder {
         for noise_ranges in noises {
             let mut current_dist = 0i64;
             for i in 0..7 {
-                current_dist += noise_ranges[i].calc_distance(sampled_noise[i]);
+                // Vanilla sums the *squared* distances (Climate.ParameterPoint#fitness).
+                let distance = noise_ranges[i].calc_distance(sampled_noise[i]);
+                current_dist += distance * distance;
             }
             min_squared_dist = min_squared_dist.min(current_dist);
         }

--- a/crates/pumpkin/src/server/mod.rs
+++ b/crates/pumpkin/src/server/mod.rs
@@ -44,6 +44,7 @@ use rsa::RsaPublicKey;
 use std::collections::HashSet;
 use std::fs;
 use std::net::IpAddr;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32};
 use std::{future::Future, sync::atomic::Ordering, time::Duration};
@@ -171,6 +172,10 @@ impl Server {
 
         let block_registry = super::block::registry::default_registry();
 
+        // A brand new world still has to pick where its spawn point goes, which needs
+        // generated terrain and therefore has to wait until the worlds are loaded.
+        let mut world_is_new = false;
+
         let level_info = match AnvilLevelInfo.read_world_info(&world_path) {
             Ok(level_info) => {
                 let dat_path = world_path.join(LEVEL_DAT_FILE_NAME);
@@ -188,6 +193,7 @@ impl Server {
                     world_path.display(),
                     basic_config.seed.0 as i64
                 );
+                world_is_new = true;
                 let default_data = LevelData::default(basic_config.seed);
                 if let Err(err) = AnvilLevelInfo.write_world_info(&default_data, &world_path) {
                     error!("Failed to save level.dat: {err}");
@@ -393,6 +399,10 @@ impl Server {
 
         info!("All worlds loaded successfully.");
 
+        if world_is_new {
+            Self::pick_initial_spawn(&server, &world_path).await;
+        }
+
         if server.advanced_config.networking.bedrock.online_mode {
             server
                 .bedrock_oidc_keys
@@ -413,6 +423,33 @@ impl Server {
                 .await;
         }
         server
+    }
+
+    /// Picks the spawn point of a freshly created world and persists it.
+    ///
+    /// Runs once, right after the worlds are loaded, because choosing a spot needs
+    /// generated terrain. Without this the spawn stays at the origin, which drops
+    /// players into the ocean whenever (0, 0) happens to be water.
+    // MinecraftServer.setInitialSpawn
+    async fn pick_initial_spawn(server: &Arc<Self>, world_path: &Path) {
+        let world = server.get_world_from_dimension(&Dimension::OVERWORLD);
+        let spawn = world.find_initial_spawn_pos().await;
+
+        let mut info = (**server.level_info.load()).clone();
+        info.spawn_x = spawn.0.x;
+        info.spawn_y = spawn.0.y;
+        info.spawn_z = spawn.0.z;
+
+        info!(
+            "World spawn set to {}, {}, {}",
+            spawn.0.x, spawn.0.y, spawn.0.z
+        );
+
+        if let Err(err) = AnvilLevelInfo.write_world_info(&info, world_path) {
+            error!("Failed to save the world spawn: {err}");
+        }
+
+        server.level_info.store(Arc::new(info));
     }
 
     /// Spawns a task associated with this server. All tasks spawned with this method are awaited

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -167,7 +167,9 @@ pub mod weather;
 use crate::world::natural_spawner::{SpawnState, spawn_for_chunk};
 use pumpkin_config::lighting::LightingEngineConfig;
 use pumpkin_data::effect::StatusEffect;
+use pumpkin_world::biome::position_finder::find_climate_spawn_position;
 use pumpkin_world::chunk::ChunkHeightmapType::{self, MotionBlocking};
+use pumpkin_world::generation::generator::WorldGenerator;
 use uuid::Uuid;
 use weather::Weather;
 
@@ -292,6 +294,10 @@ impl PartialEq for World {
 impl Eq for World {}
 
 impl World {
+    /// How far from the world spawn a player may be placed when the spawn itself has
+    /// become unusable. Matches the default `spawnRadius` game rule.
+    const SPAWN_SEARCH_RADIUS: i32 = 10;
+
     pub async fn get_block_state_id_async(&self, position: &BlockPos) -> BlockStateId {
         if !self.is_in_build_limit(*position) {
             return Block::AIR.default_state.id;
@@ -2053,6 +2059,201 @@ impl World {
             .unwrap_or(self.min_y)
     }
 
+    /// Finds a standing position in the column at `x`/`z` that is not inside a fluid.
+    ///
+    /// Walks down from the top of the column and returns the position directly above
+    /// the first block with a solid upper face, provided the player also fits there.
+    /// Returns `None` as soon as a fluid is met, so a caller never places a player
+    /// inside water or lava.
+    ///
+    /// The chunk must already be loaded; use [`Self::get_or_fetch_chunk`] first.
+    // PlayerRespawnLogic.getOverworldRespawnPos
+    pub async fn get_safe_spawn_pos_in_column(&self, x: i32, z: i32) -> Option<BlockPos> {
+        let min_y = self.dimension.min_y;
+        let max_y = min_y + self.dimension.height;
+
+        // Start one block above the heightmap so a block placed on the spawn, or a
+        // stale heightmap, cannot hide the real surface from the walk below.
+        let top = self.get_heightmap_height(MotionBlocking, x, z) + 2;
+        if top < min_y || top > max_y {
+            return None;
+        }
+
+        for y in (min_y..=top).rev() {
+            let state = self.get_block_state_async(&BlockPos::new(x, y, z)).await;
+
+            // Vanilla stops at the first fluid rather than digging under an ocean.
+            if state.is_liquid() {
+                return None;
+            }
+
+            if state.is_side_solid(BlockDirection::Up) {
+                let stand = BlockPos::new(x, y + 1, z);
+                return self.fits_standing(&stand).await.then_some(stand);
+            }
+        }
+
+        None
+    }
+
+    /// Whether a player standing at `pos` would be free of blocks.
+    ///
+    /// Checks the two blocks a player occupies. Without this, spawning under a tree
+    /// puts the player inside the leaves, and a block placed on the spawn point
+    /// suffocates them on respawn.
+    async fn fits_standing(&self, pos: &BlockPos) -> bool {
+        for offset in 0..2 {
+            let at = BlockPos::new(pos.0.x, pos.0.y + offset, pos.0.z);
+            let state = self.get_block_state_async(&at).await;
+            if state.is_solid() || state.is_liquid() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Where a player should appear when they spawn at the world spawn.
+    ///
+    /// Prefers the stored spawn point, which was validated when the world was
+    /// created, and only re-derives a position when the terrain no longer allows
+    /// standing there. Callers must not recompute this from the surface height:
+    /// `WORLD_SURFACE` counts water and leaves as ground.
+    pub async fn world_spawn_position(&self) -> Vector3<f64> {
+        let (spawn_x, spawn_y, spawn_z) = {
+            let info = self.level_info.load();
+            (info.spawn_x, info.spawn_y, info.spawn_z)
+        };
+
+        let chunk_pos = Vector2::new(spawn_x >> 4, spawn_z >> 4);
+        self.level.get_or_fetch_chunk(chunk_pos, |_| ()).await;
+
+        let stored = BlockPos::new(spawn_x, spawn_y, spawn_z);
+        if self.fits_standing(&stored).await {
+            return Vector3::new(
+                f64::from(spawn_x) + 0.5,
+                f64::from(spawn_y),
+                f64::from(spawn_z) + 0.5,
+            );
+        }
+
+        // The spawn was built over, flooded or covered in lava since it was picked.
+        // Looking only at this column is not enough: it can be impassable all the way
+        // down, so widen the search the way vanilla spreads players around the spawn.
+        if let Some(safe) = self
+            .find_standable_near(spawn_x, spawn_z, Self::SPAWN_SEARCH_RADIUS)
+            .await
+        {
+            return Vector3::new(
+                f64::from(safe.0.x) + 0.5,
+                f64::from(safe.0.y),
+                f64::from(safe.0.z) + 0.5,
+            );
+        }
+
+        warn!("No standable ground near the world spawn; using the surface height");
+        Vector3::new(
+            f64::from(spawn_x) + 0.5,
+            f64::from(self.get_top_block(Vector2::new(spawn_x, spawn_z)) + 1),
+            f64::from(spawn_z) + 0.5,
+        )
+    }
+
+    /// Searches outwards from `x`/`z` for a column a player can stand in.
+    ///
+    /// Walks square rings of growing radius so the closest usable spot wins. Loads
+    /// each chunk it reaches, since the search can cross chunk borders.
+    async fn find_standable_near(&self, x: i32, z: i32, radius: i32) -> Option<BlockPos> {
+        for ring in 0..=radius {
+            for dx in -ring..=ring {
+                for dz in -ring..=ring {
+                    // Only the edge of the ring; the inside was covered already.
+                    if ring > 0 && dx.abs() != ring && dz.abs() != ring {
+                        continue;
+                    }
+
+                    let (cx, cz) = (x + dx, z + dz);
+                    self.level
+                        .get_or_fetch_chunk(Vector2::new(cx >> 4, cz >> 4), |_| ())
+                        .await;
+
+                    if let Some(pos) = self.get_safe_spawn_pos_in_column(cx, cz).await {
+                        return Some(pos);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Finds a safe standing position anywhere in the given chunk.
+    ///
+    /// Scans the chunk column by column and returns the first position that
+    /// [`Self::get_safe_spawn_pos_in_column`] accepts, or `None` for a chunk that is
+    /// entirely covered by fluid or air.
+    // PlayerRespawnLogic.getSpawnPosInChunk
+    pub async fn get_safe_spawn_pos_in_chunk(&self, chunk_pos: Vector2<i32>) -> Option<BlockPos> {
+        self.level.get_or_fetch_chunk(chunk_pos, |_| ()).await;
+
+        let min_x = chunk_pos.x << 4;
+        let min_z = chunk_pos.y << 4;
+
+        for x in min_x..min_x + 16 {
+            for z in min_z..min_z + 16 {
+                if let Some(pos) = self.get_safe_spawn_pos_in_column(x, z).await {
+                    return Some(pos);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Chooses where a brand new world puts its spawn point.
+    ///
+    /// Picks the climatically fitting region, then spirals over the 11x11 chunks
+    /// around it looking for solid ground. Falls back to the centre of that region
+    /// when every candidate chunk is water, which keeps the old behaviour rather
+    /// than failing world creation.
+    // MinecraftServer.setInitialSpawn
+    pub async fn find_initial_spawn_pos(&self) -> BlockPos {
+        let WorldGenerator::Noise(generator) = &*self.level.world_gen else {
+            // Flat worlds have no climate to sample; the origin is as good as anywhere.
+            return BlockPos::new(0, self.get_top_block(Vector2::new(0, 0)) + 1, 0);
+        };
+
+        let climate_pos = find_climate_spawn_position(generator);
+        let chunk_pos = Vector2::new(climate_pos.x >> 4, climate_pos.y >> 4);
+
+        // Spiral outwards, clamped to the 11x11 chunks vanilla considers.
+        let (mut dx, mut dz) = (0i32, 0i32);
+        let (mut step_x, mut step_z) = (0i32, -1i32);
+
+        for _ in 0..11 * 11 {
+            if (-5..=5).contains(&dx) && (-5..=5).contains(&dz) {
+                let candidate = Vector2::new(chunk_pos.x + dx, chunk_pos.y + dz);
+                if let Some(pos) = self.get_safe_spawn_pos_in_chunk(candidate).await {
+                    return pos;
+                }
+            }
+
+            if dx == dz || (dx < 0 && dx == -dz) || (dx > 0 && dx == 1 - dz) {
+                std::mem::swap(&mut step_x, &mut step_z);
+                step_x = -step_x;
+            }
+
+            dx += step_x;
+            dz += step_z;
+        }
+
+        let center_x = (chunk_pos.x << 4) + 8;
+        let center_z = (chunk_pos.y << 4) + 8;
+        self.level.get_or_fetch_chunk(chunk_pos, |_| ()).await;
+        let y = self.get_top_block(Vector2::new(center_x, center_z)) + 1;
+
+        BlockPos::new(center_x, y, center_z)
+    }
+
     #[allow(clippy::too_many_lines)]
     pub async fn spawn_bedrock_player(
         &self,
@@ -2077,16 +2278,7 @@ impl World {
 
             (position, yaw, pitch)
         } else {
-            let spawn_position = Vector2::new(level_info.spawn_x, level_info.spawn_z);
-            let chunk_pos = Vector2::new(level_info.spawn_x >> 4, level_info.spawn_z >> 4);
-            self.level.get_or_fetch_chunk(chunk_pos, |_| ()).await;
-            let pos_y = self.get_top_block(spawn_position) + 1; // +1 to spawn on top of the block
-
-            let position = Vector3::new(
-                f64::from(level_info.spawn_x) + 0.5,
-                f64::from(pos_y),
-                f64::from(level_info.spawn_z) + 0.5,
-            );
+            let position = self.world_spawn_position().await;
             (position, level_info.spawn_yaw, level_info.spawn_pitch)
         };
 
@@ -2910,17 +3102,8 @@ impl World {
 
             (position, yaw, pitch)
         } else {
+            let position = self.world_spawn_position().await;
             let info = &self.level_info.load();
-            let spawn_position = Vector2::new(info.spawn_x, info.spawn_z);
-            let chunk_pos = Vector2::new(info.spawn_x >> 4, info.spawn_z >> 4);
-            self.level.get_or_fetch_chunk(chunk_pos, |_| ()).await;
-            let pos_y = self.get_top_block(spawn_position) + 1; // +1 to spawn on top of the block
-
-            let position = Vector3::new(
-                f64::from(info.spawn_x) + 0.5,
-                f64::from(pos_y),
-                f64::from(info.spawn_z) + 0.5,
-            );
             (position, info.spawn_yaw, info.spawn_pitch)
         };
 
@@ -3647,11 +3830,9 @@ impl World {
         let data_kept = u8::from(alive);
 
         // Copy spawn info from level_info to avoid holding lock across await
-        let (spawn_x, spawn_z, spawn_yaw, spawn_pitch, keep_inventory) = {
+        let (spawn_yaw, spawn_pitch, keep_inventory) = {
             let info = self.level_info.load();
             (
-                info.spawn_x,
-                info.spawn_z,
                 info.spawn_yaw,
                 info.spawn_pitch,
                 info.game_rules.keep_inventory,
@@ -3674,23 +3855,9 @@ impl World {
                     .send_packet_now(&CGameEvent::new(GameEvent::NoRespawnBlockAvailable, 0.0))
                     .await;
 
-                // FIXME: This spawn position calculation is incorrect. Should use vanilla's
-                // proper spawn position calculation (see #1381). The y-level calculation
-                // needs to account for spawn radius and find a safe spawn position.
-                let chunk_pos = Vector2::new(spawn_x >> 4, spawn_z >> 4);
-                self.level.get_or_fetch_chunk(chunk_pos, |_| ()).await;
-                let top = self.get_top_block(Vector2::new(spawn_x, spawn_z));
+                let position = self.world_spawn_position().await;
 
-                (
-                    Vector3::new(
-                        f64::from(spawn_x) + 0.5,
-                        (top + 1).into(),
-                        f64::from(spawn_z) + 0.5,
-                    ),
-                    spawn_yaw,
-                    spawn_pitch,
-                    self.dimension.clone(),
-                )
+                (position, spawn_yaw, spawn_pitch, self.dimension.clone())
             };
 
         let mut spawn_loc_event = crate::plugin::api::events::player::player_spawn_location::PlayerSpawnLocationEvent::new(
@@ -3792,16 +3959,7 @@ impl World {
         let (target_world, position, yaw, pitch) = if let Some(ref new_world) = resolved_world {
             (new_world.clone(), position, yaw, pitch)
         } else if respawn_dimension != self.dimension {
-            // FIXME: This spawn position calculation is incorrect. Should use vanilla's
-            // proper spawn position calculation (see #1381).
-            let chunk_pos = Vector2::new(spawn_x >> 4, spawn_z >> 4);
-            self.level.get_or_fetch_chunk(chunk_pos, |_| ()).await;
-            let top = self.get_top_block(Vector2::new(spawn_x, spawn_z));
-            let fallback_pos = Vector3::new(
-                f64::from(spawn_x) + 0.5,
-                (top + 1).into(),
-                f64::from(spawn_z) + 0.5,
-            );
+            let fallback_pos = self.world_spawn_position().await;
             (self.clone(), fallback_pos, spawn_yaw, spawn_pitch)
         } else {
             (self.clone(), position, yaw, pitch)

--- a/tools/pumpkin-codegen/src/biome.rs
+++ b/tools/pumpkin-codegen/src/biome.rs
@@ -506,6 +506,11 @@ pub fn build() -> TokenStream {
         }
 
         impl ParameterRange {
+            #[must_use]
+            pub const fn new(min: i64, max: i64) -> Self {
+                Self { min, max }
+            }
+
             pub fn calc_distance(&self, noise: i64) -> i64 {
                 if noise > self.max {
                     noise - self.max


### PR DESCRIPTION
## What was changed?

A new world now picks its spawn point instead of leaving it at the origin,
following `MinecraftServer.setInitialSpawn`: find the climatically fitting
region with `FittestPositionFinder`, then spiral over the surrounding 11x11
chunks for ground a player can actually stand on.

The search runs right after the worlds are loaded, since choosing a spot needs
generated terrain and `level.dat` is written before any of it exists.

## Why were these changes necessary?

`LevelData::default` leaves `spawn_x`/`spawn_z` at 0 and `set_pos` is never
called, so every new world spawns players at the origin — in the ocean whenever
(0, 0) happens to be water (#1303).

`FittestPositionFinder` was added for exactly this and was never wired up; the
two `FIXME`s in `world/mod.rs` still point at #1381.

## Relationship to #1381

#1381 was closed with the note that vanilla uses biome noise rather than a
nearest-solid-block scan. This PR takes that route: it uses the existing
`FittestPositionFinder` with vanilla's overworld spawn targets.

One thing from #1381 did turn out to be necessary, and testing found it the hard
way: the standing-room check. Without it a spawn under a tree puts the player
inside the leaves, and a block placed on the spawn suffocates them on respawn.

## Fixes needed along the way

**`FittestPositionFinder` scoring.** `calculate_fitness` summed the raw
parameter distances, while `Climate.ParameterPoint#fitness` sums their
*squares*. Since the result feeds a `min` across targets and is then scaled by
`2048²`, the unsquared sum ranks candidates differently and would not reproduce
vanilla coordinates. Now squared.

**Spawn targets.** `overworld_spawn_target()` transcribes
`OverworldBiomeBuilder.spawnTarget()`: two points differing only in weirdness
(`[-1, -0.16]` and `[0.16, 1]`), with continentalness held inland at
`[-0.11, 1.0]` — that bound is what keeps the search out of oceans.

**`ParameterRange::new`.** Needed to build those targets outside
`pumpkin-data`. Added to `tools/pumpkin-codegen` as well as to the generated
file, so regenerating does not drop it. Happy to take another approach here if
you would rather not widen that type's API.

**Four paths discarded the computed spawn.** `spawn_java_player`,
`spawn_bedrock_player` and both respawn paths each recomputed the height from
`WORLD_SURFACE`, which counts water *and leaves* as ground (per the crate's own
tests, `chunk/mod.rs:901`). They now share `world_spawn_position`.

**Impassable spawn columns.** If the column is flooded or full of lava all the
way down, falling back to the surface height drops the player straight into it.
The search now widens to the surrounding columns, radius 10, matching the
default `spawnRadius` game rule.

## What is the impact of this change?

Tested in-game on `a2b92e6d`, seed `2691798227039107061` — a seed whose origin
is underwater, so it reproduced #1303 exactly before the change:

| Scenario | Before | After |
|---|---|---|
| New world | spawned in the ocean at (0, 0) | `World spawn set to 80, 70, -13`, dry land |
| Spawn under a tree | feet inside the ground, head in leaves | standing room checked |
| Block placed on the spawn | suffocated on respawn | respawns on top |
| Lava over the spawn | respawned inside the lava | moves to the nearest dry column |
| Water over the spawn | respawned floating | moves to the nearest dry column |
| Obstructed bed | falls back to world spawn | unchanged, matches vanilla |

First startup is slower on a new world (~5s here versus ~0.8s) because the
terrain around the candidate has to be generated to inspect it, which is the
same reason vanilla shows "Preparing spawn area".

Side effect worth noting: the spawn is persisted after the worlds are loaded, at
which point the `world` folder exists, so that second write of `level.dat`
succeeds where the first one fails (#2423).

## Known limitations

- Flat worlds keep the origin; there is no climate to sample.
- `find_bed_spawn_position` is still the simplified version its own comment
  describes; untouched here.
- Beds can be placed underwater and set a spawn there. Reproduced, but it is a
  placement issue rather than a spawn-search one, so it is left out of this PR.

Fixes #1303
