### PR TITLE
fix(worldgen): stop overworld biomes leaking into other dimensions 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-world/src/biome/mod.rs
+++ b/crates/pumpkin-world/src/biome/mod.rs
@@ -17,8 +17,12 @@ pub use pumpkin_data::chunk::{
 };
 
 thread_local! {
-    /// A shortcut; check if last used biome is what we should use
-    static LAST_RESULT_NODE: RefCell<Option<&'static BiomeTree>> = const {RefCell::new(None) };
+    /// A shortcut; reuse the last matched biome-tree leaf when consecutive
+    /// lookups land nearby. Keyed by the source tree so a leaf cached for one
+    /// dimension's tree is never reused for another (which previously let an
+    /// overworld biome leak into Nether lookups and corrupt Nether decoration).
+    static LAST_RESULT_NODE: RefCell<Option<(&'static BiomeTree, &'static BiomeTree)>> =
+        const { RefCell::new(None) };
 }
 
 pub trait BiomeSupplier {
@@ -42,7 +46,16 @@ impl BiomeSupplier for MultiNoiseBiomeSupplier {
     fn biome(&self, x: i32, y: i32, z: i32, noise: &mut MultiNoiseSampler<'_>) -> &'static Biome {
         let point = noise.sample(x, y, z);
         let point_list = point.convert_to_list();
-        LAST_RESULT_NODE.with_borrow_mut(|last_result| self.source.get(&point_list, last_result))
+        LAST_RESULT_NODE.with_borrow_mut(|cache| {
+            // Only reuse a cached leaf that belongs to this supplier's tree.
+            let mut last_node = match *cache {
+                Some((source, node)) if std::ptr::eq(source, self.source) => Some(node),
+                _ => None,
+            };
+            let biome = self.source.get(&point_list, &mut last_node);
+            *cache = last_node.map(|node| (self.source, node));
+            biome
+        })
     }
 }
 

--- a/crates/pumpkin-world/src/chunk_system/generation.rs
+++ b/crates/pumpkin-world/src/chunk_system/generation.rs
@@ -97,6 +97,7 @@ mod tests {
     use crate::generation::get_world_gen;
     use crate::world::WorldPortalExt;
     use pumpkin_data::BlockStateId;
+    use pumpkin_data::chunk::Biome;
     use pumpkin_data::dimension::Dimension;
     use pumpkin_util::world_seed::Seed;
     use std::sync::Arc;
@@ -180,6 +181,67 @@ mod tests {
             assert!(dumped.contains(&terrain_state));
             let top_section = &dumped[dumped.len() - 16 * 16 * 16..];
             assert!(top_section.iter().all(|&state| state == BlockStateId::AIR));
+        }
+    }
+
+    /// The biome-tree leaf cache in [`crate::biome`] is a thread-local shared by
+    /// every dimension, and a leaf cached from one dimension's tree seeds the search
+    /// in another: `BiomeTree::get` only accepts nodes strictly closer than the
+    /// cached one, so a stale overworld leaf can beat every node of the Nether tree
+    /// and be returned as-is. A worker thread that generated an overworld chunk then
+    /// gave the next Nether chunk overworld biomes, and with them overworld surface
+    /// rules, features and mob spawns.
+    #[test]
+    fn nether_chunks_only_contain_nether_biomes() {
+        let nether_biomes = [
+            Biome::NETHER_WASTES.id,
+            Biome::SOUL_SAND_VALLEY.id,
+            Biome::CRIMSON_FOREST.id,
+            Biome::WARPED_FOREST.id,
+            Biome::BASALT_DELTAS.id,
+        ];
+        let seed = Seed(1_789_685_981_366_416_087);
+        let block_registry = Arc::new(BlockRegistry);
+
+        // Warm this thread's biome cache with an overworld leaf first.
+        let overworld = get_world_gen(seed, Dimension::OVERWORLD, false, Vec::new(), String::new());
+        let _ = generate_single_chunk(
+            &overworld,
+            block_registry.as_ref(),
+            0,
+            0,
+            StagedChunkEnum::Biomes,
+        );
+
+        let nether = get_world_gen(
+            seed,
+            Dimension::THE_NETHER,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+        let chunk = generate_single_chunk(
+            &nether,
+            block_registry.as_ref(),
+            0,
+            0,
+            StagedChunkEnum::Biomes,
+        );
+        let Chunk::Proto(chunk) = chunk else {
+            panic!("biome generation must return a proto chunk");
+        };
+
+        for biome_x in 0..4 {
+            for biome_z in 0..4 {
+                for biome_y in 0..(Dimension::THE_NETHER.height / 4) {
+                    let biome = chunk.get_biome(biome_x, biome_y, biome_z);
+                    assert!(
+                        nether_biomes.contains(&biome.id),
+                        "cell {biome_x},{biome_y},{biome_z} generated non-Nether biome id {}",
+                        biome.id
+                    );
+                }
+            }
         }
     }
 

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1415,8 +1415,22 @@ impl ProtoChunk {
             let center_x = chunk_pos::get_center_x(self.x);
             let center_z = chunk_pos::get_center_z(self.z);
             let start_y = height_sampler.estimate_ocean_floor_height(center_x, center_z);
+            // Validate against this dimension's biomes, not a hardcoded overworld
+            // tree. Ocean monuments only list overworld biomes, so this naturally
+            // rejects them outside the overworld instead of querying the wrong tree.
+            let active_supplier = if generator.dimension == Dimension::THE_END {
+                ActiveSupplier::End(TheEndBiomeSupplier)
+            } else if generator.dimension == Dimension::THE_NETHER {
+                ActiveSupplier::Nether(MultiNoiseBiomeSupplier::NETHER)
+            } else {
+                ActiveSupplier::Overworld(MultiNoiseBiomeSupplier::OVERWORLD)
+            };
+            let biome_supplier: &dyn BiomeSupplier = match &active_supplier {
+                ActiveSupplier::End(s) => s,
+                ActiveSupplier::Nether(s) | ActiveSupplier::Overworld(s) => s,
+            };
             if !crate::generation::structure::structures::ocean_monument::has_valid_biomes(
-                &MultiNoiseBiomeSupplier::OVERWORLD,
+                biome_supplier,
                 &mut sampler,
                 self.x,
                 self.z,


### PR DESCRIPTION
## Description

Addresses the biome half of #2466 (overworld trees generating in the Nether).

`LAST_RESULT_NODE` in `pumpkin-world/src/biome/mod.rs` is a thread-local shortcut holding the last matched biome-tree leaf, but it was shared by every dimension's tree. `BiomeTree::get` seeds its search distance from that leaf and `search` only accepts nodes **strictly closer**, so a leaf cached from the overworld tree can beat every node of the Nether tree and be returned unchanged.

The consequence: a worker thread that generated an overworld chunk hands the next Nether chunk overworld biomes, and with them overworld surface rules, features and mob spawns. On a 6400-chunk Nether scan before the fix, over 5 million biome cells resolved to `minecraft:river`.

- **Key the cache by its source tree**, so a leaf is only ever reused for the tree it came from. This matches vanilla, where `lastResult` lives on the `RTree` itself rather than being shared across all of them.
- **Ocean monument placement uses the current dimension's biome supplier.** Monument placement is a spacing-only check (`is_start_chunk` for `RandomSpread` does no biome filtering), so it runs in every dimension and then validated against a hardcoded `MultiNoiseBiomeSupplier::OVERWORLD`. That both queried the wrong tree and was one of the paths poisoning the cache. Monuments only list overworld biomes, so they are still correctly rejected elsewhere.

## Testing

- New regression test `nether_chunks_only_contain_nether_biomes`: generate an overworld chunk, then a Nether chunk on the same thread, assert every biome cell is one of the five Nether biomes. Fails on `master` with `cell 0,0,0 generated non-Nether biome id 41` (river), passes with the fix. Runs in 0.06s in debug.
- `cargo clippy --all-targets -p pumpkin-world`: zero warnings, debug and release.
- `cargo fmt --all --check`: clean.
- `cargo test -p pumpkin-world`: 170 pass. The 7 `proto_chunk_test::no_blend_no_beard*` / `nether_surface_no_blend_no_beard_0_0` failures are **pre-existing on current `master`** and unrelated to this change; I verified they fail identically on a clean `master` checkout with none of this branch applied, in both debug and release.

## AI assistance

This PR was developed with AI assistance (Claude Code, model: claude-opus-5).