### PR TITLE
fix(docs): Replace a dead link to github docs in the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # GitHub CODEOWNERS File
-# https://docs.github.com/en/repositories/managing-repository-settings-and-features/customizing-your-repository/about-code-owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owner for the entire project
 * @Snowiiii


### PR DESCRIPTION
https://docs.github.com/en/repositories/managing-repository-settings-and-features/customizing-your-repository/about-code-owners leads to a 404 page, 
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners is the new link
## Description
Pretty simple commit, github changed a path where they changed managing-repository-settings-and-features to managing-your-repositorys-settings-and-features.

## Testing
My web browser and curl --head.