### PR TITLE
fix(inventory): stop the item count arithmetic wrapping in screen_handler

### DIFF
--- a/crates/pumpkin-inventory/src/screen_handler.rs
+++ b/crates/pumpkin-inventory/src/screen_handler.rs
@@ -53,9 +53,9 @@ use pumpkin_world::{
     block::entities::PropertyDelegate,
     inventory::{ComparableInventory, Inventory},
 };
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::{any::Any, collections::HashMap, sync::Arc};
-use std::{cmp::max, pin::Pin};
 use tokio::sync::Mutex;
 use tracing::warn;
 
@@ -875,7 +875,9 @@ pub trait ScreenHandler: Send + Sync {
             if action_type == SlotActionType::PickupAll && button == 0 {
                 let behavior = self.get_behaviour_mut();
                 let mut cursor_stack = behavior.cursor_stack.lock().await;
-                let mut to_pick_up = cursor_stack.get_max_stack_size() - cursor_stack.item_count;
+                let mut to_pick_up = cursor_stack
+                    .get_max_stack_size()
+                    .saturating_sub(cursor_stack.item_count);
 
                 for slot in &behavior.slots {
                     if to_pick_up == 0 {
@@ -894,7 +896,9 @@ pub trait ScreenHandler: Send + Sync {
                     let taken_stack = slot
                         .safe_take(
                             item_stack.item_count.min(to_pick_up),
-                            cursor_stack.get_max_stack_size() - cursor_stack.item_count,
+                            cursor_stack
+                                .get_max_stack_size()
+                                .saturating_sub(cursor_stack.item_count),
                             player,
                         )
                         .await;
@@ -966,12 +970,15 @@ pub trait ScreenHandler: Send + Sync {
                                 }
                                 _ => 0,
                             };
+                            // `max(0, ..)` did nothing here: the subtraction is
+                            // on `u8`, so it had already wrapped by the time
+                            // `max` saw it.
                             inserting_count = inserting_count
-                                .min(max(
-                                    0,
-                                    slot.get_max_item_count_for_stack(&stack).await
-                                        - stack.item_count,
-                                ))
+                                .min(
+                                    slot.get_max_item_count_for_stack(&stack)
+                                        .await
+                                        .saturating_sub(stack.item_count),
+                                )
                                 .min(cursor_stack.item_count);
                             if inserting_count > 0 {
                                 let mut new_stack = stack.clone();
@@ -1410,9 +1417,132 @@ impl ScreenHandlerBehaviour {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::entity_equipment::EntityEquipment;
     use crate::slot::NormalSlot;
     use pumpkin_data::item::Item;
     use pumpkin_world::inventory::SimpleInventory;
+    use std::collections::HashMap;
+
+    /// A player that answers every question the click path asks and sends
+    /// nothing anywhere.
+    struct TestPlayer {
+        inventory: Arc<PlayerInventory>,
+    }
+
+    impl TestPlayer {
+        fn new() -> Self {
+            Self {
+                inventory: Arc::new(PlayerInventory::new(
+                    Arc::new(Mutex::new(EntityEquipment::default())),
+                    Arc::new(HashMap::new()),
+                )),
+            }
+        }
+    }
+
+    impl InventoryPlayer for TestPlayer {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn drop_item(&self, _item: ItemStack, _retain_ownership: bool) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+
+        fn get_inventory(&self) -> Arc<PlayerInventory> {
+            self.inventory.clone()
+        }
+
+        fn has_infinite_materials(&self) -> bool {
+            false
+        }
+
+        fn is_creative(&self) -> bool {
+            false
+        }
+
+        fn experience_level(&self) -> i32 {
+            0
+        }
+
+        fn add_experience_levels(&self, _levels: i32) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+
+        fn enchantment_seed(&self) -> i32 {
+            0
+        }
+
+        fn set_enchantment_seed(&self, _seed: i32) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_inventory_packet<'a>(
+            &'a self,
+            _packet: &'a CSetContainerContent,
+            _window_type: Option<WindowType>,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_slot_packet<'a>(
+            &'a self,
+            _packet: &'a CSetContainerSlot,
+            _window_type: Option<WindowType>,
+            _total_slots: usize,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_cursor_packet<'a>(
+            &'a self,
+            _packet: &'a CSetCursorItem,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_property_packet<'a>(
+            &'a self,
+            _packet: &'a CSetContainerProperty,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_slot_set_packet<'a>(
+            &'a self,
+            _packet: &'a CSetPlayerInventory,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_set_held_item_packet<'a>(
+            &'a self,
+            _packet: &'a CSetSelectedSlot,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn enqueue_equipment_change<'a>(
+            &'a self,
+            _slot: &'a EquipmentSlot,
+            _stack: &'a ItemStack,
+        ) -> PlayerFuture<'a, ()> {
+            Box::pin(async {})
+        }
+
+        fn award_experience(&self, _amount: i32) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+
+        fn increment_stat(
+            &self,
+            _category: StatisticCategory,
+            _stat_id: i32,
+            _amount: i32,
+        ) -> PlayerFuture<'_, ()> {
+            Box::pin(async {})
+        }
+    }
 
     /// The smallest thing `insert_item` needs: somewhere to keep the slots.
     struct TestScreenHandler {
@@ -1438,6 +1568,14 @@ mod tests {
 
         async fn count(&self, index: usize) -> u8 {
             self.behaviour.slots[index].get_stack().await.item_count
+        }
+
+        async fn set_cursor(&self, stack: ItemStack) {
+            *self.behaviour.cursor_stack.lock().await = stack;
+        }
+
+        async fn cursor_count(&self) -> u8 {
+            self.behaviour.cursor_stack.lock().await.item_count
         }
     }
 
@@ -1513,5 +1651,26 @@ mod tests {
                 + u16::from(incoming.item_count),
             300
         );
+    }
+
+    /// The cursor can end up holding more than its own limit — a slot can be
+    /// filled past it and the swap further down this function hands that stack
+    /// to the cursor — so the headroom left on it has to survive going below
+    /// zero. Left wrapping, the cursor picks up more on top of being full.
+    #[tokio::test]
+    async fn pickup_all_does_not_underflow_the_cursor_headroom() {
+        let mut handler = TestScreenHandler::with_slots(2);
+        let player = TestPlayer::new();
+        handler.set_cursor(ItemStack::new(200, &Item::STONE)).await;
+        handler.set(0, ItemStack::new(10, &Item::STONE)).await;
+
+        handler
+            .internal_on_slot_click(0, 0, SlotActionType::PickupAll, &player)
+            .await;
+
+        // There is no room left on the cursor, so the double-click must pull
+        // nothing in.
+        assert_eq!(handler.cursor_count().await, 200);
+        assert_eq!(handler.count(0).await, 10);
     }
 }

--- a/crates/pumpkin-inventory/src/screen_handler.rs
+++ b/crates/pumpkin-inventory/src/screen_handler.rs
@@ -758,9 +758,14 @@ pub trait ScreenHandler: Send + Sync {
                     let mut slot_stack = slot.get_stack().await;
 
                     if !slot_stack.is_empty() && slot_stack.are_items_and_components_equal(stack) {
-                        let combined_count = slot_stack.item_count + stack.item_count;
+                        // A count past `u8::MAX` cannot fit a slot anyway, so `None`
+                        // falls through to the partial-fill arm below like any other
+                        // combination too large to merge outright.
+                        let combined_count = slot_stack.item_count.checked_add(stack.item_count);
                         let max_slot_count = slot.get_max_item_count_for_stack(&slot_stack).await;
-                        if combined_count <= max_slot_count {
+                        if let Some(combined_count) = combined_count
+                            && combined_count <= max_slot_count
+                        {
                             stack.set_count(0);
                             slot_stack.set_count(combined_count);
                             slot.set_stack(slot_stack).await;
@@ -1399,5 +1404,114 @@ impl ScreenHandlerBehaviour {
     pub fn next_revision(&self) -> u32 {
         self.revision.fetch_add(1, Ordering::Relaxed);
         self.revision.fetch_and(32767, Ordering::Relaxed) & 32767
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slot::NormalSlot;
+    use pumpkin_data::item::Item;
+    use pumpkin_world::inventory::SimpleInventory;
+
+    /// The smallest thing `insert_item` needs: somewhere to keep the slots.
+    struct TestScreenHandler {
+        behaviour: ScreenHandlerBehaviour,
+    }
+
+    impl TestScreenHandler {
+        /// Builds a handler over one inventory, one slot per inventory slot.
+        fn with_slots(size: usize) -> Self {
+            let inventory: Arc<dyn Inventory> = Arc::new(SimpleInventory::new(size));
+            let mut behaviour = ScreenHandlerBehaviour::new(0, None);
+            for index in 0..size {
+                behaviour
+                    .slots
+                    .push(Arc::new(NormalSlot::new(inventory.clone(), index)));
+            }
+            Self { behaviour }
+        }
+
+        async fn set(&self, index: usize, stack: ItemStack) {
+            self.behaviour.slots[index].set_stack(stack).await;
+        }
+
+        async fn count(&self, index: usize) -> u8 {
+            self.behaviour.slots[index].get_stack().await.item_count
+        }
+    }
+
+    impl ScreenHandler for TestScreenHandler {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+
+        fn get_behaviour(&self) -> &ScreenHandlerBehaviour {
+            &self.behaviour
+        }
+
+        fn get_behaviour_mut(&mut self) -> &mut ScreenHandlerBehaviour {
+            &mut self.behaviour
+        }
+
+        fn quick_move<'a>(
+            &'a mut self,
+            _player: &'a dyn InventoryPlayer,
+            _slot_index: i32,
+        ) -> ItemStackFuture<'a> {
+            Box::pin(async { ItemStack::EMPTY.clone() })
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_item_tops_up_a_matching_stack() {
+        let mut handler = TestScreenHandler::with_slots(2);
+        handler.set(0, ItemStack::new(32, &Item::STONE)).await;
+
+        let mut incoming = ItemStack::new(16, &Item::STONE);
+        assert!(handler.insert_item(&mut incoming, 0, 2, false).await);
+
+        assert_eq!(handler.count(0).await, 48);
+        assert!(incoming.is_empty());
+    }
+
+    #[tokio::test]
+    async fn insert_item_fills_to_the_limit_and_carries_the_rest_over() {
+        let mut handler = TestScreenHandler::with_slots(2);
+        handler.set(0, ItemStack::new(60, &Item::STONE)).await;
+
+        let mut incoming = ItemStack::new(10, &Item::STONE);
+        assert!(handler.insert_item(&mut incoming, 0, 2, false).await);
+
+        // Stone caps at 64, so slot 0 takes 4 and the remaining 6 go to slot 1.
+        assert_eq!(handler.count(0).await, 64);
+        assert_eq!(handler.count(1).await, 6);
+        assert!(incoming.is_empty());
+    }
+
+    /// Counts above 127 do reach here: the plugin API's `item-stack.new` and
+    /// `set-count` take a raw `u8` and clamp nothing, so two stacks can sum
+    /// past `u8::MAX`.
+    #[tokio::test]
+    async fn insert_item_does_not_overflow_the_count() {
+        let mut handler = TestScreenHandler::with_slots(2);
+        handler.set(0, ItemStack::new(200, &Item::STONE)).await;
+
+        let mut incoming = ItemStack::new(100, &Item::STONE);
+        handler.insert_item(&mut incoming, 0, 2, false).await;
+
+        // Slot 0 already holds more than it can take, so it is left alone and
+        // nothing is lost on the way past it.
+        assert_eq!(handler.count(0).await, 200);
+        assert_eq!(
+            u16::from(handler.count(0).await)
+                + u16::from(handler.count(1).await)
+                + u16::from(incoming.item_count),
+            300
+        );
     }
 }


### PR DESCRIPTION
## Description

Item counts in `screen_handler.rs` are `u8` and the arithmetic on them wraps, so a stack holding more than a slot can take corrupts the counts around it instead of being skipped.

Merging: `insert_item` adds the two counts with `+` (`screen_handler.rs:761`). A slot of 200 taking 100 wraps to 44, which then passes the `combined_count <= max_slot_count` check, so the incoming stack is zeroed and the slot is rewritten to 44. 300 items become 44 and nothing is logged.

Clicking: the "how much more fits" expression `max - current` appears four times in this file. One already uses `saturating_sub` (`:1234`); the other three subtract directly. With a cursor already past its own limit, `64 - 200` wraps to 120 and a double-click pulls another stack in on top of a full cursor — measured, 200 becomes 210. The `max(0, ..)` around one of them does nothing, since the operands are `u8` and the subtraction has already wrapped by the time `max` sees it.

Debug builds panic at each of these instead of wrapping.

Counts above 127 are reachable through the plugin API, which clamps nothing: `item-stack.new(registry_key, count)` and `set-count(count)` take a raw `u8` (`wit/v0_1/item_stack.rs:143`, `:173`), and `gui.set-item` writes the stack straight into a slot (`wit/v0_1/gui.rs:83`). From there the swap at `:1222` moves such a stack onto the cursor.

`checked_add` leaves the merge case to the partial-fill arm right below it, which already handles a combination too large to merge outright, and `saturating_sub` leaves no headroom on a slot that is already over. Nothing changes for counts that fit.

This fixes the corruption, not the source of the oversized counts — clamping in the plugin API would be a separate change.

## Testing

`cargo test -p pumpkin-inventory`, with four new tests: topping up a matching stack, filling to the slot limit and carrying the rest over, the merge overflow, and the cursor-headroom underflow.

Both new failure cases fail on `master`. The merge one gives `attempt to add with overflow` in debug and `left: 44, right: 200` in release; the cursor one gives `attempt to subtract with overflow` in debug and `left: 210, right: 200` in release. The two baseline tests pass on `master`, so they pin existing behaviour rather than the fix.

`cargo fmt --all -- --check` and `cargo clippy --all-targets` are clean, and `cargo test --workspace` is 603 passed / 0 failed.
