### PR TITLE
perf(worldgen): port the 26.3 volume density sampler

### DIFF
--- a/crates/pumpkin-data/src/generated/noise_router.rs
+++ b/crates/pumpkin-data/src/generated/noise_router.rs
@@ -142,7 +142,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(9usize, WrapperType::CacheFlat, pos, &eval_overworld_8)
+        ctx.sample_wrapper(9usize, WrapperType::Cache, pos, &eval_overworld_8)
     }
     #[inline(always)]
     pub fn eval_overworld_10<C: NoiseEvaluationContext>(
@@ -172,7 +172,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(13usize, WrapperType::CacheFlat, pos, &eval_overworld_12)
+        ctx.sample_wrapper(13usize, WrapperType::Cache, pos, &eval_overworld_12)
     }
     #[inline(always)]
     pub fn eval_overworld_14<C: NoiseEvaluationContext>(
@@ -204,7 +204,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(16usize, WrapperType::CacheFlat, pos, &eval_overworld_15)
+        ctx.sample_wrapper(16usize, WrapperType::Cache, pos, &eval_overworld_15)
     }
     #[inline(always)]
     pub fn eval_overworld_17<C: NoiseEvaluationContext>(
@@ -236,7 +236,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(19usize, WrapperType::CacheFlat, pos, &eval_overworld_18)
+        ctx.sample_wrapper(19usize, WrapperType::Cache, pos, &eval_overworld_18)
     }
     #[inline(always)]
     pub fn eval_overworld_20<C: NoiseEvaluationContext>(
@@ -268,7 +268,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(22usize, WrapperType::CacheFlat, pos, &eval_overworld_21)
+        ctx.sample_wrapper(22usize, WrapperType::Cache, pos, &eval_overworld_21)
     }
     #[inline(always)]
     pub fn eval_overworld_23<C: NoiseEvaluationContext>(
@@ -343,7 +343,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(32usize, WrapperType::CacheFlat, pos, &eval_overworld_31)
+        ctx.sample_wrapper(32usize, WrapperType::Cache, pos, &eval_overworld_31)
     }
     #[inline(always)]
     pub fn eval_overworld_33<C: NoiseEvaluationContext>(
@@ -391,7 +391,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(38usize, WrapperType::CacheFlat, pos, &eval_overworld_37)
+        ctx.sample_wrapper(38usize, WrapperType::Cache, pos, &eval_overworld_37)
     }
     #[inline(always)]
     pub fn eval_overworld_39<C: NoiseEvaluationContext>(
@@ -433,7 +433,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(43usize, WrapperType::CacheFlat, pos, &eval_overworld_42)
+        ctx.sample_wrapper(43usize, WrapperType::Cache, pos, &eval_overworld_42)
     }
     #[inline(always)]
     pub fn eval_overworld_44<C: NoiseEvaluationContext>(
@@ -489,7 +489,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(50usize, WrapperType::CacheFlat, pos, &eval_overworld_49)
+        ctx.sample_wrapper(50usize, WrapperType::Cache, pos, &eval_overworld_49)
     }
     #[inline(always)]
     pub fn eval_overworld_51<C: NoiseEvaluationContext>(
@@ -540,7 +540,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(57usize, WrapperType::CacheOnce, pos, &eval_overworld_56)
+        ctx.sample_wrapper(57usize, WrapperType::Cache, pos, &eval_overworld_56)
     }
     #[inline(always)]
     pub fn eval_overworld_58<C: NoiseEvaluationContext>(
@@ -642,7 +642,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(69usize, WrapperType::CacheOnce, pos, &eval_overworld_68)
+        ctx.sample_wrapper(69usize, WrapperType::Cache, pos, &eval_overworld_68)
     }
     #[inline(always)]
     pub fn eval_overworld_70<C: NoiseEvaluationContext>(
@@ -661,7 +661,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(71usize, WrapperType::CacheOnce, pos, &eval_overworld_70)
+        ctx.sample_wrapper(71usize, WrapperType::Cache, pos, &eval_overworld_70)
     }
     #[inline(always)]
     pub fn eval_overworld_72<C: NoiseEvaluationContext>(
@@ -937,7 +937,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(100usize, WrapperType::CacheOnce, pos, &eval_overworld_99)
+        ctx.sample_wrapper(100usize, WrapperType::Cache, pos, &eval_overworld_99)
     }
     #[inline(always)]
     pub fn eval_overworld_101<C: NoiseEvaluationContext>(
@@ -1215,7 +1215,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(131usize, WrapperType::CacheOnce, pos, &eval_overworld_130)
+        ctx.sample_wrapper(131usize, WrapperType::Cache, pos, &eval_overworld_130)
     }
     #[inline(always)]
     pub fn eval_overworld_132<C: NoiseEvaluationContext>(
@@ -1263,7 +1263,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(137usize, WrapperType::CacheFlat, pos, &eval_overworld_136)
+        ctx.sample_wrapper(137usize, WrapperType::Cache, pos, &eval_overworld_136)
     }
     #[inline(always)]
     pub fn eval_overworld_138<C: NoiseEvaluationContext>(
@@ -1438,7 +1438,7 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(159usize, WrapperType::CacheOnce, pos, &eval_overworld_158)
+        ctx.sample_wrapper(159usize, WrapperType::Cache, pos, &eval_overworld_158)
     }
     #[inline(always)]
     pub fn eval_overworld_160<C: NoiseEvaluationContext>(
@@ -1521,7 +1521,10 @@ pub mod overworld_compiled {
     ) -> f32 {
         ctx.sample_wrapper(
             168usize,
-            WrapperType::Interpolated,
+            WrapperType::Interpolated {
+                cell_size_xz: 4i32,
+                cell_size_y: 8i32,
+            },
             pos,
             &eval_overworld_167,
         )
@@ -1583,7 +1586,10 @@ pub mod overworld_compiled {
     ) -> f32 {
         ctx.sample_wrapper(
             174usize,
-            WrapperType::Interpolated,
+            WrapperType::Interpolated {
+                cell_size_xz: 4i32,
+                cell_size_y: 8i32,
+            },
             pos,
             &eval_overworld_173,
         )
@@ -1641,7 +1647,10 @@ pub mod overworld_compiled {
     ) -> f32 {
         ctx.sample_wrapper(
             180usize,
-            WrapperType::Interpolated,
+            WrapperType::Interpolated {
+                cell_size_xz: 4i32,
+                cell_size_y: 8i32,
+            },
             pos,
             &eval_overworld_179,
         )
@@ -1677,7 +1686,10 @@ pub mod overworld_compiled {
     ) -> f32 {
         ctx.sample_wrapper(
             183usize,
-            WrapperType::Interpolated,
+            WrapperType::Interpolated {
+                cell_size_xz: 4i32,
+                cell_size_y: 8i32,
+            },
             pos,
             &eval_overworld_182,
         )
@@ -1720,7 +1732,10 @@ pub mod overworld_compiled {
     ) -> f32 {
         ctx.sample_wrapper(
             187usize,
-            WrapperType::Interpolated,
+            WrapperType::Interpolated {
+                cell_size_xz: 4i32,
+                cell_size_y: 8i32,
+            },
             pos,
             &eval_overworld_186,
         )
@@ -1791,13 +1806,6 @@ pub mod overworld_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(196usize, WrapperType::CellCache, pos, &eval_overworld_195)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_197<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
         ctx.sample_noise(
             DoublePerlinNoiseParameters::AQUIFER_BARRIER,
             pos.x as f32 * 1f32,
@@ -1806,7 +1814,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_198<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_197<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1818,7 +1826,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_199<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_198<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1830,7 +1838,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_200<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_199<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1842,7 +1850,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_201<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_200<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1854,38 +1862,41 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_202<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_201<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
         let val = eval_overworld_170(pos, ctx);
         if val >= -64f32 && val < 57f32 {
-            eval_overworld_201(pos, ctx)
+            eval_overworld_200(pos, ctx)
         } else {
             eval_overworld_10(pos, ctx)
         }
+    }
+    #[inline(always)]
+    pub fn eval_overworld_202<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(
+            202usize,
+            WrapperType::Interpolated {
+                cell_size_xz: 4i32,
+                cell_size_y: 8i32,
+            },
+            pos,
+            &eval_overworld_201,
+        )
     }
     #[inline(always)]
     pub fn eval_overworld_203<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(
-            203usize,
-            WrapperType::Interpolated,
-            pos,
-            &eval_overworld_202,
-        )
+        ctx.sample_wrapper(203usize, WrapperType::Cache, pos, &eval_overworld_202)
     }
     #[inline(always)]
     pub fn eval_overworld_204<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(204usize, WrapperType::CacheOnce, pos, &eval_overworld_203)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_205<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1893,7 +1904,7 @@ pub mod overworld_compiled {
         0.08f32
     }
     #[inline(always)]
-    pub fn eval_overworld_206<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_205<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1905,7 +1916,7 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_207<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_206<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1913,38 +1924,41 @@ pub mod overworld_compiled {
         1f32
     }
     #[inline(always)]
-    pub fn eval_overworld_208<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_207<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
         let val = eval_overworld_170(pos, ctx);
         if val >= -64f32 && val < 57f32 {
-            eval_overworld_206(pos, ctx)
+            eval_overworld_205(pos, ctx)
         } else {
-            eval_overworld_207(pos, ctx)
+            eval_overworld_206(pos, ctx)
         }
+    }
+    #[inline(always)]
+    pub fn eval_overworld_208<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(
+            208usize,
+            WrapperType::Interpolated {
+                cell_size_xz: 4i32,
+                cell_size_y: 8i32,
+            },
+            pos,
+            &eval_overworld_207,
+        )
     }
     #[inline(always)]
     pub fn eval_overworld_209<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(
-            209usize,
-            WrapperType::Interpolated,
-            pos,
-            &eval_overworld_208,
-        )
+        eval_overworld_208(pos, ctx).abs()
     }
     #[inline(always)]
     pub fn eval_overworld_210<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        eval_overworld_209(pos, ctx).abs()
-    }
-    #[inline(always)]
-    pub fn eval_overworld_211<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -1956,71 +1970,74 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_212<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_211<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
         let val = eval_overworld_170(pos, ctx);
         if val >= -64f32 && val < 57f32 {
-            eval_overworld_211(pos, ctx)
+            eval_overworld_210(pos, ctx)
         } else {
-            eval_overworld_207(pos, ctx)
+            eval_overworld_206(pos, ctx)
         }
+    }
+    #[inline(always)]
+    pub fn eval_overworld_212<C: NoiseEvaluationContext>(
+        pos: &pumpkin_util::math::vector3::Vector3<i32>,
+        ctx: &mut C,
+    ) -> f32 {
+        ctx.sample_wrapper(
+            212usize,
+            WrapperType::Interpolated {
+                cell_size_xz: 4i32,
+                cell_size_y: 8i32,
+            },
+            pos,
+            &eval_overworld_211,
+        )
     }
     #[inline(always)]
     pub fn eval_overworld_213<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(
-            213usize,
-            WrapperType::Interpolated,
-            pos,
-            &eval_overworld_212,
-        )
+        eval_overworld_212(pos, ctx).abs()
     }
     #[inline(always)]
     pub fn eval_overworld_214<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_213(pos, ctx).abs()
+        eval_overworld_209(pos, ctx).max(eval_overworld_213(pos, ctx))
     }
     #[inline(always)]
     pub fn eval_overworld_215<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_210(pos, ctx).max(eval_overworld_214(pos, ctx))
+        eval_overworld_204(pos, ctx) - eval_overworld_214(pos, ctx)
     }
     #[inline(always)]
     pub fn eval_overworld_216<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_205(pos, ctx) - eval_overworld_215(pos, ctx)
+        let val = eval_overworld_203(pos, ctx);
+        if val >= -0.4f32 && val < 0.4f32 {
+            eval_overworld_172(pos, ctx)
+        } else {
+            eval_overworld_215(pos, ctx)
+        }
     }
     #[inline(always)]
     pub fn eval_overworld_217<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        let val = eval_overworld_204(pos, ctx);
-        if val >= -0.4f32 && val < 0.4f32 {
-            eval_overworld_172(pos, ctx)
-        } else {
-            eval_overworld_216(pos, ctx)
-        }
+        ctx.sample_wrapper(217usize, WrapperType::Cache, pos, &eval_overworld_216)
     }
     #[inline(always)]
     pub fn eval_overworld_218<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(218usize, WrapperType::CacheOnce, pos, &eval_overworld_217)
-    }
-    #[inline(always)]
-    pub fn eval_overworld_219<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -2028,7 +2045,7 @@ pub mod overworld_compiled {
         -0.3f32
     }
     #[inline(always)]
-    pub fn eval_overworld_220<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_219<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -2040,14 +2057,14 @@ pub mod overworld_compiled {
         )
     }
     #[inline(always)]
-    pub fn eval_overworld_221<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_220<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        eval_overworld_219(pos, ctx) - eval_overworld_220(pos, ctx)
+        eval_overworld_218(pos, ctx) - eval_overworld_219(pos, ctx)
     }
     #[inline(always)]
