### PR TITLE
perf(worldgen): add 26.3 density sampler contract and slice rewrite

### DIFF
--- a/crates/pumpkin-data/src/generated/noise_router.rs
+++ b/crates/pumpkin-data/src/generated/noise_router.rs
@@ -134,10 +134,18 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(8usize, WrapperType::CacheFlat, pos, &eval_overworld_7)
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_7(&slice_pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_9<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(9usize, WrapperType::CacheFlat, pos, &eval_overworld_8)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_10<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -145,35 +153,19 @@ pub mod overworld_compiled {
         0f32
     }
     #[inline(always)]
-    pub fn eval_overworld_10<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_11<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
         ctx.sample_shift_b(DoublePerlinNoiseParameters::OFFSET, pos)
     }
     #[inline(always)]
-    pub fn eval_overworld_11<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(11usize, WrapperType::CacheFlat, pos, &eval_overworld_10)
-    }
-    #[inline(always)]
     pub fn eval_overworld_12<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let sx = eval_overworld_8(pos, ctx);
-        let sy = eval_overworld_9(pos, ctx);
-        let sz = eval_overworld_11(pos, ctx);
-        ctx.sample_shifted_noise(
-            DoublePerlinNoiseParameters::CONTINENTALNESS,
-            sx,
-            sy,
-            sz,
-            0.25f32,
-            0f32,
-        )
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_11(&slice_pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_13<C: NoiseEvaluationContext>(
@@ -187,11 +179,11 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let sx = eval_overworld_8(pos, ctx);
-        let sy = eval_overworld_9(pos, ctx);
-        let sz = eval_overworld_11(pos, ctx);
+        let sx = eval_overworld_9(pos, ctx);
+        let sy = eval_overworld_10(pos, ctx);
+        let sz = eval_overworld_13(pos, ctx);
         ctx.sample_shifted_noise(
-            DoublePerlinNoiseParameters::EROSION,
+            DoublePerlinNoiseParameters::CONTINENTALNESS,
             sx,
             sy,
             sz,
@@ -204,16 +196,56 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(15usize, WrapperType::CacheFlat, pos, &eval_overworld_14)
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_14(&slice_pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_16<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let sx = eval_overworld_8(pos, ctx);
-        let sy = eval_overworld_9(pos, ctx);
-        let sz = eval_overworld_11(pos, ctx);
+        ctx.sample_wrapper(16usize, WrapperType::CacheFlat, pos, &eval_overworld_15)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_17<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let sx = eval_overworld_9(pos, ctx);
+        let sy = eval_overworld_10(pos, ctx);
+        let sz = eval_overworld_13(pos, ctx);
+        ctx.sample_shifted_noise(
+            DoublePerlinNoiseParameters::EROSION,
+            sx,
+            sy,
+            sz,
+            0.25f32,
+            0f32,
+        )
+    }
+    #[inline(always)]
+    pub fn eval_overworld_18<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_17(&slice_pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_19<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(19usize, WrapperType::CacheFlat, pos, &eval_overworld_18)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_20<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let sx = eval_overworld_9(pos, ctx);
+        let sy = eval_overworld_10(pos, ctx);
+        let sz = eval_overworld_13(pos, ctx);
         ctx.sample_shifted_noise(
             DoublePerlinNoiseParameters::RIDGE,
             sx,
@@ -224,92 +256,61 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_17<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(17usize, WrapperType::CacheFlat, pos, &eval_overworld_16)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_18<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_17(pos, ctx).abs()
-    }
-    #[inline(always)]
-    pub fn eval_overworld_19<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_18(pos, ctx) + -0.6666667f32
-    }
-    #[inline(always)]
-    pub fn eval_overworld_20<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_19(pos, ctx).abs()
-    }
-    #[inline(always)]
     pub fn eval_overworld_21<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_20(pos, ctx) + -0.33333334f32
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_20(&slice_pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_22<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_21(pos, ctx) * -3f32
+        ctx.sample_wrapper(22usize, WrapperType::CacheFlat, pos, &eval_overworld_21)
     }
     #[inline(always)]
     pub fn eval_overworld_23<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let location_val = eval_overworld_13(pos, ctx);
-        ctx.sample_spline(23usize, location_val, pos)
+        eval_overworld_22(pos, ctx).abs()
     }
     #[inline(always)]
     pub fn eval_overworld_24<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_23(pos, ctx) + -0.50375f32
+        eval_overworld_23(pos, ctx) + -0.6666667f32
     }
     #[inline(always)]
     pub fn eval_overworld_25<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let a = eval_overworld_5(pos, ctx);
-        let f = eval_overworld_6(pos, ctx);
-        let s = eval_overworld_24(pos, ctx);
-        f + a * (s - f)
+        eval_overworld_24(pos, ctx).abs()
     }
     #[inline(always)]
     pub fn eval_overworld_26<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(26usize, WrapperType::CacheFlat, pos, &eval_overworld_25)
+        eval_overworld_25(pos, ctx) + -0.33333334f32
     }
     #[inline(always)]
     pub fn eval_overworld_27<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_4(pos, ctx) + eval_overworld_26(pos, ctx)
+        eval_overworld_26(pos, ctx) * -3f32
     }
     #[inline(always)]
     pub fn eval_overworld_28<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let location_val = eval_overworld_13(pos, ctx);
+        let location_val = eval_overworld_16(pos, ctx);
         ctx.sample_spline(28usize, location_val, pos)
     }
     #[inline(always)]
@@ -317,20 +318,83 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let a = eval_overworld_5(pos, ctx);
-        let f = eval_overworld_9(pos, ctx);
-        let s = eval_overworld_28(pos, ctx);
-        f + a * (s - f)
+        eval_overworld_28(pos, ctx) + -0.50375f32
     }
     #[inline(always)]
     pub fn eval_overworld_30<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(30usize, WrapperType::CacheFlat, pos, &eval_overworld_29)
+        let a = eval_overworld_5(pos, ctx);
+        let f = eval_overworld_6(pos, ctx);
+        let s = eval_overworld_29(pos, ctx);
+        f + a * (s - f)
     }
     #[inline(always)]
     pub fn eval_overworld_31<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_30(&slice_pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_32<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(32usize, WrapperType::CacheFlat, pos, &eval_overworld_31)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_33<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_32(&slice_pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_34<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_4(pos, ctx) + eval_overworld_33(pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_35<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let location_val = eval_overworld_16(pos, ctx);
+        ctx.sample_spline(35usize, location_val, pos)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_36<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let a = eval_overworld_5(pos, ctx);
+        let f = eval_overworld_10(pos, ctx);
+        let s = eval_overworld_35(pos, ctx);
+        f + a * (s - f)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_37<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_36(&slice_pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_38<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(38usize, WrapperType::CacheFlat, pos, &eval_overworld_37)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_39<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -342,36 +406,52 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_32<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_40<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let v = eval_overworld_31(pos, ctx);
+        let v = eval_overworld_39(pos, ctx);
         if v > 0.0 { v } else { v * 0.5 }
     }
     #[inline(always)]
-    pub fn eval_overworld_33<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_41<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_30(pos, ctx) * eval_overworld_32(pos, ctx)
+        eval_overworld_38(pos, ctx) * eval_overworld_40(pos, ctx)
     }
     #[inline(always)]
-    pub fn eval_overworld_34<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_42<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(34usize, WrapperType::CacheFlat, pos, &eval_overworld_33)
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_41(&slice_pos, ctx)
     }
     #[inline(always)]
-    pub fn eval_overworld_35<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_43<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_27(pos, ctx) + eval_overworld_34(pos, ctx)
+        ctx.sample_wrapper(43usize, WrapperType::CacheFlat, pos, &eval_overworld_42)
     }
     #[inline(always)]
-    pub fn eval_overworld_36<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_44<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_43(&slice_pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_45<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_34(pos, ctx) + eval_overworld_44(pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_46<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -379,167 +459,81 @@ pub mod overworld_compiled {
         10f32
     }
     #[inline(always)]
-    pub fn eval_overworld_37<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        let location_val = eval_overworld_13(pos, ctx);
-        ctx.sample_spline(37usize, location_val, pos)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_38<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        let a = eval_overworld_5(pos, ctx);
-        let f = eval_overworld_36(pos, ctx);
-        let s = eval_overworld_37(pos, ctx);
-        f + a * (s - f)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_39<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(39usize, WrapperType::CacheFlat, pos, &eval_overworld_38)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_40<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_35(pos, ctx) * eval_overworld_39(pos, ctx)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_41<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        let v = eval_overworld_40(pos, ctx);
-        if v > 0.0 { v } else { v * 0.25 }
-    }
-    #[inline(always)]
-    pub fn eval_overworld_42<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_41(pos, ctx) * 4f32
-    }
-    #[inline(always)]
-    pub fn eval_overworld_43<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_interpolated_noise(pos)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_44<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_42(pos, ctx) + eval_overworld_43(pos, ctx)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_45<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(45usize, WrapperType::CacheOnce, pos, &eval_overworld_44)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_46<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_noise(
-            DoublePerlinNoiseParameters::CAVE_ENTRANCE,
-            pos.x as f32 * 0.75f32,
-            pos.y as f32 * 0.5f32,
-            pos.z as f32 * 0.75f32,
-        )
-    }
-    #[inline(always)]
     pub fn eval_overworld_47<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_46(pos, ctx) + 0.37f32
+        let location_val = eval_overworld_16(pos, ctx);
+        ctx.sample_spline(47usize, location_val, pos)
     }
     #[inline(always)]
     pub fn eval_overworld_48<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let _ = ctx;
-        let coord = pos.y;
-        let rel = coord.clamp(-10i32, 30i32) - -10i32;
-        0.3f32 + rel as f32 * -0.0075000003f32
+        let a = eval_overworld_5(pos, ctx);
+        let f = eval_overworld_46(pos, ctx);
+        let s = eval_overworld_47(pos, ctx);
+        f + a * (s - f)
     }
     #[inline(always)]
     pub fn eval_overworld_49<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_47(pos, ctx) + eval_overworld_48(pos, ctx)
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_48(&slice_pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_50<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_noise(
-            DoublePerlinNoiseParameters::SPAGHETTI_ROUGHNESS_MODULATOR,
-            pos.x as f32 * 1f32,
-            pos.y as f32 * 1f32,
-            pos.z as f32 * 1f32,
-        )
+        ctx.sample_wrapper(50usize, WrapperType::CacheFlat, pos, &eval_overworld_49)
     }
     #[inline(always)]
     pub fn eval_overworld_51<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_50(pos, ctx) * -0.05f32
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_50(&slice_pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_52<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_51(pos, ctx) + -0.05f32
+        eval_overworld_45(pos, ctx) * eval_overworld_51(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_53<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_noise(
-            DoublePerlinNoiseParameters::SPAGHETTI_ROUGHNESS,
-            pos.x as f32 * 1f32,
-            pos.y as f32 * 1f32,
-            pos.z as f32 * 1f32,
-        )
+        let v = eval_overworld_52(pos, ctx);
+        if v > 0.0 { v } else { v * 0.25 }
     }
     #[inline(always)]
     pub fn eval_overworld_54<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_53(pos, ctx).abs()
+        eval_overworld_53(pos, ctx) * 4f32
     }
     #[inline(always)]
     pub fn eval_overworld_55<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_54(pos, ctx) + -0.4f32
+        ctx.sample_interpolated_noise(pos)
     }
     #[inline(always)]
     pub fn eval_overworld_56<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_52(pos, ctx) * eval_overworld_55(pos, ctx)
+        eval_overworld_54(pos, ctx) + eval_overworld_55(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_57<C: NoiseEvaluationContext>(
@@ -554,10 +548,10 @@ pub mod overworld_compiled {
         ctx: &mut C,
     ) -> f32 {
         ctx.sample_noise(
-            DoublePerlinNoiseParameters::SPAGHETTI_3D_RARITY,
-            pos.x as f32 * 2f32,
-            pos.y as f32 * 1f32,
-            pos.z as f32 * 2f32,
+            DoublePerlinNoiseParameters::CAVE_ENTRANCE,
+            pos.x as f32 * 0.75f32,
+            pos.y as f32 * 0.5f32,
+            pos.z as f32 * 0.75f32,
         )
     }
     #[inline(always)]
@@ -565,26 +559,24 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(59usize, WrapperType::CacheOnce, pos, &eval_overworld_58)
+        eval_overworld_58(pos, ctx) + 0.37f32
     }
     #[inline(always)]
     pub fn eval_overworld_60<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_noise(
-            DoublePerlinNoiseParameters::SPAGHETTI_3D_1,
-            pos.x as f32 * 1.3333334f32,
-            pos.y as f32 * 1.3333334f32,
-            pos.z as f32 * 1.3333334f32,
-        )
+        let _ = ctx;
+        let coord = pos.y;
+        let rel = coord.clamp(-10i32, 30i32) - -10i32;
+        0.3f32 + rel as f32 * -0.0075000003f32
     }
     #[inline(always)]
     pub fn eval_overworld_61<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_60(pos, ctx) * 0.75f32
+        eval_overworld_59(pos, ctx) + eval_overworld_60(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_62<C: NoiseEvaluationContext>(
@@ -592,7 +584,7 @@ pub mod overworld_compiled {
         ctx: &mut C,
     ) -> f32 {
         ctx.sample_noise(
-            DoublePerlinNoiseParameters::SPAGHETTI_3D_1,
+            DoublePerlinNoiseParameters::SPAGHETTI_ROUGHNESS_MODULATOR,
             pos.x as f32 * 1f32,
             pos.y as f32 * 1f32,
             pos.z as f32 * 1f32,
@@ -603,10 +595,114 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_62(pos, ctx) * 1f32
+        eval_overworld_62(pos, ctx) * -0.05f32
     }
     #[inline(always)]
     pub fn eval_overworld_64<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_63(pos, ctx) + -0.05f32
+    }
+    #[inline(always)]
+    pub fn eval_overworld_65<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_noise(
+            DoublePerlinNoiseParameters::SPAGHETTI_ROUGHNESS,
+            pos.x as f32 * 1f32,
+            pos.y as f32 * 1f32,
+            pos.z as f32 * 1f32,
+        )
+    }
+    #[inline(always)]
+    pub fn eval_overworld_66<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_65(pos, ctx).abs()
+    }
+    #[inline(always)]
+    pub fn eval_overworld_67<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_66(pos, ctx) + -0.4f32
+    }
+    #[inline(always)]
+    pub fn eval_overworld_68<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_64(pos, ctx) * eval_overworld_67(pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_69<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(69usize, WrapperType::CacheOnce, pos, &eval_overworld_68)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_70<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_noise(
+            DoublePerlinNoiseParameters::SPAGHETTI_3D_RARITY,
+            pos.x as f32 * 2f32,
+            pos.y as f32 * 1f32,
+            pos.z as f32 * 2f32,
+        )
+    }
+    #[inline(always)]
+    pub fn eval_overworld_71<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(71usize, WrapperType::CacheOnce, pos, &eval_overworld_70)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_72<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_noise(
+            DoublePerlinNoiseParameters::SPAGHETTI_3D_1,
+            pos.x as f32 * 1.3333334f32,
+            pos.y as f32 * 1.3333334f32,
+            pos.z as f32 * 1.3333334f32,
+        )
+    }
+    #[inline(always)]
+    pub fn eval_overworld_73<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_72(pos, ctx) * 0.75f32
+    }
+    #[inline(always)]
+    pub fn eval_overworld_74<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_noise(
+            DoublePerlinNoiseParameters::SPAGHETTI_3D_1,
+            pos.x as f32 * 1f32,
+            pos.y as f32 * 1f32,
+            pos.z as f32 * 1f32,
+        )
+    }
+    #[inline(always)]
+    pub fn eval_overworld_75<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_74(pos, ctx) * 1f32
+    }
+    #[inline(always)]
+    pub fn eval_overworld_76<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -618,14 +714,14 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_65<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_77<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_64(pos, ctx) * 1.5f32
+        eval_overworld_76(pos, ctx) * 1.5f32
     }
     #[inline(always)]
