### PR TITLE
fix(worldgen): existing chunk state loading

### DIFF
--- a/crates/pumpkin-world/src/chunk_system/chunk_state.rs
+++ b/crates/pumpkin-world/src/chunk_system/chunk_state.rs
@@ -327,7 +327,7 @@ impl Chunk {
             x: proto_chunk.x,
             z: proto_chunk.z,
             dirty: AtomicBool::new(true),
-            block_ticks: ChunkTickScheduler::default(),
+            block_ticks: ChunkTickScheduler::from_iter(proto_chunk.block_ticks),
             fluid_ticks: ChunkTickScheduler::from_iter(proto_chunk.fluid_ticks),
             pending_block_entities: Mutex::new(pending_block_entities),
             status: proto_chunk.stage.into(),

--- a/crates/pumpkin-world/src/chunk_system/schedule.rs
+++ b/crates/pumpkin-world/src/chunk_system/schedule.rs
@@ -23,6 +23,10 @@ use std::thread;
 use std::time::Duration;
 use tracing::{debug, error, info, trace, warn};
 
+pub(super) const fn should_save_proto_chunk(stage: StagedChunkEnum) -> bool {
+    !matches!(stage, StagedChunkEnum::None | StagedChunkEnum::Empty)
+}
+
 pub(crate) struct TaskHeapNode(i8, NodeKey);
 impl PartialEq for TaskHeapNode {
     fn eq(&self, other: &Self) -> bool {
@@ -929,14 +933,7 @@ impl GenerationSchedule {
             if let Some(chunk) = &holder.chunk {
                 let should_save = match chunk {
                     Chunk::Level(sync_chunk) => sync_chunk.is_dirty(),
-                    Chunk::Proto(proto) => {
-                        save_proto_chunk
-                            && !matches!(
-                                proto.stage,
-                                crate::chunk_system::chunk_state::StagedChunkEnum::Empty
-                                    | crate::chunk_system::chunk_state::StagedChunkEnum::None
-                            )
-                    }
+                    Chunk::Proto(proto) => save_proto_chunk && should_save_proto_chunk(proto.stage),
                 };
 
                 if should_save {

--- a/crates/pumpkin-world/src/chunk_system/tests.rs
+++ b/crates/pumpkin-world/src/chunk_system/tests.rs
@@ -6,6 +6,16 @@ use std::collections::BinaryHeap;
 use std::collections::HashMap;
 
 #[test]
+fn ungenerated_proto_chunks_are_not_saved() {
+    use crate::chunk_system::schedule::should_save_proto_chunk;
+
+    assert!(!should_save_proto_chunk(StagedChunkEnum::None));
+    assert!(!should_save_proto_chunk(StagedChunkEnum::Empty));
+    assert!(should_save_proto_chunk(StagedChunkEnum::Biomes));
+    assert!(should_save_proto_chunk(StagedChunkEnum::Full));
+}
+
+#[test]
 fn ensure_dependency_chain_builds_multistage_chain() {
     let mut graph = DAG::default();
     let mut queue = BinaryHeap::new();

--- a/crates/pumpkin-world/src/chunk_system/worker_logic.rs
+++ b/crates/pumpkin-world/src/chunk_system/worker_logic.rs
@@ -88,6 +88,16 @@ fn process_loaded_chunk(chunk: Arc<crate::chunk::ChunkData>, level: &Level) -> C
     }
 }
 
+fn chunk_load_failure(pos: ChunkPos, error: impl std::fmt::Display) -> RecvChunk {
+    let error = format!("Failed to read chunk from disk: {error}");
+    error!("Chunk {pos:?} was not loaded: {error}");
+    RecvChunk::GenerationFailure {
+        pos,
+        stage: StagedChunkEnum::Empty,
+        error,
+    }
+}
+
 pub async fn io_read_work(
     recv: Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<Vec<ChunkPos>>>>,
     send: crossbeam::channel::Sender<(ChunkPos, RecvChunk)>,
@@ -171,19 +181,7 @@ pub async fn io_read_work(
                     }
                 }
                 LoadedData::Error((pos, error)) => {
-                    let error = format!("Failed to read chunk from disk: {error}");
-                    tracing::error!("Chunk {pos:?} was not loaded: {error}");
-                    if send
-                        .send((
-                            pos,
-                            RecvChunk::GenerationFailure {
-                                pos,
-                                stage: StagedChunkEnum::Empty,
-                                error,
-                            },
-                        ))
-                        .is_err()
-                    {
+                    if send.send((pos, chunk_load_failure(pos, error))).is_err() {
                         break;
                     }
                 }

--- a/crates/pumpkin-world/src/chunk_system/worker_logic.rs
+++ b/crates/pumpkin-world/src/chunk_system/worker_logic.rs
@@ -155,7 +155,7 @@ pub async fn io_read_work(
                         break;
                     }
                 }
-                LoadedData::Missing(pos) | LoadedData::Error((pos, _)) => {
+                LoadedData::Missing(pos) => {
                     if send
                         .send((
                             pos,
@@ -164,6 +164,23 @@ pub async fn io_read_work(
                                 pos.y,
                                 &level.world_gen.load(),
                             )))),
+                        ))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                LoadedData::Error((pos, error)) => {
+                    let error = format!("Failed to read chunk from disk: {error}");
+                    tracing::error!("Chunk {pos:?} was not loaded: {error}");
+                    if send
+                        .send((
+                            pos,
+                            RecvChunk::GenerationFailure {
+                                pos,
+                                stage: StagedChunkEnum::Empty,
+                                error,
+                            },
                         ))
                         .is_err()
                     {

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -156,6 +156,7 @@ pub struct ProtoChunk {
     pub blending_data: Option<crate::generation::blender::blending_data::BlendingData>,
     pub pending_block_entities: Vec<NbtCompound>,
     pending_structure_entities: Vec<NbtCompound>,
+    pub block_ticks: Vec<ScheduledTick<&'static Block>>,
     pub fluid_ticks: Vec<ScheduledTick<&'static Fluid>>,
 }
 
@@ -269,6 +270,7 @@ impl ProtoChunk {
             blending_data: None,
             pending_block_entities: Vec::new(),
             pending_structure_entities: Vec::new(),
+            block_ticks: Vec::new(),
             fluid_ticks: Vec::new(),
         }
     }
@@ -288,6 +290,15 @@ impl ProtoChunk {
         proto_chunk
             .blending_data
             .clone_from(&chunk_data.blending_data);
+        proto_chunk.pending_block_entities = chunk_data
+            .pending_block_entities
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values()
+            .cloned()
+            .collect();
+        proto_chunk.block_ticks = chunk_data.block_ticks.to_vec();
+        proto_chunk.fluid_ticks = chunk_data.fluid_ticks.to_vec();
 
         let section_data = &chunk_data.section;
         let heightmap_data = chunk_data

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -103,6 +103,104 @@ mod test {
     }
 
     #[test]
+    fn loaded_chunk_state_survives_proto_chunk_round_trip() {
+        use crate::chunk_system::chunk_state::Chunk;
+        use crate::tick::{ScheduledTick, TickPriority};
+        use pumpkin_config::lighting::LightingEngineConfig;
+        use pumpkin_data::{
+            Block,
+            block_properties::{FacingHopper, HopperLikeProperties},
+            fluid::Fluid,
+        };
+        use pumpkin_nbt::compound::NbtCompound;
+        use pumpkin_util::math::position::BlockPos;
+
+        let world_gen = get_world_gen(
+            Seed(0),
+            Dimension::OVERWORLD,
+            true,
+            Vec::new(),
+            String::new(),
+        );
+        let mut staged = Chunk::Proto(Box::new(ProtoChunk::new(0, 0, &world_gen)));
+        staged.upgrade_to_level_chunk(&Dimension::OVERWORLD, &LightingEngineConfig::Default);
+        let Chunk::Level(chunk) = staged else {
+            unreachable!()
+        };
+
+        let hopper_pos = BlockPos::new(5, 64, 7);
+        let hopper_state = HopperLikeProperties {
+            enabled: true,
+            facing: FacingHopper::East,
+        }
+        .to_state_id(&Block::HOPPER);
+        chunk.set_block_absolute_y(5, 64, 7, hopper_state);
+        let mut hopper_nbt = NbtCompound::new();
+        hopper_nbt.put_string("id", "minecraft:hopper".to_string());
+        hopper_nbt.put_int("x", hopper_pos.0.x);
+        hopper_nbt.put_int("y", hopper_pos.0.y);
+        hopper_nbt.put_int("z", hopper_pos.0.z);
+        chunk
+            .pending_block_entities
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(hopper_pos, hopper_nbt);
+        chunk.block_ticks.schedule_tick(
+            &ScheduledTick {
+                delay: 2,
+                priority: TickPriority::Normal,
+                position: hopper_pos,
+                value: &Block::HOPPER,
+            },
+            0,
+        );
+        let fluid_pos = BlockPos::new(1, 60, 2);
+        chunk.fluid_ticks.schedule_tick(
+            &ScheduledTick {
+                delay: 1,
+                priority: TickPriority::High,
+                position: fluid_pos,
+                value: &Fluid::WATER,
+            },
+            1,
+        );
+
+        let mut rebuilt = Chunk::Proto(Box::new(ProtoChunk::from_chunk_data(&chunk, &world_gen)));
+        rebuilt.upgrade_to_level_chunk(&Dimension::OVERWORLD, &LightingEngineConfig::Default);
+        let Chunk::Level(rebuilt) = rebuilt else {
+            unreachable!()
+        };
+
+        assert_eq!(
+            rebuilt.section.get_block_absolute_y(5, 64, 7),
+            Some(hopper_state)
+        );
+
+        let entities = rebuilt
+            .pending_block_entities
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(entities.len(), 1);
+        assert_eq!(
+            entities
+                .get(&hopper_pos)
+                .and_then(|nbt| nbt.get_string("id")),
+            Some("minecraft:hopper")
+        );
+        drop(entities);
+
+        let block_ticks = rebuilt.block_ticks.to_vec();
+        assert_eq!(block_ticks.len(), 1);
+        assert_eq!(block_ticks[0].position, hopper_pos);
+        assert_eq!(block_ticks[0].value, &Block::HOPPER);
+
+        let fluid_ticks = rebuilt.fluid_ticks.to_vec();
+        assert_eq!(fluid_ticks.len(), 1);
+        assert_eq!(fluid_ticks[0].position, fluid_pos);
+        assert_eq!(fluid_ticks[0].value.id, Fluid::WATER.id);
+    }
+
+    #[test]
     fn structure_references_are_rebuilt_when_resuming_generation() {
         use crate::chunk_system::chunk_state::Chunk;
         use pumpkin_config::lighting::LightingEngineConfig;

--- a/crates/pumpkin/src/block/blocks/hopper.rs
+++ b/crates/pumpkin/src/block/blocks/hopper.rs
@@ -13,7 +13,7 @@ use crate::block::{
 use crate::world::World;
 
 use crate::block::entities::hopper::HopperBlockEntity;
-use pumpkin_data::block_properties::FacingHopper;
+use pumpkin_data::block_properties::{BlockProperties, FacingHopper};
 use pumpkin_data::{Block, BlockDirection, BlockState, BlockStateId, translation};
 use pumpkin_inventory::generic_container_screen_handler::create_hopper;
 use pumpkin_inventory::player::player_inventory::PlayerInventory;
@@ -134,6 +134,9 @@ impl BlockBehaviour for HopperBlock {
 
 fn check_powered_state(world: &Arc<World>, pos: &BlockPos, state_id: BlockStateId, block: &Block) {
     let signal = !block_receives_redstone_power(world, pos);
+    if !HopperLikeProperties::handles_block_id(Block::from_state_id(state_id).id) {
+        return;
+    }
     let mut state = HopperLikeProperties::from_state_id(state_id);
     if signal != state.enabled {
         state.enabled = signal;

--- a/crates/pumpkin/src/block/entities/hopper.rs
+++ b/crates/pumpkin/src/block/entities/hopper.rs
@@ -1,11 +1,11 @@
 use crate::block::entities::BlockEntity;
 use crate::entity::experience_orb::ExperienceOrbEntity;
 use crate::world::World;
-use pumpkin_data::{Block, BlockStateId};
 use pumpkin_data::block_properties::{BlockProperties, FacingHopper, HopperLikeProperties};
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::tag;
 use pumpkin_data::tag::Taggable;
+use pumpkin_data::{Block, BlockStateId};
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_nbt::tag::NbtTag;
 use pumpkin_util::math::position::BlockPos;

--- a/crates/pumpkin/src/block/entities/hopper.rs
+++ b/crates/pumpkin/src/block/entities/hopper.rs
@@ -1,8 +1,8 @@
 use crate::block::entities::BlockEntity;
 use crate::entity::experience_orb::ExperienceOrbEntity;
 use crate::world::World;
-use pumpkin_data::BlockStateId;
-use pumpkin_data::block_properties::{FacingHopper, HopperLikeProperties};
+use pumpkin_data::{Block, BlockStateId};
+use pumpkin_data::block_properties::{BlockProperties, FacingHopper, HopperLikeProperties};
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::tag;
 use pumpkin_data::tag::Taggable;
@@ -77,9 +77,9 @@ impl BlockEntity for HopperBlockEntity {
             .store(world.get_world_age(), Ordering::Relaxed);
         if self.cooldown_time.fetch_sub(1, Ordering::Relaxed) <= 0 {
             self.cooldown_time.store(0, Ordering::Relaxed);
-            let state =
-                HopperLikeProperties::from_state_id(world.get_block_state(&self.position).id);
-            if state.enabled
+            if let Some(state_id) = world.get_block_state_id_if_loaded(&self.position)
+                && let Some(state) = hopper_properties(state_id)
+                && state.enabled
                 && let Some(entity) = world.get_block_entity(&self.position)
                 && let Some(hopper) = entity.as_any().downcast_ref::<Self>()
             {
@@ -101,8 +101,9 @@ impl BlockEntity for HopperBlockEntity {
     }
 
     fn set_block_state(&mut self, block_state: BlockStateId) {
-        // TODO !!!IMPORTANT!!! set block state when loading the chunk
-        self.facing = HopperLikeProperties::from_state_id(block_state).facing;
+        if let Some(properties) = hopper_properties(block_state) {
+            self.facing = properties.facing;
+        }
     }
 
     fn is_dirty(&self) -> bool {
@@ -377,6 +378,12 @@ impl HopperBlockEntity {
     }
 }
 
+fn hopper_properties(state_id: BlockStateId) -> Option<HopperLikeProperties> {
+    let block = Block::from_state_id(state_id);
+    HopperLikeProperties::handles_block_id(block.id)
+        .then(|| HopperLikeProperties::from_state_id(state_id))
+}
+
 impl Inventory for HopperBlockEntity {
     fn size(&self) -> usize {
         Self::INVENTORY_SIZE
@@ -448,5 +455,41 @@ impl Clearable for HopperBlockEntity {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         items.fill_with(|| ItemStack::EMPTY.clone());
         self.mark_dirty();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pumpkin_data::{
+        Block, BlockStateId,
+        block_properties::{FacingHopper, HopperLikeProperties},
+    };
+    use pumpkin_nbt::compound::NbtCompound;
+    use pumpkin_util::math::position::BlockPos;
+
+    use super::{BlockEntity, HopperBlockEntity};
+
+    #[test]
+    fn loaded_hopper_restores_facing_from_block_state() {
+        let mut hopper = HopperBlockEntity::from_nbt(&NbtCompound::new(), BlockPos::new(0, 64, 0));
+        assert_eq!(hopper.facing, FacingHopper::Down);
+
+        let state = HopperLikeProperties {
+            enabled: true,
+            facing: FacingHopper::East,
+        }
+        .to_state_id(&Block::HOPPER);
+        hopper.set_block_state(state);
+
+        assert_eq!(hopper.facing, FacingHopper::East);
+    }
+
+    #[test]
+    fn missing_chunk_state_does_not_reset_or_panic() {
+        let mut hopper = HopperBlockEntity::new(BlockPos::new(0, 64, 0), FacingHopper::East);
+
+        hopper.set_block_state(BlockStateId::AIR);
+
+        assert_eq!(hopper.facing, FacingHopper::East);
     }
 }

--- a/crates/pumpkin/src/block/entities/mod.rs
+++ b/crates/pumpkin/src/block/entities/mod.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, sync::Arc};
 
-use pumpkin_data::{Block, block_properties::BLOCK_ENTITY_TYPES};
+use pumpkin_data::{Block, BlockState, block_properties::BLOCK_ENTITY_TYPES};
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::math::position::BlockPos;
 
@@ -109,6 +109,17 @@ pub trait BlockEntity: Any + Send + Sync {
             .iter()
             .position(|block_entity_name| *block_entity_name == name)
             .unwrap_or(0) as u32
+    }
+
+    fn is_valid_for_block_state(&self, block_state: &BlockState) -> bool {
+        BLOCK_ENTITY_TYPES
+            .get(block_state.block_entity_type as usize)
+            .is_some_and(|expected| {
+                self.resource_location()
+                    .split(':')
+                    .next_back()
+                    .is_some_and(|actual| actual == *expected)
+            })
     }
 
     /// Obtain NBT data for sending to the client in `ChunkData`
@@ -427,8 +438,10 @@ pub fn create_block_entity(
 
 #[cfg(test)]
 mod test {
-    use super::{BlockEntity, block_entity_from_nbt, furnace::FurnaceBlockEntity};
-    use pumpkin_data::{item::Item, item_stack::ItemStack};
+    use super::{
+        BlockEntity, block_entity_from_nbt, furnace::FurnaceBlockEntity, hopper::HopperBlockEntity,
+    };
+    use pumpkin_data::{Block, block_properties::FacingHopper, item::Item, item_stack::ItemStack};
     use pumpkin_nbt::compound::NbtCompound;
     use pumpkin_util::math::position::BlockPos;
     use pumpkin_world::inventory::Inventory;
@@ -457,5 +470,13 @@ mod test {
             assert_eq!(stack.get_item().id, Item::DIAMOND.id);
             assert_eq!(stack.item_count, 5);
         }
+    }
+
+    #[test]
+    fn block_entity_type_must_match_block_state() {
+        let hopper = HopperBlockEntity::new(BlockPos::new(0, 64, 0), FacingHopper::Down);
+
+        assert!(hopper.is_valid_for_block_state(Block::HOPPER.default_state));
+        assert!(!hopper.is_valid_for_block_state(Block::AIR.default_state));
     }
 }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1587,6 +1587,12 @@ impl World {
         block_entities.par_chunks(16).for_each(|batch| {
             let _guard = be_handle.enter();
             for be in batch {
+                let Some(block_state) = self.get_block_state_if_loaded(&be.get_position()) else {
+                    continue;
+                };
+                if !be.is_valid_for_block_state(block_state) {
+                    continue;
+                }
                 be.tick(self);
             }
         });
@@ -6177,17 +6183,34 @@ impl World {
             return Some(entity);
         }
 
-        let nbt = self
+        let relative = block_pos.chunk_relative_position();
+        let (nbt, state_id) = self
             .level
             .read_chunk_sync(&chunk_pos, |chunk| {
-                chunk
+                let nbt = chunk
                     .pending_block_entities
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .get(block_pos)
-                    .cloned()
+                    .cloned()?;
+                let state_id = chunk.section.get_block_absolute_y(
+                    relative.x as usize,
+                    relative.y,
+                    relative.z as usize,
+                )?;
+                Some((nbt, state_id))
             })
             .flatten()?;
+        let mut entity = block_entity_from_nbt(&nbt)?;
+        let block_state = BlockState::from_id(state_id);
+        if !entity.is_valid_for_block_state(block_state) {
+            debug!(
+                "Ignoring block entity {} at {block_pos:?}: block state {state_id} belongs to {}",
+                entity.resource_location(),
+                Block::from_state_id(state_id).name,
+            );
+            return None;
+        }
         if let Some(custom_data) = nbt
             .get_compound("PumpkinCustomData")
             .or_else(|| nbt.get_compound("BukkitValues"))
@@ -6195,7 +6218,9 @@ impl World {
             self.custom_block_entity_data
                 .insert(*block_pos, custom_data.clone());
         }
-        let entity = block_entity_from_nbt(&nbt)?;
+        if let Some(entity) = Arc::get_mut(&mut entity) {
+            entity.set_block_state(state_id);
+        }
         self.block_entities
             .entry(chunk_pos)
             .or_default()


### PR DESCRIPTION
### Description
Prevents existing chunks from appearing missing or being overwritten with empty chunk data during loading and regeneration. This PR was made cause I've been using the same world with Pumpkin and testing for a while now. After recent changes to the main branch a bunch of my chunks got corrupted which resulted in my world having holes that resulted in entities and me falling out of the map. This PR addresses that issue and could potentially come in handy in the future for long term worlds with the same issue.

### What
- Distinguishes genuinely missing chunks from chunks that failed to load.
- Prevents empty, ungenerated `ProtoChunk`s from being saved.
- Preserves pending block entities and scheduled block/fluid ticks when existing chunks pass through `ProtoChunk`.
- Restores state-dependent block entity data such as hopper facing.
- Prevents stale or mismatched hopper block entities from panicking during chunk transitions.

### How
- Reports chunk read failures through the scheduler instead of treating them as new chunks.
- Only persists `ProtoChunk`s that have progressed beyond the empty generation stage.
- Copies block entities and scheduled ticks during full chunk-to-proto conversion.
- Validates loaded block entities against their current block state before ticking them.
- Uses loaded-only, validated block states when ticking or updating hoppers.

### Testing
- `cargo test -p pumpkin-world -p pumpkin`
- `cargo clippy -p pumpkin-world -p pumpkin --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Verified that existing chunks load without the previously observed missing rectangular regions.