### PR TITLE
fix(bedrock): NetherNet direct connection ICE routing

### DIFF
--- a/crates/pumpkin/src/net/bedrock/nethernet.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet.rs
@@ -368,7 +368,10 @@ async fn build_peer(
     advertised_ip: Option<IpAddr>,
 ) -> Result<Arc<dyn PeerConnection>, String> {
     let ice_bind_addr = if direct_ip {
-        SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), 0)
+        // Direct connections are relayed through the router's loopback socket.
+        // Binding every interface would make the inner ICE source differ from
+        // the loopback route registered after SDP generation.
+        SocketAddr::new(state.ice_router.internal_addr().ip(), 0)
     } else {
         SocketAddr::new(state.ice_local_addr.ip(), 0)
     };


### PR DESCRIPTION
## Description
Fixes NetherNet direct connections failing when the client connects from the same machine as the Pumpkin server.

## What
- Ensures direct-IP NetherNet peers use the ICE router’s loopback interface.
- Prevents internal ICE packets from being dropped because their source address does not match the registered route.
- Restores same-host Bedrock connections.
- Leaves native NetherNet LAN discovery and its ICE candidate handling unchanged.

## How
- Direct-IP connections are relayed through Pumpkin’s internal ICE router.
- The internal WebRTC socket is now bound to the router’s loopback IP instead of every network interface.
- This keeps the SDP candidate, registered route, and actual packet source consistent.
- The change is limited to the direct-IP/HTTP signaling path.

## Testing
- `cargo test -p pumpkin net::bedrock::nethernet --lib`
- `cargo fmt --all -- --check`
- Verified in game that a Bedrock client can connect from the same computer hosting Pumpkin.
- Verified that the change does not modify the native LAN-discovery connection path.