### PR TITLE
fix(ci): unblock the build jobs after the async-to-sync refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,7 +3464,6 @@ dependencies = [
  "pumpkin-world",
  "rand",
  "thiserror 2.0.20",
- "tokio",
  "tracing",
 ]
 

--- a/crates/pumpkin-inventory/Cargo.toml
+++ b/crates/pumpkin-inventory/Cargo.toml
@@ -24,7 +24,6 @@ pumpkin-util.workspace = true
 
 rand.workspace = true
 tracing.workspace = true
-tokio.workspace = true
 thiserror.workspace = true
 
 [lints]

--- a/crates/pumpkin/src/command/context/command_context.rs
+++ b/crates/pumpkin/src/command/context/command_context.rs
@@ -141,15 +141,13 @@ impl CommandContext<'_> {
     ///
     /// struct Executor;
     /// impl CommandExecutor for Executor {
-    ///     fn execute<'a>(&'a self, context: &'a CommandContext) -> CommandExecutorResult<'a> {
-    ///         Box::pin(async move {
-    ///             // The `get_argument` method returns a `Result<&i32, CommandSyntaxError>`.
-    ///             // We apply the `?` operator first, propagating the `CommandSyntaxError` if contained.
-    ///             // Finally, we dereference the `&i32`, as `i32` implements Copy.
-    ///             let operand1: i32 = *context.get_argument("operand1")?;
-    ///             let operand2: i32 = *context.get_argument("operand2")?;
-    ///             Ok(operand1 + operand2)
-    ///         })
+    ///     fn execute(&self, context: &CommandContext) -> CommandExecutorResult {
+    ///         // The `get_argument` method returns a `Result<&i32, CommandSyntaxError>`.
+    ///         // We apply the `?` operator first, propagating the `CommandSyntaxError` if contained.
+    ///         // Finally, we dereference the `&i32`, as `i32` implements Copy.
+    ///         let operand1: i32 = *context.get_argument("operand1")?;
+    ///         let operand2: i32 = *context.get_argument("operand2")?;
+    ///         Ok(operand1 + operand2)
     ///     }
     /// }
     /// ```


### PR DESCRIPTION
## Description

**What changed.** Two follow-ups to the async-to-sync refactor series that together get CI back to green. One line removed from `crates/pumpkin-inventory/Cargo.toml` plus its `Cargo.lock` entry, and one stale doc example corrected.

**Why.** `master` is currently red for two independent reasons, and the second is only visible once the first is fixed.

1. `52038e335` ("refactor(inventory): from async to sync Part 3") removed the last use of `tokio` from `pumpkin-inventory` but left the dependency declared, so `cargo-machete` reports it and `Detect unused dependencies` fails:

```
cargo-machete found the following unused dependencies in this directory:
pumpkin-inventory -- ./crates/pumpkin-inventory/Cargo.toml:
	tokio
```

2. `66a5f5340` ("refactor(commands): from async to sync Part 3") changed `CommandExecutorResult` to a plain `Result<i32, CommandSyntaxError>` with no lifetime parameter, and `CommandExecutor::execute` to a sync method. The doc example on `CommandContext::get_argument` still declared `fn execute<'a>(&'a self, ..) -> CommandExecutorResult<'a>` returning a `Box::pin(async move { .. })`, so it fails to compile with E0107 and E0308 and `cargo test --doc` fails.

**Impact.** `Build project and test`, `Build project in release` and `draft_release` are all gated behind `Detect unused dependencies`, so they have been skipped on `master` and on every open pull request based on it. Fixing only the dependency turns that job green and lets the build job run, at which point the `Cargo doctest` step fails on all five platforms — so both fixes are needed for a green run. Note that `crates/pumpkin` sets `[lib] doctest = false`, which is why `cargo test --workspace` does not surface the second one; the CI `Cargo doctest` step runs `cargo test --doc` explicitly and does.

**Known limitations.** The doc example is corrected to the current sync API rather than rewritten, so it still demonstrates exactly what it did before. There is no `tokio` reference left anywhere in `pumpkin-inventory`, in `src`, tests or benches, so nothing else has to change, and `tokio` remains in the workspace dependency table for the crates that do use it.

**Difference from similar open PRs.** No open PR mentions `machete`, unused dependencies or doctests, and none touches `crates/pumpkin-inventory/Cargo.toml` or `crates/pumpkin/src/command/context/command_context.rs`. This is cleanup after the refactor series rather than a change of its own.

This supersedes #3080, which was opened and closed while the branch was still being finalised and can no longer be reopened because its head commit was replaced.

## Testing

`cargo machete` goes from failing to clean:

```
# on master
pumpkin-inventory -- ./crates/pumpkin-inventory/Cargo.toml:
	tokio
exit 1

# with this branch
cargo-machete didn't find any unused dependencies in this directory. Good job!
exit 0
```

`cargo test --doc` on the affected example goes from failing to passing:

```
# on master
... command_context::CommandContext<'_>::get_argument (line 138) ... FAILED

# with this branch
... command_context::CommandContext<'_>::get_argument (line 138) ... ok
```

`cargo fmt --check`, `RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features` in both debug and release, and `cargo test --workspace` all pass, the last at 730 passed / 0 failed. `cargo check --workspace --all-targets` also passes, confirming nothing was relying on `pumpkin-inventory` pulling `tokio` in transitively.