-    pub fn eval_overworld_66<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_78<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -637,18 +733,18 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_67<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_79<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_66(pos, ctx) * 2f32
+        eval_overworld_78(pos, ctx) * 2f32
     }
     #[inline(always)]
-    pub fn eval_overworld_68<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_80<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let input_val = eval_overworld_59(pos, ctx);
+        let input_val = eval_overworld_71(pos, ctx);
         let thresholds = &[-0.5f32, 0f32, 0.5f32];
         let mut selected = thresholds.len();
         for (i, &t) in thresholds.iter().enumerate() {
@@ -658,21 +754,21 @@ pub mod overworld_compiled {
             }
         }
         match selected {
-            0usize => eval_overworld_61(pos, ctx),
-            1usize => eval_overworld_63(pos, ctx),
-            2usize => eval_overworld_65(pos, ctx),
-            _ => eval_overworld_67(pos, ctx),
+            0usize => eval_overworld_73(pos, ctx),
+            1usize => eval_overworld_75(pos, ctx),
+            2usize => eval_overworld_77(pos, ctx),
+            _ => eval_overworld_79(pos, ctx),
         }
     }
     #[inline(always)]
-    pub fn eval_overworld_69<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_81<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_68(pos, ctx).abs()
+        eval_overworld_80(pos, ctx).abs()
     }
     #[inline(always)]
-    pub fn eval_overworld_70<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_82<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -684,14 +780,14 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_71<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_83<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_70(pos, ctx) * 0.75f32
+        eval_overworld_82(pos, ctx) * 0.75f32
     }
     #[inline(always)]
-    pub fn eval_overworld_72<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_84<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -703,14 +799,14 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_73<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_85<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_72(pos, ctx) * 1f32
+        eval_overworld_84(pos, ctx) * 1f32
     }
     #[inline(always)]
-    pub fn eval_overworld_74<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_86<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -722,14 +818,14 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_75<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_87<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_74(pos, ctx) * 1.5f32
+        eval_overworld_86(pos, ctx) * 1.5f32
     }
     #[inline(always)]
-    pub fn eval_overworld_76<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_88<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -741,18 +837,18 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_77<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_89<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_76(pos, ctx) * 2f32
+        eval_overworld_88(pos, ctx) * 2f32
     }
     #[inline(always)]
-    pub fn eval_overworld_78<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_90<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let input_val = eval_overworld_59(pos, ctx);
+        let input_val = eval_overworld_71(pos, ctx);
         let thresholds = &[-0.5f32, 0f32, 0.5f32];
         let mut selected = thresholds.len();
         for (i, &t) in thresholds.iter().enumerate() {
@@ -762,28 +858,28 @@ pub mod overworld_compiled {
             }
         }
         match selected {
-            0usize => eval_overworld_71(pos, ctx),
-            1usize => eval_overworld_73(pos, ctx),
-            2usize => eval_overworld_75(pos, ctx),
-            _ => eval_overworld_77(pos, ctx),
+            0usize => eval_overworld_83(pos, ctx),
+            1usize => eval_overworld_85(pos, ctx),
+            2usize => eval_overworld_87(pos, ctx),
+            _ => eval_overworld_89(pos, ctx),
         }
     }
     #[inline(always)]
-    pub fn eval_overworld_79<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_91<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_78(pos, ctx).abs()
+        eval_overworld_90(pos, ctx).abs()
     }
     #[inline(always)]
-    pub fn eval_overworld_80<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_92<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_69(pos, ctx).max(eval_overworld_79(pos, ctx))
+        eval_overworld_81(pos, ctx).max(eval_overworld_91(pos, ctx))
     }
     #[inline(always)]
-    pub fn eval_overworld_81<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_93<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -795,70 +891,70 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_82<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_94<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_81(pos, ctx) * -0.011500001f32
+        eval_overworld_93(pos, ctx) * -0.011500001f32
     }
     #[inline(always)]
-    pub fn eval_overworld_83<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_95<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_82(pos, ctx) + -0.0765f32
+        eval_overworld_94(pos, ctx) + -0.0765f32
     }
     #[inline(always)]
-    pub fn eval_overworld_84<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_96<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_80(pos, ctx) + eval_overworld_83(pos, ctx)
+        eval_overworld_92(pos, ctx) + eval_overworld_95(pos, ctx)
     }
     #[inline(always)]
-    pub fn eval_overworld_85<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_97<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_84(pos, ctx).clamp(-1f32, 1f32)
+        eval_overworld_96(pos, ctx).clamp(-1f32, 1f32)
     }
     #[inline(always)]
-    pub fn eval_overworld_86<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_98<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_57(pos, ctx) + eval_overworld_85(pos, ctx)
+        eval_overworld_69(pos, ctx) + eval_overworld_97(pos, ctx)
     }
     #[inline(always)]
-    pub fn eval_overworld_87<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_99<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_49(pos, ctx).min(eval_overworld_86(pos, ctx))
+        eval_overworld_61(pos, ctx).min(eval_overworld_98(pos, ctx))
     }
     #[inline(always)]
-    pub fn eval_overworld_88<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_100<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(88usize, WrapperType::CacheOnce, pos, &eval_overworld_87)
+        ctx.sample_wrapper(100usize, WrapperType::CacheOnce, pos, &eval_overworld_99)
     }
     #[inline(always)]
-    pub fn eval_overworld_89<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_101<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_88(pos, ctx) * 5f32
+        eval_overworld_100(pos, ctx) * 5f32
     }
     #[inline(always)]
-    pub fn eval_overworld_90<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_102<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_45(pos, ctx).min(eval_overworld_89(pos, ctx))
+        eval_overworld_57(pos, ctx).min(eval_overworld_101(pos, ctx))
     }
     #[inline(always)]
-    pub fn eval_overworld_91<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_103<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -870,22 +966,22 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_92<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_104<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let v = eval_overworld_91(pos, ctx);
+        let v = eval_overworld_103(pos, ctx);
         v * v
     }
     #[inline(always)]
-    pub fn eval_overworld_93<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_105<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_92(pos, ctx) * 4f32
+        eval_overworld_104(pos, ctx) * 4f32
     }
     #[inline(always)]
-    pub fn eval_overworld_94<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_106<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -897,63 +993,63 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_95<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_107<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_94(pos, ctx) + 0.27f32
+        eval_overworld_106(pos, ctx) + 0.27f32
     }
     #[inline(always)]
-    pub fn eval_overworld_96<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_108<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_95(pos, ctx).clamp(-1f32, 1f32)
+        eval_overworld_107(pos, ctx).clamp(-1f32, 1f32)
     }
     #[inline(always)]
-    pub fn eval_overworld_97<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_109<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_45(pos, ctx) * -0.64f32
+        eval_overworld_57(pos, ctx) * -0.64f32
     }
     #[inline(always)]
-    pub fn eval_overworld_98<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_110<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_97(pos, ctx) + 1.5f32
+        eval_overworld_109(pos, ctx) + 1.5f32
     }
     #[inline(always)]
-    pub fn eval_overworld_99<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_111<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_98(pos, ctx).clamp(0f32, 0.5f32)
+        eval_overworld_110(pos, ctx).clamp(0f32, 0.5f32)
     }
     #[inline(always)]
-    pub fn eval_overworld_100<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_112<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_96(pos, ctx) + eval_overworld_99(pos, ctx)
+        eval_overworld_108(pos, ctx) + eval_overworld_111(pos, ctx)
     }
     #[inline(always)]
-    pub fn eval_overworld_101<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_113<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_93(pos, ctx) + eval_overworld_100(pos, ctx)
+        eval_overworld_105(pos, ctx) + eval_overworld_112(pos, ctx)
     }
     #[inline(always)]
-    pub fn eval_overworld_102<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_114<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_101(pos, ctx).min(eval_overworld_88(pos, ctx))
+        eval_overworld_113(pos, ctx).min(eval_overworld_100(pos, ctx))
     }
     #[inline(always)]
-    pub fn eval_overworld_103<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_115<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -965,7 +1061,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_104<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_116<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -977,14 +1073,14 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_105<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_117<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_104(pos, ctx) * 0.5f32
+        eval_overworld_116(pos, ctx) * 0.5f32
     }
     #[inline(always)]
-    pub fn eval_overworld_106<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_118<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -996,14 +1092,14 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_107<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_119<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_106(pos, ctx) * 0.75f32
+        eval_overworld_118(pos, ctx) * 0.75f32
     }
     #[inline(always)]
-    pub fn eval_overworld_108<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_120<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1015,14 +1111,14 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_109<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_121<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_108(pos, ctx) * 1f32
+        eval_overworld_120(pos, ctx) * 1f32
     }
     #[inline(always)]
-    pub fn eval_overworld_110<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_122<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1034,14 +1130,14 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_111<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_123<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_110(pos, ctx) * 2f32
+        eval_overworld_122(pos, ctx) * 2f32
     }
     #[inline(always)]
-    pub fn eval_overworld_112<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_124<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1053,18 +1149,18 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_113<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_125<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_112(pos, ctx) * 3f32
+        eval_overworld_124(pos, ctx) * 3f32
     }
     #[inline(always)]
-    pub fn eval_overworld_114<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_126<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let input_val = eval_overworld_103(pos, ctx);
+        let input_val = eval_overworld_115(pos, ctx);
         let thresholds = &[-0.75f32, -0.5f32, 0.5f32, 0.75f32];
         let mut selected = thresholds.len();
         for (i, &t) in thresholds.iter().enumerate() {
@@ -1074,109 +1170,12 @@ pub mod overworld_compiled {
             }
         }
         match selected {
-            0usize => eval_overworld_105(pos, ctx),
-            1usize => eval_overworld_107(pos, ctx),
-            2usize => eval_overworld_109(pos, ctx),
-            3usize => eval_overworld_111(pos, ctx),
-            _ => eval_overworld_113(pos, ctx),
+            0usize => eval_overworld_117(pos, ctx),
+            1usize => eval_overworld_119(pos, ctx),
+            2usize => eval_overworld_121(pos, ctx),
+            3usize => eval_overworld_123(pos, ctx),
+            _ => eval_overworld_125(pos, ctx),
         }
-    }
-    #[inline(always)]
-    pub fn eval_overworld_115<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_114(pos, ctx).abs()
-    }
-    #[inline(always)]
-    pub fn eval_overworld_116<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_noise(
-            DoublePerlinNoiseParameters::SPAGHETTI_2D_THICKNESS,
-            pos.x as f32 * 2f32,
-            pos.y as f32 * 1f32,
-            pos.z as f32 * 2f32,
-        )
-    }
-    #[inline(always)]
-    pub fn eval_overworld_117<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_116(pos, ctx) * -0.34999996f32
-    }
-    #[inline(always)]
-    pub fn eval_overworld_118<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_117(pos, ctx) + -0.95f32
-    }
-    #[inline(always)]
-    pub fn eval_overworld_119<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(119usize, WrapperType::CacheOnce, pos, &eval_overworld_118)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_120<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_119(pos, ctx) * 0.083f32
-    }
-    #[inline(always)]
-    pub fn eval_overworld_121<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_115(pos, ctx) + eval_overworld_120(pos, ctx)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_122<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_noise(
-            DoublePerlinNoiseParameters::SPAGHETTI_2D_ELEVATION,
-            pos.x as f32 * 1f32,
-            pos.y as f32 * 0f32,
-            pos.z as f32 * 1f32,
-        )
-    }
-    #[inline(always)]
-    pub fn eval_overworld_123<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_122(pos, ctx) * 8f32
-    }
-    #[inline(always)]
-    pub fn eval_overworld_124<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(124usize, WrapperType::CacheFlat, pos, &eval_overworld_123)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_125<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        let _ = ctx;
-        let coord = pos.y;
-        let rel = coord.clamp(-64i32, 320i32) - -64i32;
-        8f32 + rel as f32 * -0.125f32
-    }
-    #[inline(always)]
-    pub fn eval_overworld_126<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_124(pos, ctx) + eval_overworld_125(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_127<C: NoiseEvaluationContext>(
@@ -1190,43 +1189,47 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_127(pos, ctx) + eval_overworld_119(pos, ctx)
+        ctx.sample_noise(
+            DoublePerlinNoiseParameters::SPAGHETTI_2D_THICKNESS,
+            pos.x as f32 * 2f32,
+            pos.y as f32 * 1f32,
+            pos.z as f32 * 2f32,
+        )
     }
     #[inline(always)]
     pub fn eval_overworld_129<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let v = eval_overworld_128(pos, ctx);
-        v * v * v
+        eval_overworld_128(pos, ctx) * -0.34999996f32
     }
     #[inline(always)]
     pub fn eval_overworld_130<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_121(pos, ctx).max(eval_overworld_129(pos, ctx))
+        eval_overworld_129(pos, ctx) + -0.95f32
     }
     #[inline(always)]
     pub fn eval_overworld_131<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_130(pos, ctx).clamp(-1f32, 1f32)
+        ctx.sample_wrapper(131usize, WrapperType::CacheOnce, pos, &eval_overworld_130)
     }
     #[inline(always)]
     pub fn eval_overworld_132<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_131(pos, ctx) + eval_overworld_57(pos, ctx)
+        eval_overworld_131(pos, ctx) * 0.083f32
     }
     #[inline(always)]
     pub fn eval_overworld_133<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_102(pos, ctx).min(eval_overworld_132(pos, ctx))
+        eval_overworld_127(pos, ctx) + eval_overworld_132(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_134<C: NoiseEvaluationContext>(
@@ -1234,10 +1237,10 @@ pub mod overworld_compiled {
         ctx: &mut C,
     ) -> f32 {
         ctx.sample_noise(
-            DoublePerlinNoiseParameters::PILLAR,
-            pos.x as f32 * 25f32,
-            pos.y as f32 * 0.3f32,
-            pos.z as f32 * 25f32,
+            DoublePerlinNoiseParameters::SPAGHETTI_2D_ELEVATION,
+            pos.x as f32 * 1f32,
+            pos.y as f32 * 0f32,
+            pos.z as f32 * 1f32,
         )
     }
     #[inline(always)]
@@ -1245,66 +1248,61 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_134(pos, ctx) * 2f32
+        eval_overworld_134(pos, ctx) * 8f32
     }
     #[inline(always)]
     pub fn eval_overworld_136<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_noise(
-            DoublePerlinNoiseParameters::PILLAR_RARENESS,
-            pos.x as f32 * 1f32,
-            pos.y as f32 * 1f32,
-            pos.z as f32 * 1f32,
-        )
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_135(&slice_pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_137<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_136(pos, ctx) * -1f32
+        ctx.sample_wrapper(137usize, WrapperType::CacheFlat, pos, &eval_overworld_136)
     }
     #[inline(always)]
     pub fn eval_overworld_138<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_137(pos, ctx) + -1f32
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_137(&slice_pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_139<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_135(pos, ctx) + eval_overworld_138(pos, ctx)
+        let _ = ctx;
+        let coord = pos.y;
+        let rel = coord.clamp(-64i32, 320i32) - -64i32;
+        8f32 + rel as f32 * -0.125f32
     }
     #[inline(always)]
     pub fn eval_overworld_140<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_noise(
-            DoublePerlinNoiseParameters::PILLAR_THICKNESS,
-            pos.x as f32 * 1f32,
-            pos.y as f32 * 1f32,
-            pos.z as f32 * 1f32,
-        )
+        eval_overworld_138(pos, ctx) + eval_overworld_139(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_141<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_140(pos, ctx) * 0.55f32
+        eval_overworld_140(pos, ctx).abs()
     }
     #[inline(always)]
     pub fn eval_overworld_142<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_141(pos, ctx) + 0.55f32
+        eval_overworld_141(pos, ctx) + eval_overworld_131(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_143<C: NoiseEvaluationContext>(
@@ -1319,99 +1317,91 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_139(pos, ctx) * eval_overworld_143(pos, ctx)
+        eval_overworld_133(pos, ctx).max(eval_overworld_143(pos, ctx))
     }
     #[inline(always)]
     pub fn eval_overworld_145<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(145usize, WrapperType::CacheOnce, pos, &eval_overworld_144)
+        eval_overworld_144(pos, ctx).clamp(-1f32, 1f32)
     }
     #[inline(always)]
     pub fn eval_overworld_146<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let _ = (pos, ctx);
-        -1000000f32
+        eval_overworld_145(pos, ctx) + eval_overworld_69(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_147<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_overworld_145(pos, ctx);
-        if val >= -1000000f32 && val < 0.03f32 {
-            eval_overworld_146(pos, ctx)
-        } else {
-            eval_overworld_145(pos, ctx)
-        }
+        eval_overworld_114(pos, ctx).min(eval_overworld_146(pos, ctx))
     }
     #[inline(always)]
     pub fn eval_overworld_148<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_133(pos, ctx).max(eval_overworld_147(pos, ctx))
+        ctx.sample_noise(
+            DoublePerlinNoiseParameters::PILLAR,
+            pos.x as f32 * 25f32,
+            pos.y as f32 * 0.3f32,
+            pos.z as f32 * 25f32,
+        )
     }
     #[inline(always)]
     pub fn eval_overworld_149<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_overworld_45(pos, ctx);
