### PR TITLE
feat(plugin-api): Better method chaining (Rust)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5298,16 +5298,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.254.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.254.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
@@ -5317,15 +5307,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-metadata"
-version = "0.254.0"
+name = "wasm-encoder"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01df5f3b4ca7881e843f3bc0fb8a3905d79c68692250dcb8e33e698705ccdb6"
+checksum = "e974fe6821a8cf64575d51ea2194e2c8f77e7b66e9afe7419ce8a97f9ee0d251"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.258.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a11585adb92fe9b55ad1d760e8d8fb5d87e0d2e303cb8eed57f078d54293a2"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.254.0",
- "wasmparser 0.254.0",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
@@ -5343,23 +5343,23 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.254.0"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
+checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
 dependencies = [
  "bitflags 2.13.1",
- "hashbrown 0.17.1",
  "indexmap",
  "semver",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.257.1"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
+checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
 dependencies = [
  "bitflags 2.13.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
 ]
@@ -6022,29 +6022,29 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.60.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a301904d6657d6364c758d869e5389d05d393b16d5b65db60b4f03cbe71bb80d"
+checksum = "fbfef9403167686bfe35ffa8787df4c0f50742e5b0f471c7fb156a6614193c5d"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.60.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48521bb96e56cbb9e031ad306c80dc20e89e69e49ada02781ee06f60fbcb545f"
+checksum = "4814f3904ce1f5ba05f82d868edd2e0fc197b3f87f930b0777ca795de17df772"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser 0.254.0",
+ "wit-parser 0.258.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.60.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df3fe9b9a0066f82fd0c2f07f79d0ffc0f85c53fa5f998516d8722712479042"
+checksum = "b4c760bc63d9d3271f0e6476eba4c37707d983cf492095a9db1fed232f29d551"
 dependencies = [
  "anyhow",
  "heck",
@@ -6058,9 +6058,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.60.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d689c4bc9d6af067c651cfba444766343c9a4bdef15fad1e2efab95c0c277af0"
+checksum = "3521448f8b53272f9aa1caf134e8f008ce13a2b43b832672435c0c5328b01077"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -6073,9 +6073,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.254.0"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e65bb94c369b3c4741ce3d1d2704b1fec93db7c540df0e521a097e7ceeb5be"
+checksum = "481b5c47b2ecce0389b5e08a05557d6a190c9cd761773b8880a8017ee04dc7ef"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",
@@ -6084,10 +6084,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.254.0",
+ "wasm-encoder 0.258.0",
  "wasm-metadata",
- "wasmparser 0.254.0",
- "wit-parser 0.254.0",
+ "wasmparser 0.258.0",
+ "wit-parser 0.258.0",
 ]
 
 [[package]]
@@ -6124,25 +6124,6 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.254.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1655131e4f7d3f0cb141f6eca71315ca40eff0f3d4de7cff0a82bacedd8c89b4"
-dependencies = [
- "anyhow",
- "hashbrown 0.17.1",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-ident",
- "wasmparser 0.254.0",
-]
-
-[[package]]
-name = "wit-parser"
 version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f815340f0bb65d9775ae21e56b503b496683557b9b627b195d2766c25fb24ae"
@@ -6158,6 +6139,25 @@ dependencies = [
  "serde_json",
  "unicode-ident",
  "wasmparser 0.257.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4daaa3cd97ae49ecd0a99dc009d453f93e0f083dd3be38c0f24a83a93e37ac"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-ident",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ hyper = { version = "^1.11", default-features = false }
 axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio"] }
 webrtc = { version = "0.20.3" }
 async-trait = "0.1"
-wit-bindgen = { version = "0.60", default-features = false, features = ["macros"] }
+wit-bindgen = { version = "0.61", default-features = false, features = ["macros"] }
 
 postcard = { version = "1.1", default-features = false, features = ["alloc"] }
 tracing-serde-structured = { version = "0.4", default-features = false }

--- a/crates/pumpkin-plugin-api/src/commands.rs
+++ b/crates/pumpkin-plugin-api/src/commands.rs
@@ -109,9 +109,7 @@ impl Command {
             .unwrap_or_else(|e| e.into_inner())
             .insert(id, Box::new(handler));
 
-        self.execute_with_handler_id(id);
-
-        self
+        self.execute_with_handler_id(id)
     }
 }
 
@@ -129,9 +127,7 @@ impl CommandNode {
             .unwrap_or_else(|e| e.into_inner())
             .insert(id, Box::new(handler));
 
-        self.execute_with_handler_id(id);
-
-        self
+        self.execute_with_handler_id(id)
     }
 
     /// Attaches a server-side suggestion handler to this argument node.
@@ -147,9 +143,7 @@ impl CommandNode {
             .unwrap_or_else(|e| e.into_inner())
             .insert(id, Box::new(handler));
 
-        self.suggest_with_handler_id(id);
-
-        self
+        self.suggest_with_handler_id(id)
     }
 }
 

