### PR TITLE
fix(config): don't overwrite the config file when a field has the wrong type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3469,6 +3469,7 @@ version = "0.1.0-dev+26.2-26.40"
 dependencies = [
  "pumpkin-util",
  "serde",
+ "tempfile",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "uuid",

--- a/crates/pumpkin-config/Cargo.toml
+++ b/crates/pumpkin-config/Cargo.toml
@@ -13,6 +13,8 @@ uuid.workspace = true
 
 toml.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/pumpkin-config/src/lib.rs
+++ b/crates/pumpkin-config/src/lib.rs
@@ -364,7 +364,19 @@ pub trait LoadConfiguration {
 
         let (merged_value, changed) = Self::merge_toml_values(default_toml_value, parsed_toml);
 
-        let config = merged_value.try_into().unwrap_or_else(|_| Self::default());
+        let config = match merged_value.try_into() {
+            Ok(config) => config,
+            Err(err) => {
+                error!(
+                    "Couldn't apply the values in {}. Reason: {err}. Using default config.",
+                    Self::get_path().display()
+                );
+                // Report nothing as changed. `load` writes the merged config
+                // back when something did, which here would replace the file
+                // we just failed to make sense of with plain defaults.
+                return (Self::default(), false);
+            }
+        };
 
         (config, changed)
     }
@@ -408,4 +420,54 @@ pub trait LoadConfiguration {
 
     /// Validates the configuration after loading or merging.
     fn validate(&self);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LoadConfiguration, PumpkinConfig, fs};
+
+    /// Parses as TOML, but `tps` is an `f32` and this gives it a string.
+    const BAD_FIELD_TYPE: &str = r#"
+default_level_name = "my-precious-world"
+hardcore = true
+allow_nether = false
+tps = "sixty"
+"#;
+
+    /// Valid, but leaves nearly every key for the defaults to fill in.
+    const MISSING_VALUES: &str = r#"
+default_level_name = "my-precious-world"
+"#;
+
+    #[test]
+    fn a_field_of_the_wrong_type_does_not_overwrite_the_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(PumpkinConfig::get_path());
+        fs::write(&path, BAD_FIELD_TYPE).expect("write config");
+
+        let config = PumpkinConfig::load(dir.path());
+
+        // Nothing in the file can be trusted, so the server runs on defaults,
+        assert_eq!(config.basic.default_level_name, "world");
+        // but the file itself is still the one the user wrote.
+        assert_eq!(
+            fs::read_to_string(&path).expect("read config back"),
+            BAD_FIELD_TYPE
+        );
+    }
+
+    #[test]
+    fn missing_values_are_still_filled_in() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(PumpkinConfig::get_path());
+        fs::write(&path, MISSING_VALUES).expect("write config");
+
+        let config = PumpkinConfig::load(dir.path());
+
+        assert_eq!(config.basic.default_level_name, "my-precious-world");
+
+        let on_disk = fs::read_to_string(&path).expect("read config back");
+        assert!(on_disk.contains("my-precious-world"), "{on_disk}");
+        assert!(on_disk.contains("allow_nether"), "{on_disk}");
+    }
 }


### PR DESCRIPTION
## Description

One field of the wrong type in `pumpkin.toml` makes the server throw the whole file away and overwrite it with defaults.

`LoadConfiguration::load` handles two failure modes properly — it can't read the file, it can't parse the TOML — and logs an `error!` for each before falling back to defaults. There is a third one, in `merge_with_default_toml`:

```rust
let config = merged_value.try_into().unwrap_or_else(|_| Self::default());

(config, changed)
```

The file parsed as TOML, but the merged value doesn't deserialize into the config struct. That happens when a key has the wrong type — `tps = "sixty"` instead of `tps = 20.0`, `max_players = "1000"`, a bool where a number goes. There is no `deny_unknown_fields` anywhere, so a misspelled key is harmless; it's specifically a type mismatch that lands here.

Two things then go wrong:

1. It's silent. No `error!`, no warning, nothing. The server just comes up with every setting at its default.
2. `changed` is still `true` — it's set by `merge_toml_values` whenever the user's file omits any default key, which is nearly always — so `load` takes the write-back branch at the end and `fs::write`s the defaults over the user's file.

The only thing printed is actively misleading:

```
pumpkin.toml changed because values were missing. The missing values were filled with default values.
```

Nothing was filled in. Everything was replaced.

A four-line `pumpkin.toml` with one bad `tps` comes back as ~3.2 KB of pure defaults; `default_level_name`, `hardcore` and `allow_nether` are gone from disk, not just from the running server. If the world name was custom, the next start also looks for the wrong world folder.

The fix logs the failure like the other two paths do, and reports `changed = false` so `load` skips the write-back and leaves the file alone. Falling back to defaults for this run is unchanged — that's what the read and parse failures already do.

## Testing

`a_field_of_the_wrong_type_does_not_overwrite_the_file` writes a config whose `tps` is a string, calls `load`, and asserts the file on disk is still byte-for-byte what was written. It fails on `master` with the entire default config as the actual value.

`missing_values_are_still_filled_in` is the counterpart — a config that only sets `default_level_name` still gets read, and the defaults still get written back around it. Reverting the fix alone leaves this one passing and fails only the first, so the new test is pinned to the fix and not to the surrounding setup.

Run locally, twice on identical file hashes:

- `cargo nextest run` (workspace) and `cargo test --doc`
- `cargo clippy --all-targets --all-features`, debug and release
- `cargo fmt --check`
- `cargo machete` — `tempfile` is new as a dev-dependency for the temp config directory
