### PR TITLE
feat(plugin): implement get-command-sender-type

### DIFF
--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/mod.rs
@@ -347,11 +347,23 @@ impl pumpkin::plugin::command::HostCommand for PluginHostState {
 impl pumpkin::plugin::command::HostCommandSender for PluginHostState {
     async fn get_command_sender_type(
         &mut self,
-        _res: Resource<CommandSender>,
+        res: Resource<CommandSender>,
     ) -> wasmtime::Result<CommandSenderType> {
-        Err(wasmtime::Error::msg(
-            "get_command_sender_type not implemented",
-        ))
+        let sender = self.get_sender_res(&res)?.provider.clone();
+        match sender {
+            crate::command::CommandSender::Rcon(_) => Ok(CommandSenderType::Rcon),
+            crate::command::CommandSender::Console => Ok(CommandSenderType::Console),
+            crate::command::CommandSender::Player(player) => {
+                Ok(CommandSenderType::Player(self.add_player(player)?))
+            }
+            crate::command::CommandSender::CommandBlock(block_entity, world) => {
+                Ok(CommandSenderType::CommandBlock((
+                    self.add_block_entity(block_entity)?,
+                    self.add_world(world)?,
+                )))
+            }
+            crate::command::CommandSender::Dummy => Ok(CommandSenderType::Dummy),
+        }
     }
 
     async fn get_name(&mut self, sender: Resource<CommandSender>) -> wasmtime::Result<String> {


### PR DESCRIPTION
## Description

Implements `command-sender.get-command-sender-type`, which was a stub returning `Err`. Part of #3163.

The WIT signature has no `result`, so that `Err` trapped instead of reaching the guest, and left the instance entered. Every later call into the plugin then failed with `cannot enter component instance`, so calling a documented API function killed the plugin until restart.

`CommandSender` maps 1:1 onto the WIT variant, so this is just filling in the match. It covers what `is-console` and `as-player` can't express: `is-console` is true for both `Console` and `Rcon`, and there was no way to see a `CommandBlock` sender or reach its block entity and world.

`require-with-handler-id` is the other stub in that file and is left alone here. It needs a new export on the `plugin` world, which is a bigger change. Tracked in #3163.

## Testing

`cargo check`, `cargo clippy` and `cargo fmt --check` clean on `-p pumpkin`.

Ran a test plugin that calls `get_command_sender_type` from a command executor, then makes a second call into the plugin to check the instance survived.

On master, the first call traps:

```
wasm backtrace:
  0x60cfa - sendertype_test.wasm!...command::CommandSender::get_command_sender_type
  0x16825 - sendertype_test.wasm!...SenderTypeExecutor as CommandHandler>::handle
```

and every call after that fails with `wasm trap: cannot enter component instance`, including from a different sender.

With this patch, running the same command from the server console reports `console` and over RCON reports `rcon`, and the follow-up call into the plugin succeeds in both cases. The console and RCON split is the case `is-console` cannot distinguish, since it returns true for both.

Not covered: the `CommandBlock` and `Dummy` arms are by inspection only, since `CommandSender` maps straight onto the variant.
