### PR TITLE
Only send new player info about entities after the CLogin packet has been sent

### DIFF
--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -510,14 +510,14 @@ impl EntityTracker {
 
         let players = world.players.load();
         tracked.update_players(players.as_ref(), world);
+    }
 
-        if let Some(player) = entity.get_player()
-            && let Some(player_arc) = world.get_player_by_uuid(player.gameprofile.id)
-        {
-            for entry in &self.entity_map {
-                if *entry.key() != entity_id {
-                    entry.value().update_player(&player_arc, world);
-                }
+    /// Must only be called after the player's own `CLogin` packet has been sent.
+    pub fn pair_new_player_with_tracked_entities(&self, player_arc: &Arc<Player>, world: &World) {
+        let entity_id = player_arc.get_entity().entity_id;
+        for entry in &self.entity_map {
+            if *entry.key() != entity_id {
+                entry.value().update_player(player_arc, world);
             }
         }
     }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -3328,6 +3328,8 @@ impl World {
             ))
             .await;
 
+        self.pair_new_player_with_tracked_entities(player);
+
         // Send the current ticking state to the new player so they are in sync.
         server.tick_rate_manager.update_joining_player(player).await;
 
@@ -4903,6 +4905,12 @@ impl World {
         self.entity_tracker
             .add_entity(&(player.clone() as Arc<dyn EntityBase>), self);
         Ok(())
+    }
+
+    /// Must only be called after the player's own `CLogin` packet has been sent.
+    pub fn pair_new_player_with_tracked_entities(&self, player: &Arc<Player>) {
+        self.entity_tracker
+            .pair_new_player_with_tracked_entities(player, self);
     }
 
     /// Removes a player from the world and broadcasts a disconnect message if enabled.


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description
Defers sending tracked entities to newly joined players until after the `CLogin` packet is sent. This fixes a bug where clients could be disconnected for "Network Protocol Error" if entity packets arrived before the `CLogin` packet

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
