### PR TITLE
fix(world): preserve pending block entities and scheduled ticks on chunk upgrade

### DIFF
--- a/crates/pumpkin-world/src/chunk_system/chunk_state.rs
+++ b/crates/pumpkin-world/src/chunk_system/chunk_state.rs
@@ -320,7 +320,7 @@ impl Chunk {
             x: proto_chunk.x,
             z: proto_chunk.z,
             dirty: AtomicBool::new(true),
-            block_ticks: ChunkTickScheduler::default(),
+            block_ticks: ChunkTickScheduler::from_iter(proto_chunk.block_ticks),
             fluid_ticks: ChunkTickScheduler::from_iter(proto_chunk.fluid_ticks),
             pending_block_entities: Mutex::new(pending_block_entities),
             status: proto_chunk.stage.into(),

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -149,6 +149,7 @@ pub struct ProtoChunk {
     pub blending_data: Option<crate::generation::blender::blending_data::BlendingData>,
     pub pending_block_entities: Vec<NbtCompound>,
     pending_structure_entities: Vec<NbtCompound>,
+    pub block_ticks: Vec<ScheduledTick<&'static Block>>,
     pub fluid_ticks: Vec<ScheduledTick<&'static Fluid>>,
 }
 
@@ -257,6 +258,7 @@ impl ProtoChunk {
             blending_data: None,
             pending_block_entities: Vec::new(),
             pending_structure_entities: Vec::new(),
+            block_ticks: Vec::new(),
             fluid_ticks: Vec::new(),
         }
     }
