### PR TITLE
fix(worldgen): generate both halves of double-height plants

### DIFF
--- a/crates/pumpkin-world/src/generation/feature/features/simple_block.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/simple_block.rs
@@ -1,4 +1,7 @@
-use pumpkin_data::Block;
+use pumpkin_data::{
+    Block, BlockState,
+    block_properties::{BlockProperties, DoubleBlockHalf, TallSeagrassLikeProperties},
+};
 use pumpkin_util::{math::position::BlockPos, random::RandomGenerator};
 
 use crate::generation::proto_chunk::GenerationCache;
@@ -21,15 +24,80 @@ impl SimpleBlockFeature {
         pos: BlockPos,
     ) -> bool {
         let state = self.to_place.get(random, pos, chunk, block_registry);
-        let block = Block::from_state_id(state.id);
+        let (state_to_place, upper_state) = tall_plant_states(state)
+            .map_or((state, None), |(lower_state, upper_state)| {
+                (lower_state, Some(upper_state))
+            });
+        let block = Block::from_state_id(state_to_place.id);
         let block_accessor: &dyn BlockAccessor = chunk;
-        if !block_registry.can_place_at(block, state, block_accessor, &pos) {
+        if !block_registry.can_place_at(block, state_to_place, block_accessor, &pos) {
             return false;
         }
 
-        // TODO: check things..
-        chunk.set_block_state(&pos.0, state);
+        if let Some(upper_state) = upper_state {
+            let upper_pos = pos.up();
+
+            // Vanilla places a double plant only when both halves fit. Check the upper block
+            // before writing the lower one so a failed attempt cannot leave an orphaned plant.
+            if !chunk.is_air(&upper_pos.0) {
+                return false;
+            }
+
+            chunk.set_block_state(&pos.0, state_to_place);
+            chunk.set_block_state(&upper_pos.0, upper_state);
+        } else {
+            chunk.set_block_state(&pos.0, state_to_place);
+        }
+
         // TODO: schedule tick when needed
         true
+    }
+}
+
+/// Resolves the two states used by Minecraft's tall natural plants. Restricting this to the
+/// generated property group avoids mistaking stairs or other blocks with an unrelated half field
+/// for a two-block plant.
+fn tall_plant_states(
+    state: &'static BlockState,
+) -> Option<(&'static BlockState, &'static BlockState)> {
+    let block = Block::from_state_id(state.id);
+    if !TallSeagrassLikeProperties::handles_block_id(block.id) {
+        return None;
+    }
+
+    let mut properties = TallSeagrassLikeProperties::from_state_id(state.id, block);
+    properties.r#half = DoubleBlockHalf::Lower;
+    let lower_state = BlockState::from_id(properties.to_state_id(block));
+    properties.r#half = DoubleBlockHalf::Upper;
+    let upper_state = BlockState::from_id(properties.to_state_id(block));
+
+    Some((lower_state, upper_state))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tall_plant_states;
+    use pumpkin_data::{
+        Block,
+        block_properties::{BlockProperties, DoubleBlockHalf, TallSeagrassLikeProperties},
+    };
+
+    #[test]
+    fn tall_plants_resolve_to_a_lower_and_upper_pair() {
+        let (lower, upper) = tall_plant_states(Block::SUNFLOWER.default_state)
+            .expect("sunflowers use the tall-plant property group");
+
+        let lower_properties =
+            TallSeagrassLikeProperties::from_state_id(lower.id, &Block::SUNFLOWER);
+        let upper_properties =
+            TallSeagrassLikeProperties::from_state_id(upper.id, &Block::SUNFLOWER);
+
+        assert_eq!(lower_properties.r#half, DoubleBlockHalf::Lower);
+        assert_eq!(upper_properties.r#half, DoubleBlockHalf::Upper);
+    }
+
+    #[test]
+    fn unrelated_half_blocks_are_not_treated_as_tall_plants() {
+        assert!(tall_plant_states(Block::OAK_STAIRS.default_state).is_none());
     }
 }


### PR DESCRIPTION
## Description

Updates `SimpleBlockFeature` to place both the lower and upper states of double-height plants such as sunflowers, lilacs, and tall grass, matching vanilla world generation.

Previously, `SimpleBlockFeature` wrote only the single configured block state. This produced an orphaned lower half and could still place that lower half when the position above was obstructed.

### Changes

- Identified double-height plants through `TallSeagrassLikeProperties` and resolved them into explicit `half=lower` and `half=upper` state pairs.
- Added upper-position validation before either state is written, placing neither half when the position above is obstructed.
- Ensured that unrelated blocks with a `half` property, such as stairs, are not treated as double-height plants.

## Testing

- Added unit tests in `simple_block::tests`:
  - Resolves a sunflower into lower and upper state pairs.
  - Rejects unrelated blocks that expose a `half` property.
- `cargo fmt --all -- --check` (passed)
- `cargo test -p pumpkin-world simple_block::tests --lib -- --nocapture` (2 passed)
- `cargo check -p pumpkin-world` (passed)
- `cargo test --workspace --lib --bins --tests --examples` (17 suites, 723 passed on the isolated PR branch)
- `cargo clippy -p pumpkin-world --lib --all-features -- -D warnings` (clean)
- `cargo build --release -p pumpkin --bin pumpkin` (passed)
- In-game verification completed: generated double-height plants contained both halves, obstructed upper positions did not leave orphaned lower halves, and ordinary single-block vegetation generation did not regress.