-    pub fn eval_overworld_222<C: NoiseEvaluationContext>(
+    pub fn eval_overworld_221<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -2140,7 +2157,15 @@ pub mod nether_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(9usize, WrapperType::Interpolated, pos, &eval_nether_8)
+        ctx.sample_wrapper(
+            9usize,
+            WrapperType::Interpolated {
+                cell_size_xz: 4i32,
+                cell_size_y: 8i32,
+            },
+            pos,
+            &eval_nether_8,
+        )
     }
     #[inline(always)]
     pub fn eval_nether_10<C: NoiseEvaluationContext>(
@@ -2166,13 +2191,6 @@ pub mod nether_compiled {
     }
     #[inline(always)]
     pub fn eval_nether_13<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(13usize, WrapperType::CellCache, pos, &eval_nether_12)
-    }
-    #[inline(always)]
-    pub fn eval_nether_14<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -2308,7 +2326,7 @@ pub mod end_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(15usize, WrapperType::CacheFlat, pos, &eval_end_14)
+        ctx.sample_wrapper(15usize, WrapperType::Cache, pos, &eval_end_14)
     }
     #[inline(always)]
     pub fn eval_end_16<C: NoiseEvaluationContext>(
@@ -2372,7 +2390,15 @@ pub mod end_compiled {
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
-        ctx.sample_wrapper(23usize, WrapperType::Interpolated, pos, &eval_end_22)
+        ctx.sample_wrapper(
+            23usize,
+            WrapperType::Interpolated {
+                cell_size_xz: 8i32,
+                cell_size_y: 4i32,
+            },
+            pos,
+            &eval_end_22,
+        )
     }
     #[inline(always)]
     pub fn eval_end_24<C: NoiseEvaluationContext>(
@@ -2398,13 +2424,6 @@ pub mod end_compiled {
     }
     #[inline(always)]
     pub fn eval_end_27<C: NoiseEvaluationContext>(
-        pos: &pumpkin_util::math::vector3::Vector3<i32>,
-        ctx: &mut C,
-    ) -> f32 {
-        ctx.sample_wrapper(27usize, WrapperType::CellCache, pos, &eval_end_26)
-    }
-    #[inline(always)]
-    pub fn eval_end_28<C: NoiseEvaluationContext>(
         pos: &pumpkin_util::math::vector3::Vector3<i32>,
         ctx: &mut C,
     ) -> f32 {
@@ -2627,13 +2646,10 @@ pub enum SplineRepr {
         value: f32,
     },
 }
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum WrapperType {
-    Interpolated,
-    CacheFlat,
-    Cache2D,
-    CacheOnce,
-    CellCache,
+    Interpolated { cell_size_xz: i32, cell_size_y: i32 },
+    Cache,
 }
 pub enum BaseNoiseFunctionComponent {
     Beardifier,
@@ -2810,7 +2826,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 8usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
             BaseNoiseFunctionComponent::ShiftB {
@@ -2823,7 +2839,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 12usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 9usize,
@@ -2842,7 +2858,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 15usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 9usize,
@@ -2861,7 +2877,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 18usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 9usize,
@@ -2880,7 +2896,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 21usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Unary {
                 input_index: 22usize,
@@ -4532,7 +4548,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 31usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 32usize,
@@ -4868,7 +4884,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 37usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Noise {
                 data: &NoiseData {
@@ -4897,7 +4913,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 42usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 43usize,
@@ -5833,7 +5849,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 49usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 50usize,
@@ -5878,7 +5894,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 56usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Noise {
                 data: &NoiseData {
@@ -5961,7 +5977,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 68usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Noise {
                 data: &NoiseData {
@@ -5972,7 +5988,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 70usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Noise {
                 data: &NoiseData {
@@ -6166,7 +6182,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 99usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Linear {
                 input_index: 100usize,
@@ -6376,7 +6392,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 130usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Linear {
                 input_index: 131usize,
@@ -6413,7 +6429,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 136usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 137usize,
@@ -6562,7 +6578,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 158usize,
-                wrapper: WrapperType::CacheOnce,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Constant { value: -1000000f32 },
             BaseNoiseFunctionComponent::RangeChoice {
@@ -6612,7 +6628,10 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 167usize,
-                wrapper: WrapperType::Interpolated,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 4i32,
+                    cell_size_y: 8i32,
+                },
             },
             BaseNoiseFunctionComponent::Unary {
                 input_index: 168usize,
@@ -6649,7 +6668,10 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 173usize,
-                wrapper: WrapperType::Interpolated,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 4i32,
+                    cell_size_y: 8i32,
+                },
             },
             BaseNoiseFunctionComponent::Constant { value: 64f32 },
             BaseNoiseFunctionComponent::Noise {
@@ -6684,7 +6706,10 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 179usize,
-                wrapper: WrapperType::Interpolated,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 4i32,
+                    cell_size_y: 8i32,
+                },
             },
             BaseNoiseFunctionComponent::Noise {
                 data: &NoiseData {
@@ -6704,7 +6729,10 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 182usize,
-                wrapper: WrapperType::Interpolated,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 4i32,
+                    cell_size_y: 8i32,
+                },
             },
             BaseNoiseFunctionComponent::Unary {
                 input_index: 183usize,
@@ -6730,7 +6758,10 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 186usize,
-                wrapper: WrapperType::Interpolated,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 4i32,
+                    cell_size_y: 8i32,
+                },
             },
             BaseNoiseFunctionComponent::Unary {
                 input_index: 187usize,
@@ -6783,10 +6814,6 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                     operation: BinaryOperation::Add,
                 },
             },
-            BaseNoiseFunctionComponent::Wrapper {
-                input_index: 195usize,
-                wrapper: WrapperType::CellCache,
-            },
             BaseNoiseFunctionComponent::Noise {
                 data: &NoiseData {
                     noise_id: DoublePerlinNoiseParameters::AQUIFER_BARRIER,
@@ -6824,7 +6851,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::RangeChoice {
                 input_index: 170usize,
-                when_in_range_index: 201usize,
+                when_in_range_index: 200usize,
                 when_out_range_index: 10usize,
                 data: &RangeChoiceData {
                     min_inclusive: -64f32,
@@ -6832,12 +6859,15 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 202usize,
-                wrapper: WrapperType::Interpolated,
+                input_index: 201usize,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 4i32,
+                    cell_size_y: 8i32,
+                },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 203usize,
-                wrapper: WrapperType::CacheOnce,
+                input_index: 202usize,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Constant { value: 0.08f32 },
             BaseNoiseFunctionComponent::Noise {
@@ -6850,19 +6880,22 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             BaseNoiseFunctionComponent::Constant { value: 1f32 },
             BaseNoiseFunctionComponent::RangeChoice {
                 input_index: 170usize,
-                when_in_range_index: 206usize,
-                when_out_range_index: 207usize,
+                when_in_range_index: 205usize,
+                when_out_range_index: 206usize,
                 data: &RangeChoiceData {
                     min_inclusive: -64f32,
                     max_exclusive: 57f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 208usize,
-                wrapper: WrapperType::Interpolated,
+                input_index: 207usize,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 4i32,
+                    cell_size_y: 8i32,
+                },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 209usize,
+                input_index: 208usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
@@ -6876,49 +6909,52 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::RangeChoice {
                 input_index: 170usize,
-                when_in_range_index: 211usize,
-                when_out_range_index: 207usize,
+                when_in_range_index: 210usize,
+                when_out_range_index: 206usize,
                 data: &RangeChoiceData {
                     min_inclusive: -64f32,
                     max_exclusive: 57f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 212usize,
-                wrapper: WrapperType::Interpolated,
+                input_index: 211usize,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 4i32,
+                    cell_size_y: 8i32,
+                },
             },
             BaseNoiseFunctionComponent::Unary {
-                input_index: 213usize,
+                input_index: 212usize,
                 data: &UnaryData {
                     operation: UnaryOperation::Abs,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 210usize,
-                argument2_index: 214usize,
+                argument1_index: 209usize,
+                argument2_index: 213usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Max,
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 205usize,
-                argument2_index: 215usize,
+                argument1_index: 204usize,
+                argument2_index: 214usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Sub,
                 },
             },
             BaseNoiseFunctionComponent::RangeChoice {
-                input_index: 204usize,
+                input_index: 203usize,
                 when_in_range_index: 172usize,
-                when_out_range_index: 216usize,
+                when_out_range_index: 215usize,
                 data: &RangeChoiceData {
                     min_inclusive: -0.4f32,
                     max_exclusive: 0.4f32,
                 },
             },
             BaseNoiseFunctionComponent::Wrapper {
-                input_index: 217usize,
-                wrapper: WrapperType::CacheOnce,
+                input_index: 216usize,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Constant { value: -0.3f32 },
             BaseNoiseFunctionComponent::Noise {
@@ -6929,8 +6965,8 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 },
             },
             BaseNoiseFunctionComponent::Binary {
-                argument1_index: 219usize,
-                argument2_index: 220usize,
+                argument1_index: 218usize,
+                argument2_index: 219usize,
                 data: &BinaryData {
                     operation: BinaryOperation::Sub,
                 },
@@ -6941,16 +6977,16 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                 coordinate: 0i32,
             },
         ],
-        barrier_noise: 197usize,
-        fluid_level_floodedness_noise: 198usize,
-        fluid_level_spread_noise: 199usize,
-        lava_noise: 200usize,
-        erosion: 222usize,
+        barrier_noise: 196usize,
+        fluid_level_floodedness_noise: 197usize,
+        fluid_level_spread_noise: 198usize,
+        lava_noise: 199usize,
+        erosion: 221usize,
         depth: 34usize,
-        final_density: 196usize,
-        vein_toggle: 204usize,
-        vein_ridged: 218usize,
-        vein_gap: 221usize,
+        final_density: 195usize,
+        vein_toggle: 203usize,
+        vein_ridged: 217usize,
+        vein_gap: 220usize,
     },
     surface_estimator: BaseSurfaceEstimator {
         full_component_stack: &[
@@ -7002,7 +7038,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 8usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
             BaseNoiseFunctionComponent::ShiftB {
@@ -7015,7 +7051,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 12usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 9usize,
@@ -7034,7 +7070,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 15usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 9usize,
@@ -7053,7 +7089,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 18usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 9usize,
@@ -7072,7 +7108,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 21usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Unary {
                 input_index: 22usize,
@@ -8724,7 +8760,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 31usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 32usize,
@@ -9660,7 +9696,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 38usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 39usize,
@@ -9766,7 +9802,10 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 55usize,
-                wrapper: WrapperType::Interpolated,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 16i32,
+                    cell_size_y: 1i32,
+                },
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 56usize,
@@ -9787,7 +9826,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 1usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
             BaseNoiseFunctionComponent::ShiftB {
@@ -9800,7 +9839,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 5usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::ShiftedNoise {
                 shift_x_index: 2usize,
@@ -9819,7 +9858,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 8usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 9usize,
@@ -9873,7 +9912,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 16usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 17usize,
@@ -9897,7 +9936,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 20usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 21usize,
@@ -11566,7 +11605,7 @@ pub const OVERWORLD_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 34usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 35usize,
@@ -11645,7 +11684,10 @@ pub const NETHER_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 8usize,
-                wrapper: WrapperType::Interpolated,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 4i32,
+                    cell_size_y: 8i32,
+                },
             },
             BaseNoiseFunctionComponent::Unary {
                 input_index: 9usize,
@@ -11661,22 +11703,18 @@ pub const NETHER_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                     operation: BinaryOperation::Add,
                 },
             },
-            BaseNoiseFunctionComponent::Wrapper {
-                input_index: 12usize,
-                wrapper: WrapperType::CellCache,
-            },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
         ],
-        barrier_noise: 14usize,
-        fluid_level_floodedness_noise: 14usize,
-        fluid_level_spread_noise: 14usize,
-        lava_noise: 14usize,
-        erosion: 14usize,
-        depth: 14usize,
-        final_density: 13usize,
-        vein_toggle: 14usize,
-        vein_ridged: 14usize,
-        vein_gap: 14usize,
+        barrier_noise: 13usize,
+        fluid_level_floodedness_noise: 13usize,
+        fluid_level_spread_noise: 13usize,
+        lava_noise: 13usize,
+        erosion: 13usize,
+        depth: 13usize,
+        final_density: 12usize,
+        vein_toggle: 13usize,
+        vein_ridged: 13usize,
+        vein_gap: 13usize,
     },
     surface_estimator: BaseSurfaceEstimator {
         full_component_stack: &[BaseNoiseFunctionComponent::Constant { value: 0f32 }],
@@ -11800,7 +11838,7 @@ pub const END_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 14usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 15usize,
@@ -11845,7 +11883,10 @@ pub const END_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 22usize,
-                wrapper: WrapperType::Interpolated,
+                wrapper: WrapperType::Interpolated {
+                    cell_size_xz: 8i32,
+                    cell_size_y: 4i32,
+                },
             },
             BaseNoiseFunctionComponent::Unary {
                 input_index: 23usize,
@@ -11861,22 +11902,18 @@ pub const END_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
                     operation: BinaryOperation::Add,
                 },
             },
-            BaseNoiseFunctionComponent::Wrapper {
-                input_index: 26usize,
-                wrapper: WrapperType::CellCache,
-            },
             BaseNoiseFunctionComponent::Constant { value: 0f32 },
         ],
-        barrier_noise: 28usize,
-        fluid_level_floodedness_noise: 28usize,
-        fluid_level_spread_noise: 28usize,
-        lava_noise: 28usize,
+        barrier_noise: 27usize,
+        fluid_level_floodedness_noise: 27usize,
+        fluid_level_spread_noise: 27usize,
+        lava_noise: 27usize,
         erosion: 16usize,
-        depth: 28usize,
-        final_density: 27usize,
-        vein_toggle: 28usize,
-        vein_ridged: 28usize,
-        vein_gap: 28usize,
+        depth: 27usize,
+        final_density: 26usize,
+        vein_toggle: 27usize,
+        vein_ridged: 27usize,
+        vein_gap: 27usize,
     },
     surface_estimator: BaseSurfaceEstimator {
         full_component_stack: &[BaseNoiseFunctionComponent::Constant { value: 0f32 }],
@@ -11940,7 +11977,7 @@ pub const END_BASE_NOISE_ROUTER: BaseNoiseRouters = BaseNoiseRouters {
             },
             BaseNoiseFunctionComponent::Wrapper {
                 input_index: 11usize,
-                wrapper: WrapperType::CacheFlat,
+                wrapper: WrapperType::Cache,
             },
             BaseNoiseFunctionComponent::Slice {
                 input_index: 12usize,

--- a/crates/pumpkin-world/benches/noise_router.rs
+++ b/crates/pumpkin-world/benches/noise_router.rs
@@ -20,8 +20,7 @@ fn bench_noise_router_creation(c: &mut Criterion) {
 
     // Production overworld cell geometry (384 block world height / 8 = 48 vertical
     // cells). the previous vertical_cell_count of 4 under-measured by ~12x.
-    let builder_options =
-        ChunkNoiseFunctionBuilderOptions::new(4, 8, 48, 4, 0, 0, 4, vec![], vec![], None);
+    let builder_options = ChunkNoiseFunctionBuilderOptions::new(vec![], vec![], None);
 
     // Benchmarking
     c.bench_function("noise_router_creation_with_pooling", |b| {

--- a/crates/pumpkin-world/src/biome/mod.rs
+++ b/crates/pumpkin-world/src/biome/mod.rs
@@ -63,11 +63,8 @@ mod test {
     use serde::Deserialize;
 
     use crate::{
-        ProtoChunk,
-        chunk::palette::BIOME_NETWORK_MAX_BITS,
-        generation::noise::router::multi_noise_sampler::{
-            MultiNoiseSampler, MultiNoiseSamplerBuilderOptions,
-        },
+        ProtoChunk, chunk::palette::BIOME_NETWORK_MAX_BITS,
+        generation::noise::router::multi_noise_sampler::MultiNoiseSampler,
     };
 
     use super::{BiomeSupplier, MultiNoiseBiomeSupplier, hash_seed};
@@ -78,9 +75,7 @@ mod test {
         use pumpkin_util::world_seed::Seed;
         let seed = 13579;
         let generator = VanillaGenerator::new(Seed(seed as u64), Dimension::OVERWORLD);
-        let multi_noise_config = MultiNoiseSamplerBuilderOptions::new(1, 1, 1);
-        let mut sampler =
-            MultiNoiseSampler::generate(&generator.base_router.multi_noise, &multi_noise_config);
+        let mut sampler = MultiNoiseSampler::generate(&generator.base_router.multi_noise);
         let biome = MultiNoiseBiomeSupplier::OVERWORLD.biome(-24, 1, 8, &mut sampler);
         assert_eq!(biome, &Biome::DESERT);
     }
@@ -88,10 +83,7 @@ mod test {
     #[test]
     fn wide_area_surface() {
         use crate::generation::generator::{GeneratorInit, VanillaGenerator, WorldGenerator};
-        use crate::generation::noise::router::multi_noise_sampler::{
-            MultiNoiseSampler, MultiNoiseSamplerBuilderOptions,
-        };
-        use crate::generation::{biome_coords, positions::chunk_pos};
+        use crate::generation::noise::router::multi_noise_sampler::MultiNoiseSampler;
         use pumpkin_util::world_seed::Seed;
         #[derive(Deserialize)]
         struct BiomeData {
@@ -118,21 +110,8 @@ mod test {
 
             let mut chunk = ProtoChunk::new(chunk_x, chunk_z, &world_gen);
 
-            // Create MultiNoiseSampler for populate_biomes
-
-            let start_x = chunk_pos::start_block_x(chunk_x);
-            let start_z = chunk_pos::start_block_z(chunk_z);
-
-            let horizontal_biome_end = biome_coords::from_block(16);
-            let multi_noise_config = MultiNoiseSamplerBuilderOptions::new(
-                biome_coords::from_block(start_x),
-                biome_coords::from_block(start_z),
-                horizontal_biome_end as usize,
-            );
-            let mut multi_noise_sampler = MultiNoiseSampler::generate(
-                &generator.base_router.multi_noise,
-                &multi_noise_config,
-            );
+            let mut multi_noise_sampler =
+                MultiNoiseSampler::generate(&generator.base_router.multi_noise);
 
             chunk.populate_biomes(generator, &mut multi_noise_sampler);
 

--- a/crates/pumpkin-world/src/biome/multi_noise.rs
+++ b/crates/pumpkin-world/src/biome/multi_noise.rs
@@ -19,10 +19,7 @@ mod test {
     #[test]
     fn sample_value() {
         use crate::generation::generator::{GeneratorInit, VanillaGenerator, WorldGenerator};
-        use crate::generation::noise::router::multi_noise_sampler::{
-            MultiNoiseSampler, MultiNoiseSamplerBuilderOptions,
-        };
-        use crate::generation::{biome_coords, positions::chunk_pos};
+        use crate::generation::noise::router::multi_noise_sampler::MultiNoiseSampler;
         use pumpkin_util::world_seed::Seed;
         type PosToPoint = (i32, i32, i32, i64, i64, i64, i64, i64, i64);
         let expected_data: Vec<PosToPoint> = read_data_from_file!(
@@ -44,16 +41,8 @@ mod test {
 
         let _chunk = ProtoChunk::new(chunk_x, chunk_z, &world_gen);
 
-        let start_x = chunk_pos::start_block_x(chunk_x);
-        let start_z = chunk_pos::start_block_z(chunk_z);
-        let horizontal_biome_end = biome_coords::from_block(16);
-        let multi_noise_config = MultiNoiseSamplerBuilderOptions::new(
-            biome_coords::from_block(start_x),
-            biome_coords::from_block(start_z),
-            horizontal_biome_end as usize,
-        );
         let mut multi_noise_sampler =
-            MultiNoiseSampler::generate(&generator.base_router.multi_noise, &multi_noise_config);
+            MultiNoiseSampler::generate(&generator.base_router.multi_noise);
 
         for (x, y, z, tem, hum, con, ero, dep, wei) in expected_data {
             let point = multi_noise_sampler.sample(x, y, z);
@@ -77,10 +66,7 @@ mod test {
     //     let seed = 0;
     //     let generator = VanillaGenerator::new(Seed(seed as u64), Dimension::OVERWORLD);
 
-    //     let mut sampler = MultiNoiseSampler::generate(
-    //         &generator.base_router.multi_noise,
-    //         &MultiNoiseSamplerBuilderOptions::new(0, 0, 4),
-    //     );
+    //     let mut sampler = MultiNoiseSampler::generate(&generator.base_router.multi_noise);
 
     //     for (x, y, z, biome_id) in expected_data {
     //         let calculated_biome = MultiNoiseBiomeSupplier::OVERWORLD.biome(x, y, z, &mut sampler);

--- a/crates/pumpkin-world/src/generation/carver/mod.rs
+++ b/crates/pumpkin-world/src/generation/carver/mod.rs
@@ -128,18 +128,8 @@ pub fn carve(chunk: &mut ProtoChunk, generator: &VanillaGenerator) {
 
     let carvers_to_use = carvers_for_dimension(&generator.dimension);
 
-    let start_x = crate::generation::positions::chunk_pos::start_block_x(chunk_x);
-    let start_z = crate::generation::positions::chunk_pos::start_block_z(chunk_z);
     let generation_shape = &generator.settings.shape;
-    let horizontal_cell_count = 16 / generation_shape.horizontal_cell_block_count();
-
-    let horizontal_biome_end = crate::generation::biome_coords::from_block(
-        horizontal_cell_count as i32 * generation_shape.horizontal_cell_block_count() as i32,
-    );
     let surface_config = SurfaceHeightSamplerBuilderOptions::new(
-        crate::generation::biome_coords::from_block(start_x),
-        crate::generation::biome_coords::from_block(start_z),
-        horizontal_biome_end as usize,
         generation_shape.min_y as i32,
         generation_shape.max_y() as i32,
         generation_shape.vertical_cell_block_count() as usize,
@@ -367,17 +357,8 @@ fn with_carve_run_options<F>(
     };
     let mut chunk = ProtoChunk::new(0, 0, &world_gen);
 
-    let start_x = crate::generation::positions::chunk_pos::start_block_x(chunk.x);
-    let start_z = crate::generation::positions::chunk_pos::start_block_z(chunk.z);
     let generation_shape = &generator.settings.shape;
-    let horizontal_cell_count = 16 / generation_shape.horizontal_cell_block_count();
-    let horizontal_biome_end = crate::generation::biome_coords::from_block(
-        horizontal_cell_count as i32 * generation_shape.horizontal_cell_block_count() as i32,
-    );
     let surface_config = SurfaceHeightSamplerBuilderOptions::new(
-        crate::generation::biome_coords::from_block(start_x),
-        crate::generation::biome_coords::from_block(start_z),
-        horizontal_biome_end as usize,
         generation_shape.min_y as i32,
         generation_shape.max_y() as i32,
         generation_shape.vertical_cell_block_count() as usize,

--- a/crates/pumpkin-world/src/generation/generator/biome_finder.rs
+++ b/crates/pumpkin-world/src/generation/generator/biome_finder.rs
@@ -5,9 +5,7 @@ use rustc_hash::FxHashSet;
 
 use crate::biome::{BiomeSupplier, MultiNoiseBiomeSupplier, end::TheEndBiomeSupplier};
 use crate::generation::biome_coords;
-use crate::generation::noise::router::multi_noise_sampler::{
-    MultiNoiseSampler, MultiNoiseSamplerBuilderOptions,
-};
+use crate::generation::noise::router::multi_noise_sampler::MultiNoiseSampler;
 
 use super::{VanillaGenerator, WorldGenerator};
 
@@ -77,8 +75,7 @@ fn find_in_noise_world(
         &MultiNoiseBiomeSupplier::OVERWORLD
     };
 
-    let options = MultiNoiseSamplerBuilderOptions::new(1, 1, 1);
-    let mut sampler = MultiNoiseSampler::generate(&generator.base_router.multi_noise, &options);
+    let mut sampler = MultiNoiseSampler::generate(&generator.base_router.multi_noise);
 
     // `level.getMinY() + 1` to `level.getMaxY() + 1` in vanilla.
     let min_y = i32::from(generator.settings.shape.min_y) + 1;

--- a/crates/pumpkin-world/src/generation/generator/mod.rs
+++ b/crates/pumpkin-world/src/generation/generator/mod.rs
@@ -145,11 +145,9 @@ impl VanillaGenerator {
         if self.settings.spawn_target.is_empty() {
             return pumpkin_util::math::position::BlockPos::ZERO;
         }
-        let options = crate::generation::noise::router::multi_noise_sampler::MultiNoiseSamplerBuilderOptions::new(1, 1, 1);
         let mut sampler =
             crate::generation::noise::router::multi_noise_sampler::MultiNoiseSampler::generate(
                 &self.base_router.multi_noise,
-                &options,
             );
         crate::biome::position_finder::SpawnFinder::find_spawn_position(
             self.settings.spawn_target,

--- a/crates/pumpkin-world/src/generation/generator/structure_finder.rs
+++ b/crates/pumpkin-world/src/generation/generator/structure_finder.rs
@@ -112,14 +112,12 @@ pub fn find_nearest_structure_start(
         ProtoChunk,
         biome::{BiomeSupplier, MultiNoiseBiomeSupplier},
         generation::{
-            biome_coords,
             noise::router::{
-                multi_noise_sampler::{MultiNoiseSampler, MultiNoiseSamplerBuilderOptions},
+                multi_noise_sampler::MultiNoiseSampler,
                 surface_height_sampler::{
                     SurfaceHeightEstimateSampler, SurfaceHeightSamplerBuilderOptions,
                 },
             },
-            positions::chunk_pos::{start_block_x, start_block_z},
             structure::{
                 lazily_generate_structure,
                 placement::should_generate_structure,
@@ -174,15 +172,10 @@ pub fn find_nearest_structure_start(
                 for &key in target_structures {
                     let start =
                         global_cache.get_or_compute_structure_start(key, chunk_x, chunk_z, || {
-                            let start_x = start_block_x(chunk_x);
-                            let start_z = start_block_z(chunk_z);
                             let settings = noise_generator.settings;
                             let mut height_sampler = SurfaceHeightEstimateSampler::generate(
                                 &noise_generator.base_router.surface_estimator,
                                 &SurfaceHeightSamplerBuilderOptions::new(
-                                    biome_coords::from_block(start_x),
-                                    biome_coords::from_block(start_z),
-                                    4,
                                     settings.shape.min_y as i32,
                                     settings.shape.height as i32,
                                     (settings.shape.height
@@ -192,7 +185,6 @@ pub fn find_nearest_structure_start(
                             );
                             let mut biome_sampler = MultiNoiseSampler::generate(
                                 &noise_generator.base_router.multi_noise,
-                                &MultiNoiseSamplerBuilderOptions::new(0, 0, 0),
                             );
                             let biome_supplier: &dyn BiomeSupplier =
                                 &MultiNoiseBiomeSupplier::OVERWORLD;

--- a/crates/pumpkin-world/src/generation/noise/aquifer_sampler.rs
+++ b/crates/pumpkin-world/src/generation/noise/aquifer_sampler.rs
@@ -5,15 +5,12 @@ use pumpkin_util::{
 };
 
 use crate::generation::{
-    GlobalRandomConfig, biome_coords,
+    GlobalRandomConfig,
     noise::{
-        CHUNK_DIM, LAVA_BLOCK, WATER_BLOCK,
+        LAVA_BLOCK, WATER_BLOCK,
         router::{
-            chunk_density_function::{
-                ChunkNoiseFunctionBuilderOptions, ChunkNoiseFunctionSampleOptions, SampleAction,
-            },
-            chunk_noise_router::ChunkNoiseRouter,
-            proto_noise_router::ProtoNoiseRouters,
+            chunk_density_function::ChunkNoiseFunctionBuilderOptions,
+            chunk_noise_router::ChunkNoiseRouter, proto_noise_router::ProtoNoiseRouters,
             surface_height_sampler::SurfaceHeightEstimateSampler,
         },
     },
@@ -67,7 +64,6 @@ pub struct CarverAquiferSampler<'a> {
     aquifer: WorldAquiferSampler,
     router: ChunkNoiseRouter<'a>,
     height_estimator: SurfaceHeightEstimateSampler<'a>,
-    sample_options: ChunkNoiseFunctionSampleOptions,
 }
 
 impl<'a> CarverAquiferSampler<'a> {
@@ -80,32 +76,9 @@ impl<'a> CarverAquiferSampler<'a> {
         settings: &NoiseSettings,
     ) -> Self {
         let shape = &settings.shape;
-        let horizontal_cell_count = CHUNK_DIM / shape.horizontal_cell_block_count();
-        let start_x = chunk_pos::start_block_x(chunk_x);
-        let start_z = chunk_pos::start_block_z(chunk_z);
-        let horizontal_biome_end = biome_coords::from_block(
-            horizontal_cell_count as i32 * shape.horizontal_cell_block_count() as i32,
-        );
-        let builder_options = ChunkNoiseFunctionBuilderOptions::new(
-            shape.horizontal_cell_block_count() as usize,
-            shape.vertical_cell_block_count() as usize,
-            floor_div(
-                shape.height as usize,
-                shape.vertical_cell_block_count() as usize,
-            ),
-            horizontal_cell_count as usize,
-            biome_coords::from_block(start_x),
-            biome_coords::from_block(start_z),
-            horizontal_biome_end as usize,
-            Vec::new(),
-            Vec::new(),
-            None,
-        );
+        let builder_options = ChunkNoiseFunctionBuilderOptions::new(Vec::new(), Vec::new(), None);
         let surface_config =
             super::router::surface_height_sampler::SurfaceHeightSamplerBuilderOptions::new(
-                biome_coords::from_block(start_x),
-                biome_coords::from_block(start_z),
-                horizontal_biome_end as usize,
                 shape.min_y as i32,
                 shape.max_y() as i32,
                 shape.vertical_cell_block_count() as usize,
@@ -132,24 +105,13 @@ impl<'a> CarverAquiferSampler<'a> {
                 &base_router.surface_estimator,
                 &surface_config,
             ),
-            sample_options: ChunkNoiseFunctionSampleOptions::new(
-                false,
-                SampleAction::SkipCellCaches,
-                0,
-                0,
-                0,
-            ),
         }
     }
 
     pub fn compute(&mut self, pos: &Vector3<i32>, density: f32) -> CarverAquiferResult {
-        let (state, should_schedule_fluid_update) = self.aquifer.apply_internal(
-            &mut self.router,
-            pos,
-            &self.sample_options,
-            &mut self.height_estimator,
-            density,
-        );
+        let (state, should_schedule_fluid_update) =
+            self.aquifer
+                .apply_internal(&mut self.router, pos, &mut self.height_estimator, density);
 
         CarverAquiferResult {
             state,
@@ -375,7 +337,6 @@ impl WorldAquiferSampler {
         barrier_sample: &mut Option<f32>,
         pos: &Vector3<i32>,
         router: &mut ChunkNoiseRouter,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
         level_1: &FluidLevel,
         level_2: &FluidLevel,
     ) -> f32 {
@@ -403,7 +364,7 @@ impl WorldAquiferSampler {
                 };
 
                 let r = if (-2.0..=2.0).contains(&q) {
-                    *barrier_sample.get_or_insert_with(|| router.barrier_noise(pos, sample_options))
+                    *barrier_sample.get_or_insert_with(|| router.barrier_noise(pos))
                 } else {
                     0.0
                 };
@@ -420,7 +381,6 @@ impl WorldAquiferSampler {
         packed_pos: i64,
         router: &mut ChunkNoiseRouter,
         height_estimator: &mut SurfaceHeightEstimateSampler,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> FluidLevel {
         let x = block_pos::unpack_x(packed_pos);
         let y = block_pos::unpack_y(packed_pos);
@@ -438,7 +398,6 @@ impl WorldAquiferSampler {
                 z,
                 router,
                 height_estimator,
-                sample_options,
             );
         };
 
@@ -446,15 +405,8 @@ impl WorldAquiferSampler {
             return level.clone();
         }
 
-        let sampled = Self::get_fluid_level(
-            &self.fluid_level_sampler,
-            x,
-            y,
-            z,
-            router,
-            height_estimator,
-            sample_options,
-        );
+        let sampled =
+            Self::get_fluid_level(&self.fluid_level_sampler, x, y, z, router, height_estimator);
 
         self.levels[index] = Some(sampled.clone());
         sampled
@@ -467,7 +419,6 @@ impl WorldAquiferSampler {
         block_z: i32,
         router: &mut ChunkNoiseRouter,
         height_estimator: &mut SurfaceHeightEstimateSampler,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> FluidLevel {
         let fluid_level = fluid_level_sampler.get_fluid_level(block_x, block_y, block_z);
         let j = block_y + 12;
@@ -512,23 +463,13 @@ impl WorldAquiferSampler {
             min_surface_estimate,
             bl,
             router,
-            sample_options,
         );
         FluidLevel::new(
             p,
-            Self::get_fluid_block_state(
-                block_x,
-                block_y,
-                block_z,
-                fluid_level,
-                p,
-                router,
-                sample_options,
-            ),
+            Self::get_fluid_block_state(block_x, block_y, block_z, fluid_level, p, router),
         )
     }
 
-    #[expect(clippy::too_many_arguments)]
     fn get_fluid_block_y(
         block_x: i32,
         block_y: i32,
@@ -537,12 +478,10 @@ impl WorldAquiferSampler {
         surface_height_estimate: i32,
         map_y: bool,
         router: &mut ChunkNoiseRouter,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> i32 {
         let pos = Vector3::new(block_x, block_y, block_z);
 
-        let is_deep_dark = router.erosion(&pos, sample_options) < -0.225
-            && router.depth(&pos, sample_options) > 0.9;
+        let is_deep_dark = router.erosion(&pos) < -0.225 && router.depth(&pos) > 0.9;
 
         let (d, e) = if is_deep_dark {
             (-1.0, -1.0)
@@ -554,9 +493,7 @@ impl WorldAquiferSampler {
                 0.0
             };
 
-            let g = router
-                .fluid_level_floodedness_noise(&pos, sample_options)
-                .clamp(-1.0, 1.0);
+            let g = router.fluid_level_floodedness_noise(&pos).clamp(-1.0, 1.0);
             let h = pumpkin_util::math::map(f, 1.0, 0.0, -0.3, 0.8);
             let k = pumpkin_util::math::map(f, 1.0, 0.0, -0.8, 0.4);
 
@@ -572,7 +509,6 @@ impl WorldAquiferSampler {
                 block_z,
                 surface_height_estimate,
                 router,
-                sample_options,
             )
         } else {
             MIN_HEIGHT_CELL
@@ -585,7 +521,6 @@ impl WorldAquiferSampler {
         block_z: i32,
         surface_height_estimate: i32,
         router: &mut ChunkNoiseRouter,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> i32 {
         let x = floor_div(block_x, 16);
         let y = floor_div(block_y, 40);
@@ -593,7 +528,7 @@ impl WorldAquiferSampler {
 
         let local_y = y * 40 + 20;
 
-        let sample = router.fluid_level_spread_noise(&Vector3::new(x, y, z), sample_options) * 10.0;
+        let sample = router.fluid_level_spread_noise(&Vector3::new(x, y, z)) * 10.0;
         let to_nearest_multiple_of_three = (sample / 3.0).floor() as i32 * 3;
         let local_height = to_nearest_multiple_of_three + local_y;
 
@@ -607,14 +542,13 @@ impl WorldAquiferSampler {
         default_level: &FluidLevel,
         level: i32,
         router: &mut ChunkNoiseRouter,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> &'static Block {
         if level <= -10 && level != MIN_HEIGHT_CELL && default_level.block != &LAVA_BLOCK {
             let x = floor_div(block_x, 64);
             let y = floor_div(block_y, 40);
             let z = floor_div(block_z, 64);
 
-            let sample = router.lava_noise(&Vector3::new(x, y, z), sample_options);
+            let sample = router.lava_noise(&Vector3::new(x, y, z));
 
             if sample.abs() > 0.3 {
                 return &LAVA_BLOCK;
@@ -629,7 +563,6 @@ impl WorldAquiferSampler {
         &mut self,
         router: &mut ChunkNoiseRouter,
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
         height_estimator: &mut SurfaceHeightEstimateSampler,
         density: f32,
     ) -> (Option<&'static BlockState>, bool) {
@@ -703,16 +636,14 @@ impl WorldAquiferSampler {
             process!(packed);
         }
 
-        let fluid_level2 =
-            self.get_water_level(nearest[0].0, router, height_estimator, sample_options);
+        let fluid_level2 = self.get_water_level(nearest[0].0, router, height_estimator);
         let block_state = fluid_level2.get_block(sample_y);
         let sim12 = Self::max_distance(nearest[0].1, nearest[1].1);
 
         if sim12 <= 0.0 {
             let should_schedule = if sim12 >= -0.12 {
                 // FLOWING_UPDATE_SIMILARITY
-                let fluid_level3 =
-                    self.get_water_level(nearest[1].0, router, height_estimator, sample_options);
+                let fluid_level3 = self.get_water_level(nearest[1].0, router, height_estimator);
                 fluid_level2.block != fluid_level3.block || fluid_level2.max_y != fluid_level3.max_y
             } else {
                 false
@@ -731,14 +662,12 @@ impl WorldAquiferSampler {
         }
 
         let mut barrier_sample = None;
-        let fluid_level3 =
-            self.get_water_level(nearest[1].0, router, height_estimator, sample_options);
+        let fluid_level3 = self.get_water_level(nearest[1].0, router, height_estimator);
         let barrier12 = sim12
             * Self::calculate_density(
                 &mut barrier_sample,
                 pos,
                 router,
-                sample_options,
                 &fluid_level2,
                 &fluid_level3,
             );
@@ -747,8 +676,7 @@ impl WorldAquiferSampler {
             return (None, false);
         }
 
-        let fluid_level4 =
-            self.get_water_level(nearest[2].0, router, height_estimator, sample_options);
+        let fluid_level4 = self.get_water_level(nearest[2].0, router, height_estimator);
         let sim13 = Self::max_distance(nearest[0].1, nearest[2].1);
         if sim13 > 0.0 {
             let barrier13 = sim12
@@ -757,7 +685,6 @@ impl WorldAquiferSampler {
                     &mut barrier_sample,
                     pos,
                     router,
-                    sample_options,
                     &fluid_level2,
                     &fluid_level4,
                 );
@@ -774,7 +701,6 @@ impl WorldAquiferSampler {
                     &mut barrier_sample,
                     pos,
                     router,
-                    sample_options,
                     &fluid_level3,
                     &fluid_level4,
                 );
@@ -795,8 +721,7 @@ impl WorldAquiferSampler {
         let should_schedule = if may_flow12 || may_flow23 || may_flow13 {
             true
         } else {
-            let fluid_level5 =
-                self.get_water_level(nearest[3].0, router, height_estimator, sample_options);
+            let fluid_level5 = self.get_water_level(nearest[3].0, router, height_estimator);
             sim13 >= -0.12
                 && Self::max_distance(nearest[0].1, nearest[3].1) >= -0.12
                 && (fluid_level2.block != fluid_level5.block
@@ -813,11 +738,10 @@ impl AquiferSamplerImpl for WorldAquiferSampler {
         &mut self,
         router: &mut ChunkNoiseRouter,
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
+        density: f32,
         height_estimator: &mut SurfaceHeightEstimateSampler,
     ) -> (Option<&'static BlockState>, bool) {
-        let density = router.final_density(pos, sample_options);
-        self.apply_internal(router, pos, sample_options, height_estimator, density)
+        self.apply_internal(router, pos, height_estimator, density)
     }
 }
 
@@ -835,13 +759,12 @@ impl SeaLevelAquiferSampler {
 impl AquiferSamplerImpl for SeaLevelAquiferSampler {
     fn apply(
         &mut self,
-        router: &mut ChunkNoiseRouter,
+        _router: &mut ChunkNoiseRouter,
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
+        density: f32,
         _height_estimator: &mut SurfaceHeightEstimateSampler,
     ) -> (Option<&'static BlockState>, bool) {
-        let sample = router.final_density(pos, sample_options);
-        if sample > 0.0 {
+        if density > 0.0 {
             (None, false)
         } else {
             (
@@ -862,7 +785,7 @@ pub trait AquiferSamplerImpl {
         &mut self,
         router: &mut ChunkNoiseRouter,
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
+        density: f32,
         height_estimator: &mut SurfaceHeightEstimateSampler,
     ) -> (Option<&'static BlockState>, bool);
 }
@@ -873,12 +796,12 @@ impl AquiferSamplerImpl for AquiferSampler {
         &mut self,
         router: &mut ChunkNoiseRouter,
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
+        density: f32,
         height_estimator: &mut SurfaceHeightEstimateSampler,
     ) -> (Option<&'static BlockState>, bool) {
         match self {
-            Self::SeaLevel(s) => s.apply(router, pos, sample_options, height_estimator),
-            Self::Aquifer(a) => a.apply(router, pos, sample_options, height_estimator),
+            Self::SeaLevel(s) => s.apply(router, pos, density, height_estimator),
+            Self::Aquifer(a) => a.apply(router, pos, density, height_estimator),
         }
     }
 }
@@ -895,12 +818,12 @@ mod random_positions_and_hypot {
     use pumpkin_util::math::vector3::Vector3;
 
     use crate::generation::{
-        GlobalRandomConfig, biome_coords,
+        GlobalRandomConfig,
         noise::{
             BlockStateSampler, ChunkNoiseGenerator, LAVA_BLOCK, WATER_BLOCK,
             router::{
-                chunk_density_function::{ChunkNoiseFunctionSampleOptions, SampleAction},
                 chunk_noise_router::ChunkNoiseRouter,
+                density_volume::DensityVolume,
                 proto_noise_router::ProtoNoiseRouters,
                 surface_height_sampler::{
                     SurfaceHeightEstimateSampler, SurfaceHeightSamplerBuilderOptions,
@@ -928,7 +851,6 @@ mod random_positions_and_hypot {
         WorldAquiferSampler,
         ChunkNoiseRouter<'_>,
         SurfaceHeightEstimateSampler<'_>,
-        ChunkNoiseFunctionSampleOptions,
     ) {
         const CHUNK_WIDTH: usize = 16;
 
@@ -944,9 +866,14 @@ mod random_positions_and_hypot {
         let noise = ChunkNoiseGenerator::new(
             &base_router.noise,
             &RANDOM_CONFIG,
-            CHUNK_WIDTH / shape.horizontal_cell_block_count() as usize,
-            chunk_pos::start_block_x(chunk_x),
-            chunk_pos::start_block_z(chunk_z),
+            DensityVolume::with_block_step(
+                CHUNK_WIDTH,
+                shape.height as usize,
+                CHUNK_WIDTH,
+                chunk_pos::start_block_x(chunk_x),
+                i32::from(shape.min_y),
+                chunk_pos::start_block_z(chunk_z),
+            ),
             shape,
             sampler,
             true,
@@ -955,8 +882,6 @@ mod random_positions_and_hypot {
             Vec::new(),
             None,
         );
-        let options =
-            ChunkNoiseFunctionSampleOptions::new(false, SampleAction::SkipCellCaches, 0, 0, 0);
         let mut samplers_vec = noise.state_sampler.samplers.into_vec();
         let first_sampler = samplers_vec.remove(0);
 
@@ -968,16 +893,7 @@ mod random_positions_and_hypot {
             unreachable!()
         };
 
-        let horizontal_cell_count = CHUNK_WIDTH / shape.horizontal_cell_block_count() as usize;
-
-        let horizontal_biome_end = biome_coords::from_block(
-            horizontal_cell_count as i32 * shape.horizontal_cell_block_count() as i32,
-        );
-
         let surface_height_estimator_options = SurfaceHeightSamplerBuilderOptions::new(
-            chunk_x,
-            chunk_z,
-            horizontal_biome_end as usize,
             shape.min_y as i32,
             shape.max_y() as i32,
             shape.vertical_cell_block_count() as usize,
@@ -987,7 +903,7 @@ mod random_positions_and_hypot {
             &surface_height_estimator_options,
         );
 
-        (aquifer, noise.router, height_estimator, options)
+        (aquifer, noise.router, height_estimator)
     }
 
     fn create_carver_aquifer() -> CarverAquiferSampler<'static> {
@@ -1044,7 +960,7 @@ mod random_positions_and_hypot {
     #[test]
     #[expect(clippy::too_many_lines)]
     fn get_fluid_block_state() {
-        let (_, mut router, _, options) = create_aquifer(&PROTO_ROUTER);
+        let (_, mut router, _) = create_aquifer(&PROTO_ROUTER);
         let level = FluidLevel::new(0, &WATER_BLOCK);
 
         let values = [
@@ -1177,15 +1093,7 @@ mod random_positions_and_hypot {
 
         for ((x, y, z), result) in values {
             assert_eq!(
-                WorldAquiferSampler::get_fluid_block_state(
-                    x,
-                    y,
-                    z,
-                    &level,
-                    -10,
-                    &mut router,
-                    &options
-                ),
+                WorldAquiferSampler::get_fluid_block_state(x, y, z, &level, -10, &mut router),
                 &result
             );
         }
@@ -1194,7 +1102,7 @@ mod random_positions_and_hypot {
     #[test]
     #[expect(clippy::too_many_lines)]
     fn get_noise_based_fluid_level() {
-        let (_, mut router, _, options) = create_aquifer(&PROTO_ROUTER);
+        let (_, mut router, _) = create_aquifer(&PROTO_ROUTER);
 
         let values = [
             ((-100, -100, -100), -103),
@@ -1326,14 +1234,7 @@ mod random_positions_and_hypot {
 
         for ((x, y, z), result) in values {
             assert_eq!(
-                WorldAquiferSampler::get_noise_based_fluid_level(
-                    x,
-                    y,
-                    z,
-                    200,
-                    &mut router,
-                    &options
-                ),
+                WorldAquiferSampler::get_noise_based_fluid_level(x, y, z, 200, &mut router),
                 result
             );
         }
@@ -1342,7 +1243,7 @@ mod random_positions_and_hypot {
     #[test]
     #[expect(clippy::too_many_lines)]
     fn get_fluid_block_y() {
-        let (_, mut router, _, env) = create_aquifer(&PROTO_ROUTER);
+        let (_, mut router, _) = create_aquifer(&PROTO_ROUTER);
         let level = FluidLevel::new(0, &WATER_BLOCK);
         let values = [
             ((-100, -100, -100), -32512),
@@ -1474,16 +1375,7 @@ mod random_positions_and_hypot {
 
         for ((x, y, z), result) in values {
             assert_eq!(
-                WorldAquiferSampler::get_fluid_block_y(
-                    x,
-                    y,
-                    z,
-                    &level,
-                    80,
-                    true,
-                    &mut router,
-                    &env
-                ),
+                WorldAquiferSampler::get_fluid_block_y(x, y, z, &level, 80, true, &mut router,),
                 result
             );
         }
@@ -1618,16 +1510,7 @@ mod random_positions_and_hypot {
 
         for ((x, y, z), result) in values {
             assert_eq!(
-                WorldAquiferSampler::get_fluid_block_y(
-                    x,
-                    y,
-                    z,
-                    &level,
-                    80,
-                    false,
-                    &mut router,
-                    &env
-                ),
+                WorldAquiferSampler::get_fluid_block_y(x, y, z, &level, 80, false, &mut router,),
                 result
             );
         }
@@ -1636,7 +1519,7 @@ mod random_positions_and_hypot {
     #[test]
     #[expect(clippy::too_many_lines)]
     fn get_fluid_level() {
-        let (aquifer, mut router, mut height_estimator, env) = create_aquifer(&PROTO_ROUTER);
+        let (aquifer, mut router, mut height_estimator) = create_aquifer(&PROTO_ROUTER);
         let values = [
             ((-100, -100, -100), (-32512, LAVA_BLOCK)),
             ((-100, -100, -50), (-32512, LAVA_BLOCK)),
@@ -1774,7 +1657,6 @@ mod random_positions_and_hypot {
                 z,
                 &mut router,
                 &mut height_estimator,
-                &env,
             );
             assert_eq!(level.max_y, y1, "Failed at x={x}, y={y}, z={z}");
             assert_eq!(level.block, &state);
@@ -1784,7 +1666,7 @@ mod random_positions_and_hypot {
     #[test]
     #[expect(clippy::too_many_lines)]
     fn calculate_density() {
-        let (_, mut router, _, env) = create_aquifer(&PROTO_ROUTER);
+        let (_, mut router, _) = create_aquifer(&PROTO_ROUTER);
 
         let values = [
             ((-100, -100, -100, 0, 0), 0.0),
@@ -1924,7 +1806,6 @@ mod random_positions_and_hypot {
                 &mut sample,
                 &pos,
                 &mut router,
-                &env,
                 &level1,
                 &level2,
             );
@@ -1938,7 +1819,7 @@ mod random_positions_and_hypot {
     #[test]
     #[expect(clippy::too_many_lines)]
     fn apply() {
-        let (mut aquifer, mut router, mut height_estimator, env) = create_aquifer(&PROTO_ROUTER);
+        let (mut aquifer, mut router, mut height_estimator) = create_aquifer(&PROTO_ROUTER);
         let values = [
             ((112, -100, 64, 0.037482421875), None),
             ((112, -100, 66, 0.037482421875), None),
@@ -2690,7 +2571,7 @@ mod random_positions_and_hypot {
             let pos = Vector3::new(x, y, z);
             assert_eq!(
                 aquifer
-                    .apply_internal(&mut router, &pos, &env, &mut height_estimator, sample)
+                    .apply_internal(&mut router, &pos, &mut height_estimator, sample)
                     .0,
                 result.map(pumpkin_data::BlockStateId::to_state)
             );

--- a/crates/pumpkin-world/src/generation/noise/mod.rs
+++ b/crates/pumpkin-world/src/generation/noise/mod.rs
@@ -18,14 +18,11 @@ use crate::generation::{
 };
 
 use super::{
-    GlobalRandomConfig, biome_coords,
+    GlobalRandomConfig,
     noise::router::{
-        chunk_density_function::{
-            ChunkNoiseFunctionBuilderOptions, ChunkNoiseFunctionSampleOptions, SampleAction,
-            WrapperData,
-        },
+        chunk_density_function::ChunkNoiseFunctionBuilderOptions,
         chunk_noise_router::ChunkNoiseRouter,
-        density_function::IndexToNoisePos,
+        density_volume::{DensityBuffer, DensityVolume},
         proto_noise_router::ProtoNoiseRouter,
         surface_height_sampler::SurfaceHeightEstimateSampler,
     },
@@ -35,6 +32,26 @@ pub const LAVA_BLOCK: Block = Block::LAVA;
 pub const WATER_BLOCK: Block = Block::WATER;
 
 pub const CHUNK_DIM: u8 = 16;
+
+pub struct VeinSample {
+    pub toggle: f32,
+    pub ridged: f32,
+}
+
+pub struct ChunkDensities {
+    pub density: DensityBuffer,
+    veins: Option<[DensityBuffer; 2]>,
+}
+
+impl ChunkDensities {
+    #[must_use]
+    pub fn vein_sample(&self, index: usize) -> Option<VeinSample> {
+        self.veins.as_ref().map(|[toggle, ridged]| VeinSample {
+            toggle: toggle[index],
+            ridged: ridged[index],
+        })
+    }
+}
 
 pub enum BlockStateSampler {
     Aquifer(AquiferSampler),
@@ -47,16 +64,15 @@ impl BlockStateSampler {
         router: &mut ChunkNoiseRouter,
         ore_random_deriver: &XoroshiroSplitter,
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
+        density: f32,
+        veins: Option<&VeinSample>,
         height_estimator: &mut SurfaceHeightEstimateSampler,
     ) -> Option<&'static BlockState> {
         match self {
-            Self::Aquifer(aquifer) => {
-                aquifer
-                    .apply(router, pos, sample_options, height_estimator)
-                    .0
+            Self::Aquifer(aquifer) => aquifer.apply(router, pos, density, height_estimator).0,
+            Self::Ore(ore) => {
+                veins.and_then(|veins| ore.sample(router, ore_random_deriver, pos, veins))
             }
-            Self::Ore(ore) => ore.sample(router, ore_random_deriver, pos, sample_options),
         }
     }
 }
@@ -76,7 +92,8 @@ impl ChainedBlockStateSampler {
         router: &mut ChunkNoiseRouter,
         ore_random_deriver: &XoroshiroSplitter,
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
+        density: f32,
+        veins: Option<&VeinSample>,
         height_estimator: &mut SurfaceHeightEstimateSampler,
     ) -> Option<&'static BlockState> {
         for sampler in &mut self.samplers {
@@ -84,7 +101,8 @@ impl ChainedBlockStateSampler {
                 router,
                 ore_random_deriver,
                 pos,
-                sample_options,
+                density,
+                veins,
                 height_estimator,
             ) {
                 return Some(state);
@@ -94,83 +112,11 @@ impl ChainedBlockStateSampler {
     }
 }
 
-struct InterpolationIndexMapper {
-    x: i32,
-    z: i32,
-
-    minimum_cell_y: i32,
-    vertical_cell_block_count: i32,
-}
-
-impl IndexToNoisePos for InterpolationIndexMapper {
-    fn at(
-        &self,
-        index: usize,
-        sample_data: Option<&mut ChunkNoiseFunctionSampleOptions>,
-    ) -> Vector3<i32> {
-        if let Some(sample_data) = sample_data {
-            sample_data.cache_result_unique_id += 1;
-            sample_data.fill_index = index;
-        }
-
-        let y = (index as i32 + self.minimum_cell_y) * self.vertical_cell_block_count;
-
-        // TODO: Change this when Blender is implemented
-        Vector3::new(self.x, y, self.z)
-    }
-}
-
-struct ChunkIndexMapper {
-    start_x: i32,
-    start_y: i32,
-    start_z: i32,
-
-    horizontal_cell_block_count: usize,
-    vertical_cell_block_count: usize,
-}
-
-impl IndexToNoisePos for ChunkIndexMapper {
-    fn at(
-        &self,
-        index: usize,
-        sample_options: Option<&mut ChunkNoiseFunctionSampleOptions>,
-    ) -> Vector3<i32> {
-        // Matches vanilla mathematical index mapping (yInCell, xInCell, zInCell)
-        let cell_z_position = index % self.horizontal_cell_block_count;
-        let xy_portion = index / self.horizontal_cell_block_count;
-        let cell_x_position = xy_portion % self.horizontal_cell_block_count;
-        let cell_y_position =
-            self.vertical_cell_block_count - 1 - (xy_portion / self.horizontal_cell_block_count);
-
-        if let Some(sample_options) = sample_options {
-            sample_options.fill_index = index;
-            if let SampleAction::CellCaches(wrapper_data) = &mut sample_options.action {
-                wrapper_data.update_position(cell_x_position, cell_y_position, cell_z_position);
-            }
-        }
-
-        // TODO: Change this when Blender is implemented
-        Vector3::new(
-            self.start_x + cell_x_position as i32,
-            self.start_y + cell_y_position as i32,
-            self.start_z + cell_z_position as i32,
-        )
-    }
-}
-
 pub struct ChunkNoiseGenerator<'a> {
     pub state_sampler: ChainedBlockStateSampler,
     generation_shape: &'a GenerationShapeConfig,
-    start_cell_pos_x: i32,
-    start_cell_pos_z: i32,
-    horizontal_cell_count: usize,
-
-    vertical_cell_count: usize,
-    minimum_cell_y: i32,
-
-    cache_fill_unique_id: u64,
-    cache_result_unique_id: u64,
-
+    volume: DensityVolume,
+    ore_veins: bool,
     pub router: ChunkNoiseRouter<'a>,
 }
 
@@ -180,9 +126,7 @@ impl<'a> ChunkNoiseGenerator<'a> {
     pub fn new(
         noise_router_base: &'a ProtoNoiseRouter,
         random_config: &GlobalRandomConfig,
-        horizontal_cell_count: usize,
-        start_block_x: i32,
-        start_block_z: i32,
+        volume: DensityVolume,
         generation_shape: &'a GenerationShapeConfig,
         level_sampler: StandardChunkFluidLevelSampler,
         aquifers: bool,
@@ -195,38 +139,15 @@ impl<'a> ChunkNoiseGenerator<'a> {
         >,
         affected_box: Option<pumpkin_util::math::block_box::BlockBox>,
     ) -> Self {
-        let start_cell_pos_x =
-            start_block_x / generation_shape.horizontal_cell_block_count() as i32;
-        let start_cell_pos_z =
-            start_block_z / generation_shape.horizontal_cell_block_count() as i32;
-
-        let horizontal_biome_end = biome_coords::from_block(
-            horizontal_cell_count as i32 * generation_shape.horizontal_cell_block_count() as i32,
-        );
-        let vertical_cell_count = (generation_shape.height as usize)
-            / (generation_shape.vertical_cell_block_count() as usize);
-        let minimum_cell_y =
-            (generation_shape.min_y as i32) / (generation_shape.vertical_cell_block_count() as i32);
-
-        let vertical_cell_block_count = generation_shape.vertical_cell_block_count();
-        let horizontal_cell_block_count = generation_shape.horizontal_cell_block_count();
-
         let builder_options = ChunkNoiseFunctionBuilderOptions::new(
-            horizontal_cell_block_count as usize,
-            vertical_cell_block_count as usize,
-            vertical_cell_count,
-            horizontal_cell_count,
-            biome_coords::from_block(start_block_x),
-            biome_coords::from_block(start_block_z),
-            horizontal_biome_end as usize,
             beardifier_structures,
             beardifier_junctions,
             affected_box,
         );
 
         let aquifer_sampler = if aquifers {
-            let section_x = section_coords::block_to_section(start_block_x);
-            let section_z = section_coords::block_to_section(start_block_z);
+            let section_x = section_coords::block_to_section(volume.min_block_x);
+            let section_z = section_coords::block_to_section(volume.min_block_z);
             AquiferSampler::Aquifer(WorldAquiferSampler::new(
                 section_x,
                 section_z,
@@ -254,183 +175,48 @@ impl<'a> ChunkNoiseGenerator<'a> {
         Self {
             state_sampler,
             generation_shape,
-            start_cell_pos_x,
-            start_cell_pos_z,
-            horizontal_cell_count,
-            vertical_cell_count,
-            minimum_cell_y,
-
-            cache_fill_unique_id: 0,
-            cache_result_unique_id: 0,
-
+            volume,
+            ore_veins,
             router,
         }
     }
 
-    #[inline]
-    pub fn sample_start_density(&mut self) {
-        self.cache_result_unique_id = 0;
-        self.sample_density(true, self.start_cell_pos_x);
+    #[must_use]
+    pub const fn volume(&self) -> &DensityVolume {
+        &self.volume
     }
 
-    #[inline]
-    pub fn sample_end_density(&mut self, cell_x: i32) {
-        self.sample_density(false, self.start_cell_pos_x + cell_x + 1);
+    pub fn sample_density(&mut self) -> ChunkDensities {
+        let mut density = DensityBuffer::acquire(&self.volume);
+        self.router.final_density_volume(&mut density, &self.volume);
+        let veins = self.ore_veins.then(|| {
+            let mut toggle = DensityBuffer::acquire(&self.volume);
+            self.router.vein_toggle_volume(&mut toggle, &self.volume);
+            let mut ridged = DensityBuffer::acquire(&self.volume);
+            self.router.vein_ridged_volume(&mut ridged, &self.volume);
+            [toggle, ridged]
+        });
+        ChunkDensities { density, veins }
     }
 
-    fn sample_density(&mut self, start: bool, current_x: i32) {
-        let x = current_x * self.horizontal_cell_block_count() as i32;
-
-        for cell_z in 0..=self.horizontal_cell_count {
-            let current_cell_z_pos = self.start_cell_pos_z + cell_z as i32;
-            let z = current_cell_z_pos * self.horizontal_cell_block_count() as i32;
-            self.cache_fill_unique_id += 1;
-
-            let mapper = InterpolationIndexMapper {
-                x,
-                z,
-                minimum_cell_y: self.minimum_cell_y,
-                vertical_cell_block_count: self.vertical_cell_block_count() as i32,
-            };
-
-            let mut options = ChunkNoiseFunctionSampleOptions::new(
-                false,
-                SampleAction::CellCaches(WrapperData::new(
-                    0,
-                    0,
-                    0,
-                    self.horizontal_cell_block_count() as usize,
-                    self.vertical_cell_block_count() as usize,
-                )),
-                self.cache_result_unique_id,
-                self.cache_fill_unique_id,
-                0,
-            );
-
-            self.fill_interpolator_buffers(start, cell_z, &mapper, &mut options);
-            self.cache_result_unique_id = options.cache_result_unique_id;
-        }
-        self.cache_fill_unique_id += 1;
-    }
-
-    #[inline]
-    fn fill_interpolator_buffers(
-        &mut self,
-        start: bool,
-        cell_z: usize,
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        self.router
-            .fill_interpolator_buffers(start, cell_z, mapper, sample_options);
-    }
-
-    #[inline]
-    pub fn interpolate_x(&mut self, delta: f32) {
-        self.router.interpolate_x(delta);
-    }
-
-    #[inline]
-    pub fn interpolate_y(&mut self, delta: f32) {
-        self.router.interpolate_y(delta);
-    }
-
-    #[inline]
-    pub fn interpolate_z(&mut self, delta: f32) {
-        self.cache_result_unique_id += 1;
-        self.router.interpolate_z(delta);
-    }
-
-    #[inline]
-    pub fn swap_buffers(&mut self) {
-        self.router.swap_buffers();
-    }
-
-    pub fn on_sampled_cell_corners(&mut self, cell_x: i32, cell_y: i32, cell_z: i32) {
-        self.router
-            .on_sampled_cell_corners(cell_y as usize, cell_z as usize);
-        self.cache_fill_unique_id += 1;
-
-        let start_x = (self.start_cell_pos_x + cell_x) * self.horizontal_cell_block_count() as i32;
-        let start_y = (cell_y + self.minimum_cell_y) * self.vertical_cell_block_count() as i32;
-        let start_z = (self.start_cell_pos_z + cell_z) * self.horizontal_cell_block_count() as i32;
-
-        let mapper = ChunkIndexMapper {
-            start_x,
-            start_y,
-            start_z,
-            horizontal_cell_block_count: self.horizontal_cell_block_count() as usize,
-            vertical_cell_block_count: self.vertical_cell_block_count() as usize,
-        };
-
-        let mut sample_options = ChunkNoiseFunctionSampleOptions::new(
-            true,
-            SampleAction::CellCaches(WrapperData::new(
-                0,
-                0,
-                0,
-                self.horizontal_cell_block_count() as usize,
-                self.vertical_cell_block_count() as usize,
-            )),
-            self.cache_result_unique_id,
-            self.cache_fill_unique_id,
-            0,
-        );
-
-        self.router.fill_cell_caches(&mapper, &mut sample_options);
-        self.cache_fill_unique_id += 1;
-    }
-
-    #[expect(clippy::too_many_arguments)]
     pub fn sample_block_state(
         &mut self,
         ore_random_deriver: &XoroshiroSplitter,
-        start_x: i32,
-        start_y: i32,
-        start_z: i32,
-        cell_x: i32,
-        cell_y: i32,
-        cell_z: i32,
+        pos: &Vector3<i32>,
+        density: f32,
+        veins: Option<&VeinSample>,
         height_estimator: &mut SurfaceHeightEstimateSampler,
     ) -> Option<&'static BlockState> {
-        let pos = Vector3::new(start_x + cell_x, start_y + cell_y, start_z + cell_z);
-
-        let options = ChunkNoiseFunctionSampleOptions::new(
-            false,
-            SampleAction::CellCaches(WrapperData::new(
-                cell_x as usize,
-                cell_y as usize,
-                cell_z as usize,
-                self.horizontal_cell_block_count() as usize,
-                self.vertical_cell_block_count() as usize,
-            )),
-            self.cache_result_unique_id,
-            self.cache_fill_unique_id,
-            0,
-        );
-
         self.state_sampler.sample(
             &mut self.router,
             ore_random_deriver,
-            &pos,
-            &options,
+            pos,
+            density,
+            veins,
             height_estimator,
         )
     }
 
-    #[inline]
-    #[must_use]
-    pub const fn horizontal_cell_block_count(&self) -> u8 {
-        self.generation_shape.horizontal_cell_block_count()
-    }
-
-    #[inline]
-    #[must_use]
-    pub const fn vertical_cell_block_count(&self) -> u8 {
-        self.generation_shape.vertical_cell_block_count()
-    }
-
-    /// Aka `bottom_y`
     #[inline]
     #[must_use]
     pub const fn min_y(&self) -> i8 {
@@ -442,9 +228,4 @@ impl<'a> ChunkNoiseGenerator<'a> {
     pub const fn height(&self) -> u16 {
         self.generation_shape.height
     }
-}
-
-#[cfg(test)]
-mod test {
-    // TODO: Add test to verify the height estimator has no interpolators or cell caches
 }

--- a/crates/pumpkin-world/src/generation/noise/ore_sampler.rs
+++ b/crates/pumpkin-world/src/generation/noise/ore_sampler.rs
@@ -4,21 +4,20 @@ use pumpkin_util::{
     random::{RandomImpl, xoroshiro128::XoroshiroSplitter},
 };
 
-use crate::generation::noise::router::{
-    chunk_density_function::ChunkNoiseFunctionSampleOptions, chunk_noise_router::ChunkNoiseRouter,
-};
+use crate::generation::noise::{VeinSample, router::chunk_noise_router::ChunkNoiseRouter};
 
 pub struct OreVeinSampler;
 
 impl OreVeinSampler {
+    #[must_use]
     pub fn sample(
         &self,
         router: &mut ChunkNoiseRouter,
         ore_random_deriver: &XoroshiroSplitter,
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
+        veins: &VeinSample,
     ) -> Option<&'static BlockState> {
-        let vein_toggle = router.vein_toggle(pos, sample_options);
+        let vein_toggle = veins.toggle;
         let vein_type: &VeinType = if vein_toggle > 0.0 {
             &vein_type::COPPER
         } else {
@@ -35,11 +34,11 @@ impl OreVeinSampler {
             if abs_sample + mapped_diff >= 0.4 {
                 let mut random = ore_random_deriver.split_pos(pos.x, block_y, pos.z);
 
-                let vein_ridged_sample = router.vein_ridged(pos, sample_options);
+                let vein_ridged_sample = veins.ridged;
                 if random.next_f32() <= 0.7 && vein_ridged_sample < 0.0 {
                     let clamped_sample = clamped_map(abs_sample, 0.4, 0.6, 0.1, 0.3);
 
-                    let vein_gap = router.vein_gap(pos, sample_options);
+                    let vein_gap = router.vein_gap(pos);
                     return if random.next_f32() < clamped_sample && vein_gap > -0.3 {
                         Some(if random.next_f32() < 0.02 {
                             vein_type.raw_ore.default_state

--- a/crates/pumpkin-world/src/generation/noise/router/chunk_density_function.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/chunk_density_function.rs
@@ -1,190 +1,28 @@
-use std::cell::RefCell;
-use std::mem;
+use pumpkin_util::math::{block_box::BlockBox, lerp, vector3::Vector3};
 
 use super::{
     chunk_noise_router::{ChunkNoiseFunctionComponent, MutableChunkNoiseFunctionComponentImpl},
-    density_function::{IndexToNoisePos, NoiseFunctionComponentRange},
-    density_volume::DensityVolume,
+    density_function::{
+        NoiseFunctionComponentRange,
+        beardifier::{Beardifier, BeardifierJunction, BeardifierStructure},
+    },
+    density_volume::{DensityBuffer, DensityVolume},
 };
-use pumpkin_util::math::{lerp, lerp2, lerp3, vector3::Vector3};
-
-use crate::generation::{biome_coords, positions::chunk_pos};
-
-thread_local! {
-    static F64_BUFFER_POOL: RefCell<Vec<Vec<f32>>> = const {
-        RefCell::new(Vec::new())
-    };
-}
-
-#[inline]
-fn get_buffer(len: usize) -> Box<[f32]> {
-    F64_BUFFER_POOL.with(|pool| {
-        let mut buffers = pool.borrow_mut();
-        buffers.pop().map_or_else(
-            || vec![0.0; len].into_boxed_slice(),
-            |mut buf| {
-                if buf.len() == len {
-                    buf.fill(0.0);
-                } else {
-                    buf.resize(len, 0.0);
-                }
-                buf.into_boxed_slice()
-            },
-        )
-    })
-}
-
-#[inline]
-fn recycle_buffer(buf: Box<[f32]>) {
-    F64_BUFFER_POOL.with(|pool| {
-        pool.borrow_mut().push(Vec::from(buf));
-    });
-}
-
-pub struct WrapperData {
-    // Our relative position within the cell
-    cell_x_block_position: usize,
-    cell_y_block_position: usize,
-    cell_z_block_position: usize,
-
-    // Number of blocks per cell per axis
-    horizontal_cell_block_count: usize,
-    vertical_cell_block_count: usize,
-
-    x_delta: f32,
-    y_delta: f32,
-    z_delta: f32,
-}
-
-impl WrapperData {
-    #[must_use]
-    pub const fn new(
-        cell_x_block_position: usize,
-        cell_y_block_position: usize,
-        cell_z_block_position: usize,
-        horizontal_cell_block_count: usize,
-        vertical_cell_block_count: usize,
-    ) -> Self {
-        Self {
-            cell_x_block_position,
-            cell_y_block_position,
-            cell_z_block_position,
-            horizontal_cell_block_count,
-            vertical_cell_block_count,
-            x_delta: cell_x_block_position as f32 / horizontal_cell_block_count as f32,
-            y_delta: cell_y_block_position as f32 / vertical_cell_block_count as f32,
-            z_delta: cell_z_block_position as f32 / horizontal_cell_block_count as f32,
-        }
-    }
-
-    pub const fn update_position(
-        &mut self,
-        cell_x_block_position: usize,
-        cell_y_block_position: usize,
-        cell_z_block_position: usize,
-    ) {
-        if cell_x_block_position != self.cell_x_block_position {
-            self.cell_x_block_position = cell_x_block_position;
-            self.x_delta = cell_x_block_position as f32 / self.horizontal_cell_block_count as f32;
-        }
-
-        if cell_y_block_position != self.cell_y_block_position {
-            self.cell_y_block_position = cell_y_block_position;
-            self.y_delta = cell_y_block_position as f32 / self.vertical_cell_block_count as f32;
-        }
-
-        if cell_z_block_position != self.cell_z_block_position {
-            self.cell_z_block_position = cell_z_block_position;
-            self.z_delta = cell_z_block_position as f32 / self.horizontal_cell_block_count as f32;
-        }
-    }
-}
-
-pub enum SampleAction {
-    SkipCellCaches,
-    CellCaches(WrapperData),
-}
-
-pub struct ChunkNoiseFunctionSampleOptions {
-    pub(crate) populating_caches: bool,
-    pub(crate) action: SampleAction,
-
-    // Global IDs for the `CacheOnce` wrapper
-    pub(crate) cache_result_unique_id: u64,
-    pub(crate) cache_fill_unique_id: u64,
-
-    // The current index of a slice being filled by the `fill` function
-    pub(crate) fill_index: usize,
-}
-
-impl ChunkNoiseFunctionSampleOptions {
-    #[must_use]
-    pub const fn new(
-        populating_caches: bool,
-        action: SampleAction,
-        cache_result_unique_id: u64,
-        cache_fill_unique_id: u64,
-        fill_index: usize,
-    ) -> Self {
-        Self {
-            populating_caches,
-            action,
-            cache_result_unique_id,
-            cache_fill_unique_id,
-            fill_index,
-        }
-    }
-}
 
 pub struct ChunkNoiseFunctionBuilderOptions {
-    // Number of blocks per cell per axis
-    horizontal_cell_block_count: usize,
-    vertical_cell_block_count: usize,
-
-    // Number of cells per chunk per axis
-    vertical_cell_count: usize,
-    horizontal_cell_count: usize,
-
-    // The biome coords of this chunk
-    pub start_biome_x: i32,
-    pub start_biome_z: i32,
-
-    // Number of biome regions per chunk per axis
-    pub horizontal_biome_end: usize,
-
-    pub beardifier_structures:
-        Vec<crate::generation::noise::router::density_function::beardifier::BeardifierStructure>,
-    pub beardifier_junctions:
-        Vec<crate::generation::noise::router::density_function::beardifier::BeardifierJunction>,
-    pub affected_box: Option<pumpkin_util::math::block_box::BlockBox>,
+    pub beardifier_structures: Vec<BeardifierStructure>,
+    pub beardifier_junctions: Vec<BeardifierJunction>,
+    pub affected_box: Option<BlockBox>,
 }
+
 impl ChunkNoiseFunctionBuilderOptions {
     #[must_use]
-    #[allow(clippy::too_many_arguments)]
     pub const fn new(
-        horizontal_cell_block_count: usize,
-        vertical_cell_block_count: usize,
-        vertical_cell_count: usize,
-        horizontal_cell_count: usize,
-        start_biome_x: i32,
-        start_biome_z: i32,
-        horizontal_biome_end: usize,
-        beardifier_structures: Vec<
-            crate::generation::noise::router::density_function::beardifier::BeardifierStructure,
-        >,
-        beardifier_junctions: Vec<
-            crate::generation::noise::router::density_function::beardifier::BeardifierJunction,
-        >,
-        affected_box: Option<pumpkin_util::math::block_box::BlockBox>,
+        beardifier_structures: Vec<BeardifierStructure>,
+        beardifier_junctions: Vec<BeardifierJunction>,
+        affected_box: Option<BlockBox>,
     ) -> Self {
         Self {
-            horizontal_cell_block_count,
-            vertical_cell_block_count,
-            vertical_cell_count,
-            horizontal_cell_count,
-            start_biome_x,
-            start_biome_z,
-            horizontal_biome_end,
             beardifier_structures,
             beardifier_junctions,
             affected_box,
@@ -192,249 +30,32 @@ impl ChunkNoiseFunctionBuilderOptions {
     }
 }
 
-// These are chunk specific function components that are picked based on the wrapper type
-pub struct DensityInterpolator {
-    // What we are interpolating
+pub struct Cache {
     pub(crate) input_index: usize,
-
-    // y-z plane buffers to be interpolated together, each of these values is that of the cell, not
-    // the block
-    pub(crate) start_buffer: Box<[f32]>,
-    pub(crate) end_buffer: Box<[f32]>,
-
-    first_pass: [f32; 8],
-    second_pass: [f32; 4],
-    third_pass: [f32; 2],
-    pub(crate) result: f32,
-
-    pub(crate) vertical_cell_count: usize,
+    volume: Option<DensityVolume>,
+    buffer: Option<DensityBuffer>,
+    value_key: Option<Vector3<i32>>,
+    value: f32,
     min_value: f32,
     max_value: f32,
 }
 
-impl NoiseFunctionComponentRange for DensityInterpolator {
-    #[inline]
-    fn min(&self) -> f32 {
-        self.min_value
-    }
-
-    #[inline]
-    fn max(&self) -> f32 {
-        self.max_value
-    }
-}
-
-impl DensityInterpolator {
+impl Cache {
     #[must_use]
-    pub fn new(
-        input_index: usize,
-        min_value: f32,
-        max_value: f32,
-        builder_options: &ChunkNoiseFunctionBuilderOptions,
-    ) -> Self {
-        // These are all dummy values to be populated when sampling values
+    pub const fn new(input_index: usize, min_value: f32, max_value: f32) -> Self {
         Self {
             input_index,
-            start_buffer: get_buffer(
-                (builder_options.vertical_cell_count + 1)
-                    * (builder_options.horizontal_cell_count + 1),
-            ),
-            end_buffer: get_buffer(
-                (builder_options.vertical_cell_count + 1)
-                    * (builder_options.horizontal_cell_count + 1),
-            ),
-            first_pass: Default::default(),
-            second_pass: Default::default(),
-            third_pass: Default::default(),
-            result: Default::default(),
-            vertical_cell_count: builder_options.vertical_cell_count,
+            volume: None,
+            buffer: None,
+            value_key: None,
+            value: 0.0,
             min_value,
             max_value,
         }
     }
-
-    #[inline]
-    pub(crate) const fn yz_to_buf_index(
-        &self,
-        cell_y_position: usize,
-        cell_z_position: usize,
-    ) -> usize {
-        cell_z_position * (self.vertical_cell_count + 1) + cell_y_position
-    }
-
-    pub(crate) const fn on_sampled_cell_corners(
-        &mut self,
-        cell_y_position: usize,
-        cell_z_position: usize,
-    ) {
-        self.first_pass[0] =
-            self.start_buffer[self.yz_to_buf_index(cell_y_position, cell_z_position)];
-        self.first_pass[1] =
-            self.start_buffer[self.yz_to_buf_index(cell_y_position, cell_z_position + 1)];
-        self.first_pass[4] =
-            self.end_buffer[self.yz_to_buf_index(cell_y_position, cell_z_position)];
-        self.first_pass[5] =
-            self.end_buffer[self.yz_to_buf_index(cell_y_position, cell_z_position + 1)];
-        self.first_pass[2] =
-            self.start_buffer[self.yz_to_buf_index(cell_y_position + 1, cell_z_position)];
-        self.first_pass[3] =
-            self.start_buffer[self.yz_to_buf_index(cell_y_position + 1, cell_z_position + 1)];
-        self.first_pass[6] =
-            self.end_buffer[self.yz_to_buf_index(cell_y_position + 1, cell_z_position)];
-        self.first_pass[7] =
-            self.end_buffer[self.yz_to_buf_index(cell_y_position + 1, cell_z_position + 1)];
-    }
-
-    pub(crate) fn interpolate_y(&mut self, delta: f32) {
-        self.second_pass[0] = lerp(delta, self.first_pass[0], self.first_pass[2]);
-        self.second_pass[2] = lerp(delta, self.first_pass[4], self.first_pass[6]);
-        self.second_pass[1] = lerp(delta, self.first_pass[1], self.first_pass[3]);
-        self.second_pass[3] = lerp(delta, self.first_pass[5], self.first_pass[7]);
-    }
-
-    #[inline]
-    pub(crate) fn interpolate_x(&mut self, delta: f32) {
-        self.third_pass[0] = lerp(delta, self.second_pass[0], self.second_pass[2]);
-        self.third_pass[1] = lerp(delta, self.second_pass[1], self.second_pass[3]);
-    }
-
-    #[inline]
-    pub(crate) fn interpolate_z(&mut self, delta: f32) {
-        self.result = lerp(delta, self.third_pass[0], self.third_pass[1]);
-    }
-
-    #[inline]
-    pub(crate) const fn swap_buffers(&mut self) {
-        mem::swap(&mut self.start_buffer, &mut self.end_buffer);
-    }
 }
 
-impl Drop for DensityInterpolator {
-    fn drop(&mut self) {
-        recycle_buffer(std::mem::replace(
-            &mut self.start_buffer,
-            Vec::new().into_boxed_slice(),
-        ));
-        recycle_buffer(std::mem::replace(
-            &mut self.end_buffer,
-            Vec::new().into_boxed_slice(),
-        ));
-    }
-}
-
-impl MutableChunkNoiseFunctionComponentImpl for DensityInterpolator {
-    fn sample(
-        &mut self,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
-    ) -> f32 {
-        match &sample_options.action {
-            SampleAction::CellCaches(WrapperData {
-                x_delta,
-                y_delta,
-                z_delta,
-                ..
-            }) => {
-                if sample_options.populating_caches {
-                    lerp3(
-                        *x_delta,
-                        *y_delta,
-                        *z_delta,
-                        self.first_pass[0],
-                        self.first_pass[4],
-                        self.first_pass[2],
-                        self.first_pass[6],
-                        self.first_pass[1],
-                        self.first_pass[5],
-                        self.first_pass[3],
-                        self.first_pass[7],
-                    )
-                } else {
-                    self.result
-                }
-            }
-            SampleAction::SkipCellCaches => ChunkNoiseFunctionComponent::sample_from_stack(
-                &mut component_stack[..=self.input_index],
-                pos,
-                sample_options,
-            ),
-        }
-    }
-
-    fn fill(
-        &mut self,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        if sample_options.populating_caches {
-            let mut cached_xy_delta: Option<(f32, f32)> = None;
-            let mut cached_a = 0.0;
-            let mut cached_b = 0.0;
-
-            array.iter_mut().enumerate().for_each(|(index, value)| {
-                let pos = mapper.at(index, Some(sample_options));
-
-                let SampleAction::CellCaches(WrapperData {
-                    x_delta,
-                    y_delta,
-                    z_delta,
-                    ..
-                }) = &sample_options.action
-                else {
-                    *value = self.sample(component_stack, &pos, sample_options);
-                    return;
-                };
-                let (x_delta, y_delta, z_delta) = (*x_delta, *y_delta, *z_delta);
-
-                if cached_xy_delta != Some((x_delta, y_delta)) {
-                    cached_a = lerp2(
-                        x_delta,
-                        y_delta,
-                        self.first_pass[0],
-                        self.first_pass[4],
-                        self.first_pass[2],
-                        self.first_pass[6],
-                    );
-                    cached_b = lerp2(
-                        x_delta,
-                        y_delta,
-                        self.first_pass[1],
-                        self.first_pass[5],
-                        self.first_pass[3],
-                        self.first_pass[7],
-                    );
-                    cached_xy_delta = Some((x_delta, y_delta));
-                }
-
-                *value = lerp(z_delta, cached_a, cached_b);
-            });
-        } else {
-            ChunkNoiseFunctionComponent::fill_from_stack(
-                &mut component_stack[..=self.input_index],
-                array,
-                mapper,
-                sample_options,
-            );
-        }
-    }
-}
-
-pub struct FlatCache {
-    pub(crate) input_index: usize,
-
-    pub(crate) cache: Box<[f32]>,
-    start_biome_x: i32,
-    start_biome_z: i32,
-    horizontal_biome_end: usize,
-
-    min_value: f32,
-    max_value: f32,
-}
-
-impl NoiseFunctionComponentRange for FlatCache {
+impl NoiseFunctionComponentRange for Cache {
     #[inline]
     fn min(&self) -> f32 {
         self.min_value
@@ -446,255 +67,200 @@ impl NoiseFunctionComponentRange for FlatCache {
     }
 }
 
-impl MutableChunkNoiseFunctionComponentImpl for FlatCache {
+impl MutableChunkNoiseFunctionComponentImpl for Cache {
     fn sample(
         &mut self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
-        let absolute_biome_x_position = biome_coords::from_block(pos.x);
-        let absolute_biome_z_position = biome_coords::from_block(pos.z);
-
-        let relative_biome_x_position = absolute_biome_x_position - self.start_biome_x;
-        let relative_biome_z_position = absolute_biome_z_position - self.start_biome_z;
-
-        if relative_biome_x_position >= 0
-            && relative_biome_z_position >= 0
-            && relative_biome_x_position <= self.horizontal_biome_end as i32
-            && relative_biome_z_position <= self.horizontal_biome_end as i32
+        if self.value_key == Some(*pos) {
+            return self.value;
+        }
+        if let (Some(volume), Some(buffer)) = (&self.volume, &self.buffer)
+            && let Some(index) = volume.index_of_block(pos.x, pos.y, pos.z)
         {
-            let cache_index = self.xz_to_index_const(
-                relative_biome_x_position as usize,
-                relative_biome_z_position as usize,
-            );
-            self.cache[cache_index]
-        } else {
-            ChunkNoiseFunctionComponent::sample_from_stack(
-                &mut component_stack[..=self.input_index],
-                pos,
-                sample_options,
-            )
+            return buffer[index];
         }
-    }
-}
-
-impl Drop for FlatCache {
-    fn drop(&mut self) {
-        recycle_buffer(std::mem::replace(
-            &mut self.cache,
-            Vec::new().into_boxed_slice(),
-        ));
-    }
-}
-
-impl FlatCache {
-    #[must_use]
-    pub fn new(
-        input_index: usize,
-        min_value: f32,
-        max_value: f32,
-        start_biome_x: i32,
-        start_biome_z: i32,
-        horizontal_biome_end: usize,
-    ) -> Self {
-        Self {
-            input_index,
-            cache: get_buffer((horizontal_biome_end + 1) * (horizontal_biome_end + 1)),
-            start_biome_x,
-            start_biome_z,
-            horizontal_biome_end,
-            min_value,
-            max_value,
-        }
-    }
-
-    #[inline]
-    #[must_use]
-    pub const fn xz_to_index_const(
-        &self,
-        biome_x_position: usize,
-        biome_z_position: usize,
-    ) -> usize {
-        biome_x_position * (self.horizontal_biome_end + 1) + biome_z_position
-    }
-}
-
-pub struct Cache2D {
-    pub(crate) input_index: usize,
-    last_sample_column: u64,
-    last_sample_result: f32,
-
-    min_value: f32,
-    max_value: f32,
-}
-
-impl NoiseFunctionComponentRange for Cache2D {
-    #[inline]
-    fn min(&self) -> f32 {
-        self.min_value
-    }
-
-    #[inline]
-    fn max(&self) -> f32 {
-        self.max_value
-    }
-}
-
-impl MutableChunkNoiseFunctionComponentImpl for Cache2D {
-    fn sample(
-        &mut self,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
-    ) -> f32 {
-        let packed_column = chunk_pos::packed(pos.x as u64, pos.z as u64);
-        if packed_column == self.last_sample_column {
-            self.last_sample_result
-        } else {
-            let result = ChunkNoiseFunctionComponent::sample_from_stack(
-                &mut component_stack[..=self.input_index],
-                pos,
-                sample_options,
-            );
-            self.last_sample_column = packed_column;
-            self.last_sample_result = result;
-
-            result
-        }
-    }
-}
-
-impl Cache2D {
-    #[must_use]
-    pub fn new(input_index: usize, min_value: f32, max_value: f32) -> Self {
-        Self {
-            input_index,
-            // I know this is because there's is definitely world coords that are this marker, but this
-            // is how vanilla does it, so I'm going to for pairity
-            last_sample_column: chunk_pos::MARKER,
-            last_sample_result: Default::default(),
-            min_value,
-            max_value,
-        }
-    }
-}
-
-pub struct CacheOnce {
-    pub(crate) input_index: usize,
-    cache_result_unique_id: u64,
-    cache_fill_unique_id: u64,
-    last_sample_result: f32,
-
-    cache: Box<[f32]>,
-
-    min_value: f32,
-    max_value: f32,
-}
-
-impl NoiseFunctionComponentRange for CacheOnce {
-    #[inline]
-    fn min(&self) -> f32 {
-        self.min_value
-    }
-
-    #[inline]
-    fn max(&self) -> f32 {
-        self.max_value
-    }
-}
-
-impl MutableChunkNoiseFunctionComponentImpl for CacheOnce {
-    fn sample(
-        &mut self,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
-    ) -> f32 {
-        match sample_options.action {
-            SampleAction::CellCaches(_) => {
-                if self.cache_fill_unique_id == sample_options.cache_fill_unique_id
-                    && !self.cache.is_empty()
-                {
-                    self.cache[sample_options.fill_index]
-                } else if self.cache_result_unique_id == sample_options.cache_result_unique_id {
-                    self.last_sample_result
-                } else {
-                    let result = ChunkNoiseFunctionComponent::sample_from_stack(
-                        &mut component_stack[..=self.input_index],
-                        pos,
-                        sample_options,
-                    );
-                    self.cache_result_unique_id = sample_options.cache_result_unique_id;
-                    self.last_sample_result = result;
-
-                    result
-                }
-            }
-            SampleAction::SkipCellCaches => ChunkNoiseFunctionComponent::sample_from_stack(
-                &mut component_stack[..=self.input_index],
-                pos,
-                sample_options,
-            ),
-        }
-    }
-
-    fn fill(
-        &mut self,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        if self.cache_fill_unique_id == sample_options.cache_fill_unique_id
-            && !self.cache.is_empty()
-        {
-            array.copy_from_slice(&self.cache);
-            return;
-        }
-
-        ChunkNoiseFunctionComponent::fill_from_stack(
+        let value = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_index],
-            array,
-            mapper,
-            sample_options,
+            pos,
+        );
+        self.value_key = Some(*pos);
+        self.value = value;
+        value
+    }
+
+    fn sample_volume(
+        &mut self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+    ) {
+        if self.volume.as_ref() != Some(volume) || self.buffer.is_none() {
+            self.buffer = None;
+            let mut cached = DensityBuffer::acquire(volume);
+            ChunkNoiseFunctionComponent::sample_volume_from_stack(
+                &mut component_stack[..=self.input_index],
+                &mut cached,
+                volume,
+            );
+            self.volume = Some(*volume);
+            self.buffer = Some(cached);
+        }
+        if let Some(cached) = &self.buffer {
+            buffer.copy_from_slice(cached);
+        }
+    }
+}
+
+pub struct Interpolated {
+    pub(crate) input_index: usize,
+    cell_size_xz: i32,
+    cell_size_y: i32,
+    min_value: f32,
+    max_value: f32,
+}
+
+impl Interpolated {
+    #[must_use]
+    pub const fn new(
+        input_index: usize,
+        cell_size_xz: i32,
+        cell_size_y: i32,
+        min_value: f32,
+        max_value: f32,
+    ) -> Self {
+        Self {
+            input_index,
+            cell_size_xz,
+            cell_size_y,
+            min_value,
+            max_value,
+        }
+    }
+
+    const fn is_cell_aligned(&self, volume: &DensityVolume) -> bool {
+        (volume.step_block_x == self.cell_size_xz || volume.size_x == 1)
+            && (volume.step_block_y == self.cell_size_y || volume.size_y == 1)
+            && (volume.step_block_z == self.cell_size_xz || volume.size_z == 1)
+            && volume.min_block_x.rem_euclid(self.cell_size_xz) == 0
+            && volume.min_block_y.rem_euclid(self.cell_size_y) == 0
+            && volume.min_block_z.rem_euclid(self.cell_size_xz) == 0
+    }
+
+    fn sample_with_block_step(
+        &self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+    ) {
+        let min_cell_x = volume.min_block_x.div_euclid(self.cell_size_xz);
+        let min_cell_y = volume.min_block_y.div_euclid(self.cell_size_y);
+        let min_cell_z = volume.min_block_z.div_euclid(self.cell_size_xz);
+        let max_block_x = volume.max_block_x();
+        let max_block_y = volume.max_block_y();
+        let max_block_z = volume.max_block_z();
+        let cell_count_x = (max_block_x.div_euclid(self.cell_size_xz) - min_cell_x + 1) as usize;
+        let cell_count_y = (max_block_y.div_euclid(self.cell_size_y) - min_cell_y + 1) as usize;
+        let cell_count_z = (max_block_z.div_euclid(self.cell_size_xz) - min_cell_z + 1) as usize;
+        let corner_count = |count: usize, max_block: i32, cell_size: i32| {
+            if max_block.rem_euclid(cell_size) == 0 {
+                count
+            } else {
+                count + 1
+            }
+        };
+        let cell_volume = DensityVolume::new(
+            corner_count(cell_count_x, max_block_x, self.cell_size_xz),
+            corner_count(cell_count_y, max_block_y, self.cell_size_y),
+            corner_count(cell_count_z, max_block_z, self.cell_size_xz),
+            min_cell_x * self.cell_size_xz,
+            min_cell_y * self.cell_size_y,
+            min_cell_z * self.cell_size_xz,
+            self.cell_size_xz,
+            self.cell_size_y,
+            self.cell_size_xz,
+        );
+        let mut corners = DensityBuffer::acquire(&cell_volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.input_index],
+            &mut corners,
+            &cell_volume,
         );
 
-        // We need to make a new cache
-        if self.cache.len() != array.len() {
-            self.cache = vec![0.0; array.len()].into_boxed_slice();
+        for cell_z in 0..cell_count_z {
+            let next_z = (cell_z + 1).min(cell_volume.size_z - 1);
+            for cell_x in 0..cell_count_x {
+                let next_x = (cell_x + 1).min(cell_volume.size_x - 1);
+                for cell_y in 0..cell_count_y {
+                    let next_y = (cell_y + 1).min(cell_volume.size_y - 1);
+                    let corner = |x: usize, y: usize, z: usize| {
+                        corners[cell_volume.index_unchecked(x, y, z)]
+                    };
+                    self.fill_cell(
+                        buffer,
+                        volume,
+                        &cell_volume,
+                        [cell_x, cell_y, cell_z],
+                        [
+                            corner(cell_x, cell_y, cell_z),
+                            corner(next_x, cell_y, cell_z),
+                            corner(cell_x, next_y, cell_z),
+                            corner(next_x, next_y, cell_z),
+                            corner(cell_x, cell_y, next_z),
+                            corner(next_x, cell_y, next_z),
+                            corner(cell_x, next_y, next_z),
+                            corner(next_x, next_y, next_z),
+                        ],
+                    );
+                }
+            }
         }
+    }
 
-        self.cache.copy_from_slice(array);
-        self.cache_fill_unique_id = sample_options.cache_fill_unique_id;
+    fn fill_cell(
+        &self,
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+        cell_volume: &DensityVolume,
+        cell: [usize; 3],
+        [v000, v100, v010, v110, v001, v101, v011, v111]: [f32; 8],
+    ) {
+        let cell_out_x = cell_volume.block_x(cell[0]) - volume.min_block_x;
+        let cell_out_y = cell_volume.block_y(cell[1]) - volume.min_block_y;
+        let cell_out_z = cell_volume.block_z(cell[2]) - volume.min_block_z;
+        let x0 = 0.max(-cell_out_x);
+        let y0 = 0.max(-cell_out_y);
+        let z0 = 0.max(-cell_out_z);
+        let x1 = self.cell_size_xz.min(volume.size_x as i32 - cell_out_x) - 1;
+        let y1 = self.cell_size_y.min(volume.size_y as i32 - cell_out_y) - 1;
+        let z1 = self.cell_size_xz.min(volume.size_z as i32 - cell_out_z) - 1;
+
+        for z in z0..=z1 {
+            let delta_z = z as f32 / self.cell_size_xz as f32;
+            let out_z = (cell_out_z + z) as usize;
+            for x in x0..=x1 {
+                let delta_x = x as f32 / self.cell_size_xz as f32;
+                let out_x = (cell_out_x + x) as usize;
+                let x0y0z0 = lerp(delta_x, v000, v100);
+                let x0y1z0 = lerp(delta_x, v010, v110);
+                let x0y0z1 = lerp(delta_x, v001, v101);
+                let x0y1z1 = lerp(delta_x, v011, v111);
+                let start = volume.index_unchecked(out_x, (cell_out_y + y0) as usize, out_z);
+                for (index, y) in (start..).zip(y0..=y1) {
+                    let delta_y = y as f32 / self.cell_size_y as f32;
+                    buffer[index] = lerp(
+                        delta_z,
+                        lerp(delta_y, x0y0z0, x0y1z0),
+                        lerp(delta_y, x0y0z1, x0y1z1),
+                    );
+                }
+            }
+        }
     }
 }
 
-impl CacheOnce {
-    #[must_use]
-    pub fn new(input_index: usize, min_value: f32, max_value: f32) -> Self {
-        Self {
-            input_index,
-            // Make these max, just to be different from the overall default of 0
-            cache_result_unique_id: 0,
-            cache_fill_unique_id: 0,
-            last_sample_result: Default::default(),
-            cache: Box::new([]),
-            min_value,
-            max_value,
-        }
-    }
-}
-
-pub struct CellCache {
-    pub(crate) input_index: usize,
-    pub(crate) cache: Box<[f32]>,
-
-    min_value: f32,
-    max_value: f32,
-}
-
-impl NoiseFunctionComponentRange for CellCache {
+impl NoiseFunctionComponentRange for Interpolated {
     #[inline]
     fn min(&self) -> f32 {
         self.min_value
@@ -706,78 +272,110 @@ impl NoiseFunctionComponentRange for CellCache {
     }
 }
 
-impl MutableChunkNoiseFunctionComponentImpl for CellCache {
+impl MutableChunkNoiseFunctionComponentImpl for Interpolated {
     fn sample(
         &mut self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
-        match &sample_options.action {
-            SampleAction::CellCaches(WrapperData {
-                cell_x_block_position,
-                cell_y_block_position,
-                cell_z_block_position,
-                horizontal_cell_block_count,
-                vertical_cell_block_count,
-                ..
-            }) => {
-                let cache_index = ((vertical_cell_block_count - 1 - cell_y_block_position)
-                    * horizontal_cell_block_count
-                    + cell_x_block_position)
-                    * horizontal_cell_block_count
-                    + cell_z_block_position;
-
-                self.cache[cache_index]
-            }
-            SampleAction::SkipCellCaches => ChunkNoiseFunctionComponent::sample_from_stack(
+        let x_in_cell = pos.x.rem_euclid(self.cell_size_xz);
+        let y_in_cell = pos.y.rem_euclid(self.cell_size_y);
+        let z_in_cell = pos.z.rem_euclid(self.cell_size_xz);
+        if x_in_cell == 0 && y_in_cell == 0 && z_in_cell == 0 {
+            return ChunkNoiseFunctionComponent::sample_from_stack(
                 &mut component_stack[..=self.input_index],
                 pos,
-                sample_options,
-            ),
+            );
         }
-    }
-}
-
-impl CellCache {
-    #[must_use]
-    pub fn new(
-        input_index: usize,
-        min_value: f32,
-        max_value: f32,
-        build_options: &ChunkNoiseFunctionBuilderOptions,
-    ) -> Self {
-        Self {
-            input_index,
-            cache: get_buffer(
-                build_options.horizontal_cell_block_count
-                    * build_options.horizontal_cell_block_count
-                    * build_options.vertical_cell_block_count,
+        let cell_volume = DensityVolume::new(
+            2,
+            2,
+            2,
+            pos.x - x_in_cell,
+            pos.y - y_in_cell,
+            pos.z - z_in_cell,
+            self.cell_size_xz,
+            self.cell_size_y,
+            self.cell_size_xz,
+        );
+        let mut corners = DensityBuffer::acquire(&cell_volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.input_index],
+            &mut corners,
+            &cell_volume,
+        );
+        let corner = |x: usize, y: usize, z: usize| corners[cell_volume.index_unchecked(x, y, z)];
+        let delta_x = x_in_cell as f32 / self.cell_size_xz as f32;
+        let delta_y = y_in_cell as f32 / self.cell_size_y as f32;
+        let delta_z = z_in_cell as f32 / self.cell_size_xz as f32;
+        lerp(
+            delta_z,
+            lerp(
+                delta_y,
+                lerp(delta_x, corner(0, 0, 0), corner(1, 0, 0)),
+                lerp(delta_x, corner(0, 1, 0), corner(1, 1, 0)),
             ),
-            min_value,
-            max_value,
+            lerp(
+                delta_y,
+                lerp(delta_x, corner(0, 0, 1), corner(1, 0, 1)),
+                lerp(delta_x, corner(0, 1, 1), corner(1, 1, 1)),
+            ),
+        )
+    }
+
+    fn sample_volume(
+        &mut self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+    ) {
+        if self.is_cell_aligned(volume) {
+            ChunkNoiseFunctionComponent::sample_volume_from_stack(
+                &mut component_stack[..=self.input_index],
+                buffer,
+                volume,
+            );
+        } else if volume.is_block_step() {
+            self.sample_with_block_step(component_stack, buffer, volume);
+        } else {
+            let block_volume = DensityVolume::with_block_step(
+                volume.size_x * volume.step_block_x as usize,
+                volume.size_y * volume.step_block_y as usize,
+                volume.size_z * volume.step_block_z as usize,
+                volume.min_block_x,
+                volume.min_block_y,
+                volume.min_block_z,
+            );
+            let mut blocks = DensityBuffer::acquire(&block_volume);
+            self.sample_with_block_step(component_stack, &mut blocks, &block_volume);
+            for z in 0..volume.size_z {
+                for x in 0..volume.size_x {
+                    for y in 0..volume.size_y {
+                        buffer[volume.index_unchecked(x, y, z)] = blocks[block_volume
+                            .index_unchecked(
+                                x * volume.step_block_x as usize,
+                                y * volume.step_block_y as usize,
+                                z * volume.step_block_z as usize,
+                            )];
+                    }
+                }
+            }
         }
     }
 }
 
 pub enum ChunkSpecificNoiseFunctionComponent {
-    DensityInterpolator(DensityInterpolator),
-    FlatCache(FlatCache),
-    Cache2D(Cache2D),
-    CacheOnce(CacheOnce),
-    CellCache(CellCache),
-    Beardifier(crate::generation::noise::router::density_function::beardifier::Beardifier),
+    Cache(Cache),
+    Interpolated(Interpolated),
+    Beardifier(Beardifier),
 }
 
 impl NoiseFunctionComponentRange for ChunkSpecificNoiseFunctionComponent {
     #[inline]
     fn min(&self) -> f32 {
         match self {
-            Self::DensityInterpolator(d) => d.min(),
-            Self::FlatCache(f) => f.min(),
-            Self::Cache2D(c) => c.min(),
-            Self::CacheOnce(c) => c.min(),
-            Self::CellCache(c) => c.min(),
+            Self::Cache(c) => c.min(),
+            Self::Interpolated(i) => i.min(),
             Self::Beardifier(b) => b.min(),
         }
     }
@@ -785,11 +383,8 @@ impl NoiseFunctionComponentRange for ChunkSpecificNoiseFunctionComponent {
     #[inline]
     fn max(&self) -> f32 {
         match self {
-            Self::DensityInterpolator(d) => d.max(),
-            Self::FlatCache(f) => f.max(),
-            Self::Cache2D(c) => c.max(),
-            Self::CacheOnce(c) => c.max(),
-            Self::CellCache(c) => c.max(),
+            Self::Cache(c) => c.max(),
+            Self::Interpolated(i) => i.max(),
             Self::Beardifier(b) => b.max(),
         }
     }
@@ -801,33 +396,11 @@ impl MutableChunkNoiseFunctionComponentImpl for ChunkSpecificNoiseFunctionCompon
         &mut self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         match self {
-            Self::DensityInterpolator(d) => d.sample(component_stack, pos, sample_options),
-            Self::FlatCache(f) => f.sample(component_stack, pos, sample_options),
-            Self::Cache2D(c) => c.sample(component_stack, pos, sample_options),
-            Self::CacheOnce(c) => c.sample(component_stack, pos, sample_options),
-            Self::CellCache(c) => c.sample(component_stack, pos, sample_options),
-            Self::Beardifier(b) => b.sample(component_stack, pos, sample_options),
-        }
-    }
-
-    #[inline]
-    fn fill(
-        &mut self,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        match self {
-            Self::DensityInterpolator(d) => d.fill(component_stack, array, mapper, sample_options),
-            Self::FlatCache(f) => f.fill(component_stack, array, mapper, sample_options),
-            Self::Cache2D(c) => c.fill(component_stack, array, mapper, sample_options),
-            Self::CacheOnce(c) => c.fill(component_stack, array, mapper, sample_options),
-            Self::CellCache(c) => c.fill(component_stack, array, mapper, sample_options),
-            Self::Beardifier(b) => b.fill(component_stack, array, mapper, sample_options),
+            Self::Cache(c) => c.sample(component_stack, pos),
+            Self::Interpolated(i) => i.sample(component_stack, pos),
+            Self::Beardifier(b) => b.sample(component_stack, pos),
         }
     }
 
@@ -837,17 +410,11 @@ impl MutableChunkNoiseFunctionComponentImpl for ChunkSpecificNoiseFunctionCompon
         component_stack: &mut [ChunkNoiseFunctionComponent],
         buffer: &mut [f32],
         volume: &DensityVolume,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) {
         match self {
-            Self::DensityInterpolator(d) => {
-                d.sample_volume(component_stack, buffer, volume, sample_options);
-            }
-            Self::FlatCache(f) => f.sample_volume(component_stack, buffer, volume, sample_options),
-            Self::Cache2D(c) => c.sample_volume(component_stack, buffer, volume, sample_options),
-            Self::CacheOnce(c) => c.sample_volume(component_stack, buffer, volume, sample_options),
-            Self::CellCache(c) => c.sample_volume(component_stack, buffer, volume, sample_options),
-            Self::Beardifier(b) => b.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Cache(c) => c.sample_volume(component_stack, buffer, volume),
+            Self::Interpolated(i) => i.sample_volume(component_stack, buffer, volume),
+            Self::Beardifier(b) => b.sample_volume(component_stack, buffer, volume),
         }
     }
 }

--- a/crates/pumpkin-world/src/generation/noise/router/chunk_noise_router.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/chunk_noise_router.rs
@@ -1,17 +1,13 @@
 use pumpkin_data::noise_router::WrapperType;
 use pumpkin_util::math::vector3::Vector3;
 
-use crate::generation::biome_coords;
-
 use super::{
     chunk_density_function::{
-        Cache2D, CacheOnce, CellCache, ChunkNoiseFunctionBuilderOptions,
-        ChunkNoiseFunctionSampleOptions, ChunkSpecificNoiseFunctionComponent, DensityInterpolator,
-        FlatCache, SampleAction,
+        Cache, ChunkNoiseFunctionBuilderOptions, ChunkSpecificNoiseFunctionComponent, Interpolated,
     },
     density_function::{
-        IndexToNoisePos, NoiseFunctionComponentRange, PassThrough,
-        StaticIndependentChunkNoiseFunctionComponentImpl,
+        NoiseFunctionComponentRange, PassThrough, StaticIndependentChunkNoiseFunctionComponentImpl,
+        beardifier::Beardifier,
     },
     density_volume::DensityVolume,
     proto_noise_router::{
@@ -25,7 +21,6 @@ pub trait StaticChunkNoiseFunctionComponentImpl {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32;
 
     fn sample_volume(
@@ -33,24 +28,8 @@ pub trait StaticChunkNoiseFunctionComponentImpl {
         component_stack: &mut [ChunkNoiseFunctionComponent],
         buffer: &mut [f32],
         volume: &DensityVolume,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) {
-        volume.fill_with(buffer, |pos| {
-            self.sample(component_stack, pos, sample_options)
-        });
-    }
-
-    fn fill(
-        &self,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        array.iter_mut().enumerate().for_each(|(index, value)| {
-            let pos = mapper.at(index, Some(sample_options));
-            *value = self.sample(component_stack, &pos, sample_options);
-        });
+        volume.fill_with(buffer, |pos| self.sample(component_stack, pos));
     }
 }
 
@@ -59,7 +38,6 @@ pub trait MutableChunkNoiseFunctionComponentImpl {
         &mut self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32;
 
     fn sample_volume(
@@ -67,24 +45,8 @@ pub trait MutableChunkNoiseFunctionComponentImpl {
         component_stack: &mut [ChunkNoiseFunctionComponent],
         buffer: &mut [f32],
         volume: &DensityVolume,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) {
-        volume.fill_with(buffer, |pos| {
-            self.sample(component_stack, pos, sample_options)
-        });
-    }
-
-    fn fill(
-        &mut self,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        array.iter_mut().enumerate().for_each(|(index, value)| {
-            let pos = mapper.at(index, Some(sample_options));
-            *value = self.sample(component_stack, &pos, sample_options);
-        });
+        volume.fill_with(buffer, |pos| self.sample(component_stack, pos));
     }
 }
 
@@ -123,39 +85,14 @@ impl MutableChunkNoiseFunctionComponentImpl for ChunkNoiseFunctionComponent<'_> 
         &mut self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         match self {
             Self::Independent(independent) => independent.sample(pos),
-            Self::Dependent(dependent) => dependent.sample(component_stack, pos, sample_options),
-            Self::Chunk(chunk) => chunk.sample(component_stack, pos, sample_options),
+            Self::Dependent(dependent) => dependent.sample(component_stack, pos),
+            Self::Chunk(chunk) => chunk.sample(component_stack, pos),
             Self::PassThrough(pass_through) => ChunkNoiseFunctionComponent::sample_from_stack(
                 &mut component_stack[..=pass_through.input_index()],
                 pos,
-                sample_options,
-            ),
-        }
-    }
-
-    #[inline]
-    fn fill(
-        &mut self,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        match self {
-            Self::Independent(independent) => independent.fill(array, mapper),
-            Self::Dependent(dependent) => {
-                dependent.fill(component_stack, array, mapper, sample_options);
-            }
-            Self::Chunk(chunk) => chunk.fill(component_stack, array, mapper, sample_options),
-            Self::PassThrough(pass_through) => ChunkNoiseFunctionComponent::fill_from_stack(
-                &mut component_stack[..=pass_through.input_index()],
-                array,
-                mapper,
-                sample_options,
             ),
         }
     }
@@ -166,22 +103,16 @@ impl MutableChunkNoiseFunctionComponentImpl for ChunkNoiseFunctionComponent<'_> 
         component_stack: &mut [ChunkNoiseFunctionComponent],
         buffer: &mut [f32],
         volume: &DensityVolume,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) {
         match self {
             Self::Independent(independent) => independent.sample_volume(buffer, volume),
-            Self::Dependent(dependent) => {
-                dependent.sample_volume(component_stack, buffer, volume, sample_options);
-            }
-            Self::Chunk(chunk) => {
-                chunk.sample_volume(component_stack, buffer, volume, sample_options);
-            }
+            Self::Dependent(dependent) => dependent.sample_volume(component_stack, buffer, volume),
+            Self::Chunk(chunk) => chunk.sample_volume(component_stack, buffer, volume),
             Self::PassThrough(pass_through) => {
                 ChunkNoiseFunctionComponent::sample_volume_from_stack(
                     &mut component_stack[..=pass_through.input_index()],
                     buffer,
                     volume,
-                    sample_options,
                 );
             }
         }
@@ -193,40 +124,20 @@ impl ChunkNoiseFunctionComponent<'_> {
     pub fn sample_from_stack(
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let Some((top_component, component_stack)) = component_stack.split_last_mut() else {
             return 0.0;
         };
-        if !sample_options.populating_caches
-            && let ChunkNoiseFunctionComponent::Chunk(
-                ChunkSpecificNoiseFunctionComponent::DensityInterpolator(interp),
-            ) = top_component
-        {
-            return interp.result;
-        }
-        top_component.sample(component_stack, pos, sample_options)
-    }
-
-    pub fn fill_from_stack(
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        if let Some((top_component, component_stack)) = component_stack.split_last_mut() {
-            top_component.fill(component_stack, array, mapper, sample_options);
-        }
+        top_component.sample(component_stack, pos)
     }
 
     pub fn sample_volume_from_stack(
         component_stack: &mut [ChunkNoiseFunctionComponent],
         buffer: &mut [f32],
         volume: &DensityVolume,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) {
         if let Some((top_component, component_stack)) = component_stack.split_last_mut() {
-            top_component.sample_volume(component_stack, buffer, volume, sample_options);
+            top_component.sample_volume(component_stack, buffer, volume);
         }
     }
 }
@@ -237,72 +148,32 @@ pub struct ChunkNoiseDensityFunction<'a> {
 
 impl ChunkNoiseDensityFunction<'_> {
     #[inline]
-    pub fn sample(
-        &mut self,
-        pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
-    ) -> f32 {
-        ChunkNoiseFunctionComponent::sample_from_stack(self.component_stack, pos, sample_options)
+    pub fn sample(&mut self, pos: &Vector3<i32>) -> f32 {
+        ChunkNoiseFunctionComponent::sample_from_stack(self.component_stack, pos)
     }
 
     #[inline]
-    fn fill(
-        &mut self,
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        ChunkNoiseFunctionComponent::fill_from_stack(
-            self.component_stack,
-            array,
-            mapper,
-            sample_options,
-        );
-    }
-
-    #[inline]
-    pub fn sample_volume(
-        &mut self,
-        buffer: &mut [f32],
-        volume: &DensityVolume,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
-    ) {
-        ChunkNoiseFunctionComponent::sample_volume_from_stack(
-            self.component_stack,
-            buffer,
-            volume,
-            sample_options,
-        );
+    pub fn sample_volume(&mut self, buffer: &mut [f32], volume: &DensityVolume) {
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(self.component_stack, buffer, volume);
     }
 }
 
 macro_rules! sample_function {
     ($name:ident, $volume_name:ident) => {
         #[inline]
-        pub fn $name(
-            &mut self,
-            pos: &Vector3<i32>,
-            sample_options: &ChunkNoiseFunctionSampleOptions,
-        ) -> f32 {
+        pub fn $name(&mut self, pos: &Vector3<i32>) -> f32 {
             ChunkNoiseFunctionComponent::sample_from_stack(
                 &mut self.component_stack[..=self.$name],
                 pos,
-                sample_options,
             )
         }
 
         #[inline]
-        pub fn $volume_name(
-            &mut self,
-            buffer: &mut [f32],
-            volume: &DensityVolume,
-            sample_options: &ChunkNoiseFunctionSampleOptions,
-        ) {
+        pub fn $volume_name(&mut self, buffer: &mut [f32], volume: &DensityVolume) {
             ChunkNoiseFunctionComponent::sample_volume_from_stack(
                 &mut self.component_stack[..=self.$name],
                 buffer,
                 volume,
-                sample_options,
             );
         }
     };
@@ -320,8 +191,6 @@ pub struct ChunkNoiseRouter<'a> {
     vein_ridged: usize,
     vein_gap: usize,
     component_stack: Box<[ChunkNoiseFunctionComponent<'a>]>,
-    interpolator_indices: Box<[usize]>,
-    cell_indices: Box<[usize]>,
 }
 
 impl ChunkNoiseRouter<'_> {
@@ -342,17 +211,19 @@ impl ChunkNoiseRouter<'_> {
 
 impl<'a> ChunkNoiseRouter<'a> {
     #[must_use]
-    #[expect(clippy::too_many_lines)]
+    pub fn component_stack_mut(&mut self) -> &mut [ChunkNoiseFunctionComponent<'a>] {
+        &mut self.component_stack
+    }
+
+    #[must_use]
     pub fn generate(
         base: &'a ProtoNoiseRouter,
         build_options: &ChunkNoiseFunctionBuilderOptions,
     ) -> Self {
         let mut component_stack =
             Vec::<ChunkNoiseFunctionComponent>::with_capacity(base.full_component_stack.len());
-        let mut cell_cache_indices = Vec::new();
-        let mut interpolator_indices = Vec::new();
 
-        for (component_index, base_component) in base.full_component_stack.iter().enumerate() {
+        for base_component in &base.full_component_stack {
             let chunk_component = match base_component {
                 ProtoNoiseFunctionComponent::Dependent(dependent) => {
                     ChunkNoiseFunctionComponent::Dependent(dependent)
@@ -363,109 +234,37 @@ impl<'a> ChunkNoiseRouter<'a> {
                 ProtoNoiseFunctionComponent::PassThrough(pass_through) => {
                     ChunkNoiseFunctionComponent::PassThrough(pass_through.clone())
                 }
-                ProtoNoiseFunctionComponent::Beardifier(_) => {
-                    ChunkNoiseFunctionComponent::Chunk(
-                        ChunkSpecificNoiseFunctionComponent::Beardifier(
-                            crate::generation::noise::router::density_function::beardifier::Beardifier::new(
-                                build_options.beardifier_structures.clone(),
-                                build_options.beardifier_junctions.clone(),
-                                build_options.affected_box,
-                            ),
-                        ),
-                    )
-                }
+                ProtoNoiseFunctionComponent::Beardifier(_) => ChunkNoiseFunctionComponent::Chunk(
+                    ChunkSpecificNoiseFunctionComponent::Beardifier(Beardifier::new(
+                        build_options.beardifier_structures.clone(),
+                        build_options.beardifier_junctions.clone(),
+                        build_options.affected_box,
+                    )),
+                ),
                 ProtoNoiseFunctionComponent::Wrapper(wrapper) => {
                     let min_value = component_stack[wrapper.input_index].min();
                     let max_value = component_stack[wrapper.input_index].max();
 
                     match wrapper.wrapper_type {
-                        WrapperType::Interpolated => {
-                            interpolator_indices.push(component_index);
-                            ChunkNoiseFunctionComponent::Chunk(
-                                ChunkSpecificNoiseFunctionComponent::DensityInterpolator(
-                                    DensityInterpolator::new(
-                                        wrapper.input_index,
-                                        min_value,
-                                        max_value,
-                                        build_options,
-                                    ),
-                                ),
-                            )
-                        }
-                        WrapperType::CellCache => {
-                            cell_cache_indices.push(component_index);
-                            ChunkNoiseFunctionComponent::Chunk(
-                                ChunkSpecificNoiseFunctionComponent::CellCache(CellCache::new(
-                                    wrapper.input_index,
-                                    min_value,
-                                    max_value,
-                                    build_options,
-                                )),
-                            )
-                        }
-                        WrapperType::CacheOnce => ChunkNoiseFunctionComponent::Chunk(
-                            ChunkSpecificNoiseFunctionComponent::CacheOnce(CacheOnce::new(
+                        WrapperType::Interpolated {
+                            cell_size_xz,
+                            cell_size_y,
+                        } => ChunkNoiseFunctionComponent::Chunk(
+                            ChunkSpecificNoiseFunctionComponent::Interpolated(Interpolated::new(
+                                wrapper.input_index,
+                                cell_size_xz,
+                                cell_size_y,
+                                min_value,
+                                max_value,
+                            )),
+                        ),
+                        WrapperType::Cache => ChunkNoiseFunctionComponent::Chunk(
+                            ChunkSpecificNoiseFunctionComponent::Cache(Cache::new(
                                 wrapper.input_index,
                                 min_value,
                                 max_value,
                             )),
                         ),
-                        WrapperType::Cache2D => ChunkNoiseFunctionComponent::Chunk(
-                            ChunkSpecificNoiseFunctionComponent::Cache2D(Cache2D::new(
-                                wrapper.input_index,
-                                min_value,
-                                max_value,
-                            )),
-                        ),
-                        WrapperType::CacheFlat => {
-                            let mut flat_cache = FlatCache::new(
-                                wrapper.input_index,
-                                min_value,
-                                max_value,
-                                build_options.start_biome_x,
-                                build_options.start_biome_z,
-                                build_options.horizontal_biome_end,
-                            );
-                            let sample_options = ChunkNoiseFunctionSampleOptions::new(
-                                false,
-                                SampleAction::SkipCellCaches,
-                                0,
-                                0,
-                                0,
-                            );
-
-                            for biome_x_position in 0..=build_options.horizontal_biome_end {
-                                let absolute_biome_x_position =
-                                    build_options.start_biome_x + biome_x_position as i32;
-                                let block_x_position =
-                                    biome_coords::to_block(absolute_biome_x_position);
-
-                                for biome_z_position in 0..=build_options.horizontal_biome_end {
-                                    let absolute_biome_z_position =
-                                        build_options.start_biome_z + biome_z_position as i32;
-                                    let block_z_position =
-                                        biome_coords::to_block(absolute_biome_z_position);
-
-                                    let pos = Vector3::new(block_x_position, 0, block_z_position);
-
-                                    //NOTE: Due to our stack invariant, what is on the stack is a
-                                    // valid density function
-                                    let sample = ChunkNoiseFunctionComponent::sample_from_stack(
-                                        &mut component_stack[..=wrapper.input_index],
-                                        &pos,
-                                        &sample_options,
-                                    );
-
-                                    let cache_index = flat_cache
-                                        .xz_to_index_const(biome_x_position, biome_z_position);
-                                    flat_cache.cache[cache_index] = sample;
-                                }
-                            }
-
-                            ChunkNoiseFunctionComponent::Chunk(
-                                ChunkSpecificNoiseFunctionComponent::FlatCache(flat_cache),
-                            )
-                        }
                     }
                 }
             };
@@ -484,191 +283,6 @@ impl<'a> ChunkNoiseRouter<'a> {
             vein_ridged: base.vein_ridged,
             vein_gap: base.vein_gap,
             component_stack: component_stack.into_boxed_slice(),
-            interpolator_indices: interpolator_indices.into_boxed_slice(),
-            cell_indices: cell_cache_indices.into_boxed_slice(),
-        }
-    }
-
-    pub fn fill_cell_caches(
-        &mut self,
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        let indices = &self.cell_indices;
-        let components = &mut self.component_stack;
-        for cell_cache_index in indices {
-            let (component_stack, component) = components.split_at_mut(*cell_cache_index);
-
-            let Some(ChunkNoiseFunctionComponent::Chunk(chunk)) = component.first_mut() else {
-                tracing::error!("Expected ChunkNoiseFunctionComponent::Chunk");
-                continue;
-            };
-            let ChunkSpecificNoiseFunctionComponent::CellCache(cell_cache) = chunk else {
-                tracing::error!("Expected ChunkSpecificNoiseFunctionComponent::CellCache");
-                continue;
-            };
-
-            ChunkNoiseFunctionComponent::fill_from_stack(
-                &mut component_stack[..=cell_cache.input_index],
-                &mut cell_cache.cache,
-                mapper,
-                sample_options,
-            );
-        }
-    }
-
-    pub fn fill_interpolator_buffers(
-        &mut self,
-        start: bool,
-        cell_z: usize,
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        let indices = &self.interpolator_indices;
-        let components = &mut self.component_stack;
-        for interpolator_index in indices {
-            let (component_stack, component) = components.split_at_mut(*interpolator_index);
-
-            let Some(ChunkNoiseFunctionComponent::Chunk(chunk)) = component.first_mut() else {
-                tracing::error!("Expected ChunkNoiseFunctionComponent::Chunk");
-                continue;
-            };
-            let ChunkSpecificNoiseFunctionComponent::DensityInterpolator(density_interpolator) =
-                chunk
-            else {
-                tracing::error!(
-                    "Expected ChunkSpecificNoiseFunctionComponent::DensityInterpolator"
-                );
-                continue;
-            };
-
-            let start_index = density_interpolator.yz_to_buf_index(0, cell_z);
-            let buf = if start {
-                &mut density_interpolator.start_buffer
-                    [start_index..=start_index + density_interpolator.vertical_cell_count]
-            } else {
-                &mut density_interpolator.end_buffer
-                    [start_index..=start_index + density_interpolator.vertical_cell_count]
-            };
-
-            ChunkNoiseFunctionComponent::fill_from_stack(
-                &mut component_stack[..=density_interpolator.input_index],
-                buf,
-                mapper,
-                sample_options,
-            );
-        }
-    }
-
-    pub fn interpolate_x(&mut self, delta: f32) {
-        let indices = &self.interpolator_indices;
-        let components = &mut self.component_stack;
-        for interpolator_index in indices {
-            let ChunkNoiseFunctionComponent::Chunk(chunk) = &mut components[*interpolator_index]
-            else {
-                tracing::error!("Expected ChunkNoiseFunctionComponent::Chunk");
-                continue;
-            };
-
-            let ChunkSpecificNoiseFunctionComponent::DensityInterpolator(density_interpolator) =
-                chunk
-            else {
-                tracing::error!(
-                    "Expected ChunkSpecificNoiseFunctionComponent::DensityInterpolator"
-                );
-                continue;
-            };
-
-            density_interpolator.interpolate_x(delta);
-        }
-    }
-
-    pub fn interpolate_y(&mut self, delta: f32) {
-        let indices = &self.interpolator_indices;
-        let components = &mut self.component_stack;
-        for interpolator_index in indices {
-            let ChunkNoiseFunctionComponent::Chunk(chunk) = &mut components[*interpolator_index]
-            else {
-                tracing::error!("Expected ChunkNoiseFunctionComponent::Chunk");
-                continue;
-            };
-
-            let ChunkSpecificNoiseFunctionComponent::DensityInterpolator(density_interpolator) =
-                chunk
-            else {
-                tracing::error!(
-                    "Expected ChunkSpecificNoiseFunctionComponent::DensityInterpolator"
-                );
-                continue;
-            };
-
-            density_interpolator.interpolate_y(delta);
-        }
-    }
-
-    pub fn interpolate_z(&mut self, delta: f32) {
-        let indices = &self.interpolator_indices;
-        let components = &mut self.component_stack;
-        for interpolator_index in indices {
-            let ChunkNoiseFunctionComponent::Chunk(chunk) = &mut components[*interpolator_index]
-            else {
-                tracing::error!("Expected ChunkNoiseFunctionComponent::Chunk");
-                continue;
-            };
-            let ChunkSpecificNoiseFunctionComponent::DensityInterpolator(density_interpolator) =
-                chunk
-            else {
-                tracing::error!(
-                    "Expected ChunkSpecificNoiseFunctionComponent::DensityInterpolator"
-                );
-                continue;
-            };
-
-            density_interpolator.interpolate_z(delta);
-        }
-    }
-
-    pub fn on_sampled_cell_corners(&mut self, cell_y_position: usize, cell_z_position: usize) {
-        let indices = &self.interpolator_indices;
-        let components = &mut self.component_stack;
-        for interpolator_index in indices {
-            let ChunkNoiseFunctionComponent::Chunk(chunk) = &mut components[*interpolator_index]
-            else {
-                tracing::error!("Expected ChunkNoiseFunctionComponent::Chunk");
-                continue;
-            };
-            let ChunkSpecificNoiseFunctionComponent::DensityInterpolator(density_interpolator) =
-                chunk
-            else {
-                tracing::error!(
-                    "Expected ChunkSpecificNoiseFunctionComponent::DensityInterpolator"
-                );
-                continue;
-            };
-
-            density_interpolator.on_sampled_cell_corners(cell_y_position, cell_z_position);
-        }
-    }
-
-    pub fn swap_buffers(&mut self) {
-        let indices = &self.interpolator_indices;
-        let components = &mut self.component_stack;
-        for interpolator_index in indices {
-            let ChunkNoiseFunctionComponent::Chunk(chunk) = &mut components[*interpolator_index]
-            else {
-                tracing::error!("Expected ChunkNoiseFunctionComponent::Chunk");
-                continue;
-            };
-            let ChunkSpecificNoiseFunctionComponent::DensityInterpolator(density_interpolator) =
-                chunk
-            else {
-                tracing::error!(
-                    "Expected ChunkSpecificNoiseFunctionComponent::DensityInterpolator"
-                );
-                continue;
-            };
-
-            density_interpolator.swap_buffers();
         }
     }
 }

--- a/crates/pumpkin-world/src/generation/noise/router/density_function/beardifier.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/density_function/beardifier.rs
@@ -1,7 +1,7 @@
-use crate::generation::noise::router::chunk_density_function::ChunkNoiseFunctionSampleOptions;
 use crate::generation::noise::router::chunk_noise_router::{
     ChunkNoiseFunctionComponent, MutableChunkNoiseFunctionComponentImpl,
 };
+use crate::generation::noise::router::density_volume::DensityVolume;
 pub use pumpkin_data::structures::TerrainAdaptation;
 use pumpkin_util::math::{block_box::BlockBox, vector3::Vector3};
 use std::sync::OnceLock;
@@ -203,9 +203,55 @@ impl MutableChunkNoiseFunctionComponentImpl for Beardifier {
         &mut self,
         _component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        _sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         StaticIndependentChunkNoiseFunctionComponentImpl::sample(self, pos)
+    }
+
+    fn sample_volume(
+        &mut self,
+        _component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+    ) {
+        buffer.fill(0.0);
+        let Some(affected_box) = self.affected_box else {
+            return;
+        };
+        if affected_box.min.x > volume.max_block_x()
+            || affected_box.max.x < volume.min_block_x
+            || affected_box.min.y > volume.max_block_y()
+            || affected_box.max.y < volume.min_block_y
+            || affected_box.min.z > volume.max_block_z()
+            || affected_box.max.z < volume.min_block_z
+        {
+            return;
+        }
+        let min_x = 0
+            .max(affected_box.min.x - volume.min_block_x)
+            .div_euclid(volume.step_block_x);
+        let min_y = 0
+            .max(affected_box.min.y - volume.min_block_y)
+            .div_euclid(volume.step_block_y);
+        let min_z = 0
+            .max(affected_box.min.z - volume.min_block_z)
+            .div_euclid(volume.step_block_z);
+        let max_x = (volume.size_x as i32 - 1)
+            .min((affected_box.max.x - volume.min_block_x).div_euclid(volume.step_block_x));
+        let max_y = (volume.size_y as i32 - 1)
+            .min((affected_box.max.y - volume.min_block_y).div_euclid(volume.step_block_y));
+        let max_z = (volume.size_z as i32 - 1)
+            .min((affected_box.max.z - volume.min_block_z).div_euclid(volume.step_block_z));
+        for z in min_z..=max_z {
+            let block_z = volume.block_z(z as usize);
+            for x in min_x..=max_x {
+                let block_x = volume.block_x(x as usize);
+                for y in min_y..=max_y {
+                    let index = volume.index_unchecked(x as usize, y as usize, z as usize);
+                    buffer[index] =
+                        self.sample_value_unchecked(block_x, volume.block_y(y as usize), block_z);
+                }
+            }
+        }
     }
 }
 

--- a/crates/pumpkin-world/src/generation/noise/router/density_function/math.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/density_function/math.rs
@@ -1,22 +1,14 @@
-use std::cell::RefCell;
-
 use pumpkin_data::noise_router::{
     BinaryData, BinaryOperation, ClampData, LinearData, RoundingData, RoundingOperation, UnaryData,
 };
 use pumpkin_util::math::vector3::Vector3;
 
 use crate::generation::noise::router::{
-    chunk_density_function::ChunkNoiseFunctionSampleOptions,
     chunk_noise_router::{ChunkNoiseFunctionComponent, StaticChunkNoiseFunctionComponentImpl},
+    density_volume::{DensityBuffer, DensityVolume},
 };
 
-thread_local! {
-    static SCRATCH_BUFFER: RefCell<Vec<f32>> = const { RefCell::new(Vec::new()) };
-}
-
-use super::{
-    IndexToNoisePos, NoiseFunctionComponentRange, StaticIndependentChunkNoiseFunctionComponentImpl,
-};
+use super::{NoiseFunctionComponentRange, StaticIndependentChunkNoiseFunctionComponentImpl};
 
 pub struct Constant {
     value: f32,
@@ -45,8 +37,8 @@ impl StaticIndependentChunkNoiseFunctionComponentImpl for Constant {
         self.value
     }
 
-    fn fill(&self, array: &mut [f32], _mapper: &impl IndexToNoisePos) {
-        array.fill(self.value);
+    fn sample_volume(&self, buffer: &mut [f32], _volume: &DensityVolume) {
+        buffer.fill(self.value);
     }
 }
 
@@ -74,14 +66,28 @@ impl StaticChunkNoiseFunctionComponentImpl for Linear {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let input_density = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_index],
             pos,
-            sample_options,
         );
         self.data.apply_density(input_density)
+    }
+
+    fn sample_volume(
+        &self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+    ) {
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.input_index],
+            buffer,
+            volume,
+        );
+        for value in buffer.iter_mut() {
+            *value = self.data.apply_density(*value);
+        }
     }
 }
 
@@ -126,12 +132,10 @@ impl StaticChunkNoiseFunctionComponentImpl for Binary {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let input1_density = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input1_index],
             pos,
-            sample_options,
         );
 
         match self.data.operation {
@@ -139,7 +143,6 @@ impl StaticChunkNoiseFunctionComponentImpl for Binary {
                 let input2_density = ChunkNoiseFunctionComponent::sample_from_stack(
                     &mut component_stack[..=self.input2_index],
                     pos,
-                    sample_options,
                 );
                 input1_density + input2_density
             }
@@ -150,7 +153,6 @@ impl StaticChunkNoiseFunctionComponentImpl for Binary {
                     let input2_density = ChunkNoiseFunctionComponent::sample_from_stack(
                         &mut component_stack[..=self.input2_index],
                         pos,
-                        sample_options,
                     );
                     input1_density * input2_density
                 }
@@ -164,7 +166,6 @@ impl StaticChunkNoiseFunctionComponentImpl for Binary {
                     let input2_density = ChunkNoiseFunctionComponent::sample_from_stack(
                         &mut component_stack[..=self.input2_index],
                         pos,
-                        sample_options,
                     );
 
                     input1_density.min(input2_density)
@@ -179,7 +180,6 @@ impl StaticChunkNoiseFunctionComponentImpl for Binary {
                     let input2_density = ChunkNoiseFunctionComponent::sample_from_stack(
                         &mut component_stack[..=self.input2_index],
                         pos,
-                        sample_options,
                     );
 
                     input1_density.max(input2_density)
@@ -189,7 +189,6 @@ impl StaticChunkNoiseFunctionComponentImpl for Binary {
                 let input2_density = ChunkNoiseFunctionComponent::sample_from_stack(
                     &mut component_stack[..=self.input2_index],
                     pos,
-                    sample_options,
                 );
                 input1_density - input2_density
             }
@@ -197,7 +196,6 @@ impl StaticChunkNoiseFunctionComponentImpl for Binary {
                 let input2_density = ChunkNoiseFunctionComponent::sample_from_stack(
                     &mut component_stack[..=self.input2_index],
                     pos,
-                    sample_options,
                 );
                 if input2_density == 0.0 {
                     0.0
@@ -209,126 +207,43 @@ impl StaticChunkNoiseFunctionComponentImpl for Binary {
                 let input2_density = ChunkNoiseFunctionComponent::sample_from_stack(
                     &mut component_stack[..=self.input2_index],
                     pos,
-                    sample_options,
                 );
                 input1_density.powf(input2_density)
             }
         }
     }
 
-    #[expect(clippy::too_many_lines)]
-    fn fill(
+    fn sample_volume(
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
+        buffer: &mut [f32],
+        volume: &DensityVolume,
     ) {
-        ChunkNoiseFunctionComponent::fill_from_stack(
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
             &mut component_stack[..=self.input1_index],
-            array,
-            mapper,
-            sample_options,
+            buffer,
+            volume,
         );
-
-        let len = array.len();
+        let mut input2 = DensityBuffer::acquire(volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.input2_index],
+            &mut input2,
+            volume,
+        );
         match self.data.operation {
-            BinaryOperation::Add => {
-                SCRATCH_BUFFER.with(|scratch_cell| {
-                    let mut scratch = scratch_cell.borrow_mut();
-                    if scratch.len() < len {
-                        scratch.resize(len, 0.0);
-                    }
-                    let scratch_slice = &mut scratch[..len];
-
-                    ChunkNoiseFunctionComponent::fill_from_stack(
-                        &mut component_stack[..=self.input2_index],
-                        scratch_slice,
-                        mapper,
-                        sample_options,
-                    );
-
-                    for (a, b) in array.iter_mut().zip(scratch_slice.iter()) {
-                        *a += b;
-                    }
-                });
-            }
             BinaryOperation::Mul => {
-                for (index, value) in array.iter_mut().enumerate() {
-                    if *value != 0.0 {
-                        let pos = mapper.at(index, Some(sample_options));
-                        let density2 = ChunkNoiseFunctionComponent::sample_from_stack(
-                            &mut component_stack[..=self.input2_index],
-                            &pos,
-                            sample_options,
-                        );
-                        *value *= density2;
-                    }
-                }
-            }
-            BinaryOperation::Min => {
-                let input2_min = component_stack[self.input2_index].min();
-                for (index, value) in array.iter_mut().enumerate() {
-                    if *value >= input2_min {
-                        let pos = mapper.at(index, Some(sample_options));
-                        let density2 = ChunkNoiseFunctionComponent::sample_from_stack(
-                            &mut component_stack[..=self.input2_index],
-                            &pos,
-                            sample_options,
-                        );
-                        *value = value.min(density2);
-                    }
-                }
-            }
-            BinaryOperation::Max => {
-                let input2_max = component_stack[self.input2_index].max();
-                for (index, value) in array.iter_mut().enumerate() {
-                    if *value <= input2_max {
-                        let pos = mapper.at(index, Some(sample_options));
-                        let density2 = ChunkNoiseFunctionComponent::sample_from_stack(
-                            &mut component_stack[..=self.input2_index],
-                            &pos,
-                            sample_options,
-                        );
-                        *value = value.max(density2);
-                    }
-                }
-            }
-            BinaryOperation::Sub => {
-                for (index, value) in array.iter_mut().enumerate() {
-                    let pos = mapper.at(index, Some(sample_options));
-                    let density2 = ChunkNoiseFunctionComponent::sample_from_stack(
-                        &mut component_stack[..=self.input2_index],
-                        &pos,
-                        sample_options,
-                    );
-                    *value -= density2;
-                }
-            }
-            BinaryOperation::Div => {
-                for (index, value) in array.iter_mut().enumerate() {
-                    let pos = mapper.at(index, Some(sample_options));
-                    let density2 = ChunkNoiseFunctionComponent::sample_from_stack(
-                        &mut component_stack[..=self.input2_index],
-                        &pos,
-                        sample_options,
-                    );
-                    *value = if density2 == 0.0 {
-                        0.0
-                    } else {
-                        *value / density2
-                    };
+                for (value, input2) in buffer.iter_mut().zip(input2.iter()) {
+                    *value = if *value == 0.0 { 0.0 } else { *value * *input2 };
                 }
             }
             BinaryOperation::Pow => {
-                for (index, value) in array.iter_mut().enumerate() {
-                    let pos = mapper.at(index, Some(sample_options));
-                    let density2 = ChunkNoiseFunctionComponent::sample_from_stack(
-                        &mut component_stack[..=self.input2_index],
-                        &pos,
-                        sample_options,
-                    );
-                    *value = value.powf(density2);
+                for (value, input2) in buffer.iter_mut().zip(input2.iter()) {
+                    *value = value.powf(*input2);
+                }
+            }
+            _ => {
+                for (value, input2) in buffer.iter_mut().zip(input2.iter()) {
+                    *value = self.data.apply_density(*value, *input2);
                 }
             }
         }
@@ -377,30 +292,26 @@ impl StaticChunkNoiseFunctionComponentImpl for Unary {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let input_density = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_index],
             pos,
-            sample_options,
         );
         self.data.apply_density(input_density)
     }
 
-    fn fill(
+    fn sample_volume(
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
+        buffer: &mut [f32],
+        volume: &DensityVolume,
     ) {
-        ChunkNoiseFunctionComponent::fill_from_stack(
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
             &mut component_stack[..=self.input_index],
-            array,
-            mapper,
-            sample_options,
+            buffer,
+            volume,
         );
-        for value in array.iter_mut() {
+        for value in buffer.iter_mut() {
             *value = self.data.apply_density(*value);
         }
     }
@@ -450,30 +361,26 @@ impl StaticChunkNoiseFunctionComponentImpl for Clamp {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let input_density = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_index],
             pos,
-            sample_options,
         );
         self.data.apply_density(input_density)
     }
 
-    fn fill(
+    fn sample_volume(
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
+        buffer: &mut [f32],
+        volume: &DensityVolume,
     ) {
-        ChunkNoiseFunctionComponent::fill_from_stack(
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
             &mut component_stack[..=self.input_index],
-            array,
-            mapper,
-            sample_options,
+            buffer,
+            volume,
         );
-        for value in array.iter_mut() {
+        for value in buffer.iter_mut() {
             *value = self.data.apply_density(*value);
         }
     }
@@ -522,36 +429,47 @@ impl StaticChunkNoiseFunctionComponentImpl for Lerp {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let alpha = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.alpha_index],
             pos,
-            sample_options,
         );
         let first = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.first_index],
             pos,
-            sample_options,
         );
         let second = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.second_index],
             pos,
-            sample_options,
         );
         first + alpha * (second - first)
     }
 
-    fn fill(
+    fn sample_volume(
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
+        buffer: &mut [f32],
+        volume: &DensityVolume,
     ) {
-        for (index, value) in array.iter_mut().enumerate() {
-            let pos = mapper.at(index, Some(sample_options));
-            *value = self.sample(component_stack, &pos, sample_options);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.alpha_index],
+            buffer,
+            volume,
+        );
+        let mut first = DensityBuffer::acquire(volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.first_index],
+            &mut first,
+            volume,
+        );
+        let mut second = DensityBuffer::acquire(volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.second_index],
+            &mut second,
+            volume,
+        );
+        for ((value, first), second) in buffer.iter_mut().zip(first.iter()).zip(second.iter()) {
+            *value = first + *value * (second - first);
         }
     }
 }
@@ -616,17 +534,14 @@ impl StaticChunkNoiseFunctionComponentImpl for Rounding {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let input = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_index],
             pos,
-            sample_options,
         );
         let multiple = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.multiple_index],
             pos,
-            sample_options,
         );
         if multiple == 0.0 {
             input
@@ -635,16 +550,27 @@ impl StaticChunkNoiseFunctionComponentImpl for Rounding {
         }
     }
 
-    fn fill(
+    fn sample_volume(
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
+        buffer: &mut [f32],
+        volume: &DensityVolume,
     ) {
-        for (index, value) in array.iter_mut().enumerate() {
-            let pos = mapper.at(index, Some(sample_options));
-            *value = self.sample(component_stack, &pos, sample_options);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.input_index],
+            buffer,
+            volume,
+        );
+        let mut multiple = DensityBuffer::acquire(volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.multiple_index],
+            &mut multiple,
+            volume,
+        );
+        for (value, multiple) in buffer.iter_mut().zip(multiple.iter()) {
+            if *multiple != 0.0 {
+                *value = round_to_integer(*value / multiple, self.data.operation) * multiple;
+            }
         }
     }
 }

--- a/crates/pumpkin-world/src/generation/noise/router/density_function/misc.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/density_function/misc.rs
@@ -11,13 +11,11 @@ use pumpkin_util::{
 };
 
 use crate::generation::noise::router::{
-    chunk_density_function::ChunkNoiseFunctionSampleOptions,
     chunk_noise_router::{ChunkNoiseFunctionComponent, StaticChunkNoiseFunctionComponentImpl},
+    density_volume::{DensityBuffer, DensityVolume},
 };
 
-use super::{
-    IndexToNoisePos, NoiseFunctionComponentRange, StaticIndependentChunkNoiseFunctionComponentImpl,
-};
+use super::{NoiseFunctionComponentRange, StaticIndependentChunkNoiseFunctionComponentImpl};
 
 pub struct EndIsland {
     sampler: Arc<SimplexNoiseSampler>,
@@ -78,6 +76,17 @@ impl StaticIndependentChunkNoiseFunctionComponentImpl for EndIsland {
     fn sample(&self, pos: &Vector3<i32>) -> f32 {
         (Self::sample_2d(&self.sampler, pos.x / 8, pos.z / 8) - 8.0) / 128.0
     }
+
+    fn sample_volume(&self, buffer: &mut [f32], volume: &DensityVolume) {
+        for z in 0..volume.size_z {
+            let block_z = volume.block_z(z);
+            for x in 0..volume.size_x {
+                let value = self.sample(&Vector3::new(volume.block_x(x), 0, block_z));
+                let index = volume.index_unchecked(x, 0, z);
+                buffer[index..index + volume.size_y].fill(value);
+            }
+        }
+    }
 }
 
 pub struct IntervalSelect {
@@ -111,12 +120,10 @@ impl StaticChunkNoiseFunctionComponentImpl for IntervalSelect {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let input_val = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_index],
             pos,
-            sample_options,
         );
 
         let mut selected_index = self.thresholds.len();
@@ -128,28 +135,31 @@ impl StaticChunkNoiseFunctionComponentImpl for IntervalSelect {
         }
 
         let func_index = self.functions_indices[selected_index];
-        ChunkNoiseFunctionComponent::sample_from_stack(
-            &mut component_stack[..=func_index],
-            pos,
-            sample_options,
-        )
+        ChunkNoiseFunctionComponent::sample_from_stack(&mut component_stack[..=func_index], pos)
     }
 
-    fn fill(
+    fn sample_volume(
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
+        buffer: &mut [f32],
+        volume: &DensityVolume,
     ) {
-        ChunkNoiseFunctionComponent::fill_from_stack(
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
             &mut component_stack[..=self.input_index],
-            array,
-            mapper,
-            sample_options,
+            buffer,
+            volume,
         );
-
-        array.iter_mut().enumerate().for_each(|(index, value)| {
+        let mut function_buffers = Vec::with_capacity(self.functions_indices.len());
+        for &function_index in self.functions_indices {
+            let mut function_buffer = DensityBuffer::acquire(volume);
+            ChunkNoiseFunctionComponent::sample_volume_from_stack(
+                &mut component_stack[..=function_index],
+                &mut function_buffer,
+                volume,
+            );
+            function_buffers.push(function_buffer);
+        }
+        for (index, value) in buffer.iter_mut().enumerate() {
             let mut selected_index = self.thresholds.len();
             for (i, &threshold) in self.thresholds.iter().enumerate() {
                 if *value < threshold {
@@ -157,15 +167,8 @@ impl StaticChunkNoiseFunctionComponentImpl for IntervalSelect {
                     break;
                 }
             }
-
-            let func_index = self.functions_indices[selected_index];
-            let pos = mapper.at(index, Some(sample_options));
-            *value = ChunkNoiseFunctionComponent::sample_from_stack(
-                &mut component_stack[..=func_index],
-                &pos,
-                sample_options,
-            );
-        });
+            *value = function_buffers[selected_index][index];
+        }
     }
 }
 
@@ -214,17 +217,21 @@ impl StaticIndependentChunkNoiseFunctionComponentImpl for ClampedYGradient {
         )
     }
 
-    fn fill(&self, array: &mut [f32], mapper: &impl IndexToNoisePos) {
-        array.iter_mut().enumerate().for_each(|(index, value)| {
-            let pos = mapper.at(index, None);
-            *value = clamped_map(
-                pos.y as f32,
+    fn sample_volume(&self, buffer: &mut [f32], volume: &DensityVolume) {
+        for y in 0..volume.size_y {
+            let value = clamped_map(
+                volume.block_y(y) as f32,
                 self.data.from_y,
                 self.data.to_y,
                 self.data.from_value,
                 self.data.to_value,
             );
-        });
+            for z in 0..volume.size_z {
+                for x in 0..volume.size_x {
+                    buffer[volume.index_unchecked(x, y, z)] = value;
+                }
+            }
+        }
     }
 }
 
@@ -250,13 +257,8 @@ impl NoiseFunctionComponentRange for Gradient {
     }
 }
 
-impl StaticIndependentChunkNoiseFunctionComponentImpl for Gradient {
-    fn sample(&self, pos: &Vector3<i32>) -> f32 {
-        let coordinate = match self.data.axis {
-            Axis::X => pos.x,
-            Axis::Y => pos.y,
-            Axis::Z => pos.z,
-        };
+impl Gradient {
+    fn compute(&self, coordinate: i32) -> f32 {
         let coordinate_range = self.data.to_coordinate - self.data.from_coordinate;
         let coordinate_factor =
             (self.data.to_value - self.data.from_value) / (coordinate_range as f32);
@@ -286,12 +288,47 @@ impl StaticIndependentChunkNoiseFunctionComponentImpl for Gradient {
             }
         }
     }
+}
 
-    fn fill(&self, array: &mut [f32], mapper: &impl IndexToNoisePos) {
-        array.iter_mut().enumerate().for_each(|(index, value)| {
-            let pos = mapper.at(index, None);
-            *value = self.sample(&pos);
-        });
+impl StaticIndependentChunkNoiseFunctionComponentImpl for Gradient {
+    fn sample(&self, pos: &Vector3<i32>) -> f32 {
+        self.compute(match self.data.axis {
+            Axis::X => pos.x,
+            Axis::Y => pos.y,
+            Axis::Z => pos.z,
+        })
+    }
+
+    fn sample_volume(&self, buffer: &mut [f32], volume: &DensityVolume) {
+        match self.data.axis {
+            Axis::X => {
+                for x in 0..volume.size_x {
+                    let value = self.compute(volume.block_x(x));
+                    for z in 0..volume.size_z {
+                        let index = volume.index_unchecked(x, 0, z);
+                        buffer[index..index + volume.size_y].fill(value);
+                    }
+                }
+            }
+            Axis::Y => {
+                for y in 0..volume.size_y {
+                    let value = self.compute(volume.block_y(y));
+                    for z in 0..volume.size_z {
+                        for x in 0..volume.size_x {
+                            buffer[volume.index_unchecked(x, y, z)] = value;
+                        }
+                    }
+                }
+            }
+            Axis::Z => {
+                let slab = volume.size_x * volume.size_y;
+                for z in 0..volume.size_z {
+                    let value = self.compute(volume.block_z(z));
+                    let index = volume.index_unchecked(0, 0, z);
+                    buffer[index..index + slab].fill(value);
+                }
+            }
+        }
     }
 }
 
@@ -328,13 +365,6 @@ impl StaticIndependentChunkNoiseFunctionComponentImpl for DistanceToPoint {
             DistanceMetric::Manhattan => dx.abs() + dy.abs() + dz.abs(),
             DistanceMetric::Chebyshev => dx.abs().max(dy.abs()).max(dz.abs()),
         }
-    }
-
-    fn fill(&self, array: &mut [f32], mapper: &impl IndexToNoisePos) {
-        array.iter_mut().enumerate().for_each(|(index, value)| {
-            let pos = mapper.at(index, None);
-            *value = self.sample(&pos);
-        });
     }
 }
 
@@ -381,7 +411,6 @@ impl StaticChunkNoiseFunctionComponentImpl for Slice {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let slice_pos = match self.axis {
             Axis::X => Vector3::new(self.coordinate, pos.y, pos.z),
@@ -391,20 +420,114 @@ impl StaticChunkNoiseFunctionComponentImpl for Slice {
         ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_index],
             &slice_pos,
-            sample_options,
         )
     }
 
-    fn fill(
+    fn sample_volume(
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
+        buffer: &mut [f32],
+        volume: &DensityVolume,
     ) {
-        for (index, value) in array.iter_mut().enumerate() {
-            let pos = mapper.at(index, Some(sample_options));
-            *value = self.sample(component_stack, &pos, sample_options);
+        let input_volume = match self.axis {
+            Axis::X => {
+                if volume.size_x == 1 && volume.min_block_x == self.coordinate {
+                    ChunkNoiseFunctionComponent::sample_volume_from_stack(
+                        &mut component_stack[..=self.input_index],
+                        buffer,
+                        volume,
+                    );
+                    return;
+                }
+                DensityVolume::new(
+                    1,
+                    volume.size_y,
+                    volume.size_z,
+                    self.coordinate,
+                    volume.min_block_y,
+                    volume.min_block_z,
+                    volume.step_block_x,
+                    volume.step_block_y,
+                    volume.step_block_z,
+                )
+            }
+            Axis::Y => {
+                if volume.size_y == 1 && volume.min_block_y == self.coordinate {
+                    ChunkNoiseFunctionComponent::sample_volume_from_stack(
+                        &mut component_stack[..=self.input_index],
+                        buffer,
+                        volume,
+                    );
+                    return;
+                }
+                DensityVolume::new(
+                    volume.size_x,
+                    1,
+                    volume.size_z,
+                    volume.min_block_x,
+                    self.coordinate,
+                    volume.min_block_z,
+                    volume.step_block_x,
+                    volume.step_block_y,
+                    volume.step_block_z,
+                )
+            }
+            Axis::Z => {
+                if volume.size_z == 1 && volume.min_block_z == self.coordinate {
+                    ChunkNoiseFunctionComponent::sample_volume_from_stack(
+                        &mut component_stack[..=self.input_index],
+                        buffer,
+                        volume,
+                    );
+                    return;
+                }
+                DensityVolume::new(
+                    volume.size_x,
+                    volume.size_y,
+                    1,
+                    volume.min_block_x,
+                    volume.min_block_y,
+                    self.coordinate,
+                    volume.step_block_x,
+                    volume.step_block_y,
+                    volume.step_block_z,
+                )
+            }
+        };
+        let mut input = DensityBuffer::acquire(&input_volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.input_index],
+            &mut input,
+            &input_volume,
+        );
+        match self.axis {
+            Axis::X => {
+                let mut index = 0;
+                for z in 0..volume.size_z {
+                    for _ in 0..volume.size_x {
+                        for y in 0..volume.size_y {
+                            buffer[index] = input[input_volume.index_unchecked(0, y, z)];
+                            index += 1;
+                        }
+                    }
+                }
+            }
+            Axis::Y => {
+                for z in 0..volume.size_z {
+                    for x in 0..volume.size_x {
+                        let value = input[input_volume.index_unchecked(x, 0, z)];
+                        let index = volume.index_unchecked(x, 0, z);
+                        buffer[index..index + volume.size_y].fill(value);
+                    }
+                }
+            }
+            Axis::Z => {
+                let slab = volume.size_x * volume.size_y;
+                for z in 0..volume.size_z {
+                    let index = volume.index_unchecked(0, 0, z);
+                    buffer[index..index + slab].copy_from_slice(&input[..slab]);
+                }
+            }
         }
     }
 }
@@ -455,58 +578,52 @@ impl StaticChunkNoiseFunctionComponentImpl for RangeChoice {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let input_sample = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_index],
             pos,
-            sample_options,
         );
 
         if self.data.min_inclusive <= input_sample && input_sample < self.data.max_exclusive {
             ChunkNoiseFunctionComponent::sample_from_stack(
                 &mut component_stack[..=self.when_in_index],
                 pos,
-                sample_options,
             )
         } else {
             ChunkNoiseFunctionComponent::sample_from_stack(
                 &mut component_stack[..=self.when_out_index],
                 pos,
-                sample_options,
             )
         }
     }
 
-    fn fill(
+    fn sample_volume(
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
+        buffer: &mut [f32],
+        volume: &DensityVolume,
     ) {
-        ChunkNoiseFunctionComponent::fill_from_stack(
-            &mut component_stack[..=self.input_index],
-            array,
-            mapper,
-            sample_options,
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.when_in_index],
+            buffer,
+            volume,
         );
-
-        array.iter_mut().enumerate().for_each(|(index, value)| {
-            let pos = mapper.at(index, Some(sample_options));
-            *value = if self.data.min_inclusive <= *value && *value < self.data.max_exclusive {
-                ChunkNoiseFunctionComponent::sample_from_stack(
-                    &mut component_stack[..=self.when_in_index],
-                    &pos,
-                    sample_options,
-                )
-            } else {
-                ChunkNoiseFunctionComponent::sample_from_stack(
-                    &mut component_stack[..=self.when_out_index],
-                    &pos,
-                    sample_options,
-                )
-            };
-        });
+        let mut input = DensityBuffer::acquire(volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.input_index],
+            &mut input,
+            volume,
+        );
+        let mut when_out = DensityBuffer::acquire(volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.when_out_index],
+            &mut when_out,
+            volume,
+        );
+        for ((value, input), when_out) in buffer.iter_mut().zip(input.iter()).zip(when_out.iter()) {
+            if !(self.data.min_inclusive <= *input && *input < self.data.max_exclusive) {
+                *value = *when_out;
+            }
+        }
     }
 }

--- a/crates/pumpkin-world/src/generation/noise/router/density_function/mod.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/density_function/mod.rs
@@ -1,7 +1,6 @@
 use pumpkin_data::noise_router::WrapperType;
 use pumpkin_util::math::vector3::Vector3;
 
-use super::chunk_density_function::ChunkNoiseFunctionSampleOptions;
 use super::density_volume::DensityVolume;
 
 pub(crate) mod beardifier;
@@ -16,14 +15,6 @@ mod test;
 #[cfg(test)]
 mod test_deserializer;
 
-pub trait IndexToNoisePos {
-    fn at(
-        &self,
-        index: usize,
-        sample_options: Option<&mut ChunkNoiseFunctionSampleOptions>,
-    ) -> Vector3<i32>;
-}
-
 pub trait NoiseFunctionComponentRange {
     fn min(&self) -> f32;
     fn max(&self) -> f32;
@@ -34,12 +25,6 @@ pub trait StaticIndependentChunkNoiseFunctionComponentImpl: NoiseFunctionCompone
 
     fn sample_volume(&self, buffer: &mut [f32], volume: &DensityVolume) {
         volume.fill_with(buffer, |pos| self.sample(pos));
-    }
-    fn fill(&self, array: &mut [f32], mapper: &impl IndexToNoisePos) {
-        array.iter_mut().enumerate().for_each(|(index, value)| {
-            let pos = mapper.at(index, None);
-            *value = self.sample(&pos);
-        });
     }
 }
 

--- a/crates/pumpkin-world/src/generation/noise/router/density_function/noise.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/density_function/noise.rs
@@ -10,8 +10,8 @@ use pumpkin_util::{
 use crate::generation::{
     noise::perlin::DoublePerlinNoiseSampler,
     noise::router::{
-        chunk_density_function::ChunkNoiseFunctionSampleOptions,
         chunk_noise_router::{ChunkNoiseFunctionComponent, StaticChunkNoiseFunctionComponentImpl},
+        density_volume::{DensityBuffer, DensityVolume},
     },
 };
 
@@ -48,6 +48,21 @@ impl StaticIndependentChunkNoiseFunctionComponentImpl for Noise {
             pos.z as f32 * self.data.xz_scale,
         )
     }
+
+    fn sample_volume(&self, buffer: &mut [f32], volume: &DensityVolume) {
+        let mut index = 0;
+        for z in 0..volume.size_z {
+            let noise_z = volume.block_z(z) as f32 * self.data.xz_scale;
+            for x in 0..volume.size_x {
+                let noise_x = volume.block_x(x) as f32 * self.data.xz_scale;
+                for y in 0..volume.size_y {
+                    let noise_y = volume.block_y(y) as f32 * self.data.y_scale;
+                    buffer[index] = self.sampler.sample(noise_x, noise_y, noise_z);
+                    index += 1;
+                }
+            }
+        }
+    }
 }
 
 #[inline]
@@ -81,6 +96,18 @@ impl StaticIndependentChunkNoiseFunctionComponentImpl for ShiftA {
     fn sample(&self, pos: &Vector3<i32>) -> f32 {
         shift_sample_3d(&self.sampler, pos.x as f32, 0.0, pos.z as f32)
     }
+
+    fn sample_volume(&self, buffer: &mut [f32], volume: &DensityVolume) {
+        for z in 0..volume.size_z {
+            let block_z = volume.block_z(z);
+            for x in 0..volume.size_x {
+                let value =
+                    shift_sample_3d(&self.sampler, volume.block_x(x) as f32, 0.0, block_z as f32);
+                let index = volume.index_unchecked(x, 0, z);
+                buffer[index..index + volume.size_y].fill(value);
+            }
+        }
+    }
 }
 
 pub struct ShiftB {
@@ -108,6 +135,18 @@ impl NoiseFunctionComponentRange for ShiftB {
 impl StaticIndependentChunkNoiseFunctionComponentImpl for ShiftB {
     fn sample(&self, pos: &Vector3<i32>) -> f32 {
         shift_sample_3d(&self.sampler, pos.z as f32, pos.x as f32, 0.0)
+    }
+
+    fn sample_volume(&self, buffer: &mut [f32], volume: &DensityVolume) {
+        for z in 0..volume.size_z {
+            let block_z = volume.block_z(z);
+            for x in 0..volume.size_x {
+                let value =
+                    shift_sample_3d(&self.sampler, block_z as f32, volume.block_x(x) as f32, 0.0);
+                let index = volume.index_unchecked(x, 0, z);
+                buffer[index..index + volume.size_y].fill(value);
+            }
+        }
     }
 }
 
@@ -153,25 +192,63 @@ impl StaticChunkNoiseFunctionComponentImpl for ShiftedNoise {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let x_shift = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_x_index],
             pos,
-            sample_options,
         );
         let y_shift = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_y_index],
             pos,
-            sample_options,
         );
         let z_shift = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.input_z_index],
             pos,
-            sample_options,
         );
 
         self.sample_with_shifts(pos, x_shift, y_shift, z_shift)
+    }
+
+    fn sample_volume(
+        &self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+    ) {
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.input_x_index],
+            buffer,
+            volume,
+        );
+        let mut y_shifts = DensityBuffer::acquire(volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.input_y_index],
+            &mut y_shifts,
+            volume,
+        );
+        let mut z_shifts = DensityBuffer::acquire(volume);
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.input_z_index],
+            &mut z_shifts,
+            volume,
+        );
+        let mut index = 0;
+        for z in 0..volume.size_z {
+            let block_z = volume.block_z(z);
+            for x in 0..volume.size_x {
+                let block_x = volume.block_x(x);
+                for y in 0..volume.size_y {
+                    let pos = Vector3::new(block_x, volume.block_y(y), block_z);
+                    buffer[index] = self.sample_with_shifts(
+                        &pos,
+                        buffer[index],
+                        y_shifts[index],
+                        z_shifts[index],
+                    );
+                    index += 1;
+                }
+            }
+        }
     }
 }
 

--- a/crates/pumpkin-world/src/generation/noise/router/density_function/spline.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/density_function/spline.rs
@@ -1,8 +1,8 @@
 use pumpkin_util::math::vector3::Vector3;
 
 use crate::generation::noise::router::{
-    chunk_density_function::ChunkNoiseFunctionSampleOptions,
     chunk_noise_router::{ChunkNoiseFunctionComponent, StaticChunkNoiseFunctionComponentImpl},
+    density_volume::{DensityBuffer, DensityVolume},
     proto_noise_router::ProtoNoiseFunctionComponent,
 };
 
@@ -15,15 +15,10 @@ pub enum SplineValue {
 
 impl SplineValue {
     #[inline]
-    fn sample(
-        &self,
-        pos: &Vector3<i32>,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        sample_options: &ChunkNoiseFunctionSampleOptions,
-    ) -> f32 {
+    fn sample_with(&self, location_of: &mut dyn FnMut(usize) -> f32) -> f32 {
         match self {
             Self::Fixed(fixed) => *fixed,
-            Self::Spline(spline) => spline.sample(pos, component_stack, sample_options),
+            Self::Spline(spline) => spline.sample_with(location_of),
         }
     }
 
@@ -154,26 +149,27 @@ impl Spline {
         &self,
         pos: &Vector3<i32>,
         component_stack: &mut [ChunkNoiseFunctionComponent],
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
-        let location = ChunkNoiseFunctionComponent::sample_from_stack(
-            &mut component_stack[..=self.input_index],
-            pos,
-            sample_options,
-        );
+        self.sample_with(&mut |index| {
+            ChunkNoiseFunctionComponent::sample_from_stack(&mut component_stack[..=index], pos)
+        })
+    }
+
+    fn sample_with(&self, location_of: &mut dyn FnMut(usize) -> f32) -> f32 {
+        let location = location_of(self.input_index);
 
         let n = self.points.len();
         let index_greater_than_x = self.points.partition_point(|p| location >= p.location);
 
         if index_greater_than_x == 0 {
             let point = &self.points[0];
-            let val = point.value.sample(pos, component_stack, sample_options);
+            let val = point.value.sample_with(location_of);
             return val + point.derivative * (location - point.location);
         }
 
         if index_greater_than_x == n {
             let point = &self.points[n - 1];
-            let val = point.value.sample(pos, component_stack, sample_options);
+            let val = point.value.sample_with(location_of);
             return val + point.derivative * (location - point.location);
         }
 
@@ -183,8 +179,8 @@ impl Spline {
         let start_x = previous.location;
         let end_x = current.location;
 
-        let start_value = previous.value.sample(pos, component_stack, sample_options);
-        let end_value = current.value.sample(pos, component_stack, sample_options);
+        let start_value = previous.value.sample_with(location_of);
+        let end_value = current.value.sample_with(location_of);
 
         let start_derivative = previous.derivative;
         let end_derivative = current.derivative;
@@ -233,9 +229,35 @@ impl StaticChunkNoiseFunctionComponentImpl for SplineFunction {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
-        self.spline.sample(pos, component_stack, sample_options)
+        self.spline.sample(pos, component_stack)
+    }
+
+    fn sample_volume(
+        &self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+    ) {
+        let mut coordinates: Vec<(usize, DensityBuffer)> = Vec::new();
+        for (index, value) in buffer.iter_mut().enumerate() {
+            *value = self.spline.sample_with(&mut |location_index| {
+                let position = coordinates
+                    .iter()
+                    .position(|(coordinate_index, _)| *coordinate_index == location_index)
+                    .unwrap_or_else(|| {
+                        let mut coordinate = DensityBuffer::acquire(volume);
+                        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+                            &mut component_stack[..=location_index],
+                            &mut coordinate,
+                            volume,
+                        );
+                        coordinates.push((location_index, coordinate));
+                        coordinates.len() - 1
+                    });
+                coordinates[position].1[index]
+            });
+        }
     }
 }
 

--- a/crates/pumpkin-world/src/generation/noise/router/density_function/test.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/density_function/test.rs
@@ -10,9 +10,6 @@ use std::sync::LazyLock;
 
 use crate::generation::GlobalRandomConfig;
 use crate::generation::noise::router::chunk_density_function::ChunkNoiseFunctionBuilderOptions;
-use crate::generation::noise::router::chunk_density_function::{
-    ChunkNoiseFunctionSampleOptions, SampleAction,
-};
 use crate::generation::noise::router::chunk_noise_router::{
     ChunkNoiseDensityFunction, ChunkNoiseFunctionComponent,
 };
@@ -24,7 +21,7 @@ use super::{NoiseFunctionComponentRange, PassThrough};
 
 // This is a dummy value because we are not actually building chunk-specific functions
 static TEST_OPTIONS: ChunkNoiseFunctionBuilderOptions =
-    ChunkNoiseFunctionBuilderOptions::new(0, 0, 0, 0, 0, 0, 0, Vec::new(), Vec::new(), None);
+    ChunkNoiseFunctionBuilderOptions::new(Vec::new(), Vec::new(), None);
 const SEED: u64 = 0;
 static RANDOM_CONFIG: LazyLock<GlobalRandomConfig> =
     LazyLock::new(|| GlobalRandomConfig::new(SEED, false));
@@ -70,9 +67,6 @@ macro_rules! build_function {
     };
 }
 
-const TEST_SAMPLE_OPTIONS: ChunkNoiseFunctionSampleOptions =
-    ChunkNoiseFunctionSampleOptions::new(false, SampleAction::SkipCellCaches, 0, 0, 0);
-
 macro_rules! sample_noise_router_function {
     ($name:ident, $pos: expr) => {{
         let base_router = &OVERWORLD_BASE_NOISE_ROUTER.noise;
@@ -82,7 +76,7 @@ macro_rules! sample_noise_router_function {
         );
         let mut stack = build_function_stack!(&proto_stack[..=base_router.$name]);
         let mut function = build_function!(&mut stack);
-        function.sample(&$pos, &TEST_SAMPLE_OPTIONS)
+        function.sample(&$pos)
     }};
 }
 
@@ -95,7 +89,7 @@ macro_rules! sample_multi_noise_router_function {
         );
         let mut stack = build_function_stack!(&proto_stack[..=base_router.$name]);
         let mut function = build_function!(&mut stack);
-        function.sample(&$pos, &TEST_SAMPLE_OPTIONS)
+        function.sample(&$pos)
     }};
 }
 
@@ -108,7 +102,7 @@ macro_rules! sample_surface_router_function {
         );
         let mut stack = build_function_stack!(&proto_stack);
         let mut function = build_function!(&mut stack);
-        function.sample(&$pos, &TEST_SAMPLE_OPTIONS)
+        function.sample(&$pos)
     }};
 }
 
@@ -586,7 +580,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data.into_iter().step_by(5) {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );
@@ -656,7 +650,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );
@@ -675,7 +669,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );
@@ -694,7 +688,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );
@@ -713,7 +707,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );
@@ -732,7 +726,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );
@@ -751,7 +745,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );
@@ -773,7 +767,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );
@@ -792,7 +786,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );
@@ -811,7 +805,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );
@@ -832,7 +826,7 @@ fn normal_surface_noisified() {
 //     for (x, y, z, sample) in expected_data {
 //         let pos = Vector3 { x, y, z };
 //         assert_eq_delta!(
-//             function.sample(&pos, &TEST_SAMPLE_OPTIONS),
+//             function.sample(&pos),
 //             sample,
 //             f32::EPSILON
 //         );

--- a/crates/pumpkin-world/src/generation/noise/router/density_volume.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/density_volume.rs
@@ -181,7 +181,7 @@ impl DensityVolume {
 
 const BUFFER_SIZE_INCREMENT: usize = 16;
 const MAX_REUSE_SIZE_FACTOR: usize = 2;
-const MAX_POOLED_BUFFERS: usize = 64;
+const MAX_POOLED_BUFFERS: usize = 1024;
 
 thread_local! {
     static DENSITY_BUFFER_POOL: RefCell<Vec<Box<[f32]>>> = const { RefCell::new(Vec::new()) };

--- a/crates/pumpkin-world/src/generation/noise/router/find_top_surface.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/find_top_surface.rs
@@ -2,9 +2,9 @@ use pumpkin_data::noise_router::FindTopSurfaceData;
 use pumpkin_util::math::vector3::Vector3;
 
 use crate::generation::noise::router::{
-    chunk_density_function::ChunkNoiseFunctionSampleOptions,
     chunk_noise_router::{ChunkNoiseFunctionComponent, StaticChunkNoiseFunctionComponentImpl},
     density_function::NoiseFunctionComponentRange,
+    density_volume::{DensityBuffer, DensityVolume},
 };
 
 pub struct FindTopSurface {
@@ -66,18 +66,72 @@ impl StaticChunkNoiseFunctionComponentImpl for FindTopSurface {
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         let upper = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.upper_bound_index],
             pos,
-            sample_options,
         );
+        self.find_surface_from(component_stack, pos.x, pos.z, upper)
+    }
 
+    fn sample_volume(
+        &self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        buffer: &mut [f32],
+        volume: &DensityVolume,
+    ) {
+        if volume.size_y != 1 {
+            let column_volume = DensityVolume::new(
+                volume.size_x,
+                1,
+                volume.size_z,
+                volume.min_block_x,
+                0,
+                volume.min_block_z,
+                volume.step_block_x,
+                volume.step_block_y,
+                volume.step_block_z,
+            );
+            let mut columns = DensityBuffer::acquire(&column_volume);
+            self.sample_volume(component_stack, &mut columns, &column_volume);
+            for z in 0..volume.size_z {
+                for x in 0..volume.size_x {
+                    let value = columns[column_volume.index_unchecked(x, 0, z)];
+                    let index = volume.index_unchecked(x, 0, z);
+                    buffer[index..index + volume.size_y].fill(value);
+                }
+            }
+            return;
+        }
+        ChunkNoiseFunctionComponent::sample_volume_from_stack(
+            &mut component_stack[..=self.upper_bound_index],
+            buffer,
+            volume,
+        );
+        let mut index = 0;
+        for z in 0..volume.size_z {
+            let block_z = volume.block_z(z);
+            for x in 0..volume.size_x {
+                let block_x = volume.block_x(x);
+                buffer[index] =
+                    self.find_surface_from(component_stack, block_x, block_z, buffer[index]);
+                index += 1;
+            }
+        }
+    }
+}
+
+impl FindTopSurface {
+    fn find_surface_from(
+        &self,
+        component_stack: &mut [ChunkNoiseFunctionComponent],
+        x: i32,
+        z: i32,
+        upper: f32,
+    ) -> f32 {
         let density = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut component_stack[..=self.density_index],
-            &Vector3::new(pos.x, upper.floor() as i32, pos.z),
-            sample_options,
+            &Vector3::new(x, upper.floor() as i32, z),
         );
         if density > 0.0 {
             return upper;
@@ -97,11 +151,10 @@ impl StaticChunkNoiseFunctionComponentImpl for FindTopSurface {
         // Walk downward in cellHeight steps, return the first Y where density > 0.0
         let mut y = top_y;
         while y >= lower_bound {
-            let sample_pos = Vector3::new(pos.x, y, pos.z);
+            let sample_pos = Vector3::new(x, y, z);
             let density = ChunkNoiseFunctionComponent::sample_from_stack(
                 &mut component_stack[..=self.density_index],
                 &sample_pos,
-                sample_options,
             );
             if density > 0.0 {
                 return y as f32;

--- a/crates/pumpkin-world/src/generation/noise/router/mod.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/mod.rs
@@ -9,3 +9,5 @@ mod parity_fingerprint_test;
 pub mod proto_noise_router;
 pub mod static_router;
 pub mod surface_height_sampler;
+#[cfg(test)]
+mod volume_parity_test;

--- a/crates/pumpkin-world/src/generation/noise/router/multi_noise_sampler.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/multi_noise_sampler.rs
@@ -7,36 +7,14 @@ use crate::{
 };
 
 use super::{
-    chunk_density_function::{
-        Cache2D, ChunkNoiseFunctionSampleOptions, ChunkSpecificNoiseFunctionComponent, FlatCache,
-        SampleAction,
-    },
+    chunk_density_function::{Cache, ChunkSpecificNoiseFunctionComponent},
     chunk_noise_router::ChunkNoiseFunctionComponent,
     density_function::{NoiseFunctionComponentRange, PassThrough},
+    density_volume::{DensityBuffer, DensityVolume},
     proto_noise_router::{
         BEARDIFIER_ZERO_CONSTANT, ProtoMultiNoiseRouter, ProtoNoiseFunctionComponent,
     },
 };
-
-pub struct MultiNoiseSamplerBuilderOptions {
-    // The biome coords of this chunk
-    start_biome_x: i32,
-    start_biome_z: i32,
-
-    // Number of biome regions per chunk per axis
-    horizontal_biome_end: usize,
-}
-
-impl MultiNoiseSamplerBuilderOptions {
-    #[must_use]
-    pub const fn new(start_biome_x: i32, start_biome_z: i32, horizontal_biome_end: usize) -> Self {
-        Self {
-            start_biome_x,
-            start_biome_z,
-            horizontal_biome_end,
-        }
-    }
-}
 
 pub struct MultiNoiseSampler<'a> {
     temperature: usize,
@@ -47,52 +25,81 @@ pub struct MultiNoiseSampler<'a> {
     // AKA: Weirdness
     ridges: usize,
     component_stack: Box<[ChunkNoiseFunctionComponent<'a>]>,
+    volume: Option<DensityVolume>,
+    buffers: Option<[DensityBuffer; 6]>,
 }
 
 impl<'a> MultiNoiseSampler<'a> {
+    pub fn fill_volume(&mut self, volume: DensityVolume) {
+        let indices = [
+            self.temperature,
+            self.humidity,
+            self.continentalness,
+            self.erosion,
+            self.depth,
+            self.ridges,
+        ];
+        let buffers = indices.map(|index| {
+            let mut buffer = DensityBuffer::acquire(&volume);
+            ChunkNoiseFunctionComponent::sample_volume_from_stack(
+                &mut self.component_stack[..=index],
+                &mut buffer,
+                &volume,
+            );
+            buffer
+        });
+        self.volume = Some(volume);
+        self.buffers = Some(buffers);
+    }
+
     pub fn sample(&mut self, biome_x: i32, biome_y: i32, biome_z: i32) -> NoiseValuePoint {
         let block_x = biome_coords::to_block(biome_x);
         let block_y = biome_coords::to_block(biome_y);
         let block_z = biome_coords::to_block(biome_z);
 
+        if let (Some(volume), Some(buffers)) = (&self.volume, &self.buffers)
+            && let Some(index) = volume.index_of_block(block_x, block_y, block_z)
+        {
+            return NoiseValuePoint {
+                temperature: to_long(buffers[0][index]),
+                humidity: to_long(buffers[1][index]),
+                continentalness: to_long(buffers[2][index]),
+                erosion: to_long(buffers[3][index]),
+                depth: to_long(buffers[4][index]),
+                weirdness: to_long(buffers[5][index]),
+            };
+        }
+
         let pos = Vector3::new(block_x, block_y, block_z);
-        let sample_options =
-            ChunkNoiseFunctionSampleOptions::new(false, SampleAction::SkipCellCaches, 0, 0, 0);
 
         let temperature = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut self.component_stack[..=self.temperature],
             &pos,
-            &sample_options,
         );
 
         let humidity = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut self.component_stack[..=self.humidity],
             &pos,
-            &sample_options,
         );
 
         let continentalness = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut self.component_stack[..=self.continentalness],
             &pos,
-            &sample_options,
         );
 
         let erosion = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut self.component_stack[..=self.erosion],
             &pos,
-            &sample_options,
         );
 
         let depth = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut self.component_stack[..=self.depth],
             &pos,
-            &sample_options,
         );
 
         let weirdness = ChunkNoiseFunctionComponent::sample_from_stack(
             &mut self.component_stack[..=self.ridges],
             &pos,
-            &sample_options,
         );
 
         NoiseValuePoint {
@@ -107,21 +114,15 @@ impl<'a> MultiNoiseSampler<'a> {
 
     pub fn sample_erosion(&mut self, block_x: i32, block_y: i32, block_z: i32) -> f32 {
         let pos = Vector3::new(block_x, block_y, block_z);
-        let sample_options =
-            ChunkNoiseFunctionSampleOptions::new(false, SampleAction::SkipCellCaches, 0, 0, 0);
 
         ChunkNoiseFunctionComponent::sample_from_stack(
             &mut self.component_stack[..=self.erosion],
             &pos,
-            &sample_options,
         )
     }
 
     #[must_use]
-    pub fn generate(
-        base: &'a ProtoMultiNoiseRouter,
-        build_options: &MultiNoiseSamplerBuilderOptions,
-    ) -> Self {
+    pub fn generate(base: &'a ProtoMultiNoiseRouter) -> Self {
         // TODO: It seems kind of wasteful to iter over all components (even those we dont need
         // because they're for chunk population), but this is the best I've got for now.
         // (Should we traverse the functions and update the indices?)
@@ -148,69 +149,20 @@ impl<'a> MultiNoiseSampler<'a> {
                     let max_value = component_stack[wrapper.input_index].max();
 
                     match wrapper.wrapper_type {
-                        WrapperType::Cache2D => ChunkNoiseFunctionComponent::Chunk(
-                            ChunkSpecificNoiseFunctionComponent::Cache2D(Cache2D::new(
+                        WrapperType::Cache => ChunkNoiseFunctionComponent::Chunk(
+                            ChunkSpecificNoiseFunctionComponent::Cache(Cache::new(
                                 wrapper.input_index,
                                 min_value,
                                 max_value,
                             )),
                         ),
-                        WrapperType::CacheFlat => {
-                            let mut flat_cache = FlatCache::new(
+                        WrapperType::Interpolated { .. } => {
+                            ChunkNoiseFunctionComponent::PassThrough(PassThrough::new(
                                 wrapper.input_index,
                                 min_value,
                                 max_value,
-                                build_options.start_biome_x,
-                                build_options.start_biome_z,
-                                build_options.horizontal_biome_end,
-                            );
-                            let sample_options = ChunkNoiseFunctionSampleOptions::new(
-                                false,
-                                SampleAction::SkipCellCaches,
-                                0,
-                                0,
-                                0,
-                            );
-
-                            for biome_x_position in 0..=build_options.horizontal_biome_end {
-                                let absolute_biome_x_position =
-                                    build_options.start_biome_x + biome_x_position as i32;
-                                let block_x_position =
-                                    biome_coords::to_block(absolute_biome_x_position);
-
-                                for biome_z_position in 0..=build_options.horizontal_biome_end {
-                                    let absolute_biome_z_position =
-                                        build_options.start_biome_z + biome_z_position as i32;
-                                    let block_z_position =
-                                        biome_coords::to_block(absolute_biome_z_position);
-
-                                    let pos = Vector3::new(block_x_position, 0, block_z_position);
-
-                                    //NOTE: Due to our stack invariant, what is on the stack is a
-                                    // valid density function
-                                    let sample = ChunkNoiseFunctionComponent::sample_from_stack(
-                                        &mut component_stack[..=wrapper.input_index],
-                                        &pos,
-                                        &sample_options,
-                                    );
-
-                                    let cache_index = flat_cache
-                                        .xz_to_index_const(biome_x_position, biome_z_position);
-                                    flat_cache.cache[cache_index] = sample;
-                                }
-                            }
-
-                            ChunkNoiseFunctionComponent::Chunk(
-                                ChunkSpecificNoiseFunctionComponent::FlatCache(flat_cache),
-                            )
+                            ))
                         }
-                        // Java passes thru if the noise pos is not the chunk itself, which it is
-                        // never for the MultiNoiseSampler
-                        _ => ChunkNoiseFunctionComponent::PassThrough(PassThrough::new(
-                            wrapper.input_index,
-                            min_value,
-                            max_value,
-                        )),
                     }
                 }
             };
@@ -225,6 +177,8 @@ impl<'a> MultiNoiseSampler<'a> {
             erosion: base.erosion,
             ridges: base.ridges,
             component_stack: component_stack.into_boxed_slice(),
+            volume: None,
+            buffers: None,
         }
     }
 }
@@ -238,7 +192,7 @@ mod test {
         generation::noise::router::proto_noise_router::ProtoNoiseRouters,
     };
 
-    use super::{MultiNoiseSampler, MultiNoiseSamplerBuilderOptions};
+    use super::MultiNoiseSampler;
 
     #[test]
     fn sample() {
@@ -246,9 +200,7 @@ mod test {
         let random_config = GlobalRandomConfig::new(seed, false);
         let noise_router =
             ProtoNoiseRouters::generate(&OVERWORLD_BASE_NOISE_ROUTER, &random_config);
-        let multi_noise_config = MultiNoiseSamplerBuilderOptions::new(1, 1, 1);
-        let mut sampler =
-            MultiNoiseSampler::generate(&noise_router.multi_noise, &multi_noise_config);
+        let mut sampler = MultiNoiseSampler::generate(&noise_router.multi_noise);
         let expected = NoiseValuePoint {
             temperature: -5727,
             humidity: 55,
@@ -267,9 +219,7 @@ mod test {
         let random_config = GlobalRandomConfig::new(seed, false);
         let noise_router =
             ProtoNoiseRouters::generate(&OVERWORLD_BASE_NOISE_ROUTER, &random_config);
-        let multi_noise_config = MultiNoiseSamplerBuilderOptions::new(1, 1, 1);
-        let mut sampler =
-            MultiNoiseSampler::generate(&noise_router.multi_noise, &multi_noise_config);
+        let mut sampler = MultiNoiseSampler::generate(&noise_router.multi_noise);
         let expected = NoiseValuePoint {
             temperature: 7489,
             humidity: 3502,

--- a/crates/pumpkin-world/src/generation/noise/router/parity_fingerprint_test.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/parity_fingerprint_test.rs
@@ -2,9 +2,7 @@ use pumpkin_data::noise_router::OVERWORLD_BASE_NOISE_ROUTER;
 use pumpkin_util::math::vector3::Vector3;
 
 use crate::generation::GlobalRandomConfig;
-use crate::generation::noise::router::chunk_density_function::{
-    ChunkNoiseFunctionBuilderOptions, ChunkNoiseFunctionSampleOptions, SampleAction,
-};
+use crate::generation::noise::router::chunk_density_function::ChunkNoiseFunctionBuilderOptions;
 use crate::generation::noise::router::chunk_noise_router::ChunkNoiseRouter;
 use crate::generation::noise::router::proto_noise_router::ProtoNoiseRouters;
 
@@ -31,32 +29,18 @@ fn overworld_density_fingerprint_is_stable() {
         let proto_routers =
             ProtoNoiseRouters::generate(&OVERWORLD_BASE_NOISE_ROUTER, &random_config);
 
-        let builder_options = ChunkNoiseFunctionBuilderOptions::new(
-            4,
-            8,
-            48,
-            4,
-            0,
-            0,
-            4,
-            Vec::new(),
-            Vec::new(),
-            None,
-        );
+        let builder_options = ChunkNoiseFunctionBuilderOptions::new(Vec::new(), Vec::new(), None);
         let mut router = ChunkNoiseRouter::generate(&proto_routers.noise, &builder_options);
-
-        let options =
-            ChunkNoiseFunctionSampleOptions::new(false, SampleAction::SkipCellCaches, 0, 0, 0);
 
         for x in (-64..64).step_by(11) {
             for y in (-64..320).step_by(19) {
                 for z in (-64..64).step_by(13) {
                     let pos = Vector3::new(x, y, z);
 
-                    results.push(router.final_density(&pos, &options));
-                    results.push(router.vein_toggle(&pos, &options));
-                    results.push(router.vein_ridged(&pos, &options));
-                    results.push(router.vein_gap(&pos, &options));
+                    results.push(router.final_density(&pos));
+                    results.push(router.vein_toggle(&pos));
+                    results.push(router.vein_ridged(&pos));
+                    results.push(router.vein_gap(&pos));
                 }
             }
         }
@@ -64,7 +48,7 @@ fn overworld_density_fingerprint_is_stable() {
 
     let hash = fnv1a_hash_f32(results.into_iter());
     assert_eq!(
-        hash, 9_544_564_030_852_513_724,
+        hash, 6_073_335_735_394_468_434,
         "Overworld density fingerprint changed"
     );
 }

--- a/crates/pumpkin-world/src/generation/noise/router/proto_noise_router.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/proto_noise_router.rs
@@ -15,11 +15,10 @@ use crate::{
 };
 
 use super::{
-    chunk_density_function::ChunkNoiseFunctionSampleOptions,
     chunk_noise_router::{ChunkNoiseFunctionComponent, StaticChunkNoiseFunctionComponentImpl},
     density_function::{
-        IndexToNoisePos, NoiseFunctionComponentRange, PassThrough,
-        StaticIndependentChunkNoiseFunctionComponentImpl, Wrapper,
+        NoiseFunctionComponentRange, PassThrough, StaticIndependentChunkNoiseFunctionComponentImpl,
+        Wrapper,
         beardifier::Beardifier,
         math::{Binary, Clamp, Constant, Lerp, Linear, Rounding, Unary},
         misc::{
@@ -93,21 +92,6 @@ impl StaticIndependentChunkNoiseFunctionComponentImpl for IndependentProtoNoiseF
             Self::ClampedYGradient(c) => c.sample(pos),
             Self::Gradient(g) => g.sample(pos),
             Self::DistanceToPoint(d) => d.sample(pos),
-        }
-    }
-
-    #[inline]
-    fn fill(&self, array: &mut [f32], mapper: &impl IndexToNoisePos) {
-        match self {
-            Self::Constant(c) => c.fill(array, mapper),
-            Self::EndIsland(e) => e.fill(array, mapper),
-            Self::Noise(n) => n.fill(array, mapper),
-            Self::ShiftA(s) => s.fill(array, mapper),
-            Self::ShiftB(s) => s.fill(array, mapper),
-            Self::InterpolatedNoise(i) => i.fill(array, mapper),
-            Self::ClampedYGradient(c) => c.fill(array, mapper),
-            Self::Gradient(g) => g.fill(array, mapper),
-            Self::DistanceToPoint(d) => d.fill(array, mapper),
         }
     }
 
@@ -186,45 +170,20 @@ impl StaticChunkNoiseFunctionComponentImpl for DependentProtoNoiseFunctionCompon
         &self,
         component_stack: &mut [ChunkNoiseFunctionComponent],
         pos: &Vector3<i32>,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) -> f32 {
         match self {
-            Self::Linear(l) => l.sample(component_stack, pos, sample_options),
-            Self::Unary(u) => u.sample(component_stack, pos, sample_options),
-            Self::Binary(b) => b.sample(component_stack, pos, sample_options),
-            Self::ShiftedNoise(s) => s.sample(component_stack, pos, sample_options),
-            Self::IntervalSelect(i) => i.sample(component_stack, pos, sample_options),
-            Self::FindTopSurface(f) => f.sample(component_stack, pos, sample_options),
-            Self::Clamp(c) => c.sample(component_stack, pos, sample_options),
-            Self::RangeChoice(r) => r.sample(component_stack, pos, sample_options),
-            Self::Spline(s) => s.sample(component_stack, pos, sample_options),
-            Self::Lerp(l) => l.sample(component_stack, pos, sample_options),
-            Self::Rounding(r) => r.sample(component_stack, pos, sample_options),
-            Self::Slice(s) => s.sample(component_stack, pos, sample_options),
-        }
-    }
-
-    #[inline]
-    fn fill(
-        &self,
-        component_stack: &mut [ChunkNoiseFunctionComponent],
-        array: &mut [f32],
-        mapper: &impl IndexToNoisePos,
-        sample_options: &mut ChunkNoiseFunctionSampleOptions,
-    ) {
-        match self {
-            Self::Linear(l) => l.fill(component_stack, array, mapper, sample_options),
-            Self::Unary(u) => u.fill(component_stack, array, mapper, sample_options),
-            Self::Binary(b) => b.fill(component_stack, array, mapper, sample_options),
-            Self::ShiftedNoise(s) => s.fill(component_stack, array, mapper, sample_options),
-            Self::IntervalSelect(i) => i.fill(component_stack, array, mapper, sample_options),
-            Self::FindTopSurface(f) => f.fill(component_stack, array, mapper, sample_options),
-            Self::Clamp(c) => c.fill(component_stack, array, mapper, sample_options),
-            Self::RangeChoice(r) => r.fill(component_stack, array, mapper, sample_options),
-            Self::Spline(s) => s.fill(component_stack, array, mapper, sample_options),
-            Self::Lerp(l) => l.fill(component_stack, array, mapper, sample_options),
-            Self::Rounding(r) => r.fill(component_stack, array, mapper, sample_options),
-            Self::Slice(s) => s.fill(component_stack, array, mapper, sample_options),
+            Self::Linear(l) => l.sample(component_stack, pos),
+            Self::Unary(u) => u.sample(component_stack, pos),
+            Self::Binary(b) => b.sample(component_stack, pos),
+            Self::ShiftedNoise(s) => s.sample(component_stack, pos),
+            Self::IntervalSelect(i) => i.sample(component_stack, pos),
+            Self::FindTopSurface(f) => f.sample(component_stack, pos),
+            Self::Clamp(c) => c.sample(component_stack, pos),
+            Self::RangeChoice(r) => r.sample(component_stack, pos),
+            Self::Spline(s) => s.sample(component_stack, pos),
+            Self::Lerp(l) => l.sample(component_stack, pos),
+            Self::Rounding(r) => r.sample(component_stack, pos),
+            Self::Slice(s) => s.sample(component_stack, pos),
         }
     }
 
@@ -234,29 +193,28 @@ impl StaticChunkNoiseFunctionComponentImpl for DependentProtoNoiseFunctionCompon
         component_stack: &mut [ChunkNoiseFunctionComponent],
         buffer: &mut [f32],
         volume: &DensityVolume,
-        sample_options: &ChunkNoiseFunctionSampleOptions,
     ) {
         match self {
-            Self::Linear(l) => l.sample_volume(component_stack, buffer, volume, sample_options),
-            Self::Unary(u) => u.sample_volume(component_stack, buffer, volume, sample_options),
-            Self::Binary(b) => b.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Linear(l) => l.sample_volume(component_stack, buffer, volume),
+            Self::Unary(u) => u.sample_volume(component_stack, buffer, volume),
+            Self::Binary(b) => b.sample_volume(component_stack, buffer, volume),
             Self::ShiftedNoise(s) => {
-                s.sample_volume(component_stack, buffer, volume, sample_options);
+                s.sample_volume(component_stack, buffer, volume);
             }
             Self::IntervalSelect(i) => {
-                i.sample_volume(component_stack, buffer, volume, sample_options);
+                i.sample_volume(component_stack, buffer, volume);
             }
             Self::FindTopSurface(f) => {
-                f.sample_volume(component_stack, buffer, volume, sample_options);
+                f.sample_volume(component_stack, buffer, volume);
             }
-            Self::Clamp(c) => c.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Clamp(c) => c.sample_volume(component_stack, buffer, volume),
             Self::RangeChoice(r) => {
-                r.sample_volume(component_stack, buffer, volume, sample_options);
+                r.sample_volume(component_stack, buffer, volume);
             }
-            Self::Spline(s) => s.sample_volume(component_stack, buffer, volume, sample_options),
-            Self::Lerp(l) => l.sample_volume(component_stack, buffer, volume, sample_options),
-            Self::Rounding(r) => r.sample_volume(component_stack, buffer, volume, sample_options),
-            Self::Slice(s) => s.sample_volume(component_stack, buffer, volume, sample_options),
+            Self::Spline(s) => s.sample_volume(component_stack, buffer, volume),
+            Self::Lerp(l) => l.sample_volume(component_stack, buffer, volume),
+            Self::Rounding(r) => r.sample_volume(component_stack, buffer, volume),
+            Self::Slice(s) => s.sample_volume(component_stack, buffer, volume),
         }
     }
 }

--- a/crates/pumpkin-world/src/generation/noise/router/static_router.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/static_router.rs
@@ -1,18 +1,8 @@
 use pumpkin_util::math::vector3::Vector3;
 
-use super::density_function::IndexToNoisePos;
-
 /// Zero-cost static trait for monomorphized density function pipeline evaluation.
 pub trait StaticDensityFunction {
     fn sample(&self, pos: &Vector3<i32>) -> f64;
-
-    #[inline]
-    fn fill(&self, array: &mut [f64], mapper: &impl IndexToNoisePos) {
-        array.iter_mut().enumerate().for_each(|(index, value)| {
-            let pos = mapper.at(index, None);
-            *value = self.sample(&pos);
-        });
-    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -22,11 +12,6 @@ impl StaticDensityFunction for Constant {
     #[inline]
     fn sample(&self, _pos: &Vector3<i32>) -> f64 {
         self.0
-    }
-
-    #[inline]
-    fn fill(&self, array: &mut [f64], _mapper: &impl IndexToNoisePos) {
-        array.fill(self.0);
     }
 }
 
@@ -121,19 +106,5 @@ impl StaticDensityFunction for ClampedYGradient {
             self.from_value,
             self.to_value,
         )
-    }
-
-    #[inline]
-    fn fill(&self, array: &mut [f64], mapper: &impl IndexToNoisePos) {
-        array.iter_mut().enumerate().for_each(|(index, value)| {
-            let pos = mapper.at(index, None);
-            *value = pumpkin_util::math::clamped_map(
-                pos.y as f64,
-                self.from_y,
-                self.to_y,
-                self.from_value,
-                self.to_value,
-            );
-        });
     }
 }

--- a/crates/pumpkin-world/src/generation/noise/router/surface_height_sampler.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/surface_height_sampler.rs
@@ -5,10 +5,7 @@ use rustc_hash::FxHashMap;
 use crate::generation::{biome_coords, positions::chunk_pos};
 
 use super::{
-    chunk_density_function::{
-        Cache2D, ChunkNoiseFunctionSampleOptions, ChunkSpecificNoiseFunctionComponent, FlatCache,
-        SampleAction,
-    },
+    chunk_density_function::{Cache, ChunkSpecificNoiseFunctionComponent},
     chunk_noise_router::ChunkNoiseFunctionComponent,
     density_function::{NoiseFunctionComponentRange, PassThrough},
     proto_noise_router::{
@@ -17,13 +14,6 @@ use super::{
 };
 
 pub struct SurfaceHeightSamplerBuilderOptions {
-    // The biome coords of this chunk
-    start_biome_x: i32,
-    start_biome_z: i32,
-
-    // Number of biome regions per chunk per axis
-    horizontal_biome_end: usize,
-
     // Minimum y level to check
     minimum_y: i32,
     // Maximum y level to check
@@ -33,18 +23,8 @@ pub struct SurfaceHeightSamplerBuilderOptions {
 
 impl SurfaceHeightSamplerBuilderOptions {
     #[must_use]
-    pub const fn new(
-        start_biome_x: i32,
-        start_biome_z: i32,
-        horizontal_biome_end: usize,
-        minimum_y: i32,
-        maximum_y: i32,
-        y_level_step_count: usize,
-    ) -> Self {
+    pub const fn new(minimum_y: i32, maximum_y: i32, y_level_step_count: usize) -> Self {
         Self {
-            start_biome_x,
-            start_biome_z,
-            horizontal_biome_end,
             minimum_y,
             maximum_y,
             y_level_step_count,
@@ -79,8 +59,6 @@ impl<'a> SurfaceHeightEstimateSampler<'a> {
     }
 
     fn calculate_height_estimate(&mut self, aligned_x: i32, aligned_z: i32) -> i32 {
-        let sample_options =
-            ChunkNoiseFunctionSampleOptions::new(false, SampleAction::SkipCellCaches, 0, 0, 0);
         let pos = Vector3::new(aligned_x, 0, aligned_z);
 
         // If the top-most component is FindTopSurface, we want to perform a precise search
@@ -92,7 +70,6 @@ impl<'a> SurfaceHeightEstimateSampler<'a> {
             let upper = ChunkNoiseFunctionComponent::sample_from_stack(
                 &mut self.component_stack[..=fts.upper_bound_index()],
                 &pos,
-                &sample_options,
             );
 
             // First find the coarse cell that contains the surface
@@ -102,7 +79,6 @@ impl<'a> SurfaceHeightEstimateSampler<'a> {
                 let density = ChunkNoiseFunctionComponent::sample_from_stack(
                     &mut self.component_stack[..=fts.density_index()],
                     &Vector3::new(aligned_x, y, aligned_z),
-                    &sample_options,
                 );
                 if density > 0.0 {
                     return y;
@@ -113,11 +89,8 @@ impl<'a> SurfaceHeightEstimateSampler<'a> {
             return self.minimum_y;
         }
 
-        let surface_y = ChunkNoiseFunctionComponent::sample_from_stack(
-            &mut self.component_stack,
-            &pos,
-            &sample_options,
-        );
+        let surface_y =
+            ChunkNoiseFunctionComponent::sample_from_stack(&mut self.component_stack, &pos);
         surface_y.floor() as i32
     }
 
@@ -152,69 +125,20 @@ impl<'a> SurfaceHeightEstimateSampler<'a> {
                     let max_value = component_stack[wrapper.input_index].max();
 
                     match wrapper.wrapper_type {
-                        WrapperType::Cache2D => ChunkNoiseFunctionComponent::Chunk(
-                            ChunkSpecificNoiseFunctionComponent::Cache2D(Cache2D::new(
+                        WrapperType::Cache => ChunkNoiseFunctionComponent::Chunk(
+                            ChunkSpecificNoiseFunctionComponent::Cache(Cache::new(
                                 wrapper.input_index,
                                 min_value,
                                 max_value,
                             )),
                         ),
-                        WrapperType::CacheFlat => {
-                            let mut flat_cache = FlatCache::new(
+                        WrapperType::Interpolated { .. } => {
+                            ChunkNoiseFunctionComponent::PassThrough(PassThrough::new(
                                 wrapper.input_index,
                                 min_value,
                                 max_value,
-                                build_options.start_biome_x,
-                                build_options.start_biome_z,
-                                build_options.horizontal_biome_end,
-                            );
-                            let sample_options = ChunkNoiseFunctionSampleOptions::new(
-                                false,
-                                SampleAction::SkipCellCaches,
-                                0,
-                                0,
-                                0,
-                            );
-
-                            for biome_x_position in 0..=build_options.horizontal_biome_end {
-                                let absolute_biome_x_position =
-                                    build_options.start_biome_x + biome_x_position as i32;
-                                let block_x_position =
-                                    biome_coords::to_block(absolute_biome_x_position);
-
-                                for biome_z_position in 0..=build_options.horizontal_biome_end {
-                                    let absolute_biome_z_position =
-                                        build_options.start_biome_z + biome_z_position as i32;
-                                    let block_z_position =
-                                        biome_coords::to_block(absolute_biome_z_position);
-
-                                    let pos = Vector3::new(block_x_position, 0, block_z_position);
-
-                                    //NOTE: Due to our stack invariant, what is on the stack is a
-                                    // valid density function
-                                    let sample = ChunkNoiseFunctionComponent::sample_from_stack(
-                                        &mut component_stack[..=wrapper.input_index],
-                                        &pos,
-                                        &sample_options,
-                                    );
-
-                                    let cache_index = flat_cache
-                                        .xz_to_index_const(biome_x_position, biome_z_position);
-                                    flat_cache.cache[cache_index] = sample;
-                                }
-                            }
-
-                            ChunkNoiseFunctionComponent::Chunk(
-                                ChunkSpecificNoiseFunctionComponent::FlatCache(flat_cache),
-                            )
+                            ))
                         }
-                        // Java passes thru if the noise pos is not the chunk itself, which it is
-                        // never for the Height estimator
-                        _ => ChunkNoiseFunctionComponent::PassThrough(PassThrough::new(
-                            wrapper.input_index,
-                            min_value,
-                            max_value,
-                        )),
                     }
                 }
             };

--- a/crates/pumpkin-world/src/generation/noise/router/volume_parity_test.rs
+++ b/crates/pumpkin-world/src/generation/noise/router/volume_parity_test.rs
@@ -1,0 +1,127 @@
+use pumpkin_data::noise_router::OVERWORLD_BASE_NOISE_ROUTER;
+
+use crate::generation::GlobalRandomConfig;
+use crate::generation::noise::router::chunk_density_function::{
+    ChunkNoiseFunctionBuilderOptions, ChunkSpecificNoiseFunctionComponent,
+};
+use crate::generation::noise::router::chunk_noise_router::{
+    ChunkNoiseFunctionComponent, ChunkNoiseRouter,
+};
+use crate::generation::noise::router::density_function::PassThrough;
+use crate::generation::noise::router::density_volume::{DensityBuffer, DensityVolume};
+use crate::generation::noise::router::proto_noise_router::{
+    ProtoNoiseFunctionComponent, ProtoNoiseRouters,
+};
+
+fn pass_through_stack(
+    base: &[ProtoNoiseFunctionComponent],
+) -> Vec<ChunkNoiseFunctionComponent<'_>> {
+    base.iter()
+        .map(|component| match component {
+            ProtoNoiseFunctionComponent::Dependent(dependent) => {
+                ChunkNoiseFunctionComponent::Dependent(dependent)
+            }
+            ProtoNoiseFunctionComponent::Independent(independent) => {
+                ChunkNoiseFunctionComponent::Independent(independent)
+            }
+            ProtoNoiseFunctionComponent::PassThrough(pass_through) => {
+                ChunkNoiseFunctionComponent::PassThrough(pass_through.clone())
+            }
+            ProtoNoiseFunctionComponent::Beardifier(beardifier) => {
+                ChunkNoiseFunctionComponent::Chunk(ChunkSpecificNoiseFunctionComponent::Beardifier(
+                    beardifier.clone(),
+                ))
+            }
+            ProtoNoiseFunctionComponent::Wrapper(wrapper) => {
+                ChunkNoiseFunctionComponent::PassThrough(PassThrough::new(
+                    wrapper.input_index,
+                    0.0,
+                    0.0,
+                ))
+            }
+        })
+        .collect()
+}
+
+fn assert_volume_matches(
+    stack: &mut [ChunkNoiseFunctionComponent],
+    volume: &DensityVolume,
+    label: &str,
+) {
+    let mut actual = DensityBuffer::acquire(volume);
+    ChunkNoiseFunctionComponent::sample_volume_from_stack(stack, &mut actual, volume);
+    let mut expected = DensityBuffer::acquire(volume);
+    volume.fill_with(&mut expected, |pos| {
+        ChunkNoiseFunctionComponent::sample_from_stack(stack, pos)
+    });
+    for (index, (a, b)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            a.to_bits() == b.to_bits() || (a.is_nan() && b.is_nan()),
+            "{label}: volume {volume:?} index {index}: got {a}, expected {b}"
+        );
+    }
+}
+
+fn small_volumes() -> [DensityVolume; 5] {
+    [
+        DensityVolume::with_block_step(8, 24, 8, 0, -16, 0),
+        DensityVolume::new(3, 7, 3, 16, -64, 16, 4, 8, 4),
+        DensityVolume::with_block_step(4, 1, 4, -13, 0, 21),
+        DensityVolume::with_block_step(1, 40, 1, 7, 60, 3),
+        DensityVolume::new(2, 3, 2, -13, 100, 5, 1, 4, 16),
+    ]
+}
+
+#[test]
+fn every_component_samples_volumes_like_values() {
+    let random_config = GlobalRandomConfig::new(42, false);
+    let proto_routers = ProtoNoiseRouters::generate(&OVERWORLD_BASE_NOISE_ROUTER, &random_config);
+
+    for (name, base) in [
+        ("noise", &proto_routers.noise.full_component_stack),
+        (
+            "surface",
+            &proto_routers.surface_estimator.full_component_stack,
+        ),
+        (
+            "multi_noise",
+            &proto_routers.multi_noise.full_component_stack,
+        ),
+    ] {
+        let mut stack = pass_through_stack(base);
+        for index in 0..stack.len() {
+            for volume in &small_volumes() {
+                assert_volume_matches(
+                    &mut stack[..=index],
+                    volume,
+                    &format!("{name} component {index}"),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn chunk_router_samples_volumes_like_values() {
+    let random_config = GlobalRandomConfig::new(42, false);
+    let proto_routers = ProtoNoiseRouters::generate(&OVERWORLD_BASE_NOISE_ROUTER, &random_config);
+    let builder_options = ChunkNoiseFunctionBuilderOptions::new(Vec::new(), Vec::new(), None);
+    let mut router = ChunkNoiseRouter::generate(&proto_routers.noise, &builder_options);
+    let chunk = DensityVolume::with_block_step(16, 384, 16, 0, -64, 0);
+    let cells = DensityVolume::new(5, 49, 5, 0, -64, 0, 4, 8, 4);
+    let unaligned = DensityVolume::with_block_step(7, 20, 5, -13, -61, 3);
+    let column = DensityVolume::with_block_step(1, 384, 1, -35, -64, 18);
+
+    for volume in [chunk, cells, unaligned, column] {
+        let mut actual = DensityBuffer::acquire(&volume);
+        router.final_density_volume(&mut actual, &volume);
+        let mut expected = DensityBuffer::acquire(&volume);
+        volume.fill_with(&mut expected, |pos| router.final_density(pos));
+        for (index, (a, b)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                a.to_bits() == b.to_bits(),
+                "final_density volume {volume:?} index {index}: got {a}, expected {b}"
+            );
+        }
+    }
+}

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -43,7 +43,7 @@ use crate::chunk_system::{StagedChunkEnum, generation_cache::SurfaceBiomeNeighbo
 use crate::generation::height_limit::HeightLimitView;
 use crate::generation::noise::aquifer_sampler::{FluidLevel, FluidLevelSamplerImpl};
 use crate::generation::noise::perlin::DoublePerlinNoiseSampler;
-use crate::generation::noise::router::multi_noise_sampler::MultiNoiseSamplerBuilderOptions;
+use crate::generation::noise::router::density_volume::DensityVolume;
 use crate::generation::noise::router::surface_height_sampler::SurfaceHeightSamplerBuilderOptions;
 use crate::generation::noise::{CHUNK_DIM, ChunkNoiseGenerator, LAVA_BLOCK, WATER_BLOCK};
 use crate::generation::section_coords::section_to_block;
@@ -596,17 +596,8 @@ impl ProtoChunk {
 
     pub fn step_to_biomes(&mut self, generator: &super::generator::VanillaGenerator) {
         debug_assert_eq!(self.stage, StagedChunkEnum::Empty);
-        let start_x = start_block_x(self.x);
-        let start_z = start_block_z(self.z);
-        let horizontal_biome_end = biome_coords::from_block(16);
-        let multi_noise_config =
-            super::noise::router::multi_noise_sampler::MultiNoiseSamplerBuilderOptions::new(
-                biome_coords::from_block(start_x),
-                biome_coords::from_block(start_z),
-                horizontal_biome_end as usize,
-            );
         let mut multi_noise_sampler =
-            MultiNoiseSampler::generate(&generator.base_router.multi_noise, &multi_noise_config);
+            MultiNoiseSampler::generate(&generator.base_router.multi_noise);
         self.populate_biomes(generator, &mut multi_noise_sampler);
         self.stage = StagedChunkEnum::Biomes;
     }
@@ -616,7 +607,6 @@ impl ProtoChunk {
         debug_assert_eq!(self.stage, StagedChunkEnum::StructureReferences);
         let settings = generator.settings;
         let generation_shape = &settings.shape;
-        let horizontal_cell_count = CHUNK_DIM / generation_shape.horizontal_cell_block_count();
         let start_x = start_block_x(self.x);
         let start_z = start_block_z(self.z);
 
@@ -732,9 +722,14 @@ impl ProtoChunk {
         let mut noise_sampler = ChunkNoiseGenerator::new(
             &generator.base_router.noise,
             &generator.random_config,
-            horizontal_cell_count as usize,
-            start_x,
-            start_z,
+            DensityVolume::with_block_step(
+                CHUNK_DIM as usize,
+                generation_shape.height as usize,
+                CHUNK_DIM as usize,
+                start_x,
+                i32::from(generation_shape.min_y),
+                start_z,
+            ),
             generation_shape,
             sampler,
             settings.aquifers_enabled,
@@ -744,13 +739,7 @@ impl ProtoChunk {
             affected_box,
         );
 
-        let horizontal_biome_end = biome_coords::from_block(
-            horizontal_cell_count as i32 * generation_shape.horizontal_cell_block_count() as i32,
-        );
         let surface_config = SurfaceHeightSamplerBuilderOptions::new(
-            biome_coords::from_block(start_x),
-            biome_coords::from_block(start_z),
-            horizontal_biome_end as usize,
             generation_shape.min_y as i32,
             generation_shape.max_y() as i32,
             generation_shape.vertical_cell_block_count() as usize,
@@ -775,18 +764,8 @@ impl ProtoChunk {
         surface_biomes: &SurfaceBiomeNeighborhood,
     ) {
         debug_assert_eq!(self.stage, StagedChunkEnum::Noise);
-        let start_x = start_block_x(self.x);
-        let start_z = start_block_z(self.z);
         let generation_shape = &generator.settings.shape;
-        let horizontal_cell_count = CHUNK_DIM / generation_shape.horizontal_cell_block_count();
-
-        let horizontal_biome_end = biome_coords::from_block(
-            horizontal_cell_count as i32 * generation_shape.horizontal_cell_block_count() as i32,
-        );
         let surface_config = SurfaceHeightSamplerBuilderOptions::new(
-            biome_coords::from_block(start_x),
-            biome_coords::from_block(start_z),
-            horizontal_biome_end as usize,
             generation_shape.min_y as i32,
             generation_shape.max_y() as i32,
             generation_shape.vertical_cell_block_count() as usize,
@@ -840,6 +819,19 @@ impl ProtoChunk {
         let start_biome_x = biome_coords::from_block(start_block_x);
         let start_biome_z = biome_coords::from_block(start_block_z);
 
+        let biome_step = biome_coords::to_block(1);
+        multi_noise_sampler.fill_volume(DensityVolume::new(
+            biome_coords::from_block(CHUNK_DIM as i32) as usize,
+            biome_coords::from_block(self.height() as i32) as usize,
+            biome_coords::from_block(CHUNK_DIM as i32) as usize,
+            start_block_x,
+            min_y as i32,
+            start_block_z,
+            biome_step,
+            biome_step,
+            biome_step,
+        ));
+
         for i in bottom_section..=top_section {
             let start_block_y = section_coords::section_to_block(i);
             let start_biome_y = biome_coords::from_block(start_block_y);
@@ -867,7 +859,6 @@ impl ProtoChunk {
         }
     }
 
-    #[expect(clippy::similar_names)]
     pub fn populate_noise(
         &mut self,
         generator: &super::generator::VanillaGenerator,
@@ -875,61 +866,28 @@ impl ProtoChunk {
         ore_random_deriver: &XoroshiroSplitter,
         surface_height_estimate_sampler: &mut SurfaceHeightEstimateSampler,
     ) {
-        let h_count = noise_sampler.horizontal_cell_block_count() as i32;
-        let v_count = noise_sampler.vertical_cell_block_count() as i32;
-        let horizontal_cells = CHUNK_DIM as i32 / h_count;
+        let volume = *noise_sampler.volume();
+        let densities = noise_sampler.sample_density();
 
-        let minimum_cell_y = noise_sampler.min_y() / v_count as i8;
-        let cell_height = noise_sampler.height() / v_count as u16;
-
-        let delta_y_step = 1.0 / v_count as f32;
-        let delta_x_z_step = 1.0 / h_count as f32;
-
-        noise_sampler.sample_start_density();
-        for cell_x in 0..horizontal_cells {
-            noise_sampler.sample_end_density(cell_x);
-            let sample_start_x = (self.start_cell_x(h_count) + cell_x) * h_count;
-            let block_x_base = self.start_block_x() + cell_x * h_count;
-
-            for cell_z in 0..horizontal_cells {
-                let sample_start_z = (self.start_cell_z(h_count) + cell_z) * h_count;
-                let block_z_base = self.start_block_z() + cell_z * h_count;
-
-                for cell_y in (0..cell_height).rev() {
-                    noise_sampler.on_sampled_cell_corners(cell_x, cell_y as i32, cell_z);
-                    let sample_start_y = (minimum_cell_y as i32 + cell_y as i32) * v_count;
-
-                    for local_y in (0..v_count).rev() {
-                        let block_y = sample_start_y + local_y;
-                        noise_sampler.interpolate_y(local_y as f32 * delta_y_step);
-
-                        for local_x in 0..h_count {
-                            noise_sampler.interpolate_x(local_x as f32 * delta_x_z_step);
-                            let block_x = block_x_base + local_x;
-
-                            for local_z in 0..h_count {
-                                noise_sampler.interpolate_z(local_z as f32 * delta_x_z_step);
-                                let block_z = block_z_base + local_z;
-
-                                let block_state = noise_sampler
-                                    .sample_block_state(
-                                        ore_random_deriver,
-                                        sample_start_x,
-                                        sample_start_y,
-                                        sample_start_z,
-                                        local_x,
-                                        block_y - sample_start_y,
-                                        local_z,
-                                        surface_height_estimate_sampler,
-                                    )
-                                    .unwrap_or(generator.default_block);
-                                self.set_block_state(block_x, block_y, block_z, block_state);
-                            }
-                        }
-                    }
+        for z in 0..volume.size_z {
+            let block_z = volume.block_z(z);
+            for x in 0..volume.size_x {
+                let block_x = volume.block_x(x);
+                for y in (0..volume.size_y).rev() {
+                    let block_y = volume.block_y(y);
+                    let index = volume.index_unchecked(x, y, z);
+                    let block_state = noise_sampler
+                        .sample_block_state(
+                            ore_random_deriver,
+                            &Vector3::new(block_x, block_y, block_z),
+                            densities.density[index],
+                            densities.vein_sample(index).as_ref(),
+                            surface_height_estimate_sampler,
+                        )
+                        .unwrap_or(generator.default_block);
+                    self.set_block_state(block_x, block_y, block_z, block_state);
                 }
             }
-            noise_sampler.swap_buffers();
         }
     }
 
@@ -1328,11 +1286,7 @@ impl ProtoChunk {
         let seed = random_config.seed;
 
         let mut height_sampler =
-            crate::generation::structure::height_sampler::NoiseHeightSampler::new(
-                generator,
-                self.start_block_x(),
-                self.start_block_z(),
-            );
+            crate::generation::structure::height_sampler::NoiseHeightSampler::new(generator);
 
         for (i, set) in StructureSet::ALL.iter().enumerate() {
             let allowed_biomes = &generator.structure_allowed_biomes[&i];
@@ -1409,9 +1363,7 @@ impl ProtoChunk {
         height_sampler: &mut dyn crate::generation::structure::structures::HeightSampler,
     ) -> bool {
         if entry.structure == StructureKeys::Monument {
-            let config = MultiNoiseSamplerBuilderOptions::new(0, 0, 0);
-            let mut sampler =
-                MultiNoiseSampler::generate(&generator.base_router.multi_noise, &config);
+            let mut sampler = MultiNoiseSampler::generate(&generator.base_router.multi_noise);
             let center_x = chunk_pos::get_center_x(self.x);
             let center_z = chunk_pos::get_center_z(self.z);
             let start_y = height_sampler.estimate_ocean_floor_height(center_x, center_z);
@@ -1481,14 +1433,10 @@ impl ProtoChunk {
         };
         let blender = Blender::empty();
         let biome_supplier = blender.get_biome_supplier(base_supplier);
-        let multi_noise_config = MultiNoiseSamplerBuilderOptions::new(0, 0, 0);
-        let mut multi_noise_sampler =
-            MultiNoiseSampler::generate(&noise_router.multi_noise, &multi_noise_config);
+        let mut multi_noise_sampler = MultiNoiseSampler::generate(&noise_router.multi_noise);
 
         let mut height_sampler =
-            crate::generation::structure::height_sampler::NoiseHeightSampler::new(
-                generator, start_x, start_z,
-            );
+            crate::generation::structure::height_sampler::NoiseHeightSampler::new(generator);
 
         let mut references = Vec::new();
         // Constant across every chunk in the dimension, so hoist it out of the loop

--- a/crates/pumpkin-world/src/generation/structure/height_sampler.rs
+++ b/crates/pumpkin-world/src/generation/structure/height_sampler.rs
@@ -1,15 +1,17 @@
 use pumpkin_data::{Block, BlockId, block_properties::blocks_movement};
-use pumpkin_util::math::floor_div;
+use pumpkin_util::math::vector3::Vector3;
 use rustc_hash::FxHashMap;
 
 use crate::generation::{
-    biome_coords,
     generator::VanillaGenerator,
     noise::{
         ChunkNoiseGenerator,
         aquifer_sampler::FluidLevel,
-        router::surface_height_sampler::{
-            SurfaceHeightEstimateSampler, SurfaceHeightSamplerBuilderOptions,
+        router::{
+            density_volume::DensityVolume,
+            surface_height_sampler::{
+                SurfaceHeightEstimateSampler, SurfaceHeightSamplerBuilderOptions,
+            },
         },
     },
     proto_chunk::StandardChunkFluidLevelSampler,
@@ -25,15 +27,11 @@ pub struct NoiseHeightSampler<'a> {
 }
 
 impl<'a> NoiseHeightSampler<'a> {
-    pub fn new(generator: &'a VanillaGenerator, start_x: i32, start_z: i32) -> Self {
+    pub fn new(generator: &'a VanillaGenerator) -> Self {
         let shape = &generator.settings.shape;
-        let horizontal_biome_end = biome_coords::from_block(16) as usize;
         let preliminary = SurfaceHeightEstimateSampler::generate(
             &generator.base_router.surface_estimator,
             &SurfaceHeightSamplerBuilderOptions::new(
-                biome_coords::from_block(start_x),
-                biome_coords::from_block(start_z),
-                horizontal_biome_end,
                 i32::from(shape.min_y),
                 i32::from(shape.max_y()),
                 shape.vertical_cell_block_count() as usize,
@@ -50,12 +48,6 @@ impl<'a> NoiseHeightSampler<'a> {
     fn sample_column(&mut self, x: i32, z: i32, ocean_floor: bool) -> i32 {
         let settings = self.generator.settings;
         let shape = &settings.shape;
-        let horizontal = i32::from(shape.horizontal_cell_block_count());
-        let vertical = i32::from(shape.vertical_cell_block_count());
-        let start_x = floor_div(x, horizontal) * horizontal;
-        let start_z = floor_div(z, horizontal) * horizontal;
-        let local_x = x.rem_euclid(horizontal);
-        let local_z = z.rem_euclid(horizontal);
         let fluid_sampler = StandardChunkFluidLevelSampler::new(
             FluidLevel::new(
                 settings.sea_level,
@@ -63,12 +55,18 @@ impl<'a> NoiseHeightSampler<'a> {
             ),
             FluidLevel::new(-54, &Block::LAVA),
         );
+        let volume = DensityVolume::with_block_step(
+            1,
+            shape.height as usize,
+            1,
+            x,
+            i32::from(shape.min_y),
+            z,
+        );
         let mut noise = ChunkNoiseGenerator::new(
             &self.generator.base_router.noise,
             &self.generator.random_config,
-            1,
-            start_x,
-            start_z,
+            volume,
             shape,
             fluid_sampler,
             settings.aquifers_enabled,
@@ -78,37 +76,25 @@ impl<'a> NoiseHeightSampler<'a> {
             None,
         );
 
-        noise.sample_start_density();
-        noise.sample_end_density(0);
-        let minimum_cell_y = floor_div(i32::from(noise.min_y()), vertical);
-        let cell_count = i32::from(noise.height()) / vertical;
-        for cell_y in (0..cell_count).rev() {
-            noise.on_sampled_cell_corners(0, cell_y, 0);
-            let sample_start_y = (minimum_cell_y + cell_y) * vertical;
-            for local_y in (0..vertical).rev() {
-                let y = sample_start_y + local_y;
-                noise.interpolate_y(local_y as f32 / vertical as f32);
-                noise.interpolate_x(local_x as f32 / horizontal as f32);
-                noise.interpolate_z(local_z as f32 / horizontal as f32);
-                let state = noise
-                    .sample_block_state(
-                        &self.generator.random_config.ore_random_deriver,
-                        start_x,
-                        sample_start_y,
-                        start_z,
-                        local_x,
-                        local_y,
-                        local_z,
-                        &mut self.preliminary,
-                    )
-                    .unwrap_or(self.generator.default_block);
-                if if ocean_floor {
-                    blocks_movement(state, BlockId::from_state_id(state.id))
-                } else {
-                    !state.is_air()
-                } {
-                    return y + 1;
-                }
+        let densities = noise.sample_density();
+        for y in (0..volume.size_y).rev() {
+            let block_y = volume.block_y(y);
+            let index = volume.index_unchecked(0, y, 0);
+            let state = noise
+                .sample_block_state(
+                    &self.generator.random_config.ore_random_deriver,
+                    &Vector3::new(x, block_y, z),
+                    densities.density[index],
+                    densities.vein_sample(index).as_ref(),
+                    &mut self.preliminary,
+                )
+                .unwrap_or(self.generator.default_block);
+            if if ocean_floor {
+                blocks_movement(state, BlockId::from_state_id(state.id))
+            } else {
+                !state.is_air()
+            } {
+                return block_y + 1;
             }
         }
 

--- a/crates/pumpkin-world/src/generation/structure/structures/jigsaw.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/jigsaw.rs
@@ -1112,9 +1112,7 @@ mod tests {
             unreachable!()
         };
         let mut height_sampler =
-            crate::generation::structure::height_sampler::NoiseHeightSampler::new(
-                world_gen, 1200, -1312,
-            );
+            crate::generation::structure::height_sampler::NoiseHeightSampler::new(world_gen);
         let generator = JigsawGenerator::new("minecraft:pillager_outpost/base_plates", 7)
             .with_expansion_hack(true);
 

--- a/crates/pumpkin-world/src/lib.rs
+++ b/crates/pumpkin-world/src/lib.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
 use pumpkin_data::{Block, dimension::Dimension};
-use pumpkin_util::math::vector2::Vector2;
 
 pub mod biome;
 pub mod block;
@@ -47,8 +46,10 @@ pub use generation::{
 };
 
 use crate::generation::{
-    biome_coords,
-    noise::{CHUNK_DIM, ChunkNoiseGenerator, aquifer_sampler::FluidLevel},
+    noise::{
+        CHUNK_DIM, ChunkNoiseGenerator, aquifer_sampler::FluidLevel,
+        router::density_volume::DensityVolume,
+    },
     positions::chunk_pos,
 };
 
@@ -72,7 +73,6 @@ pub fn bench_create_and_populate_noise(random_config: &GlobalRandomConfig) {
     // Create noise sampler and other required components
     let settings = generator.settings;
     let generation_shape = &settings.shape;
-    let horizontal_cell_count = CHUNK_DIM / generation_shape.horizontal_cell_block_count();
     let sampler = StandardChunkFluidLevelSampler::new(
         FluidLevel::new(
             settings.sea_level,
@@ -87,9 +87,14 @@ pub fn bench_create_and_populate_noise(random_config: &GlobalRandomConfig) {
     let mut noise_sampler = ChunkNoiseGenerator::new(
         &generator.base_router.noise,
         &generator.random_config,
-        horizontal_cell_count as usize,
-        start_x,
-        start_z,
+        DensityVolume::with_block_step(
+            CHUNK_DIM as usize,
+            generation_shape.height as usize,
+            CHUNK_DIM as usize,
+            start_x,
+            i32::from(generation_shape.min_y),
+            start_z,
+        ),
         generation_shape,
         sampler,
         settings.aquifers_enabled,
@@ -100,17 +105,7 @@ pub fn bench_create_and_populate_noise(random_config: &GlobalRandomConfig) {
     );
 
     // Surface height estimator
-    let biome_pos = Vector2::new(
-        biome_coords::from_block(start_x),
-        biome_coords::from_block(start_z),
-    );
-    let horizontal_biome_end = biome_coords::from_block(
-        horizontal_cell_count as i32 * generation_shape.horizontal_cell_block_count() as i32,
-    );
     let surface_config = SurfaceHeightSamplerBuilderOptions::new(
-        biome_pos.x,
-        biome_pos.y,
-        horizontal_biome_end as usize,
         generation_shape.min_y as i32,
         generation_shape.max_y() as i32,
         generation_shape.vertical_cell_block_count() as usize,
@@ -130,10 +125,7 @@ pub fn bench_create_and_populate_noise(random_config: &GlobalRandomConfig) {
 
 pub fn bench_create_and_populate_biome(random_config: &GlobalRandomConfig) {
     use crate::generation::generator::{GeneratorInit, VanillaGenerator, WorldGenerator};
-    use crate::generation::noise::router::multi_noise_sampler::{
-        MultiNoiseSampler, MultiNoiseSamplerBuilderOptions,
-    };
-    use crate::generation::{biome_coords, positions::chunk_pos};
+    use crate::generation::noise::router::multi_noise_sampler::MultiNoiseSampler;
     use pumpkin_util::world_seed::Seed;
 
     let world_gen = WorldGenerator::Noise(Box::new(VanillaGenerator::new(
@@ -146,20 +138,7 @@ pub fn bench_create_and_populate_biome(random_config: &GlobalRandomConfig) {
     let mut chunk = ProtoChunk::new(0, 0, &world_gen);
 
     // Create multi-noise sampler
-    let start_x = chunk_pos::start_block_x(0);
-    let start_z = chunk_pos::start_block_z(0);
-    let biome_pos = Vector2::new(
-        biome_coords::from_block(start_x),
-        biome_coords::from_block(start_z),
-    );
-    let horizontal_biome_end = biome_coords::from_block(16);
-    let multi_noise_config = MultiNoiseSamplerBuilderOptions::new(
-        biome_pos.x,
-        biome_pos.y,
-        horizontal_biome_end as usize,
-    );
-    let mut multi_noise_sampler =
-        MultiNoiseSampler::generate(&generator.base_router.multi_noise, &multi_noise_config);
+    let mut multi_noise_sampler = MultiNoiseSampler::generate(&generator.base_router.multi_noise);
 
     chunk.populate_biomes(generator, &mut multi_noise_sampler);
 }
@@ -168,7 +147,7 @@ pub fn bench_create_and_populate_noise_with_surface(random_config: &GlobalRandom
     use crate::chunk_system::{Chunk, generation_cache::SurfaceBiomeNeighborhood};
     use crate::generation::generator::{GeneratorInit, VanillaGenerator, WorldGenerator};
     use crate::generation::noise::router::{
-        multi_noise_sampler::{MultiNoiseSampler, MultiNoiseSamplerBuilderOptions},
+        multi_noise_sampler::MultiNoiseSampler,
         surface_height_sampler::{
             SurfaceHeightEstimateSampler, SurfaceHeightSamplerBuilderOptions,
         },
@@ -188,23 +167,11 @@ pub fn bench_create_and_populate_noise_with_surface(random_config: &GlobalRandom
     // Create all required components
     let settings = generator.settings;
     let generation_shape = &settings.shape;
-    let horizontal_cell_count = CHUNK_DIM / generation_shape.horizontal_cell_block_count();
     let start_x = chunk_pos::start_block_x(0);
     let start_z = chunk_pos::start_block_z(0);
 
     // Multi-noise sampler for biomes
-    let biome_pos = Vector2::new(
-        biome_coords::from_block(start_x),
-        biome_coords::from_block(start_z),
-    );
-    let horizontal_biome_end = biome_coords::from_block(16);
-    let multi_noise_config = MultiNoiseSamplerBuilderOptions::new(
-        biome_pos.x,
-        biome_pos.y,
-        horizontal_biome_end as usize,
-    );
-    let mut multi_noise_sampler =
-        MultiNoiseSampler::generate(&generator.base_router.multi_noise, &multi_noise_config);
+    let mut multi_noise_sampler = MultiNoiseSampler::generate(&generator.base_router.multi_noise);
 
     // Noise sampler
     let sampler = StandardChunkFluidLevelSampler::new(
@@ -218,9 +185,14 @@ pub fn bench_create_and_populate_noise_with_surface(random_config: &GlobalRandom
     let mut noise_sampler = ChunkNoiseGenerator::new(
         &generator.base_router.noise,
         &generator.random_config,
-        horizontal_cell_count as usize,
-        start_x,
-        start_z,
+        DensityVolume::with_block_step(
+            CHUNK_DIM as usize,
+            generation_shape.height as usize,
+            CHUNK_DIM as usize,
+            start_x,
+            i32::from(generation_shape.min_y),
+            start_z,
+        ),
         generation_shape,
         sampler,
         settings.aquifers_enabled,
@@ -232,9 +204,6 @@ pub fn bench_create_and_populate_noise_with_surface(random_config: &GlobalRandom
 
     // Surface height estimator
     let surface_config = SurfaceHeightSamplerBuilderOptions::new(
-        biome_pos.x,
-        biome_pos.y,
-        horizontal_biome_end as usize,
         generation_shape.min_y as i32,
         generation_shape.max_y() as i32,
         generation_shape.vertical_cell_block_count() as usize,

--- a/tools/pumpkin-codegen/src/noise_router.rs
+++ b/tools/pumpkin-codegen/src/noise_router.rs
@@ -288,22 +288,23 @@ impl Tiling {
 /// Caching or interpolation wrapper applied around an inner density function.
 #[derive(Copy, Clone, Deserialize, PartialEq, Eq, Hash)]
 enum WrapperType {
-    Interpolated,
-    #[serde(rename(deserialize = "FlatCache"))]
-    CacheFlat,
-    Cache2D,
-    CacheOnce,
-    CellCache,
+    Interpolated { cell_size_xz: i32, cell_size_y: i32 },
+    Cache,
 }
 
 impl WrapperType {
     fn into_token_stream(self) -> TokenStream {
         match self {
-            Self::Interpolated => quote! { WrapperType::Interpolated },
-            Self::CacheFlat => quote! { WrapperType::CacheFlat },
-            Self::Cache2D => quote! { WrapperType::Cache2D },
-            Self::CacheOnce => quote! { WrapperType::CacheOnce },
-            Self::CellCache => quote! { WrapperType::CellCache },
+            Self::Interpolated {
+                cell_size_xz,
+                cell_size_y,
+            } => quote! {
+                WrapperType::Interpolated {
+                    cell_size_xz: #cell_size_xz,
+                    cell_size_y: #cell_size_y,
+                }
+            },
+            Self::Cache => quote! { WrapperType::Cache },
         }
     }
 }
@@ -693,7 +694,7 @@ impl DensityFunctionRepr {
         matches!(
             self,
             Self::Wrapper {
-                wrapper: WrapperType::CacheFlat | WrapperType::Cache2D | WrapperType::CacheOnce,
+                wrapper: WrapperType::Cache,
                 ..
             }
         )
@@ -2753,15 +2754,21 @@ fn parse_vanilla_df(base_df_dir: &std::path::Path, val: &serde_json::Value) -> D
                             .or_else(|| obj.get("argument"))
                             .expect("Missing input/argument"),
                     );
-                    let wrapper = match clean_type {
-                        "interpolated" => WrapperType::Interpolated,
-                        "flat_cache" | "cache_flat" => WrapperType::CacheFlat,
-                        "cache_2d" => WrapperType::Cache2D,
-                        "cache_once" => WrapperType::CacheOnce,
-                        "cache" if input.domain_axes() & AXIS_Y == 0 => WrapperType::CacheFlat,
-                        "cache" => WrapperType::CacheOnce,
-                        "cache_all_in_cell" => WrapperType::CellCache,
-                        _ => unreachable!(),
+                    let wrapper = if clean_type == "interpolated" {
+                        let cell_size_xz =
+                            obj.get("cell_size_xz")
+                                .and_then(|v| v.as_i64())
+                                .expect("Missing cell_size_xz") as i32;
+                        let cell_size_y =
+                            obj.get("cell_size_y")
+                                .and_then(|v| v.as_i64())
+                                .expect("Missing cell_size_y") as i32;
+                        WrapperType::Interpolated {
+                            cell_size_xz,
+                            cell_size_y,
+                        }
+                    } else {
+                        WrapperType::Cache
                     };
                     DensityFunctionRepr::Wrapper {
                         input: Box::new(input),
@@ -2954,25 +2961,9 @@ fn load_vanilla_noise_routers() -> NoiseRouterReprs {
     }
 }
 
-macro_rules! fix_final_density {
-    ($router:expr) => {{
-        $router.final_density = DensityFunctionRepr::Wrapper {
-            input: Box::new($router.final_density),
-            wrapper: WrapperType::CellCache,
-        };
-    }};
-}
-
 /// Reads vanilla datapack noise_settings and density_function files and emits the complete noise-router constants `TokenStream`.
 pub fn build() -> TokenStream {
     let mut reprs: NoiseRouterReprs = load_vanilla_noise_routers();
-
-    fix_final_density!(reprs.overworld);
-    fix_final_density!(reprs.overworld_amplified);
-    fix_final_density!(reprs.overworld_large_biomes);
-    fix_final_density!(reprs.nether);
-    fix_final_density!(reprs.end);
-    fix_final_density!(reprs.end_islands);
 
     let _ = reprs.overworld_amplified;
     let _ = reprs.overworld_large_biomes;
@@ -3229,13 +3220,10 @@ pub fn build() -> TokenStream {
             Fixed { value: f32 },
         }
 
-        #[derive(Copy, Clone)]
+        #[derive(Copy, Clone, PartialEq, Eq)]
         pub enum WrapperType {
-            Interpolated,
-            CacheFlat,
-            Cache2D,
-            CacheOnce,
-            CellCache,
+            Interpolated { cell_size_xz: i32, cell_size_y: i32 },
+            Cache,
         }
 
         pub enum BaseNoiseFunctionComponent {


### PR DESCRIPTION
## Description
This is the second half of the 26.3 density sampler port, building on #3199.

Every density function node now has a volume path. Leaf nodes fill their buffers directly, while operators work over the buffers produced by their children. That brings chunk sampling down to one call per node for the whole volume instead of calling every node once per block.

The four 26.2 cache types and the old interpolator are gone. There's now a single cache keyed by `DensityVolume`, following vanilla's `SamplerContext`, plus an `Interpolated` node based on `InterpolatedFunction`. Cell sizes come from the datapack JSON through codegen.

Chunk sampling now follows the same general flow as `doFill`. `final_density` is sampled once for the full `16 x height x 16` volume, then the aquifer and ore samplers read the density they need per block. Biome generation does the same for the six climate parameters over the chunk's quart grid, similar to `createResolverForChunk`. The structure height sampler only needs a single column volume.

The old `fill` / `IndexToNoisePos` path is gone along with the sample options, cache IDs, and the separate `interpolate_x/y/z` loop.

There are still three places where I kept master behavior for bit parity. Trilinear expansion uses the old fill path's x, y, z lerp order instead of vanilla's z, x, incremental y order. `Binary Mul` still has the zero shortcut, `Lerp` still uses the plain formula per element, and `FindTopSurface` keeps the extra probe at `floor(upper)`.

A couple of things did move closer to 26.3 without changing the parity run. Vein values that previously went through the y, x, z interpolation chain now use the same interpolation order as the rest of the sampler. The aquifer also samples erosion and depth at the actual block column instead of using the quart-aligned `FlatCache` value.

`vein_gap` isn't under an interpolated node in the data, so it stays lazy and is sampled per block by the ore sampler. `vein_toggle` and `vein_ridged` are sampled as chunk volumes.

The Perlin core hasn't changed yet. That's the next PR.

## Testing
I compared block and biome hashes for 49 chunks on seed 42, up to the surface stage, between master and this branch. They match exactly.

All 180 `pumpkin-world` tests pass, including the eight vanilla chunk dump tests. I also added a test that runs `sample_volume` against per-position `sample` for every component in all three routers and checks the results bit for bit.

The density fingerprint hash did change. `final_density(pos)` now interpolates off-corner positions the same way vanilla `sampleValue` does.

`chunk_gen` benchmarks, master --> branch:

* full chunk: 40.6 ms --> 28.8 ms
* noise: 12.7 ms --> 9.6 ms
* carvers: 4.3 ms --> 1.4 ms
* biomes: 1.10 ms --> 0.56 ms
* structure starts: 50.7 us --> 1.5 us
* surface and lighting: basically unchanged
* 16 chunks / 4 threads: 170 ms --> 124 ms

