### PR TITLE
fix(util): prevent translation rendering panic on a lone %

### DIFF
--- a/crates/pumpkin-util/src/translation.rs
+++ b/crates/pumpkin-util/src/translation.rs
@@ -130,6 +130,61 @@ pub fn get_translation(key: &str, locale: Locale) -> String {
     )
 }
 
+/// What a `%` in a translation string introduces.
+enum Placeholder {
+    /// `%%`, which stands for a single literal `%`.
+    Escape,
+    /// `%<conversion>`, which takes the next substitution in order.
+    Next,
+    /// `%<digits>$<conversion>`, which takes the substitution at that one-based
+    /// index.
+    Indexed(usize),
+}
+
+/// Whether `byte` closes a placeholder. The shipped tables use `s` and `d`
+/// (`en_us_bedrock.lang` is where the `%d` forms come from), and every
+/// conversion is substituted the same way here, so the letter only marks the
+/// end of the token.
+const fn is_conversion(byte: u8) -> bool {
+    byte.is_ascii_alphabetic()
+}
+
+/// Classifies the `%` at `start`, returning what it introduces together with the
+/// inclusive byte index it ends at.
+///
+/// Returns `None` when the `%` starts nothing this module understands, such as a
+/// trailing `%` or digits with no conversion after them; those are literal text.
+/// The end is reported rather than assumed because a [`SubstitutionRange`] has to
+/// span the whole placeholder for the callers that resume reading at `end + 1`.
+fn placeholder_at(bytes: &[u8], start: usize) -> Option<(Placeholder, usize)> {
+    let after = start + 1;
+    match bytes.get(after) {
+        Some(&b'%') => return Some((Placeholder::Escape, after)),
+        Some(&byte) if is_conversion(byte) => return Some((Placeholder::Next, after)),
+        _ => {}
+    }
+
+    let mut end = after;
+    while bytes.get(end).is_some_and(u8::is_ascii_digit) {
+        end += 1;
+    }
+    if end == after
+        || bytes.get(end) != Some(&b'$')
+        || !bytes.get(end + 1).copied().is_some_and(is_conversion)
+    {
+        return None;
+    }
+
+    // Saturating so that an absurdly long run of digits still lands on the last
+    // substitution instead of failing to parse.
+    let index = bytes[after..end].iter().fold(0usize, |index, digit| {
+        index
+            .saturating_mul(10)
+            .saturating_add(usize::from(digit - b'0'))
+    });
+    Some((Placeholder::Indexed(index), end + 1))
+}
+
 /// Reorders substitution placeholders within a translation string.
 ///
 /// # Arguments
