### PR TITLE
fix(java): flush block updates before acknowledgements 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -2466,6 +2466,7 @@ impl Player {
 
                     let seq = client.packet_sequence.swap(-1, Ordering::Relaxed);
                     if seq != -1 {
+                        self.world().flush_block_updates();
                         client.try_send_packet(&CAcknowledgeBlockChange::new(seq.into()));
                     }
                 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was created with assistance from an automated AI agent and opts in to the streamlined agent PR process described in CONTRIBUTING.md.

## Summary

- Flush pending block state updates to clients before sending a Java block-change prediction acknowledgement.

## Why

Pumpkin queued authoritative block changes until the next world tick but acknowledged Java interactions immediately. The client could reconcile its prediction against stale state, then receive the authoritative update, making doors, buttons, trapdoors, and connected blocks appear to change twice (flicker).

Fixes #3123

## Testing

- cargo fmt --check
- Verified in game: doors, buttons, and trapdoors no longer flicker or double-trigger on interaction.

Assisted by Codex.