### PR TITLE
fix(piston): stop block swapping from corrupting pistons

### DIFF
--- a/crates/pumpkin/src/block/blocks/piston/mod.rs
+++ b/crates/pumpkin/src/block/blocks/piston/mod.rs
@@ -1,6 +1,7 @@
 use piston::PistonBlock;
 use pumpkin_data::Block;
 use pumpkin_data::BlockDirection;
+use pumpkin_data::BlockState;
 use pumpkin_data::block_state::PistonBehavior;
 use pumpkin_util::math::position::BlockPos;
 
@@ -51,7 +52,8 @@ impl<'a> PistonHandler<'a> {
         self.broken_blocks.clear();
         let (block, block_state) = self.world.get_block_and_state(&self.pos_to);
 
-        if !PistonBlock::is_movable(
+        if !self.is_movable(
+            &self.pos_to,
             block,
             block_state,
             self.motion_direction,
@@ -83,6 +85,19 @@ impl<'a> PistonHandler<'a> {
         block == &Block::SLIME_BLOCK || block == &Block::HONEY_BLOCK
     }
 
+    /// [`PistonBlock::is_movable`] with this handler's world filled in.
+    fn is_movable(
+        &self,
+        pos: &BlockPos,
+        block: &Block,
+        state: &BlockState,
+        dir: BlockDirection,
+        can_break: bool,
+        piston_dir: BlockDirection,
+    ) -> bool {
+        PistonBlock::is_movable(self.world, pos, block, state, dir, can_break, piston_dir)
+    }
+
     fn is_adjacent_block_stuck(state: &Block, adjacent_state: &Block) -> bool {
         if state == &Block::HONEY_BLOCK && adjacent_state == &Block::SLIME_BLOCK {
             return false;
@@ -103,7 +118,7 @@ impl<'a> PistonHandler<'a> {
         if block_state.is_air() {
             return true;
         }
-        if !PistonBlock::is_movable(block, block_state, self.motion_direction, false, dir) {
+        if !self.is_movable(&pos, block, block_state, self.motion_direction, false, dir) {
             return true;
         }
         if self.is_piston_head_or_base(pos) {
@@ -122,7 +137,8 @@ impl<'a> PistonHandler<'a> {
             let (next_block, next_state) = self.world.get_block_and_state(&block_pos);
             if next_state.is_air()
                 || !Self::is_adjacent_block_stuck(block2, next_block)
-                || !PistonBlock::is_movable(
+                || !self.is_movable(
+                    &block_pos,
                     next_block,
                     next_state,
                     self.motion_direction,
@@ -168,7 +184,8 @@ impl<'a> PistonHandler<'a> {
             {
                 return true;
             }
-            if !PistonBlock::is_movable(
+            if !self.is_movable(
+                &block_pos2,
                 block,
                 block_state,
                 self.motion_direction,

--- a/crates/pumpkin/src/block/blocks/piston/piston.rs
+++ b/crates/pumpkin/src/block/blocks/piston/piston.rs
@@ -40,13 +40,21 @@ impl BlockMetadata for PistonBlock {
 impl PistonBlock {
     #[must_use]
     pub fn is_movable(
+        world: &World,
+        pos: &BlockPos,
         block: &Block,
         state: &BlockState,
         dir: BlockDirection,
         can_break: bool,
         piston_dir: BlockDirection,
     ) -> bool {
-        // TODO: more checks
+        // Blocks may never be pushed out of the world; without this they would be
+        // silently destroyed at the build limit.
+        let min_y = world.dimension.min_y;
+        let max_y = min_y + world.dimension.height - 1;
+        if pos.0.y < min_y || pos.0.y > max_y {
+            return false;
+        }
         if state.is_air() {
             return true;
         }
@@ -56,6 +64,12 @@ impl PistonBlock {
             || block == &Block::RESPAWN_ANCHOR
             || block == &Block::REINFORCED_DEEPSLATE
         {
+            return false;
+        }
+        if dir == BlockDirection::Down && pos.0.y == min_y {
+            return false;
+        }
+        if dir == BlockDirection::Up && pos.0.y == max_y {
             return false;
         }
         if block == &Block::PISTON || block == &Block::STICKY_PISTON {
@@ -273,7 +287,7 @@ impl BlockBehaviour for PistonBlock {
                 if !piston_piece {
                     if r#type == 1
                         && !state.is_air()
-                        && Self::is_movable(block, state, dir, false, dir)
+                        && Self::is_movable(world, &pull_pos, block, state, dir, false, dir)
                         && (state.piston_behavior == PistonBehavior::Normal
                             || block == &Block::PISTON
                             || block == &Block::STICKY_PISTON)

--- a/crates/pumpkin/src/entity/falling.rs
+++ b/crates/pumpkin/src/entity/falling.rs
@@ -69,16 +69,17 @@ impl EntityBase for FallingEntity {
             entity.tick_block_collisions(caller, server).await;
             if entity.on_ground.load(Ordering::Relaxed) {
                 entity.velocity.store(velo.multiply(0.7, -0.5, 0.7));
-                entity
-                    .world
-                    .load()
-                    .set_block_state(
-                        &self.entity.block_pos.load(),
-                        self.block_state_id,
-                        BlockFlags::NOTIFY_ALL,
-                    )
-                    .await;
-                entity.remove().await;
+                let landing_pos = self.entity.block_pos.load();
+                let world = entity.world.load();
+                // A piston is animating through this position. Vanilla leaves the
+                // entity alone until the animation is over instead of overwriting
+                // the `moving_piston` block, which would destroy the piston.
+                if world.get_block(&landing_pos) != &Block::MOVING_PISTON {
+                    world
+                        .set_block_state(&landing_pos, self.block_state_id, BlockFlags::NOTIFY_ALL)
+                        .await;
+                    entity.remove().await;
+                }
             }
 
             entity.velocity.store(velo.multiply(0.98, 0.98, 0.98));

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1607,6 +1607,13 @@ impl World {
                 for scheduled_tick in batch {
                     let pos = scheduled_tick.position;
                     let block = world.get_block(&pos);
+                    // The block may have been swapped out (by a piston, for example)
+                    // between scheduling the tick and it coming due. Vanilla drops
+                    // such ticks in `ServerLevel::tickBlock` instead of running them
+                    // against whatever took the position over.
+                    if block.id != scheduled_tick.value.id {
+                        continue;
+                    }
                     if let Some(pumpkin_block) = world.block_registry.get_pumpkin_block(block.id) {
                         pumpkin_block
                             .on_scheduled_tick(OnScheduledTickArgs {
@@ -1628,6 +1635,11 @@ impl World {
                 for scheduled_tick in batch {
                     let pos = scheduled_tick.position;
                     let fluid = world.get_fluid(&pos);
+                    // Same as block ticks: vanilla's `ServerLevel::tickFluid` only
+                    // runs the tick while the scheduled fluid is still there.
+                    if fluid.id != scheduled_tick.value.id {
+                        continue;
+                    }
                     if let Some(pumpkin_fluid) = world.block_registry.get_pumpkin_fluid(fluid.id) {
                         pumpkin_fluid.on_scheduled_tick(&world, fluid, &pos).await;
                     }


### PR DESCRIPTION
Works towards the "Pistons (Sticky/Regular) & Block Swapping" item in #1402, and fixes #2191.

Pistons swap blocks around more than anything else in the game, so they are where these three divergences from Vanilla show up.

### Scheduled ticks ran against the wrong block

`tick_chunks` looked up the block currently at the position and ticked that, ignoring the block the tick was actually scheduled for — even though `ScheduledTick` already carries it. When a piston moved a block out from under a pending tick, the tick fired on whatever took the position over: a repeater pushed into a spot where sand had a pending fall check would run that check as a repeater tick.

Vanilla drops these in `ServerLevel::tickBlock` (`if (blockState.is(block))`) and `ServerLevel::tickFluid` (`if (fluidState.getType() == fluid)`). Both are now checked.

### Falling blocks destroyed pistons (#2191)

`FallingEntity` overwrote the block at its landing position unconditionally. A piston mid-animation occupies its own position with `moving_piston`, so a falling block landing on one replaced the piston: the piston block was gone and the falling block was left sitting where it had been — exactly what the screenshots in #2191 show.

Vanilla guards this with `if (!blockState.is(Blocks.MOVING_PISTON))` and leaves the entity alone, so it settles once the animation finishes. Same here.

### Pistons pushed blocks out of the world

`is_movable` carried a `TODO: more checks` and had no position, so the build-limit checks from Vanilla's `PistonBaseBlock::isPushable` were missing: positions outside the world are unpushable, pushing down at the bottom and up at the top is refused. Without them a block pushed past the limit was silently destroyed. The function now takes the world and position, and a small wrapper on `PistonHandler` keeps the call sites short.

### Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test -p pumpkin` (257 passed) are all clean.

The first change is the one worth a careful look: dropping stale ticks is what Vanilla does, but if anything in Pumpkin was relying on a tick surviving a block change, it would now stop firing. I could not find such a case.