@@ -143,63 +198,50 @@ pub fn reorder_substitutions(
     translation: &str,
     with: Vec<TextComponentBase>,
 ) -> (Vec<TextComponentBase>, Vec<SubstitutionRange>) {
-    let indices: Vec<usize> = translation
-        .match_indices('%')
-        .filter(|(i, _)| *i == 0 || translation.as_bytes()[i - 1] != b'\\')
-        .map(|(i, _)| i)
-        .collect();
-
-    if translation.matches("%s").count() == indices.len() {
-        return (
-            with,
-            indices
-                .iter()
-                .map(|&i| SubstitutionRange {
-                    start: i,
-                    end: i + 1,
-                })
-                .collect(),
-        );
-    }
-
-    let mut substitutions: Vec<TextComponentBase> = indices
-        .iter()
-        .map(|_| TextComponentBase {
-            content: Box::new(TextContent::Text { text: "".into() }),
+    fn literal(text: &'static str) -> TextComponentBase {
+        TextComponentBase {
+            content: Box::new(TextContent::Text { text: text.into() }),
             style: Box::new(Style::default()),
             extra: vec![],
-        })
-        .collect();
-    let mut ranges: Vec<SubstitutionRange> = vec![];
-
-    let bytes = translation.as_bytes();
-    let mut next_idx = 0usize;
-    for (idx, &i) in indices.iter().enumerate() {
-        let mut num_chars = String::new();
-        let mut pos = 1;
-        while i + pos < bytes.len() && bytes[i + pos].is_ascii_digit() {
-            num_chars.push(bytes[i + pos] as char);
-            pos += 1;
-        }
-
-        if num_chars.is_empty() {
-            ranges.push(SubstitutionRange {
-                start: i,
-                end: i + 1,
-            });
-            substitutions[idx] = with[next_idx].clone();
-            next_idx = (next_idx + 1).clamp(0, with.len() - 1);
-            continue;
-        }
-
-        ranges.push(SubstitutionRange {
-            start: i,
-            end: i + pos + 1,
-        });
-        if let Ok(digit) = num_chars.parse::<usize>() {
-            substitutions[idx] = with[digit.clamp(1, with.len()) - 1].clone();
         }
     }
+
+    // A placeholder may repeat an index (`%1$s ... %1$s`), so the arguments are
+    // read from rather than drained. Freeze them for that read-only access.
+    let with = with.into_boxed_slice();
+
+    let bytes = translation.as_bytes();
+    let mut substitutions: Vec<TextComponentBase> = vec![];
+    let mut ranges: Vec<SubstitutionRange> = vec![];
+    let mut next_idx = 0usize;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        if bytes[i] != b'%' || (i > 0 && bytes[i - 1] == b'\\') {
+            i += 1;
+            continue;
+        }
+        let Some((placeholder, end)) = placeholder_at(bytes, i) else {
+            i += 1;
+            continue;
+        };
+
+        substitutions.push(match placeholder {
+            Placeholder::Escape => literal("%"),
+            Placeholder::Next => {
+                let taken = with.get(next_idx).cloned().unwrap_or_else(|| literal(""));
+                next_idx = (next_idx + 1).min(with.len().saturating_sub(1));
+                taken
+            }
+            Placeholder::Indexed(index) => with
+                .get(index.clamp(1, with.len().max(1)) - 1)
+                .cloned()
+                .unwrap_or_else(|| literal("")),
+        });
+        ranges.push(SubstitutionRange { start: i, end });
+        i = end + 1;
+    }
+
     (substitutions, ranges)
 }
 
@@ -677,5 +719,185 @@ impl FromStr for Locale {
             "zlm_arab" => Ok(Self::ZlmArab), // Malay (Jawi)
             _ => Ok(Self::EnUs),             // Default to English (US) if not found
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Locale, TRANSLATIONS, get_translation_text, reorder_substitutions};
+    use crate::text::{TextComponentBase, TextContent, style::Style};
+
+    fn arg(text: &str) -> TextComponentBase {
+        TextComponentBase {
+            content: Box::new(TextContent::Text {
+                text: text.to_string().into(),
+            }),
+            style: Box::new(Style::default()),
+            extra: vec![],
+        }
+    }
+
+    /// `SubstitutionRange` documents itself as spanning the full placeholder, and
+    /// the renderer resumes at `end + 1` on that promise. A lone `%` is one byte
+    /// wide, so it is not a placeholder and must not claim a range.
+    #[test]
+    fn a_lone_percent_is_not_a_placeholder() {
+        let (substitutions, ranges) = reorder_substitutions("100% of %s", vec![arg("A")]);
+
+        assert_eq!(ranges.len(), 1, "only the %s is a placeholder");
+        assert_eq!(ranges[0].start, 8);
+        assert_eq!(ranges[0].end, 9);
+        assert_eq!(substitutions.len(), 1);
+    }
+
+    /// `assets/en_us_java.json` ships this verbatim as `attribute.modifier.plus.1`.
+    /// It also reaches the renderer as a format string in its own right, because
+    /// `get_translation` returns the key when the key is unknown.
+    #[test]
+    fn an_escaped_percent_renders_as_one_percent() {
+        assert_eq!(
+            get_translation_text("+%s%% %s", Locale::EnUs, vec![arg("10"), arg("Speed")]),
+            "+10% Speed"
+        );
+        // Shipped as `options.languageWarning`. Passed here as an unknown key, so
+        // `get_translation` hands it back as its own format string, lowercased.
+        assert_eq!(
+            get_translation_text(
+                "Language translations may not be 100%% accurate",
+                Locale::EnUs,
+                vec![arg("unused")]
+            ),
+            "language translations may not be 100% accurate"
+        );
+    }
+
+    /// Shipped as `translation.test.escape`, which is the escape rule stated as a
+    /// test by the game's own translation data: `%%` is one literal `%`, and only
+    /// a `%` left over after the escapes introduces a substitution.
+    #[test]
+    fn runs_of_percents_escape_pairwise() {
+        assert_eq!(
+            get_translation_text(
+                "%%s %%%s %%%%s %%%%%s",
+                Locale::EnUs,
+                vec![arg("A"), arg("B")]
+            ),
+            "%s %A %%s %%B"
+        );
+    }
+
+    /// Callers index `substitutions` by the position of the range they are on,
+    /// so the two must always line up. They used to diverge whenever `with` was
+    /// not exactly as long as the placeholder count.
+    #[test]
+    fn a_substitution_is_produced_for_every_range() {
+        for (translation, count) in [
+            ("%s %s %s", 3),
+            ("%s", 1),
+            ("%1$s %1$s", 2),
+            ("%% %s", 2),
+            ("no placeholders", 0),
+        ] {
+            for args in 0..4 {
+                let with = (0..args).map(|_| arg("x")).collect();
+                let (substitutions, ranges) = reorder_substitutions(translation, with);
+
+                assert_eq!(ranges.len(), count, "{translation:?} with {args} args");
+                assert_eq!(
+                    substitutions.len(),
+                    ranges.len(),
+                    "{translation:?} with {args} args"
+                );
+            }
+        }
+    }
+
+    /// Shipped as `translation.test.invalid`.
+    #[test]
+    fn a_trailing_percent_renders_instead_of_panicking() {
+        assert_eq!(
+            get_translation_text("hi %", Locale::EnUs, vec![arg("A")]),
+            "hi %"
+        );
+    }
+
+    /// Digits with no `$s` after them are not a placeholder either, and used to
+    /// run the cursor off the end of the string.
+    #[test]
+    fn trailing_digits_without_a_conversion_render_instead_of_panicking() {
+        assert_eq!(
+            get_translation_text("%5", Locale::EnUs, vec![arg("A")]),
+            "%5"
+        );
+    }
+
+    /// The renderer has to survive the data it ships with. `en_us_java.json`
+    /// alone holds 19 strings that used to take the whole server down, so walk
+    /// the loaded table and render every one of them.
+    #[test]
+    fn every_shipped_translation_renders() {
+        // Collect first: `get_translation` takes the same lock.
+        let keys: Vec<String> = {
+            let translations = TRANSLATIONS
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            translations[Locale::EnUs as usize]
+                .keys()
+                .cloned()
+                .collect()
+        };
+
+        assert!(keys.len() > 1000, "the vanilla table should be loaded");
+        for key in keys {
+            // A non-empty `with` is what sends a string down the substituting path.
+            get_translation_text(key, Locale::EnUs, vec![arg("A"), arg("B")]);
+        }
+    }
+
+    /// The control: the forms this module substitutes must be untouched.
+    #[test]
+    fn supported_placeholders_still_substitute() {
+        assert_eq!(
+            get_translation_text("%s joined", Locale::EnUs, vec![arg("Steve")]),
+            "Steve joined"
+        );
+        assert_eq!(
+            get_translation_text(
+                "%1$s was slain by %2$s",
+                Locale::EnUs,
+                vec![arg("Steve"), arg("Alex")]
+            ),
+            "Steve was slain by Alex"
+        );
+    }
+
+    /// `assets/en_us_bedrock.lang` is loaded into the same table and closes its
+    /// placeholders with `d`, so a conversion is not always `s`. Reading only `s`
+    /// would leave these rendering as literal text.
+    #[test]
+    fn a_numeric_conversion_substitutes_too() {
+        assert_eq!(
+            get_translation_text("+%d %s", Locale::EnUs, vec![arg("10"), arg("Speed")]),
+            "+10 Speed"
+        );
+        assert_eq!(
+            get_translation_text("%1$d blocks cloned", Locale::EnUs, vec![arg("42")]),
+            "42 blocks cloned"
+        );
+    }
+
+    /// Digits that never reach a conversion are not a placeholder. The renderer
+    /// used to consume the character after them, turning `(%5 blocks away)` into
+    /// `(Alocks away)`.
+    #[test]
+    fn digits_without_a_conversion_do_not_eat_the_next_character() {
+        assert_eq!(
+            get_translation_text("%1$s (%5 blocks away)", Locale::EnUs, vec![arg("Village")]),
+            "Village (%5 blocks away)"
+        );
+        assert_eq!(
+            get_translation_text("entered (%.2f)", Locale::EnUs, vec![arg("x")]),
+            "entered (%.2f)"
+        );
     }
 }


