### PR TITLE
perf(worldgen): pick density cache kind from domain axes like 26.3

### DIFF
--- a/crates/pumpkin-data/src/generated/noise_router.rs
+++ b/crates/pumpkin-data/src/generated/noise_router.rs
@@ -134,7 +134,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(8usize, WrapperType::CacheOnce, pos, &eval_overworld_7)
+        ctx.sample_wrapper(8usize, WrapperType::CacheFlat, pos, &eval_overworld_7)
     }
     #[inline(always)]
     pub fn eval_overworld_9<C: NoiseEvaluationContext>(
@@ -156,7 +156,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(11usize, WrapperType::CacheOnce, pos, &eval_overworld_10)
+        ctx.sample_wrapper(11usize, WrapperType::CacheFlat, pos, &eval_overworld_10)
     }
     #[inline(always)]
     pub fn eval_overworld_12<C: NoiseEvaluationContext>(
@@ -180,7 +180,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(13usize, WrapperType::CacheOnce, pos, &eval_overworld_12)
+        ctx.sample_wrapper(13usize, WrapperType::CacheFlat, pos, &eval_overworld_12)
     }
     #[inline(always)]
     pub fn eval_overworld_14<C: NoiseEvaluationContext>(
@@ -204,7 +204,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(15usize, WrapperType::CacheOnce, pos, &eval_overworld_14)
+        ctx.sample_wrapper(15usize, WrapperType::CacheFlat, pos, &eval_overworld_14)
     }
     #[inline(always)]
     pub fn eval_overworld_16<C: NoiseEvaluationContext>(
@@ -228,7 +228,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(17usize, WrapperType::CacheOnce, pos, &eval_overworld_16)
+        ctx.sample_wrapper(17usize, WrapperType::CacheFlat, pos, &eval_overworld_16)
     }
     #[inline(always)]
     pub fn eval_overworld_18<C: NoiseEvaluationContext>(
@@ -295,7 +295,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(26usize, WrapperType::CacheOnce, pos, &eval_overworld_25)
+        ctx.sample_wrapper(26usize, WrapperType::CacheFlat, pos, &eval_overworld_25)
     }
     #[inline(always)]
     pub fn eval_overworld_27<C: NoiseEvaluationContext>(
@@ -327,7 +327,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(30usize, WrapperType::CacheOnce, pos, &eval_overworld_29)
+        ctx.sample_wrapper(30usize, WrapperType::CacheFlat, pos, &eval_overworld_29)
     }
     #[inline(always)]
     pub fn eval_overworld_31<C: NoiseEvaluationContext>(
@@ -361,7 +361,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(34usize, WrapperType::CacheOnce, pos, &eval_overworld_33)
+        ctx.sample_wrapper(34usize, WrapperType::CacheFlat, pos, &eval_overworld_33)
     }
     #[inline(always)]
     pub fn eval_overworld_35<C: NoiseEvaluationContext>(
@@ -401,7 +401,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(39usize, WrapperType::CacheOnce, pos, &eval_overworld_38)
+        ctx.sample_wrapper(39usize, WrapperType::CacheFlat, pos, &eval_overworld_38)
     }
     #[inline(always)]
     pub fn eval_overworld_40<C: NoiseEvaluationContext>(
@@ -1159,7 +1159,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(124usize, WrapperType::CacheOnce, pos, &eval_overworld_123)
+        ctx.sample_wrapper(124usize, WrapperType::CacheFlat, pos, &eval_overworld_123)
     }
     #[inline(always)]
     pub fn eval_overworld_125<C: NoiseEvaluationContext>(
@@ -2180,7 +2180,7 @@ pub mod end_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(14usize, WrapperType::CacheOnce, pos, &eval_end_13)
+        ctx.sample_wrapper(14usize, WrapperType::CacheFlat, pos, &eval_end_13)
     }
     #[inline(always)]
     pub fn eval_end_15<C: NoiseEvaluationContext>(
@@ -2669,7 +2669,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 7usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
             BaseNoiseFunctionComponent::ShiftB {
@@ -2677,7 +2677,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 10usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 8usize,
@@ -2691,7 +2691,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 12usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 8usize,
@@ -2705,7 +2705,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 14usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 8usize,
@@ -2719,7 +2719,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 16usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Unary {
                 input_index: 17usize,
@@ -4366,7 +4366,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 25usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Binary {
                 argument1_index: 4usize,
@@ -4692,7 +4692,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 29usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Noise {
                 data: &NoiseData {
@@ -4716,7 +4716,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 33usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Binary {
                 argument1_index: 27usize,
@@ -5642,7 +5642,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 38usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Binary {
                 argument1_index: 35usize,
@@ -6212,7 +6212,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 123usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Gradient {
                 data: &GradientData {
@@ -6786,7 +6786,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 7usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
             BaseNoiseFunctionComponent::ShiftB {
@@ -6794,7 +6794,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 10usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 8usize,
@@ -6808,7 +6808,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 12usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 8usize,
@@ -6822,7 +6822,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 14usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 8usize,
@@ -6836,7 +6836,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 16usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Unary {
                 input_index: 17usize,
@@ -8483,7 +8483,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 25usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Binary {
                 argument1_index: 4usize,
@@ -9409,7 +9409,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 30usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Binary {
                 argument1_index: 27usize,
@@ -9521,7 +9521,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 0usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
             BaseNoiseFunctionComponent::ShiftB {
@@ -9529,7 +9529,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 3usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 1usize,
@@ -9543,7 +9543,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 5usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 1usize,
@@ -9577,7 +9577,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 9usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 1usize,
@@ -9591,7 +9591,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 11usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Gradient {
                 data: &GradientData {
@@ -11250,7 +11250,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 23usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Binary {
                 argument1_index: 13usize,
@@ -11464,7 +11464,7 @@ pub const END_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 13usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::InterpolatedNoiseSampler {
                 data: &InterpolatedNoiseSamplerData {
@@ -11594,7 +11594,7 @@ pub const END_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 10usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::CacheFlat,
             },
         ],
         temperature: 0usize,

--- a/tools/pumpkin-codegen/src/noise_router.rs
+++ b/tools/pumpkin-codegen/src/noise_router.rs
@@ -566,7 +566,115 @@ enum DensityFunctionRepr {
     },
 }
 
+const AXIS_X: u8 = 1;
+const AXIS_Y: u8 = 2;
+const AXIS_Z: u8 = 4;
+const AXES_XZ: u8 = AXIS_X | AXIS_Z;
+const AXES_ALL: u8 = AXIS_X | AXIS_Y | AXIS_Z;
+
+impl Axis {
+    const fn as_axes(self) -> u8 {
+        match self {
+            Self::X => AXIS_X,
+            Self::Y => AXIS_Y,
+            Self::Z => AXIS_Z,
+        }
+    }
+}
+
+fn noise_domain_axes(xz_scale: f32, y_scale: f32) -> u8 {
+    let mut axes = AXES_ALL;
+    if y_scale == 0.0 {
+        axes &= !AXIS_Y;
+    }
+    if xz_scale == 0.0 {
+        axes &= !AXES_XZ;
+    }
+    axes
+}
+
+impl SplineRepr {
+    fn domain_axes(&self) -> u8 {
+        match self {
+            Self::Fixed { .. } => 0,
+            Self::Standard {
+                location_function,
+                values,
+                ..
+            } => values
+                .iter()
+                .fold(location_function.domain_axes(), |axes, value| {
+                    axes | value.domain_axes()
+                }),
+        }
+    }
+}
+
 impl DensityFunctionRepr {
+    fn domain_axes(&self) -> u8 {
+        match self {
+            Self::Constant { .. } => 0,
+            Self::BlendAlpha
+            | Self::BlendOffset
+            | Self::EndIslands
+            | Self::ShiftA { .. }
+            | Self::ShiftB { .. } => AXES_XZ,
+            Self::Beardifier
+            | Self::InterpolatedNoiseSampler { .. }
+            | Self::DistanceToPoint { .. } => AXES_ALL,
+            Self::ClampedYGradient { .. } => AXIS_Y,
+            Self::Gradient { data } => data.axis.as_axes(),
+            Self::Noise { data } => noise_domain_axes(data.xz_scale.0, data.y_scale.0),
+            Self::ShiftedNoise {
+                shift_x,
+                shift_y,
+                shift_z,
+                data,
+            } => {
+                noise_domain_axes(data.xz_scale.0, data.y_scale.0)
+                    | shift_x.domain_axes()
+                    | shift_y.domain_axes()
+                    | shift_z.domain_axes()
+            }
+            Self::BlendDensity { input }
+            | Self::Wrapper { input, .. }
+            | Self::Linear { input, .. }
+            | Self::Unary { input, .. }
+            | Self::Clamp { input, .. } => input.domain_axes(),
+            Self::Slice { axis, input, .. } => input.domain_axes() & !axis.as_axes(),
+            Self::FindTopSurface {
+                density,
+                upper_bound,
+                ..
+            } => (density.domain_axes() | upper_bound.domain_axes()) & !AXIS_Y,
+            Self::IntervalSelect {
+                input, functions, ..
+            } => functions
+                .iter()
+                .fold(input.domain_axes(), |axes, f| axes | f.domain_axes()),
+            Self::Lerp {
+                alpha,
+                first,
+                second,
+            } => alpha.domain_axes() | first.domain_axes() | second.domain_axes(),
+            Self::Rounding {
+                input, multiple, ..
+            } => input.domain_axes() | multiple.domain_axes(),
+            Self::Binary {
+                argument1,
+                argument2,
+                ..
+            } => argument1.domain_axes() | argument2.domain_axes(),
+            Self::RangeChoice {
+                input,
+                when_in_range,
+                when_out_range,
+                ..
+            } => input.domain_axes() | when_in_range.domain_axes() | when_out_range.domain_axes(),
+            Self::Spline { spline, .. } => spline.domain_axes(),
+        }
+    }
+
     fn optimize(&mut self) {
         match self {
             Self::BlendDensity { input } => input.optimize(),
@@ -2468,20 +2576,22 @@ fn parse_vanilla_df(base_df_dir: &std::path::Path, val: &serde_json::Value) -> D
                 "beardifier" => DensityFunctionRepr::Beardifier,
                 "cache" | "interpolated" | "flat_cache" | "cache_flat" | "cache_2d"
                 | "cache_once" | "cache_all_in_cell" => {
-                    let wrapper = match clean_type {
-                        "interpolated" => WrapperType::Interpolated,
-                        "flat_cache" | "cache_flat" => WrapperType::CacheFlat,
-                        "cache_2d" => WrapperType::Cache2D,
-                        "cache_once" | "cache" => WrapperType::CacheOnce,
-                        "cache_all_in_cell" => WrapperType::CellCache,
-                        _ => unreachable!(),
-                    };
                     let input = parse_vanilla_df(
                         base_df_dir,
                         obj.get("input")
                             .or_else(|| obj.get("argument"))
                             .expect("Missing input/argument"),
                     );
+                    let wrapper = match clean_type {
+                        "interpolated" => WrapperType::Interpolated,
+                        "flat_cache" | "cache_flat" => WrapperType::CacheFlat,
+                        "cache_2d" => WrapperType::Cache2D,
+                        "cache_once" => WrapperType::CacheOnce,
+                        "cache" if input.domain_axes() & AXIS_Y == 0 => WrapperType::CacheFlat,
+                        "cache" => WrapperType::CacheOnce,
+                        "cache_all_in_cell" => WrapperType::CellCache,
+                        _ => unreachable!(),
+                    };
                     DensityFunctionRepr::Wrapper {
                         input: Box::new(input),
                         wrapper,


### PR DESCRIPTION
## Description

Chunk generation got slower since the density function data was moved to the 26.3 datapack. The full chunk pipeline in the `chunk_gen` bench went from 48 ms to 157 ms per chunk, most of it in the biome stage.

In 26.3 Mojang replaced `flat_cache`, `cache_2d` and `cache_once` with a single `cache` marker and let the engine figure out the caching itself based on which axes a function depends on. Our runtime is still the 26.2 model and the codegen was turning every `cache` into `CacheOnce`, so all the 2D shaper functions like continents, erosion, offset and factor were recomputed for every Y sample in a column instead of once.

I added the same axis inference to the codegen. Each density function reports which axes it depends on the way vanilla 26.3 does (a noise with `y_scale` 0 doesn't depend on Y, a gradient only on its axis, operators inherit from their inputs and so on), and a `cache` whose input doesn't depend on Y becomes `CacheFlat`. Nothing else changed, the datapack files and the runtime are untouched and only `noise_router.rs` was regenerated.

Carvers are also slower than in August but that comes from the carver rewrite in the same commit, not from the cache markers. I left that for a separate PR.

## Testing

`cargo bench -p pumpkin-world`, master vs this branch: full chunk generation 157 ms to 40.6 ms, biomes 13.8 ms to 1.09 ms, noise 16.4 ms to 12.9 ms, 16 chunks on 4 threads 644 ms to 182 ms.

I generated 49 chunks of seed 42 up to the surface stage on master, on this branch and on a build with the old 26.2 markers and hashed all block states and biome ids. All three match. `pumpkin-world` tests pass.

On a fresh world with one client at view distance 16 the full view loads in 12.3 s instead of 16.8 s when the client asks for 64 chunks per tick. With a normal client the gain is smaller since the client only asks for a couple of chunks per tick anyway.

While doing the hash comparison I noticed the features stage isn't deterministic, generating the same chunk twice gives different blocks in about half the chunks. That happens on master too and is unrelated to this change.