### PR TITLE
Fix efficiency

### DIFF
--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -4453,7 +4453,16 @@ impl Player {
     }
 
     pub fn get_mining_speed(&self, block: &'static Block) -> f32 {
-        let mut speed = self.inventory().held_item().get_speed(block);
+        let held_item = self.inventory.held_item();
+        let mut speed = held_item.get_speed(block);
+        // Effi only gets applied if tool's break speed for block is alreadyabove 1 (meaning it's
+        // the correct tool)
+        if speed > 1.0 {
+            let efficiency_level = held_item.get_enchantment_level(&Enchantment::EFFICIENCY);
+            if efficiency_level > 0 {
+                speed += (efficiency_level * efficiency_level + 1) as f32;
+            }
+        }
         // Haste
         if self.living_entity.has_effect(&StatusEffect::HASTE)
             || self.living_entity.has_effect(&StatusEffect::CONDUIT_POWER)

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -4457,7 +4457,7 @@ impl Player {
         !state.tool_required() || self.inventory().held_item().is_correct_for_drops(block)
     }
 
-    /// The id under which Pumpkin will store it's mining_efficiency modifier value
+    /// The id under which Pumpkin will store it's `mining_efficiency` modifier value
     const EFFICIENCY_ATTRIBUTE_MODIFIER_ID: &'static str = "minecraft:enchantment.efficiency";
 
     fn sync_mining_efficiency(&self) {

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicBool, AtomicI8, AtomicI32, AtomicU8, AtomicU32, Or
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use crate::entity::attributes::{Modifier, ModifierOperation};
 use crate::plugin::api::events::enchantment::{EnchantItemEvent, PrepareItemEnchantEvent};
 use crate::world::scoreboard::{BedrockScoreboard, Scoreboard};
 use advancement::PlayerAdvancement;
@@ -434,6 +435,9 @@ pub struct Player {
     pub current_block_destroy_stage: AtomicI32,
     /// The per-tick block destruction progress last sent to Bedrock clients.
     pub current_block_breaking_speed: AtomicU32,
+    /// The held item's Efficiency level last synced to the client via the `mining_efficiency`
+    /// attribute. -1 means never synced
+    pub synced_mining_efficiency_level: AtomicI32,
     /// Indicates if the player is currently mining a block.
     pub mining: AtomicBool,
     pub start_mining_time: AtomicI32,
@@ -719,6 +723,7 @@ impl Player {
             hunger_manager: HungerManager::default(),
             current_block_destroy_stage: AtomicI32::new(-1),
             current_block_breaking_speed: AtomicU32::new(0),
+            synced_mining_efficiency_level: AtomicI32::new(-1),
             enchantment_seed: AtomicI32::new(rand::random()),
             open_container: AtomicCell::new(None),
             open_container_pos: AtomicCell::new(None),
@@ -4452,16 +4457,49 @@ impl Player {
         !state.tool_required() || self.inventory().held_item().is_correct_for_drops(block)
     }
 
+    /// The id under which Pumpkin will store it's mining_efficiency modifier value
+    const EFFICIENCY_ATTRIBUTE_MODIFIER_ID: &'static str = "minecraft:enchantment.efficiency";
+
+    fn sync_mining_efficiency(&self) {
+        let level = self
+            .inventory()
+            .held_item()
+            .get_enchantment_level(&Enchantment::EFFICIENCY);
+        if self
+            .synced_mining_efficiency_level
+            .swap(level, Ordering::Relaxed)
+            == level
+        {
+            return;
+        }
+        self.living_entity
+            .update_attribute(&Attributes::MINING_EFFICIENCY, |inst| {
+                if level > 0 {
+                    inst.add_or_replace_modifier(Modifier {
+                        id: Self::EFFICIENCY_ATTRIBUTE_MODIFIER_ID.to_string(),
+                        amount: f64::from(level * level + 1),
+                        operation: ModifierOperation::Add,
+                    });
+                } else {
+                    inst.remove_modifier(Self::EFFICIENCY_ATTRIBUTE_MODIFIER_ID);
+                }
+            });
+        crate::entity::attributes::send_attribute_updates_for_living(
+            &self.living_entity,
+            vec![Attributes::MINING_EFFICIENCY],
+        );
+    }
+
     pub fn get_mining_speed(&self, block: &'static Block) -> f32 {
+        self.sync_mining_efficiency();
         let held_item = self.inventory.held_item();
         let mut speed = held_item.get_speed(block);
         // Effi only gets applied if tool's break speed for block is alreadyabove 1 (meaning it's
         // the correct tool)
         if speed > 1.0 {
-            let efficiency_level = held_item.get_enchantment_level(&Enchantment::EFFICIENCY);
-            if efficiency_level > 0 {
-                speed += (efficiency_level * efficiency_level + 1) as f32;
-            }
+            speed += self
+                .living_entity
+                .get_attribute_value(&Attributes::MINING_EFFICIENCY) as f32;
         }
         // Haste
         if self.living_entity.has_effect(&StatusEffect::HASTE)

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -2551,7 +2551,7 @@ impl Player {
                     state,
                     p.start_mining_time.load(Ordering::Relaxed),
                 );
-                if finished && matches!(p.client.as_ref(), ClientPlatform::Bedrock(_)) {
+                if finished {
                     p.stop_mining();
 
                     let block = Block::from_state_id(state.id);
@@ -2572,6 +2572,12 @@ impl Player {
                         if can_harvest {
                             p.add_exhaustion(MINE_BLOCK_EXHAUSTION);
                         }
+                    }
+
+                    // Java clients decide completion on their own local timer, if the block is
+                    // broken earlier the server must reset the state
+                    if matches!(p.client.as_ref(), ClientPlatform::Java(_)) {
+                        p.reset_block_change(pos);
                     }
                 }
             }


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description

This PR fixes the efficiency enchantment. A quick list of changes:
- Handles block finishing mining on the server before the client reports it as done for Java (worked before but only for Bedrock, on Java it waited for the client to send the packet that mining was done)
- If the mining speed for the tool and block combo is above 1.0 (aka. using the correct tool for the block) the server will apply the current efficiency level to the total mining speed calculation
- Syncs `mining_efficiency` attribute for currently held tool with client 
each time mining status is processed, this fixes the mining animation speed on the client
## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
