### PR TITLE
fix(command): use vanilla translation key for /setworldspawn feedback

### DIFF
--- a/crates/pumpkin/src/command/commands/setworldspawn.rs
+++ b/crates/pumpkin/src/command/commands/setworldspawn.rs
@@ -146,8 +146,8 @@ fn setworldspawn(
     server.level_info.store(Arc::new(new_info));
 
     sender.send_message(TextComponent::translate_cross(
-        translation::java::COMMANDS_SETWORLDSPAWN_SUCCESS_NEW,
-        translation::java::COMMANDS_SETWORLDSPAWN_SUCCESS_NEW,
+        translation::java::COMMANDS_SETWORLDSPAWN_SUCCESS,
+        translation::bedrock::COMMANDS_SETWORLDSPAWN_SUCCESS,
         [
             TextComponent::text(new_position.0.x.to_string()),
             TextComponent::text(new_position.0.y.to_string()),


### PR DESCRIPTION
Fixes #3016

## What

`/setworldspawn` success feedback now uses the translation key vanilla actually sends: `commands.setworldspawn.success` instead of `commands.setworldspawn.success.new`. Also fills the bedrock slot of `translate_cross` with the bedrock key instead of duplicating the java one.

## Why

The `.new` key variants exist in the extracted language data but are not used by the vanilla 26.2 server (verified against the decompiled official 26.2 `SetWorldSpawnCommand`: it sends `commands.setworldspawn.success` with args x, y, z, yaw, pitch, dimension — same 6 args this command already passed). Clients that don't know the `.new` key display it raw, which is exactly the symptom reported in #3016.

## How I verified it

- Decompiled official 26.2 server: `SetWorldSpawnCommand.setSpawn` sends `commands.setworldspawn.success` with `{x, y, z, yaw, pitch, dimensionId}`
- In-game (26.2 client): `/setworldspawn` now displays "Set the world spawn point to X, Y, Z [0]" instead of the raw key
- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` all pass

## Known limitations

The failure message a few lines above (`COMMANDS_SETWORLDSPAWN_FAILURE_NOT_OVERWORLD`) still passes the java key in the bedrock slot; left untouched to keep this diff scoped to the reported issue.