### PR DESCRIPTION
## Description

`reorder_substitutions` in `crates/pumpkin-util/src/translation.rs` treats **every** `%` in a
translation as a placeholder, and gives each one a `SubstitutionRange` - a type whose own doc
comment promises the range "corresponds to the full placeholder span (for example `%s` or `%1$s`)".
For a lone `%` that promise is false: it emits `{ start: i, end: i + 1 }`, two bytes wide, for a one
byte token.

Both renderers resume reading at `end + 1` on the strength of that promise:

```rust
result.push_str(&translation[pos..range.start]);
result.push_str(&substitution);
pos = range.end + 1;
...
result.push_str(&translation[pos..]);
```

so the cursor lands one byte past the `%` and the next slice is taken from a bad index. Three shapes
panic, all at those two lines:

| format string | panic |
| --- | --- |
| `+%s%% %s` | `byte range starts at 5 but ends at 4` |
| `hi %` | `start byte index 5 is out of bounds for string of length 4` |
| `%5` | `start byte index 4 is out of bounds for string of length 2` |

The loaded `en_us` table holds **118 entries** in these shapes, from `assets/en_us_java.json` and
`assets/en_us_bedrock.lang` both: the `attribute.modifier.*` family, `translation.test.escape`,
`translation.test.invalid` = `hi %`, and many Bedrock rows. Both entry points already require a
non-empty `with`, which is the only other precondition.

