### PR TITLE
perf: move packet and chunk CPU work off async workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,9 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cap-fs-ext"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ syn = { version = "3.0", default-features = false, features = ["full", "parsing"
 
 thiserror = { version = "2.0", default-features = false }
 
-bytes = { version = "1.12", default-features = false, features = ["std"] }
+bytes = { version = "1.12", default-features = false, features = ["serde", "std"] }
 
 # Concurrency/Parallelism and Synchronization
 futures = { version = "0.3", default-features = false, features = ["std"] }

--- a/crates/pumpkin-protocol/src/java/packet_encoder.rs
+++ b/crates/pumpkin-protocol/src/java/packet_encoder.rs
@@ -90,7 +90,6 @@ pub struct TCPNetworkEncoder<W: AsyncWrite + Unpin> {
     compressor: Option<(CompressionLevel, Compress)>,
     // Reused compression buffer to avoid allocating a new Vec for each packet.
     compression_scratch: Vec<u8>,
-    // Reused framing buffer for single-packet writes.
     frame_scratch: Vec<u8>,
 }
 
@@ -219,9 +218,6 @@ impl<W: AsyncWrite + Unpin> TCPNetworkEncoder<W> {
         result
     }
 
-    /// Writes bytes framed by [`Self::frame_packet`] to the writer.
-    ///
-    /// NOTE: This method does not flush. Call [`Self::flush`] to flush buffered data.
     pub async fn write_frame(&mut self, frame: &[u8]) -> Result<(), PacketEncodeError> {
         let writer = self
             .writer
@@ -233,15 +229,12 @@ impl<W: AsyncWrite + Unpin> TCPNetworkEncoder<W> {
             .map_err(|err| PacketEncodeError::Message(err.to_string()))
     }
 
-    /// True if this packet is big enough to get zlib compressed.
     #[must_use]
     pub fn is_compressing_packet(&self, packet_data: &Bytes) -> bool {
         self.compression
             .is_some_and(|(threshold, _)| packet_data.len() >= threshold)
     }
 
-    /// Builds the full wire frame (length prefixes + compression when needed)
-    /// into `out`. Does no IO, send the result with [`Self::write_frame`].
     #[allow(clippy::too_many_lines)]
     pub fn frame_packet(
         &mut self,

--- a/crates/pumpkin-protocol/src/java/packet_encoder.rs
+++ b/crates/pumpkin-protocol/src/java/packet_encoder.rs
@@ -90,6 +90,8 @@ pub struct TCPNetworkEncoder<W: AsyncWrite + Unpin> {
     compressor: Option<(CompressionLevel, Compress)>,
     // Reused compression buffer to avoid allocating a new Vec for each packet.
     compression_scratch: Vec<u8>,
+    // Reused framing buffer for single-packet writes.
+    frame_scratch: Vec<u8>,
 }
 
 impl<W: AsyncWrite + Unpin> TCPNetworkEncoder<W> {
@@ -99,6 +101,7 @@ impl<W: AsyncWrite + Unpin> TCPNetworkEncoder<W> {
             compression: None,
             compressor: None,
             compression_scratch: Vec::new(),
+            frame_scratch: Vec::new(),
         }
     }
 
@@ -204,8 +207,47 @@ impl<W: AsyncWrite + Unpin> TCPNetworkEncoder<W> {
     /// -   `Data`: The packet's data.
     ///
     /// NOTE: This method does not flush. Call [`Self::flush`] to flush buffered data.
-    #[allow(clippy::too_many_lines)]
     pub async fn write_packet(&mut self, packet_data: Bytes) -> Result<(), PacketEncodeError> {
+        let mut frame = std::mem::take(&mut self.frame_scratch);
+        frame.clear();
+        let framed = self.frame_packet(&packet_data, &mut frame);
+        let result = match framed {
+            Ok(()) => self.write_frame(&frame).await,
+            Err(err) => Err(err),
+        };
+        self.frame_scratch = frame;
+        result
+    }
+
+    /// Writes bytes framed by [`Self::frame_packet`] to the writer.
+    ///
+    /// NOTE: This method does not flush. Call [`Self::flush`] to flush buffered data.
+    pub async fn write_frame(&mut self, frame: &[u8]) -> Result<(), PacketEncodeError> {
+        let writer = self
+            .writer
+            .as_mut()
+            .ok_or_else(|| PacketEncodeError::Message("Writer missing".into()))?;
+        writer
+            .write_all(frame)
+            .await
+            .map_err(|err| PacketEncodeError::Message(err.to_string()))
+    }
+
+    /// True if this packet is big enough to get zlib compressed.
+    #[must_use]
+    pub fn is_compressing_packet(&self, packet_data: &Bytes) -> bool {
+        self.compression
+            .is_some_and(|(threshold, _)| packet_data.len() >= threshold)
+    }
+
+    /// Builds the full wire frame (length prefixes + compression when needed)
+    /// into `out`. Does no IO, send the result with [`Self::write_frame`].
+    #[allow(clippy::too_many_lines)]
+    pub fn frame_packet(
+        &mut self,
+        packet_data: &Bytes,
+        out: &mut Vec<u8>,
+    ) -> Result<(), PacketEncodeError> {
         let data_len = packet_data.len();
         if data_len > MAX_PACKET_DATA_SIZE {
             return Err(PacketEncodeError::TooLong(data_len));
@@ -293,19 +335,10 @@ impl<W: AsyncWrite + Unpin> TCPNetworkEncoder<W> {
 
         let header_len = header_cursor.position() as usize;
         let header_bytes = &header_buf[..header_len];
-        let writer = self
-            .writer
-            .as_mut()
-            .ok_or_else(|| PacketEncodeError::Message("Writer missing".into()))?;
 
-        writer
-            .write_all(header_bytes)
-            .await
-            .map_err(|err| PacketEncodeError::Message(err.to_string()))?;
-        writer
-            .write_all(payload_to_write)
-            .await
-            .map_err(|err| PacketEncodeError::Message(err.to_string()))?;
+        out.reserve(header_len + payload_to_write.len());
+        out.extend_from_slice(header_bytes);
+        out.extend_from_slice(payload_to_write);
 
         Ok(())
     }

--- a/crates/pumpkin-world/src/chunk/format/anvil.rs
+++ b/crates/pumpkin-world/src/chunk/format/anvil.rs
@@ -20,7 +20,7 @@ use tracing::{debug, trace};
 use crate::chunk::{
     ChunkParsingError, ChunkReadingError, ChunkSerializingError, ChunkWritingError,
     CompressionError,
-    io::{ChunkSerializer, Dirtiable, LoadedData, run_on_rayon},
+    io::{ChunkSerializer, Dirtiable, LoadedData, run_blocking},
 };
 
 /// The side size of a region in chunks (one region is 32x32 chunks)
@@ -618,7 +618,7 @@ impl<S: SingleChunkDataSerializer + 'static> ChunkSerializer for AnvilChunkFile<
             .as_ref()
             .and_then(|chunk_data| chunk_data.serialized_data.compression);
         let chunk_config_snapshot = chunk_config.clone();
-        let new_chunk_data = run_on_rayon(move || {
+        let new_chunk_data = run_blocking(move || {
             AnvilChunkData::from_chunk(&*chunk, compression_type, &chunk_config_snapshot)
         })
         .await

--- a/crates/pumpkin-world/src/chunk/format/anvil.rs
+++ b/crates/pumpkin-world/src/chunk/format/anvil.rs
@@ -8,6 +8,7 @@ use std::{
     io::{Read, SeekFrom, Write},
     marker::PhantomData,
     path::{Path, PathBuf},
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::{
@@ -19,7 +20,7 @@ use tracing::{debug, trace};
 use crate::chunk::{
     ChunkParsingError, ChunkReadingError, ChunkSerializingError, ChunkWritingError,
     CompressionError,
-    io::{ChunkSerializer, Dirtiable, LoadedData},
+    io::{ChunkSerializer, Dirtiable, LoadedData, run_on_rayon},
 };
 
 /// The side size of a region in chunks (one region is 32x32 chunks)
@@ -603,7 +604,7 @@ impl<S: SingleChunkDataSerializer + 'static> ChunkSerializer for AnvilChunkFile<
     #[expect(clippy::too_many_lines)]
     async fn update_chunk(
         &mut self,
-        chunk: &Self::Data,
+        chunk: Arc<Self::Data>,
         chunk_config: &Self::ChunkConfig,
     ) -> Result<(), ChunkWritingError> {
         let epoch = SystemTime::now()
@@ -616,7 +617,14 @@ impl<S: SingleChunkDataSerializer + 'static> ChunkSerializer for AnvilChunkFile<
         let compression_type = self.chunks_data[index]
             .as_ref()
             .and_then(|chunk_data| chunk_data.serialized_data.compression);
-        let new_chunk_data = AnvilChunkData::from_chunk(chunk, compression_type, chunk_config)?;
+        let chunk_config_snapshot = chunk_config.clone();
+        let new_chunk_data = run_on_rayon(move || {
+            AnvilChunkData::from_chunk(&*chunk, compression_type, &chunk_config_snapshot)
+        })
+        .await
+        .map_err(|_| {
+            ChunkWritingError::IoError(std::io::Error::other("chunk serialization task failed"))
+        })??;
 
         let mut write_action = self.write_action.lock().await;
         if !chunk_config.write_in_place {

--- a/crates/pumpkin-world/src/chunk/format/linear.rs
+++ b/crates/pumpkin-world/src/chunk/format/linear.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::chunk::format::anvil::{AnvilChunkFile, SingleChunkDataSerializer};
-use crate::chunk::io::{ChunkSerializer, LoadedData, run_on_rayon};
+use crate::chunk::io::{ChunkSerializer, LoadedData, run_blocking};
 use crate::chunk::{ChunkReadingError, ChunkWritingError};
 use bytes::{Buf, BufMut, Bytes};
 use pumpkin_util::math::vector2::Vector2;
@@ -395,7 +395,7 @@ impl<S: SingleChunkDataSerializer + 'static> ChunkSerializer for LinearV2File<S>
         let timestamps = self.timestamps;
         let region_x = self.region_x;
         let region_z = self.region_z;
-        let (header, compressed_buckets) = Box::pin(run_on_rayon(move || {
+        let (header, compressed_buckets) = Box::pin(run_blocking(move || {
             let bucket_count = Self::bucket_count(grid_size);
             let mut compressed_buckets: Vec<Box<[u8]>> = Vec::with_capacity(bucket_count);
             let mut bucket_entries: Vec<BucketSizeEntry> = Vec::with_capacity(bucket_count);
@@ -566,7 +566,7 @@ impl<S: SingleChunkDataSerializer + 'static> ChunkSerializer for LinearV2File<S>
         _chunk_config: &Self::ChunkConfig,
     ) -> Result<(), ChunkWritingError> {
         let index = Self::get_chunk_index(chunk.position().0, chunk.position().1);
-        let chunk_raw = run_on_rayon(move || {
+        let chunk_raw = run_blocking(move || {
             chunk
                 .to_bytes()
                 .map_err(|err| ChunkWritingError::ChunkSerializingError(err.to_string()))

--- a/crates/pumpkin-world/src/chunk/format/linear.rs
+++ b/crates/pumpkin-world/src/chunk/format/linear.rs
@@ -2,10 +2,11 @@ use rustc_hash::FxHashMap;
 use std::io::{ErrorKind, Read};
 use std::marker::PhantomData;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::chunk::format::anvil::{AnvilChunkFile, SingleChunkDataSerializer};
-use crate::chunk::io::{ChunkSerializer, LoadedData};
+use crate::chunk::io::{ChunkSerializer, LoadedData, run_on_rayon};
 use crate::chunk::{ChunkReadingError, ChunkWritingError};
 use bytes::{Buf, BufMut, Bytes};
 use pumpkin_util::math::vector2::Vector2;
@@ -371,16 +372,6 @@ impl<S: SingleChunkDataSerializer> LinearV2File<S> {
         let cx = bucket_col * stride + local_col;
         cz * 32 + cx
     }
-
-    fn build_bitmap(&self) -> ChunkBitmap {
-        let mut bitmap = ChunkBitmap::new();
-        for (i, chunk) in self.chunks_data.iter().enumerate() {
-            if chunk.is_some() {
-                bitmap.set(i, true);
-            }
-        }
-        bitmap
-    }
 }
 
 impl<S: SingleChunkDataSerializer + 'static> ChunkSerializer for LinearV2File<S> {
@@ -399,55 +390,60 @@ impl<S: SingleChunkDataSerializer + 'static> ChunkSerializer for LinearV2File<S>
 
     async fn write(&self, path: &PathBuf) -> Result<(), std::io::Error> {
         let temp_path = path.with_extension("tmp");
-        let file = tokio::fs::File::create(&temp_path).await?;
-        let mut writer = BufWriter::new(file);
-
         let grid_size = self.grid_size;
-        let bucket_count = Self::bucket_count(grid_size);
         let chunks_data = self.chunks_data.clone();
         let timestamps = self.timestamps;
+        let region_x = self.region_x;
+        let region_z = self.region_z;
+        let (header, compressed_buckets) = Box::pin(run_on_rayon(move || {
+            let bucket_count = Self::bucket_count(grid_size);
+            let mut compressed_buckets: Vec<Box<[u8]>> = Vec::with_capacity(bucket_count);
+            let mut bucket_entries: Vec<BucketSizeEntry> = Vec::with_capacity(bucket_count);
 
-        let mut compressed_buckets: Vec<Box<[u8]>> = Vec::with_capacity(bucket_count);
-        let mut bucket_entries: Vec<BucketSizeEntry> = Vec::with_capacity(bucket_count);
+            for bucket_idx in 0..bucket_count {
+                let raw = Self::serialise_bucket(&chunks_data, &timestamps, bucket_idx, grid_size);
+                let compressed =
+                    compress_to_vec(raw.as_slice(), CompressionLevel::Fastest).into_boxed_slice();
+                bucket_entries.push(BucketSizeEntry {
+                    size: compressed.len() as u32,
+                    compression_level: 1,
+                    xxhash: xxh64(&compressed, 0),
+                });
+                compressed_buckets.push(compressed);
+            }
 
-        for bucket_idx in 0..bucket_count {
-            let raw = Self::serialise_bucket(&chunks_data, &timestamps, bucket_idx, grid_size);
-            let compressed =
-                compress_to_vec(raw.as_slice(), CompressionLevel::Fastest).into_boxed_slice();
-            let hash = xxh64(&compressed, 0);
-            bucket_entries.push(BucketSizeEntry {
-                size: compressed.len() as u32,
-                compression_level: 1,
-                xxhash: hash,
-            });
-            compressed_buckets.push(compressed);
+            let superblock = LinearV2Superblock {
+                newest_timestamp: timestamps.iter().copied().max().unwrap_or(0),
+                grid_size,
+                region_x,
+                region_z,
+            };
+            let mut bitmap = ChunkBitmap::new();
+            for (index, chunk) in chunks_data.iter().enumerate() {
+                if chunk.is_some() {
+                    bitmap.set(index, true);
+                }
+            }
+            let features = NbtFeatures::empty();
+
+            let mut header = Vec::new();
+            header.extend_from_slice(&superblock.to_bytes());
+            header.extend_from_slice(&bitmap.0);
+            header.extend_from_slice(&features.to_bytes());
+            for entry in bucket_entries {
+                header.extend_from_slice(&entry.to_bytes());
+            }
+            (header, compressed_buckets)
+        }))
+        .await
+        .map_err(|_| std::io::Error::other("linear serialization task failed"))?;
+
+        let file = tokio::fs::File::create(&temp_path).await?;
+        let mut writer = BufWriter::new(file);
+        writer.write_all(&header).await?;
+        for compressed in compressed_buckets {
+            writer.write_all(&compressed).await?;
         }
-
-        let newest_timestamp = self.timestamps.iter().copied().max().unwrap_or(0);
-
-        let superblock = LinearV2Superblock {
-            newest_timestamp,
-            grid_size,
-            region_x: self.region_x,
-            region_z: self.region_z,
-        };
-
-        let bitmap = self.build_bitmap();
-
-        let features = NbtFeatures::empty();
-
-        writer.write_all(&superblock.to_bytes()).await?;
-        writer.write_all(&bitmap.0).await?;
-        writer.write_all(&features.to_bytes()).await?;
-
-        for entry in &bucket_entries {
-            writer.write_all(&entry.to_bytes()).await?;
-        }
-
-        for compressed in &compressed_buckets {
-            writer.write_all(compressed).await?;
-        }
-
         writer.write_all(&SIGNATURE).await?;
         writer.flush().await?;
 
@@ -566,13 +562,19 @@ impl<S: SingleChunkDataSerializer + 'static> ChunkSerializer for LinearV2File<S>
 
     async fn update_chunk(
         &mut self,
-        chunk: &Self::Data,
+        chunk: Arc<Self::Data>,
         _chunk_config: &Self::ChunkConfig,
     ) -> Result<(), ChunkWritingError> {
         let index = Self::get_chunk_index(chunk.position().0, chunk.position().1);
-        let chunk_raw: Bytes = chunk
-            .to_bytes()
-            .map_err(|err| ChunkWritingError::ChunkSerializingError(err.to_string()))?;
+        let chunk_raw = run_on_rayon(move || {
+            chunk
+                .to_bytes()
+                .map_err(|err| ChunkWritingError::ChunkSerializingError(err.to_string()))
+        })
+        .await
+        .map_err(|_| {
+            ChunkWritingError::IoError(std::io::Error::other("chunk serialization task failed"))
+        })??;
 
         self.timestamps[index] = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/pumpkin-world/src/chunk/format/pump.rs
+++ b/crates/pumpkin-world/src/chunk/format/pump.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::chunk::format::anvil::SingleChunkDataSerializer;
-use crate::chunk::io::{ChunkSerializer, LoadedData, run_on_rayon};
+use crate::chunk::io::{ChunkSerializer, LoadedData, run_blocking};
 use crate::chunk::{ChunkReadingError, ChunkWritingError};
 use bytes::Bytes;
 use pumpkin_util::math::vector2::Vector2;
@@ -21,7 +21,7 @@ pub struct PumpFile<D> {
 pub struct PumpData {
     pub x: i32,
     pub z: i32,
-    pub chunks: BTreeMap<String, Vec<u8>>,
+    pub chunks: BTreeMap<String, Bytes>,
 }
 
 impl<D> Default for PumpFile<D> {
@@ -53,13 +53,13 @@ where
 
     async fn write(&self, backend: &Self::WriteBackend) -> Result<(), std::io::Error> {
         let data = self.data.clone();
-        let bytes = run_on_rayon(move || {
+        let bytes = run_blocking(move || {
             let mut root = pumpkin_nbt::compound::NbtCompound::new();
             root.put_int("x", data.x);
             root.put_int("z", data.z);
             let mut chunks_comp = pumpkin_nbt::compound::NbtCompound::new();
             for (k, v) in data.chunks {
-                let i8_vec: Vec<i8> = v.into_iter().map(|b| b as i8).collect();
+                let i8_vec: Vec<i8> = v.iter().map(|&b| b as i8).collect();
                 chunks_comp.put(&k, pumpkin_nbt::tag::NbtTag::ByteArray(i8_vec.into()));
             }
             root.put_compound("chunks", chunks_comp);
@@ -88,7 +88,7 @@ where
             for (k, v) in &chunks_tag.child_tags {
                 if let pumpkin_nbt::tag::NbtTag::ByteArray(arr) = v {
                     let u8_vec: Vec<u8> = arr.iter().map(|&b| b as u8).collect();
-                    chunks.insert(k.to_string(), u8_vec);
+                    chunks.insert(k.to_string(), u8_vec.into());
                 }
             }
         }
@@ -111,7 +111,7 @@ where
         let rel_z = z.rem_euclid(32);
         let index = (rel_x + rel_z * 32) as usize;
 
-        let compressed = run_on_rayon(move || {
+        let compressed = run_blocking(move || {
             let bytes = chunk_data
                 .to_bytes()
                 .map_err(|e| ChunkWritingError::ChunkSerializingError(e.to_string()))?;
@@ -122,7 +122,9 @@ where
             ChunkWritingError::IoError(std::io::Error::other("chunk serialization task failed"))
         })??;
 
-        self.data.chunks.insert(index.to_string(), compressed);
+        self.data
+            .chunks
+            .insert(index.to_string(), compressed.into());
 
         Ok(())
     }
@@ -132,7 +134,7 @@ where
         chunks: Vec<Vector2<i32>>,
         stream: tokio::sync::mpsc::Sender<LoadedData<Self::Data, ChunkReadingError>>,
     ) {
-        let chunk_items: Vec<(Vector2<i32>, Option<Vec<u8>>)> = chunks
+        let chunk_items: Vec<(Vector2<i32>, Option<Bytes>)> = chunks
             .into_iter()
             .map(|pos| {
                 let rel_x = pos.x.rem_euclid(32);

--- a/crates/pumpkin-world/src/chunk/format/pump.rs
+++ b/crates/pumpkin-world/src/chunk/format/pump.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::chunk::format::anvil::SingleChunkDataSerializer;
-use crate::chunk::io::{ChunkSerializer, LoadedData};
+use crate::chunk::io::{ChunkSerializer, LoadedData, run_on_rayon};
 use crate::chunk::{ChunkReadingError, ChunkWritingError};
 use bytes::Bytes;
 use pumpkin_util::math::vector2::Vector2;
@@ -16,7 +17,7 @@ pub struct PumpFile<D> {
     _phantom: PhantomData<D>,
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct PumpData {
     pub x: i32,
     pub z: i32,
@@ -51,17 +52,21 @@ where
     }
 
     async fn write(&self, backend: &Self::WriteBackend) -> Result<(), std::io::Error> {
-        let mut root = pumpkin_nbt::compound::NbtCompound::new();
-        root.put_int("x", self.data.x);
-        root.put_int("z", self.data.z);
-        let mut chunks_comp = pumpkin_nbt::compound::NbtCompound::new();
-        for (k, v) in &self.data.chunks {
-            let i8_vec: Vec<i8> = v.iter().map(|&b| b as i8).collect();
-            chunks_comp.put(k, pumpkin_nbt::tag::NbtTag::ByteArray(i8_vec.into()));
-        }
-        root.put_compound("chunks", chunks_comp);
-
-        let bytes = pumpkin_nbt::Nbt::from(root).write_unnamed();
+        let data = self.data.clone();
+        let bytes = run_on_rayon(move || {
+            let mut root = pumpkin_nbt::compound::NbtCompound::new();
+            root.put_int("x", data.x);
+            root.put_int("z", data.z);
+            let mut chunks_comp = pumpkin_nbt::compound::NbtCompound::new();
+            for (k, v) in data.chunks {
+                let i8_vec: Vec<i8> = v.into_iter().map(|b| b as i8).collect();
+                chunks_comp.put(&k, pumpkin_nbt::tag::NbtTag::ByteArray(i8_vec.into()));
+            }
+            root.put_compound("chunks", chunks_comp);
+            pumpkin_nbt::Nbt::from(root).write_unnamed()
+        })
+        .await
+        .map_err(|_| std::io::Error::other("pump serialization task failed"))?;
         tokio::fs::write(backend, bytes).await
     }
 
@@ -96,7 +101,7 @@ where
 
     async fn update_chunk(
         &mut self,
-        chunk_data: &Self::Data,
+        chunk_data: Arc<Self::Data>,
         _chunk_config: &Self::ChunkConfig,
     ) -> Result<(), ChunkWritingError> {
         let (x, z) = chunk_data.position();
@@ -106,11 +111,16 @@ where
         let rel_z = z.rem_euclid(32);
         let index = (rel_x + rel_z * 32) as usize;
 
-        let bytes = chunk_data
-            .to_bytes()
-            .map_err(|e| ChunkWritingError::ChunkSerializingError(e.to_string()))?;
-
-        let compressed = compress_to_vec(&bytes[..], CompressionLevel::Fastest);
+        let compressed = run_on_rayon(move || {
+            let bytes = chunk_data
+                .to_bytes()
+                .map_err(|e| ChunkWritingError::ChunkSerializingError(e.to_string()))?;
+            Ok::<_, ChunkWritingError>(compress_to_vec(&bytes[..], CompressionLevel::Fastest))
+        })
+        .await
+        .map_err(|_| {
+            ChunkWritingError::IoError(std::io::Error::other("chunk serialization task failed"))
+        })??;
 
         self.data.chunks.insert(index.to_string(), compressed);
 
@@ -245,7 +255,7 @@ mod tests {
             data: vec![1, 2, 3],
         };
 
-        pump_file.update_chunk(&chunk, &()).await.unwrap();
+        pump_file.update_chunk(Arc::new(chunk), &()).await.unwrap();
         pump_file.write(&file_path).await.unwrap();
 
         let bytes = tokio::fs::read(&file_path).await.unwrap();

--- a/crates/pumpkin-world/src/chunk/io/file_manager.rs
+++ b/crates/pumpkin-world/src/chunk/io/file_manager.rs
@@ -17,7 +17,7 @@ use crate::{
     level::LevelFolder,
 };
 
-use super::{ChunkSerializer, FileIO, LoadedData, run_on_rayon};
+use super::{ChunkSerializer, FileIO, LoadedData, run_blocking};
 
 /// A simple implementation of the `ChunkSerializer` trait that loads and saves data
 /// to disk using parallelism and a lazy-loading cache keyed by file path.
@@ -105,7 +105,7 @@ impl<S: ChunkSerializer<WriteBackend = PathBuf> + 'static> ChunkSerializerLazyLo
                     );
                     return Ok(S::default());
                 }
-                let value = run_on_rayon(move || S::read(bytes.into()))
+                let value = run_blocking(move || S::read(bytes.into()))
                     .await
                     .map_err(|_| {
                         ChunkReadingError::IoError(std::io::Error::other(

--- a/crates/pumpkin-world/src/chunk/io/file_manager.rs
+++ b/crates/pumpkin-world/src/chunk/io/file_manager.rs
@@ -17,7 +17,7 @@ use crate::{
     level::LevelFolder,
 };
 
-use super::{ChunkSerializer, FileIO, LoadedData};
+use super::{ChunkSerializer, FileIO, LoadedData, run_on_rayon};
 
 /// A simple implementation of the `ChunkSerializer` trait that loads and saves data
 /// to disk using parallelism and a lazy-loading cache keyed by file path.
@@ -105,7 +105,13 @@ impl<S: ChunkSerializer<WriteBackend = PathBuf> + 'static> ChunkSerializerLazyLo
                     );
                     return Ok(S::default());
                 }
-                let value = S::read(bytes.into())?;
+                let value = run_on_rayon(move || S::read(bytes.into()))
+                    .await
+                    .map_err(|_| {
+                        ChunkReadingError::IoError(std::io::Error::other(
+                            "chunk deserialization task failed",
+                        ))
+                    })??;
                 trace!("Successfully read file from disk: {}", self.path.display());
                 Ok(value)
             }
@@ -360,7 +366,9 @@ where
                         chunk.mark_dirty(false);
 
                         if was_dirty {
-                            writer.update_chunk(&**chunk, &self.chunk_config).await?;
+                            writer
+                                .update_chunk(chunk.clone(), &self.chunk_config)
+                                .await?;
                         }
                     }
                     // Write-lock released here — flush can proceed under a read-lock.

--- a/crates/pumpkin-world/src/chunk/io/mod.rs
+++ b/crates/pumpkin-world/src/chunk/io/mod.rs
@@ -8,16 +8,12 @@ use crate::level::LevelFolder;
 
 pub mod file_manager;
 
-pub(crate) async fn run_on_rayon<T, F>(task: F) -> Result<T, tokio::sync::oneshot::error::RecvError>
+pub(crate) async fn run_blocking<T, F>(task: F) -> Result<T, tokio::task::JoinError>
 where
     T: Send + 'static,
     F: FnOnce() -> T + Send + 'static,
 {
-    let (send, recv) = tokio::sync::oneshot::channel();
-    rayon::spawn(move || {
-        let _ = send.send(task());
-    });
-    recv.await
+    tokio::task::spawn_blocking(task).await
 }
 
 /// The result of loading a chunk data.

--- a/crates/pumpkin-world/src/chunk/io/mod.rs
+++ b/crates/pumpkin-world/src/chunk/io/mod.rs
@@ -1,4 +1,4 @@
-use std::error;
+use std::{error, sync::Arc};
 
 use bytes::Bytes;
 use pumpkin_util::math::vector2::Vector2;
@@ -7,6 +7,18 @@ use super::{ChunkReadingError, ChunkWritingError};
 use crate::level::LevelFolder;
 
 pub mod file_manager;
+
+pub(crate) async fn run_on_rayon<T, F>(task: F) -> Result<T, tokio::sync::oneshot::error::RecvError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let (send, recv) = tokio::sync::oneshot::channel();
+    rayon::spawn(move || {
+        let _ = send.send(task());
+    });
+    recv.await
+}
 
 /// The result of loading a chunk data.
 ///
@@ -114,7 +126,7 @@ pub trait ChunkSerializer: Send + Sync + Default + 'static {
     /// Add the chunk data to the serializer
     fn update_chunk(
         &mut self,
-        chunk_data: &Self::Data,
+        chunk_data: Arc<Self::Data>,
         chunk_config: &Self::ChunkConfig,
     ) -> impl Future<Output = Result<(), ChunkWritingError>> + Send;
 

--- a/crates/pumpkin-world/src/chunk_system/worker_logic.rs
+++ b/crates/pumpkin-world/src/chunk_system/worker_logic.rs
@@ -4,7 +4,7 @@ use super::{ChunkPos, IOLock};
 use crate::ProtoChunk;
 use crate::chunk::format::LightContainer;
 use crate::chunk::io::LoadedData::Loaded;
-use crate::chunk::io::{FileIO, LoadedData};
+use crate::chunk::io::{FileIO, LoadedData, run_blocking};
 use crate::level::Level;
 use pumpkin_config::lighting::LightingEngineConfig;
 use pumpkin_data::chunk::ChunkStatus;
@@ -141,13 +141,19 @@ pub async fn io_read_work(
             match data {
                 Loaded(chunk) => {
                     let pos = ChunkPos::new(chunk.x, chunk.z);
-                    // The light scan/relight can be heavy, do it on rayon
                     let level = level.clone();
-                    let send = send.clone();
-                    rayon::spawn(move || {
-                        let processed = process_loaded_chunk(chunk, &level);
-                        let _ = send.send((pos, RecvChunk::IO(processed)));
-                    });
+                    let result = run_blocking(move || process_loaded_chunk(chunk, &level)).await;
+                    let received = match result {
+                        Ok(processed) => RecvChunk::IO(processed),
+                        Err(err) => RecvChunk::GenerationFailure {
+                            pos,
+                            stage: StagedChunkEnum::Empty,
+                            error: err.to_string(),
+                        },
+                    };
+                    if send.send((pos, received)).is_err() {
+                        break;
+                    }
                 }
                 LoadedData::Missing(pos) | LoadedData::Error((pos, _)) => {
                     if send
@@ -180,35 +186,29 @@ pub async fn io_write_work(
         // Don't check cancel_token here (keep saving chunks)
         let Some(data) = recv.recv().await else { break };
         // debug!("io write thread receive chunks size {}", data.len());
-        // Upgrading proto chunks runs the lighting engine, so do it on rayon
-        // and wait for the result
         let positions = data.iter().map(|(pos, _)| *pos).collect::<Vec<_>>();
         let level_for_upgrade = level.clone();
-        let (upgrade_send, upgrade_recv) = tokio::sync::oneshot::channel();
-        rayon::spawn(move || {
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                let mut vec = Vec::with_capacity(data.len());
-                for (pos, chunk) in data {
-                    match chunk {
-                        Chunk::Level(chunk) => vec.push((pos, chunk)),
-                        Chunk::Proto(chunk) => {
-                            let mut temp = Chunk::Proto(chunk);
-                            temp.upgrade_to_level_chunk(
-                                level_for_upgrade.world_gen.load().dimension(),
-                                &level_for_upgrade.lighting_config,
-                            );
-                            let Chunk::Level(chunk) = temp else { panic!() };
-                            vec.push((pos, chunk));
-                        }
+        let upgrade_result = run_blocking(move || {
+            let mut vec = Vec::with_capacity(data.len());
+            for (pos, chunk) in data {
+                match chunk {
+                    Chunk::Level(chunk) => vec.push((pos, chunk)),
+                    Chunk::Proto(chunk) => {
+                        let mut temp = Chunk::Proto(chunk);
+                        temp.upgrade_to_level_chunk(
+                            level_for_upgrade.world_gen.load().dimension(),
+                            &level_for_upgrade.lighting_config,
+                        );
+                        let Chunk::Level(chunk) = temp else { panic!() };
+                        vec.push((pos, chunk));
                     }
                 }
-                vec
-            }))
-            .ok();
-            let _ = upgrade_send.send(result);
-        });
-        let upgrade_failed = match upgrade_recv.await {
-            Ok(Some(vec)) => {
+            }
+            vec
+        })
+        .await;
+        let upgrade_failed = match upgrade_result {
+            Ok(vec) => {
                 if let Err(e) = level
                     .chunk_saver
                     .save_chunks(&level.level_folder, vec)
@@ -218,7 +218,7 @@ pub async fn io_write_work(
                 }
                 false
             }
-            Ok(None) | Err(_) => true,
+            Err(_) => true,
         };
 
         {

--- a/crates/pumpkin-world/src/chunk_system/worker_logic.rs
+++ b/crates/pumpkin-world/src/chunk_system/worker_logic.rs
@@ -141,10 +141,13 @@ pub async fn io_read_work(
             match data {
                 Loaded(chunk) => {
                     let pos = ChunkPos::new(chunk.x, chunk.z);
-                    let processed = process_loaded_chunk(chunk, &level);
-                    if send.send((pos, RecvChunk::IO(processed))).is_err() {
-                        break;
-                    }
+                    // The light scan/relight can be heavy, do it on rayon
+                    let level = level.clone();
+                    let send = send.clone();
+                    rayon::spawn(move || {
+                        let processed = process_loaded_chunk(chunk, &level);
+                        let _ = send.send((pos, RecvChunk::IO(processed)));
+                    });
                 }
                 LoadedData::Missing(pos) | LoadedData::Error((pos, _)) => {
                     if send
@@ -177,31 +180,46 @@ pub async fn io_write_work(
         // Don't check cancel_token here (keep saving chunks)
         let Some(data) = recv.recv().await else { break };
         // debug!("io write thread receive chunks size {}", data.len());
-        let mut vec = Vec::with_capacity(data.len());
-        let mut positions = Vec::with_capacity(data.len());
-        for (pos, chunk) in data {
-            positions.push(pos);
-
-            match chunk {
-                Chunk::Level(chunk) => vec.push((pos, chunk)),
-                Chunk::Proto(chunk) => {
-                    let mut temp = Chunk::Proto(chunk);
-                    temp.upgrade_to_level_chunk(
-                        level.world_gen.load().dimension(),
-                        &level.lighting_config,
-                    );
-                    let Chunk::Level(chunk) = temp else { panic!() };
-                    vec.push((pos, chunk));
+        // Upgrading proto chunks runs the lighting engine, so do it on rayon
+        // and wait for the result
+        let positions = data.iter().map(|(pos, _)| *pos).collect::<Vec<_>>();
+        let level_for_upgrade = level.clone();
+        let (upgrade_send, upgrade_recv) = tokio::sync::oneshot::channel();
+        rayon::spawn(move || {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let mut vec = Vec::with_capacity(data.len());
+                for (pos, chunk) in data {
+                    match chunk {
+                        Chunk::Level(chunk) => vec.push((pos, chunk)),
+                        Chunk::Proto(chunk) => {
+                            let mut temp = Chunk::Proto(chunk);
+                            temp.upgrade_to_level_chunk(
+                                level_for_upgrade.world_gen.load().dimension(),
+                                &level_for_upgrade.lighting_config,
+                            );
+                            let Chunk::Level(chunk) = temp else { panic!() };
+                            vec.push((pos, chunk));
+                        }
+                    }
                 }
+                vec
+            }))
+            .ok();
+            let _ = upgrade_send.send(result);
+        });
+        let upgrade_failed = match upgrade_recv.await {
+            Ok(Some(vec)) => {
+                if let Err(e) = level
+                    .chunk_saver
+                    .save_chunks(&level.level_folder, vec)
+                    .await
+                {
+                    error!("Failed to save chunks: {:?}", e);
+                }
+                false
             }
-        }
-        if let Err(e) = level
-            .chunk_saver
-            .save_chunks(&level.level_folder, vec)
-            .await
-        {
-            error!("Failed to save chunks: {:?}", e);
-        }
+            Ok(None) | Err(_) => true,
+        };
 
         {
             let mut data = lock
@@ -228,6 +246,11 @@ pub async fn io_write_work(
             }
         }
         lock.1.notify_waiters();
+
+        if upgrade_failed {
+            error!("Failed to upgrade chunks for saving");
+            break;
+        }
     }
 }
 

--- a/crates/pumpkin/src/net/java/mod.rs
+++ b/crates/pumpkin/src/net/java/mod.rs
@@ -5,7 +5,7 @@ use pumpkin_world::level::SyncChunk;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
-use std::{io::Write, sync::Arc};
+use std::{collections::VecDeque, io::Write, sync::Arc};
 
 use bytes::Bytes;
 use crossbeam::atomic::AtomicCell;
@@ -28,7 +28,8 @@ use pumpkin_protocol::java::server::play::{
 };
 use pumpkin_protocol::packet::MultiVersionJavaPacket;
 use pumpkin_protocol::{
-    ClientPacket, ConnectionState, PacketDecodeError, RawPacket, ServerPacket,
+    ClientPacket, ConnectionState, MAX_PACKET_SIZE, PacketDecodeError, PacketEncodeError,
+    RawPacket, ServerPacket,
     codec::var_int::VarInt,
     java::{
         client::{config::CConfigDisconnect, login::CLoginDisconnect},
@@ -131,6 +132,75 @@ pub enum OutgoingPacketType {
 struct OutgoingPacket {
     data: Bytes,
     completion: Option<oneshot::Sender<()>>,
+}
+
+const MAX_FRAME_BATCH_DATA_SIZE: usize = MAX_PACKET_SIZE as usize;
+
+fn take_frame_batch(packets: &mut VecDeque<OutgoingPacket>) -> Vec<OutgoingPacket> {
+    let mut batch = Vec::new();
+    let mut data_len = 0usize;
+
+    while let Some(packet) = packets.pop_front() {
+        let next_len = data_len.saturating_add(packet.data.len());
+        if !batch.is_empty() && next_len > MAX_FRAME_BATCH_DATA_SIZE {
+            packets.push_front(packet);
+            break;
+        }
+
+        data_len = next_len;
+        batch.push(packet);
+    }
+
+    batch
+}
+
+/// Frames a byte-bounded packet batch into one buffer. Takes the encoder by value so this can run on another thread.
+fn frame_packet_batch(
+    mut writer: TCPNetworkEncoder<BufWriter<OwnedWriteHalf>>,
+    batch: &[OutgoingPacket],
+) -> (
+    TCPNetworkEncoder<BufWriter<OwnedWriteHalf>>,
+    Vec<u8>,
+    Option<PacketEncodeError>,
+) {
+    let mut frame = Vec::new();
+    let mut frame_err = None;
+    for packet in batch {
+        if let Err(err) = writer.frame_packet(&packet.data, &mut frame) {
+            frame_err = Some(err);
+            break;
+        }
+    }
+    (writer, frame, frame_err)
+}
+
+/// Compression is the expensive part of framing, so batches that compress get framed on the blocking pool. Everything else is framed inline.
+async fn frame_batch_maybe_offload(
+    writer: TCPNetworkEncoder<BufWriter<OwnedWriteHalf>>,
+    packet_batch: Vec<OutgoingPacket>,
+) -> Result<
+    (
+        TCPNetworkEncoder<BufWriter<OwnedWriteHalf>>,
+        Vec<OutgoingPacket>,
+        Vec<u8>,
+        Option<PacketEncodeError>,
+    ),
+    tokio::task::JoinError,
+> {
+    let needs_offload = packet_batch
+        .iter()
+        .any(|packet| writer.is_compressing_packet(&packet.data));
+
+    if needs_offload {
+        tokio::task::spawn_blocking(move || {
+            let (writer, frame, frame_err) = frame_packet_batch(writer, &packet_batch);
+            (writer, packet_batch, frame, frame_err)
+        })
+        .await
+    } else {
+        let (writer, frame, frame_err) = frame_packet_batch(writer, &packet_batch);
+        Ok((writer, packet_batch, frame, frame_err))
+    }
 }
 
 impl OutgoingPacket {
@@ -676,27 +746,50 @@ impl JavaClient {
                     }
                 }
 
-                let send_failed = {
-                    let mut failed = false;
-                    for packet in &packet_batch {
-                        if let Err(err) = writer.write_packet(packet.data.clone()).await {
-                            failed = true;
-                            // It is expected that the packet will fail if we are closed
-                            if !close_token.is_cancelled() {
-                                warn!("Failed to send packet to client {id}: {err}");
+                let mut packets_to_frame = VecDeque::from(packet_batch);
+                let mut written_packets = Vec::with_capacity(packets_to_frame.len());
+                let mut send_failed = false;
+
+                while !packets_to_frame.is_empty() {
+                    let frame_batch = take_frame_batch(&mut packets_to_frame);
+                    let (returned_writer, returned_batch, frame, frame_err) =
+                        match frame_batch_maybe_offload(writer, frame_batch).await {
+                            Ok(result) => result,
+                            Err(err) => {
+                                if !close_token.is_cancelled() {
+                                    warn!("Packet framing task failed for client {id}: {err}");
+                                }
+                                close_token.cancel();
+                                return;
                             }
-                            break;
+                        };
+                    writer = returned_writer;
+
+                    if let Some(err) = frame_err {
+                        if !close_token.is_cancelled() {
+                            warn!("Failed to frame packet for client {id}: {err}");
                         }
+                        send_failed = true;
+                        break;
                     }
 
-                    if !failed && let Err(err) = writer.flush().await {
-                        failed = true;
+                    if let Err(err) = writer.write_frame(&frame).await {
                         if !close_token.is_cancelled() {
-                            warn!("Failed to flush packet batch for client {id}: {err}");
+                            warn!("Failed to send packet batch to client {id}: {err}");
                         }
+                        send_failed = true;
+                        break;
                     }
-                    failed
-                };
+
+                    written_packets.extend(returned_batch);
+                }
+
+                if !send_failed && let Err(err) = writer.flush().await {
+                    if !close_token.is_cancelled() {
+                        warn!("Failed to flush packet batch for client {id}: {err}");
+                    }
+                    send_failed = true;
+                }
 
                 if send_failed {
                     // We now need to close the connection to the client since the stream is in an unknown state.
@@ -704,7 +797,7 @@ impl JavaClient {
                     break;
                 }
 
-                for packet in packet_batch {
+                for packet in written_packets {
                     if let Some(completion) = packet.completion {
                         let _ = completion.send(());
                     }

--- a/crates/pumpkin/src/net/java/mod.rs
+++ b/crates/pumpkin/src/net/java/mod.rs
@@ -154,7 +154,6 @@ fn take_frame_batch(packets: &mut VecDeque<OutgoingPacket>) -> Vec<OutgoingPacke
     batch
 }
 
-/// Frames a byte-bounded packet batch into one buffer. Takes the encoder by value so this can run on another thread.
 fn frame_packet_batch(
     mut writer: TCPNetworkEncoder<BufWriter<OwnedWriteHalf>>,
     batch: &[OutgoingPacket],
@@ -174,7 +173,6 @@ fn frame_packet_batch(
     (writer, frame, frame_err)
 }
 
-/// Compression is the expensive part of framing, so batches that compress get framed on the blocking pool. Everything else is framed inline.
 async fn frame_batch_maybe_offload(
     writer: TCPNetworkEncoder<BufWriter<OwnedWriteHalf>>,
     packet_batch: Vec<OutgoingPacket>,

--- a/crates/pumpkin/src/plugin/mod.rs
+++ b/crates/pumpkin/src/plugin/mod.rs
@@ -1170,6 +1170,14 @@ impl PluginManager {
         });
     }
 
+    #[must_use]
+    pub fn has_handlers<E: Payload + 'static>(&self) -> bool {
+        self.handlers
+            .load()
+            .get(E::get_name_static())
+            .is_some_and(|handlers| !handlers.is_empty())
+    }
+
     /// Fire an event to all registered handlers
     pub async fn fire<E: Payload + Send + Sync + 'static>(
         &self,

--- a/crates/pumpkin/src/server/ticker.rs
+++ b/crates/pumpkin/src/server/ticker.rs
@@ -25,11 +25,13 @@ impl Ticker {
             manager.tick();
 
             let tick_number = server.tick_count.load(Ordering::Relaxed);
-            server.runtime.block_on(
-                server
-                    .plugin_manager
-                    .fire(server, &mut ServerTickStartEvent::new(tick_number)),
-            );
+            if server.plugin_manager.has_handlers::<ServerTickStartEvent>() {
+                server.runtime.block_on(
+                    server
+                        .plugin_manager
+                        .fire(server, &mut ServerTickStartEvent::new(tick_number)),
+                );
+            }
 
             if manager.is_sprinting() {
                 manager.start_sprint_tick_work();
@@ -45,10 +47,12 @@ impl Ticker {
             let tick_duration_nanos = tick_start_time.elapsed().as_nanos() as i64;
 
             let tick_number = server.tick_count.load(Ordering::Relaxed);
-            server.runtime.block_on(server.plugin_manager.fire(
-                server,
-                &mut ServerTickEndEvent::new(tick_number, tick_duration_nanos),
-            ));
+            if server.plugin_manager.has_handlers::<ServerTickEndEvent>() {
+                server.runtime.block_on(server.plugin_manager.fire(
+                    server,
+                    &mut ServerTickEndEvent::new(tick_number, tick_duration_nanos),
+                ));
+            }
 
             server.update_tick_times(tick_duration_nanos);
 


### PR DESCRIPTION
  ## Description
Alex asked if someone with threading experience could look into some of Pumpkin's performance issues, so I volunteered.

I started by checking the main hot paths and profiling the server while players were continuously loading chunks. The largest spikes came from CPU-heavy work running on Tokio workers, mainly Java packet compression, loaded chunk processing and chunk serialization.

Java packets were compressed directly inside each client's outgoing packet task. I separated packet framing from the socket write so packets can be framed in batches. Batches that require compression now run on the blocking pool, while small uncompressed packets stay on the existing path. The framed packets are then written together without changing their order, encryption or completion handling.

Loaded chunks also performed their lighting checks and conversions on the async worker after being read from disk. I moved this work to the blocking pool too. The same applies to proto chunk upgrades, region decoding and the expensive parts of Anvil, Linear and Pump serialization.

Pump copied every compressed chunk when taking a region snapshot for writing. Its compressed chunk data now uses `Bytes`, so these snapshots share the existing buffers instead.

While checking the tick loop, I also noticed that TickStart and TickEnd always entered the async runtime even when no plugin had registered a handler. This is now skipped when there is nothing to call.

## Testing

Besides the cargo/clippy checks, I tested this with actual players constantly loading chunks.

I wrote my own Bash benchmark script and used [Eoghanmc22/rust-mc-bot](https://github.com/Eoghanmc22/rust-mc-bot) to connect and control the bots. The script starts the server, runs the selected scenario and collects the tick times. I tested upstream and this branch using the same world, configuration and release build. I ran each scenario multiple times because single runs were sometimes noisy.

The main test was `stream50`, which continuously teleports 50 bots in a spiral to keep loading chunks.

Upstream averaged between 5.2 and 7.4 MSPT, with P95 between 12.3 and 18.7 ms and P99 between 19 and 34.3 ms. The worst ticks were between 259 and 407 ms.

This branch averaged between 2.7 and 2.9 MSPT, with P95 between 5.7 and 6.6 ms and P99 between 7.8 and 8.4 ms. The worst ticks were between 17 and 18 ms, and there were no ticks above 50 ms.

I also tested 50 bots staying around spawn. Upstream averaged 4.3-4.7 MSPT with a P99 of 9.0-9.6 ms. This branch averaged 3.7-4.3 MSPT with a P99 of 7.0-7.6 ms.

All 50 bots joined successfully in every run and I did not get any panics.