### PR TITLE
fix(portal): link nether portals whose chunks are unloaded 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/world/portal/nether.rs
+++ b/crates/pumpkin/src/world/portal/nether.rs
@@ -18,7 +18,7 @@ use crate::world::World;
 /// values cover the same physical box, because the nether is 8x the overworld's
 /// coordinate scale. Vanilla cut the nether radius from 128 to 16 in 1.16.2
 /// "in order to correctly account for the 1:8 position scale"; do not "fix"
-/// this back to matching SEARCH_RADIUS_OVERWORLD.
+/// this back to matching `SEARCH_RADIUS_OVERWORLD`.
 const SEARCH_RADIUS_NETHER: i32 = 16;
 const SEARCH_RADIUS_OVERWORLD: i32 = 128;
 

--- a/crates/pumpkin/src/world/portal/nether.rs
+++ b/crates/pumpkin/src/world/portal/nether.rs
@@ -5,13 +5,21 @@ use pumpkin_data::{
     tag,
     tag::Taggable,
 };
-use pumpkin_util::math::{boundingbox::EntityDimensions, position::BlockPos, vector3::Vector3};
+use pumpkin_util::math::{
+    boundingbox::EntityDimensions, position::BlockPos, vector2::Vector2, vector3::Vector3,
+};
 use pumpkin_world::{chunk::ChunkHeightmapType, world::BlockFlags};
+use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
 use crate::world::World;
 
-const SEARCH_RADIUS_NETHER: i32 = 128;
+/// Portal search radius, in blocks of the *destination* dimension. The two
+/// values cover the same physical box, because the nether is 8x the overworld's
+/// coordinate scale. Vanilla cut the nether radius from 128 to 16 in 1.16.2
+/// "in order to correctly account for the 1:8 position scale"; do not "fix"
+/// this back to matching SEARCH_RADIUS_OVERWORLD.
+const SEARCH_RADIUS_NETHER: i32 = 16;
 const SEARCH_RADIUS_OVERWORLD: i32 = 128;
 
 #[derive(Debug, Clone)]
@@ -526,17 +534,34 @@ impl NetherPortal {
             poi_storage.get_in_square(target_pos, search_radius, Some(poi::POI_TYPE_NETHER_PORTAL))
         };
 
+        let candidates: Vec<BlockPos> = portal_positions
+            .into_iter()
+            .filter(|pos| {
+                pos.0.y >= min_y
+                    && pos.0.y <= search_max_y
+                    && worldborder.contains_block(pos.0.x, pos.0.z)
+            })
+            .collect();
+        drop(worldborder);
+
+        if candidates.is_empty() {
+            return None;
+        }
+
+        // The POI index survives chunk unloading, but the block reads below do
+        // not: `World::get_block_and_state` reports an unloaded chunk as air, so
+        // every candidate would be discarded and a duplicate portal built.
+        //
+        // Keep this load ahead of the reads. #3001 fixed the same fault with
+        // `get_block_state_id_async`, and 5d841d6d3 ("refactor(entities): from
+        // async to sync Part 2") reintroduced it by swapping that accessor for
+        // the plain sync one. Preloading also covers `get_on_axis`, which walks
+        // outward across chunk borders and was never guarded by that accessor.
+        Self::load_chunks(world, &Self::candidate_chunks(&candidates));
+
         let mut best: Option<(PortalSearchResult, f64, i32)> = None;
 