Those entries are not the only way in. `get_translation` returns the key itself when the key is
unknown (`.map_or(key, Clone::clone)`), so an unknown key becomes its own format string, and a key
containing `%%` is enough on its own with no table entry involved.

### Impact

`main.rs` installs a global panic hook: the first panic on a worker thread calls `stop_server()`,
and on the main thread it calls `exit(1)`. This is not a failed render, it is the whole server going
down.

It is reachable from any command that puts a caller-supplied component somewhere the server renders
it to text rather than forwarding it to a client. `/bossbar add <id> <component>` echoes the
component into its own console reply (`commands.bossbar.create.success` = `Created custom bossbar
%s`), and `/title <targets> title <component>` runs it through `get_text()` to build the Bedrock
packet. Both sit at permission level 2, so what this reaches today is an operator or a plugin, not
an unprivileged player.

### The fix

Scan the string once and classify each `%` as one of three things, recording where it actually ends:
the `%%` escape, a `%<conversion>` taking the next substitution, or a `%<digits>$<conversion>`
taking an indexed one. Anything else is literal text and is copied through untouched. Every emitted
range is then exactly as wide as the token it covers, so `end + 1` cannot outrun it.

A conversion is any ASCII letter rather than only `s`, because `en_us_bedrock.lang` is loaded into
the same table and closes its placeholders with `d` as well; a scan of the shipped data finds only
those two in use, and every conversion is substituted the same way here, so the letter only marks
the end of the token.

Three further defects fall out of the same change:

- `%%` now renders as one literal `%` instead of being treated as two placeholders, which is what
  `translation.test.escape` (`%%s %%%s %%%%s %%%%%s`) documents.
- A run of digits that never reaches a conversion no longer swallows the character behind it, so
  `commands.locate.biome.success` stops rendering `(%5 blocks away)` as `(Alocks away)` and
  `commands.generic.double.toobig` stops rendering `(%.2f)` as `(A2f)`.
- `substitutions` and `ranges` are now always the same length. They diverged whenever `with` was not
  exactly as long as the placeholder count, because the old fast path returned `with` verbatim
  alongside a range per placeholder. `TextComponent::to_translated` indexes `substitutions[idx]` by
  range position with no clamp, so that was an out of bounds index; the two renderers survived it
  only because they clamp.

### Known limitations

Mixed-case keys such as `menu.preparingSpawn` still cannot be found: the Java loader inserts
`format!("minecraft:{key}")` without lowercasing, while `get_translation` lowercases the lookup, and
only the Bedrock loader lowercases on insert. That is a pre-existing and separate defect, left alone
here.

### Relation to open PRs

