### PR TITLE
feat(plugin): fire BlockFormEvent for lava conversions

### DIFF
--- a/crates/pumpkin/src/block/fluid/lava.rs
+++ b/crates/pumpkin/src/block/fluid/lava.rs
@@ -9,6 +9,7 @@ use pumpkin_data::{
     damage::DamageType,
     dimension::Dimension,
     fluid::{Falling, Fluid, FluidProperties, Level},
+    tag::Taggable,
     world::WorldEvent,
 };
 use pumpkin_util::math::position::BlockPos;
@@ -96,11 +97,19 @@ impl FlowingLava {
         let is_still = world.get_block_state_id(block_pos) == Block::LAVA.default_state.id;
 
         for dir in BlockDirection::all() {
+            // Vanilla tests every direction but Down here. Lava landing in water
+            // below is turned to stone by `spread_to`, not by this scan, so Down
+            // is skipped rather than ending it - a lava block with water beneath
+            // *and* water beside it still forms cobblestone.
+            if dir == BlockDirection::Down {
+                continue;
+            }
+
             let neighbor_pos = block_pos.offset(dir.to_offset());
-            if world.get_block(&neighbor_pos) == &Block::WATER {
-                if dir == BlockDirection::Down {
-                    return true;
-                }
+            if world
+                .get_fluid(&neighbor_pos)
+                .has_tag(&pumpkin_data::tag::Fluid::MINECRAFT_WATER)
+            {
                 let block = if is_still {
                     Block::OBSIDIAN
                 } else {

--- a/crates/pumpkin/src/block/fluid/lava.rs
+++ b/crates/pumpkin/src/block/fluid/lava.rs
@@ -106,11 +106,7 @@ impl FlowingLava {
                 } else {
                     Block::COBBLESTONE
                 };
-                world.set_block_state(
-                    block_pos,
-                    block.default_state.id,
-                    BlockFlags::NOTIFY_NEIGHBORS,
-                );
+                world.set_block_state(block_pos, block.default_state.id, BlockFlags::NOTIFY_ALL);
                 world.sync_world_event(WorldEvent::LavaFizz, *block_pos, 0);
                 return false;
             }
@@ -129,7 +125,7 @@ impl FlowingLava {
                 world.set_block_state(
                     block_pos,
                     Block::BASALT.default_state.id,
-                    BlockFlags::NOTIFY_NEIGHBORS,
+                    BlockFlags::NOTIFY_ALL,
                 );
                 world.sync_world_event(WorldEvent::LavaFizz, *block_pos, 0);
                 return false;

--- a/crates/pumpkin/src/block/fluid/lava.rs
+++ b/crates/pumpkin/src/block/fluid/lava.rs
@@ -2,6 +2,7 @@ use super::flowing_trait::FlowingFluid;
 use crate::{
     block::{FluidMetadata, blocks::fire::fire::FireBlock, fluid::FluidBehaviour},
     entity::EntityBase,
+    plugin::api::events::block::block_form::BlockFormEvent,
     world::World,
 };
 use pumpkin_data::{
@@ -89,6 +90,22 @@ impl FlowingLava {
         world.set_block_state(pos, fire_state_id, BlockFlags::NOTIFY_ALL);
     }
 
+    /// Turns the fluid at `block_pos` into `block`, unless a plugin cancels the
+    /// `BlockFormEvent` first. Used by every lava/water conversion (cobble, obsidian,
+    /// stone, basalt) so a plugin can gate all of them the same way.
+    fn form_block(world: &Arc<World>, block_pos: &BlockPos, block: &'static Block) {
+        if let Some(server) = world.server.upgrade() {
+            let mut event = BlockFormEvent::new(*block_pos, block);
+            server.plugin_manager.fire_blocking(&server, &mut event);
+            if event.cancelled {
+                return;
+            }
+        }
+
+        world.set_block_state(block_pos, block.default_state.id, BlockFlags::NOTIFY_ALL);
+        world.sync_world_event(WorldEvent::LavaFizz, *block_pos, 0);
+    }
+
     fn receive_neighbor_fluids(world: &Arc<World>, block_pos: &BlockPos) -> bool {
         // Logic to determine if we should replace the fluid with any of (cobble, obsidian, stone, etc.)
         let below_is_soul_soil = world
@@ -111,32 +128,15 @@ impl FlowingLava {
                 .has_tag(&pumpkin_data::tag::Fluid::MINECRAFT_WATER)
             {
                 let block = if is_still {
-                    Block::OBSIDIAN
+                    &Block::OBSIDIAN
                 } else {
-                    Block::COBBLESTONE
+                    &Block::COBBLESTONE
                 };
-                world.set_block_state(block_pos, block.default_state.id, BlockFlags::NOTIFY_ALL);
-                world.sync_world_event(WorldEvent::LavaFizz, *block_pos, 0);
+                Self::form_block(world, block_pos, block);
                 return false;
             }
             if below_is_soul_soil && world.get_block(&neighbor_pos) == &Block::BLUE_ICE {
-                if let Some(server) = world.server.upgrade() {
-                    let mut event =
-                        crate::plugin::api::events::block::block_form::BlockFormEvent::new(
-                            *block_pos,
-                            &Block::BASALT,
-                        );
-                    server.plugin_manager.fire_blocking(&server, &mut event);
-                    if event.cancelled {
-                        return false;
-                    }
-                }
-                world.set_block_state(
-                    block_pos,
-                    Block::BASALT.default_state.id,
-                    BlockFlags::NOTIFY_ALL,
-                );
-                world.sync_world_event(WorldEvent::LavaFizz, *block_pos, 0);
+                Self::form_block(world, block_pos, &Block::BASALT);
                 return false;
             }
         }
@@ -288,8 +288,7 @@ impl FlowingFluid for FlowingLava {
         if new_props.level == Level::L8 && new_props.falling == Falling::True {
             // Stone creation when lava meets water
             if block == &Block::WATER {
-                world.set_block_state(pos, Block::STONE.default_state.id, BlockFlags::NOTIFY_ALL);
-                world.sync_world_event(WorldEvent::LavaFizz, *pos, 0);
+                Self::form_block(world, pos, &Block::STONE);
                 return;
             }
         }


### PR DESCRIPTION
## Description

`BlockFormEvent` exists in the plugin API and registers fine, but the only site in the server that ever constructed it was the blue ice branch in `FlowingLava::receive_neighbor_fluids`. A plugin could therefore cancel basalt formation and nothing else, while the conversions that actually come up in normal play - the cobblestone, obsidian and stone that lava and water produce - happened with no way to see or stop them. A land claim plugin could not gate a cobblestone generator on someone else's claim, and the event's own doc comment already names cobblestone as an example.

All four conversions now go through `FlowingLava::form_block`, which fires the event, returns early if a handler cancelled it, and otherwise sets the block and plays the fizz. That covers the cobblestone and obsidian branch, the basalt branch, and the stone in `spread_to` where falling lava lands in water. The basalt path is behaviourally unchanged, it just moved into the helper rather than keeping its own copy of the fire and cancel wiring.

This matches where Bukkit puts the event. `BlockFormEvent` is documented as covering obsidian and cobblestone forming on contact with water, and SPIGOT-2886 settled that it fires for obsidian, cobblestone and stone alike, with no block forming when it is cancelled. Cancelling here skips the `set_block_state` and the fizz together, so a cancelled formation is silent as well as absent.

A cancelled event leaves the fluid as it is and the surrounding call still returns as though the conversion had happened, so the lava does not spread into that block on this pass either. The conversion is reconsidered on the next neighbour update or fluid tick, which keeps a cancelling plugin from having to hold the block down every tick.

Fired from the lava conversions only. Ice, snow and the other natural formations still do not construct the event, so those remain invisible to plugins and are worth a separate change.

Builds on #3214 and #3215, which correct the same call sites. I will rebase this once those land.

## Testing

`cargo check`, `cargo clippy` and `cargo fmt --check` clean on `-p pumpkin`.

Running on a dev server with nine plugins loaded, none of which subscribe to `BlockFormEvent`, so the uncancelled path is what is exercised there. The fire site follows the same `fire_blocking` and `event.cancelled` shape the branch it replaces already used.
