### PR TITLE
fix(plugin): clean up plugin state during unload

### DIFF
--- a/crates/pumpkin/src/command/node/dispatcher.rs
+++ b/crates/pumpkin/src/command/node/dispatcher.rs
@@ -84,6 +84,11 @@ pub struct CommandDispatcher {
     /// configuration. A disabled command behaves as if it does not exist: it
     /// cannot be executed and is left out of listings and suggestions.
     disabled: FxHashSet<String>,
+
+    /// Commands whose plugin source is currently unloaded. These are kept
+    /// separate from configuration disables so loading the plugin again can
+    /// make its commands available without overriding server configuration.
+    inactive_plugin_commands: FxHashSet<String>,
 }
 
 impl Default for CommandDispatcher {
@@ -105,34 +110,82 @@ impl CommandDispatcher {
             tree,
             consumer: RESULT_DEFERRER.clone(),
             disabled: FxHashSet::default(),
+            inactive_plugin_commands: FxHashSet::default(),
         }
+    }
+
+    fn normalize_command_name(name: &str) -> String {
+        name.to_ascii_lowercase()
     }
 
     /// Turns a command off. A disabled command's primary name is recorded here
     /// so that it can no longer be executed, listed, or suggested, regardless of
     /// which internal dispatcher it lives on.
     pub fn disable_command(&mut self, name: impl Into<String>) {
-        self.disabled.insert(name.into());
+        let name = name.into();
+        self.disabled.insert(Self::normalize_command_name(&name));
     }
 
