### PR TITLE
chore(ci): add cancel-in-progress to stop invalid CIs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"


### PR DESCRIPTION
## Description

Adds workflow-level concurrency to cancel outdated CI runs when newer commits are pushed to the same ref.

Yeah... that's it...