### PR TITLE
fix(entity): send complete entity spawn sequences during broadcast

### DIFF
--- a/crates/pumpkin/src/net/java/mod.rs
+++ b/crates/pumpkin/src/net/java/mod.rs
@@ -1144,3 +1144,98 @@ impl JavaClient {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod spawn_sequence_tests {
+    use super::*;
+    use crate::{
+        entity::{Entity, EntityBase, EntityBaseFuture, living::LivingEntity},
+        net::{ClientPlatform, GameProfile, PacketRateLimiter, PlayerConfig},
+    };
+    use std::{any::Any, sync::Arc, time::Duration};
+    use uuid::Uuid;
+
+    struct SpawnSequenceProbe;
+
+    impl EntityBase for SpawnSequenceProbe {
+        fn get_entity(&self) -> &Entity {
+            panic!("the complete spawn path must dispatch through the entity override")
+        }
+
+        fn get_living_entity(&self) -> Option<&LivingEntity> {
+            None
+        }
+
+        fn cast_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn send_java_spawn_packet<'a>(
+            &'a self,
+            client: &'a JavaClient,
+        ) -> EntityBaseFuture<'a, ()> {
+            Box::pin(async move {
+                // Distinct payloads model an entity's base packet followed by its required
+                // metadata packet without coupling this dispatch test to one entity codec.
+                client.enqueue_packet(Bytes::from_static(b"spawn")).await;
+                client.enqueue_packet(Bytes::from_static(b"metadata")).await;
+            })
+        }
+    }
+
+    async fn java_client_with_packet_receiver() -> (ClientPlatform, Receiver<OutgoingPacket>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("the test listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("the test listener should expose its address");
+        let (client_stream, accepted_stream) =
+            tokio::join!(tokio::net::TcpStream::connect(address), listener.accept());
+        let client_stream = client_stream.expect("the loopback client should connect");
+        let _accepted_stream = accepted_stream
+            .expect("the loopback server should accept the client")
+            .0;
+
+        let pending = PendingConnection::new(
+            client_stream,
+            address,
+            1,
+            PacketRateLimiter::new(false, 0.0, 0.0),
+        );
+        let profile = GameProfile {
+            id: Uuid::nil(),
+            name: "spawn-sequence-test".to_string(),
+            properties: ArcSwap::from_pointee(Vec::new()),
+            profile_actions: None,
+        };
+        let mut client = JavaClient::from_pending(pending, profile, PlayerConfig::default());
+        let receiver = client
+            .outgoing_packet_queue_recv
+            .take()
+            .expect("the test client should own its packet receiver");
+
+        (ClientPlatform::Java(client), receiver)
+    }
+
+    #[tokio::test]
+    async fn complete_spawn_sequence_preserves_entity_specific_packet_order() {
+        let (client, mut receiver) = java_client_with_packet_receiver().await;
+        let entity: Arc<dyn EntityBase> = Arc::new(SpawnSequenceProbe);
+
+        client.enqueue_spawn_packet(&entity).await;
+
+        let base_packet = tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("the base spawn packet should arrive before timeout")
+            .expect("the packet queue should remain open");
+        let metadata_packet = tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("the metadata packet should arrive before timeout")
+            .expect("the packet queue should remain open");
+
+        assert_eq!(base_packet.data, Bytes::from_static(b"spawn"));
+        assert_eq!(metadata_packet.data, Bytes::from_static(b"metadata"));
+        assert!(receiver.try_recv().is_err());
+    }
+}

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -4811,6 +4811,9 @@ impl World {
     pub fn broadcast_entity_spawn(&self, entity: &Arc<dyn EntityBase>) {
         let base_entity = entity.get_entity();
         let chunk_pos = base_entity.chunk_pos.load();
+        let Some(server) = self.server.upgrade() else {
+            return;
+        };
 
         let players = self.players.load();
         for player in players.iter() {
@@ -4818,7 +4821,18 @@ impl World {
             let view_distance = get_view_distance(player).get() as i32;
 
             if is_within_view_distance(chunk_pos, center, view_distance) {
-                player.client.try_enqueue_spawn_packet(entity);
+                // Send the complete entity-specific spawn sequence. This is intentionally
+                // dispatched asynchronously because item entities need their stack metadata
+                // after the base spawn packet; sending only the generic packet leaves the
+                // entity server-side and pickable but invisible to the client.
+                let client = player.client.clone();
+                let entity = entity.clone();
+                // Natural chunk spawning reaches this path on a Rayon Gen-Pool worker.
+                // Dispatch through the server's stored Tokio handle so packet sequencing does
+                // not require the generation thread itself to have an active Tokio reactor.
+                server.spawn_task(async move {
+                    client.enqueue_spawn_packet(&entity).await;
+                });
             }
         }
     }


### PR DESCRIPTION
## Description

Updates `World::broadcast_entity_spawn` to execute the full entity-specific spawn sequence through `ClientPlatform::enqueue_spawn_packet` instead of only sending the base spawn packet via `try_enqueue_spawn_packet`.

For Java clients, this delegates to `EntityBase::send_java_spawn_packet` and fixes an issue where item entities could become invisible. The Java entity spawn flow requires follow-up item-stack metadata after the base spawn packet; without it, the item exists and remains collectible on the server but is rendered invisible to players.

### Changes & Threading

- Switched to the async `enqueue_spawn_packet` path and reused the existing entity-specific spawn implementations to preserve packet ordering, including item-stack metadata after an item's base spawn packet.
- Handled the thread boundary between Rayon and Tokio: `broadcast_entity_spawn` can be called from chunk-generation Rayon workers (`Gen-Pool`). Dispatching through `Server::spawn_task`, which uses `TaskTracker::spawn_on` with the server's Tokio handle, makes packet scheduling independent of the caller thread's runtime context.
- Added a loopback Java-client regression test that verifies an entity-specific base packet and metadata packet are delivered in order through `ClientPlatform::enqueue_spawn_packet`.

### Out of Scope

Protochunk storage, full-chunk promotion, and natural mob persistence are left for separate parity PRs.

## Testing

- `cargo fmt --all -- --check` (passed)
- `cargo check -p pumpkin` (passed)
- `cargo test -p pumpkin complete_spawn_sequence_preserves_entity_specific_packet_order --lib -- --nocapture` (1 passed)
- `cargo clippy -p pumpkin --lib --all-features -- -D warnings` (clean)
- `cargo test --workspace --lib --bins --tests --examples` (17 suites, 724 passed on the isolated PR branch)
- `cargo build --release -p pumpkin --bin pumpkin` (passed)
- In-game verification completed: dropped items remained visible and collectible, entity visibility was restored, and generating new chunks produced no Tokio reactor or `Gen-Pool` panic.
