### PR TITLE
fix(block): restore correct lever placement orientation

### DIFF
--- a/crates/pumpkin/src/block/blocks/redstone/lever.rs
+++ b/crates/pumpkin/src/block/blocks/redstone/lever.rs
@@ -6,7 +6,7 @@ use crate::block::{
 };
 use pumpkin_data::{
     Block, BlockDirection, BlockStateId, HorizontalFacingExt,
-    block_properties::{AttachFace, BlockProperties, HorizontalFacing, LeverLikeProperties},
+    block_properties::{AttachFace, BlockProperties, LeverLikeProperties},
 };
 use pumpkin_macros::pumpkin_block;
 use pumpkin_util::math::position::BlockPos;
@@ -73,29 +73,9 @@ impl BlockBehaviour for LeverBlock {
     }
 
     fn on_place(&self, args: OnPlaceArgs<'_>) -> BlockStateId {
-        let mut props = LeverLikeProperties::default(&pumpkin_data::Block::LEVER);
-
-        props.face = match args.direction {
-            BlockDirection::Down => AttachFace::Ceiling,
-            BlockDirection::Up => AttachFace::Floor,
-            _ => AttachFace::Wall,
-        };
-
-        props.facing = match props.face {
-            AttachFace::Floor | AttachFace::Ceiling => {
-                let player_direction = args.player.living_entity.entity.get_horizontal_facing();
-                match player_direction {
-                    HorizontalFacing::North | HorizontalFacing::South => HorizontalFacing::South,
-                    HorizontalFacing::West | HorizontalFacing::East => HorizontalFacing::East,
-                }
-            }
-            AttachFace::Wall => match args.direction {
-                BlockDirection::South => HorizontalFacing::South,
-                BlockDirection::West => HorizontalFacing::West,
-                BlockDirection::East => HorizontalFacing::East,
-                _ => HorizontalFacing::North,
-            },
-        };
+        let mut props = LeverLikeProperties::from_state_id(args.block.default_state.id, args.block);
+        (props.face, props.facing) =
+            WallMountedBlock::get_placement_face(self, args.player, args.direction);
 
         props.to_state_id(args.block)
     }


### PR DESCRIPTION
## What was changed?

`LeverBlock::on_place` uses the shared `WallMountedBlock::get_placement_face` helper again, and builds its properties from `args.block` rather than a hardcoded `Block::LEVER`.

## Why were these changes necessary?

The async-to-sync refactor in 8ee11b06c replaced the helper call with hand-rolled logic that is inverted relative to the placement-direction convention. `on_place` receives the placement direction, which is the opposite of the clicked face (`final_face = face.opposite()` in `block/registry.rs`), but the hand-rolled code treated it as the clicked face:

- vertical placement mapped `Down => Ceiling` / `Up => Floor`, the reverse of the helper
- wall placement used `args.direction` unchanged instead of `direction.opposite().to_cardinal_direction()`
- floor and ceiling placement collapsed the player's horizontal facing to only `South` or `East` instead of using it verbatim

Levers consequently attached to the wrong side of walls and pointed the wrong way on floors and ceilings.

## What is the impact of this change?

Levers place as they do in vanilla again. `ButtonBlock`, `BellBlock` and `GrindstoneBlock` kept the helper through that refactor and were unaffected, so the lever was the only block that regressed.

## Are there any known issues or limitations?

None known. This restores the previous behaviour by deleting the divergent copy rather than introducing new logic, so there is no new API or state.

Fixes #3128
