### PR TITLE
fix: give suspicious sand/gravel gravity like their plain counterparts 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/block/blocks/brushable_block.rs
+++ b/crates/pumpkin/src/block/blocks/brushable_block.rs
@@ -3,10 +3,16 @@ use std::sync::Arc;
 use pumpkin_data::block_properties::{BlockProperties, SuspiciousSandLikeProperties};
 use pumpkin_data::sound::{Sound, SoundCategory};
 use pumpkin_data::{Block, BlockId, BlockStateId};
+use pumpkin_world::tick::TickPriority;
 use pumpkin_world::world::BlockFlags;
 
+use crate::block::blocks::falling::FallingBlock;
 use crate::block::entities::brushable_block::BrushableBlockBlockEntity;
-use crate::block::{BlockBehaviour, BlockMetadata, BrokenArgs, OnPlaceArgs, PlacedArgs};
+use crate::block::{
+    BlockBehaviour, BlockMetadata, BrokenArgs, GetStateForNeighborUpdateArgs, OnPlaceArgs,
+    OnScheduledTickArgs, PlacedArgs,
+};
+use crate::entity::falling::FallingEntity;
 
 pub struct BrushableBlock;
 
@@ -86,6 +92,36 @@ impl BlockBehaviour for BrushableBlock {
     fn placed(&self, args: PlacedArgs<'_>) {
         let entity = BrushableBlockBlockEntity::new(*args.position);
         args.world.add_block_entity(Arc::new(entity));
+
+        // Suspicious sand/gravel fall like their plain counterparts (vanilla:
+        // https://minecraft.wiki/w/Suspicious_Sand, https://minecraft.wiki/w/Suspicious_Gravel).
+        // TODO: make delay configurable
+        args.world
+            .schedule_block_tick(args.block, *args.position, 2, TickPriority::Normal);
+    }
+
+    fn get_state_for_neighbor_update(
+        &self,
+        args: GetStateForNeighborUpdateArgs<'_>,
+    ) -> BlockStateId {
+        // TODO: make delay configurable
+        args.world
+            .schedule_block_tick(args.block, *args.position, 2, TickPriority::Normal);
+        args.state_id
+    }
+
+    fn on_scheduled_tick(&self, args: OnScheduledTickArgs<'_>) {
+        let (block, state) = args.world.get_block_and_state(&args.position.down());
+        if !FallingBlock::can_fall_through(state, block) || args.position.0.y < args.world.min_y {
+            return;
+        }
+        let state = args.world.get_block_state(args.position);
+        // A block entity carrying in-progress brush hits or a revealed loot item is not
+        // preserved across the fall (FallingEntity only carries the block state id) -- it
+        // lands with a fresh, empty block entity, the same as a freshly-placed suspicious
+        // block. That matches this codebase's existing falling-block behavior and is a
+        // narrower gap than the reported bug (the block not falling at all).
+        FallingEntity::replace_spawn(args.world, *args.position, state.id);
     }
 
     fn broken(&self, args: BrokenArgs<'_>) {


### PR DESCRIPTION
## Summary

Suspicious sand and suspicious gravel (revealed by archaeology/brushing) never fall when unsupported, unlike regular sand and gravel. Per the [Minecraft Wiki](https://minecraft.wiki/w/Suspicious_Sand) ([gravel too](https://minecraft.wiki/w/Suspicious_Gravel)), both are "fragile gravity-affected" blocks with the same falling physics as their plain counterparts.

## Why not just add them to `FallingBlock::ids()`?

`BlockRegistry` maps one `BlockBehaviour` per `BlockId`, and `BrushableBlock` already owns both of these IDs for the brushing/archaeology mechanic. `FallingBlock` registers later in `default_registry()`, so simply adding these IDs there would silently replace `BrushableBlock` and break brushing entirely.

Instead, this adds `FallingBlock`'s own `placed`/`get_state_for_neighbor_update`/`on_scheduled_tick` gravity logic directly onto `BrushableBlock`, reusing `FallingBlock::can_fall_through` and `FallingEntity::replace_spawn` exactly as `FallingBlock` itself does.

`World::set_block_state` already recreates a block entity on landing via its existing `on_placed` machinery, so brushing still works on a suspicious block after it falls.

## Known limitation

`FallingEntity` only carries the block state id, not NBT, so an in-progress brush or an already-revealed loot item is not preserved across the fall — it lands with a fresh, empty block entity, the same as this codebase's existing falling-block behavior generally. Called out in a code comment. This is a narrower gap than the reported bug (the block not falling at all), but flagging it in case it matters for review.

Fixes #3067

## Testing

- `cargo build -p pumpkin`: clean (only a pre-existing, unrelated `proc-macro-error2` deprecation warning, present identically on `master`)
- `cargo clippy -p pumpkin --all-targets -- -D warnings`: 26 pre-existing errors on unmodified `master` (unrelated lint-version mismatches across unrelated files, e.g. `unknown lint: clippy::unused_async_trait_impl`) — identical count with this change applied, confirming it introduces none of its own
- No existing test harness in this repo covers `World`/tick-driven block behavior (only pure-geometry unit tests exist elsewhere), so no new test was added rather than inventing new test infrastructure for this fix
- Logic verified by direct comparison against `FallingBlock`'s own `placed`/`get_state_for_neighbor_update`/`on_scheduled_tick` implementations, which this mirrors exactly (including the existing `// TODO: make delay configurable` convention)

---
AI-assisted-by: Claude Opus 5, via Claude Code