-        if val >= -1000000f32 && val < 1.5625f32 {
-            eval_overworld_90(pos, ctx)
-        } else {
-            eval_overworld_148(pos, ctx)
-        }
+        eval_overworld_148(pos, ctx) * 2f32
     }
     #[inline(always)]
     pub fn eval_overworld_150<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let a = eval_overworld_2(pos, ctx);
-        let f = eval_overworld_3(pos, ctx);
-        let s = eval_overworld_149(pos, ctx);
-        f + a * (s - f)
+        ctx.sample_noise(
+            DoublePerlinNoiseParameters::PILLAR_RARENESS,
+            pos.x as f32 * 1f32,
+            pos.y as f32 * 1f32,
+            pos.z as f32 * 1f32,
+        )
     }
     #[inline(always)]
     pub fn eval_overworld_151<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let a = eval_overworld_0(pos, ctx);
-        let f = eval_overworld_1(pos, ctx);
-        let s = eval_overworld_150(pos, ctx);
-        f + a * (s - f)
+        eval_overworld_150(pos, ctx) * -1f32
     }
     #[inline(always)]
     pub fn eval_overworld_152<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_overworld_151(pos, ctx);
-        ctx.sample_blend_density(val, pos)
+        eval_overworld_151(pos, ctx) + -1f32
     }
     #[inline(always)]
     pub fn eval_overworld_153<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_152(pos, ctx) * 0.64f32
+        eval_overworld_149(pos, ctx) + eval_overworld_152(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_154<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(
-            154usize,
-            WrapperType::Interpolated,
-            pos,
-            &eval_overworld_153,
+        ctx.sample_noise(
+            DoublePerlinNoiseParameters::PILLAR_THICKNESS,
+            pos.x as f32 * 1f32,
+            pos.y as f32 * 1f32,
+            pos.z as f32 * 1f32,
         )
     }
     #[inline(always)]
@@ -1419,11 +1409,133 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let c = eval_overworld_154(pos, ctx).clamp(-1.0, 1.0);
-        c / 2.0 - c * c * c / 24.0
+        eval_overworld_154(pos, ctx) * 0.55f32
     }
     #[inline(always)]
     pub fn eval_overworld_156<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_155(pos, ctx) + 0.55f32
+    }
+    #[inline(always)]
+    pub fn eval_overworld_157<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let v = eval_overworld_156(pos, ctx);
+        v * v * v
+    }
+    #[inline(always)]
+    pub fn eval_overworld_158<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_153(pos, ctx) * eval_overworld_157(pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_159<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(159usize, WrapperType::CacheOnce, pos, &eval_overworld_158)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_160<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let _ = (pos, ctx);
+        -1000000f32
+    }
+    #[inline(always)]
+    pub fn eval_overworld_161<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let val = eval_overworld_159(pos, ctx);
+        if val >= -1000000f32 && val < 0.03f32 {
+            eval_overworld_160(pos, ctx)
+        } else {
+            eval_overworld_159(pos, ctx)
+        }
+    }
+    #[inline(always)]
+    pub fn eval_overworld_162<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_147(pos, ctx).max(eval_overworld_161(pos, ctx))
+    }
+    #[inline(always)]
+    pub fn eval_overworld_163<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let val = eval_overworld_57(pos, ctx);
+        if val >= -1000000f32 && val < 1.5625f32 {
+            eval_overworld_102(pos, ctx)
+        } else {
+            eval_overworld_162(pos, ctx)
+        }
+    }
+    #[inline(always)]
+    pub fn eval_overworld_164<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let a = eval_overworld_2(pos, ctx);
+        let f = eval_overworld_3(pos, ctx);
+        let s = eval_overworld_163(pos, ctx);
+        f + a * (s - f)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_165<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let a = eval_overworld_0(pos, ctx);
+        let f = eval_overworld_1(pos, ctx);
+        let s = eval_overworld_164(pos, ctx);
+        f + a * (s - f)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_166<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let val = eval_overworld_165(pos, ctx);
+        ctx.sample_blend_density(val, pos)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_167<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_166(pos, ctx) * 0.64f32
+    }
+    #[inline(always)]
+    pub fn eval_overworld_168<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(
+            168usize,
+            WrapperType::Interpolated,
+            pos,
+            &eval_overworld_167,
+        )
+    }
+    #[inline(always)]
+    pub fn eval_overworld_169<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let c = eval_overworld_168(pos, ctx).clamp(-1.0, 1.0);
+        c / 2.0 - c * c * c / 24.0
+    }
+    #[inline(always)]
+    pub fn eval_overworld_170<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1433,7 +1545,7 @@ pub mod overworld_compiled {
         -4064f32 + rel as f32 * 1f32
     }
     #[inline(always)]
-    pub fn eval_overworld_157<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_171<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1445,7 +1557,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_158<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_172<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1453,31 +1565,31 @@ pub mod overworld_compiled {
         -1f32
     }
     #[inline(always)]
-    pub fn eval_overworld_159<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_173<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_overworld_156(pos, ctx);
+        let val = eval_overworld_170(pos, ctx);
         if val >= -60f32 && val < 321f32 {
-            eval_overworld_157(pos, ctx)
+            eval_overworld_171(pos, ctx)
         } else {
-            eval_overworld_158(pos, ctx)
+            eval_overworld_172(pos, ctx)
         }
     }
     #[inline(always)]
-    pub fn eval_overworld_160<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_174<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
         ctx.sample_wrapper(
-            160usize,
+            174usize,
             WrapperType::Interpolated,
             pos,
-            &eval_overworld_159,
+            &eval_overworld_173,
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_161<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_175<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1485,7 +1597,7 @@ pub mod overworld_compiled {
         64f32
     }
     #[inline(always)]
-    pub fn eval_overworld_162<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_176<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1497,45 +1609,45 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_163<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_177<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_162(pos, ctx) * -0.025f32
+        eval_overworld_176(pos, ctx) * -0.025f32
     }
     #[inline(always)]
-    pub fn eval_overworld_164<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_178<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_163(pos, ctx) + -0.075f32
+        eval_overworld_177(pos, ctx) + -0.075f32
     }
     #[inline(always)]
-    pub fn eval_overworld_165<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_179<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_overworld_156(pos, ctx);
+        let val = eval_overworld_170(pos, ctx);
         if val >= -60f32 && val < 321f32 {
-            eval_overworld_164(pos, ctx)
+            eval_overworld_178(pos, ctx)
         } else {
-            eval_overworld_9(pos, ctx)
+            eval_overworld_10(pos, ctx)
         }
     }
     #[inline(always)]
-    pub fn eval_overworld_166<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_180<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
         ctx.sample_wrapper(
-            166usize,
+            180usize,
             WrapperType::Interpolated,
             pos,
-            &eval_overworld_165,
+            &eval_overworld_179,
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_167<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_181<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1547,38 +1659,38 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_168<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_182<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_overworld_156(pos, ctx);
+        let val = eval_overworld_170(pos, ctx);
         if val >= -60f32 && val < 321f32 {
-            eval_overworld_167(pos, ctx)
+            eval_overworld_181(pos, ctx)
         } else {
-            eval_overworld_9(pos, ctx)
+            eval_overworld_10(pos, ctx)
         }
     }
     #[inline(always)]
-    pub fn eval_overworld_169<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_183<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
         ctx.sample_wrapper(
-            169usize,
+            183usize,
             WrapperType::Interpolated,
             pos,
-            &eval_overworld_168,
+            &eval_overworld_182,
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_170<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_184<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_169(pos, ctx).abs()
+        eval_overworld_183(pos, ctx).abs()
     }
     #[inline(always)]
-    pub fn eval_overworld_171<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_185<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1590,99 +1702,99 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_172<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_186<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_overworld_156(pos, ctx);
+        let val = eval_overworld_170(pos, ctx);
         if val >= -60f32 && val < 321f32 {
-            eval_overworld_171(pos, ctx)
+            eval_overworld_185(pos, ctx)
         } else {
-            eval_overworld_9(pos, ctx)
+            eval_overworld_10(pos, ctx)
         }
     }
     #[inline(always)]
-    pub fn eval_overworld_173<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_187<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
         ctx.sample_wrapper(
-            173usize,
+            187usize,
             WrapperType::Interpolated,
             pos,
-            &eval_overworld_172,
+            &eval_overworld_186,
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_174<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_188<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_173(pos, ctx).abs()
+        eval_overworld_187(pos, ctx).abs()
     }
     #[inline(always)]
-    pub fn eval_overworld_175<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_189<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_170(pos, ctx).max(eval_overworld_174(pos, ctx))
+        eval_overworld_184(pos, ctx).max(eval_overworld_188(pos, ctx))
     }
     #[inline(always)]
-    pub fn eval_overworld_176<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_190<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_175(pos, ctx) * 1.5f32
+        eval_overworld_189(pos, ctx) * 1.5f32
     }
     #[inline(always)]
-    pub fn eval_overworld_177<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_191<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_166(pos, ctx) + eval_overworld_176(pos, ctx)
+        eval_overworld_180(pos, ctx) + eval_overworld_190(pos, ctx)
     }
     #[inline(always)]
-    pub fn eval_overworld_178<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_192<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_overworld_160(pos, ctx);
+        let val = eval_overworld_174(pos, ctx);
         if val >= -1000000f32 && val < 0f32 {
-            eval_overworld_161(pos, ctx)
+            eval_overworld_175(pos, ctx)
         } else {
-            eval_overworld_177(pos, ctx)
+            eval_overworld_191(pos, ctx)
         }
     }
     #[inline(always)]
-    pub fn eval_overworld_179<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_193<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_155(pos, ctx).min(eval_overworld_178(pos, ctx))
+        eval_overworld_169(pos, ctx).min(eval_overworld_192(pos, ctx))
     }
     #[inline(always)]
-    pub fn eval_overworld_180<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_194<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
         ctx.sample_beardifier(pos)
     }
     #[inline(always)]
-    pub fn eval_overworld_181<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_195<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_179(pos, ctx) + eval_overworld_180(pos, ctx)
+        eval_overworld_193(pos, ctx) + eval_overworld_194(pos, ctx)
     }
     #[inline(always)]
-    pub fn eval_overworld_182<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_196<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(182usize, WrapperType::CellCache, pos, &eval_overworld_181)
+        ctx.sample_wrapper(196usize, WrapperType::CellCache, pos, &eval_overworld_195)
     }
     #[inline(always)]
-    pub fn eval_overworld_183<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_197<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1694,7 +1806,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_184<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_198<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1706,7 +1818,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_185<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_199<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1718,7 +1830,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_186<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_200<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1730,7 +1842,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_187<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_201<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1742,163 +1854,28 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_188<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        let val = eval_overworld_156(pos, ctx);
-        if val >= -64f32 && val < 57f32 {
-            eval_overworld_187(pos, ctx)
-        } else {
-            eval_overworld_9(pos, ctx)
-        }
-    }
-    #[inline(always)]
-    pub fn eval_overworld_189<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(
-            189usize,
-            WrapperType::Interpolated,
-            pos,
-            &eval_overworld_188,
-        )
-    }
-    #[inline(always)]
-    pub fn eval_overworld_190<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(190usize, WrapperType::CacheOnce, pos, &eval_overworld_189)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_191<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        let _ = (pos, ctx);
-        0.08f32
-    }
-    #[inline(always)]
-    pub fn eval_overworld_192<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_noise(
-            DoublePerlinNoiseParameters::ORE_VEIN_A,
-            pos.x as f32 * 4f32,
-            pos.y as f32 * 4f32,
-            pos.z as f32 * 4f32,
-        )
-    }
-    #[inline(always)]
-    pub fn eval_overworld_193<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        let _ = (pos, ctx);
-        1f32
-    }
-    #[inline(always)]
-    pub fn eval_overworld_194<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        let val = eval_overworld_156(pos, ctx);
-        if val >= -64f32 && val < 57f32 {
-            eval_overworld_192(pos, ctx)
-        } else {
-            eval_overworld_193(pos, ctx)
-        }
-    }
-    #[inline(always)]
-    pub fn eval_overworld_195<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(
-            195usize,
-            WrapperType::Interpolated,
-            pos,
-            &eval_overworld_194,
-        )
-    }
-    #[inline(always)]
-    pub fn eval_overworld_196<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_195(pos, ctx).abs()
-    }
-    #[inline(always)]
-    pub fn eval_overworld_197<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_noise(
-            DoublePerlinNoiseParameters::ORE_VEIN_B,
-            pos.x as f32 * 4f32,
-            pos.y as f32 * 4f32,
-            pos.z as f32 * 4f32,
-        )
-    }
-    #[inline(always)]
-    pub fn eval_overworld_198<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        let val = eval_overworld_156(pos, ctx);
-        if val >= -64f32 && val < 57f32 {
-            eval_overworld_197(pos, ctx)
-        } else {
-            eval_overworld_193(pos, ctx)
-        }
-    }
-    #[inline(always)]
-    pub fn eval_overworld_199<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(
-            199usize,
-            WrapperType::Interpolated,
-            pos,
-            &eval_overworld_198,
-        )
-    }
-    #[inline(always)]
-    pub fn eval_overworld_200<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_199(pos, ctx).abs()
-    }
-    #[inline(always)]
-    pub fn eval_overworld_201<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_196(pos, ctx).max(eval_overworld_200(pos, ctx))
-    }
-    #[inline(always)]
     pub fn eval_overworld_202<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_191(pos, ctx) - eval_overworld_201(pos, ctx)
+        let val = eval_overworld_170(pos, ctx);
+        if val >= -64f32 && val < 57f32 {
+            eval_overworld_201(pos, ctx)
+        } else {
+            eval_overworld_10(pos, ctx)
+        }
     }
     #[inline(always)]
     pub fn eval_overworld_203<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_overworld_190(pos, ctx);
