### PR TITLE
chore: deduplicate is_waterlogged logic

### DIFF
--- a/crates/pumpkin-data/src/block_state.rs
+++ b/crates/pumpkin-data/src/block_state.rs
@@ -152,23 +152,18 @@ impl BlockState {
 
     #[must_use]
     pub fn is_waterlogged(&self) -> bool {
-        let block = Block::from_state_id(self.id);
-
-        block.properties(self.id).is_some_and(|props| {
-            props
-                .to_props()
-                .iter()
-                .any(|(k, v)| k == &"waterlogged" && v == &"true")
-        })
+        self.id.is_waterlogged()
     }
 
     /// Produce a new state identical to `self` except the waterlogged property
-    /// is set to `true`.  If the block type does not support waterlogging or
+    /// is set to `value`. If the block type does not support waterlogging or
     /// the state was already waterlogged, `None` is returned.
     #[must_use]
-    pub fn with_waterlogged(&self) -> Option<&'static BlockState> {
-        let block = Block::from_state_id(self.id);
-        block.with_waterlogged(self.id)
+    pub fn set_waterlogged(&self, value: bool) -> Option<&'static BlockState> {
+        self.id
+            .to_block()
+            .set_waterlogged(self.id, value)
+            .map(BlockStateId::to_state)
     }
 
     pub fn get_block_collision_shapes(&self) -> impl Iterator<Item = BoundingBox> + '_ {
