### PR TITLE
refactor(bedrock): Add `PacketWrite` impl for `NbtCompound`

### DIFF
--- a/crates/pumpkin-protocol/src/bedrock/client/block_actor_data.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/block_actor_data.rs
@@ -1,12 +1,11 @@
-use std::io::{Error, Write};
-
 use pumpkin_macros::packet;
-use pumpkin_nbt::{Nbt, compound::NbtCompound};
+use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::math::position::BlockPos;
 
 use crate::serial::PacketWrite;
 
 /// Synchronizes the complete block-actor data for a block position.
+#[derive(PacketWrite)]
 #[packet(56)]
 pub struct CBlockActorData {
     pub position: BlockPos,
@@ -20,18 +19,11 @@ impl CBlockActorData {
     }
 }
 
-impl PacketWrite for CBlockActorData {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        self.position.write(writer)?;
-        writer.write_all(&Nbt::from(self.data.clone()).write_bedrock())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
 
-    use pumpkin_nbt::deserializer::NbtReadHelperBedrock;
+    use pumpkin_nbt::{Nbt, deserializer::NbtReadHelperBedrock};
 
     use super::*;
     use crate::{Packet, serial::PacketWrite};

--- a/crates/pumpkin-protocol/src/serial/serializer.rs
+++ b/crates/pumpkin-protocol/src/serial/serializer.rs
@@ -4,6 +4,7 @@ use std::{
     net::SocketAddr,
 };
 
+use pumpkin_nbt::{Nbt, NbtCompound};
 use pumpkin_util::{
     GameMode,
     math::{position::BlockPos, vector2::Vector2, vector3::Vector3},
@@ -205,5 +206,11 @@ impl PacketWrite for GameMode {
 impl PacketWrite for Cow<'_, str> {
     fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.as_ref().write(writer)
+    }
+}
+
+impl PacketWrite for NbtCompound {
+    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        writer.write_all(&Nbt::from(self.clone()).write_bedrock())
     }
 }


### PR DESCRIPTION
## Description

Provides `impl PacketWrite for NbtCompound` to allow packet structs containing `NbtCompound` to use `#[derive(PacketWrite)]`.

## Testing

No in-game testing was done. The change is a NFC refactoring, and is already checked/protected by a unit test.