### PR TITLE
fix(block): restore lever's moved guard and normal_use result

### DIFF
--- a/crates/pumpkin/src/block/blocks/redstone/lever.rs
+++ b/crates/pumpkin/src/block/blocks/redstone/lever.rs
@@ -40,7 +40,7 @@ pub struct LeverBlock;
 impl BlockBehaviour for LeverBlock {
     fn normal_use(&self, args: NormalUseArgs<'_>) -> BlockActionResult {
         toggle_lever(args.world, args.position);
-        BlockActionResult::Consume
+        BlockActionResult::Success
     }
 
     fn emits_redstone_power(&self, _args: EmitsRedstonePowerArgs<'_>) -> bool {
@@ -62,13 +62,11 @@ impl BlockBehaviour for LeverBlock {
     }
 
     fn on_state_replaced(&self, args: OnStateReplacedArgs<'_>) {
-        let block_pos = args.position;
-        let block = args.block;
-
-        let lever_props = LeverLikeProperties::from_state_id(args.old_state_id, block);
-
-        if lever_props.powered {
-            Self::update_neighbors(args.world, block_pos, lever_props);
+        if !args.moved {
+            let lever_props = LeverLikeProperties::from_state_id(args.old_state_id, args.block);
+            if lever_props.powered {
+                Self::update_neighbors(args.world, args.position, lever_props);
+            }
         }
     }
 


### PR DESCRIPTION
## What was changed?

Two restorations in `LeverBlock`:

- `on_state_replaced` is guarded by `!args.moved` again
- `normal_use` returns `BlockActionResult::Success` again rather than `Consume`

## Why were these changes necessary?

Both were dropped by the async-to-sync refactor in 8ee11b06c, which rewrote `lever.rs` by hand. `ButtonBlock` shares `LeverLikeProperties`, went through the same refactor and kept both, so the two blocks had come to disagree.

`moved` originates from `BlockFlags::MOVED` (`world/mod.rs:5035`), which pistons set in `block/blocks/piston/piston.rs` (178, 418, 447, 468) and `block/entities/piston.rs` (236, 244). Without the guard, a powered lever relocated by a piston emits redstone neighbour updates that should be suppressed while the block is only being moved.

The `normal_use` change has no observable effect today: `consumes_action()` covers `Consume` and `Success` alike, and only `SuccessServer` triggers `swing_hand` (`net/java/play/use_item_on.rs:96-101`). `Consume` does map to a different vanilla `InteractionResult` though, so it is a latent divergence worth correcting while the file is open.

## What is the impact of this change?

`LeverBlock::on_state_replaced` and `normal_use` match `ButtonBlock` and their own pre-refactor behaviour again. No API or state changes.

## Are there any known issues or limitations?

The `on_state_replaced` guard was identified by code inspection rather than an in-game reproduction, and the in-game symptom is subtle while piston behaviour is itself being reworked (#3057).

Independent of #3132, which fixes `on_place` in the same file from the same root commit. The two touch different methods and do not conflict.

Fixes #3133
