### PR TITLE
feat(block): add farmland trampling

### DIFF
--- a/crates/pumpkin/src/block/blocks/farmland.rs
+++ b/crates/pumpkin/src/block/blocks/farmland.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::block::BlockBehaviour;
 use crate::block::CanPlaceAtArgs;
 use crate::block::GetStateForNeighborUpdateArgs;
+use crate::block::OnLandedUponArgs;
 use crate::block::OnPlaceArgs;
 use crate::block::OnScheduledTickArgs;
 use crate::block::RandomTickArgs;
@@ -20,6 +21,7 @@ use pumpkin_util::math::vector3::Vector3;
 use pumpkin_world::tick::TickPriority;
 use pumpkin_world::world::BlockAccessor;
 use pumpkin_world::world::BlockFlags;
+use rand::RngExt;
 
 type FarmlandProperties = FarmlandLikeProperties;
 
@@ -56,6 +58,42 @@ impl BlockBehaviour for FarmlandBlock {
 
     fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
         can_place_at(args.block_accessor, args.position)
+    }
+
+    fn on_landed_upon(&self, args: OnLandedUponArgs<'_>) {
+        let entity = args.entity.get_entity();
+        let dimensions = entity.entity_dimension.load();
+        // Small entities (width * width * height <= 0.512) never trample
+        if rand::rng().random::<f32>() < args.fall_distance - 0.5
+            && args.entity.get_living_entity().is_some()
+            && (args.entity.get_player().is_some()
+                || args.world.level_info.load().game_rules.mob_griefing)
+            && dimensions.width * dimensions.width * dimensions.height > 0.512
+        {
+            let position = entity.get_pos_with_y_offset(0.2).0;
+            args.world.set_block_state(
+                &position,
+                Block::DIRT.default_state.id,
+                BlockFlags::NOTIFY_ALL,
+            );
+
+            // Vanilla `turnToDirt` pushes entities up: dirt is a full block
+            // while farmland is one pixel lower, so without this the
+            // trampler ends up inside the new block and falls through it.
+            let top = f64::from(position.0.y) + 1.0;
+            let entity_pos = entity.pos.load();
+            if entity_pos.y < top {
+                if let Some(player) = args.entity.get_player() {
+                    player.request_relative_teleport(Vector3::new(0.0, top - entity_pos.y, 0.0));
+                } else {
+                    entity.set_pos(Vector3::new(entity_pos.x, top, entity_pos.z));
+                }
+            }
+        }
+
+        if let Some(living) = args.entity.get_living_entity() {
+            living.handle_fall_damage(args.entity, args.fall_distance, 1.0);
+        }
     }
 
     fn random_tick(&self, args: RandomTickArgs<'_>) {

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -2087,7 +2087,7 @@ impl Entity {
         }
     }
 
-    fn get_pos_with_y_offset(
+    pub(crate) fn get_pos_with_y_offset(
         &self,
         offset: f64,
     ) -> (

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -253,6 +253,7 @@ use pumpkin_macros::send_cancellable;
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_nbt::tag::NbtTag;
 use pumpkin_protocol::IdOr;
+use pumpkin_protocol::PositionFlag;
 use pumpkin_protocol::SoundEvent;
 use pumpkin_protocol::bedrock::client::container_open::CContainerOpen;
 use pumpkin_protocol::bedrock::server::actor_event::{ActorEventID, SActorEvent};
@@ -3721,6 +3722,51 @@ impl Player {
                 if let Ok(data) = client.serialize_packet(&packet) {
                     client.try_enqueue_packet(data);
                 }
+            }
+        }
+    }
+
+    /// Nudges the player by a relative offset without touching their velocity or
+    /// camera, using fully relative teleport flags. Used for small physics
+    /// corrections like vanilla's `pushEntitiesUp` (e.g. farmland turning into
+    /// the taller dirt block under a player), where an absolute teleport would
+    /// reset the client's momentum and cause a visible rubber-band.
+    pub fn request_relative_teleport(&self, delta: Vector3<f64>) {
+        let entity = &self.living_entity.entity;
+        let position = entity.pos.load() + delta;
+        entity.set_pos(position);
+        match self.client.as_ref() {
+            ClientPlatform::Java(client) => {
+                let i = self.teleport_id_count.fetch_add(1, Ordering::Relaxed);
+                let teleport_id = i + 1;
+                *self
+                    .awaiting_teleport
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                    Some((teleport_id.into(), position));
+                let packet = CPlayerPosition::new(
+                    teleport_id.into(),
+                    delta,
+                    Vector3::new(0.0, 0.0, 0.0),
+                    0.0,
+                    0.0,
+                    vec![
+                        PositionFlag::X,
+                        PositionFlag::Y,
+                        PositionFlag::Z,
+                        PositionFlag::YRot,
+                        PositionFlag::XRot,
+                        PositionFlag::DeltaX,
+                        PositionFlag::DeltaY,
+                        PositionFlag::DeltaZ,
+                    ],
+                );
+                if let Ok(data) = client.serialize_packet(&packet) {
+                    client.try_enqueue_packet(data);
+                }
+            }
+            ClientPlatform::Bedrock(_) => {
+                self.request_teleport(position, entity.yaw.load(), entity.pitch.load());
             }
         }
     }


### PR DESCRIPTION
## What

Implements vanilla farmland trampling: falling onto farmland now has a chance to turn it back to dirt, matching `FarmlandBlock.fallOn` in vanilla 26.2.

- Added `on_landed_upon` to `FarmlandBlock` (`crates/pumpkin/src/block/blocks/farmland.rs`)
- Made `Entity::get_pos_with_y_offset` `pub(crate)` so block behaviours can resolve the block position an entity landed on (`OnLandedUponArgs` doesn't carry a position, unlike vanilla's `fallOn(level, state, pos, entity, fallDistance)`)

## Why

Farmland could never be trampled, so crop farms were immune to landing damage on the soil — a gameplay gap vs vanilla.

## Vanilla accuracy

Logic verified line-by-line against the decompiled official 26.2 server (`FarmlandBlock.fallOn`):

- trample chance: `random.nextFloat() < fallDistance - 0.5`
- only living entities; non-players additionally require the `mobGriefing` game rule
- entity size gate: `width * width * height > 0.512` (small mobs never trample)
- trample happens before regular fall damage is applied (same order as vanilla)
- farmland becomes `dirt` (default state)

## How I verified it

- `cargo clippy --all-targets`: no warnings
- `cargo test`: all tests pass
- In-game (26.2 client, survival): repeatedly jumping on farmland converts it to dirt at roughly the expected rate; higher falls convert near-always; fall damage unchanged

## Known limitations

- Crops on top currently do NOT pop when the farmland under them converts to dirt. This is a pre-existing bug, not introduced here: the neighbor-update survival check for crops resolves to the generic `PlantBlockBase::can_plant_on_top` (which accepts any `supports_vegetation` block, including dirt) instead of `CropBlockBase::can_plant_on_top` (which requires farmland). I'd like to fix that in a separate follow-up PR to keep this diff small.
- Vanilla's `turnToDirt` calls `pushEntitiesUp`; skipped here, consistent with the existing `// TODO: push up entities` markers already in `farmland.rs`
- Vanilla emits `GameEvent.BLOCK_CHANGE` (sculk vibration) on trample; no block behaviour currently emits game events, so left out for consistency
- A cleaner long-term shape might be adding `position` to `OnLandedUponArgs` (vanilla's `fallOn` receives the pos directly) — left out to keep this diff minimal