### PR TITLE
fix(net): keep alive id must fit 32 bits for pre-1.12.2 clients

### DIFF
--- a/crates/pumpkin/src/net/java/mod.rs
+++ b/crates/pumpkin/src/net/java/mod.rs
@@ -298,11 +298,12 @@ impl JavaClient {
                         break;
                     }
 
-                    // Generate a unique ID (current timestamp in ms)
-                    let keep_alive_id = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis() as i64;
+                    let keep_alive_id = i64::from(
+                        SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_millis() as i32,
+                    );
 
                     self.keep_alive_id.store(keep_alive_id);
                     self.wait_for_keep_alive.store(true, Ordering::Relaxed);


### PR DESCRIPTION
## Description
Clients on 1.8 and older were getting kicked with `disconnect.timeout` about a minute after joining, even though they were responding to every keep alive.

Pumpkin uses the current Unix timestamp in milliseconds as the keep alive ID, which is a 64-bit value. The packet writer already handles the ID differently depending on the protocol version, like PacketEvents does: `long` on 1.12.2+, `VarInt` on 1.8, and a regular `int` on 1.7.

The problem is that on older versions the ID gets truncated to 32 bits when it's written to the packet. The client sends that truncated value back, but the server was still comparing it against the original 64-bit timestamp. They never matched, so the keep alive stayed pending until it timed out and kicked the player.

The fix is to clamp the ID to the 32-bit range when building `CKeepAlive`, then have the keep alive loop use the ID from the packet instead of the original timestamp. This way the stored ID is always the same one that was actually sent to the client.

No packet read/write logic had to change. Newer versions shouldnt be effected, just receive a smaller keep alive ID.


## Testing

I reproduced this on master with a 1.8.9 bot. It received keep alive IDs at 18, 33 and 48 seconds, answered each one with the exact same ID, and was kicked at 63 seconds. The ID it received was the low 32 bits of the millisecond timestamp.

With this change I ran 1.7.10, 1.8.8, 1.12.2 and 26.1 bots against the same server for 80 seconds each. All four stayed connected, every keep alive matched in both directions and the server log had no warnings or panics.