Of the 109 open PRs, two are adjacent and neither overlaps. #2918 adds a Bedrock advancement title
table and locale entries to `translation.rs`, touching neither `reorder_substitutions` nor either
renderer; it does append a `#[cfg(test)] mod tests` to the end of the same file, as this PR does, so
whichever lands second will need the two modules merged. #2700 refactors `to_pretty_console` for
nested styles in `text/mod.rs`, which this PR does not touch. No open PR mentions placeholders,
`%%`, `SubstitutionRange`, or `reorder_substitutions`.

## Testing

### Live, on a release build, with no client connected

Built with `CARGO_PROFILE_RELEASE_LTO=false CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 cargo build --release`
and driven by one line on stdin:

```
bossbar add test:crash {"translate":"%%","with":[{"text":"a"}]}
```

The key is unknown, so it becomes its own format string. `minecraft:%%` is twelve bytes with the two
`%` at 10 and 11: the first claims 10..=11 and moves the cursor to 12, the second starts at 11, and
the slice runs backwards.

**Before**, on `master` at `0d55aa541`, reproduced twice:

```
ERROR pumpkin::crash: Thread 'tokio-rt-worker' with ThreadId(12) panicked at
      crates\pumpkin-util\src\translation.rs:233:37:
ERROR pumpkin::crash: byte range starts at 12 but ends at 11
 INFO pumpkin::crash: Successfully saved the crash report to file: ./crash-reports\...
 INFO pumpkin: Gracefully shutting down...
 INFO pumpkin: The server has stopped.
```

Process exit code 1. `git show HEAD:crates/pumpkin-util/src/translation.rs | sed -n '233p'` is
`result.push_str(&translation[pos..range.start]);` inside `translation_to_pretty`, so the binary
under test was built from the committed code and the panic is on the line named.

**After**, same command and config:

```
Created custom bossbar [[minecraft:%]]
There are 1 custom bossbars active: [minecraft:%]
```

Exit code 0, no crash report. The follow-up `bossbar list` renders the stored component a second
time, so the command still works rather than only not crashing.

Real table entries were driven through the same path:

| key | before | after |
| --- | --- | --- |
| `attribute.modifier.plus.1` | panic | `+10% Attack Speed` |
| `translation.test.escape` | panic | `%s %A %%s %%B` |

### Unit tests

Ten tests, in `crates/pumpkin-util/src/translation.rs`. Against unpatched `master` seven fail, three
of them as real panics at the two slicing lines; the others cover the escape rule, the
range/substitution length invariant, and the whole shipped table. The remaining test is a control
that passes before the change as well as after, so the set is not written around the fix. With the
change applied all ten pass.

One of them, `every_shipped_translation_renders`, walks the loaded `en_us` table and renders every
entry. On unpatched `master` it panics with `start byte index 8 is out of bounds for string of
length 6`.

### Differential over the whole table

Every entry of the `en_us` table as the loader builds it, which is `en_us_java.json` plus the
Pumpkin locale files plus `en_us_bedrock.lang` - 46,437 entries, rendered under the old and the new
rule with `with` of length 1, 2 and 5, so 139,311 cases:

- 354 cases go from panicking to rendering
- 0 cases still panic
- 48 cases change output, every one a string where the old code silently consumed a character it
  should not have (`(%.2f)` as `(A2f)`, `(%5 blocks away)` as `(Alocks away)`, `%1Warning` as
  `Arning`)

Everything else renders byte for byte as before, `%d` and `%1$d` included.

That differential is a model of the code rather than the code, so it was checked against the real
thing: a throwaway test dumped 92,264 live renderings of the whole table and they matched the model
with 0 mismatches.

### Gate

On rustc 1.98.0, all exit 0:

```
cargo fmt --check
RUSTFLAGS='-Dwarnings' cargo clippy --all-targets --all-features
RUSTFLAGS='-Dwarnings' cargo clippy --release --all-targets --all-features
cargo test --workspace
```

`cargo test --workspace` goes from **722 passed / 0 failed / 16 ignored** on unpatched `master` to
**732 passed / 0 failed / 16 ignored**, measured by stashing only this file and re-running. The
delta is exactly the ten tests added, and nothing else moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved placeholder handling in formatted text, including escaped percent signs, sequential substitutions, and numbered substitutions.
  - Prevented crashes for incomplete placeholders and standalone numeric text.
  - Added support for reusing substitutions through repeated numbered placeholders.
- **Tests**
  - Added coverage for placeholder parsing and rendered output across supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->