### PR TITLE
fix(main): register SIGTERM and SIGHUP handlers before waiting

### DIFF
--- a/crates/pumpkin/src/main.rs
+++ b/crates/pumpkin/src/main.rs
@@ -323,15 +323,17 @@ async fn setup_sighandler() -> io::Result<()> {
 // Unix signal handling
 #[cfg(unix)]
 async fn setup_sighandler() -> io::Result<()> {
-    if signal(SignalKind::interrupt())?.recv().await.is_some() {
-        handle_interrupt();
-    }
+    let mut interrupt = signal(SignalKind::interrupt())?;
+    let mut hangup = signal(SignalKind::hangup())?;
+    let mut terminate = signal(SignalKind::terminate())?;
 
-    if signal(SignalKind::hangup())?.recv().await.is_some() {
-        handle_interrupt();
-    }
+    let received = tokio::select! {
+        received = interrupt.recv() => received,
+        received = hangup.recv() => received,
+        received = terminate.recv() => received,
+    };
 
-    if signal(SignalKind::terminate())?.recv().await.is_some() {
+    if received.is_some() {
         handle_interrupt();
     }
 


### PR DESCRIPTION
## Problem

`setup_sighandler` awaits the three signal streams sequentially, so only `SIGINT` is ever
registered. `signal()` is what installs the handler, and the `SIGHUP` and `SIGTERM` calls
are only reached after a `SIGINT` has already arrived and shut the server down.

Until then both signals keep their default disposition, which terminates the process
immediately. `systemctl stop`, `docker stop` and a plain `kill` therefore kill the server
with no graceful shutdown, and any chunk that has not been autosaved is lost.

Fixes #3115.

## Change

All three streams are registered up front, then `tokio::select!` waits for whichever signal
arrives first and runs the same `handle_interrupt` as before.

The `.is_some()` check is kept, so a closed stream still does not trigger a shutdown. The
non-Unix path, which only handles Ctrl-C, is untouched.

## Notes

- No behaviour change for `SIGINT`.
- `handle_interrupt` is unchanged, so the shutdown path stays the one the `stop` command
  already uses.

## Tests

No unit test. `handle_interrupt` calls into the process-wide shutdown, and signal delivery
is process-wide too, so raising `SIGTERM` inside the shared test binary would tear down the
whole test run rather than fail one case. Verified instead by building and linting the Unix
target in a Linux container.
