### PR TITLE
fix: mangrove propagule panics

### DIFF
--- a/crates/pumpkin/src/block/blocks/plant/mangrove_propagule.rs
+++ b/crates/pumpkin/src/block/blocks/plant/mangrove_propagule.rs
@@ -78,8 +78,7 @@ impl MangrovePropaguleBlock {
 
 impl BlockBehaviour for MangrovePropaguleBlock {
     fn can_place_at(&self, args: CanPlaceAtArgs<'_>) -> bool {
-        let state_id = args.block_accessor.get_block_state_id(args.position);
-        let props = MangrovePropaguleLikeProperties::from_state_id(state_id, args.block);
+        let props = MangrovePropaguleLikeProperties::from_state_id(args.state.id, args.block);
         Self::can_survive(args.block_accessor, args.position, &props)
     }
 


### PR DESCRIPTION
## Description

`can_place_at()` for mangrove propagules used the state of the existing block (not a propagule) to create the propagule's block properties, causing panics like `State ID BlockStateId(0 = "air") does not exist for mangrove_propagule` when generating biomes containing mangrove propagules.

This PR fixes those panics, but it appears like mangrove propagules are still not being placed. I have yet to investigate why.

## Testing
- [x] `cargo check && cargo clippy && cargo fmt --check`
- [x] `/locate biome minecraft:mangrove_swamp` & confirmed there are no panics.
  - loading the same world on an earlier build and generating new chunks does trigger the panic.
