### PR TITLE
Implement deserialization for LoreImpl and CustomDataImpl

### DIFF
--- a/crates/pumpkin-protocol/src/codec/data_component.rs
+++ b/crates/pumpkin-protocol/src/codec/data_component.rs
@@ -238,7 +238,7 @@ fn serialize_consume_effect(
     Ok(())
 }
 
-trait DataComponentCodec<Impl: DataComponentImpl> {
+pub(crate) trait DataComponentCodec<Impl: DataComponentImpl> {
     fn serialize(&self, seq: &mut impl NetworkWriteExt) -> Result<(), WritingError>;
     fn deserialize(seq: &mut impl NetworkReadExt) -> Result<Impl, ReadingError>;
 }
@@ -340,10 +340,12 @@ impl DataComponentCodec<Self> for CustomNameImpl {
     }
 
     fn deserialize(seq: &mut impl NetworkReadExt) -> Result<Self, ReadingError> {
-        let name = seq.get_str()?;
-        Ok(Self {
-            name: pumpkin_util::text::TextComponent::text(String::from(name)),
-        })
+        let tag = seq.get_nbt_with_version(&pumpkin_util::version::JavaMinecraftVersion::V_26_2)?;
+        let name = tag.as_ref().map_or_else(
+            pumpkin_util::text::TextComponent::empty,
+            pumpkin_util::text::TextComponent::from_nbt,
+        );
+        Ok(Self { name })
     }
 }
 
@@ -358,10 +360,28 @@ impl DataComponentCodec<Self> for LoreImpl {
         Ok(())
     }
 
-    fn deserialize(_seq: &mut impl NetworkReadExt) -> Result<Self, ReadingError> {
-        Err(ReadingError::Message(
-            "Lore component decoding is not supported".into(),
-        ))
+    fn deserialize(seq: &mut impl NetworkReadExt) -> Result<Self, ReadingError> {
+        // TODO: Could probably be extracted?
+        const MAX_LORE_LINES: i32 = 256;
+
+        let count = seq.get_var_int()?.0;
+        if !(0..=MAX_LORE_LINES).contains(&count) {
+            return Err(ReadingError::Message(format!(
+                "LoreImpl line count {count} is out of bounds (0-{MAX_LORE_LINES})"
+            )));
+        }
+
+        let mut lines = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            let tag =
+                seq.get_nbt_with_version(&pumpkin_util::version::JavaMinecraftVersion::V_26_2)?;
+            let text = tag.as_ref().map_or_else(
+                pumpkin_util::text::TextComponent::empty,
+                pumpkin_util::text::TextComponent::from_nbt,
+            );
+            lines.push(text);
+        }
+        Ok(Self { lines })
     }
 }
 
@@ -452,10 +472,11 @@ impl DataComponentCodec<Self> for CustomDataImpl {
         Ok(())
     }
 
-    fn deserialize(_seq: &mut impl NetworkReadExt) -> Result<Self, ReadingError> {
-        Err(ReadingError::Message(
-            "CustomData raw component decoding is not supported; use the custom-data item-stack API".into(),
-        ))
+    fn deserialize(seq: &mut impl NetworkReadExt) -> Result<Self, ReadingError> {
+        let data = seq
+            .get_compound_nbt_with_version(&pumpkin_util::version::JavaMinecraftVersion::V_26_2)?
+            .unwrap_or_else(pumpkin_nbt::compound::NbtCompound::new);
+        Ok(Self { data })
     }
 }
 
@@ -938,6 +959,7 @@ pub fn deserialize(
         DataComponent::ItemModel => Ok(ItemModelImpl::deserialize(seq)?.to_dyn()),
         DataComponent::ItemName => Ok(ItemNameImpl::deserialize(seq)?.to_dyn()),
         DataComponent::CustomName => Ok(CustomNameImpl::deserialize(seq)?.to_dyn()),
+        DataComponent::Lore => Ok(LoreImpl::deserialize(seq)?.to_dyn()),
         DataComponent::Consumable => Ok(ConsumableImpl::deserialize(seq)?.to_dyn()),
         DataComponent::Equippable => Ok(EquippableImpl::deserialize(seq)?.to_dyn()),
         DataComponent::StoredEnchantments => Ok(StoredEnchantmentsImpl::deserialize(seq)?.to_dyn()),

--- a/crates/pumpkin-protocol/src/codec/item_stack_seralizer.rs
+++ b/crates/pumpkin-protocol/src/codec/item_stack_seralizer.rs
@@ -1,8 +1,10 @@
 use crate::VarInt;
-use crate::codec::data_component::{deserialize, serialize};
+use crate::codec::data_component::{DataComponentCodec, deserialize, serialize};
 use crate::ser::{NetworkReadExt, NetworkWriteExt, ReadingError, WritingError};
 use pumpkin_data::data_component::DataComponent;
-use pumpkin_data::data_component_impl::{CustomNameImpl, DataComponentImpl, ItemNameImpl};
+use pumpkin_data::data_component_impl::{
+    CustomDataImpl, CustomNameImpl, DataComponentImpl, ItemNameImpl,
+};
 use pumpkin_data::item::Item;
 use pumpkin_data::item_id_remap::{remap_item_id_for_version, remap_item_id_from_version};
 use pumpkin_data::item_stack::ItemStack;
@@ -188,15 +190,7 @@ fn decode_custom_name(component_data: &[u8]) -> Result<Box<dyn DataComponentImpl
     let mut nbt_reader = pumpkin_nbt::deserializer::NbtReadHelperJava::new(&mut cursor);
     let tag = NbtTag::deserialize(&mut nbt_reader)
         .map_err(|err| ReadingError::Message(format!("Failed to decode CustomName NBT: {err}")))?;
-    let name = match tag {
-        NbtTag::String(name) => TextComponent::text(name.to_string()),
-        NbtTag::Compound(compound) => compound
-            .get_string("text")
-            .map_or_else(TextComponent::empty, |name| {
-                TextComponent::text(name.to_string())
-            }),
-        _ => TextComponent::empty(),
-    };
+    let name = TextComponent::from_nbt(&tag);
     Ok(CustomNameImpl { name }.to_dyn())
 }
 
