### PR TITLE
perf(world): batch entity ticks instead of one task per entity

### DIFF
--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1196,6 +1196,8 @@ impl World {
 
     #[expect(clippy::too_many_lines)]
     pub async fn tick(self: &Arc<Self>, server: Arc<Server>) {
+        const ENTITY_TICK_BATCH_SIZE: usize = 16;
+
         let start = tokio::time::Instant::now();
 
         self.flush_block_updates().await;
@@ -1255,7 +1257,8 @@ impl World {
 
         let entity_future = async move {
             let t = tokio::time::Instant::now();
-            let mut tasks = tokio::task::JoinSet::new();
+
+            let mut tickable = Vec::new();
             for entity in entities_to_tick.iter() {
                 // Only tick entities that sit in an active (ticking) chunk — the
                 // same set block-entity ticking and mob spawning already use, and
@@ -1280,28 +1283,35 @@ impl World {
                     continue;
                 }
 
-                let e_clone = entity.clone();
+                tickable.push((entity.clone(), entity_chunk));
+            }
+
+            let mut tasks = tokio::task::JoinSet::new();
+            for entity_batch in tickable.chunks(ENTITY_TICK_BATCH_SIZE) {
+                let batch = entity_batch.to_vec();
                 let s_clone = server_for_entities.clone();
                 let p_cache = players_cache.clone();
 
                 tasks.spawn(async move {
-                    e_clone.get_entity().age.fetch_add(1, Relaxed);
-                    e_clone.tick(&e_clone, &s_clone).await;
+                    for (entity, entity_chunk) in batch {
+                        entity.get_entity().age.fetch_add(1, Relaxed);
+                        entity.tick(&entity, &s_clone).await;
 
-                    let entity_inner = e_clone.get_entity();
-                    let entity_pos = entity_inner.pos.load();
-                    let entity_bb = entity_inner.bounding_box.load();
+                        let entity_inner = entity.get_entity();
+                        let entity_pos = entity_inner.pos.load();
+                        let entity_bb = entity_inner.bounding_box.load();
 
-                    for (player, player_pos, player_bb, player_chunk) in p_cache.iter() {
-                        if (player_chunk.x - entity_chunk.x).abs() <= 1
-                            && (player_chunk.y - entity_chunk.y).abs() <= 1
-                            && (player_pos.x - entity_pos.x).abs() < 5.0
-                            && (player_pos.y - entity_pos.y).abs() < 5.0
-                            && (player_pos.z - entity_pos.z).abs() < 5.0
-                            && player_bb.intersects(&entity_bb)
-                        {
-                            e_clone.on_player_collision(player).await;
-                            break;
+                        for (player, player_pos, player_bb, player_chunk) in p_cache.iter() {
+                            if (player_chunk.x - entity_chunk.x).abs() <= 1
+                                && (player_chunk.y - entity_chunk.y).abs() <= 1
+                                && (player_pos.x - entity_pos.x).abs() < 5.0
+                                && (player_pos.y - entity_pos.y).abs() < 5.0
+                                && (player_pos.z - entity_pos.z).abs() < 5.0
+                                && player_bb.intersects(&entity_bb)
+                            {
+                                entity.on_player_collision(player).await;
+                                break;
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
## Problem

`World::tick` spawns one `JoinSet` task per entity, every tick. At 2000 entities
and 20 TPS that is 40k task spawns per second, plus two `Arc` clones per entity
per tick for `server` and `players_cache`.

The two sibling futures in the same function already batch:

- `block_entity_future` spawns one task per `.chunks(16)` batch
- `tick_chunks` spawns one task per `.chunks(32)` batch

Entity ticking is the one that did not.

## Change

The active-chunk and loaded-chunk filters now collect survivors into a `Vec`
instead of spawning as they go, and tasks are spawned per batch of 16. Task count
drops by a factor of 16, and the `server` / `players_cache` clones go from two per
entity to two per batch.

No logic change: the filter predicates, the order of operations, the age
increment, and the player-collision check are untouched.

## Tradeoff

Today a panic inside one entity's tick only kills that entity's task. Batched, it
takes the rest of its batch with it, and those entities skip that tick. They
resume on the next tick since batches are rebuilt every time, but an entity that
panics persistently would starve its 15 batch-mates.

This is the same tradeoff `tick_chunks` and `block_entity_future` already make, so
it is at least consistent. Given how many open panic reports sit in entity ticking
(#2453, #2447), the batch size is 16 rather than 32 to keep the blast radius small.
Happy to drop it further, or to gate the batching behind a size threshold, if
reviewers would rather not take that on.

## Tests

No new test. This is a scheduling refactor with no extractable pure logic, and a
test asserting that `chunks(16)` yields batches of 16 would be tautological. The
existing suite passes (257), and `cargo clippy --all-targets` and
`cargo fmt --check` are clean.

I have not benchmarked this. The task-count reduction is arithmetic, not a
measurement, and the real-world gain depends on how much of a tick is spent in
tokio scheduling versus entity logic.
