### PR TITLE
fix(config): keep autosave enabled in the generated config

### DIFF
--- a/crates/pumpkin-config/src/world.rs
+++ b/crates/pumpkin-config/src/world.rs
@@ -5,7 +5,7 @@ use crate::{chunk::ChunkConfig, lighting::LightingEngineConfig};
 /// Configuration for world and level-specific settings.
 ///
 /// Currently, it includes chunk-related options; more settings may be added later.
-#[derive(Deserialize, Serialize, Default, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct LevelConfig {
     /// Configuration for chunk behaviour and management.
     pub chunk: ChunkConfig,
@@ -20,4 +20,42 @@ pub struct LevelConfig {
 
 const fn default_autosave_ticks() -> u64 {
     6000 // Default to 5 minutes at 20 TPS
+}
+
+impl Default for LevelConfig {
+    fn default() -> Self {
+        Self {
+            chunk: ChunkConfig::default(),
+            lighting: LightingEngineConfig::default(),
+            autosave_ticks: default_autosave_ticks(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_level_config_enables_autosave() {
+        assert_eq!(LevelConfig::default().autosave_ticks, 6000);
+    }
+
+    #[test]
+    fn generated_config_round_trip_keeps_autosave_enabled() {
+        let generated = toml::to_string(&LevelConfig::default()).unwrap();
+        let reloaded: LevelConfig = toml::from_str(&generated).unwrap();
+        assert_eq!(reloaded.autosave_ticks, 6000);
+    }
+
+    #[test]
+    fn an_explicit_zero_still_disables_autosave() {
+        let disabled = LevelConfig {
+            autosave_ticks: 0,
+            ..LevelConfig::default()
+        };
+        let generated = toml::to_string(&disabled).unwrap();
+        let reloaded: LevelConfig = toml::from_str(&generated).unwrap();
+        assert_eq!(reloaded.autosave_ticks, 0);
+    }
 }


### PR DESCRIPTION
## Problem

`LevelConfig` derives `Default`, so `LevelConfig::default()` returns
`autosave_ticks: 0`. The `#[serde(default = "default_autosave_ticks")]` attribute on
that field only applies when deserializing a *missing* key, not to `Default`.

On first run the server writes its generated config from `AdvancedConfiguration::default()`,
so a fresh install ships `autosave_ticks = 0`. The key is then present on every later
load, the serde default never applies, and `World::tick` gates the whole autosave path on
`autosave_ticks > 0`. A fresh server therefore never autosaves, and the doc comment on the
field says exactly that 0 means disabled.

## Change

Replace the derived `Default` with a manual one that reads `default_autosave_ticks()`,
matching what `ChatConfig` in this crate already does.

## Tests

- `default_level_config_enables_autosave` and `generated_config_round_trip_keeps_autosave_enabled`
  both fail on the current code with `left: 0, right: 6000`. The second one covers the real
  failure path: write the generated config, read it back.
- `an_explicit_zero_still_disables_autosave` guards the other direction, so autosave stays
  something an operator can turn off on purpose.
