### PR TITLE
fix(block): send trail particle options when eyeblossoms change state

### DIFF
--- a/crates/pumpkin-protocol/src/java/client/play/particle.rs
+++ b/crates/pumpkin-protocol/src/java/client/play/particle.rs
@@ -41,6 +41,82 @@ pub struct CParticle<'a> {
     pub data: &'a [u8],
 }
 
+/// The payload that follows the particle ID for particle types whose vanilla
+/// `ParticleOptions` is not a plain `SimpleParticleType`.
+///
+/// The particle ID is taken from [`Self::particle`] rather than passed
+/// alongside, so a payload can never be paired with the wrong particle.
+/// Particles that take no options are spawned through [`CParticle`] directly
+/// with an empty `data`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ParticleOptions {
+    /// `minecraft:trail`, vanilla's `TrailParticleOption`.
+    Trail {
+        /// The position the trail travels towards.
+        target: Vector3<f64>,
+        /// The trail color, encoded as `0xRRGGBB`. The top bits are ignored.
+        color: i32,
+        /// Life time in ticks.
+        duration: i32,
+    },
+}
+
+impl ParticleOptions {
+    /// The particle this payload belongs to.
+    #[must_use]
+    pub const fn particle(&self) -> pumpkin_data::particle::Particle {
+        match self {
+            Self::Trail { .. } => pumpkin_data::particle::Particle::Trail,
+        }
+    }
+
+    /// Whether `version` still has this particle under an ID of its own.
+    ///
+    /// On older versions [`remap_particle_id_for_version`] folds the particle
+    /// onto an unrelated one that reads a different payload — `trail` becomes
+    /// `entity_effect`, for instance — so no byte string we could write would be
+    /// read correctly and the packet has to be dropped instead.
+    #[must_use]
+    pub fn is_supported_by(&self, version: JavaMinecraftVersion) -> bool {
+        match self {
+            Self::Trail { .. } => version >= JavaMinecraftVersion::V_1_21_2,
+        }
+    }
+
+    /// Writes the payload that follows the particle ID.
+    pub fn write(&self, write: impl Write) -> Result<(), WritingError> {
+        let mut write = write;
+        match *self {
+            Self::Trail {
+                target,
+                color,
+                duration,
+            } => {
+                write.write_f64_be(target.x)?;
+                write.write_f64_be(target.y)?;
+                write.write_f64_be(target.z)?;
+                write.write_i32_be(color)?;
+                write.write_var_int(&VarInt(duration))
+            }
+        }
+    }
+
+    /// The payload to send to a client on `version`, or `None` when that client
+    /// cannot read this particle and the packet must be dropped instead.
+    ///
+    /// See [`Self::is_supported_by`] for when that happens. `None` also covers a
+    /// write failure, which a `Vec` sink cannot actually produce.
+    #[must_use]
+    pub fn encode_for(&self, version: JavaMinecraftVersion) -> Option<Vec<u8>> {
+        if !self.is_supported_by(version) {
+            return None;
+        }
+        let mut payload = Vec::new();
+        self.write(&mut payload).ok()?;
+        Some(payload)
+    }
+}
+
 impl<'a> CParticle<'a> {
     #[expect(clippy::too_many_arguments)]
     #[must_use]
@@ -305,7 +381,7 @@ mod tests {
 
     use crate::{ClientPacket, VarInt};
 
-    use super::CParticle;
+    use super::{CParticle, ParticleOptions};
 
     fn encoded_particle_id(version: JavaMinecraftVersion) -> VarInt {
         let packet = CParticle::new(
@@ -388,6 +464,199 @@ mod tests {
         let mut slice = bytes.as_slice();
         let id = slice.get_i32_be().unwrap();
         assert_eq!(id, 18);
+    }
+
+    /// Byte offset at which `write_packet_data` puts the particle ID for
+    /// 1.20.5+, pinned by `particle_id_stays_latest_for_26_2` above.
+    const PARTICLE_ID_OFFSET: usize = 46;
+
+    fn trail_options() -> ParticleOptions {
+        ParticleOptions::Trail {
+            target: Vector3::new(1.5, 2.25, -3.75),
+            color: 16_545_810,
+            duration: 23,
+        }
+    }
+
+    fn trail_packet(options: &ParticleOptions) -> Vec<u8> {
+        let mut payload = Vec::new();
+        options.write(&mut payload).unwrap();
+        let packet = CParticle::new(
+            false,
+            false,
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.0, 0.0),
+            0.0,
+            1,
+            VarInt(options.particle() as i32),
+            &payload,
+        );
+        let mut bytes = Vec::new();
+        packet
+            .write_packet_data(&mut bytes, &JavaMinecraftVersion::V_26_2)
+            .unwrap();
+        bytes
+    }
+
+    #[test]
+    fn trail_options_match_vanilla_stream_codec() {
+        let mut payload = Vec::new();
+        trail_options().write(&mut payload).unwrap();
+
+        // Vanilla `TrailParticleOption.STREAM_CODEC`: Vec3, then INT, then VAR_INT.
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&1.5f64.to_be_bytes());
+        expected.extend_from_slice(&2.25f64.to_be_bytes());
+        expected.extend_from_slice(&(-3.75f64).to_be_bytes());
+        expected.extend_from_slice(&16_545_810i32.to_be_bytes());
+        expected.push(23);
+
+        assert_eq!(payload, expected);
+        assert_eq!(payload.len(), 29);
+    }
+
+    /// Decodes the packet the way `ClientboundLevelParticlesPacket` does and
+    /// checks that the trail payload is complete and nothing is left over.
+    ///
+    /// Without the payload the client reads past the end of the buffer, which
+    /// is the disconnect reported in #3065.
+    #[test]
+    fn trail_packet_carries_a_complete_particle_option() {
+        use crate::ser::NetworkReadExt;
+
+        let options = trail_options();
+        let bytes = trail_packet(&options);
+
+        let mut tail = &bytes[PARTICLE_ID_OFFSET..];
+        assert_eq!(VarInt::decode(&mut tail).unwrap(), VarInt(56));
+
+        let target = Vector3::new(
+            tail.get_f64_be().unwrap(),
+            tail.get_f64_be().unwrap(),
+            tail.get_f64_be().unwrap(),
+        );
+        let color = tail.get_i32_be().unwrap();
+        let duration = tail.get_var_int().unwrap();
+
+        assert_eq!(
+            options,
+            ParticleOptions::Trail {
+                target,
+                color,
+                duration: duration.0,
+            }
+        );
+        assert!(
+            tail.is_empty(),
+            "{} trailing bytes after the particle option",
+            tail.len()
+        );
+    }
+
+    /// The reporter's client failed at `readerIndex(48) + length(8)`: the whole
+    /// packet was 48 bytes and the first double of `target` needed eight more, so
+    /// it ended exactly where the particle option should have started.
+    ///
+    /// Measured through `serialize_packet`, the same call `Player` makes, so the
+    /// length includes the packet ID.
+    #[test]
+    fn trail_packet_no_longer_ends_at_the_particle_id() {
+        use crate::java::packet_encoder::serialize_packet;
+
+        let options = trail_options();
+        let mut payload = Vec::new();
+        options.write(&mut payload).unwrap();
+
+        let packet = |data: &[u8]| {
+            let packet = CParticle::new(
+                false,
+                false,
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::new(0.0, 0.0, 0.0),
+                0.0,
+                1,
+                VarInt(options.particle() as i32),
+                data,
+            );
+            serialize_packet(&packet, &JavaMinecraftVersion::V_26_2)
+                .unwrap()
+                .len()
+        };
+
+        assert_eq!(packet(&[]), 48);
+        assert_eq!(packet(&payload), 48 + 29);
+    }
+
+    /// `encode_for` is the whole decision `Player::spawn_particle_with_options`
+    /// makes: which clients get a payload, and which get no packet at all.
+    #[test]
+    fn encode_for_yields_a_payload_only_where_the_particle_exists() {
+        let options = trail_options();
+        let mut written = Vec::new();
+        options.write(&mut written).unwrap();
+
+        for version in [
+            JavaMinecraftVersion::V_26_2,
+            JavaMinecraftVersion::V_1_21_4,
+            JavaMinecraftVersion::V_1_21_2,
+        ] {
+            assert_eq!(
+                options.encode_for(version).as_deref(),
+                Some(written.as_slice()),
+                "{version:?} should receive the full payload"
+            );
+        }
+
+        for version in [
+            JavaMinecraftVersion::V_1_21,
+            JavaMinecraftVersion::V_1_20_5,
+            JavaMinecraftVersion::V_1_8,
+        ] {
+            assert_eq!(
+                options.encode_for(version),
+                None,
+                "{version:?} should be sent no packet at all"
+            );
+        }
+    }
+
+    /// Below 1.21.2 the ID remap folds `trail` onto `entity_effect`, which reads
+    /// a different payload, so those clients must be skipped entirely.
+    #[test]
+    fn trail_options_are_gated_on_versions_that_have_the_particle() {
+        use pumpkin_data::particle_id_remap::remap_particle_id_for_version;
+
+        let options = trail_options();
+        let trail = Particle::Trail as u16;
+        let entity_effect = Particle::EntityEffect as u16;
+
+        for version in [
+            JavaMinecraftVersion::V_26_2,
+            JavaMinecraftVersion::V_1_21_11,
+            JavaMinecraftVersion::V_1_21_4,
+            JavaMinecraftVersion::V_1_21_2,
+        ] {
+            assert!(options.is_supported_by(version), "{version:?}");
+            assert_ne!(
+                remap_particle_id_for_version(trail, version),
+                remap_particle_id_for_version(entity_effect, version),
+                "{version:?} was expected to keep a dedicated trail ID"
+            );
+        }
+
+        for version in [
+            JavaMinecraftVersion::V_1_21,
+            JavaMinecraftVersion::V_1_20_5,
+            JavaMinecraftVersion::V_1_16,
+            JavaMinecraftVersion::V_1_8,
+        ] {
+            assert!(!options.is_supported_by(version), "{version:?}");
+            assert_eq!(
+                remap_particle_id_for_version(trail, version),
+                remap_particle_id_for_version(entity_effect, version),
+                "{version:?} was expected to fold trail onto entity_effect"
+            );
+        }
     }
 
     #[test]

--- a/crates/pumpkin/src/block/blocks/plant/eyeblossom.rs
+++ b/crates/pumpkin/src/block/blocks/plant/eyeblossom.rs
@@ -5,9 +5,9 @@ use pumpkin_data::{
     dimension::Dimension,
     effect::StatusEffect,
     entity::EntityType,
-    particle::Particle,
     sound::{Sound, SoundCategory},
 };
+use pumpkin_protocol::java::client::play::ParticleOptions;
 use pumpkin_util::{
     Difficulty,
     math::{position::BlockPos, vector3::Vector3},
@@ -25,6 +25,10 @@ use crate::{
 
 const EYEBLOSSOM_XZ_RANGE: i32 = 3;
 const EYEBLOSSOM_Y_RANGE: i32 = 2;
+
+/// Trail particle colors from vanilla `EyeblossomBlock.Type.particleColor`.
+const OPEN_PARTICLE_COLOR: i32 = 16_545_810;
+const CLOSED_PARTICLE_COLOR: i32 = 6_250_335;
 
 pub struct EyeblossomBlock;
 
@@ -141,15 +145,9 @@ pub fn try_changing_state(world: &Arc<World>, current_block: &Block, pos: &Block
 
     world.set_block_state(pos, new_block.default_state.id, BlockFlags::NOTIFY_ALL);
 
-    world.spawn_particle(
-        pos.to_centered_f64(),
-        Vector3::new(0.0, 0.0, 0.0),
-        0.0,
-        1,
-        Particle::Trail,
-    );
-
     let mut rng = rand::rng();
+    spawn_transform_particle(world, new_block, pos, &mut rng);
+
     for dx in -EYEBLOSSOM_XZ_RANGE..=EYEBLOSSOM_XZ_RANGE {
         for dy in -EYEBLOSSOM_Y_RANGE..=EYEBLOSSOM_Y_RANGE {
             for dz in -EYEBLOSSOM_XZ_RANGE..=EYEBLOSSOM_XZ_RANGE {
@@ -180,4 +178,95 @@ pub fn try_changing_state(world: &Arc<World>, current_block: &Block, pos: &Block
     }
 
     true
+}
+
+/// Emits the `minecraft:trail` particle that marks a flower changing state,
+/// mirroring vanilla `EyeblossomBlock.Type.spawnTransformParticle`.
+fn spawn_transform_particle(
+    world: &Arc<World>,
+    new_block: &Block,
+    pos: &BlockPos,
+    rng: &mut impl RngExt,
+) {
+    world.spawn_particle_with_options(
+        pos.to_centered_f64(),
+        Vector3::new(0.0, 0.0, 0.0),
+        0.0,
+        1,
+        &transform_particle(new_block, pos, rng),
+    );
+}
+
+/// Builds that particle. Vanilla runs this on the type the flower turned *into*,
+/// so `new_block` is the new state and the color comes from it.
+fn transform_particle(new_block: &Block, pos: &BlockPos, rng: &mut impl RngExt) -> ParticleOptions {
+    let color = if new_block == &Block::OPEN_EYEBLOSSOM {
+        OPEN_PARTICLE_COLOR
+    } else {
+        CLOSED_PARTICLE_COLOR
+    };
+
+    let start = pos.to_centered_f64();
+    let lifetime = 0.5 + rng.random::<f64>();
+    let velocity = Vector3::new(
+        rng.random::<f64>() - 0.5,
+        rng.random::<f64>() + 1.0,
+        rng.random::<f64>() - 0.5,
+    );
+
+    ParticleOptions::Trail {
+        target: start.add(&velocity.multiply(lifetime, lifetime, lifetime)),
+        color,
+        duration: (20.0 * lifetime) as i32,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pumpkin_protocol::java::client::play::ParticleOptions;
+    use rand::{SeedableRng, rngs::StdRng};
+
+    use super::{Block, BlockPos, CLOSED_PARTICLE_COLOR, OPEN_PARTICLE_COLOR, transform_particle};
+
+    /// Vanilla bounds: `lifetime` is `0.5 + random()`, so it lies in `[0.5, 1.5)`,
+    /// and the velocity components in `[-0.5, 0.5)` and `[1.0, 2.0)`.
+    #[test]
+    fn transform_particle_stays_within_the_vanilla_envelope() {
+        let mut rng = StdRng::seed_from_u64(0x376C_0554);
+        let pos = BlockPos::new(12, 70, -34);
+        let center = pos.to_centered_f64();
+
+        for _ in 0..10_000 {
+            let ParticleOptions::Trail {
+                target,
+                color,
+                duration,
+            } = transform_particle(&Block::OPEN_EYEBLOSSOM, &pos, &mut rng);
+
+            assert_eq!(color, OPEN_PARTICLE_COLOR);
+            // duration is `(20.0 * lifetime) as i32` over `[0.5, 1.5)`.
+            assert!((10..=29).contains(&duration), "duration {duration}");
+
+            let offset = target.sub(&center);
+            assert!(offset.x.abs() < 0.75, "x {}", offset.x);
+            assert!(offset.z.abs() < 0.75, "z {}", offset.z);
+            assert!(
+                offset.y > 0.0 && offset.y < 3.0,
+                "y {} should rise but stay near the flower",
+                offset.y
+            );
+        }
+    }
+
+    /// The color identifies the state the flower turned into, not the one it left.
+    #[test]
+    fn transform_particle_takes_the_color_of_the_new_state() {
+        let mut rng = StdRng::seed_from_u64(0x0EFE_B105);
+        let pos = BlockPos::new(0, 64, 0);
+
+        let closed = transform_particle(&Block::CLOSED_EYEBLOSSOM, &pos, &mut rng);
+        let ParticleOptions::Trail { color, .. } = closed;
+        assert_eq!(color, CLOSED_PARTICLE_COLOR);
+        assert_ne!(CLOSED_PARTICLE_COLOR, OPEN_PARTICLE_COLOR);
+    }
 }

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -265,8 +265,8 @@ use pumpkin_protocol::java::client::play::{
     CSetContainerProperty, CSetContainerSlot, CSetCursorItem, CSetExperience, CSetHealth,
     CSetPlayerInventory, CSetSelectedSlot, CSoundEffect, CStopSound, CSubtitle, CSystemChatMessage,
     CTabList, CTitleAnimation, CTitleText, CUnloadChunk, CUpdateMobEffect, CUpdateTime, GameEvent,
-    MapIcon, MapPatch, Metadata, PlayerAction, PlayerInfoFlags, PlayerSpawnData, PreviousMessage,
-    Statistic,
+    MapIcon, MapPatch, Metadata, ParticleOptions, PlayerAction, PlayerInfoFlags, PlayerSpawnData,
+    PreviousMessage, Statistic,
 };
 use pumpkin_protocol::java::server::play::{
     SClickSlot, SContainerButtonClick, SRenameItem, SlotActionType,
@@ -2386,6 +2386,42 @@ impl Player {
         if let ClientPlatform::Java(client) = self.client.as_ref()
             && let Ok(data) = client.serialize_packet(&packet)
         {
+            client.try_enqueue_packet(data);
+        }
+    }
+
+    /// Spawns a particle that carries a [`ParticleOptions`] payload.
+    ///
+    /// Particles whose vanilla `ParticleOptions` is not a `SimpleParticleType`
+    /// must be sent with that payload; without it the client cannot decode the
+    /// packet and drops the connection. Clients too old to know the particle are
+    /// skipped, see [`ParticleOptions::is_supported_by`].
+    pub fn spawn_particle_with_options(
+        &self,
+        position: Vector3<f64>,
+        offset: Vector3<f32>,
+        max_speed: f32,
+        particle_count: i32,
+        options: &ParticleOptions,
+    ) {
+        let ClientPlatform::Java(client) = self.client.as_ref() else {
+            return;
+        };
+        let Some(payload) = options.encode_for(client.version.load()) else {
+            return;
+        };
+
+        let packet = CParticle::new(
+            false,
+            false,
+            position,
+            offset,
+            max_speed,
+            particle_count,
+            VarInt(options.particle() as i32),
+            &payload,
+        );
+        if let Ok(data) = client.serialize_packet(&packet) {
             client.try_enqueue_packet(data);
         }
     }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -89,7 +89,7 @@ use pumpkin_protocol::java::client::play::{
 use pumpkin_protocol::java::client::play::{
     CPlayerSpawnPosition, CRecipeBookAdd, CRecipeBookSettings, CSystemChatMessage,
 };
-use pumpkin_protocol::java::client::play::{CSetEntityMetadata, Metadata};
+use pumpkin_protocol::java::client::play::{CSetEntityMetadata, Metadata, ParticleOptions};
 use pumpkin_protocol::{
     BClientPacket, ClientPacket, IdOr, SoundEvent,
     bedrock::{
@@ -1051,6 +1051,27 @@ impl World {
     ) {
         for player in self.players.load().iter() {
             player.spawn_particle(position, offset, max_speed, particle_count, particle);
+        }
+    }
+
+    /// Spawns a particle that carries a [`ParticleOptions`] payload for every
+    /// player in this world.
+    pub fn spawn_particle_with_options(
+        &self,
+        position: Vector3<f64>,
+        offset: Vector3<f32>,
+        max_speed: f32,
+        particle_count: i32,
+        options: &ParticleOptions,
+    ) {
+        for player in self.players.load().iter() {
+            player.spawn_particle_with_options(
+                position,
+                offset,
+                max_speed,
+                particle_count,
+                options,
+            );
         }
     }
 


### PR DESCRIPTION
## Description

**What changed.** Eyeblossoms now send a complete `minecraft:trail` particle payload when they open or close, instead of a truncated `level_particles` packet that disconnects the client.

**Why.** `Player::spawn_particle` builds `CParticle` with `data: &[]`, so there is no way to attach a particle's `ParticleOptions`. `eyeblossom.rs` used that path for `Particle::Trail`, but vanilla's `TrailParticleOption` requires a payload after the particle ID:

```
target:   Vec3    (three doubles)
color:    int
duration: VarInt
```

so the packet ended exactly where the client expects `target` to begin. The reported failure lines up byte for byte with what this crate encodes:

```
readerIndex(48) + length(8) exceeds writerIndex(48)
  48 = 1 (packet ID VarInt) + 46 (header) + 1 (trail's ID, 56)
   8 = the first double of TrailParticleOption.target
```

The 46-byte header offset is already pinned by the existing `particle_id_stays_latest_for_26_2` test.

**How.** `ParticleOptions` is a new enum in `pumpkin-protocol` that owns both the payload and the particle it belongs to, so a payload can never be paired with the wrong particle ID. `Player`/`World` gain `spawn_particle_with_options`, and `eyeblossom.rs` grows a `spawn_transform_particle` that mirrors vanilla `EyeblossomBlock.Type.spawnTransformParticle`: `lifetime = 0.5 + random()`, `velocity = (random() - 0.5, random() + 1.0, random() - 0.5)`, `target = centre + velocity * lifetime`, `duration = (int) (20.0 * lifetime)`, with the colours `16545810` (open) and `6250335` (closed) taken from the state the flower turns *into*, as vanilla does.

**Impact.** Placing eyeblossoms no longer disconnects players when day turns to night or back. This is not 26.2-only: below 1.21.2 the particle ID remap folds `trail` onto `entity_effect`, which has required a four-byte colour since 1.20.5, so 1.20.5–1.21 clients are disconnected by the same empty payload today.

**Known limitations.**

- The payload is only written for 1.21.2+, where `trail` still has an ID of its own. Below that the remap folds it onto `entity_effect`, whose layout differs, so there is no byte string that would be read correctly and the packet is dropped instead. Those clients lose a cosmetic they were never rendering as a trail anyway; translating options across the particle ID remap is a much larger job than this fix. `is_supported_by` is covered by a test that asserts the boundary against `remap_particle_id_for_version` itself, so it cannot silently drift from the ID actually being written.
- `Particle::BlockCrumble` in `entity/mob/creaking.rs` has the same empty-payload bug (it needs a block state `VarInt`) and still disconnects clients when a creaking tears down. That is a different bug from the one this issue reports, so it is deliberately left alone rather than folded in here.
- `/particle` and the WASM plugin `spawn_particle` can still request an option-carrying particle with no payload. Both already carry TODOs for this.

**Difference from the similar open PRs.**

- **#2542** (`fix(entity): use block particles when an armor stand breaks`) hits the same gap from the other side and adds `spawn_block_particle` to `Player`/`World` for `Particle::Block`. It is a different particle, a different call site and a different bug (#1621, wrong particle rather than a malformed packet). The two do collide textually, because both add a method at the same two places and the signatures share five lines, so git interleaves them; note that resolving by keeping both sides verbatim produces two `fn` signatures sharing one parameter list, and the two methods have to be reconstructed separately. I merged #2542 into this branch to check: neither side modifies anything the other depends on — `spawn_particle`, `CParticle` and the packet encoding are untouched by both — and once resolved by keeping both methods and unioning the imports, `cargo check -p pumpkin --all-targets` passes with both call sites intact. So the order they land in does not matter. `ParticleOptions` also has room for a `BlockState` variant if you would rather `spawn_block_particle` fold into it later; happy to do that either way round.
- **#3006** (`perf(world): only send particles to players within 32 blocks`) changes `World::spawn_particle`; `spawn_particle_with_options` fans out over `self.players` the same way, so it should get the same distance check when that lands.
- **#1799** proposed eyeblossom behaviour including a raw `spawn_particle_with_data(&[u8])` and was closed for hardcoding. Here the payload is built by a type in the protocol crate rather than by hand at the call site.

Fixes #3065

## Testing

`cargo fmt --check`, `RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features` in both debug and release, and `cargo test --workspace` all pass: 736 passed / 0 failed / 16 ignored across 29 suites, up from 730 by the six tests below.

In `pumpkin-protocol`:

- `trail_options_match_vanilla_stream_codec` — the 29 payload bytes against vanilla `TrailParticleOption.STREAM_CODEC` (`Vec3.STREAM_CODEC`, `ByteBufCodecs.INT`, `ByteBufCodecs.VAR_INT`).
- `trail_packet_carries_a_complete_particle_option` — decodes the encoded packet the way `ClientboundLevelParticlesPacket` does and asserts the payload is complete with nothing left over.
- `trail_packet_no_longer_ends_at_the_particle_id` — measures the framed packet through `serialize_packet`, the same call `Player` makes: 48 bytes before, 77 after. The 48 is exactly the `writerIndex(48)` in the report.
- `trail_options_are_gated_on_versions_that_have_the_particle` — checks `is_supported_by` against `remap_particle_id_for_version` on both sides of the 1.21.2 boundary, so the gate cannot drift from the ID actually written.

In `pumpkin`:

- `transform_particle_stays_within_the_vanilla_envelope` — 10,000 draws, asserting `duration` lands in `[10, 29]` and the target stays inside the bounds vanilla's `lifetime` and velocity ranges imply.
- `transform_particle_takes_the_color_of_the_new_state`.

Red/green both ways. Making `ParticleOptions::write` emit nothing reproduces the shipped `data: &[]`: the decode test then fails with `Incomplete("failed to fill whole buffer")`, the server-side twin of the client's `IndexOutOfBoundsException`, and the length test reports 48 against the expected 77. Separately, changing the velocity's Y term from `random() + 1.0` to `random() - 0.5` fails the envelope test on a downward target.

The 29 emitted bytes were also decoded by an independent implementation written from the protocol documentation rather than from this crate: `target = (1.5, 2.25, -3.75)`, `color = 16545810` (`#FC7812`), `duration = 23`, zero bytes left over.

Confirmed live against a real 26.2 client on a release build. 25 `closed_eyeblossom` were placed with `/fill`, then `/time set night` and `/tick rate 2000`; the saved region afterwards contains only `open_eyeblossom` and no `closed_eyeblossom`, so every flower transitioned and therefore sent the packet, and the client stayed connected throughout instead of dropping on the first transition. Worth noting for anyone reproducing this: a specific block random-ticks with probability `3/4096` per tick, a 68-second mean at 20 tps, so the state change needs either a raised tick rate or many flowers to fire promptly.