-        if val >= -0.4f32 && val < 0.4f32 {
-            eval_overworld_158(pos, ctx)
-        } else {
-            eval_overworld_202(pos, ctx)
-        }
+        ctx.sample_wrapper(
+            203usize,
+            WrapperType::Interpolated,
+            pos,
+            &eval_overworld_202,
+        )
     }
     #[inline(always)]
     pub fn eval_overworld_204<C: NoiseEvaluationContext>(
@@ -1913,10 +1890,145 @@ pub mod overworld_compiled {
         ctx: &mut C,
     ) -> f32 {
         let _ = (pos, ctx);
-        -0.3f32
+        0.08f32
     }
     #[inline(always)]
     pub fn eval_overworld_206<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_noise(
+            DoublePerlinNoiseParameters::ORE_VEIN_A,
+            pos.x as f32 * 4f32,
+            pos.y as f32 * 4f32,
+            pos.z as f32 * 4f32,
+        )
+    }
+    #[inline(always)]
+    pub fn eval_overworld_207<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let _ = (pos, ctx);
+        1f32
+    }
+    #[inline(always)]
+    pub fn eval_overworld_208<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let val = eval_overworld_170(pos, ctx);
+        if val >= -64f32 && val < 57f32 {
+            eval_overworld_206(pos, ctx)
+        } else {
+            eval_overworld_207(pos, ctx)
+        }
+    }
+    #[inline(always)]
+    pub fn eval_overworld_209<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(
+            209usize,
+            WrapperType::Interpolated,
+            pos,
+            &eval_overworld_208,
+        )
+    }
+    #[inline(always)]
+    pub fn eval_overworld_210<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_209(pos, ctx).abs()
+    }
+    #[inline(always)]
+    pub fn eval_overworld_211<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_noise(
+            DoublePerlinNoiseParameters::ORE_VEIN_B,
+            pos.x as f32 * 4f32,
+            pos.y as f32 * 4f32,
+            pos.z as f32 * 4f32,
+        )
+    }
+    #[inline(always)]
+    pub fn eval_overworld_212<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let val = eval_overworld_170(pos, ctx);
+        if val >= -64f32 && val < 57f32 {
+            eval_overworld_211(pos, ctx)
+        } else {
+            eval_overworld_207(pos, ctx)
+        }
+    }
+    #[inline(always)]
+    pub fn eval_overworld_213<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(
+            213usize,
+            WrapperType::Interpolated,
+            pos,
+            &eval_overworld_212,
+        )
+    }
+    #[inline(always)]
+    pub fn eval_overworld_214<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_213(pos, ctx).abs()
+    }
+    #[inline(always)]
+    pub fn eval_overworld_215<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_210(pos, ctx).max(eval_overworld_214(pos, ctx))
+    }
+    #[inline(always)]
+    pub fn eval_overworld_216<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_overworld_205(pos, ctx) - eval_overworld_215(pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_217<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let val = eval_overworld_204(pos, ctx);
+        if val >= -0.4f32 && val < 0.4f32 {
+            eval_overworld_172(pos, ctx)
+        } else {
+            eval_overworld_216(pos, ctx)
+        }
+    }
+    #[inline(always)]
+    pub fn eval_overworld_218<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(218usize, WrapperType::CacheOnce, pos, &eval_overworld_217)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_219<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let _ = (pos, ctx);
+        -0.3f32
+    }
+    #[inline(always)]
+    pub fn eval_overworld_220<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1928,11 +2040,19 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_207<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_221<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_205(pos, ctx) - eval_overworld_206(pos, ctx)
+        eval_overworld_219(pos, ctx) - eval_overworld_220(pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_overworld_222<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_overworld_19(&slice_pos, ctx)
     }
 }
 pub mod nether_compiled {
@@ -2180,95 +2300,111 @@ pub mod end_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(14usize, WrapperType::CacheFlat, pos, &eval_end_13)
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_end_13(&slice_pos, ctx)
     }
     #[inline(always)]
     pub fn eval_end_15<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_interpolated_noise(pos)
+        ctx.sample_wrapper(15usize, WrapperType::CacheFlat, pos, &eval_end_14)
     }
     #[inline(always)]
     pub fn eval_end_16<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_end_14(pos, ctx) + eval_end_15(pos, ctx)
+        let slice_pos = pumpkin_util::math::vector3::Vector3::new(pos.x, 0i32, pos.z);
+        eval_end_15(&slice_pos, ctx)
     }
     #[inline(always)]
     pub fn eval_end_17<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let a = eval_end_2(pos, ctx);
-        let f = eval_end_3(pos, ctx);
-        let s = eval_end_16(pos, ctx);
-        f + a * (s - f)
+        ctx.sample_interpolated_noise(pos)
     }
     #[inline(always)]
     pub fn eval_end_18<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let a = eval_end_0(pos, ctx);
-        let f = eval_end_1(pos, ctx);
-        let s = eval_end_17(pos, ctx);
-        f + a * (s - f)
+        eval_end_16(pos, ctx) + eval_end_17(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_end_19<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_end_18(pos, ctx);
-        ctx.sample_blend_density(val, pos)
+        let a = eval_end_2(pos, ctx);
+        let f = eval_end_3(pos, ctx);
+        let s = eval_end_18(pos, ctx);
+        f + a * (s - f)
     }
     #[inline(always)]
     pub fn eval_end_20<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_end_19(pos, ctx) * 0.64f32
+        let a = eval_end_0(pos, ctx);
+        let f = eval_end_1(pos, ctx);
+        let s = eval_end_19(pos, ctx);
+        f + a * (s - f)
     }
     #[inline(always)]
     pub fn eval_end_21<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(21usize, WrapperType::Interpolated, pos, &eval_end_20)
+        let val = eval_end_20(pos, ctx);
+        ctx.sample_blend_density(val, pos)
     }
     #[inline(always)]
     pub fn eval_end_22<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let c = eval_end_21(pos, ctx).clamp(-1.0, 1.0);
-        c / 2.0 - c * c * c / 24.0
+        eval_end_21(pos, ctx) * 0.64f32
     }
     #[inline(always)]
     pub fn eval_end_23<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_beardifier(pos)
+        ctx.sample_wrapper(23usize, WrapperType::Interpolated, pos, &eval_end_22)
     }
     #[inline(always)]
     pub fn eval_end_24<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_end_22(pos, ctx) + eval_end_23(pos, ctx)
+        let c = eval_end_23(pos, ctx).clamp(-1.0, 1.0);
+        c / 2.0 - c * c * c / 24.0
     }
     #[inline(always)]
     pub fn eval_end_25<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(25usize, WrapperType::CellCache, pos, &eval_end_24)
+        ctx.sample_beardifier(pos)
     }
     #[inline(always)]
     pub fn eval_end_26<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        eval_end_24(pos, ctx) + eval_end_25(pos, ctx)
+    }
+    #[inline(always)]
+    pub fn eval_end_27<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(27usize, WrapperType::CellCache, pos, &eval_end_26)
+    }
+    #[inline(always)]
+    pub fn eval_end_28<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -2667,88 +2803,113 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::ShiftA {
                 noise_id: DoublePerlinNoiseParameters::OFFSET,
             },