@@ -278,6 +273,12 @@ impl BlockStateId {
     #[must_use]
     pub const fn to_block(self) -> &'static Block {
         Block::from_state_id(self)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn is_waterlogged(self) -> bool {
+        self.to_block().is_waterlogged(self)
     }
 
     #[inline]

--- a/crates/pumpkin-data/src/block_state.rs
+++ b/crates/pumpkin-data/src/block_state.rs
@@ -157,7 +157,7 @@ impl BlockState {
 
     /// Produce a new state identical to `self` except the waterlogged property
     /// is set to `value`. If the block type does not support waterlogging or
-    /// the state was already waterlogged, `None` is returned.
+    /// the state already had waterlogged set to `value`, `None` is returned.
     #[must_use]
     pub fn set_waterlogged(&self, value: bool) -> Option<&'static BlockState> {
         self.id

--- a/crates/pumpkin-data/src/blocks.rs
+++ b/crates/pumpkin-data/src/blocks.rs
@@ -179,9 +179,9 @@ impl Block {
     }
 
     /// Returns a new [`BlockStateId`] for the given [`BlockStateId`] with the
-    /// `waterlogged` property forced to `value` if the block supports that
-    /// property. If the state is already waterlogged or the block does not
-    /// expose a `waterlogged` property then `None` is returned.
+    /// `waterlogged` property forced to `value`. If the state already has
+    /// waterlogged set to `value` or the  block does not expose a `waterlogged`
+    /// property then `None` is returned.
     #[must_use]
     pub fn set_waterlogged(&self, id: BlockStateId, value: bool) -> Option<BlockStateId> {
         self.properties(id).and_then(|props| {

--- a/crates/pumpkin-data/src/blocks.rs
+++ b/crates/pumpkin-data/src/blocks.rs
@@ -172,37 +172,29 @@ impl Block {
         })
     }
 
-    /// Returns a new [`BlockState`] reference for the given [`BlockStateId`] with the
-    /// `waterlogged` property forced to `true` if the block supports that
-    /// property.  If the state is already waterlogged or the block does not
+    #[must_use]
+    pub fn is_waterloggable(&self) -> bool {
+        self.properties(self.default_state.id)
+            .is_some_and(|props| props.to_props().iter().any(|p| p.0 == "waterlogged"))
+    }
+
+    /// Returns a new [`BlockStateId`] for the given [`BlockStateId`] with the
+    /// `waterlogged` property forced to `value` if the block supports that
+    /// property. If the state is already waterlogged or the block does not
     /// expose a `waterlogged` property then `None` is returned.
     #[must_use]
-    pub fn with_waterlogged(&self, id: BlockStateId) -> Option<&'static BlockState> {
-        // Check if already waterlogged
-        if self.is_waterlogged(id) {
-            return Some(BlockState::from_id(id));
-        }
-
-        // Modify the property list if available
-        if let Some(props_source) = self.properties(id) {
-            let mut props: Vec<(&str, &str)> = props_source
-                .to_props()
-                .iter()
-                .map(|(k, v)| (*k, *v))
-                .collect();
-
-            // Look for an existing waterlogged key or add one
-            if let Some(idx) = props.iter().position(|(k, _)| *k == "waterlogged") {
-                props[idx] = ("waterlogged", "true");
-            } else {
-                props.push(("waterlogged", "true"));
+    pub fn set_waterlogged(&self, id: BlockStateId, value: bool) -> Option<BlockStateId> {
+        self.properties(id).and_then(|props| {
+            let mut props = props.to_props();
+            let waterlogged = &mut props.iter_mut().find(|p| p.0 == "waterlogged")?.1;
+            let new_waterlogged = value.to_string();
+            if new_waterlogged.as_str() == *waterlogged {
+                return None;
             }
 
-            let new_state_id = self.from_properties(&props).to_state_id(self);
-            return Some(BlockState::from_id(new_state_id));
-        }
-
-        None
+            *waterlogged = &new_waterlogged;
+            Some(self.from_properties(&props).to_state_id(self))
+        })
     }
 
     /// Returns whether this block is solid (based on default state)

--- a/crates/pumpkin-world/src/chunk_system/generation_cache.rs
+++ b/crates/pumpkin-world/src/chunk_system/generation_cache.rs
@@ -233,24 +233,13 @@ impl GenerationCache for Cache {
         let id = GenerationCache::get_block_state(self, pos);
 
         let Some(fluid) = Fluid::from_state_id(id) else {
-            let block = Block::from_state_id(id);
-            if let Some(properties) = block.properties(id) {
-                for (name, value) in properties.to_props() {
-                    if name == "waterlogged" {
-                        if value == "true" {
-                            let fluid = Fluid::FLOWING_WATER;
-                            let state = fluid.states[0].clone();
-                            return (fluid, state);
-                        }
+            let fluid = if id.is_waterlogged() {
+                Fluid::FLOWING_WATER
+            } else {
+                Fluid::EMPTY
+            };
 
-                        break;
-                    }
-                }
-            }
-
-            let fluid = Fluid::EMPTY;
             let state = fluid.states[0].clone();
-
             return (fluid, state);
         };
 

--- a/crates/pumpkin-world/src/generation/feature/features/tree/root/mangrove.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/tree/root/mangrove.rs
@@ -200,6 +200,6 @@ impl MangroveRootPlacer {
         if fluid != Fluid::WATER {
             return state;
         }
-        state.with_waterlogged().unwrap_or(state)
+        state.set_waterlogged(true).unwrap_or(state)
     }
 }

--- a/crates/pumpkin-world/src/generation/feature/features/waterlogged_vegetation_patch.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/waterlogged_vegetation_patch.rs
@@ -115,12 +115,9 @@ impl WaterloggedVegetationPatchFeature {
             placement_pos,
         ) {
             let placed_raw = GenerationCache::get_block_state(chunk, &placement_pos.0);
-            let placed_state = placed_raw.to_state();
-
-            if !placed_state.is_waterlogged()
-                && let Some(new_state) = placed_raw.to_block().with_waterlogged(placed_raw)
-            {
-                chunk.set_block_state(&placement_pos.0, new_state);
+            let placed_waterlogged = placed_raw.to_block().set_waterlogged(placed_raw, true);
+            if let Some(new_state) = placed_waterlogged {
+                chunk.set_block_state(&placement_pos.0, new_state.to_state());
             }
 
             true

--- a/crates/pumpkin/src/block/blocks/fire/fire.rs
+++ b/crates/pumpkin/src/block/blocks/fire/fire.rs
@@ -4,7 +4,7 @@ use pumpkin_data::block_properties::{BlockProperties, HorizontalAxis};
 use pumpkin_data::dimension::Dimension;
 use pumpkin_data::fluid::Fluid;
 use pumpkin_data::tag::{self, Taggable};
-use pumpkin_data::{Block, BlockDirection, BlockState};
+use pumpkin_data::{Block, BlockDirection};
 use pumpkin_macros::pumpkin_block;
 use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
@@ -34,31 +34,21 @@ impl FireBlock {
         30 + rand::rng().random_range(0..10)
     }
 
-    fn is_flammable(block_state: &BlockState) -> bool {
-        if Block::from_state_id(block_state.id)
-            .properties(block_state.id)
-            .and_then(|props| {
-                props
-                    .to_props()
-                    .into_iter()
-                    .find(|p| p.0 == "waterlogged")
-                    .map(|(_, v)| v == "true")
-            })
-            .unwrap_or(false)
-        {
+    fn is_flammable(id: BlockStateId) -> bool {
+        let block = id.to_block();
+
+        if block.is_waterlogged(id) {
             return false;
         }
-        Block::from_state_id(block_state.id)
-            .flammable
-            .as_ref()
-            .is_some_and(|f| f.burn_chance > 0)
+
+        block.flammable.as_ref().is_some_and(|f| f.burn_chance > 0)
     }
 
     fn are_blocks_around_flammable(block_accessor: &dyn BlockAccessor, pos: &BlockPos) -> bool {
         for direction in BlockDirection::all() {
             let neighbor_pos = pos.offset(direction.to_offset());
-            let block_state = block_accessor.get_block_state(&neighbor_pos);
-            if Self::is_flammable(block_state) {
+            let state_id = block_accessor.get_block_state_id(&neighbor_pos);
+            if Self::is_flammable(state_id) {
                 return true;
             }
         }
@@ -73,14 +63,14 @@ impl FireBlock {
     ) -> BlockStateId {
         let down_pos = pos.down();
         let down_state = world.get_block_state(&down_pos);
-        if Self::is_flammable(down_state) || down_state.is_side_solid(BlockDirection::Up) {
+        if Self::is_flammable(down_state.id) || down_state.is_side_solid(BlockDirection::Up) {
             return block.default_state.id;
         }
         let mut fire_props = FireProperties::from_state_id(block.default_state.id, block);
         for direction in BlockDirection::all() {
             let neighbor_pos = pos.offset(direction.to_offset());
-            let neighbor_state = world.get_block_state(&neighbor_pos);
-            if Self::is_flammable(neighbor_state) {
+            let neighbor_state_id = world.get_block_state_id(&neighbor_pos);
+            if Self::is_flammable(neighbor_state_id) {
                 match direction {
                     BlockDirection::North => fire_props.north = true,
                     BlockDirection::South => fire_props.south = true,
@@ -320,7 +310,7 @@ impl BlockBehaviour for FireBlock {
             // At max age, fire has a chance to extinguish if not on flammable block
             if new_age == 15
                 && rand::rng().random_range(0..4) == 0
-                && !Self::is_flammable(world.get_block_state(&pos.down()))
+                && !Self::is_flammable(world.get_block_state_id(&pos.down()))
             {
                 world.set_block_state(pos, Block::AIR.default_state.id, BlockFlags::NOTIFY_ALL);
                 return;

--- a/crates/pumpkin/src/item/items/bucket.rs
+++ b/crates/pumpkin/src/item/items/bucket.rs
@@ -5,7 +5,7 @@ use crate::{
     item::{ItemBehaviour, ItemMetadata},
 };
 use pumpkin_data::{
-    Block, BlockDirection, BlockStateId,
+    Block, BlockDirection,
     dimension::Dimension,
     fluid::Fluid,
     item::Item,
@@ -69,39 +69,6 @@ fn get_start_and_end_pos(player: &Player) -> (Vector3<f64>, Vector3<f64>) {
     (start_pos, end_pos)
 }
 
-fn waterlogged_check(block: &Block, state: BlockStateId) -> Option<bool> {
-    block.properties(state).and_then(|properties| {
-        properties
-            .to_props()
-            .into_iter()
-            .find(|p| p.0 == "waterlogged")
-            .map(|(_, value)| value == "true")
-    })
-}
-
-fn is_waterlogged(block: &Block, state: BlockStateId) -> bool {
-    waterlogged_check(block, state).unwrap_or(false)
-}
-
-fn set_waterlogged(block: &Block, state: BlockStateId, waterlogged: bool) -> BlockStateId {
-    let Some(props) = block.properties(state) else {
-        return state;
-    };
-    let original_props = &props.to_props();
-    let waterlogged = waterlogged.to_string();
-    let props: Vec<(&str, &str)> = original_props
-        .iter()
-        .map(|(key, value)| {
-            if *key == "waterlogged" {
-                ("waterlogged", waterlogged.as_str())
-            } else {
-                (*key, *value)
-            }
-        })
-        .collect();
-    block.from_properties(&props).to_state_id(block)
-}
-
 fn give_player_bucket_item(player: &Player, item: &'static Item) {
     if player.gamemode.load() == GameMode::Creative {
         let has_item = {
@@ -154,8 +121,8 @@ pub(crate) fn try_pickup_fluid_at(
         return Some(&Item::POWDER_SNOW_BUCKET);
     }
 
-    if is_waterlogged(block, state) {
-        let state_id = set_waterlogged(block, state, false);
+    if block.is_waterlogged(state) {
+        let state_id = block.set_waterlogged(state, false).unwrap_or(state);
         world.set_block_state(&block_pos, state_id, BlockFlags::NOTIFY_ALL);
         world.schedule_fluid_tick(&Fluid::WATER, block_pos, 5, TickPriority::Normal);
         return Some(&Item::WATER_BUCKET);
@@ -189,14 +156,12 @@ fn try_pickup_bucket_item(
 
     let target_pos = block_pos.offset(direction.to_offset());
     let (block, state) = world.get_block_and_state_id(&target_pos);
-    if waterlogged_check(block, state).is_some() {
-        let state_id = set_waterlogged(block, state, false);
-        world.set_block_state(&target_pos, state_id, BlockFlags::NOTIFY_ALL);
-        world.schedule_fluid_tick(&Fluid::WATER, target_pos, 5, TickPriority::Normal);
-        return Some(&Item::WATER_BUCKET);
-    }
 
-    None
+    let unwaterlogged = block.set_waterlogged(state, false)?;
+
+    world.set_block_state(&target_pos, unwaterlogged, BlockFlags::NOTIFY_ALL);
+    world.schedule_fluid_tick(&Fluid::WATER, target_pos, 5, TickPriority::Normal);
+    Some(&Item::WATER_BUCKET)
 }
 
 pub(crate) fn should_evaporate_in_nether(item: &Item, world: &World) -> bool {
@@ -245,8 +210,8 @@ pub(crate) fn try_place_filled_bucket(
         return try_place_powder_snow(world, pos, direction);
     }
 
-    if is_waterlogged(block, state.id) && item.id == Item::WATER_BUCKET.id {
-        let state_id = set_waterlogged(block, state.id, true);
+    if item.id == Item::WATER_BUCKET.id && block.is_waterlogged(state.id) {
+        let state_id = block.set_waterlogged(state.id, true).unwrap_or(state.id);
         world.set_block_state(&pos, state_id, BlockFlags::NOTIFY_ALL);
         world.schedule_fluid_tick(&Fluid::WATER, pos, 5, TickPriority::Normal);
         return true;
@@ -255,11 +220,11 @@ pub(crate) fn try_place_filled_bucket(
     let target_pos = pos.offset(direction.to_offset());
     let (block, state) = world.get_block_and_state(&target_pos);
 
-    if waterlogged_check(block, state.id).is_some() {
+    if block.is_waterloggable() {
         if item.id == Item::LAVA_BUCKET.id {
             return false;
         }
-        let state_id = set_waterlogged(block, state.id, true);
+        let state_id = block.set_waterlogged(state.id, true).unwrap_or(state.id);
         world.set_block_state(&target_pos, state_id, BlockFlags::NOTIFY_ALL);
         world.schedule_fluid_tick(&Fluid::WATER, target_pos, 5, TickPriority::Normal);
         return true;

--- a/crates/pumpkin/src/world/explosion.rs
+++ b/crates/pumpkin/src/world/explosion.rs
@@ -303,15 +303,7 @@ impl Explosion {
 
                         let (_fluid, fluid_state) = Fluid::from_state_id(state_id).map_or_else(
                             || {
-                                let is_waterlogged =
-                                    block.properties(state_id).is_some_and(|props| {
-                                        props
-                                            .to_props()
-                                            .into_iter()
-                                            .any(|(k, v)| k == "waterlogged" && v == "true")
-                                    });
-
-                                if is_waterlogged {
+                                if block.is_waterlogged(state_id) {
                                     (&Fluid::FLOWING_WATER, &Fluid::FLOWING_WATER.states[0])
                                 } else {
                                     (&Fluid::EMPTY, &Fluid::EMPTY.states[0])

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -5326,17 +5326,7 @@ impl World {
             crate::block::drop_loot(self, broken_block, position, true, params);
         }
 
-        let new_state_id = if broken_block
-            .properties(broken_block_state.id)
-            .and_then(|properties| {
-                properties
-                    .to_props()
-                    .into_iter()
-                    .find(|p| p.0 == "waterlogged")
-                    .map(|(_, value)| value == "true")
-            })
-            .unwrap_or(false)
-        {
+        let new_state_id = if broken_block.is_waterlogged(broken_block_state.id) {
             Block::WATER.default_state.id
         } else {
             Block::AIR.default_state.id
@@ -5626,29 +5616,20 @@ impl World {
         self.get_block_state_id_if_loaded(position).is_some()
     }
 
-    pub fn get_fluid(&self, position: &BlockPos) -> &'static pumpkin_data::fluid::Fluid {
-        let id = self.get_block_state_id(position);
-        let fluid = Fluid::from_state_id(id).ok_or(&Fluid::EMPTY);
-        if let Ok(fluid) = fluid {
+    fn get_fluid_from_state_id(id: BlockStateId) -> &'static pumpkin_data::fluid::Fluid {
+        if let Some(fluid) = Fluid::from_state_id(id) {
             return fluid.to_flowing();
         }
-        let block = Block::from_state_id(id);
-        block
-            .properties(id)
-            .and_then(|props| {
-                props
-                    .to_props()
-                    .into_iter()
-                    .find(|p| p.0 == "waterlogged")
-                    .map(|(_, value)| {
-                        if value == "true" {
-                            &Fluid::FLOWING_WATER
-                        } else {
-                            &Fluid::EMPTY
-                        }
-                    })
-            })
-            .unwrap_or(&Fluid::EMPTY)
+        if id.is_waterlogged() {
+            &Fluid::FLOWING_WATER
+        } else {
+            &Fluid::EMPTY
+        }
+    }
+
+    pub fn get_fluid(&self, position: &BlockPos) -> &'static pumpkin_data::fluid::Fluid {
+        let id = self.get_block_state_id(position);
+        Self::get_fluid_from_state_id(id)
     }
 
     pub fn get_block_and_fluid(
@@ -5659,30 +5640,7 @@ impl World {
         &'static pumpkin_data::fluid::Fluid,
     ) {
         let id = self.get_block_state_id(position);
-        let block = Block::from_state_id(id);
-
-        let fluid = Fluid::from_state_id(id)
-            .map(Fluid::to_flowing)
-            .ok_or(&Fluid::EMPTY)
-            .unwrap_or_else(|_| {
-                block
-                    .properties(id)
-                    .and_then(|props| {
-                        props
-                            .to_props()
-                            .into_iter()
-                            .find(|p| p.0 == "waterlogged")
-                            .map(|(_, value)| {
-                                if value == "true" {
-                                    &Fluid::FLOWING_WATER
-                                } else {
-                                    &Fluid::EMPTY
-                                }
-                            })
-                    })
-                    .unwrap_or(&Fluid::EMPTY)
-            });
-        (block, fluid)
+        (id.to_block(), Self::get_fluid_from_state_id(id))
     }
 
     pub fn get_fluid_and_fluid_state(
@@ -5690,30 +5648,8 @@ impl World {
         position: &BlockPos,
     ) -> (&'static Fluid, &'static FluidState) {
         let id = self.get_block_state_id(position);
-
-        let Some(raw_fluid) = Fluid::from_state_id(id) else {
-            let block = Block::from_state_id(id);
-            if let Some(properties) = block.properties(id) {
-                for (name, value) in properties.to_props() {
-                    if name == "waterlogged" {
-                        if value == "true" {
-                            let state = &Fluid::FLOWING_WATER.states[0];
-                            return (&Fluid::FLOWING_WATER, state);
-                        }
-
-                        break;
-                    }
-                }
-            }
-
-            let state = &Fluid::EMPTY.states[0];
-            return (&Fluid::EMPTY, state);
-        };
-
-        let fluid = raw_fluid.to_flowing();
-        let state = &fluid.states[0];
-
-        (fluid, state)
+        let fluid = Self::get_fluid_from_state_id(id);
+        (fluid, &fluid.states[0])
     }
 
     pub fn get_block_state_id(&self, position: &BlockPos) -> BlockStateId {


### PR DESCRIPTION
## Description
This PR removes some manual re-implementations of the already existing `Block::is_waterlogged(&self, id: BlockStateId)` (or `BlockState::is_waterlogged(&self)`) methods.

## Changes
There should be no behavioral changes introduced by this PR.

- added `Block::is_waterloggable`
- refactored `Block::with_waterlogged(&self, id: BlockStateId)` to `Block::set_waterlogged(&self, id: BlockStateId, value: bool)`
- also added `BlockStateId::is_waterlogged(self)` since that is effectively what `BlockState::is_waterlogged` calls.
- made all other implementations call one of these functions
  - and made all these functions delegate to the impl on `Block`

### Further work
Reevaluate if other `Box<dyn Properties>.to_props()` calls across the codebase can be replaced with downcasting.

## Testing
- [x] `cargo check && cargo clippy && cargo fmt --check`