### PR TITLE
fix: java player immortality

### DIFF
--- a/crates/pumpkin-world/src/chunk_system/schedule.rs
+++ b/crates/pumpkin-world/src/chunk_system/schedule.rs
@@ -536,6 +536,7 @@ impl GenerationSchedule {
                             for dz in -radius..=radius {
                                 let new_pos = pos.add_raw(dx, dz);
                                 let req_stage = dependency[dx.abs().max(dz.abs()) as usize];
+                                self.unload_chunks.remove(&new_pos);
                                 if new_pos == pos {
                                     Self::ensure_dependency_chain(
                                         &mut self.graph,
@@ -728,7 +729,12 @@ impl GenerationSchedule {
             let Some(mut holder) = self.chunk_map.remove(&pos) else {
                 continue;
             };
-            debug_assert_eq!(holder.target_stage, StagedChunkEnum::None);
+            if holder.target_stage != StagedChunkEnum::None
+                || holder.dependency_stage != StagedChunkEnum::None
+            {
+                self.chunk_map.insert(pos, holder);
+                continue;
+            }
             if !holder.occupied.is_null() {
                 self.chunk_map.insert(pos, holder);
                 self.unload_chunks.insert(pos);

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1821,8 +1821,7 @@ impl LivingEntity {
     }
 
     /// Tries to use a totem of undying from the entity's hands. If successful, applies the totem effects and returns true.
-    #[allow(dead_code)]
-    async fn try_use_death_protector(&self, caller: &dyn EntityBase) -> bool {
+    fn try_use_death_protector(&self, caller: &dyn EntityBase) -> bool {
         for hand in Hand::all() {
             let mut stack = self.get_stack_in_hand(caller, hand);
 
@@ -1835,8 +1834,7 @@ impl LivingEntity {
                 if let Some(server) = self.entity.world.load().server.upgrade() {
                     server
                         .plugin_manager
-                        .fire(&server, &mut resurrect_event)
-                        .await;
+                        .fire_blocking(&server, &mut resurrect_event);
                 }
                 if resurrect_event.cancelled {
                     return false;
@@ -2587,7 +2585,9 @@ impl LivingEntity {
             }
         }
 
-        if clamped_health <= 0.0 {
+        if clamped_health <= 0.0
+            && (bypasses_cooldown_protection || !self.try_use_death_protector(caller))
+        {
             let mut death_event =
                 crate::plugin::api::events::entity::entity_death::EntityDeathEvent::new(
                     self.entity.entity_id,
@@ -2598,11 +2598,29 @@ impl LivingEntity {
                     .plugin_manager
                     .fire_blocking(&server, &mut death_event);
             }
-            world.send_entity_status(
-                &self.entity,
-                pumpkin_data::entity::EntityStatus::Death,
-                None,
-            );
+
+            if let Some(player) = caller.get_player()
+                && let Some(player) = world.get_player_by_uuid(player.gameprofile.id)
+            {
+                let mut player_death_event =
+                    crate::plugin::api::events::entity::entity_death::PlayerDeathEvent::new(
+                        player,
+                        TextComponent::text("Died"),
+                        0,
+                    );
+                if let Some(server) = world.server.upgrade() {
+                    server
+                        .plugin_manager
+                        .fire_blocking(&server, &mut player_death_event);
+                }
+            }
+
+            self.on_death(damage_type, source, cause);
+        }
+
+        // Armor durability is based on incoming raw damage, not post-absorption remaining.
+        if damage_amount > 0.0 && !bypasses_armor_durability(&damage_type) {
+            self.damage_armor_items(caller, damage_amount);
         }
 
         true

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -3973,20 +3973,34 @@ impl Player {
         {
             return false;
         }
-        self.living_entity
-            .damage_with_context(caller, amount, damage_type, position, source, cause)
+        let damaged = self.living_entity.damage_with_context(
+            caller,
+            amount,
+            damage_type,
+            position,
+            source,
+            cause,
+        );
+        if damaged && self.living_entity.health.load() <= 0.0 {
+            let death_message = LivingEntity::get_death_message(self, damage_type, source, cause);
+            if let Some(player) = self.world().get_player_by_uuid(self.gameprofile.id) {
+                self.spawn_task(async move {
+                    player.handle_killed(death_message).await;
+                });
+            }
+        }
+        damaged
     }
 
     pub fn damage_generic(&self, amount: f32) -> bool {
         use pumpkin_data::damage::DamageType;
-        self.living_entity.damage(self, amount, DamageType::GENERIC)
+        self.damage(self, amount, DamageType::GENERIC)
     }
 
     pub fn kill(&self) {
         use pumpkin_data::damage::DamageType;
         let health = self.living_entity.health.load();
-        self.living_entity
-            .damage(self, health + 10.0, DamageType::OUT_OF_WORLD);
+        self.damage(self, health + 10.0, DamageType::OUT_OF_WORLD);
     }
 
     pub fn send_health(&self) {
@@ -4374,7 +4388,6 @@ impl Player {
         }
     }
 
-    #[allow(dead_code)]
     async fn handle_killed(&self, death_msg: TextComponent) {
         self.trigger_advancement(
             crate::entity::player::advancement::trigger::AdvancementTrigger::PlayerKilled,

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -4150,9 +4150,11 @@ impl World {
                 .await;
         }
 
-        // Send respawn packet with target dimension (using send_packet_now to ensure proper order)
-        player
-            .send_client_packet(&CRespawn::new(
+        // Flush respawn before the high-priority spawn-position packet below.
+        // Otherwise the spawn position can overtake respawn and leave Java clients
+        // stuck on the loading-terrain screen.
+        if let crate::net::ClientPlatform::Java(java_client) = player.client.as_ref() {
+            let packet = CRespawn::new(
                 PlayerSpawnData::new(
                     target_world.dimension.clone(),
                     biome::hash_seed(target_world.level.seed.0),
@@ -4165,8 +4167,11 @@ impl World {
                     target_world.sea_level.into(),
                 ),
                 data_kept,
-            ))
-            .await;
+            );
+            if let Ok(data) = java_client.serialize_packet(&packet) {
+                java_client.send_packet_now(data).await;
+            }
+        }
 
         // Inform the client of the default spawn position so the client doesn't
         // fall back to (0, 2, 0) while the world reloads (fixes rubberbanding).


### PR DESCRIPTION
## Description
Restores player death processing that was lost during the async-to-sync refactor.

Java players can now die and respawn normally instead of remaining alive at zero health or becoming stuck on the loading-terrain screen.

Built on top of https://github.com/Pumpkin-MC/Pumpkin/pull/3137 so the server doesnt panic.

## What
- Restores complete lethal-damage handling for living entities.
- Reactivates player-specific death handling and client death notifications.
- Routes `/kill`, void damage, and generic player damage through the complete damage pipeline.
- Restores death protection and armor durability handling.
- Ensures the Java respawn packet is flushed before the high-priority spawn-position packet.
- Prevents Java clients from becoming stuck on `Loading terrain` after respawning.

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p pumpkin`
  - 295 tests passed.
- Clippy passed with exceptions for existing unrelated baseline lint/toolchain issues.
- Verified in game that a Java player:
  - Dies correctly.
  - Receives the death screen.
  - Can respawn successfully.
  - Loads back into the world without becoming stuck on `Loading terrain`.