-            BaseNoiseFunctionComponent::Wrapper {
+            BaseNoiseFunctionComponent::Slice {
                 input_index: 7usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
+            BaseNoiseFunctionComponent::Wrapper {
+                input_index: 8usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
             BaseNoiseFunctionComponent::ShiftB {
                 noise_id: DoublePerlinNoiseParameters::OFFSET,
             },
-            BaseNoiseFunctionComponent::Wrapper {
-                input_index: 10usize,
-                wrapper: WrapperType::CacheFlat,
-            },
-            BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 8usize,
-                shift_y_index: 9usize,
-                shift_z_index: 11usize,
-                data: &ShiftedNoiseData {
-                    xz_scale: 0.25f32,
-                    y_scale: 0f32,
-                    noise_id: DoublePerlinNoiseParameters::CONTINENTALNESS,
-                },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 11usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 12usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 8usize,
-                shift_y_index: 9usize,
-                shift_z_index: 11usize,
+                shift_x_index: 9usize,
+                shift_y_index: 10usize,
+                shift_z_index: 13usize,
+                data: &ShiftedNoiseData {
+                    xz_scale: 0.25f32,
+                    y_scale: 0f32,
+                    noise_id: DoublePerlinNoiseParameters::CONTINENTALNESS,
+                },
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 14usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
+            BaseNoiseFunctionComponent::Wrapper {
+                input_index: 15usize,
+                wrapper: WrapperType::CacheFlat,
+            },
+            BaseNoiseFunctionComponent::ShiftedNoise {
+                shift_x_index: 9usize,
+                shift_y_index: 10usize,
+                shift_z_index: 13usize,
                 data: &ShiftedNoiseData {
                     xz_scale: 0.25f32,
                     y_scale: 0f32,
                     noise_id: DoublePerlinNoiseParameters::EROSION,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 17usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 14usize,
+                input_index: 18usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 8usize,
-                shift_y_index: 9usize,
-                shift_z_index: 11usize,
+                shift_x_index: 9usize,
+                shift_y_index: 10usize,
+                shift_z_index: 13usize,
                 data: &ShiftedNoiseData {
                     xz_scale: 0.25f32,
                     y_scale: 0f32,
                     noise_id: DoublePerlinNoiseParameters::RIDGE,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 20usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 16usize,
+                input_index: 21usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 17usize,
+                input_index: 22usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 18usize,
+                input_index: 23usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.6666667f32,
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 19usize,
+                input_index: 24usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 20usize,
+                input_index: 25usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.33333334f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 21usize,
+                input_index: 26usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: -3f32,
@@ -2756,7 +2917,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Spline {
                 spline: &SplineRepr::Standard {
-                    location_function_index: 13usize,
+                    location_function_index: 16usize,
                     points: &[
                         SplinePoint {
                             location: -1.1f32,
@@ -2786,12 +2947,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.16f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -2814,7 +2975,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -2837,7 +2998,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -2882,7 +3043,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -2918,7 +3079,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -2954,7 +3115,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -2988,7 +3149,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3026,12 +3187,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.15f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3054,7 +3215,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3077,7 +3238,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3122,7 +3283,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3158,7 +3319,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3194,7 +3355,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3228,7 +3389,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3266,12 +3427,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.1f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3294,7 +3455,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3317,7 +3478,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3362,7 +3523,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3398,7 +3559,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3434,7 +3595,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3468,7 +3629,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3506,12 +3667,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 0.25f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3539,7 +3700,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3565,7 +3726,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3593,7 +3754,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3629,7 +3790,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3667,7 +3828,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3701,7 +3862,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3735,7 +3896,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3745,7 +3906,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 22usize,
+                                                        location_function_index: 27usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -3798,7 +3959,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3808,7 +3969,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 22usize,
+                                                        location_function_index: 27usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -3861,7 +4022,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.58f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3895,7 +4056,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3933,12 +4094,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 1f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3966,7 +4127,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -3992,7 +4153,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -4018,7 +4179,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -4052,7 +4213,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -4086,7 +4247,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -4120,7 +4281,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -4154,7 +4315,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -4164,7 +4325,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 22usize,
+                                                        location_function_index: 27usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -4217,7 +4378,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -4227,7 +4388,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 22usize,
+                                                        location_function_index: 27usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -4280,7 +4441,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.58f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -4314,7 +4475,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -4353,7 +4514,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 23usize,
+                input_index: 28usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.50375f32,
@@ -4362,22 +4523,32 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 5usize,
                 first_index: 6usize,
-                second_index: 24usize,
+                second_index: 29usize,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 30usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 25usize,
+                input_index: 31usize,
                 wrapper: WrapperType::CacheFlat,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 32usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Binary {
                 argument1_index: 4usize,
-                argument2_index: 26usize,
+                argument2_index: 33usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::Spline {
                 spline: &SplineRepr::Standard {
-                    location_function_index: 13usize,
+                    location_function_index: 16usize,
                     points: &[
                         SplinePoint {
                             location: -0.11f32,
@@ -4387,12 +4558,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 0.03f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: 0.19999999f32,
@@ -4407,7 +4578,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: 1f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.01f32,
@@ -4434,7 +4605,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.78f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: 0.19999999f32,
@@ -4449,7 +4620,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: 1f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.01f32,
@@ -4476,7 +4647,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.5775f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: 0.19999999f32,
@@ -4491,7 +4662,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: 1f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.01f32,
@@ -4527,12 +4698,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 0.65f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: 0.19999999f32,
@@ -4542,7 +4713,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: 0.44999996f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.01f32,
@@ -4565,7 +4736,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: 1f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.01f32,
@@ -4592,7 +4763,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.78f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: 0.19999999f32,
@@ -4607,7 +4778,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: 1f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.01f32,
@@ -4634,7 +4805,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.5775f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: 0.19999999f32,
@@ -4649,7 +4820,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: 1f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.01f32,
@@ -4687,11 +4858,16 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 5usize,
-                first_index: 9usize,
-                second_index: 28usize,
+                first_index: 10usize,
+                second_index: 35usize,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 36usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 29usize,
+                input_index: 37usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Noise {
@@ -4702,25 +4878,35 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 31usize,
+                input_index: 39usize,
                 data: &UnaryData {
                     operation: UnaryOperation::HalfNegative,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 30usize,
-                argument2_index: 32usize,
+                argument1_index: 38usize,
+                argument2_index: 40usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Mul,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 41usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 33usize,
+                input_index: 42usize,
                 wrapper: WrapperType::CacheFlat,
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 43usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 27usize,
-                argument2_index: 34usize,
+                argument1_index: 34usize,
+                argument2_index: 44usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
@@ -4728,7 +4914,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::Constant { value: 10f32 },
             BaseNoiseFunctionComponent::Spline {
                 spline: &SplineRepr::Standard {
-                    location_function_index: 13usize,
+                    location_function_index: 16usize,
                     points: &[
                         SplinePoint {
                             location: -0.19f32,
@@ -4738,12 +4924,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.15f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.6f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -4762,7 +4948,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.5f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -4781,7 +4967,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -4800,7 +4986,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.25f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -4819,7 +5005,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -4838,7 +5024,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.03f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -4862,7 +5048,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -4872,7 +5058,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -4899,7 +5085,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -4909,7 +5095,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -4945,12 +5131,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.1f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.6f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -4969,7 +5155,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.5f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -4988,7 +5174,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5007,7 +5193,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.25f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5026,7 +5212,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -5045,7 +5231,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.03f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5069,7 +5255,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -5079,7 +5265,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -5106,7 +5292,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -5116,7 +5302,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -5152,12 +5338,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 0.03f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.6f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5176,7 +5362,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.5f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -5195,7 +5381,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5214,7 +5400,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.25f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5233,7 +5419,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -5252,7 +5438,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.03f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5276,7 +5462,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -5286,7 +5472,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -5313,7 +5499,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -5323,7 +5509,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -5359,12 +5545,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 0.06f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.6f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5383,7 +5569,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.5f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -5402,7 +5588,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5421,7 +5607,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.25f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5440,7 +5626,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -5459,7 +5645,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.03f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -5478,12 +5664,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.05f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: 0.45f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.2f32,
@@ -5515,12 +5701,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: 0.45f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.2f32,
@@ -5552,12 +5738,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.7f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.2f32,
@@ -5589,12 +5775,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.7f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.2f32,
@@ -5637,28 +5823,38 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 5usize,
-                first_index: 36usize,
-                second_index: 37usize,
+                first_index: 46usize,
+                second_index: 47usize,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 48usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 38usize,
+                input_index: 49usize,
                 wrapper: WrapperType::CacheFlat,
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 50usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 35usize,
-                argument2_index: 39usize,
+                argument1_index: 45usize,
+                argument2_index: 51usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Mul,
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 40usize,
+                input_index: 52usize,
                 data: &UnaryData {
                     operation: UnaryOperation::QuarterNegative,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 41usize,
+                input_index: 53usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 4f32,
@@ -5674,14 +5870,14 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 42usize,
-                argument2_index: 43usize,
+                argument1_index: 54usize,
+                argument2_index: 55usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 44usize,
+                input_index: 56usize,
                 wrapper: WrapperType::CacheOnce,
             },
             BaseNoiseFunctionComponent::Noise {
@@ -5692,7 +5888,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 46usize,
+                input_index: 58usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: 0.37f32,
@@ -5709,8 +5905,8 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 47usize,
-                argument2_index: 48usize,
+                argument1_index: 59usize,
+                argument2_index: 60usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
@@ -5723,14 +5919,14 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 50usize,
+                input_index: 62usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: -0.05f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 51usize,
+                input_index: 63usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.05f32,
@@ -5744,27 +5940,27 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 53usize,
+                input_index: 65usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 54usize,
+                input_index: 66usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.4f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 52usize,
-                argument2_index: 55usize,
+                argument1_index: 64usize,
+                argument2_index: 67usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Mul,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 56usize,
+                input_index: 68usize,
                 wrapper: WrapperType::CacheOnce,
             },
             BaseNoiseFunctionComponent::Noise {
@@ -5775,7 +5971,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 58usize,
+                input_index: 70usize,
                 wrapper: WrapperType::CacheOnce,
             },
             BaseNoiseFunctionComponent::Noise {
@@ -5786,7 +5982,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 60usize,
+                input_index: 72usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 0.75f32,
@@ -5800,7 +5996,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 62usize,
+                input_index: 74usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 1f32,
@@ -5814,7 +6010,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 64usize,
+                input_index: 76usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 1.5f32,
@@ -5828,19 +6024,19 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 66usize,
+                input_index: 78usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 2f32,
                 },
             },
             BaseNoiseFunctionComponent::IntervalSelect {
-                input_index: 59usize,
+                input_index: 71usize,
                 thresholds: &[-0.5f32, 0f32, 0.5f32],
-                functions_indices: &[61usize, 63usize, 65usize, 67usize],
+                functions_indices: &[73usize, 75usize, 77usize, 79usize],
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 68usize,
+                input_index: 80usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
@@ -5853,7 +6049,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 70usize,
+                input_index: 82usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 0.75f32,
@@ -5867,7 +6063,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 72usize,
+                input_index: 84usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 1f32,
@@ -5881,7 +6077,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 74usize,
+                input_index: 86usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 1.5f32,
@@ -5895,26 +6091,26 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 76usize,
+                input_index: 88usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 2f32,
                 },
             },
             BaseNoiseFunctionComponent::IntervalSelect {
-                input_index: 59usize,
+                input_index: 71usize,
                 thresholds: &[-0.5f32, 0f32, 0.5f32],
-                functions_indices: &[71usize, 73usize, 75usize, 77usize],
+                functions_indices: &[83usize, 85usize, 87usize, 89usize],
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 78usize,
+                input_index: 90usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 69usize,
-                argument2_index: 79usize,
+                argument1_index: 81usize,
+                argument2_index: 91usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Max,
                 },
@@ -5927,61 +6123,61 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 81usize,
+                input_index: 93usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: -0.011500001f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 82usize,
+                input_index: 94usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.0765f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 80usize,
-                argument2_index: 83usize,
+                argument1_index: 92usize,
+                argument2_index: 95usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::Clamp {
-                input_index: 84usize,
+                input_index: 96usize,
                 data: &ClampData {
                     min_value: -1f32,
                     max_value: 1f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 57usize,
-                argument2_index: 85usize,
+                argument1_index: 69usize,
+                argument2_index: 97usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 49usize,
-                argument2_index: 86usize,
+                argument1_index: 61usize,
+                argument2_index: 98usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Min,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 87usize,
+                input_index: 99usize,
                 wrapper: WrapperType::CacheOnce,
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 88usize,
+                input_index: 100usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 5f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 45usize,
-                argument2_index: 89usize,
+                argument1_index: 57usize,
+                argument2_index: 101usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Min,
                 },
@@ -5994,13 +6190,13 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 91usize,
+                input_index: 103usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Square,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 92usize,
+                input_index: 104usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 4f32,
@@ -6014,57 +6210,57 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 94usize,
+                input_index: 106usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: 0.27f32,
                 },
             },
             BaseNoiseFunctionComponent::Clamp {
-                input_index: 95usize,
+                input_index: 107usize,
                 data: &ClampData {
                     min_value: -1f32,
                     max_value: 1f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 45usize,
+                input_index: 57usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: -0.64f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 97usize,
+                input_index: 109usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: 1.5f32,
                 },
             },
             BaseNoiseFunctionComponent::Clamp {
-                input_index: 98usize,
+                input_index: 110usize,
                 data: &ClampData {
                     min_value: 0f32,
                     max_value: 0.5f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 96usize,
-                argument2_index: 99usize,
+                argument1_index: 108usize,
+                argument2_index: 111usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 93usize,
+                argument1_index: 105usize,
+                argument2_index: 112usize,
+                data: &BinaryData {
+                    operation: BinaryOperation::Add,
+                },
+            },
+            BaseNoiseFunctionComponent::Binary {
+                argument1_index: 113usize,
                 argument2_index: 100usize,
-                data: &BinaryData {
-                    operation: BinaryOperation::Add,
-                },
-            },
-            BaseNoiseFunctionComponent::Binary {
-                argument1_index: 101usize,
-                argument2_index: 88usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Min,
                 },
@@ -6084,7 +6280,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 104usize,
+                input_index: 116usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 0.5f32,
@@ -6098,7 +6294,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 106usize,
+                input_index: 118usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 0.75f32,
@@ -6112,7 +6308,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 108usize,
+                input_index: 120usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 1f32,
@@ -6126,7 +6322,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 110usize,
+                input_index: 122usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 2f32,
@@ -6140,19 +6336,19 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 112usize,
+                input_index: 124usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 3f32,
                 },
             },
             BaseNoiseFunctionComponent::IntervalSelect {
-                input_index: 103usize,
+                input_index: 115usize,
                 thresholds: &[-0.75f32, -0.5f32, 0.5f32, 0.75f32],
-                functions_indices: &[105usize, 107usize, 109usize, 111usize, 113usize],
+                functions_indices: &[117usize, 119usize, 121usize, 123usize, 125usize],
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 114usize,
+                input_index: 126usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
@@ -6165,33 +6361,33 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 116usize,
+                input_index: 128usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: -0.34999996f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 117usize,
+                input_index: 129usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.95f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 118usize,
+                input_index: 130usize,
                 wrapper: WrapperType::CacheOnce,
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 119usize,
+                input_index: 131usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 0.083f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 115usize,
-                argument2_index: 120usize,
+                argument1_index: 127usize,
+                argument2_index: 132usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
@@ -6204,15 +6400,25 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 122usize,
+                input_index: 134usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 8f32,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 135usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 123usize,
+                input_index: 136usize,
                 wrapper: WrapperType::CacheFlat,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 137usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Gradient {
                 data: &GradientData {
@@ -6225,55 +6431,55 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 124usize,
-                argument2_index: 125usize,
+                argument1_index: 138usize,
+                argument2_index: 139usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 126usize,
+                input_index: 140usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 127usize,
-                argument2_index: 119usize,
+                argument1_index: 141usize,
+                argument2_index: 131usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 128usize,
+                input_index: 142usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Cube,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 121usize,
-                argument2_index: 129usize,
+                argument1_index: 133usize,
+                argument2_index: 143usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Max,
                 },
             },
             BaseNoiseFunctionComponent::Clamp {
-                input_index: 130usize,
+                input_index: 144usize,
                 data: &ClampData {
                     min_value: -1f32,
                     max_value: 1f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 131usize,
-                argument2_index: 57usize,
+                argument1_index: 145usize,
+                argument2_index: 69usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 102usize,
-                argument2_index: 132usize,
+                argument1_index: 114usize,
+                argument2_index: 146usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Min,
                 },
@@ -6286,7 +6492,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 134usize,
+                input_index: 148usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 2f32,
@@ -6300,22 +6506,22 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 136usize,
+                input_index: 150usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: -1f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 137usize,
+                input_index: 151usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -1f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 135usize,
-                argument2_index: 138usize,
+                argument1_index: 149usize,
+                argument2_index: 152usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
@@ -6328,57 +6534,57 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 140usize,
+                input_index: 154usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 0.55f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 141usize,
+                input_index: 155usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: 0.55f32,
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 142usize,
+                input_index: 156usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Cube,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 139usize,
-                argument2_index: 143usize,
+                argument1_index: 153usize,
+                argument2_index: 157usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Mul,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 144usize,
+                input_index: 158usize,
                 wrapper: WrapperType::CacheOnce,
             },
             BaseNoiseFunctionComponent::Constant { value: -1000000f32 },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 145usize,
-                when_in_range_index: 146usize,
-                when_out_range_index: 145usize,
+                input_index: 159usize,
+                when_in_range_index: 160usize,
+                when_out_range_index: 159usize,
                 data: &RangeChoiceData {
                     min_inclusive: -1000000f32,
                     max_exclusive: 0.03f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 133usize,
-                argument2_index: 147usize,
+                argument1_index: 147usize,
+                argument2_index: 161usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Max,
                 },
             },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 45usize,
-                when_in_range_index: 90usize,
-                when_out_range_index: 148usize,
+                input_index: 57usize,
+                when_in_range_index: 102usize,
+                when_out_range_index: 162usize,
                 data: &RangeChoiceData {
                     min_inclusive: -1000000f32,
                     max_exclusive: 1.5625f32,
@@ -6387,29 +6593,29 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 2usize,
                 first_index: 3usize,
-                second_index: 149usize,
+                second_index: 163usize,
             },
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 0usize,
                 first_index: 1usize,
-                second_index: 150usize,
+                second_index: 164usize,
             },
             BaseNoiseFunctionComponent::BlendDensity {
-                input_index: 151usize,
+                input_index: 165usize,
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 152usize,
+                input_index: 166usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 0.64f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 153usize,
+                input_index: 167usize,
                 wrapper: WrapperType::Interpolated,
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 154usize,
+                input_index: 168usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Squeeze,
                 },
@@ -6433,16 +6639,16 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Constant { value: -1f32 },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 156usize,
-                when_in_range_index: 157usize,
-                when_out_range_index: 158usize,
+                input_index: 170usize,
+                when_in_range_index: 171usize,
+                when_out_range_index: 172usize,
                 data: &RangeChoiceData {
                     min_inclusive: -60f32,
                     max_exclusive: 321f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 159usize,
+                input_index: 173usize,
                 wrapper: WrapperType::Interpolated,
             },
             BaseNoiseFunctionComponent::Constant { value: 64f32 },
@@ -6454,30 +6660,30 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 162usize,
+                input_index: 176usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: -0.025f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 163usize,
+                input_index: 177usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.075f32,
                 },
             },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 156usize,
-                when_in_range_index: 164usize,
-                when_out_range_index: 9usize,
+                input_index: 170usize,
+                when_in_range_index: 178usize,
+                when_out_range_index: 10usize,
                 data: &RangeChoiceData {
                     min_inclusive: -60f32,
                     max_exclusive: 321f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 165usize,
+                input_index: 179usize,
                 wrapper: WrapperType::Interpolated,
             },
             BaseNoiseFunctionComponent::Noise {
@@ -6488,20 +6694,20 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 156usize,
-                when_in_range_index: 167usize,
-                when_out_range_index: 9usize,
+                input_index: 170usize,
+                when_in_range_index: 181usize,
+                when_out_range_index: 10usize,
                 data: &RangeChoiceData {
                     min_inclusive: -60f32,
                     max_exclusive: 321f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 168usize,
+                input_index: 182usize,
                 wrapper: WrapperType::Interpolated,
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 169usize,
+                input_index: 183usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
@@ -6514,71 +6720,71 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 156usize,
-                when_in_range_index: 171usize,
-                when_out_range_index: 9usize,
+                input_index: 170usize,
+                when_in_range_index: 185usize,
+                when_out_range_index: 10usize,
                 data: &RangeChoiceData {
                     min_inclusive: -60f32,
                     max_exclusive: 321f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 172usize,
+                input_index: 186usize,
                 wrapper: WrapperType::Interpolated,
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 173usize,
+                input_index: 187usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 170usize,
-                argument2_index: 174usize,
+                argument1_index: 184usize,
+                argument2_index: 188usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Max,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 175usize,
+                input_index: 189usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 1.5f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 166usize,
-                argument2_index: 176usize,
+                argument1_index: 180usize,
+                argument2_index: 190usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 160usize,
-                when_in_range_index: 161usize,
-                when_out_range_index: 177usize,
+                input_index: 174usize,
+                when_in_range_index: 175usize,
+                when_out_range_index: 191usize,
                 data: &RangeChoiceData {
                     min_inclusive: -1000000f32,
                     max_exclusive: 0f32,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 155usize,
-                argument2_index: 178usize,
+                argument1_index: 169usize,
+                argument2_index: 192usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Min,
                 },
             },
             BaseNoiseFunctionComponent::Beardifier,
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 179usize,
-                argument2_index: 180usize,
+                argument1_index: 193usize,
+                argument2_index: 194usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 181usize,
+                input_index: 195usize,
                 wrapper: WrapperType::CellCache,
             },
             BaseNoiseFunctionComponent::Noise {
@@ -6617,20 +6823,20 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 156usize,
-                when_in_range_index: 187usize,
-                when_out_range_index: 9usize,
+                input_index: 170usize,
+                when_in_range_index: 201usize,
+                when_out_range_index: 10usize,
                 data: &RangeChoiceData {
                     min_inclusive: -64f32,
                     max_exclusive: 57f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 188usize,
+                input_index: 202usize,
                 wrapper: WrapperType::Interpolated,
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 189usize,
+                input_index: 203usize,
                 wrapper: WrapperType::CacheOnce,
             },
             BaseNoiseFunctionComponent::Constant { value: 0.08f32 },
@@ -6643,20 +6849,20 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Constant { value: 1f32 },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 156usize,
-                when_in_range_index: 192usize,
-                when_out_range_index: 193usize,
+                input_index: 170usize,
+                when_in_range_index: 206usize,
+                when_out_range_index: 207usize,
                 data: &RangeChoiceData {
                     min_inclusive: -64f32,
                     max_exclusive: 57f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 194usize,
+                input_index: 208usize,
                 wrapper: WrapperType::Interpolated,
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 195usize,
+                input_index: 209usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
@@ -6669,49 +6875,49 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 156usize,
-                when_in_range_index: 197usize,
-                when_out_range_index: 193usize,
+                input_index: 170usize,
+                when_in_range_index: 211usize,
+                when_out_range_index: 207usize,
                 data: &RangeChoiceData {
                     min_inclusive: -64f32,
                     max_exclusive: 57f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 198usize,
+                input_index: 212usize,
                 wrapper: WrapperType::Interpolated,
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 199usize,
+                input_index: 213usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 196usize,
-                argument2_index: 200usize,
+                argument1_index: 210usize,
+                argument2_index: 214usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Max,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 191usize,
-                argument2_index: 201usize,
+                argument1_index: 205usize,
+                argument2_index: 215usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Sub,
                 },
             },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 190usize,
-                when_in_range_index: 158usize,
-                when_out_range_index: 202usize,
+                input_index: 204usize,
+                when_in_range_index: 172usize,
+                when_out_range_index: 216usize,
                 data: &RangeChoiceData {
                     min_inclusive: -0.4f32,
                     max_exclusive: 0.4f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 203usize,
+                input_index: 217usize,
                 wrapper: WrapperType::CacheOnce,
             },
             BaseNoiseFunctionComponent::Constant { value: -0.3f32 },
@@ -6723,23 +6929,28 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 205usize,
-                argument2_index: 206usize,
+                argument1_index: 219usize,
+                argument2_index: 220usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Sub,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 19usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
         ],
-        barrier_noise: 183usize,
-        fluid_level_floodedness_noise: 184usize,
-        fluid_level_spread_noise: 185usize,
-        lava_noise: 186usize,
-        erosion: 15usize,
-        depth: 27usize,
-        final_density: 182usize,
-        vein_toggle: 190usize,
-        vein_ridged: 204usize,
-        vein_gap: 207usize,
+        barrier_noise: 197usize,
+        fluid_level_floodedness_noise: 198usize,
+        fluid_level_spread_noise: 199usize,
+        lava_noise: 200usize,
+        erosion: 222usize,
+        depth: 34usize,
+        final_density: 196usize,
+        vein_toggle: 204usize,
+        vein_ridged: 218usize,
+        vein_gap: 221usize,
     },
     surface_estimator: BaseSurfaceEstimator {
         full_component_stack: &[
@@ -6784,88 +6995,113 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::ShiftA {
                 noise_id: DoublePerlinNoiseParameters::OFFSET,
             },
-            BaseNoiseFunctionComponent::Wrapper {
+            BaseNoiseFunctionComponent::Slice {
                 input_index: 7usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
+            BaseNoiseFunctionComponent::Wrapper {
+                input_index: 8usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
             BaseNoiseFunctionComponent::ShiftB {
                 noise_id: DoublePerlinNoiseParameters::OFFSET,
             },
-            BaseNoiseFunctionComponent::Wrapper {
-                input_index: 10usize,
-                wrapper: WrapperType::CacheFlat,
-            },
-            BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 8usize,
-                shift_y_index: 9usize,
-                shift_z_index: 11usize,
-                data: &ShiftedNoiseData {
-                    xz_scale: 0.25f32,
-                    y_scale: 0f32,
-                    noise_id: DoublePerlinNoiseParameters::CONTINENTALNESS,
-                },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 11usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 12usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 8usize,
-                shift_y_index: 9usize,
-                shift_z_index: 11usize,
+                shift_x_index: 9usize,
+                shift_y_index: 10usize,
+                shift_z_index: 13usize,
+                data: &ShiftedNoiseData {
+                    xz_scale: 0.25f32,
+                    y_scale: 0f32,
+                    noise_id: DoublePerlinNoiseParameters::CONTINENTALNESS,
+                },
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 14usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
+            BaseNoiseFunctionComponent::Wrapper {
+                input_index: 15usize,
+                wrapper: WrapperType::CacheFlat,
+            },
+            BaseNoiseFunctionComponent::ShiftedNoise {
+                shift_x_index: 9usize,
+                shift_y_index: 10usize,
+                shift_z_index: 13usize,
                 data: &ShiftedNoiseData {
                     xz_scale: 0.25f32,
                     y_scale: 0f32,
                     noise_id: DoublePerlinNoiseParameters::EROSION,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 17usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 14usize,
+                input_index: 18usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 8usize,
-                shift_y_index: 9usize,
-                shift_z_index: 11usize,
+                shift_x_index: 9usize,
+                shift_y_index: 10usize,
+                shift_z_index: 13usize,
                 data: &ShiftedNoiseData {
                     xz_scale: 0.25f32,
                     y_scale: 0f32,
                     noise_id: DoublePerlinNoiseParameters::RIDGE,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 20usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 16usize,
+                input_index: 21usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 17usize,
+                input_index: 22usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 18usize,
+                input_index: 23usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.6666667f32,
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 19usize,
+                input_index: 24usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 20usize,
+                input_index: 25usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.33333334f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 21usize,
+                input_index: 26usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: -3f32,
@@ -6873,7 +7109,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Spline {
                 spline: &SplineRepr::Standard {
-                    location_function_index: 13usize,
+                    location_function_index: 16usize,
                     points: &[
                         SplinePoint {
                             location: -1.1f32,
@@ -6903,12 +7139,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.16f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -6931,7 +7167,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -6954,7 +7190,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -6999,7 +7235,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7035,7 +7271,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7071,7 +7307,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7105,7 +7341,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7143,12 +7379,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.15f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7171,7 +7407,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7194,7 +7430,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7239,7 +7475,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7275,7 +7511,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7311,7 +7547,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7345,7 +7581,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7383,12 +7619,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.1f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7411,7 +7647,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7434,7 +7670,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7479,7 +7715,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7515,7 +7751,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7551,7 +7787,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7585,7 +7821,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7623,12 +7859,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 0.25f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7656,7 +7892,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7682,7 +7918,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7710,7 +7946,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7746,7 +7982,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7784,7 +8020,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7818,7 +8054,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7852,7 +8088,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7862,7 +8098,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 22usize,
+                                                        location_function_index: 27usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -7915,7 +8151,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -7925,7 +8161,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 22usize,
+                                                        location_function_index: 27usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -7978,7 +8214,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.58f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8012,7 +8248,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8050,12 +8286,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 1f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8083,7 +8319,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8109,7 +8345,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8135,7 +8371,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8169,7 +8405,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8203,7 +8439,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8237,7 +8473,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8271,7 +8507,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8281,7 +8517,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 22usize,
+                                                        location_function_index: 27usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -8334,7 +8570,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8344,7 +8580,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 22usize,
+                                                        location_function_index: 27usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -8397,7 +8633,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.58f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8431,7 +8667,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -8470,7 +8706,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 23usize,
+                input_index: 28usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.50375f32,
@@ -8479,15 +8715,25 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 5usize,
                 first_index: 6usize,
-                second_index: 24usize,
+                second_index: 29usize,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 30usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 25usize,
+                input_index: 31usize,
                 wrapper: WrapperType::CacheFlat,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 32usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Binary {
                 argument1_index: 4usize,
-                argument2_index: 26usize,
+                argument2_index: 33usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
@@ -8495,7 +8741,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::Constant { value: 10f32 },
             BaseNoiseFunctionComponent::Spline {
                 spline: &SplineRepr::Standard {
-                    location_function_index: 13usize,
+                    location_function_index: 16usize,
                     points: &[
                         SplinePoint {
                             location: -0.19f32,
@@ -8505,12 +8751,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.15f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.6f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -8529,7 +8775,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.5f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -8548,7 +8794,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -8567,7 +8813,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.25f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -8586,7 +8832,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -8605,7 +8851,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.03f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -8629,7 +8875,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -8639,7 +8885,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -8666,7 +8912,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -8676,7 +8922,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -8712,12 +8958,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.1f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.6f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -8736,7 +8982,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.5f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -8755,7 +9001,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -8774,7 +9020,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.25f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -8793,7 +9039,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -8812,7 +9058,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.03f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -8836,7 +9082,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -8846,7 +9092,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -8873,7 +9119,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -8883,7 +9129,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -8919,12 +9165,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 0.03f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.6f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -8943,7 +9189,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.5f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -8962,7 +9208,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -8981,7 +9227,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.25f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -9000,7 +9246,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -9019,7 +9265,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.03f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -9043,7 +9289,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -9053,7 +9299,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -9080,7 +9326,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.9f32,
@@ -9090,7 +9336,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.69f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: 0f32,
@@ -9126,12 +9372,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 0.06f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 15usize,
+                                location_function_index: 19usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.6f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -9150,7 +9396,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.5f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -9169,7 +9415,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -9188,7 +9434,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.25f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -9207,7 +9453,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.05f32,
@@ -9226,7 +9472,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.03f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 17usize,
+                                            location_function_index: 22usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.2f32,
@@ -9245,12 +9491,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.05f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: 0.45f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.2f32,
@@ -9282,12 +9528,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: 0.45f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.2f32,
@@ -9319,12 +9565,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.7f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.2f32,
@@ -9356,12 +9602,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 22usize,
+                                            location_function_index: 27usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -0.7f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 17usize,
+                                                        location_function_index: 22usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -0.2f32,
@@ -9404,42 +9650,52 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 5usize,
-                first_index: 28usize,
-                second_index: 29usize,
+                first_index: 35usize,
+                second_index: 36usize,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 37usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 30usize,
+                input_index: 38usize,
                 wrapper: WrapperType::CacheFlat,
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 39usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 27usize,
-                argument2_index: 31usize,
+                argument1_index: 34usize,
+                argument2_index: 40usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Mul,
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 32usize,
+                input_index: 41usize,
                 data: &UnaryData {
                     operation: UnaryOperation::QuarterNegative,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 33usize,
+                input_index: 42usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 4f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 34usize,
+                input_index: 43usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.703125f32,
                 },
             },
             BaseNoiseFunctionComponent::Clamp {
-                input_index: 35usize,
+                input_index: 44usize,
                 data: &ClampData {
                     min_value: -64f32,
                     max_value: 64f32,
@@ -9448,15 +9704,15 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 2usize,
                 first_index: 3usize,
-                second_index: 36usize,
+                second_index: 45usize,
             },
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 0usize,
                 first_index: 1usize,
-                second_index: 37usize,
+                second_index: 46usize,
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 38usize,
+                input_index: 47usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.390625f32,
@@ -9466,51 +9722,56 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 value: 0.2734375f32,
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 40usize,
-                argument2_index: 31usize,
+                argument1_index: 49usize,
+                argument2_index: 39usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Div,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 41usize,
-                argument2_index: 26usize,
+                argument1_index: 50usize,
+                argument2_index: 32usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Sub,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 42usize,
+                input_index: 51usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: -128f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 43usize,
+                input_index: 52usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: 128f32,
                 },
             },
             BaseNoiseFunctionComponent::Clamp {
-                input_index: 44usize,
+                input_index: 53usize,
                 data: &ClampData {
                     min_value: -40f32,
                     max_value: 320f32,
                 },
             },
             BaseNoiseFunctionComponent::FindTopSurface {
-                density_index: 39usize,
-                upper_bound_index: 45usize,
+                density_index: 48usize,
+                upper_bound_index: 54usize,
                 data: &FindTopSurfaceData {
                     lower_bound: -64i32,
                     cell_height: 8i32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 46usize,
+                input_index: 55usize,
                 wrapper: WrapperType::Interpolated,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 56usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
         ],
     },
@@ -9519,79 +9780,129 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::ShiftA {
                 noise_id: DoublePerlinNoiseParameters::OFFSET,
             },
-            BaseNoiseFunctionComponent::Wrapper {
+            BaseNoiseFunctionComponent::Slice {
                 input_index: 0usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
+            BaseNoiseFunctionComponent::Wrapper {
+                input_index: 1usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
             BaseNoiseFunctionComponent::ShiftB {
                 noise_id: DoublePerlinNoiseParameters::OFFSET,
             },
-            BaseNoiseFunctionComponent::Wrapper {
-                input_index: 3usize,
-                wrapper: WrapperType::CacheFlat,
-            },
-            BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 1usize,
-                shift_y_index: 2usize,
-                shift_z_index: 4usize,
-                data: &ShiftedNoiseData {
-                    xz_scale: 0.25f32,
-                    y_scale: 0f32,
-                    noise_id: DoublePerlinNoiseParameters::RIDGE,
-                },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 4usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 5usize,
                 wrapper: WrapperType::CacheFlat,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 1usize,
-                shift_y_index: 2usize,
-                shift_z_index: 4usize,
+                shift_x_index: 2usize,
+                shift_y_index: 3usize,
+                shift_z_index: 6usize,
+                data: &ShiftedNoiseData {
+                    xz_scale: 0.25f32,
+                    y_scale: 0f32,
+                    noise_id: DoublePerlinNoiseParameters::RIDGE,
+                },
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 7usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
+            BaseNoiseFunctionComponent::Wrapper {
+                input_index: 8usize,
+                wrapper: WrapperType::CacheFlat,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 9usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
+            BaseNoiseFunctionComponent::ShiftedNoise {
+                shift_x_index: 2usize,
+                shift_y_index: 3usize,
+                shift_z_index: 6usize,
                 data: &ShiftedNoiseData {
                     xz_scale: 0.25f32,
                     y_scale: 0f32,
                     noise_id: DoublePerlinNoiseParameters::TEMPERATURE,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 11usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 1usize,
-                shift_y_index: 2usize,
-                shift_z_index: 4usize,
+                shift_x_index: 2usize,
+                shift_y_index: 3usize,
+                shift_z_index: 6usize,
                 data: &ShiftedNoiseData {
                     xz_scale: 0.25f32,
                     y_scale: 0f32,
                     noise_id: DoublePerlinNoiseParameters::VEGETATION,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 13usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 1usize,
-                shift_y_index: 2usize,
-                shift_z_index: 4usize,
+                shift_x_index: 2usize,
+                shift_y_index: 3usize,
+                shift_z_index: 6usize,
                 data: &ShiftedNoiseData {
                     xz_scale: 0.25f32,
                     y_scale: 0f32,
                     noise_id: DoublePerlinNoiseParameters::CONTINENTALNESS,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 15usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 9usize,
+                input_index: 16usize,
                 wrapper: WrapperType::CacheFlat,
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 17usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::ShiftedNoise {
-                shift_x_index: 1usize,
-                shift_y_index: 2usize,
-                shift_z_index: 4usize,
+                shift_x_index: 2usize,
+                shift_y_index: 3usize,
+                shift_z_index: 6usize,
                 data: &ShiftedNoiseData {
                     xz_scale: 0.25f32,
                     y_scale: 0f32,
                     noise_id: DoublePerlinNoiseParameters::EROSION,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 19usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 11usize,
+                input_index: 20usize,
                 wrapper: WrapperType::CacheFlat,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 21usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Gradient {
                 data: &GradientData {
@@ -9606,33 +9917,33 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::BlendAlpha,
             BaseNoiseFunctionComponent::BlendOffset,
             BaseNoiseFunctionComponent::Unary {
-                input_index: 6usize,
+                input_index: 9usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 16usize,
+                input_index: 26usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.6666667f32,
                 },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 17usize,
+                input_index: 27usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 18usize,
+                input_index: 28usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.33333334f32,
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 19usize,
+                input_index: 29usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: -3f32,
@@ -9640,7 +9951,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Spline {
                 spline: &SplineRepr::Standard {
-                    location_function_index: 10usize,
+                    location_function_index: 17usize,
                     points: &[
                         SplinePoint {
                             location: -1.1f32,
@@ -9670,12 +9981,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.16f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 12usize,
+                                location_function_index: 21usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -9698,7 +10009,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -9721,7 +10032,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -9766,7 +10077,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -9802,7 +10113,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -9838,7 +10149,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -9872,7 +10183,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -9910,12 +10221,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.15f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 12usize,
+                                location_function_index: 21usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -9938,7 +10249,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -9961,7 +10272,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10006,7 +10317,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10042,7 +10353,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10078,7 +10389,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10112,7 +10423,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10150,12 +10461,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: -0.1f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 12usize,
+                                location_function_index: 21usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10178,7 +10489,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10201,7 +10512,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10246,7 +10557,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10282,7 +10593,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10318,7 +10629,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10352,7 +10663,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10390,12 +10701,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 0.25f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 12usize,
+                                location_function_index: 21usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10423,7 +10734,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10449,7 +10760,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10477,7 +10788,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10513,7 +10824,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10551,7 +10862,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10585,7 +10896,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10619,7 +10930,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10629,7 +10940,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 20usize,
+                                                        location_function_index: 30usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -10682,7 +10993,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10692,7 +11003,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 20usize,
+                                                        location_function_index: 30usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -10745,7 +11056,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.58f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10779,7 +11090,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10817,12 +11128,12 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                         SplinePoint {
                             location: 1f32,
                             value: &SplineRepr::Standard {
-                                location_function_index: 12usize,
+                                location_function_index: 21usize,
                                 points: &[
                                     SplinePoint {
                                         location: -0.85f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10850,7 +11161,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10876,7 +11187,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10902,7 +11213,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.35f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10936,7 +11247,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: -0.1f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -10970,7 +11281,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.2f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -11004,7 +11315,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.4f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -11038,7 +11349,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.45f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -11048,7 +11359,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 20usize,
+                                                        location_function_index: 30usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -11101,7 +11412,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.55f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -11111,7 +11422,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                                 SplinePoint {
                                                     location: -0.4f32,
                                                     value: &SplineRepr::Standard {
-                                                        location_function_index: 20usize,
+                                                        location_function_index: 30usize,
                                                         points: &[
                                                             SplinePoint {
                                                                 location: -1f32,
@@ -11164,7 +11475,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.58f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -11198,7 +11509,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                                     SplinePoint {
                                         location: 0.7f32,
                                         value: &SplineRepr::Standard {
-                                            location_function_index: 20usize,
+                                            location_function_index: 30usize,
                                             points: &[
                                                 SplinePoint {
                                                     location: -1f32,
@@ -11237,35 +11548,45 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 21usize,
+                input_index: 31usize,
                 data: &LinearData {
                     operation: LinearOperation::Add,
                     argument: -0.50375f32,
                 },
             },
             BaseNoiseFunctionComponent::Lerp {
-                alpha_index: 14usize,
-                first_index: 15usize,
-                second_index: 22usize,
+                alpha_index: 24usize,
+                first_index: 25usize,
+                second_index: 32usize,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 33usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 23usize,
+                input_index: 34usize,
                 wrapper: WrapperType::CacheFlat,
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 35usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 13usize,
-                argument2_index: 24usize,
+                argument1_index: 23usize,
+                argument2_index: 36usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
         ],
-        temperature: 7usize,
-        vegetation: 8usize,
-        continents: 10usize,
-        erosion: 12usize,
-        depth: 25usize,
-        ridges: 6usize,
+        temperature: 12usize,
+        vegetation: 14usize,
+        continents: 18usize,
+        erosion: 22usize,
+        depth: 37usize,
+        ridges: 10usize,
     },
 };
 pub const NETHER_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
@@ -11370,6 +11691,11 @@ pub const NETHER_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                     y_scale: 0f32,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 1usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
             BaseNoiseFunctionComponent::Noise {
                 data: &NoiseData {
                     noise_id: DoublePerlinNoiseParameters::NETHER_VEGETATION,
@@ -11377,9 +11703,14 @@ pub const NETHER_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                     y_scale: 0f32,
                 },
             },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 3usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
         ],
-        temperature: 1usize,
-        vegetation: 2usize,
+        temperature: 2usize,
+        vegetation: 4usize,
         continents: 0usize,
         erosion: 0usize,
         depth: 0usize,
@@ -11462,9 +11793,19 @@ pub const END_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                     operation: BinaryOperation::Max,
                 },
             },
-            BaseNoiseFunctionComponent::Wrapper {
+            BaseNoiseFunctionComponent::Slice {
                 input_index: 13usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
+            BaseNoiseFunctionComponent::Wrapper {
+                input_index: 14usize,
                 wrapper: WrapperType::CacheFlat,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 15usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
             BaseNoiseFunctionComponent::InterpolatedNoiseSampler {
                 data: &InterpolatedNoiseSamplerData {
@@ -11476,8 +11817,8 @@ pub const END_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 14usize,
-                argument2_index: 15usize,
+                argument1_index: 16usize,
+                argument2_index: 17usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
@@ -11485,57 +11826,57 @@ pub const END_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 2usize,
                 first_index: 3usize,
-                second_index: 16usize,
+                second_index: 18usize,
             },
             BaseNoiseFunctionComponent::Lerp {
                 alpha_index: 0usize,
                 first_index: 1usize,
-                second_index: 17usize,
+                second_index: 19usize,
             },
             BaseNoiseFunctionComponent::BlendDensity {
-                input_index: 18usize,
+                input_index: 20usize,
             },
             BaseNoiseFunctionComponent::Linear {
-                input_index: 19usize,
+                input_index: 21usize,
                 data: &LinearData {
                     operation: LinearOperation::Mul,
                     argument: 0.64f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 20usize,
+                input_index: 22usize,
                 wrapper: WrapperType::Interpolated,
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 21usize,
+                input_index: 23usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Squeeze,
                 },
             },
             BaseNoiseFunctionComponent::Beardifier,
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 22usize,
-                argument2_index: 23usize,
+                argument1_index: 24usize,
+                argument2_index: 25usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Add,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 24usize,
+                input_index: 26usize,
                 wrapper: WrapperType::CellCache,
             },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
         ],
-        barrier_noise: 26usize,
-        fluid_level_floodedness_noise: 26usize,
-        fluid_level_spread_noise: 26usize,
-        lava_noise: 26usize,
-        erosion: 14usize,
-        depth: 26usize,
-        final_density: 25usize,
-        vein_toggle: 26usize,
-        vein_ridged: 26usize,
-        vein_gap: 26usize,
+        barrier_noise: 28usize,
+        fluid_level_floodedness_noise: 28usize,
+        fluid_level_spread_noise: 28usize,
+        lava_noise: 28usize,
+        erosion: 16usize,
+        depth: 28usize,
+        final_density: 27usize,
+        vein_toggle: 28usize,
+        vein_ridged: 28usize,
+        vein_gap: 28usize,
     },
     surface_estimator: BaseSurfaceEstimator {
         full_component_stack: &[BaseNoiseFunctionComponent::Constant { value: 0f32 }],
@@ -11592,15 +11933,25 @@ pub const END_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                     operation: BinaryOperation::Max,
                 },
             },
-            BaseNoiseFunctionComponent::Wrapper {
+            BaseNoiseFunctionComponent::Slice {
                 input_index: 10usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
+            },
+            BaseNoiseFunctionComponent::Wrapper {
+                input_index: 11usize,
                 wrapper: WrapperType::CacheFlat,
+            },
+            BaseNoiseFunctionComponent::Slice {
+                input_index: 12usize,
+                axis: Axis::Y,
+                coordinate: 0i32,
             },
         ],
         temperature: 0usize,
         vegetation: 0usize,
         continents: 0usize,
-        erosion: 11usize,
+        erosion: 13usize,
         depth: 0usize,
         ridges: 0usize,
     },

--- a/crates/pumpkin-world/src/generation/noise/router/chunk_density_function.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/chunk_density_function.rs
@@ -4,6 +4,7 @@ use std::mem;
 use super::{
     chunk_noise_router::{ChunkNoiseFunctionComponent, MutableChunkNoiseFunctionComponentImpl},
     density_function::{IndexToNoisePos, NoiseFunctionComponentRange},
+    density_volume::DensityVolume,
 };
 use pumpkin_util::math::{lerp, lerp2, lerp3, vector3::Vector3};
 
@@ -827,6 +828,26 @@ impl MutableChunkNoiseFunctionComponentImpl for ChunkSpecificNoiseFunctionCompon
             Self::CacheOnce(c) => c.fill(component_stack, array, mapper, sample_options),
             Self::CellCache(c) => c.fill(component_stack, array, mapper, sample_options),
             Self::Beardifier(b) => b.fill(component_stack, array, mapper, sample_options),
+        }
+    }
+
+    #[inline]
+    fn sample_volume(
+        &mut self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+        sample_options: &ChunkNoiseFunctionSampleOptions,
+    ) {
+        match self {
+            Self::DensityInterpolator(d) => {
+                d.sample_volume(component_stack, buffer, volume, sample_options);
+            }
+            Self::FlatCache(f) => f.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Cache2D(c) => c.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::CacheOnce(c) => c.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::CellCache(c) => c.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Beardifier(b) => b.sample_volume(component_stack, buffer, volume, sample_options),
         }
     }
 }

--- a/crates/pumpkin-world/src/generation/noise/router/chunk_noise_router.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/chunk_noise_router.rs
@@ -13,6 +13,7 @@ use super::{
         IndexToNoisePos, NoiseFunctionComponentRange, PassThrough,
         StaticIndependentChunkNoiseFunctionComponentImpl,
     },
+    density_volume::DensityVolume,
     proto_noise_router::{
         DependentProtoNoiseFunctionComponent, IndependentProtoNoiseFunctionComponent,
         ProtoNoiseFunctionComponent, ProtoNoiseRouter,
@@ -26,6 +27,18 @@ pub trait StaticChunkNoiseFunctionComponentImpl {
         pos: &Vector3<i32>,
         sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32;
+
+    fn sample_volume(
+        &self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+        sample_options: &ChunkNoiseFunctionSampleOptions,
+    ) {
+        volume.fill_with(buffer, |pos| {
+            self.sample(component_stack, pos, sample_options)
+        });
+    }
 
     fn fill(
         &self,
@@ -48,6 +61,18 @@ pub trait MutableChunkNoiseFunctionComponentImpl {
         pos: &Vector3<i32>,
         sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32;
+
+    fn sample_volume(
+        &mut self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+        sample_options: &ChunkNoiseFunctionSampleOptions,
+    ) {
+        volume.fill_with(buffer, |pos| {
+            self.sample(component_stack, pos, sample_options)
+        });
+    }
 
     fn fill(
         &mut self,
@@ -134,6 +159,33 @@ impl MutableChunkNoiseFunctionComponentImpl for ChunkNoiseFunctionComponent<'_> 
             ),
         }
     }
+
+    #[inline]
+    fn sample_volume(
+        &mut self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+        sample_options: &ChunkNoiseFunctionSampleOptions,
+    ) {
+        match self {
+            Self::Independent(independent) => independent.sample_volume(buffer, volume),
+            Self::Dependent(dependent) => {
+                dependent.sample_volume(component_stack, buffer, volume, sample_options);
+            }
+            Self::Chunk(chunk) => {
+                chunk.sample_volume(component_stack, buffer, volume, sample_options);
+            }
+            Self::PassThrough(pass_through) => {
+                ChunkNoiseFunctionComponent::sample_volume_from_stack(
+                    &mut component_stack[..=pass_through.input_index()],
+                    buffer,
+                    volume,
+                    sample_options,
+                );
+            }
+        }
+    }
 }
 
 impl ChunkNoiseFunctionComponent<'_> {
@@ -166,6 +218,17 @@ impl ChunkNoiseFunctionComponent<'_> {
             top_component.fill(component_stack, array, mapper, sample_options);
         }
     }
+
+    pub fn sample_volume_from_stack(
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+        sample_options: &ChunkNoiseFunctionSampleOptions,
+    ) {
+        if let Some((top_component, component_stack)) = component_stack.split_last_mut() {
+            top_component.sample_volume(component_stack, buffer, volume, sample_options);
+        }
+    }
 }
 
 pub struct ChunkNoiseDensityFunction<'a> {
@@ -196,10 +259,25 @@ impl ChunkNoiseDensityFunction<'_> {
             sample_options,
         );
     }
+
+    #[inline]
+    pub fn sample_volume(
+        &mut self,
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+        sample_options: &ChunkNoiseFunctionSampleOptions,
+    ) {
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            self.component_stack,
+            buffer,
+            volume,
+            sample_options,
+        );
+    }
 }
 
 macro_rules! sample_function {
-    ($name:ident) => {
+    ($name:ident, $volume_name:ident) => {
         #[inline]
         pub fn $name(
             &mut self,
@@ -211,6 +289,21 @@ macro_rules! sample_function {
                 pos,
                 sample_options,
             )
+        }
+
+        #[inline]
+        pub fn $volume_name(
+            &mut self,
+            buffer: &mut [f32],
+            volume: &DensityVolume,
+            sample_options: &ChunkNoiseFunctionSampleOptions,
+        ) {
+            ChunkNoiseFunctionComponent::sample_volume_from_stack(
+                &mut self.component_stack[..=self.$name],
+                buffer,
+                volume,
+                sample_options,
+            );
         }
     };
 }
@@ -232,16 +325,19 @@ pub struct ChunkNoiseRouter<'a> {
 }
 
 impl ChunkNoiseRouter<'_> {
-    sample_function!(barrier_noise);
-    sample_function!(fluid_level_floodedness_noise);
-    sample_function!(fluid_level_spread_noise);
-    sample_function!(lava_noise);
-    sample_function!(erosion);
-    sample_function!(depth);
-    sample_function!(final_density);
-    sample_function!(vein_toggle);
-    sample_function!(vein_ridged);
-    sample_function!(vein_gap);
+    sample_function!(barrier_noise, barrier_noise_volume);
+    sample_function!(
+        fluid_level_floodedness_noise,
+        fluid_level_floodedness_noise_volume
+    );
+    sample_function!(fluid_level_spread_noise, fluid_level_spread_noise_volume);
+    sample_function!(lava_noise, lava_noise_volume);
+    sample_function!(erosion, erosion_volume);
+    sample_function!(depth, depth_volume);
+    sample_function!(final_density, final_density_volume);
+    sample_function!(vein_toggle, vein_toggle_volume);
+    sample_function!(vein_ridged, vein_ridged_volume);
+    sample_function!(vein_gap, vein_gap_volume);
 }
 
 impl<'a> ChunkNoiseRouter<'a> {

--- a/crates/pumpkin-world/src/generation/noise/router/density_function/mod.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/density_function/mod.rs
@@ -2,6 +2,7 @@ use pumpkin_data::noise_router::WrapperType;
 use pumpkin_util::math::vector3::Vector3;
 
 use super::chunk_density_function::ChunkNoiseFunctionSampleOptions;
+use super::density_volume::DensityVolume;
 
 pub(crate) mod beardifier;
 pub(crate) mod math;
@@ -30,6 +31,10 @@ pub trait NoiseFunctionComponentRange {
 
 pub trait StaticIndependentChunkNoiseFunctionComponentImpl: NoiseFunctionComponentRange {
     fn sample(&self, pos: &Vector3<i32>) -> f32;
+
+    fn sample_volume(&self, buffer: &mut [f32], volume: &DensityVolume) {
+        volume.fill_with(buffer, |pos| self.sample(pos));
+    }
     fn fill(&self, array: &mut [f32], mapper: &impl IndexToNoisePos) {
         array.iter_mut().enumerate().for_each(|(index, value)| {
             let pos = mapper.at(index, None);

--- a/crates/pumpkin-world/src/generation/noise/router/density_volume.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/density_volume.rs
@@ -1,0 +1,268 @@
+use std::cell::RefCell;
+use std::ops::{Deref, DerefMut};
+
+use pumpkin_util::math::vector3::Vector3;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct DensityVolume {
+    pub size_x: usize,
+    pub size_y: usize,
+    pub size_z: usize,
+    pub min_block_x: i32,
+    pub min_block_y: i32,
+    pub min_block_z: i32,
+    pub step_block_x: i32,
+    pub step_block_y: i32,
+    pub step_block_z: i32,
+}
+
+impl DensityVolume {
+    #[must_use]
+    #[expect(clippy::too_many_arguments)]
+    pub const fn new(
+        size_x: usize,
+        size_y: usize,
+        size_z: usize,
+        min_block_x: i32,
+        min_block_y: i32,
+        min_block_z: i32,
+        step_block_x: i32,
+        step_block_y: i32,
+        step_block_z: i32,
+    ) -> Self {
+        debug_assert!(size_x > 0 && size_y > 0 && size_z > 0);
+        debug_assert!(step_block_x > 0 && step_block_y > 0 && step_block_z > 0);
+        Self {
+            size_x,
+            size_y,
+            size_z,
+            min_block_x,
+            min_block_y,
+            min_block_z,
+            step_block_x,
+            step_block_y,
+            step_block_z,
+        }
+    }
+
+    #[must_use]
+    pub const fn with_block_step(
+        size_x: usize,
+        size_y: usize,
+        size_z: usize,
+        min_block_x: i32,
+        min_block_y: i32,
+        min_block_z: i32,
+    ) -> Self {
+        Self::new(
+            size_x,
+            size_y,
+            size_z,
+            min_block_x,
+            min_block_y,
+            min_block_z,
+            1,
+            1,
+            1,
+        )
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn index_unchecked(&self, x: usize, y: usize, z: usize) -> usize {
+        y + (x + z * self.size_x) * self.size_y
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn block_x(&self, x: usize) -> i32 {
+        self.min_block_x + x as i32 * self.step_block_x
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn block_y(&self, y: usize) -> i32 {
+        self.min_block_y + y as i32 * self.step_block_y
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn block_z(&self, z: usize) -> i32 {
+        self.min_block_z + z as i32 * self.step_block_z
+    }
+
+    #[must_use]
+    pub const fn max_block_x(&self) -> i32 {
+        self.min_block_x + self.size_x as i32 * self.step_block_x - 1
+    }
+
+    #[must_use]
+    pub const fn max_block_y(&self) -> i32 {
+        self.min_block_y + self.size_y as i32 * self.step_block_y - 1
+    }
+
+    #[must_use]
+    pub const fn max_block_z(&self) -> i32 {
+        self.min_block_z + self.size_z as i32 * self.step_block_z - 1
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn size(&self) -> usize {
+        self.size_x * self.size_y * self.size_z
+    }
+
+    #[must_use]
+    pub const fn is_block_step(&self) -> bool {
+        self.step_block_x == 1 && self.step_block_y == 1 && self.step_block_z == 1
+    }
+
+    const fn contains_block_relative(
+        &self,
+        relative_x: i32,
+        relative_y: i32,
+        relative_z: i32,
+    ) -> bool {
+        relative_x >= 0
+            && relative_y >= 0
+            && relative_z >= 0
+            && relative_x < self.size_x as i32 * self.step_block_x
+            && relative_y < self.size_y as i32 * self.step_block_y
+            && relative_z < self.size_z as i32 * self.step_block_z
+            && relative_x.rem_euclid(self.step_block_x) == 0
+            && relative_y.rem_euclid(self.step_block_y) == 0
+            && relative_z.rem_euclid(self.step_block_z) == 0
+    }
+
+    #[must_use]
+    pub const fn index_of_block(&self, block_x: i32, block_y: i32, block_z: i32) -> Option<usize> {
+        let relative_x = block_x - self.min_block_x;
+        let relative_y = block_y - self.min_block_y;
+        let relative_z = block_z - self.min_block_z;
+        if self.is_block_step() {
+            if relative_x >= 0
+                && relative_y >= 0
+                && relative_z >= 0
+                && relative_x < self.size_x as i32
+                && relative_y < self.size_y as i32
+                && relative_z < self.size_z as i32
+            {
+                return Some(self.index_unchecked(
+                    relative_x as usize,
+                    relative_y as usize,
+                    relative_z as usize,
+                ));
+            }
+        } else if self.contains_block_relative(relative_x, relative_y, relative_z) {
+            return Some(self.index_unchecked(
+                relative_x.div_euclid(self.step_block_x) as usize,
+                relative_y.div_euclid(self.step_block_y) as usize,
+                relative_z.div_euclid(self.step_block_z) as usize,
+            ));
+        }
+        None
+    }
+
+    pub fn fill_with(&self, buffer: &mut [f32], mut sample: impl FnMut(&Vector3<i32>) -> f32) {
+        debug_assert_eq!(buffer.len(), self.size());
+        let mut index = 0;
+        for z in 0..self.size_z {
+            let block_z = self.block_z(z);
+            for x in 0..self.size_x {
+                let block_x = self.block_x(x);
+                for y in 0..self.size_y {
+                    buffer[index] = sample(&Vector3::new(block_x, self.block_y(y), block_z));
+                    index += 1;
+                }
+            }
+        }
+    }
+}
+
+const BUFFER_SIZE_INCREMENT: usize = 16;
+const MAX_REUSE_SIZE_FACTOR: usize = 2;
+const MAX_POOLED_BUFFERS: usize = 64;
+
+thread_local! {
+    static DENSITY_BUFFER_POOL: RefCell<Vec<Box<[f32]>>> = const { RefCell::new(Vec::new()) };
+}
+
+fn take_best(
+    pool: &mut Vec<Box<[f32]>>,
+    min_capacity: usize,
+    max_capacity: usize,
+) -> Option<Box<[f32]>> {
+    let mut best_index = None;
+    let mut best_capacity = max_capacity + 1;
+    for i in (0..pool.len()).rev() {
+        let capacity = pool[i].len();
+        if capacity == min_capacity {
+            return Some(pool.remove(i));
+        }
+        if capacity > min_capacity && capacity < best_capacity {
+            best_index = Some(i);
+            best_capacity = capacity;
+        }
+    }
+    best_index.map(|i| pool.remove(i))
+}
+
+pub struct DensityBuffer {
+    values: Box<[f32]>,
+    len: usize,
+}
+
+impl DensityBuffer {
+    #[must_use]
+    pub fn acquire(volume: &DensityVolume) -> Self {
+        Self::with_len(volume.size())
+    }
+
+    #[must_use]
+    pub fn with_len(len: usize) -> Self {
+        let min_capacity = len.next_multiple_of(BUFFER_SIZE_INCREMENT);
+        let values = DENSITY_BUFFER_POOL
+            .with(|pool| {
+                take_best(
+                    &mut pool.borrow_mut(),
+                    min_capacity,
+                    min_capacity * MAX_REUSE_SIZE_FACTOR,
+                )
+            })
+            .unwrap_or_else(|| vec![0.0; min_capacity].into_boxed_slice());
+        Self { values, len }
+    }
+
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        self.values.len()
+    }
+}
+
+impl Deref for DensityBuffer {
+    type Target = [f32];
+
+    #[inline]
+    fn deref(&self) -> &[f32] {
+        &self.values[..self.len]
+    }
+}
+
+impl DerefMut for DensityBuffer {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [f32] {
+        &mut self.values[..self.len]
+    }
+}
+
+impl Drop for DensityBuffer {
+    fn drop(&mut self) {
+        let values = std::mem::take(&mut self.values);
+        DENSITY_BUFFER_POOL.with(|pool| {
+            let mut pool = pool.borrow_mut();
+            if pool.len() < MAX_POOLED_BUFFERS {
+                pool.push(values);
+            }
+        });
+    }
+}

--- a/crates/pumpkin-world/src/generation/noise/router/mod.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/mod.rs
@@ -1,6 +1,7 @@
 pub mod chunk_density_function;
 pub mod chunk_noise_router;
 pub mod density_function;
+pub mod density_volume;
 pub mod find_top_surface;
 pub mod multi_noise_sampler;
 #[cfg(test)]

--- a/crates/pumpkin-world/src/generation/noise/router/proto_noise_router.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/proto_noise_router.rs
@@ -29,6 +29,7 @@ use super::{
         noise::{InterpolatedNoiseSampler, Noise, ShiftA, ShiftB, ShiftedNoise},
         spline::{Spline, SplineFunction, SplinePoint, SplineValue},
     },
+    density_volume::DensityVolume,
 };
 use pumpkin_util::math::vector3::Vector3;
 
@@ -107,6 +108,21 @@ impl StaticIndependentChunkNoiseFunctionComponentImpl for IndependentProtoNoiseF
             Self::ClampedYGradient(c) => c.fill(array, mapper),
             Self::Gradient(g) => g.fill(array, mapper),
             Self::DistanceToPoint(d) => d.fill(array, mapper),
+        }
+    }
+
+    #[inline]
+    fn sample_volume(&self, buffer: &mut [f32], volume: &DensityVolume) {
+        match self {
+            Self::Constant(c) => c.sample_volume(buffer, volume),
+            Self::EndIsland(e) => e.sample_volume(buffer, volume),
+            Self::Noise(n) => n.sample_volume(buffer, volume),
+            Self::ShiftA(s) => s.sample_volume(buffer, volume),
+            Self::ShiftB(s) => s.sample_volume(buffer, volume),
+            Self::InterpolatedNoise(i) => i.sample_volume(buffer, volume),
+            Self::ClampedYGradient(c) => c.sample_volume(buffer, volume),
+            Self::Gradient(g) => g.sample_volume(buffer, volume),
+            Self::DistanceToPoint(d) => d.sample_volume(buffer, volume),
         }
     }
 }
@@ -209,6 +225,38 @@ impl StaticChunkNoiseFunctionComponentImpl for DependentProtoNoiseFunctionCompon
             Self::Lerp(l) => l.fill(component_stack, array, mapper, sample_options),
             Self::Rounding(r) => r.fill(component_stack, array, mapper, sample_options),
             Self::Slice(s) => s.fill(component_stack, array, mapper, sample_options),
+        }
+    }
+
+    #[inline]
+    fn sample_volume(
+        &self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+        sample_options: &ChunkNoiseFunctionSampleOptions,
+    ) {
+        match self {
+            Self::Linear(l) => l.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Unary(u) => u.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Binary(b) => b.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::ShiftedNoise(s) => {
+                s.sample_volume(component_stack, buffer, volume, sample_options);
+            }
+            Self::IntervalSelect(i) => {
+                i.sample_volume(component_stack, buffer, volume, sample_options);
+            }
+            Self::FindTopSurface(f) => {
+                f.sample_volume(component_stack, buffer, volume, sample_options);
+            }
+            Self::Clamp(c) => c.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::RangeChoice(r) => {
+                r.sample_volume(component_stack, buffer, volume, sample_options);
+            }
+            Self::Spline(s) => s.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Lerp(l) => l.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Rounding(r) => r.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Slice(s) => s.sample_volume(component_stack, buffer, volume, sample_options),
         }
     }
 }

--- a/tools/pumpkin-codegen/src/noise_router.rs
+++ b/tools/pumpkin-codegen/src/noise_router.rs
@@ -594,6 +594,20 @@ fn noise_domain_axes(xz_scale: f32, y_scale: f32) -> u8 {
 }
 
 impl SplineRepr {
+    fn for_each_function(&mut self, f: &mut dyn FnMut(&mut DensityFunctionRepr)) {
+        if let Self::Standard {
+            location_function,
+            values,
+            ..
+        } = self
+        {
+            f(location_function);
+            for value in values.iter_mut() {
+                value.for_each_function(f);
+            }
+        }
+    }
+
     fn domain_axes(&self) -> u8 {
         match self {
             Self::Fixed { .. } => 0,
@@ -672,6 +686,143 @@ impl DensityFunctionRepr {
                 ..
             } => input.domain_axes() | when_in_range.domain_axes() | when_out_range.domain_axes(),
             Self::Spline { spline, .. } => spline.domain_axes(),
+        }
+    }
+
+    fn is_cache(&self) -> bool {
+        matches!(
+            self,
+            Self::Wrapper {
+                wrapper: WrapperType::CacheFlat | WrapperType::Cache2D | WrapperType::CacheOnce,
+                ..
+            }
+        )
+    }
+
+    fn for_each_child(&mut self, f: &mut dyn FnMut(&mut Self)) {
+        match self {
+            Self::Beardifier
+            | Self::BlendAlpha
+            | Self::BlendOffset
+            | Self::EndIslands
+            | Self::Noise { .. }
+            | Self::ShiftA { .. }
+            | Self::ShiftB { .. }
+            | Self::InterpolatedNoiseSampler { .. }
+            | Self::Constant { .. }
+            | Self::ClampedYGradient { .. }
+            | Self::Gradient { .. }
+            | Self::DistanceToPoint { .. } => {}
+            Self::BlendDensity { input }
+            | Self::Wrapper { input, .. }
+            | Self::Linear { input, .. }
+            | Self::Unary { input, .. }
+            | Self::Clamp { input, .. }
+            | Self::Slice { input, .. } => f(input),
+            Self::FindTopSurface {
+                density,
+                upper_bound,
+                ..
+            } => {
+                f(density);
+                f(upper_bound);
+            }
+            Self::ShiftedNoise {
+                shift_x,
+                shift_y,
+                shift_z,
+                ..
+            } => {
+                f(shift_x);
+                f(shift_y);
+                f(shift_z);
+            }
+            Self::IntervalSelect {
+                input, functions, ..
+            } => {
+                f(input);
+                for function in functions.iter_mut() {
+                    f(function);
+                }
+            }
+            Self::Lerp {
+                alpha,
+                first,
+                second,
+            } => {
+                f(alpha);
+                f(first);
+                f(second);
+            }
+            Self::Rounding {
+                input, multiple, ..
+            } => {
+                f(input);
+                f(multiple);
+            }
+            Self::Binary {
+                argument1,
+                argument2,
+                ..
+            } => {
+                f(argument1);
+                f(argument2);
+            }
+            Self::RangeChoice {
+                input,
+                when_in_range,
+                when_out_range,
+                ..
+            } => {
+                f(input);
+                f(when_in_range);
+                f(when_out_range);
+            }
+            Self::Spline { spline, .. } => spline.for_each_function(f),
+        }
+    }
+
+    fn existing_removed_axes(&self) -> u8 {
+        let mut axes = 0;
+        let mut function = self;
+        while let Self::Slice { axis, input, .. } = function {
+            axes |= axis.as_axes();
+            function = input;
+        }
+        axes
+    }
+
+    fn remove_axes(&mut self, axes: u8) {
+        let filtered = axes & !self.existing_removed_axes();
+        for (bit, axis) in [(AXIS_X, Axis::X), (AXIS_Z, Axis::Z), (AXIS_Y, Axis::Y)] {
+            if filtered & bit != 0 {
+                let input = std::mem::replace(
+                    self,
+                    Self::Constant {
+                        value: HashableF32(0.0),
+                    },
+                );
+                *self = Self::Slice {
+                    axis,
+                    coordinate: 0,
+                    input: Box::new(input),
+                };
+            }
+        }
+    }
+
+    fn slice_uniform_axes(&mut self, parent_axes: u8) {
+        if matches!(
+            self,
+            Self::Constant { .. } | Self::Gradient { .. } | Self::ClampedYGradient { .. }
+        ) {
+            return;
+        }
+        let axes = self.domain_axes();
+        let child_parent_axes = if self.is_cache() { AXES_ALL } else { axes };
+        self.for_each_child(&mut |child| child.slice_uniform_axes(child_parent_axes));
+        if parent_axes != axes {
+            self.remove_axes(parent_axes & !axes);
         }
     }
 
@@ -1832,6 +1983,25 @@ struct NoiseRouterRepr {
 }
 
 impl NoiseRouterRepr {
+    fn slice_uniform_axes(&mut self) {
+        self.barrier_noise.slice_uniform_axes(AXES_ALL);
+        self.fluid_level_floodedness_noise
+            .slice_uniform_axes(AXES_ALL);
+        self.fluid_level_spread_noise.slice_uniform_axes(AXES_ALL);
+        self.lava_noise.slice_uniform_axes(AXES_ALL);
+        self.temperature.slice_uniform_axes(AXES_ALL);
+        self.vegetation.slice_uniform_axes(AXES_ALL);
+        self.continents.slice_uniform_axes(AXES_ALL);
+        self.erosion.slice_uniform_axes(AXES_ALL);
+        self.depth.slice_uniform_axes(AXES_ALL);
+        self.ridges.slice_uniform_axes(AXES_ALL);
+        self.preliminary_surface_level.slice_uniform_axes(AXES_ALL);
+        self.final_density.slice_uniform_axes(AXES_ALL);
+        self.vein_toggle.slice_uniform_axes(AXES_ALL);
+        self.vein_ridged.slice_uniform_axes(AXES_ALL);
+        self.vein_gap.slice_uniform_axes(AXES_ALL);
+    }
+
     fn optimize(&mut self) {
         self.barrier_noise.optimize();
         self.fluid_level_floodedness_noise.optimize();
@@ -1852,6 +2022,7 @@ impl NoiseRouterRepr {
 
     fn into_token_stream_compiled(mut self, dim_name: &str) -> (TokenStream, TokenStream) {
         self.optimize();
+        self.slice_uniform_axes();
 
         let mut noise_component_stack = Vec::new();
         let mut noise_nodes = Vec::new();


### PR DESCRIPTION
## Description

This is the first of two PRs for moving the density function runtime to the 26.3 sampler model. It adds the runtime pieces needed for the port without changing any generated values.

The codegen now applies vanilla's `SLICE_UNIFORM_AXES` rewrite. A subtree that does not depend on an axis gets wrapped in a slice for that axis. Cache inputs restart the rule with the full axis set, while constants and gradients are skipped. This also reproduces the double slice around caches that vanilla generates.

On the runtime side, this adds `DensityVolume` and `DensityBuffer`, backed by a pooled arena that follows `DensityBufferPool`'s rounding and best-fit rules. Component traits also get a `sample_volume` method whose default implementation samples every position in vanilla's index order. That gives the follow-up PR a base to replace the per-sample paths with volume sampling node by node.

Cache IDs use component indices since the codegen already merges identical wrapper subtrees. The pool differs slightly from vanilla here: instead of age-based garbage collection, each thread keeps at most 64 buffers.

## Testing

I compared block and biome hashes of 49 chunks (seed 42, up to the surface stage) between master and this branch and they are identical. The 178 pumpkin-world tests pass including the density fingerprint. The chunk_gen bench shows a small cost from the extra slice nodes on the per sample path: full chunk generation 40.3 ms to 41.4 ms, biomes 1.06 ms to 1.14 ms, noise 12.4 ms to 12.5 ms, the other stages unchanged. That cost disappears once the driver samples volumes, which is the second PR.
