### PR TITLE
Fix wrong argument name in worldborder error messages

### DIFF
--- a/crates/pumpkin/src/command/commands/worldborder.rs
+++ b/crates/pumpkin/src/command/commands/worldborder.rs
@@ -146,7 +146,7 @@ impl CommandExecutor for SetTimeExecutor {
             let Ok(time) = time_consumer().find_arg_default_name(args)? else {
                 return Err(CommandError::CommandFailed(TextComponent::text(format!(
                     "{} is out of bounds.",
-                    distance_consumer().default_name()
+                    time_consumer().default_name()
                 ))));
             };
 
@@ -271,7 +271,7 @@ impl CommandExecutor for AddTimeExecutor {
             let Ok(time) = time_consumer().find_arg_default_name(args)? else {
                 return Err(CommandError::CommandFailed(TextComponent::text(format!(
                     "{} is out of bounds.",
-                    distance_consumer().default_name()
+                    time_consumer().default_name()
                 ))));
             };
 


### PR DESCRIPTION
## Description

 when the `time` arg fails to parse in `/worldborder set` and `/worldborder add`, the error says "distance is out of bounds" instead of "time". The error message uses `distance_consumer().default_name()` but the block is parsing `time`.

Fixed both spots.

## Testing

Not tested on a running server