### PR TITLE
fix(enchantment): implement soul speed 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3100,7 +3100,7 @@ impl LivingEntity {
         None
     }
 
-/// Applies the Soul Speed boots enchantment, mirroring the `minecraft:location_changed`
+    /// Applies the Soul Speed boots enchantment, mirroring the `minecraft:location_changed`
     /// effects of `minecraft:soul_speed`: a flat movement speed bonus plus full movement
     /// efficiency, which cancels the slowdown of the soul block underneath.
     ///

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3100,12 +3100,23 @@ impl LivingEntity {
         None
     }
 
-    /// Applies the Soul Speed boots enchantment, mirroring the `minecraft:location_changed`
+/// Applies the Soul Speed boots enchantment, mirroring the `minecraft:location_changed`
     /// effects of `minecraft:soul_speed`: a flat movement speed bonus plus full movement
     /// efficiency, which cancels the slowdown of the soul block underneath.
     ///
     /// The boost is kept while airborne (vanilla's `enchantment_active_check`) so jumping
     /// does not drop it, and the boots wear down while actually walking on the block.
+    ///
+    /// The `level == 0` early-out / `active`-modifier bookkeeping pattern here is generic to
+    /// any "boot enchantment that reacts to a block/fluid under the entity" effect — Frost
+    /// Walker (`minecraft:frost_walker`, freezing water into frosted ice) could recycle this
+    /// same shape: read the boot level, gate the per-tick world lookup behind `level > 0`,
+    /// but still read the existing `active` state unconditionally so the effect gets torn
+    /// down cleanly when the boots come off. One extra optimization specific to Frost Walker:
+    /// it only ever interacts with water, which has no placeable source blocks in the Nether,
+    /// so a Frost Walker tick could skip its block/fluid lookup entirely whenever the entity's
+    /// world is a Nether dimension — saving that lookup for every Frost-Walker-booted entity
+    /// there, the same way `level > 0` already saves it here for entities without the enchant.
     fn tick_soul_speed(&self, caller: &dyn EntityBase) {
         let level = self
             .entity_equipment
@@ -3130,15 +3141,13 @@ impl LivingEntity {
                     .map(|modifier| modifier.amount)
             });
 
-        // No enchantment and no leftover modifier: skip the per-tick world lookup that
-        // would otherwise run for every loaded entity. When the boots are removed while
-        // the boost is active, `level` is 0 but `active` is still set, so we fall through
-        // and clean up the modifier on the same tick.
+        // Skip lookup for entities with no enchantment and no lingering
+        // modifier (e.g. boots were just taken off)
         if level == 0 && active.is_none() {
             return;
         }
 
