### PR TITLE
fix(worldgen): retain chunks required by generation

### DIFF
--- a/crates/pumpkin-world/src/chunk_system/schedule.rs
+++ b/crates/pumpkin-world/src/chunk_system/schedule.rs
@@ -622,6 +622,7 @@ impl GenerationSchedule {
                             for dz in -radius..=radius {
                                 let new_pos = pos.add_raw(dx, dz);
                                 let req_stage = dependency[dx.abs().max(dz.abs()) as usize];
+                                self.unload_chunks.remove(&new_pos);
                                 if new_pos == pos {
                                     let newly_created = Self::ensure_dependency_chain(
                                         &mut self.graph,
@@ -674,6 +675,7 @@ impl GenerationSchedule {
         }
 
         while let Some((pos, req_stage, dep_task)) = worklist.pop_front() {
+            self.unload_chunks.remove(&pos);
             let mut holder = self.chunk_map.remove(&pos).unwrap_or_default();
             let newly_created = Self::ensure_dependency_chain(
                 &mut self.graph,
@@ -861,7 +863,12 @@ impl GenerationSchedule {
             let Some(mut holder) = self.chunk_map.remove(&pos) else {
                 continue;
             };
-            debug_assert_eq!(holder.target_stage, StagedChunkEnum::None);
+            if holder.target_stage != StagedChunkEnum::None
+                || holder.dependency_stage != StagedChunkEnum::None
+            {
+                self.chunk_map.insert(pos, holder);
+                continue;
+            }
             if !holder.occupied.is_null() {
                 self.chunk_map.insert(pos, holder);
                 self.unload_chunks.insert(pos);


### PR DESCRIPTION
## Description
Fixes a chunk-scheduler panic caused by stale delayed-unload entries removing chunks that are still required as world-generation dependencies.
This could leave a generation task permanently parked and eventually trigger the scheduler’s `nodes count error` invariant.

## What
- Cancels pending unloads when a chunk becomes required by a generation dependency.
- Revalidates chunk targets and dependencies immediately before processing delayed unloads.
- Prevents required neighboring chunks from disappearing while tasks such as surface generation are reading them.
- Prevents stranded generation nodes without suppressing the scheduler’s invariant checks.

## How
- Chunk unloads are batched and processed after a delay. During that delay, a chunk may become necessary again because another chunk’s generation task depends on it.
- The scheduler previously updated the chunk’s dependency state without removing its stale unload entry. When that entry was later processed, the required chunk was removed anyway, leaving its dependent task unable to proceed.
- The fix removes stale unload entries when dependencies are established and adds a final safety check before unloading a chunk.

## Testing
- `cargo test -p pumpkin-world chunk_system`
- `cargo clippy -p pumpkin-world --all-targets -- -D warnings`
- `cargo fmt --all -- --check`