### PR TITLE
fix(world): reject region entries that underflow when read

### DIFF
--- a/crates/pumpkin-world/src/chunk/format/anvil.rs
+++ b/crates/pumpkin-world/src/chunk/format/anvil.rs
@@ -247,8 +247,16 @@ impl AnvilChunkData {
 
     fn from_bytes(bytes: Bytes) -> Result<Self, ChunkReadingError> {
         let mut bytes = bytes;
-        // Minus one for the compression byte
-        let length = bytes.get_u32() as usize - 1;
+        // Minus one for the compression byte, which the length covers, so
+        // anything below one does not describe a chunk at all.
+        let declared_length = bytes.get_u32() as usize;
+        let Some(length) = declared_length.checked_sub(1) else {
+            return Err(ChunkReadingError::ParsingError(
+                ChunkParsingError::ErrorDeserializingChunk(
+                    "Chunk length does not cover its compression byte".to_string(),
+                ),
+            ));
+        };
 
         if length > bytes.len() {
             return Err(ChunkReadingError::ParsingError(
@@ -564,8 +572,9 @@ impl<S: SingleChunkDataSerializer + 'static> ChunkSerializer for AnvilChunkFile<
             let sector_offset = (location >> 8) as usize;
             let end_offset = sector_offset + sector_count;
 
-            // If the sector offset or count is 0, the chunk is not present (we should not parse empty chunks)
-            if sector_offset == 0 || sector_count == 0 {
+            // If the sector offset or count is 0, the chunk is not present (we should not parse empty chunks).
+            // Sector 1 is the timestamp table, so a chunk cannot start there either.
+            if sector_offset < 2 || sector_count == 0 {
                 continue;
             }
 
@@ -1326,7 +1335,57 @@ mod tests {
  */
 #[cfg(test)]
 mod tests {
-    use super::{Compression, CompressionError};
+    use super::{AnvilChunkFile, Compression, CompressionError, SECTOR_BYTES};
+    use crate::chunk::ChunkData;
+    use crate::chunk::io::ChunkSerializer;
+    use bytes::{BufMut, Bytes, BytesMut};
+
+    /// A region file whose first location entry is `location`, whose other
+    /// 1023 entries are absent, and whose single payload sector starts with
+    /// `declared_len` followed by the "no compression" marker.
+    fn region_with_first_location(location: u32, declared_len: u32) -> Bytes {
+        let mut buf = BytesMut::with_capacity(SECTOR_BYTES * 3);
+        buf.put_u32(location);
+        buf.put_bytes(0, SECTOR_BYTES - 4);
+        buf.put_bytes(0, SECTOR_BYTES);
+
+        buf.put_u32(declared_len);
+        buf.put_u8(3);
+        buf.put_bytes(0, SECTOR_BYTES - 5);
+
+        buf.freeze()
+    }
+
+    #[test]
+    fn a_chunk_pointing_into_the_header_is_skipped() {
+        // Sectors 0 and 1 hold the location and timestamp tables, so a chunk
+        // cannot start before sector 2. Offset 0 is already skipped; offset 1
+        // is just as impossible and used to be subtracted from anyway.
+        let file = AnvilChunkFile::<ChunkData>::read(region_with_first_location((1 << 8) | 1, 1))
+            .expect("one bad location entry should not fail the whole region");
+
+        assert!(file.chunks_data[0].is_none());
+    }
+
+    #[test]
+    fn a_chunk_at_the_first_free_sector_is_read() {
+        // The control for the test above: sector 2 is the first legal one, and
+        // a chunk there must not be skipped.
+        let file = AnvilChunkFile::<ChunkData>::read(region_with_first_location((2 << 8) | 1, 1))
+            .expect("a chunk at the first free sector is well formed");
+
+        assert!(file.chunks_data[0].is_some());
+    }
+
+    #[test]
+    fn a_chunk_declaring_no_length_is_an_error_not_a_panic() {
+        // The length covers the compression byte, so the smallest legal value
+        // is 1 and the byte count is that minus one. Zero came from a file, so
+        // it has to be rejected rather than subtracted from.
+        let file = AnvilChunkFile::<ChunkData>::read(region_with_first_location((2 << 8) | 1, 0));
+
+        assert!(file.is_err());
+    }
 
     #[test]
     fn custom_compression_returns_unknown_compression_error() {


### PR DESCRIPTION
## Description

Two values read straight out of a region file are subtracted from without a check, and both wrap.

Sector offset: sectors 0 and 1 hold the location and timestamp tables, so a chunk can only start at sector 2 or later. The presence check at `anvil.rs:568` skips offset 0 but not offset 1, and `(sector_offset - 2) * SECTOR_BYTES` at `:578` underflows on it. Release is worse than a wrong read rather than better: `bytes_offset` becomes 2^64 − 4096, adding `bytes_count` wraps it back to 0, so the bounds check at `:581` is satisfied by the same overflow that broke it, and the slice at `:593` dies inside `bytes` with `range start must not be greater than end: 18446744073709547520 <= 0`. Debug panics at the subtraction itself.

Chunk length: the length prefix covers the compression byte, so `:251` subtracts one from it. A declared length of 0 underflows. This one is debug-only — in release `usize::MAX > bytes.len()` holds, so it lands in the "Chunk length is greater than available bytes" error path at `:256` and is reported correctly.

Offset 1 now joins the presence check, and the length uses `checked_sub` and returns that same parsing error. A bad entry is skipped or reported like any other and the rest of the region still loads, which is what the surrounding code already does for offset 0 and for an over-long length.

Both values come from the file, so a truncated or corrupt region reaches them. I have not tried to produce one from a real save — the tests build the region bytes directly.

## Testing

`cargo test -p pumpkin-world`, with three new tests: a location entry pointing at sector 1, the same entry at sector 2 as a control, and a chunk declaring length 0.

Reverting either fix on its own fails only its own test and leaves the control passing, so neither test is passing for an unrelated reason.

`cargo fmt --all -- --check` and `cargo clippy --all-targets` are clean, and `cargo test --workspace` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed chunk data to prevent parsing failures caused by invalid length declarations.
  - Region entries pointing into reserved file headers are now treated as absent instead of being parsed as chunk data.
  - Added coverage for invalid, reserved, and valid chunk-location scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->