-        let on_soul_speed_block = {
+        let on_soul_speed_block = level > 0 && {
             let world = self.entity.world.load();
             let pos = self.entity.get_block_pos_below_that_affects_my_movement();
             world
@@ -3161,10 +3170,7 @@ impl LivingEntity {
             .get_player()
             .is_some_and(super::player::Player::is_flying);
 
-        // Only a still-enchanted player emits the cosmetic particles/sound.
-        if level > 0 {
-            self.tick_soul_speed_effects(caller, on_soul_speed_block, on_ground, flying);
-        }
+        self.tick_soul_speed_effects(caller, on_soul_speed_block, on_ground, flying);
 
         let applies = level > 0
             && !flying

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3151,7 +3151,9 @@ impl LivingEntity {
 
         let applies = level > 0
             && !self.entity.has_vehicle()
-            && !caller.get_player().is_some_and(|player| player.is_flying())
+            && !caller
+                .get_player()
+                .is_some_and(super::player::Player::is_flying)
             && (on_soul_speed_block || (active.is_some() && !on_ground));
         let desired = applies.then(|| soul_speed_bonus(level));
 

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3117,6 +3117,11 @@ impl LivingEntity {
                 boots.get_enchantment_level(&Enchantment::SOUL_SPEED)
             });
 
+        // Skip the per-tick world lookup for every loaded entity without the enchantment.
+        if level == 0 {
+            return;
+        }
+
         let on_soul_speed_block = {
             let world = self.entity.world.load();
             let pos = self.entity.get_block_pos_below_that_affects_my_movement();
@@ -3140,7 +3145,7 @@ impl LivingEntity {
             .get_player()
             .is_some_and(super::player::Player::is_flying);
 
-        self.tick_soul_speed_effects(caller, level, on_soul_speed_block, on_ground, flying);
+        self.tick_soul_speed_effects(caller, on_soul_speed_block, on_ground, flying);
 
         let active = self
             .attributes
@@ -3204,12 +3209,11 @@ impl LivingEntity {
     fn tick_soul_speed_effects(
         &self,
         caller: &dyn EntityBase,
-        level: i32,
         on_soul_speed_block: bool,
         on_ground: bool,
         flying: bool,
     ) {
-        if level == 0 || !on_soul_speed_block || !on_ground || flying {
+        if !on_soul_speed_block || !on_ground || flying {
             return;
         }
 

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3136,6 +3136,12 @@ impl LivingEntity {
             player.damage_item_in_slot(&EquipmentSlot::FEET, 1);
         }
 
+        let flying = caller
+            .get_player()
+            .is_some_and(super::player::Player::is_flying);
+
+        self.tick_soul_speed_effects(caller, level, on_soul_speed_block, on_ground, flying);
+
         let active = self
             .attributes
             .read()
@@ -3150,10 +3156,8 @@ impl LivingEntity {
             });
 
         let applies = level > 0
+            && !flying
             && !self.entity.has_vehicle()
-            && !caller
-                .get_player()
-                .is_some_and(super::player::Player::is_flying)
             && (on_soul_speed_block || (active.is_some() && !on_ground));
         let desired = applies.then(|| soul_speed_bonus(level));
 
@@ -3190,6 +3194,65 @@ impl LivingEntity {
             self,
             vec![Attributes::MOVEMENT_SPEED, Attributes::MOVEMENT_EFFICIENCY],
         );
+    }
+
+    /// The cosmetic `minecraft:tick` effects of `minecraft:soul_speed`: a trailing soul
+    /// particle every fifth tick while moving along the ground on a soul speed block, and
+    /// the soul escape sound on 35% of those ticks.
+    ///
+    /// Only players are covered; the periodic tick counter vanilla reads lives on `Player`.
+    fn tick_soul_speed_effects(
+        &self,
+        caller: &dyn EntityBase,
+        level: i32,
+        on_soul_speed_block: bool,
+        on_ground: bool,
+        flying: bool,
+    ) {
+        if level == 0 || !on_soul_speed_block || !on_ground || flying {
+            return;
+        }
+
+        let Some(player) = caller.get_player() else {
+            return;
+        };
+        if player.tick_counter.load(Relaxed) % 5 != 0 {
+            return;
+        }
+
+        let velocity = self.entity.velocity.load();
+        if velocity.horizontal_length() < 1.0e-5 {
+            return;
+        }
+
+        let pos = self.entity.pos.load();
+        let bounding_box = self.entity.bounding_box.load();
+        let mut rng = rand::rng();
+        let world = self.entity.world.load();
+
+        // Position: random point in the bounding box footprint, 0.1 above the feet.
+        // Velocity: a fifth of the entity's horizontal movement, reversed, drifting upward.
+        world.spawn_particle(
+            Vector3::new(
+                (rng.random::<f64>() - 0.5).mul_add(bounding_box.max.x - bounding_box.min.x, pos.x),
+                pos.y + 0.1,
+                (rng.random::<f64>() - 0.5).mul_add(bounding_box.max.z - bounding_box.min.z, pos.z),
+            ),
+            Vector3::new((velocity.x * -0.2) as f32, 0.1, (velocity.z * -0.2) as f32),
+            1.0,
+            0,
+            Particle::Soul,
+        );
+
+        if rng.random::<f32>() < 0.35 {
+            world.play_sound_raw(
+                Sound::ParticleSoulEscape as u16,
+                SoundCategory::Players,
+                &pos,
+                0.6,
+                rng.random_range(0.6f32..1.0),
+            );
+        }
     }
 }
 

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -2697,6 +2697,9 @@ impl EntityBase for LivingEntity {
     fn tick(&self, caller: &dyn EntityBase, server: &Server) {
         self.entity.tick(caller, server);
 
+        // Must run before movement so the modifiers take effect this tick.
+        self.tick_soul_speed(caller);
+
         // Only tick movement if the entity is alive. This prevents a dead "corpse"
         // from continuing to be simulated (accumulating fall_distance/velocity).
         // We allow movement during death animation (20 ticks) so knockback is applied.
@@ -2927,6 +2930,7 @@ impl EntityBase for LivingEntity {
 }
 
 pub const SPEED_MODIFIER_SPRINTING_ID: &str = "minecraft:sprinting";
+pub const SOUL_SPEED_MODIFIER_ID: &str = "minecraft:enchantment.soul_speed";
 pub const SPEED_MODIFIER_SPRINTING_AMOUNT: f64 = 0.300_000_011_920_928_96;
 
 impl LivingEntity {
@@ -3095,6 +3099,101 @@ impl LivingEntity {
 
         None
     }
+
+    /// Applies the Soul Speed boots enchantment, mirroring the `minecraft:location_changed`
+    /// effects of `minecraft:soul_speed`: a flat movement speed bonus plus full movement
+    /// efficiency, which cancels the slowdown of the soul block underneath.
+    ///
+    /// The boost is kept while airborne (vanilla's `enchantment_active_check`) so jumping
+    /// does not drop it, and the boots wear down while actually walking on the block.
+    fn tick_soul_speed(&self, caller: &dyn EntityBase) {
+        let level = self
+            .entity_equipment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .equipment
+            .get(&EquipmentSlot::FEET)
+            .map_or(0, |boots| {
+                boots.get_enchantment_level(&Enchantment::SOUL_SPEED)
+            });
+
+        let on_soul_speed_block = {
+            let world = self.entity.world.load();
+            let pos = self.entity.get_block_pos_below_that_affects_my_movement();
+            world
+                .get_block(&pos)
+                .has_tag(&tag::Block::MINECRAFT_SOUL_SPEED_BLOCKS)
+        };
+        let on_ground = self.entity.on_ground.load(Relaxed);
+
+        // Vanilla: 4% chance per level each tick to consume a point of boot durability.
+        if level > 0
+            && on_soul_speed_block
+            && on_ground
+            && rand::random::<f64>() < 0.04 * f64::from(level)
+            && let Some(player) = caller.get_player()
+        {
+            player.damage_item_in_slot(&EquipmentSlot::FEET, 1);
+        }
+
+        let active = self
+            .attributes
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&Attributes::MOVEMENT_SPEED.id)
+            .and_then(|instance| {
+                instance
+                    .modifiers
+                    .iter()
+                    .find(|modifier| modifier.id == SOUL_SPEED_MODIFIER_ID)
+                    .map(|modifier| modifier.amount)
+            });
+
+        let applies = level > 0
+            && !self.entity.has_vehicle()
+            && !caller.get_player().is_some_and(|player| player.is_flying())
+            && (on_soul_speed_block || (active.is_some() && !on_ground));
+        let desired = applies.then(|| soul_speed_bonus(level));
+
+        // Nothing to sync unless the state or the enchantment level changed.
+        if active == desired {
+            return;
+        }
+
+        if let Some(amount) = desired {
+            self.update_attribute(&Attributes::MOVEMENT_SPEED, |speed| {
+                speed.add_or_replace_modifier(Modifier {
+                    id: SOUL_SPEED_MODIFIER_ID.to_string(),
+                    amount,
+                    operation: ModifierOperation::Add,
+                });
+            });
+            self.update_attribute(&Attributes::MOVEMENT_EFFICIENCY, |efficiency| {
+                efficiency.add_or_replace_modifier(Modifier {
+                    id: SOUL_SPEED_MODIFIER_ID.to_string(),
+                    amount: 1.0,
+                    operation: ModifierOperation::Add,
+                });
+            });
+        } else {
+            self.update_attribute(&Attributes::MOVEMENT_SPEED, |speed| {
+                speed.remove_modifier(SOUL_SPEED_MODIFIER_ID);
+            });
+            self.update_attribute(&Attributes::MOVEMENT_EFFICIENCY, |efficiency| {
+                efficiency.remove_modifier(SOUL_SPEED_MODIFIER_ID);
+            });
+        }
+
+        crate::entity::attributes::send_attribute_updates_for_living(
+            self,
+            vec![Attributes::MOVEMENT_SPEED, Attributes::MOVEMENT_EFFICIENCY],
+        );
+    }
+}
+
+/// Soul Speed movement speed bonus: 0.0405 base plus 0.0105 per level above the first.
+fn soul_speed_bonus(level: i32) -> f64 {
+    0.010_5f64.mul_add(f64::from(level - 1), 0.040_5)
 }
 
 fn random_teleport_coordinate(center: f64, diameter: f32, random: f64) -> f64 {
@@ -3179,6 +3278,16 @@ pub(crate) const fn bypasses_armor_durability(damage_type: &DamageType) -> bool 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── soul_speed_bonus ──────────────────────────────────────────────
+
+    /// Matches the `minecraft:soul_speed` linear value: base 0.0405, +0.0105 per extra level.
+    #[test]
+    fn soul_speed_bonus_matches_vanilla_levels() {
+        assert!((soul_speed_bonus(1) - 0.0405).abs() < 1e-9);
+        assert!((soul_speed_bonus(2) - 0.0510).abs() < 1e-9);
+        assert!((soul_speed_bonus(3) - 0.0615).abs() < 1e-9);
+    }
 
     // ── bypasses_armor_durability ─────────────────────────────────────
 

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3117,8 +3117,24 @@ impl LivingEntity {
                 boots.get_enchantment_level(&Enchantment::SOUL_SPEED)
             });
 
-        // Skip the per-tick world lookup for every loaded entity without the enchantment.
-        if level == 0 {
+        let active = self
+            .attributes
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&Attributes::MOVEMENT_SPEED.id)
+            .and_then(|instance| {
+                instance
+                    .modifiers
+                    .iter()
+                    .find(|modifier| modifier.id == SOUL_SPEED_MODIFIER_ID)
+                    .map(|modifier| modifier.amount)
+            });
+
+        // No enchantment and no leftover modifier: skip the per-tick world lookup that
+        // would otherwise run for every loaded entity. When the boots are removed while
+        // the boost is active, `level` is 0 but `active` is still set, so we fall through
+        // and clean up the modifier on the same tick.
+        if level == 0 && active.is_none() {
             return;
         }
 
@@ -3145,20 +3161,10 @@ impl LivingEntity {
             .get_player()
             .is_some_and(super::player::Player::is_flying);
 
-        self.tick_soul_speed_effects(caller, on_soul_speed_block, on_ground, flying);
-
-        let active = self
-            .attributes
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .get(&Attributes::MOVEMENT_SPEED.id)
-            .and_then(|instance| {
-                instance
-                    .modifiers
-                    .iter()
-                    .find(|modifier| modifier.id == SOUL_SPEED_MODIFIER_ID)
-                    .map(|modifier| modifier.amount)
-            });
+        // Only a still-enchanted player emits the cosmetic particles/sound.
+        if level > 0 {
+            self.tick_soul_speed_effects(caller, on_soul_speed_block, on_ground, flying);
+        }
 
         let applies = level > 0
             && !flying

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3220,8 +3220,10 @@ impl LivingEntity {
             return;
         }
 
-        let velocity = self.entity.velocity.load();
-        if velocity.horizontal_length() < 1.0e-5 {
+        // Vanilla reads `getKnownMovement()` here, not the velocity field: a player's
+        // movement is client driven, so `Entity::velocity` stays zero for them.
+        let movement = self.get_movement();
+        if movement.horizontal_length() < 1.0e-5 {
             return;
         }
 
@@ -3238,7 +3240,7 @@ impl LivingEntity {
                 pos.y + 0.1,
                 (rng.random::<f64>() - 0.5).mul_add(bounding_box.max.z - bounding_box.min.z, pos.z),
             ),
-            Vector3::new((velocity.x * -0.2) as f32, 0.1, (velocity.z * -0.2) as f32),
+            Vector3::new((movement.x * -0.2) as f32, 0.1, (movement.z * -0.2) as f32),
             1.0,
             0,
             Particle::Soul,


### PR DESCRIPTION
Fixes #3166

## Problem

Soul Speed existed only as data. `EnchantmentEffects` has no `location_changed` variant, and nothing outside the mob equipment roll table ever read `Enchantment::SOUL_SPEED`, so the enchantment had no gameplay effect at all: soul sand still slowed the wearer down and nothing offset it.

Soul sand itself was already correct. Its slowdown comes from `Block::velocity_multiplier`, and `LivingEntity::get_block_speed_factor` already folds in the `movement_efficiency` attribute that is meant to cancel it. Nothing ever wrote to that attribute.

## Change

`LivingEntity::tick_soul_speed`, run from `LivingEntity::tick` before movement so the modifiers apply the same tick. It implements the enchantment's effects as defined in `assets/datapacks/*/data/minecraft/enchantment/soul_speed.json`:

**`location_changed`** — while the velocity-affecting block is in `#minecraft:soul_speed_blocks`, apply two `add_value` modifiers under the id `minecraft:enchantment.soul_speed`:
- `movement_speed` += 0.0405 + 0.0105 per level above the first
- `movement_efficiency` += 1.0, which cancels the soul block slowdown

The modifiers are kept while airborne so jumping does not drop the boost, matching the datapack's `enchantment_active_check` branch, and are skipped while flying or riding. Attributes are written and broadcast only when the state or the enchantment level actually changes, so a player standing on soul sand does not generate an attribute packet every tick. Boots take one durability point at a 4% per level chance per tick while walking on the block.

**`tick`** — every fifth tick, while moving along the ground on a soul block and not flying, spawn one `minecraft:soul` particle at a random point in the bounding box footprint 0.1 above the feet, with velocity `(movement.x * -0.2, 0.1, movement.z * -0.2)`. On 35% of those ticks also play `particle.soul_escape` at volume 0.6 with pitch uniform in [0.6, 1.0).

The movement predicate reads `LivingEntity::get_movement` rather than `Entity::velocity`, mirroring vanilla's `getKnownMovement()`: a player's movement is client driven, so their `velocity` field stays zero and gating on it never fires.

## Scope

Implemented as one routine rather than a general data-driven effect engine, which would need a new codegen variant plus the whole entity predicate system. This follows how Frost Walker is handled today in `block/blocks/magma.rs`.

The cosmetic `tick` effects are player-only, since the periodic tick counter vanilla reads lives on `Player`. Mobs can roll Soul Speed boots and do get the speed boost, they just do not emit the particles.

## AI assistance

This PR was developed with AI assistance (Claude Code, model: claude-opus-5).

## Testing

- `cargo clippy --all-targets` clean, `cargo build` clean, `cargo test` passing
- New unit test `soul_speed_bonus_matches_vanilla_levels` covers the per-level value
- Verified in game on Java: faster on soul sand and soul soil instead of slower, boost held through jumps, dropped on stepping off, absent while flying, boots wearing down, and soul particles plus the soul escape sound while running
