### PR TITLE
fix: re-enable http-outbound plugin permission

### DIFF
--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
@@ -277,6 +277,10 @@ impl WasmPlugin {
             builder.inherit_network();
         }
 
+        if has_permission(permissions::HTTP_OUTBOUND) {
+            store.data_mut().wasi_http_hooks.allow_outbound = true;
+        }
+
         // --- System Permissions & Environment Variables ---
 
         // Environment Variables


### PR DESCRIPTION
Summary
- The `HTTP_OUTBOUND` plugin permission was correctly wired up in #2128, gating `wasi_http_hooks.allow_outbound` based on a plugin's declared permissions.
- That check was accidentally dropped in 8ce513f ("feat: more plugin features") when unrelated changes overwrote the same permission-checking region in `wasm_host/mod.rs`.
- As a result, `allow_outbound` has been permanently `false` since that commit, regardless of what a plugin declares — outbound HTTP from plugins is silently broken.

This restores the single `if has_permission(...) { ... }` block so a plugin granted `http-outbound` can make outbound HTTP requests again, matching the original #2128 behavior.

## Test plan
- [x] `cargo check -p pumpkin` passes
- [x] `cargo fmt --check -p pumpkin` passes
- [ ] Manual: load a plugin with `http-outbound` permission declared and confirm an outbound HTTP request now succeeds 
