### PR TITLE
Add version gates for dialog and timeline tag registries

### DIFF
--- a/crates/pumpkin-data/src/generated/tag.rs
+++ b/crates/pumpkin-data/src/generated/tag.rs
@@ -106,6 +106,8 @@ impl RegistryKey {
             Self::Enchantment | Self::Potion => {
                 (version as u32) >= (JavaMinecraftVersion::V_1_20_5 as u32)
             }
+            Self::Dialog => (version as u32) >= (JavaMinecraftVersion::V_1_21_6 as u32),
+            Self::Timeline => (version as u32) >= (JavaMinecraftVersion::V_1_21_11 as u32),
             _ => (version as u32) >= (JavaMinecraftVersion::V_26_1 as u32),
         }
     }

--- a/tools/pumpkin-codegen/src/tag.rs
+++ b/tools/pumpkin-codegen/src/tag.rs
@@ -119,6 +119,10 @@ impl ToTokens for EnumCreator {
                         Self::Enchantment | Self::Potion => {
                             (version as u32) >= (JavaMinecraftVersion::V_1_20_5 as u32)
                         }
+                        Self::Dialog => (version as u32) >= (JavaMinecraftVersion::V_1_21_6 as u32),
+                        Self::Timeline => {
+                            (version as u32) >= (JavaMinecraftVersion::V_1_21_11 as u32)
+                        }
                         _ => (version as u32) >= (JavaMinecraftVersion::V_26_1 as u32),
                     }
                 }


### PR DESCRIPTION
Fixed: Unable to join in versions 1.21.11