### PR TITLE
fix(block): break suspicious sand and gravel when they fall 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/entity/falling.rs
+++ b/crates/pumpkin/src/entity/falling.rs
@@ -1,7 +1,6 @@
-use pumpkin_data::Block;
-use pumpkin_data::BlockStateId;
 use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::EntityType;
+use pumpkin_data::{Block, BlockState, BlockStateId, item::Item, item_stack::ItemStack};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::world::BlockFlags;
 use std::sync::{Arc, atomic::Ordering};
@@ -15,6 +14,12 @@ use crate::{
 pub struct FallingEntity {
     entity: Entity,
     block_state_id: BlockStateId,
+}
+
+/// Vanilla only lets a falling block settle where it can replace what is already
+/// there; anything else (torches, slabs, stairs, ...) makes it drop as an item.
+const fn can_replace_landing_block(state: &BlockState) -> bool {
+    state.replaceable()
 }
 
 impl FallingEntity {
@@ -42,6 +47,22 @@ impl FallingEntity {
         let entity = Arc::new(Self::new(entity, block_state));
         world.spawn_entity_non_save(entity);
     }
+
+    /// Vanilla `FallingBlockEntity` landing branch: place the block back when the
+    /// landing position is replaceable, otherwise drop it as an item.
+    fn land(&self) {
+        let world = self.entity.world.load();
+        let position = self.entity.block_pos.load();
+
+        if can_replace_landing_block(world.get_block_state(&position)) {
+            world.set_block_state(&position, self.block_state_id, BlockFlags::NOTIFY_ALL);
+        } else if world.level_info.load().game_rules.entity_drops {
+            let block = Block::from_state_id(self.block_state_id);
+            if let Some(item) = Item::from_id(block.item_id) {
+                world.drop_stack(&position, ItemStack::new(1, item));
+            }
+        }
+    }
 }
 
 impl EntityBase for FallingEntity {
@@ -56,11 +77,7 @@ impl EntityBase for FallingEntity {
         entity.tick_block_collisions(caller);
         if entity.on_ground.load(Ordering::Relaxed) {
             entity.velocity.store(velo.multiply(0.7, -0.5, 0.7));
-            entity.world.load().set_block_state(
-                &self.entity.block_pos.load(),
-                self.block_state_id,
-                BlockFlags::NOTIFY_ALL,
-            );
+            self.land();
             self.entity.remove();
         }
 
@@ -96,5 +113,18 @@ impl EntityBase for FallingEntity {
 
     fn cast_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn falling_blocks_do_not_replace_partial_blocks() {
+        assert!(can_replace_landing_block(Block::AIR.default_state));
+        assert!(!can_replace_landing_block(Block::TORCH.default_state));
+        assert!(!can_replace_landing_block(Block::STONE_SLAB.default_state));
+        assert!(!can_replace_landing_block(Block::OAK_STAIRS.default_state));
     }
 }

--- a/crates/pumpkin/src/entity/falling.rs
+++ b/crates/pumpkin/src/entity/falling.rs
@@ -1,6 +1,7 @@
 use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::EntityType;
-use pumpkin_data::{Block, BlockState, BlockStateId, item::Item, item_stack::ItemStack};
+use pumpkin_data::world::WorldEvent;
+use pumpkin_data::{Block, BlockId, BlockState, BlockStateId, item::Item, item_stack::ItemStack};
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_world::world::BlockFlags;
 use std::sync::{Arc, atomic::Ordering};
@@ -20,6 +21,15 @@ pub struct FallingEntity {
 /// there; anything else (torches, slabs, stairs, ...) makes it drop as an item.
 const fn can_replace_landing_block(state: &BlockState) -> bool {
     state.replaceable()
+}
+
+/// Suspicious sand and gravel keep their loot in a block entity that cannot ride
+/// along with the falling entity, so vanilla breaks them where they land.
+const fn breaks_on_landing(state_id: BlockStateId) -> bool {
+    matches!(
+        Block::from_state_id(state_id).id,
+        BlockId::SUSPICIOUS_SAND | BlockId::SUSPICIOUS_GRAVEL
+    )
 }
 
 impl FallingEntity {
@@ -53,6 +63,17 @@ impl FallingEntity {
     fn land(&self) {
         let world = self.entity.world.load();
         let position = self.entity.block_pos.load();
+
+        if breaks_on_landing(self.block_state_id) {
+            // Vanilla `BrushableBlock::onBrokenAfterFall`: break particles and
+            // sound, and the block (with its loot) is gone.
+            world.sync_world_event(
+                WorldEvent::ParticlesDestroyBlock,
+                position,
+                i32::from(self.block_state_id.as_u16()),
+            );
+            return;
+        }
 
         if can_replace_landing_block(world.get_block_state(&position)) {
             world.set_block_state(&position, self.block_state_id, BlockFlags::NOTIFY_ALL);
@@ -126,5 +147,13 @@ mod tests {
         assert!(!can_replace_landing_block(Block::TORCH.default_state));
         assert!(!can_replace_landing_block(Block::STONE_SLAB.default_state));
         assert!(!can_replace_landing_block(Block::OAK_STAIRS.default_state));
+    }
+
+    #[test]
+    fn suspicious_blocks_break_when_they_fall() {
+        assert!(breaks_on_landing(Block::SUSPICIOUS_SAND.default_state.id));
+        assert!(breaks_on_landing(Block::SUSPICIOUS_GRAVEL.default_state.id));
+        assert!(!breaks_on_landing(Block::SAND.default_state.id));
+        assert!(!breaks_on_landing(Block::GRAVEL.default_state.id));
     }
 }


### PR DESCRIPTION
## Description

Fixes #3067

As reported in the issue:

> Suspicious sand and gravel do not have gravity. Unlike vanilla behavior where they fall and break when touching the ground.

`3a3ba2c87` has since added `SUSPICIOUS_SAND` and `SUSPICIOUS_GRAVEL` to `FallingBlock::ids()`, so the gravity half of this issue is already fixed on `master`. This PR has been rescoped to the half that is still missing: the blocks fall, but they land as an ordinary block instead of breaking.

Their loot lives in a `BrushableBlockBlockEntity` that does not ride along with the falling entity, so a suspicious block that lands intact has lost its contents. Vanilla breaks it where it lands (`BrushableBlock.onBrokenAfterFall`, level event 2001: break particles and sound).

The gravity plumbing this PR used to carry (`FallingBlock::try_fall`, the `BrushableBlock` fall hooks, and the `cancel_drop` flag on `FallingEntity`) is all gone, since `master` covers it. What is left is one branch in `FallingEntity::land()`.

## Depends on #3154

This branch is stacked on #3154, whose commit it carries as its base. `land()` is introduced there; this PR adds a branch to it. Please merge #3154 first, or the diff here will not apply.

## Testing

- `cargo test -p pumpkin falling`: passing
- `cargo clippy -p pumpkin --all-targets`: zero warnings
- In game (Java): placed suspicious sand/gravel with air below, it falls and breaks with particles and sound on landing instead of being placed back as a block.

## Not in scope

Two neighbouring issues found while rescoping, both from `3a3ba2c87` registering `FallingBlock` after `BrushableBlock` in `block/registry.rs`, which shadows the latter for these two ids:

- `BrushableBlock::broken` no longer runs, so breaking a structure generated suspicious block does not drop its contained item.
- `BrushableBlock::placed` no longer runs, so no block entity is created on placement.

Happy to open a separate PR for those.

## AI assistance

This PR was developed with AI assistance (OpenCode, model: GLM-5.2); rescope and rebase by Claude Opus 5 in Claude Code.
