### PR TITLE
perf(world): only send particles to players within 32 blocks

### DIFF
--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -175,6 +175,12 @@ use uuid::Uuid;
 use weather::Weather;
 
 const MAX_LIGHT_LEVEL: u8 = 15;
+const PARTICLE_VIEW_DISTANCE: f64 = 32.0;
+
+fn is_particle_visible(particle_position: &Vector3<f64>, player_position: &Vector3<f64>) -> bool {
+    player_position.squared_distance_to_vec(particle_position)
+        <= PARTICLE_VIEW_DISTANCE * PARTICLE_VIEW_DISTANCE
+}
 
 fn bedrock_chest_block_actor(state_id: BlockStateId, position: BlockPos) -> Option<NbtCompound> {
     let (block, _) = BlockState::from_id_with_block(state_id);
@@ -1154,9 +1160,24 @@ impl World {
         particle_count: i32,
         particle: Particle,
     ) {
-        for player in self.players.load().iter() {
-            player.spawn_particle(position, offset, max_speed, particle_count, particle);
-        }
+        let packet = CParticle::new(
+            false,
+            false,
+            position,
+            offset,
+            max_speed,
+            particle_count,
+            VarInt(particle as i32),
+            &[],
+        );
+
+        let players = self.players.load();
+        let recipients = players
+            .iter()
+            .filter(|player| is_particle_visible(&position, &player.get_entity().pos.load()));
+
+        let recipients_by_version = Self::collect_java_recipients_by_version(recipients);
+        Self::broadcast_java_grouped(&packet, recipients_by_version);
     }
 
     pub fn play_sound(&self, sound: Sound, category: SoundCategory, position: &Vector3<f64>) {
@@ -7117,9 +7138,29 @@ mod tests {
         Block,
         block_properties::{ChestLikeProperties, ChestType, HorizontalFacing},
     };
-    use pumpkin_util::math::position::BlockPos;
+    use pumpkin_util::math::{position::BlockPos, vector3::Vector3};
 
-    use super::{bedrock_block_breaking_rate, bedrock_chest_block_actor};
+    use super::{
+        PARTICLE_VIEW_DISTANCE, bedrock_block_breaking_rate, bedrock_chest_block_actor,
+        is_particle_visible,
+    };
+
+    #[test]
+    fn particles_are_only_visible_within_the_vanilla_radius() {
+        let particle = Vector3::new(0.0, 64.0, 0.0);
+
+        let inside = Vector3::new(PARTICLE_VIEW_DISTANCE - 0.5, 64.0, 0.0);
+        assert!(is_particle_visible(&particle, &inside));
+
+        let outside = Vector3::new(PARTICLE_VIEW_DISTANCE + 0.5, 64.0, 0.0);
+        assert!(!is_particle_visible(&particle, &outside));
+
+        let diagonal = Vector3::new(25.0, 64.0, 25.0);
+        assert!(!is_particle_visible(&particle, &diagonal));
+
+        let far_above = Vector3::new(0.0, 64.0 + PARTICLE_VIEW_DISTANCE + 0.5, 0.0);
+        assert!(!is_particle_visible(&particle, &far_above));
+    }
 
     #[test]
     fn bedrock_block_breaking_rate_uses_progress_per_tick() {

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1269,17 +1269,7 @@ impl World {
         offset: Vector3<f32>,
         max_speed: f32,
     ) {
-        let packet = CParticle::new(
-            false,
-            false,
-            pos,
-            offset,
-            max_speed,
-            count as i32,
-            (particle.to_id() as i32).into(),
-            &[],
-        );
-        self.broadcast_packet_all(&packet);
+        self.spawn_particle(pos, offset, max_speed, count as i32, particle);
     }
 
     /// Plays a Bedrock level sound for players close enough to hear it.


### PR DESCRIPTION
## Problem

`World::spawn_particle` sends the particle packet to every player in the world,
with no distance check, and serializes the packet once per player on top of that.

Vanilla limits particle broadcasts to 32 blocks (`ServerLevel#sendParticles`
uses `closerToCenterThan(pos, 32.0)`), so this both wastes bandwidth and leaks
activity to players who should never see it.

The callers are per-tick paths, which makes it add up quickly:

- arrow crit particles (`entity/projectile/arrow.rs`)
- shulker bullet trails (`entity/projectile/shulker_bullet.rs`)
- animal love-mode hearts (`entity/passive/animal.rs`)
- creaking, enderman, furnace/tnt minecarts
- every melee hit (`entity/combat.rs`)

With a mob farm running and a decent player count, every one of those packets
went to every connected player.

## Change

`World::spawn_particle` now filters recipients to players within 32 blocks and
goes through `collect_java_recipients_by_version` + `broadcast_java_grouped`,
which is the pattern already used by `play_sound_raw` and `broadcast_to_chunk`.
As a side effect the packet is now serialized once per protocol version instead
of once per player.

The distance check is spherical, matching vanilla, not the Chebyshev chunk-grid
check used by `broadcast_to_chunk`.

`Player::spawn_particle` is untouched, it stays the way to send a particle to one
specific player.

`World::spawn_particles` had the same problem: its doc comment claimed it only
reached players in range, but it called `broadcast_packet_all`. It now delegates
to `World::spawn_particle` and inherits the distance filter. The packet it emits
is unchanged, since `Particle::to_id` is `*self as u16`.

## Notes

- No behaviour change for players in range.
- `force_spawn` / `important` are hardcoded to `false` at this call site, so the
  512-block long-distance case vanilla has does not apply here.

## Tests

Added `particles_are_only_visible_within_the_vanilla_radius`, covering the
in-range case, the just-out-of-range case, a diagonal position that is in range
on each axis alone but out of range in 3D, and vertical distance.