-    /// Returns `true` if the command with the given primary name has been turned
-    /// off through the server configuration.
+    /// Makes a plugin command unavailable until it is registered again.
+    fn deactivate_plugin_command(&mut self, name: impl AsRef<str>) {
+        self.inactive_plugin_commands
+            .insert(Self::normalize_command_name(name.as_ref()));
+    }
+
+    /// Makes a plugin command and its aliases unavailable until registration.
+    pub(crate) fn deactivate_plugin_command_and_aliases(&mut self, name: &str) {
+        let primary_name = self.primary_command_name(name);
+        for alias in self.tree_alias_names(&primary_name) {
+            self.deactivate_plugin_command(alias);
+        }
+        self.deactivate_plugin_command(primary_name);
+    }
+
+    /// Makes every root command registered by a plugin source unavailable.
+    pub(crate) fn deactivate_commands_from_source(&mut self, source: &str) {
+        let primary_names = self
+            .tree
+            .get_root_children()
+            .into_iter()
+            .filter_map(|node_id| {
+                let metadata = &self.tree[node_id].meta;
+                (metadata.source.as_deref() == Some(source)).then(|| metadata.literal.to_string())
+            })
+            .collect::<Vec<_>>();
+
+        for primary_name in primary_names {
+            self.deactivate_plugin_command_and_aliases(&primary_name);
+        }
+    }
+
+    /// Returns `true` if a command is disabled or its plugin is inactive.
     #[must_use]
     pub fn is_disabled(&self, name: &str) -> bool {
-        if self.disabled.contains(name) {
+        Self::contains_command_name(&self.disabled, name)
+            || Self::contains_command_name(&self.inactive_plugin_commands, name)
+    }
+
+    fn contains_command_name(commands: &FxHashSet<String>, name: &str) -> bool {
+        let name = Self::normalize_command_name(name);
+        if commands.contains(&name) {
             return true;
         }
-        if name.starts_with('/') && self.disabled.contains(name.trim_start_matches('/')) {
-            return true;
-        }
-        if !name.starts_with('/') {
-            let single = format!("/{name}");
-            let double = format!("//{name}");
-            if self.disabled.contains(&single) || self.disabled.contains(&double) {
-                return true;
-            }
-        }
-        false
+
+        let base_name = name.trim_start_matches('/');
+        commands.contains(base_name)
+            || commands.contains(&format!("/{base_name}"))
+            || commands.contains(&format!("//{base_name}"))
+    }
+
+    fn reactivate_plugin_command(&mut self, name: &str) {
+        let name = Self::normalize_command_name(name);
+        let base_name = name.trim_start_matches('/');
+        self.inactive_plugin_commands.remove(&name);
+        self.inactive_plugin_commands.remove(base_name);
+        self.inactive_plugin_commands
+            .remove(&format!("/{base_name}"));
+        self.inactive_plugin_commands
+            .remove(&format!("//{base_name}"));
     }
 
     /// Returns `true` if a command (or alias) with the given name is registered
@@ -151,7 +204,8 @@ impl CommandDispatcher {
     /// could still reach the live executor through one of them.
     #[must_use]
     pub fn tree_alias_names(&self, primary: &str) -> Vec<String> {
-        let Some(primary_id) = self.tree.get(primary) else {
+        let primary = Self::normalize_command_name(primary);
+        let Some(primary_id) = self.tree.get(&primary) else {
             return Vec::new();
         };
         let primary_node: NodeId = primary_id.into();
@@ -174,7 +228,8 @@ impl CommandDispatcher {
     /// Resolves the primary name of a command from either an alias or a primary name.
     #[must_use]
     pub fn primary_command_name(&self, name: &str) -> String {
-        if let Some(node_id) = self.tree.get(name) {
+        let name = Self::normalize_command_name(name);
+        if let Some(node_id) = self.tree.get(&name) {
             let node = &self.tree[NodeId::from(node_id)];
             if let Some(redirect) = node.redirect()
                 && let Some(resolved) = self.tree.resolve(redirect)
@@ -183,7 +238,7 @@ impl CommandDispatcher {
             }
             return node.name().to_ascii_lowercase();
         }
-        name.to_string()
+        name
     }
 
     /// Extracts the command name (the first whitespace-separated token) from a
@@ -199,8 +254,11 @@ impl CommandDispatcher {
     /// unregister a command. This is due to redirection to
     /// potentially unregistered (freed) nodes.
     pub fn register(&mut self, command_node: impl Into<CommandDetachedNode>) -> CommandNodeId {
-        let node = command_node.into();
-        let name = node.meta.literal.to_string();
+        let mut node = command_node.into();
+        let name = Self::normalize_command_name(&node.meta.literal);
+        node.meta.literal = name.clone().into();
+        node.meta.literal_lowercase.clone_from(&name);
+        self.reactivate_plugin_command(&name);
         let main_node_id = self.tree.add_child_to_root(node);
 
         // For double-slash or slash-prefixed commands (e.g. //set or /set),
@@ -995,6 +1053,64 @@ mod test {
         let source = CommandSource::dummy();
         let result = dispatcher.execute_input("simple", &source);
         assert!(result.is_err_and(|error| error.error_type == &DISPATCHER_UNKNOWN_COMMAND));
+    }
+
+    #[test]
+    fn plugin_commands_follow_unload_and_reload_lifecycle() {
+        let mut dispatcher = CommandDispatcher::new();
+        let executor: fn(&CommandContext) -> CommandExecutorResult = |_| Ok(1);
+        let command = || {
+            CommandArgumentBuilder::new("Plugin-Command", "A plugin command")
+                .with_source("test-plugin")
+                .executes(executor)
+        };
+
+        dispatcher.register_with_aliases(command(), &["Plugin-Alias"]);
+        let source = CommandSource::dummy();
+        assert_eq!(dispatcher.execute_input("plugin-command", &source), Ok(1));
+        assert_eq!(dispatcher.execute_input("plugin-alias", &source), Ok(1));
+
+        dispatcher.deactivate_commands_from_source("test-plugin");
+        assert!(
+            dispatcher
+                .execute_input("plugin-command", &source)
+                .is_err_and(|error| error.error_type == &DISPATCHER_UNKNOWN_COMMAND)
+        );
+        assert!(
+            dispatcher
+                .execute_input("plugin-alias", &source)
+                .is_err_and(|error| error.error_type == &DISPATCHER_UNKNOWN_COMMAND)
+        );
+
+        dispatcher.register_with_aliases(command(), &["Plugin-Alias"]);
+        assert_eq!(dispatcher.execute_input("plugin-command", &source), Ok(1));
+        assert_eq!(dispatcher.execute_input("plugin-alias", &source), Ok(1));
+        assert_eq!(
+            dispatcher.tree_alias_names("PLUGIN-COMMAND"),
+            vec!["plugin-alias"]
+        );
+
+        dispatcher.deactivate_plugin_command_and_aliases("PLUGIN-ALIAS");
+        assert!(
+            dispatcher
+                .execute_input("plugin-command", &source)
+                .is_err_and(|error| error.error_type == &DISPATCHER_UNKNOWN_COMMAND)
+        );
+        assert!(
+            dispatcher
+                .execute_input("plugin-alias", &source)
+                .is_err_and(|error| error.error_type == &DISPATCHER_UNKNOWN_COMMAND)
+        );
+
+        dispatcher.register_with_aliases(command(), &["Plugin-Alias"]);
+        dispatcher.disable_command("PLUGIN-COMMAND");
+        dispatcher.deactivate_commands_from_source("test-plugin");
+        dispatcher.register_with_aliases(command(), &["Plugin-Alias"]);
+        assert!(
+            dispatcher
+                .execute_input("plugin-command", &source)
+                .is_err_and(|error| error.error_type == &DISPATCHER_UNKNOWN_COMMAND)
+        );
     }
 
     #[test]

--- a/crates/pumpkin/src/command/node/tree.rs
+++ b/crates/pumpkin/src/command/node/tree.rs
@@ -182,7 +182,7 @@ impl Tree {
         let node = node.into();
         let name = node.meta.literal.to_string();
         let node = self.attach(node.into());
-        self.add_attached_child(ROOT_NODE_ID, node);
+        let node = self.add_attached_child(ROOT_NODE_ID, node);
 
         // This is safe as the node ID now points to a `CommandAttachedNode`.
         let node = CommandNodeId(node.0);
@@ -208,8 +208,7 @@ impl Tree {
 
         // First, attach the node to this tree.
         let node = self.attach(node);
-        self.add_attached_child(parent, node);
-        node
+        self.add_attached_child(parent, node)
     }
 
     /// Adds an already-attached child to a given node.
@@ -221,7 +220,7 @@ impl Tree {
     ///
     /// Essentially, this means that a [`CommandAttachedNode`] must have the root node
     /// of the tree *as its parent*, and [`RootAttachedNode`] cannot have a parent.
-    fn add_attached_child(&mut self, parent: NodeId, node: NodeId) {
+    fn add_attached_child(&mut self, parent: NodeId, node: NodeId) -> NodeId {
         assert!(
             parent == ROOT_NODE_ID || self[node].classification() != NodeClassification::Command,
             "Cannot add a CommandAttachedNode as a child of a non-root node"
@@ -242,8 +241,10 @@ impl Tree {
             for grandchild in node_children {
                 self.add_attached_child(child, grandchild);
             }
+            child
         } else {
             self[parent].children_mut_ref().insert(node_name, node);
+            node
         }
     }
 

--- a/crates/pumpkin/src/plugin/api/context.rs
+++ b/crates/pumpkin/src/plugin/api/context.rs
@@ -328,6 +328,7 @@ impl Context {
             handler,
             priority,
             blocking,
+            source: Some(self.metadata.name.clone()),
             _phantom: std::marker::PhantomData,
         });
 

--- a/crates/pumpkin/src/plugin/api/context.rs
+++ b/crates/pumpkin/src/plugin/api/context.rs
@@ -230,7 +230,18 @@ impl Context {
     pub fn unregister_command(&self, name: &str) {
         self.server.command_dispatcher.rcu(|dispatcher| {
             let mut new_dispatcher = (**dispatcher).clone();
-            new_dispatcher.disable_command(name.to_string());
+            new_dispatcher.deactivate_plugin_command_and_aliases(name);
+            Arc::new(new_dispatcher)
+        });
+
+        self.reload_commands_for_everyone();
+    }
+
+    pub(crate) fn unregister_commands(&self) {
+        let source = self.metadata.name.clone();
+        self.server.command_dispatcher.rcu(|dispatcher| {
+            let mut new_dispatcher = (**dispatcher).clone();
+            new_dispatcher.deactivate_commands_from_source(&source);
             Arc::new(new_dispatcher)
         });
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
@@ -403,7 +403,7 @@ impl WasmPlugin {
         if let Some(weak_plugin) = &store.data().plugin
             && let Some(plugin) = weak_plugin.upgrade()
         {
-            context.server.task_scheduler.cancel_all_tasks(&plugin);
+            context.server.task_scheduler.disable_plugin(&plugin);
         }
 
         match self.plugin_instance {

--- a/crates/pumpkin/src/plugin/mod.rs
+++ b/crates/pumpkin/src/plugin/mod.rs
@@ -1085,6 +1085,8 @@ impl PluginManager {
             plugins.remove(index)
         };
 
+        plugin.context.unregister_commands();
+
         if let Some(instance) = plugin.instance.take() {
             instance.on_unload(plugin.context.clone()).await.ok();
         }

--- a/crates/pumpkin/src/plugin/mod.rs
+++ b/crates/pumpkin/src/plugin/mod.rs
@@ -73,6 +73,11 @@ pub trait DynEventHandler: Send + Sync {
     /// # Returns
     /// The priority of the event handler.
     fn get_priority(&self) -> &EventPriority;
+
+    /// Returns the plugin that registered this handler, when applicable.
+    fn source(&self) -> Option<&str> {
+        None
+    }
 }
 
 /// A trait for handling specific events.
@@ -111,6 +116,7 @@ where
     pub handler: Arc<H>,
     pub priority: EventPriority,
     pub blocking: bool,
+    pub source: Option<String>,
     pub _phantom: std::marker::PhantomData<E>,
 }
 
@@ -155,6 +161,10 @@ where
     /// Retrieves the priority of the handler.
     fn get_priority(&self) -> &EventPriority {
         &self.priority
+    }
+
+    fn source(&self) -> Option<&str> {
+        self.source.as_deref()
     }
 }
 
@@ -1085,6 +1095,7 @@ impl PluginManager {
             plugins.remove(index)
         };
 
+        self.unregister_handlers(name);
         plugin.context.unregister_commands();
 
         if let Some(instance) = plugin.instance.take() {
@@ -1107,6 +1118,17 @@ impl PluginManager {
         self.plugin_states.write().await.remove(name);
 
         Ok(())
+    }
+
+    fn unregister_handlers(&self, source: &str) {
+        self.handlers.rcu(|handlers| {
+            let mut new_handlers = (**handlers).clone();
+            new_handlers.retain(|_, handlers| {
+                handlers.retain(|handler| handler.source() != Some(source));
+                !handlers.is_empty()
+            });
+            Arc::new(new_handlers)
+        });
     }
 
     /// Get all plugins that are currently loading
@@ -1159,6 +1181,7 @@ impl PluginManager {
             handler,
             priority,
             blocking,
+            source: None,
             _phantom: std::marker::PhantomData,
         });
 

--- a/crates/pumpkin/src/server/scheduler.rs
+++ b/crates/pumpkin/src/server/scheduler.rs
@@ -3,7 +3,7 @@ use crate::server::Server;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashSet};
 use std::sync::atomic::Ordering as AtomicOrdering;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 
 pub type TaskId = u32;
 
@@ -39,6 +39,7 @@ impl Ord for ScheduledTask {
 pub struct TaskScheduler {
     tasks: Mutex<BinaryHeap<ScheduledTask>>,
     cancelled_tasks: Mutex<HashSet<TaskId>>,
+    disabled_plugins: Mutex<Vec<Weak<WasmPlugin>>>,
     next_task_id: std::sync::atomic::AtomicU32,
 }
 
@@ -54,6 +55,7 @@ impl TaskScheduler {
         Self {
             tasks: Mutex::new(BinaryHeap::new()),
             cancelled_tasks: Mutex::new(HashSet::new()),
+            disabled_plugins: Mutex::new(Vec::new()),
             next_task_id: std::sync::atomic::AtomicU32::new(0),
         }
     }
@@ -66,6 +68,13 @@ impl TaskScheduler {
         current_tick: u64,
     ) -> TaskId {
         let id = self.next_task_id.fetch_add(1, AtomicOrdering::SeqCst);
+        let mut disabled_plugins = self
+            .disabled_plugins
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if Self::is_plugin_disabled(&mut disabled_plugins, &plugin) {
+            return id;
+        }
         let task = ScheduledTask {
             id,
             plugin,
@@ -89,6 +98,13 @@ impl TaskScheduler {
         current_tick: u64,
     ) -> TaskId {
         let id = self.next_task_id.fetch_add(1, AtomicOrdering::SeqCst);
+        let mut disabled_plugins = self
+            .disabled_plugins
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if Self::is_plugin_disabled(&mut disabled_plugins, &plugin) {
+            return id;
+        }
         let task = ScheduledTask {
             id,
             plugin,
@@ -110,20 +126,30 @@ impl TaskScheduler {
             .insert(id);
     }
 
-    pub fn cancel_all_tasks(&self, plugin: &Arc<WasmPlugin>) {
-        let tasks = self
-            .tasks
+    pub fn disable_plugin(&self, plugin: &Arc<WasmPlugin>) {
+        let mut disabled_plugins = self
+            .disabled_plugins
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut cancelled = self
-            .cancelled_tasks
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        for task in tasks.iter() {
-            if Arc::ptr_eq(&task.plugin, plugin) {
-                cancelled.insert(task.id);
-            }
+        if !Self::is_plugin_disabled(&mut disabled_plugins, plugin) {
+            disabled_plugins.push(Arc::downgrade(plugin));
         }
+
+        self.tasks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .retain(|task| !Arc::ptr_eq(&task.plugin, plugin));
+    }
+
+    fn is_plugin_disabled(
+        disabled_plugins: &mut Vec<Weak<WasmPlugin>>,
+        plugin: &Arc<WasmPlugin>,
+    ) -> bool {
+        disabled_plugins.retain(|entry| entry.strong_count() > 0);
+        let plugin = Arc::downgrade(plugin);
+        disabled_plugins
+            .iter()
+            .any(|entry| Weak::ptr_eq(entry, &plugin))
     }
 
     pub fn tick(&self, server: &Arc<Server>) {
@@ -157,6 +183,15 @@ impl TaskScheduler {
         }
 
         for mut task in tasks_to_run {
+            let mut disabled_plugins = self
+                .disabled_plugins
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if Self::is_plugin_disabled(&mut disabled_plugins, &task.plugin) {
+                continue;
+            }
+            drop(disabled_plugins);
+
             // Run the task
             let plugin = task.plugin.clone();
             let handler_id = task.handler_id;
@@ -185,10 +220,16 @@ impl TaskScheduler {
             // If repeating, schedule next run
             if let Some(period) = task.period {
                 task.next_tick = current_tick + period;
-                self.tasks
+                let mut disabled_plugins = self
+                    .disabled_plugins
                     .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .push(task);
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if !Self::is_plugin_disabled(&mut disabled_plugins, &task.plugin) {
+                    self.tasks
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .push(task);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary:
This PR improves plugin unloading by ensuring plugin-owned commands, event handlers, and scheduled tasks cannot continue running after their plugin has been unloaded. This work was originally part of #3185, but has been pulled into a standalone PR because it is useful independently of the WASM reentry changes and doesn't exactly fall within it's scope while still being a good change alongside it for stability.
## Changes:
Plugin commands are now tracked by their source and deactivated during unload, including any aliases that point to them. Commands can be reactivated if the plugin is loaded and registers them again, and their inactive state is preserved when the command dispatcher is rebuilt.

Event handlers registered by the plugin are removed during unload. The scheduler also disables the plugin, removes its pending tasks, rejects new scheduled work, and prevents repeating tasks from scheduling themselves again after unloading begins.

## Validation:
Validated with `cargo fmt --all -- --check`, `cargo check -p pumpkin` & `cargo clippy -p pumpkin --lib --all-features -- -D warnings`