@@ -276,6 +278,15 @@ impl ProtoChunk {
         proto_chunk
             .blending_data
             .clone_from(&chunk_data.blending_data);
+
+        let pending_block_entities_guard = chunk_data
+            .pending_block_entities
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        proto_chunk.pending_block_entities =
+            pending_block_entities_guard.values().cloned().collect();
+        proto_chunk.block_ticks = chunk_data.block_ticks.to_vec();
+        proto_chunk.fluid_ticks = chunk_data.fluid_ticks.to_vec();
 
         let section_data = &chunk_data.section;
         let heightmap_data = chunk_data
@@ -414,6 +425,15 @@ impl ProtoChunk {
 
     fn take_pending_structure_entities(&mut self) -> Vec<NbtCompound> {
         std::mem::take(&mut self.pending_structure_entities)
+    }
+
+    pub fn schedule_block_tick(&mut self, x: i32, y: i32, z: i32, block: &'static Block) {
+        self.block_ticks.push(ScheduledTick {
+            delay: 0,
+            priority: TickPriority::Normal,
+            position: BlockPos::new(x, y, z),
+            value: block,
+        });
     }
 
     pub fn schedule_fluid_tick(&mut self, x: i32, y: i32, z: i32, fluid: &'static Fluid) {

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -7,6 +7,100 @@ mod test {
     use pumpkin_util::world_seed::Seed;
 
     #[test]
+    fn pending_block_entities_and_ticks_survive_proto_chunk_round_trip() {
+        use crate::chunk_system::chunk_state::Chunk;
+        use crate::tick::{ScheduledTick, TickPriority};
+        use pumpkin_config::lighting::LightingEngineConfig;
+        use pumpkin_data::Block;
+        use pumpkin_data::fluid::Fluid;
+        use pumpkin_nbt::compound::NbtCompound;
+        use pumpkin_util::math::position::BlockPos;
+
+        let seed = Seed(0);
+        let world_gen = get_world_gen(seed, Dimension::OVERWORLD, true, Vec::new(), String::new());
+
+        let proto = ProtoChunk::new(0, 0, &world_gen);
+        let mut staged = Chunk::Proto(Box::new(proto));
+        staged.upgrade_to_level_chunk(&Dimension::OVERWORLD, &LightingEngineConfig::Default);
+        let Chunk::Level(chunk_data) = staged else {
+            unreachable!()
+        };
+
+        // Add a block entity (e.g., chest)
+        let mut chest_nbt = NbtCompound::new();
+        chest_nbt.put_string("id", "minecraft:chest".to_string());
+        chest_nbt.put_int("x", 5);
+        chest_nbt.put_int("y", 64);
+        chest_nbt.put_int("z", 7);
+        chunk_data
+            .pending_block_entities
+            .lock()
+            .unwrap()
+            .insert(BlockPos::new(5, 64, 7), chest_nbt.clone());
+
+        // Add a scheduled block tick
+        chunk_data.block_ticks.schedule_tick(
+            &ScheduledTick {
+                delay: 2,
+                priority: TickPriority::Normal,
+                position: BlockPos::new(5, 64, 7),
+                value: &Block::REPEATER,
+            },
+            0,
+        );
+
+        // Add a scheduled fluid tick
+        chunk_data.fluid_ticks.schedule_tick(
+            &ScheduledTick {
+                delay: 1,
+                priority: TickPriority::High,
+                position: BlockPos::new(1, 60, 2),
+                value: &Fluid::WATER,
+            },
+            0,
+        );
+
+        // Convert chunk_data -> ProtoChunk
+        let proto = ProtoChunk::from_chunk_data(&chunk_data, &world_gen);
+        assert_eq!(proto.pending_block_entities.len(), 1);
+        assert_eq!(
+            proto.pending_block_entities[0].get_string("id"),
+            Some("minecraft:chest")
+        );
+        assert_eq!(proto.block_ticks.len(), 1);
+        assert_eq!(proto.block_ticks[0].value, &Block::REPEATER);
+        assert_eq!(proto.fluid_ticks.len(), 1);
+        assert_eq!(proto.fluid_ticks[0].value.id, Fluid::WATER.id);
+
+        // Upgrade ProtoChunk -> LevelChunk (ChunkData)
+        let mut staged = Chunk::Proto(Box::new(proto));
+        staged.upgrade_to_level_chunk(&Dimension::OVERWORLD, &LightingEngineConfig::Default);
+        let Chunk::Level(rebuilt) = staged else {
+            panic!("upgrade_to_level_chunk did not produce a level chunk");
+        };
+
+        // Verify pending block entities preserved
+        let rebuilt_entities = rebuilt.pending_block_entities.lock().unwrap();
+        assert_eq!(rebuilt_entities.len(), 1);
+        let entity = rebuilt_entities
+            .get(&BlockPos::new(5, 64, 7))
+            .expect("chest block entity must be preserved");
+        assert_eq!(entity.get_string("id"), Some("minecraft:chest"));
+
+        // Verify block ticks preserved
+        let rebuilt_block_ticks = rebuilt.block_ticks.to_vec();
+        assert_eq!(rebuilt_block_ticks.len(), 1);
+        assert_eq!(rebuilt_block_ticks[0].value, &Block::REPEATER);
+        assert_eq!(rebuilt_block_ticks[0].position, BlockPos::new(5, 64, 7));
+
+        // Verify fluid ticks preserved
+        let rebuilt_fluid_ticks = rebuilt.fluid_ticks.to_vec();
+        assert_eq!(rebuilt_fluid_ticks.len(), 1);
+        assert_eq!(rebuilt_fluid_ticks[0].value.id, Fluid::WATER.id);
+        assert_eq!(rebuilt_fluid_ticks[0].position, BlockPos::new(1, 60, 2));
+    }
+
+    #[test]
     fn structure_references_are_rebuilt_when_resuming_generation() {
         use crate::chunk_system::chunk_state::Chunk;
         use pumpkin_config::lighting::LightingEngineConfig;


### PR DESCRIPTION
### Summary
Resolves the data-loss issue noted in #2626 where `pending_block_entities`, `block_ticks`, and `fluid_ticks` were dropped during chunk promotion (`ProtoChunk` to `LevelChunk`).

### Changes
* **`crates/pumpkin-world/src/generation/proto_chunk.rs`**:
  * Added `block_ticks` to `ProtoChunk`.
  * Updated `ProtoChunk::from_chunk_data` to preserve `pending_block_entities`, `block_ticks`, and `fluid_ticks`.
* **`crates/pumpkin-world/src/chunk_system/chunk_state.rs`**:
  * Carried over `block_ticks` and `fluid_ticks` schedulers during `upgrade_to_level_chunk`.
* **`crates/pumpkin-world/src/generation/proto_chunk_test.rs`**:
  * Added `pending_block_entities_and_ticks_survive_proto_chunk_round_trip` unit test.

Closes #2626