### PR TITLE
fix(bedrock): experience sync

### DIFF
--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -4904,11 +4904,27 @@ impl Player {
 
             self.last_sent_xp.store(level, Ordering::Relaxed);
 
-            self.try_send_client_packet(&CSetExperience::new(
-                progress.clamp(0.0, 1.0),
-                level.into(),
-                points.into(),
-            ));
+            let attribute = |name: &str, current_value, max_value| BedrockAttribute {
+                min_value: 0.0,
+                max_value,
+                current_value,
+                default_min_value: 0.0,
+                default_max_value: max_value,
+                default_value: 0.0,
+                name: name.to_string(),
+                modifiers: Vec::new(),
+            };
+            self.try_enqueue_packet_editioned(
+                &CSetExperience::new(progress.clamp(0.0, 1.0), level.into(), points.into()),
+                &CBedrockAttributes {
+                    target_runtime_id: VarULong(self.entity_id() as u64),
+                    attribute_list: vec![
+                        attribute("minecraft:player.experience", progress.clamp(0.0, 1.0), 1.0),
+                        attribute("minecraft:player.level", level.max(0) as f32, 24_791.0),
+                    ],
+                    tick: VarULong(0),
+                },
+            );
         }
     }
 


### PR DESCRIPTION
## Description
Fixes experience levels and bar progress not synchronizing correctly for Bedrock players.

## What
- Synchronizes the player’s experience level and progress with all Bedrock clients.
- Fixes Nintendo Switch players incorrectly seeing a full experience bar.
- Fixes desktop Bedrock players not seeing their saved experience.
- Keeps Java experience synchronization unchanged.
- Updates the Bedrock display whenever the player’s experience changes.

## How
- Sends Bedrock’s `minecraft:player.experience` and `minecraft:player.level` attributes.
- Delays the initial update until the client has finished loading, preventing Bedrock from discarding or resetting it during initialization.
- Uses Pumpkin’s authoritative stored experience values.

## Testing
- `cargo test -p pumpkin --lib`
- `cargo check -p pumpkin`
- `cargo clippy -p pumpkin --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Verified saved experience levels and progress on Nintendo Switch and desktop Bedrock.
- Resolves: https://github.com/Pumpkin-MC/Pumpkin/issues/2895
- Built on top of: https://github.com/Pumpkin-MC/Pumpkin/pull/2993 cause I cant connect to Pumpkin via my Switch otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Bedrock clients now receive experience progress and level updates alongside Java clients.
  - Experience updates use a zero client tick for improved Bedrock compatibility.
  - Experience changes should now remain synchronized more reliably across Bedrock and Java clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->