@@ -220,6 +214,18 @@ fn decode_item_name(component_data: &[u8]) -> Result<Box<dyn DataComponentImpl>,
     .to_dyn())
 }
 
+fn decode_custom_data(component_data: &[u8]) -> Result<Box<dyn DataComponentImpl>, ReadingError> {
+    let mut cursor = Cursor::new(component_data);
+    let mut nbt_reader = pumpkin_nbt::deserializer::NbtReadHelperJava::new(&mut cursor);
+    let tag = NbtTag::deserialize(&mut nbt_reader)
+        .map_err(|err| ReadingError::Message(format!("Failed to decode CustomData NBT: {err}")))?;
+    let data = match tag {
+        NbtTag::Compound(compound) => compound,
+        _ => pumpkin_nbt::compound::NbtCompound::new(),
+    };
+    Ok(CustomDataImpl::new(data).to_dyn())
+}
+
 fn decode_component(
     id: DataComponent,
     component_data: &[u8],
@@ -227,6 +233,7 @@ fn decode_component(
     match id {
         DataComponent::CustomName => decode_custom_name(component_data),
         DataComponent::ItemName => decode_item_name(component_data),
+        DataComponent::CustomData => decode_custom_data(component_data),
         _ => {
             let mut cursor = Cursor::new(component_data);
             deserialize(id, &mut cursor)
@@ -296,7 +303,11 @@ impl ItemStackSerializer<'_> {
             let id = DataComponent::try_from_id(id_val as u8)
                 .ok_or_else(|| ReadingError::Message(format!("Unknown component ID: {id_val}")))?;
 
-            let component_impl = deserialize(id, read)?;
+            let component_impl = if id == DataComponent::CustomData {
+                CustomDataImpl::deserialize(read)?.to_dyn()
+            } else {
+                deserialize(id, read)?
+            };
             patch.push((id, Some(component_impl)));
         }
 
@@ -462,7 +473,11 @@ impl ItemStackSerializer<'_> {
             let id = DataComponent::try_from_id(remapped_comp_id as u8)
                 .ok_or_else(|| ReadingError::Message(format!("Unknown component ID: {id_val}")))?;
 
-            let component_impl = deserialize(id, read)?;
+            let component_impl = if id == DataComponent::CustomData {
+                CustomDataImpl::deserialize(read)?.to_dyn()
+            } else {
+                deserialize(id, read)?
+            };
             patch.push((id, Some(component_impl)));
         }
 

--- a/crates/pumpkin-util/src/text/mod.rs
+++ b/crates/pumpkin-util/src/text/mod.rs
@@ -1278,6 +1278,12 @@ impl TextComponent {
         Self::text("")
     }
 
+    /// Parses a text component from its NBT representation
+    #[must_use]
+    pub fn from_nbt(tag: &pumpkin_nbt::tag::NbtTag) -> Self {
+        serde_json::from_value(nbt_tag_to_json(tag)).unwrap_or_else(|_| Self::empty())
+    }
+
     /// Creates a new text component with plain text content.
     ///
     /// # Arguments


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description
Implement deserialize methods for `LoreImpl` and `CustomDataImpl`. Also implements full NBT parsing for these and `CustomNameImpl` to preserve TextComponent styling (previously the server only parsed and stored the base text wrapping it in a new TextComponent, causing styling to be lost on server restart. The main reason for needing both ser and deser for `LoreImpl` and `CustomDataImpl` is that when the client has an item in its inventory with either custom lore lines or storing custom data, the client may send this data back to the server alongside other information related to the item. Before these changes, giving the player an item with custom lore lines or custom data could cause the player to be kicked from the server when it sent this data because the deserialization methods returned an error.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
