### PR TITLE
chore(lints): resolve the pre-existing clippy::unused_async_trait_impl wall

### DIFF
--- a/crates/pumpkin/src/block/blocks/plant/big_dripleaf.rs
+++ b/crates/pumpkin/src/block/blocks/plant/big_dripleaf.rs
@@ -229,6 +229,7 @@ impl PlantBlockBase for BigDripleafBlock {
         let support_block = block_accessor.get_block(pos);
         can_plant_dripleaf_on_top(support_block)
     }
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_state_for_neighbor_update(
         &self,
         block_accessor: &dyn BlockAccessor,

--- a/crates/pumpkin/src/block/blocks/plant/big_dripleaf_stem.rs
+++ b/crates/pumpkin/src/block/blocks/plant/big_dripleaf_stem.rs
@@ -49,6 +49,7 @@ impl PlantBlockBase for BigDripleafStemBlock {
         can_plant_dripleaf_on_top(support_block)
     }
 
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_state_for_neighbor_update(
         &self,
         block_accessor: &dyn BlockAccessor,

--- a/crates/pumpkin/src/block/blocks/plant/cactus_flower.rs
+++ b/crates/pumpkin/src/block/blocks/plant/cactus_flower.rs
@@ -43,6 +43,7 @@ impl PlantBlockBase for CactusFlowerBlock {
         }
         false
     }
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_state_for_neighbor_update(
         &self,
         block_accessor: &dyn BlockAccessor,

--- a/crates/pumpkin/src/block/blocks/plant/crop/sweet_berry_bush.rs
+++ b/crates/pumpkin/src/block/blocks/plant/crop/sweet_berry_bush.rs
@@ -150,6 +150,7 @@ impl BlockBehaviour for SweetBerryBushBlock {
 }
 
 impl PlantBlockBase for SweetBerryBushBlock {
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_state_for_neighbor_update(
         &self,
         block_accessor: &dyn BlockAccessor,

--- a/crates/pumpkin/src/block/blocks/plant/kelp.rs
+++ b/crates/pumpkin/src/block/blocks/plant/kelp.rs
@@ -113,6 +113,7 @@ impl PlantBlockBase for KelpBlock {
         }
         false
     }
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_state_for_neighbor_update(
         &self,
         block_accessor: &dyn BlockAccessor,

--- a/crates/pumpkin/src/block/blocks/plant/seagrass.rs
+++ b/crates/pumpkin/src/block/blocks/plant/seagrass.rs
@@ -49,6 +49,7 @@ impl PlantBlockBase for SeaGrassBlock {
         }
         false
     }
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_state_for_neighbor_update(
         &self,
         block_accessor: &dyn BlockAccessor,

--- a/crates/pumpkin/src/block/blocks/plant/small_dripleaf.rs
+++ b/crates/pumpkin/src/block/blocks/plant/small_dripleaf.rs
@@ -107,6 +107,7 @@ impl PlantBlockBase for SmallDripleafBlock {
         }
     }
 
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_state_for_neighbor_update(
         &self,
         block_accessor: &dyn BlockAccessor,

--- a/crates/pumpkin/src/block/blocks/plant/tall_seagrass.rs
+++ b/crates/pumpkin/src/block/blocks/plant/tall_seagrass.rs
@@ -60,6 +60,7 @@ impl PlantBlockBase for TallSeaGrassBlock {
         }
         false
     }
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_state_for_neighbor_update(
         &self,
         block_accessor: &dyn BlockAccessor,

--- a/crates/pumpkin/src/block/blocks/plant/twisting_vines.rs
+++ b/crates/pumpkin/src/block/blocks/plant/twisting_vines.rs
@@ -86,6 +86,7 @@ impl PlantBlockBase for TwistingVinesBlock {
         }
         false
     }
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_state_for_neighbor_update(
         &self,
         block_accessor: &dyn BlockAccessor,

--- a/crates/pumpkin/src/block/blocks/plant/weeping_vines.rs
+++ b/crates/pumpkin/src/block/blocks/plant/weeping_vines.rs
@@ -85,6 +85,7 @@ impl PlantBlockBase for WeepingVinesBlock {
         }
         false
     }
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_state_for_neighbor_update(
         &self,
         block_accessor: &dyn BlockAccessor,

--- a/crates/pumpkin/src/block/blocks/redstone/pressure_plate/plate.rs
+++ b/crates/pumpkin/src/block/blocks/redstone/pressure_plate/plate.rs
@@ -98,6 +98,7 @@ impl PressurePlate for PressurePlateBlock {
         if props.powered { 15 } else { 0 }
     }
 
+    #[allow(clippy::unused_async_trait_impl)]
     async fn calculate_redstone_output(&self, world: &World, _block: &Block, pos: &BlockPos) -> u8 {
         let aabb = detection_box_at(pos);
         if !world.get_entities_at_box(&aabb).is_empty()

--- a/crates/pumpkin/src/block/blocks/redstone/pressure_plate/weighted.rs
+++ b/crates/pumpkin/src/block/blocks/redstone/pressure_plate/weighted.rs
@@ -99,6 +99,7 @@ impl PressurePlate for WeightedPressurePlateBlock {
         props.power
     }
 
+    #[allow(clippy::unused_async_trait_impl)]
     async fn calculate_redstone_output(&self, world: &World, block: &Block, pos: &BlockPos) -> u8 {
         // light = Gold
         // heavy = Iron

--- a/crates/pumpkin/src/entity/ai/pathfinder/walk_node_evaluator.rs
+++ b/crates/pumpkin/src/entity/ai/pathfinder/walk_node_evaluator.rs
@@ -476,6 +476,7 @@ impl NodeEvaluator for WalkNodeEvaluator {
         }
     }
 
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_path_type_of_mob(
         &mut self,
         context: &mut PathfindingContext,
@@ -556,6 +557,7 @@ impl NodeEvaluator for WalkNodeEvaluator {
         result
     }
 
+    #[allow(clippy::unused_async_trait_impl)]
     async fn get_path_type(
         &mut self,
         context: &mut PathfindingContext,

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -2708,6 +2708,7 @@ impl Entity {
 
     /// Sets whether the entity is invisible and sends updated metadata.
     #[expect(clippy::unused_async)]
+    #[allow(clippy::unused_async_trait_impl)]
     pub async fn set_invisible(&self, invisible: bool) {
         if self.invisible.load(Ordering::Relaxed) != invisible {
             self.invisible.store(invisible, Relaxed);
@@ -2717,6 +2718,7 @@ impl Entity {
 
     /// Sets whether the entity is glowing and sends updated metadata.
     #[expect(clippy::unused_async)]
+    #[allow(clippy::unused_async_trait_impl)]
     pub async fn set_glowing(&self, glowing: bool) {
         if self.glowing.load(Ordering::Relaxed) != glowing {
             self.glowing.store(glowing, Ordering::Relaxed);
@@ -2726,6 +2728,7 @@ impl Entity {
 
     /// Sets whether the entity is on fire for visual and damage purposes. This is separate from `fire_ticks` which tracks the damage aspect of being on fire.
     #[expect(clippy::unused_async)]
+    #[allow(clippy::unused_async_trait_impl)]
     pub async fn set_on_fire(&self, on_fire: bool) {
         if self.has_visual_fire.load(Ordering::Relaxed) != on_fire {
             self.has_visual_fire.store(on_fire, Ordering::Relaxed);

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
@@ -9,32 +9,53 @@ use wasmtime::component::{HasSelf, InstancePre, Linker, bindgen};
 use wasmtime::{Engine, Store};
 
 pub mod advancement;
+// wasmtime's `bindgen!` requires every Host trait method to be `async fn`, even the ones whose
+// implementation here happens not to need to `.await` anything - so `unused_async_trait_impl`
+// can't be avoided without breaking the generated trait signatures.
+#[allow(clippy::unused_async_trait_impl)]
 pub mod block_entity;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod boss_bar;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod commands;
 pub mod common;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod context;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod display;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod enchantment;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod entity;
 pub mod events;
 pub mod forms;
 pub mod generated_packets;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod gui;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod i18n;
 pub mod ipc;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod item_stack;
 pub mod java_dialogs;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod logging;
 pub mod permission;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod player;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod recipe;
 pub mod scheduler;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod scoreboard;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod server;
 pub mod status_effect;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod text;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod uuid;
+#[allow(clippy::unused_async_trait_impl)]
 pub mod world;
 
 bindgen!({


### PR DESCRIPTION
## Summary
Split out per QuantumSegfault's feedback on #3011 — this was previously bundled into that PR and #2946, both unrelated.

`wasmtime`'s `bindgen!` requires every Host trait method to be `async fn`, regardless of whether a given implementation needs to `.await` anything. That triggers `clippy::unused_async_trait_impl` 578 times across the WASM plugin bridge (`crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1`), plus a handful of similarly-shaped trait impls elsewhere (redstone pressure plates, several plant blocks, the pathfinder, three `Entity` setter methods). This has been blocking "Run lints (debug/release)" CI on every branch regardless of what it actually changes.

- Allowed the lint at the module level for `wasm_host`'s submodules (one attribute per module covers every impl inside it) and per-function for the scattered non-WASM occurrences, rather than restructuring any of the affected code.
- Also fixes three unrelated pre-existing lint failures uncovered once the above stopped masking them:
  - `pumpkin-macros::count_placeholders` needed to be a `const fn` (`clippy::missing_const_for_fn`) — this alone was blocking every other lint check from running at all, since `pumpkin-macros` failing to compile takes the whole workspace down with it.
  - `serde_json5` unused dependency in `pumpkin-codegen` (`cargo-machete`).
  - `Result<_, ()>` in `Plugin::send_message` (`clippy::result_unit_err`).
  - `.ok().is_some_and(..)` that `clippy::manual_is_variant_and` wants as `.is_ok_and(..)`.

No behavior changes — this is purely lint suppression plus two semantically-equivalent one-liners.

## Test plan
- [x] `cargo clippy --all-targets --all-features` (debug) — clean
- [x] `cargo clippy --release --all-targets --all-features` — clean
- [x] `cargo test -p pumpkin --lib` — 257 passed