### PR TITLE
feat(plugin): fire LeavesDecayEvent when leaves decay

### DIFF
--- a/crates/pumpkin/src/block/blocks/leaves.rs
+++ b/crates/pumpkin/src/block/blocks/leaves.rs
@@ -102,6 +102,17 @@ impl BlockBehaviour for LeavesBlock {
         let state_id = args.world.get_block_state_id(args.position);
         let props = OakLeavesLikeProperties::from_state_id(state_id, args.block);
         if !props.persistent && props.distance == DECAY_DISTANCE {
+            let mut event = crate::plugin::api::events::block::leaves_decay::LeavesDecayEvent::new(
+                *args.position,
+                args.world.clone(),
+            );
+            if let Some(server) = args.world.server.upgrade() {
+                server.plugin_manager.fire_blocking(&server, &mut event);
+            }
+            if event.cancelled {
+                return;
+            }
+
             args.world
                 .break_block(args.position, None, BlockFlags::empty());
         }


### PR DESCRIPTION
## Description

Fires `LeavesDecayEvent` when leaves decay. Closes #3169.

The event was in the API and registered fine, but nothing constructed it, so a handler on it never ran. Decay is implemented in `LeavesBlock::random_tick`, which called `break_block` directly. Since `break_block` does not fire `BlockBreakEvent` either, decaying leaves were invisible to plugins entirely, and a claim or tree farm plugin had no way to see or stop them.

The event is cancellable and carries the position and world, so a cancelled event leaves the block alone and it is reconsidered on the next random tick.

Fired only from the decay branch, so leaves broken by a player or by a neighbour update are unaffected.

## Testing

`cargo check`, `cargo clippy` and `cargo fmt --check` clean on `-p pumpkin`.

In-game verification to follow. The fire site follows the same `fire_blocking` and `event.cancelled` shape as the other block events in this tree.
