### PR TITLE
refactor(world): remove the unused get_fluid_collisions

### DIFF
--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1739,34 +1739,6 @@ impl World {
         }
     }
 
-    pub fn get_fluid_collisions(self: &Arc<Self>, bounding_box: BoundingBox) -> Vec<&Fluid> {
-        let mut collisions = Vec::new();
-
-        let min = bounding_box.min_block_pos();
-
-        let max = bounding_box.max_block_pos();
-
-        for x in min.0.x..=max.0.x {
-            for y in min.0.y..=max.0.y {
-                for z in min.0.z..=max.0.z {
-                    let pos = BlockPos::new(x, y, z);
-
-                    let (fluid, state) = self.get_fluid_and_fluid_state(&pos);
-
-                    if fluid.id != Fluid::EMPTY.id {
-                        let height = f64::from(state.height);
-
-                        if height >= bounding_box.min.y {
-                            collisions.push(fluid);
-                        }
-                    }
-                }
-            }
-        }
-
-        collisions
-    }
-
     pub fn check_fluid_collision(self: &Arc<Self>, bounding_box: BoundingBox) -> bool {
         let min = bounding_box.min_block_pos();
 


### PR DESCRIPTION
## Change

`World::get_fluid_collisions` has no callers. The only occurrence of the name in
the repository is its own definition, and it is not part of the plugin surface,
which goes through the WIT interface.

It is also a verbatim copy of `check_fluid_collision` sitting directly below it,
the only difference being that one accumulates into a `Vec` while the other
short-circuits. Deleting the unused one removes the duplication on its own, so
there is nothing left to factor out.

## Tests

No new test, this only removes code. `cargo clippy --all-targets` is clean, which
confirms no import was left dangling, and the existing suite passes (257).