-        for pos in portal_positions {
-            if pos.0.y < min_y || pos.0.y > search_max_y {
-                continue;
-            }
-
-            if !worldborder.contains_block(pos.0.x, pos.0.z) {
-                continue;
-            }
-
+        for pos in candidates {
             let (block, state) = world.get_block_and_state(&pos);
             if block != &Block::NETHER_PORTAL {
                 continue;
@@ -575,6 +600,41 @@ impl NetherPortal {
         }
 
         best.map(|(result, _, _)| result)
+    }
+
+    /// Chunks that must be resident before the candidates' portal frames can be
+    /// measured. The scan walks up to `MAX_WIDTH`/`MAX_HEIGHT` blocks out from a
+    /// POI, so it can cross a chunk border in any direction.
+    fn candidate_chunks(candidates: &[BlockPos]) -> Vec<Vector2<i32>> {
+        let mut seen = FxHashSet::default();
+        let mut chunks = Vec::new();
+        for pos in candidates {
+            for dx in -1..=1 {
+                for dz in -1..=1 {
+                    let chunk = Vector2::new((pos.0.x >> 4) + dx, (pos.0.z >> 4) + dz);
+                    if seen.insert(chunk) {
+                        chunks.push(chunk);
+                    }
+                }
+            }
+        }
+        chunks
+    }
+
+    /// Loads `chunks` into memory, bridging from this Rayon thread back onto the
+    /// Tokio runtime. Vanilla gets this for free: `Level#getBlockState` loads the
+    /// chunk it needs rather than reporting a missing one as air.
+    fn load_chunks(world: &Arc<World>, chunks: &[Vector2<i32>]) {
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        tokio::task::block_in_place(|| {
+            handle.block_on(async {
+                for chunk in chunks {
+                    world.level.get_or_fetch_chunk(*chunk, |_| ()).await;
+                }
+            });
+        });
     }
 
     #[allow(clippy::too_many_lines)]
@@ -834,6 +894,30 @@ impl NetherPortal {
 mod tests {
     use super::*;
     use pumpkin_util::math::boundingbox::EntityDimensions;
+
+    #[test]
+    fn candidate_chunks_are_deduped_with_neighbours() {
+        // Six portal blocks spanning one chunk -> that chunk plus its 8 neighbours.
+        let portal: Vec<BlockPos> = (0..2)
+            .flat_map(|dx| (0..3).map(move |dy| BlockPos::new(20 + dx, 64 + dy, 40)))
+            .collect();
+        let chunks = NetherPortal::candidate_chunks(&portal);
+        assert_eq!(chunks.len(), 9);
+        assert!(chunks.contains(&Vector2::new(1, 2)));
+        assert!(chunks.contains(&Vector2::new(0, 1)));
+        assert!(chunks.contains(&Vector2::new(2, 3)));
+
+        // Negative coordinates floor-divide, they do not truncate towards zero.
+        assert_eq!(
+            NetherPortal::candidate_chunks(&[BlockPos::new(-1, 64, -1)])[0],
+            Vector2::new(-2, -2)
+        );
+
+        // Candidates in adjacent chunks (1 and 2) share a 3-chunk column, so the
+        // union is 4x3, not two separate 3x3 blocks.
+        let split = [BlockPos::new(20, 64, 40), BlockPos::new(36, 64, 40)];
+        assert_eq!(NetherPortal::candidate_chunks(&split).len(), 12);
+    }
 
     #[test]
     fn portal_teleport_position_x_axis() {


### PR DESCRIPTION
## Description

Nether portals stop linking to each other once their chunks unload. Each crossing builds a fresh portal instead of reusing the existing one, so you end up with a chain of orphaned pairs and get dropped somewhere new every time you switch dimensions.

`search_for_portal` finds candidates in the POI index, which survives chunk unloading, then validates them with `World::get_block_and_state`. That resolves through `read_chunk_sync`, a bare `loaded_chunks` lookup that reports an unloaded chunk as **air**. Leaving a dimension unloads exactly the chunks the portal sits in, so on the return trip every candidate reads as air and is discarded, the search returns `None`, and the fallback builds a duplicate.

The chunk loading in `PortalType::get_portal_destination` only runs in the `or_else` arm, *after* the search has already failed, and the search is never retried.

### This is a regression

#3001 fixed the same fault using the chunk-loading `get_block_state_id_async`. 5d841d6d3 (`refactor(entities): from async to sync Part 2`) swapped that accessor for the plain sync one:

```diff
-if world.get_block_state_id_async(&pos).await.to_block() != &Block::NETHER_PORTAL {
+if world.get_block_state_id(&pos).to_block() != &Block::NETHER_PORTAL {
```

The async accessor still exists but is unusable here now that the call path is sync, and it only ever guarded the *first* read — `get_on_axis` walks up to 21 blocks outward from the POI and crosses chunk borders unguarded.

## Changes

**Preload candidate chunks.** Filter candidates by Y and world border first, drop the world-border guard, then load each survivor's chunk plus its 8 neighbours before any block read. Deduplicated by chunk coordinate, so one portal costs a single 3×3 load rather than one per portal block. Bridges Rayon → Tokio with the `block_in_place` + `block_on` pattern already used in `portal/mod.rs`. Vanilla gets this for free: `Level#getBlockState` loads the chunk it needs.

**`SEARCH_RADIUS_NETHER`: 128 → 16.** Vanilla reduced this in 1.16.2 "in order to correctly account for the 1:8 position scale" ([wiki](https://minecraft.wiki/w/Nether_portal)); the branch already keys on the destination dimension, only the value was wrong. At 128, two overworld portals up to 1024 blocks apart share one nether portal instead of each getting their own — walk into portal B, come back out of portal A. It was unreachable while the search above always failed, so it has to land here rather than in a follow-up. PaperMC hit the same divergence in PaperMC/Paper#3795 and PaperMC/Paper#4573.

Both changes are in one commit deliberately: shipping the chunk fix alone would activate the 1024-block snap bug that was previously dead code.

## Testing

- [x] In-game: crossed to the nether, travelled far enough for the overworld chunks to unload, returned through the same portal — arrives at the original portal, no duplicate built. Fails on `master`.
- [x] `cargo test` — 256 pass
- [x] `cargo clippy --all-targets` — clean
- [x] New unit test for the chunk-set math: 3×3 union, dedupe across adjacent chunks, and negative coordinates (`>> 4` floor-divides, `-1 → -2`)

There is no end-to-end regression test — that needs a `World` harness with force-unloaded chunks, which doesn't exist in the repo. The load-before-read ordering is guarded by a comment naming this regression's history so the next async→sync pass doesn't silently undo it again.

## Not in scope

- `find_safe_location` scans a ±32 box; vanilla `createPortal` uses `BlockPos.spiralAround(pos, 16, …)`. Different size and shape, and its edges read past the chunks the `or_else` arm loads — same cold-chunk class, different function.
- Teleport-time portal measuring uses the `PortalShape` obsidian-frame validator; vanilla uses `BlockUtil.getLargestRectangleAround` for both source and exit rectangles and ignores the frame. Affects sliced/partly-mined portals. Left alone deliberately — it interacts with block-update-suppression behaviour that's a judgement call for the core team.

## AI assistance

Investigated and implemented with Claude Code (Opus 5). Root cause traced from the reported symptom, confirmed against the reporter's world save by decoding its POI region files, and verified in-game before submission. All vanilla behaviour cited above was checked against primary sources rather than recalled.