### PR TITLE
perf(world): reduce per-tick active chunk rebuilds

### DIFF
--- a/crates/pumpkin-world/src/chunk_system/schedule.rs
+++ b/crates/pumpkin-world/src/chunk_system/schedule.rs
@@ -9,7 +9,7 @@ use super::{
     LevelChannel,
 };
 use crate::chunk::io::Dirtiable;
-use crate::level::{Level, SyncChunk};
+use crate::level::{Level, LoadedChunkChange, SyncChunk};
 use dashmap::DashMap;
 use pumpkin_config::lighting::LightingEngineConfig;
 use pumpkin_util::math::vector2::Vector2;
@@ -56,6 +56,7 @@ pub struct GenerationSchedule {
     send_level: Arc<LevelChannel>,
 
     public_chunk_map: Arc<DashMap<Vector2<i32>, SyncChunk>>,
+    loaded_chunk_changes: Arc<crossbeam::queue::SegQueue<LoadedChunkChange>>,
     chunk_map: HashMap<ChunkPos, ChunkHolder>,
     unload_chunks: HashSetType<ChunkPos>,
 
@@ -79,6 +80,24 @@ pub struct GenerationSchedule {
 }
 
 impl GenerationSchedule {
+    fn publish_chunk(&self, pos: ChunkPos, chunk: SyncChunk) -> Option<SyncChunk> {
+        let previous = self.public_chunk_map.insert(pos, chunk);
+        if previous.is_none() {
+            self.loaded_chunk_changes
+                .push(LoadedChunkChange::Loaded(pos));
+        }
+        previous
+    }
+
+    fn unpublish_chunk(&self, pos: ChunkPos) -> Option<SyncChunk> {
+        let removed = self.public_chunk_map.remove(&pos).map(|(_, chunk)| chunk);
+        if removed.is_some() {
+            self.loaded_chunk_changes
+                .push(LoadedChunkChange::Unloaded(pos));
+        }
+        removed
+    }
+
     pub fn create(
         io_read_thread_count: usize,
         level: Arc<Level>,
@@ -136,6 +155,7 @@ impl GenerationSchedule {
                     last_high_priority: Vec::new(),
                     send_level: level_channel,
                     public_chunk_map: level_sched.loaded_chunks.clone(),
+                    loaded_chunk_changes: level_sched.loaded_chunk_changes.clone(),
                     unload_chunks: HashSetType::default(),
                     waiting_for_chunks: HashSetType::default(),
                     io_lock,
@@ -577,7 +597,7 @@ impl GenerationSchedule {
                         match holder.chunk.as_ref().expect("chunk exists") {
                             Chunk::Level(chunk) => {
                                 self.apply_lighting_override(chunk);
-                                self.public_chunk_map.insert(pos, chunk.clone());
+                                self.publish_chunk(pos, chunk.clone());
                                 self.listener.process_new_chunk(pos, chunk);
                             }
                             Chunk::Proto(_) => panic!(),
@@ -862,7 +882,7 @@ impl GenerationSchedule {
             holder.occupied_by = EdgeKey::null();
 
             if holder.public {
-                self.public_chunk_map.remove(&pos);
+                self.unpublish_chunk(pos);
                 holder.public = false;
             }
 
@@ -1017,7 +1037,7 @@ impl GenerationSchedule {
                 match &chunk {
                     Chunk::Level(data) => {
                         self.apply_lighting_override(data);
-                        let result = self.public_chunk_map.insert(pos, data.clone());
+                        let result = self.publish_chunk(pos, data.clone());
                         if result.is_some() {
                             warn!(
                                 "receive_chunk(IO): replacing existing public chunk at {:?}",
@@ -1037,7 +1057,7 @@ impl GenerationSchedule {
                                 "Chunk {:?} downgraded to Proto for relighting, marking as non-public",
                                 pos
                             );
-                            self.public_chunk_map.remove(&pos);
+                            self.unpublish_chunk(pos);
                             holder.public = false;
                         }
                     }
@@ -1078,7 +1098,7 @@ impl GenerationSchedule {
                                 self.apply_lighting_override(&chunk);
                                 let public_chunk = chunk.clone();
                                 if was_public {
-                                    self.public_chunk_map.insert(new_pos, public_chunk);
+                                    self.publish_chunk(new_pos, public_chunk);
                                     info!(
                                         "Notifying players: regenerated chunk at {:?} (was already public)",
                                         new_pos
@@ -1087,8 +1107,7 @@ impl GenerationSchedule {
                                     holder.chunk = Some(Chunk::Level(chunk));
                                 } else {
                                     holder.chunk = Some(Chunk::Level(chunk));
-                                    let result =
-                                        self.public_chunk_map.insert(new_pos, public_chunk);
+                                    let result = self.publish_chunk(new_pos, public_chunk);
                                     holder.public = true;
                                     if result.is_some() {
                                         warn!(

--- a/crates/pumpkin-world/src/level.rs
+++ b/crates/pumpkin-world/src/level.rs
@@ -18,6 +18,7 @@ use crate::{
     world::WorldPortalExt,
 };
 use arc_swap::ArcSwap;
+use crossbeam::queue::SegQueue;
 use dashmap::{DashMap, Entry};
 use pumpkin_config::{chunk::ChunkConfig, lighting::LightingEngineConfig, world::LevelConfig};
 use pumpkin_data::biome::Biome;
@@ -50,6 +51,12 @@ use tokio_util::task::TaskTracker;
 pub type SyncChunk = Arc<ChunkData>;
 pub type SyncEntityChunk = Arc<ChunkEntityData>;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LoadedChunkChange {
+    Loaded(Vector2<i32>),
+    Unloaded(Vector2<i32>),
+}
+
 pub type ChunkSaver =
     LevelFileIO<LinearV2File<ChunkData>, AnvilChunkFile<ChunkData>, PumpFile<ChunkData>>;
 
@@ -80,6 +87,7 @@ pub struct Level {
     // Chunks that are paired with chunk watchers. When a chunk is no longer watched, it is removed
     // from the loaded chunks map and sent to the underlying ChunkIO
     pub loaded_chunks: Arc<DashMap<Vector2<i32>, SyncChunk>>,
+    pub(crate) loaded_chunk_changes: Arc<SegQueue<LoadedChunkChange>>,
     loaded_entity_chunks: Arc<DashMap<Vector2<i32>, SyncEntityChunk>>,
     pub chunks_with_scheduled_ticks: Arc<dashmap::DashSet<Vector2<i32>>>,
     pub chunk_loading: Mutex<ChunkLoading>,
@@ -263,6 +271,7 @@ impl Level {
             entity_saver,
             schedule_tick_counts: AtomicU64::new(0),
             loaded_chunks: Arc::new(DashMap::new()),
+            loaded_chunk_changes: Arc::new(SegQueue::new()),
             loaded_entity_chunks: Arc::new(DashMap::new()),
             chunks_with_scheduled_ticks: Arc::new(dashmap::DashSet::new()),
             chunk_loading: Mutex::new(ChunkLoading::new(level_channel.clone())),
@@ -634,8 +643,15 @@ impl Level {
             return res;
         }
         let chunk = self.fetch_chunk(pos).await;
-        self.loaded_chunks.insert(pos, chunk.clone());
+        if self.loaded_chunks.insert(pos, chunk.clone()).is_none() {
+            self.loaded_chunk_changes
+                .push(LoadedChunkChange::Loaded(pos));
+        }
         f(&chunk)
+    }
+
+    pub fn loaded_chunk_changes(&self) -> impl Iterator<Item = LoadedChunkChange> + '_ {
+        std::iter::from_fn(|| self.loaded_chunk_changes.pop())
     }
 
     async fn fetch_chunk(self: &Arc<Self>, pos: Vector2<i32>) -> SyncChunk {

--- a/crates/pumpkin/src/world/active_chunks.rs
+++ b/crates/pumpkin/src/world/active_chunks.rs
@@ -1,0 +1,196 @@
+use pumpkin_util::math::vector2::Vector2;
+use rustc_hash::{FxHashMap, FxHashSet};
+use uuid::Uuid;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) struct ActivePlayerArea {
+    pub center: Vector2<i32>,
+    pub simulation_distance: i32,
+}
+
+#[derive(Default)]
+pub(super) struct ActiveChunkTracker {
+    pub players: FxHashMap<Uuid, ActivePlayerArea>,
+    pub loaded_active_chunks: FxHashSet<Vector2<i32>>,
+    watcher_counts: FxHashMap<Vector2<i32>, u32>,
+    forced_chunks: FxHashSet<Vector2<i32>>,
+}
+
+impl ActiveChunkTracker {
+    fn add_chunk(
+        &mut self,
+        pos: Vector2<i32>,
+        active_chunks: &mut FxHashSet<Vector2<i32>>,
+        newly_active: &mut Vec<Vector2<i32>>,
+    ) {
+        let count = self.watcher_counts.entry(pos).or_default();
+        *count += 1;
+        if *count == 1 {
+            active_chunks.insert(pos);
+            newly_active.push(pos);
+        }
+    }
+
+    fn remove_chunk(&mut self, pos: Vector2<i32>, active_chunks: &mut FxHashSet<Vector2<i32>>) {
+        let Some(count) = self.watcher_counts.get_mut(&pos) else {
+            return;
+        };
+        *count -= 1;
+        if *count == 0 {
+            self.watcher_counts.remove(&pos);
+            self.loaded_active_chunks.remove(&pos);
+            active_chunks.remove(&pos);
+        }
+    }
+
+    fn add_area(
+        &mut self,
+        area: ActivePlayerArea,
+        active_chunks: &mut FxHashSet<Vector2<i32>>,
+        newly_active: &mut Vec<Vector2<i32>>,
+    ) {
+        for dx in -area.simulation_distance..=area.simulation_distance {
+            for dz in -area.simulation_distance..=area.simulation_distance {
+                self.add_chunk(area.center.add_raw(dx, dz), active_chunks, newly_active);
+            }
+        }
+    }
+
+    fn remove_area(&mut self, area: ActivePlayerArea, active_chunks: &mut FxHashSet<Vector2<i32>>) {
+        for dx in -area.simulation_distance..=area.simulation_distance {
+            for dz in -area.simulation_distance..=area.simulation_distance {
+                self.remove_chunk(area.center.add_raw(dx, dz), active_chunks);
+            }
+        }
+    }
+
+    pub fn update_player(
+        &mut self,
+        id: Uuid,
+        area: ActivePlayerArea,
+        active_chunks: &mut FxHashSet<Vector2<i32>>,
+        newly_active: &mut Vec<Vector2<i32>>,
+    ) {
+        let previous = self.players.insert(id, area);
+        match previous {
+            None => self.add_area(area, active_chunks, newly_active),
+            Some(previous) if previous != area => {
+                for dx in -previous.simulation_distance..=previous.simulation_distance {
+                    for dz in -previous.simulation_distance..=previous.simulation_distance {
+                        let pos = previous.center.add_raw(dx, dz);
+                        if (pos.x - area.center.x).abs() > area.simulation_distance
+                            || (pos.y - area.center.y).abs() > area.simulation_distance
+                        {
+                            self.remove_chunk(pos, active_chunks);
+                        }
+                    }
+                }
+                for dx in -area.simulation_distance..=area.simulation_distance {
+                    for dz in -area.simulation_distance..=area.simulation_distance {
+                        let pos = area.center.add_raw(dx, dz);
+                        if (pos.x - previous.center.x).abs() > previous.simulation_distance
+                            || (pos.y - previous.center.y).abs() > previous.simulation_distance
+                        {
+                            self.add_chunk(pos, active_chunks, newly_active);
+                        }
+                    }
+                }
+            }
+            Some(_) => {}
+        }
+    }
+
+    pub fn remove_player(&mut self, id: Uuid, active_chunks: &mut FxHashSet<Vector2<i32>>) {
+        if let Some(area) = self.players.remove(&id) {
+            self.remove_area(area, active_chunks);
+        }
+    }
+
+    pub fn sync_forced_chunks(
+        &mut self,
+        forced_chunks: &FxHashSet<Vector2<i32>>,
+        active_chunks: &mut FxHashSet<Vector2<i32>>,
+        newly_active: &mut Vec<Vector2<i32>>,
+    ) {
+        let removed: Vec<_> = self
+            .forced_chunks
+            .difference(forced_chunks)
+            .copied()
+            .collect();
+        let added: Vec<_> = forced_chunks
+            .difference(&self.forced_chunks)
+            .copied()
+            .collect();
+        for pos in removed {
+            self.remove_chunk(pos, active_chunks);
+        }
+        for pos in added {
+            self.add_chunk(pos, active_chunks, newly_active);
+        }
+        self.forced_chunks.clone_from(forced_chunks);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn area(x: i32, z: i32, simulation_distance: i32) -> ActivePlayerArea {
+        ActivePlayerArea {
+            center: Vector2::new(x, z),
+            simulation_distance,
+        }
+    }
+
+    #[test]
+    fn follows_player_boundary_crossing() {
+        let id = Uuid::from_u128(1);
+        let mut tracker = ActiveChunkTracker::default();
+        let mut active = FxHashSet::default();
+        let mut newly_active = Vec::new();
+
+        tracker.update_player(id, area(0, 0, 1), &mut active, &mut newly_active);
+        assert_eq!(active.len(), 9);
+        newly_active.clear();
+
+        tracker.update_player(id, area(1, 0, 1), &mut active, &mut newly_active);
+
+        assert_eq!(active.len(), 9);
+        assert_eq!(newly_active.len(), 3);
+        assert!(!active.contains(&Vector2::new(-1, 0)));
+        assert!(active.contains(&Vector2::new(2, 0)));
+    }
+
+    #[test]
+    fn removes_chunks_when_player_leaves() {
+        let id = Uuid::from_u128(1);
+        let mut tracker = ActiveChunkTracker::default();
+        let mut active = FxHashSet::default();
+        let mut newly_active = Vec::new();
+
+        tracker.update_player(id, area(0, 0, 1), &mut active, &mut newly_active);
+        tracker.remove_player(id, &mut active);
+
+        assert!(active.is_empty());
+        assert!(tracker.watcher_counts.is_empty());
+    }
+
+    #[test]
+    fn keeps_overlaps_active_until_both_players_leave() {
+        let first = Uuid::from_u128(1);
+        let second = Uuid::from_u128(2);
+        let mut tracker = ActiveChunkTracker::default();
+        let mut active = FxHashSet::default();
+        let mut newly_active = Vec::new();
+
+        tracker.update_player(first, area(0, 0, 1), &mut active, &mut newly_active);
+        tracker.update_player(second, area(0, 0, 1), &mut active, &mut newly_active);
+        tracker.remove_player(first, &mut active);
+
+        assert_eq!(active.len(), 9);
+        assert!(tracker.watcher_counts.values().all(|count| *count == 1));
+
+        tracker.remove_player(second, &mut active);
+        assert!(active.is_empty());
+    }
+}

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -10,13 +10,14 @@ use pumpkin_protocol::codec::data_component::data_to_proto_sound;
 use pumpkin_world::generation::proto_chunk::GenerationCache;
 use rayon::prelude::*;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, RwLock, Weak};
 use std::{
     collections::{BTreeMap, HashMap},
     sync::atomic::Ordering,
 };
 use tracing::{debug, error, info, trace, warn};
 
+mod active_chunks;
 pub mod chunker;
 pub mod explosion;
 pub mod loot;
@@ -50,6 +51,7 @@ use crate::{
     },
     server::Server,
 };
+use active_chunks::{ActiveChunkTracker, ActivePlayerArea};
 use arc_swap::ArcSwap;
 use border::Worldborder;
 use bytes::BufMut;
@@ -278,11 +280,13 @@ pub struct World {
     /// End Dragon fight manager (only present in `THE_END` dimension).
     pub dragon_fight: Option<std::sync::Mutex<dragon_fight::DragonFight>>,
     pub spawn_state: ArcSwap<SpawnState>,
-    pub active_chunks: ArcSwap<FxHashSet<Vector2<i32>>>,
+    pub active_chunks: RwLock<FxHashSet<Vector2<i32>>>,
+    active_chunk_tracker: std::sync::Mutex<ActiveChunkTracker>,
     pub forced_chunks: std::sync::Mutex<FxHashSet<Vector2<i32>>>,
     /// Block entities indexed by chunk, so ticking only visits the currently
     /// active chunks instead of scanning every loaded block entity each tick.
     pub block_entities: DashMap<Vector2<i32>, FxHashMap<BlockPos, Arc<dyn BlockEntity>>>,
+    pending_block_entity_migrations: crossbeam::queue::SegQueue<Vector2<i32>>,
     /// Persistent custom data for the world (matching Bukkit's `PersistentDataHolder`)
     pub custom_data: std::sync::Mutex<NbtCompound>,
     /// Persistent custom data for block entities at specific positions
@@ -406,10 +410,12 @@ impl World {
             raids: std::sync::Mutex::new(raid::Raids::default()),
             dragon_fight,
             spawn_state: ArcSwap::new(Arc::new(SpawnState::empty())),
-            active_chunks: ArcSwap::new(Arc::new(FxHashSet::default())),
+            active_chunks: RwLock::new(FxHashSet::default()),
+            active_chunk_tracker: std::sync::Mutex::new(ActiveChunkTracker::default()),
             forced_chunks: std::sync::Mutex::new(FxHashSet::default()),
             server,
             block_entities: DashMap::new(),
+            pending_block_entity_migrations: crossbeam::queue::SegQueue::new(),
             custom_data: std::sync::Mutex::new(custom_data),
             custom_block_entity_data: DashMap::new(),
             entity_tracker: entity_tracker::EntityTracker::new(),
@@ -417,34 +423,87 @@ impl World {
     }
 
     pub fn update_active_chunks(&self) {
-        let mut active_chunks = FxHashSet::default();
         let sim_dist = self.server.upgrade().map_or(10, |s| {
             s.advanced_config.networking.java.simulation_distance.get()
         }) as i32;
-        for player in self.players.load().iter() {
+        let players = self.players.load();
+        let forced_chunks = self
+            .forced_chunks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let mut tracker = self
+            .active_chunk_tracker
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut active_chunks = self
+            .active_chunks
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut newly_active = Vec::new();
+        let mut current_players = FxHashSet::default();
+
+        for player in players.iter() {
             if player.is_spectator() {
                 continue;
             }
-            let center = player.get_entity().chunk_pos.load();
-            for dx in -sim_dist..=sim_dist {
-                for dy in -sim_dist..=sim_dist {
-                    active_chunks.insert(center.add_raw(dx, dy));
+            let id = player.gameprofile.id;
+            current_players.insert(id);
+            tracker.update_player(
+                id,
+                ActivePlayerArea {
+                    center: player.get_entity().chunk_pos.load(),
+                    simulation_distance: sim_dist,
+                },
+                &mut active_chunks,
+                &mut newly_active,
+            );
+        }
+        let removed_players: Vec<_> = tracker
+            .players
+            .keys()
+            .filter(|id| !current_players.contains(id))
+            .copied()
+            .collect();
+        for id in removed_players {
+            tracker.remove_player(id, &mut active_chunks);
+        }
+        tracker.sync_forced_chunks(&forced_chunks, &mut active_chunks, &mut newly_active);
+
+        for pos in newly_active {
+            if self.level.is_chunk_loaded(&pos) && tracker.loaded_active_chunks.insert(pos) {
+                self.migrate_pending_block_entities(pos);
+            }
+        }
+        for change in self.level.loaded_chunk_changes() {
+            match change {
+                pumpkin_world::level::LoadedChunkChange::Loaded(pos) => {
+                    if active_chunks.contains(&pos)
+                        && self.level.is_chunk_loaded(&pos)
+                        && tracker.loaded_active_chunks.insert(pos)
+                    {
+                        self.migrate_pending_block_entities(pos);
+                    }
+                }
+                pumpkin_world::level::LoadedChunkChange::Unloaded(pos) => {
+                    if !self.level.is_chunk_loaded(&pos) {
+                        tracker.loaded_active_chunks.remove(&pos);
+                    }
                 }
             }
         }
-        if let Ok(forced) = self.forced_chunks.lock() {
-            active_chunks.extend(forced.iter().copied());
+        let mut pending_migrations = FxHashSet::default();
+        while let Some(pos) = self.pending_block_entity_migrations.pop() {
+            pending_migrations.insert(pos);
         }
-
-        let mut spawnable_chunks = 0;
-        for pos in &active_chunks {
-            if self.level.is_chunk_loaded(pos) {
-                spawnable_chunks += 1;
-                self.migrate_pending_block_entities(*pos);
+        for pos in pending_migrations {
+            if active_chunks.contains(&pos) && self.level.is_chunk_loaded(&pos) {
+                self.migrate_pending_block_entities(pos);
             }
         }
-
-        self.active_chunks.store(Arc::new(active_chunks));
+        let spawnable_chunks = tracker.loaded_active_chunks.len() as i32;
+        drop(active_chunks);
+        drop(tracker);
 
         self.spawn_state.store(Arc::new(SpawnState::new(
             spawnable_chunks,
@@ -1449,7 +1508,10 @@ impl World {
 
         let entities_to_tick = self.entities.load();
         let entity_count = entities_to_tick.len();
-        let active_chunks = self.active_chunks.load();
+        let active_chunks = self
+            .active_chunks
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let level_for_entities = self.level.clone();
         let entity_handle = handle.clone();
 
@@ -1823,7 +1885,10 @@ impl World {
         const BATCH_SIZE: usize = 32;
         let random_tick_speed = self.level_info.load().game_rules.random_tick_speed;
 
-        let active_chunks = self.active_chunks.load();
+        let active_chunks = self
+            .active_chunks
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let tick_data = self.level.get_tick_data(&active_chunks, random_tick_speed);
         let handle = server.runtime.clone();
 
@@ -6093,7 +6158,8 @@ impl World {
     }
 
     pub(crate) fn add_block_entity_nbt(&self, block_pos: BlockPos, nbt: &NbtCompound) {
-        self.level
+        if self
+            .level
             .read_chunk_sync(&block_pos.chunk_position(), |chunk| {
                 chunk
                     .pending_block_entities
@@ -6101,7 +6167,12 @@ impl World {
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
                     .insert(block_pos, nbt.clone());
                 chunk.mark_dirty(true);
-            });
+            })
+            .is_some()
+        {
+            self.pending_block_entity_migrations
+                .push(block_pos.chunk_position());
+        }
     }
 
     pub fn remove_block_entity(&self, block_pos: &BlockPos) {

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1567,9 +1567,17 @@ impl World {
         self.entity_tracker.update_all(self);
 
         let mut block_entities: Vec<Arc<dyn BlockEntity>> = Vec::new();
-        for chunk_pos in active_chunks.iter() {
-            if let Some(chunk_block_entities) = self.block_entities.get(chunk_pos) {
-                block_entities.extend(chunk_block_entities.values().cloned());
+        if self.block_entities.len() < active_chunks.len() {
+            for chunk_block_entities in &self.block_entities {
+                if active_chunks.contains(chunk_block_entities.key()) {
+                    block_entities.extend(chunk_block_entities.values().cloned());
+                }
+            }
+        } else {
+            for chunk_pos in active_chunks.iter() {
+                if let Some(chunk_block_entities) = self.block_entities.get(chunk_pos) {
+                    block_entities.extend(chunk_block_entities.values().cloned());
+                }
             }
         }
         let block_entity_count = block_entities.len();

--- a/crates/pumpkin/src/world/natural_spawner.rs
+++ b/crates/pumpkin/src/world/natural_spawner.rs
@@ -877,7 +877,11 @@ pub fn is_right_distance_to_player_and_spawn_point(
     let chunk_z = get_section_cord(pos.0.z);
     let target_chunk = Vector2::new(chunk_x, chunk_z);
     target_chunk == *chunk_pos
-        || (world.active_chunks.load().contains(&target_chunk)
+        || (world
+            .active_chunks
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(&target_chunk)
             && world
                 .worldborder
                 .lock()

--- a/crates/pumpkin/src/world/natural_spawner.rs
+++ b/crates/pumpkin/src/world/natural_spawner.rs
@@ -75,7 +75,7 @@ impl MobCounts {
 
 pub struct LocalMobCapCalculator {
     player_mob_counts: DashMap<i32, MobCounts>,
-    players_near_chunk: DashMap<Vector2<i32>, Vec<i32>>,
+    players_near_chunk: DashMap<Vector2<i32>, Arc<[i32]>>,
 }
 
 impl Clone for LocalMobCapCalculator {
@@ -119,7 +119,7 @@ impl LocalMobCapCalculator {
         dx * dx + dy * dy
     }
 
-    fn get_players_near(&self, world: &World, chunk_pos: Vector2<i32>) -> Vec<i32> {
+    fn get_players_near(&self, world: &World, chunk_pos: Vector2<i32>) -> Arc<[i32]> {
         if let Some(players) = self.players_near_chunk.get(&chunk_pos) {
             return players.value().clone();
         }
@@ -133,13 +133,14 @@ impl LocalMobCapCalculator {
                 players.push(player.entity_id());
             }
         }
+        let players: Arc<[i32]> = players.into();
         self.players_near_chunk.insert(chunk_pos, players.clone());
         players
     }
 
     pub fn add_mob(&self, chunk_pos: Vector2<i32>, world: &World, category: &'static MobCategory) {
         let players = self.get_players_near(world, chunk_pos);
-        for player in players {
+        for &player in players.iter() {
             self.player_mob_counts
                 .entry(player)
                 .or_default()
@@ -154,7 +155,7 @@ impl LocalMobCapCalculator {
         category: &'static MobCategory,
     ) {
         let players = self.get_players_near(world, chunk_pos);
-        for player in players {
+        for &player in players.iter() {
             if let Some(count) = self.player_mob_counts.get(&player) {
                 count.remove(category);
             }
@@ -168,7 +169,7 @@ impl LocalMobCapCalculator {
         chunk_pos: Vector2<i32>,
     ) -> bool {
         let players = self.get_players_near(world, chunk_pos);
-        for player in players {
+        for &player in players.iter() {
             if let Some(count) = self.player_mob_counts.get(&player) {
                 if count.can_spawn(category) {
                     return true;

--- a/crates/pumpkin/src/world/natural_spawner.rs
+++ b/crates/pumpkin/src/world/natural_spawner.rs
@@ -360,7 +360,10 @@ impl SpawnState {
         let potential = PotentialCalculator::default();
         let local_mob_cap = LocalMobCapCalculator::default();
         let counter = MobCounts::default();
-        let active_chunks = world.active_chunks.load();
+        let active_chunks = world
+            .active_chunks
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for entity in entities.load().iter() {
             if let Some(mob) = entity.get_mob()
                 && (mob.get_mob_entity().persistence_required.load(Relaxed)


### PR DESCRIPTION
## Description

This is a follow-up to #3171

The active chunk set was recreated for every world tick. For each player, Pumpkin inserted the full simulation-distance area into a new hash set, checked `loaded_chunks` for every entry and attempted to migrate pending block entities. With 200 players at simulation distance 10, this meant around 88000 hash inserts and 88000 `DashMap` probes per tick, even when no player had crossed a chunk boundary.

The active set is now kept between ticks with a watcher count for each chunk. Overlapping player areas share the same entry and only remove it after the last watcher leaves. When a player joins, leaves, crosses a chunk boundary or the simulation distance changes, only the difference between the old and new area is applied. A one-chunk movement at simulation distance 10 touches around 40 chunks instead of rebuilding all 88000 entries.

Chunk load and unload changes are passed back to the world tick so newly loaded active chunks still migrate their pending block entities. The consumers of `active_chunks` continue to see the same chunk set.

The natural spawner's nearby-player cache also cloned its `Vec<i32>` on every read and insert. These lists now use shared storage, removing the repeated vector cloning without changing the spawning cadence or spawn decisions. `SpawnState` is still rebuilt every tick because keeping it across ticks would also require tracking mobs moving between chunks and biomes.

Block entity collection previously probed the block entity map once for every active chunk. It now iterates whichever side is smaller: the active chunk set or the chunks that contain block entities, then checks the other set. The same block entities are still ticked.

No gameplay changes are intended. The active chunk set, spawning behavior and block entity ticking remain unchanged.

## Testing

I tested this with 200 [rust-mc-bot](https://github.com/Eoghanmc22/rust-mc-bot) clients. All bots join at once, then after 30 seconds they are teleported onto a deterministic golden-angle spiral. Bot `i` uses an angle of `137.5 * i` degrees and a distance of `300 + 6 * i` blocks, placing the bots between 300 and 1500 blocks from spawn in mostly separate simulation areas. They then wander for another 150 seconds.

The world was restored from the same pregenerated snapshot before every run. World time was pinned to noon, view and simulation distance were both 10, and both master and this branch used release builds with LTO on the same machine. I alternated the run order between master and this branch.

Tick durations were recorded with [pumpkin-pulse](https://github.com/MegalithOfficial/pumpkin-pulse), and outgoing traffic was sampled with `ss`.

The first 120 seconds are the most useful comparison because they mostly measure the deterministic engine load. After that point, underground hostile mob spawning and mob AI begin to increase. Spawn rolls are not seeded, so the later part of the run has noticeably higher variance and is outside the scope of this PR.

During the first 120 seconds, master had 39 and 33 ticks above 50 ms. This branch had 22 and 21, around 40% fewer. The mean tick time was equal or lower for this branch in every 30-second slice across all four runs, generally by around 10%.

The complete 180-second results were:

Master run 1 averaged 35.68 ms with a P99 of 65.62 ms and 520 ticks above 50 ms. Master run 2 averaged 35.39 ms with a P99 of 64.83 ms and 453 ticks above 50 ms.

This branch run 1 averaged 31.73 ms with a P99 of 60.14 ms and 168 ticks above 50 ms. Run 2 averaged 33.55 ms with a P99 of 64.33 ms and 427 ticks above 50 ms.

The full-run mean tick times did not overlap between the two branches, although the later spawning and AI load introduced substantial variance in the tail results. Most of the difference between the two branch runs appears after roughly 120 seconds, when underground, hostile mob spawning and mob AI begin to dominate tick time.

Because spawn rolls are not seeded, the number and distribution of mobs naturally differ between runs. Fixed Run 2 happened to encounter a heavier late-run mob load, which pushed up its P99 and the number of ticks exceeding 50 ms.

Before that point, however, both branch runs show the same improvement, consistently across every 30-second slice.

This mainly benefits servers with many players spread across separate simulation areas. At low player counts, rebuilding the old set was cheap enough that the difference is expected to be small.