### PR TITLE
Fix text component errors in events

### DIFF
--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/player.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/player.rs
@@ -1154,7 +1154,6 @@ impl ToFromWasmEvent for AsyncPlayerChatEvent {
     }
 
     fn apply_wasm_event(&mut self, event: Event, state: &mut PluginHostState) {
-        cleanup_event(&event, state);
         if let Event::AsyncPlayerChatEvent(data) = event {
             self.cancelled = data.cancelled;
             self.message = data.message;
@@ -1190,7 +1189,6 @@ impl ToFromWasmEvent for AsyncPlayerPreLoginEvent {
     }
 
     fn apply_wasm_event(&mut self, event: Event, state: &mut PluginHostState) {
-        cleanup_event(&event, state);
         if let Event::AsyncPlayerPreLoginEvent(data) = event {
             self.cancelled = data.cancelled;
             self.kick_message = consume_text_component(state, &data.kick_message);
@@ -1823,7 +1821,6 @@ impl ToFromWasmEvent for PlayerNameEntityEvent {
     }
 
     fn apply_wasm_event(&mut self, event: Event, state: &mut PluginHostState) {
-        cleanup_event(&event, state);
         if let Event::PlayerNameEntityEvent(data) = event {
             self.cancelled = data.cancelled;
             self.name = consume_text_component(state, &data.name);
@@ -1925,7 +1922,6 @@ impl ToFromWasmEvent for PlayerPreLoginEvent {
     }
 
     fn apply_wasm_event(&mut self, event: Event, state: &mut PluginHostState) {
-        cleanup_event(&event, state);
         if let Event::PlayerPreLoginEvent(data) = event {
             self.cancelled = data.cancelled;
             self.kick_message = consume_text_component(state, &data.kick_message);

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/server.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/server.rs
@@ -209,7 +209,6 @@ impl ToFromWasmEvent for ServerListPingEvent {
     }
 
     fn apply_wasm_event(&mut self, event: Event, state: &mut PluginHostState) {
-        cleanup_event(&event, state);
         match event {
             Event::ServerListPingEvent(data) => {
                 self.motd = consume_text_component(state, &data.motd);


### PR DESCRIPTION
I will happily admit this is an AI PR 🤖🤖🤖 I couldn't figure out why setting my ServerListPingEvent MOTD to a TextComponent made my server crash on ping. I recently added the possibility to use TextComponent as MOTD in [this PR](https://github.com/Pumpkin-MC/Pumpkin/pull/2912), I tested it and it worked. But now it doesn't. AI suggested this, I personally feel like this isn't a good fix, but that's up to maintainers to decide I guess. But feel free to add a better fix.

I believe this commit/file caused it: https://github.com/Pumpkin-MC/Pumpkin/commit/8ce513ff8978609d3ecf66d5e83e98346ff89b37#diff-fba470b4a7a98ebb687a5a9e6858cf222740f0d673459e47e4813c35a01e74e8