--- a/crates/pumpkin-plugin-api/src/lib.rs
+++ b/crates/pumpkin-plugin-api/src/lib.rs
@@ -176,7 +176,11 @@ mod wit {
         skip: ["init-plugin"],
         path: "../pumpkin-plugin-wit/v0.1",
         world: "plugin",
-        enable_method_chaining: true
+        chainable_methods: [
+            "pumpkin:plugin/command@0.1.0#command",
+            "pumpkin:plugin/command@0.1.0#command-node",
+            "pumpkin:plugin/text@0.1.0#text-component"
+        ]
     });
 
     use super::Component;

--- a/crates/pumpkin-plugin-api/src/lib.rs
+++ b/crates/pumpkin-plugin-api/src/lib.rs
@@ -467,3 +467,16 @@ pub mod persistent_data;
 pub use persistent_data::PersistentDataHolder;
 /// Game rules definitions and values.
 pub use wit::pumpkin::plugin::game_rules::{GameRule, GameRuleValue};
+
+/// Stub for component model `cabi_realloc`
+/// Remove me after bytecodealliance/wit-bindgen#1697 makes it to release
+#[cfg(not(target_arch = "wasm32"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn cabi_realloc(
+    _old_ptr: *mut u8,
+    _old_len: usize,
+    _align: usize,
+    _new_len: usize,
+) -> *mut u8 {
+    panic!("Call to cabi_realloc on native?")
+}

--- a/crates/pumpkin-plugin-utils/src/lib.rs
+++ b/crates/pumpkin-plugin-utils/src/lib.rs
@@ -190,16 +190,3 @@ pub fn evaluate_license(grace_period_days: u32) -> LicenseStatus {
     let checker = LicenseChecker::new(folder);
     checker.evaluate_license(meta, grace_period_days)
 }
-
-/// Stub for component model `cabi_realloc`
-/// Remove me after bytecodealliance/wit-bindgen#1697 makes it to release
-#[cfg(not(target_arch = "wasm32"))]
-#[unsafe(no_mangle)]
-pub extern "C" fn cabi_realloc(
-    _old_ptr: *mut u8,
-    _old_len: usize,
-    _align: usize,
-    _new_len: usize,
-) -> *mut u8 {
-    panic!("Call to cabi_realloc on native?")
-}

--- a/crates/pumpkin-plugin-utils/src/lib.rs
+++ b/crates/pumpkin-plugin-utils/src/lib.rs
@@ -190,3 +190,16 @@ pub fn evaluate_license(grace_period_days: u32) -> LicenseStatus {
     let checker = LicenseChecker::new(folder);
     checker.evaluate_license(meta, grace_period_days)
 }
+
+/// Stub for component model `cabi_realloc`
+/// Remove me after bytecodealliance/wit-bindgen#1697 makes it to release
+#[cfg(not(target_arch = "wasm32"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn cabi_realloc(
+    _old_ptr: *mut u8,
+    _old_len: usize,
+    _align: usize,
+    _new_len: usize,
+) -> *mut u8 {
+    panic!("Call to cabi_realloc on native?")
+}


### PR DESCRIPTION
## Description

Updates `wit-bindgen` for the `pumpkin-plugin-api` (Rust bindings) to `0.61` to take advantage of https://github.com/bytecodealliance/wit-bindgen/pull/1602

The configuration has been updated so that only some resources enable method chaining, and that said methods/resources use owning method chaining, rather than borrowing (they return `Self` rather than `&Self`).

## Testing

Testing was done to ensure bindings still compile, and that a Rust plugin using commands and text components can compile successfully (after modification).

Some of the methods in the crate wrap around generated methods from the WIT, so they show evidence that the transition to owning borrowing is working.

`wit-bindgen` itself has tests for whether the chaining functions correctly.