### PR TITLE
fix(bedrock): support 1.26.45 connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "aes 0.9.3",
  "arc-swap",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-api-macros"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-codecs"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "serde_json",
  "tracing",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-config"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "pumpkin-util",
  "serde",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-data"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "crc-fast",
  "criterion",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-fuzzer"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "clap",
  "colored",
@@ -3595,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-gametest"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "async-trait",
  "pumpkin-data",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-inventory"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "pumpkin-data",
  "pumpkin-nbt",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-macros"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "heck",
  "proc-macro-error2",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-nbt"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "bytes",
  "cesu8",
@@ -3677,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-protocol"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "aes 0.9.3",
  "async-compression",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-util"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "pumpkin-world"
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 dependencies = [
  "arc-swap",
  "bitflags 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ struct_excessive_bools = "allow"
 unused_async_trait_impl = "allow"
 
 [workspace.package]
-version = "0.1.0-dev+26.2-26.40"
+version = "0.1.0-dev+26.2-26.45"
 edition = "2024"
 rust-version = "1.95"
 license = "GPL-3.0"

--- a/crates/pumpkin-protocol/src/bedrock/server/login.rs
+++ b/crates/pumpkin-protocol/src/bedrock/server/login.rs
@@ -72,7 +72,7 @@ mod tests {
         let connection_request_len = 4 + jwt.len() + 4 + client_token.len();
         let mut input = Vec::new();
 
-        2168i32
+        2169i32
             .write_be(&mut input)
             .expect("write protocol version");
         VarUInt(connection_request_len as u32)
@@ -89,7 +89,7 @@ mod tests {
 
         let packet = SLogin::read(&mut Cursor::new(input)).expect("read login packet");
 
-        assert_eq!(packet.protocol_version, 2168);
+        assert_eq!(packet.protocol_version, 2169);
         assert_eq!(packet.jwt, jwt);
         assert_eq!(packet.raw_token.len(), RAW_TOKEN_LEN);
         assert_eq!(packet.raw_token, client_token);

--- a/crates/pumpkin-protocol/src/bedrock/status.rs
+++ b/crates/pumpkin-protocol/src/bedrock/status.rs
@@ -120,11 +120,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn formats_vanilla_26_40_advertisement() {
+    fn formats_vanilla_26_45_advertisement() {
         let info = ServerInfo {
             motd: "Pumpkin",
-            protocol: 2168,
-            version: "1.26.40",
+            protocol: 2169,
+            version: "1.26.45",
             players: 2,
             max_players: 20,
             server_guid: 42,
@@ -137,7 +137,7 @@ mod tests {
 
         assert_eq!(
             info.to_string(),
-            "MCPE;Pumpkin;2168;1.26.40;2;20;42;world;Creative;1;19132;19133;0;"
+            "MCPE;Pumpkin;2169;1.26.45;2;20;42;world;Creative;1;19132;19133;0;"
         );
     }
 

--- a/crates/pumpkin-util/src/version.rs
+++ b/crates/pumpkin-util/src/version.rs
@@ -289,8 +289,8 @@ impl std::fmt::Display for JavaMinecraftVersion {
 pub enum BedrockMinecraftVersion {
     /// 1.21: Tricky Trials.
     V_1_21,
-    /// 1.26.40
-    V_1_26_40,
+    /// 1.26.45
+    V_1_26_45,
     /// Fallback for unrecognized protocol versions.
     Unknown,
 }
@@ -303,7 +303,7 @@ impl BedrockMinecraftVersion {
     pub const fn protocol_version(&self) -> i32 {
         match self {
             Self::V_1_21 => 671,
-            Self::V_1_26_40 => 2168,
+            Self::V_1_26_45 => 2169,
             Self::Unknown => -1,
         }
     }
@@ -315,7 +315,7 @@ impl BedrockMinecraftVersion {
     pub const fn from_protocol(protocol: u32) -> Self {
         match protocol {
             671 => Self::V_1_21,
-            2168 => Self::V_1_26_40,
+            2169 => Self::V_1_26_45,
             _ => Self::Unknown,
         }
     }
@@ -325,8 +325,22 @@ impl std::fmt::Display for BedrockMinecraftVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::V_1_21 => write!(f, "1.21"),
-            Self::V_1_26_40 => write!(f, "1.26.40"),
+            Self::V_1_26_45 => write!(f, "1.26.45"),
             Self::Unknown => write!(f, "unknown"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BedrockMinecraftVersion;
+
+    #[test]
+    fn resolves_bedrock_26_45_protocol() {
+        let version = BedrockMinecraftVersion::from_protocol(2169);
+
+        assert_eq!(version, BedrockMinecraftVersion::V_1_26_45);
+        assert_eq!(version.protocol_version(), 2169);
+        assert_eq!(version.to_string(), "1.26.45");
     }
 }

--- a/crates/pumpkin-world/src/lib.rs
+++ b/crates/pumpkin-world/src/lib.rs
@@ -21,8 +21,8 @@ pub mod world;
 pub mod world_info;
 
 pub const CURRENT_MC_VERSION: &str = "26.2";
-pub const CURRENT_BEDROCK_MC_VERSION: &str = "1.26.40";
-pub const CURRENT_BEDROCK_MC_PROTOCOL: u32 = 2168;
+pub const CURRENT_BEDROCK_MC_VERSION: &str = "1.26.45";
+pub const CURRENT_BEDROCK_MC_PROTOCOL: u32 = 2169;
 
 #[macro_export]
 macro_rules! global_path {

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -2583,8 +2583,13 @@ impl Player {
             sender.prepare_batch(&world.level, player_chunk, epoch, version)
         });
 
-        let total_sent_chunks = if let Some(batch) = prepared_batch {
-            match self.client.as_ref() {
+        let total_sent_chunks = prepared_batch.map_or_else(
+            || {
+                self.chunk_sender
+                    .try_lock()
+                    .map_or(0, |s| s.sent_chunks_count())
+            },
+            |batch| match self.client.as_ref() {
                 ClientPlatform::Java(_) => {
                     let mut per_player_cache = rustc_hash::FxHashMap::default();
                     let encoded =
@@ -2596,21 +2601,25 @@ impl Player {
                     })
                 }
                 ClientPlatform::Bedrock(_) => {
-                    let chunks: Vec<_> = batch.chunks.into_iter().map(|c| c.chunk).collect();
-                    let client = self.client.clone();
-                    self.spawn_task(async move {
-                        client.send_chunks(&chunks).await;
-                    });
-                    self.chunk_sender
-                        .try_lock()
-                        .map_or(0, |s| s.sent_chunks_count())
+                    let current_epoch = self.chunk_send_epoch.load(Ordering::Relaxed);
+                    let (chunks, total_sent_chunks) = self.chunk_sender.try_lock().map_or_else(
+                        |_| (Vec::new(), 0),
+                        |mut sender| {
+                            let chunks = sender.commit_bedrock_batch(&batch, current_epoch);
+                            let total_sent_chunks = sender.sent_chunks_count();
+                            (chunks, total_sent_chunks)
+                        },
+                    );
+                    if !chunks.is_empty() {
+                        let client = self.client.clone();
+                        self.spawn_task(async move {
+                            client.send_chunks(&chunks).await;
+                        });
+                    }
+                    total_sent_chunks
                 }
-            }
-        } else {
-            self.chunk_sender
-                .try_lock()
-                .map_or(0, |s| s.sent_chunks_count())
-        };
+            },
+        );
 
         if let ClientPlatform::Bedrock(bedrock_client) = self.client.as_ref()
             && !self.bedrock_spawned.load(Ordering::Relaxed)

--- a/crates/pumpkin/src/net/bedrock/login/request_network_settings.rs
+++ b/crates/pumpkin/src/net/bedrock/login/request_network_settings.rs
@@ -1,20 +1,21 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
 
+fn incompatible_protocol_status(client_network_version: i32) -> Option<CPlayStatus> {
+    match client_network_version.cmp(&(CURRENT_BEDROCK_MC_PROTOCOL as i32)) {
+        std::cmp::Ordering::Less => Some(CPlayStatus::OutdatedClient),
+        std::cmp::Ordering::Greater => Some(CPlayStatus::OutdatedServer),
+        std::cmp::Ordering::Equal => None,
+    }
+}
+
 impl BedrockClient {
     pub async fn handle_request_network_settings(
         &self,
         packet: SRequestNetworkSettings,
         server: &Server,
     ) -> bool {
-        let status = match packet
-            .client_network_version
-            .cmp(&(CURRENT_BEDROCK_MC_PROTOCOL as i32))
-        {
-            std::cmp::Ordering::Less => Some(CPlayStatus::OutdatedClient),
-            std::cmp::Ordering::Greater => Some(CPlayStatus::OutdatedServer),
-            std::cmp::Ordering::Equal => None,
-        };
+        let status = incompatible_protocol_status(packet.client_network_version);
         if let Some(status) = status {
             self.send_packet(&status).await;
             self.close().await;
@@ -43,5 +44,23 @@ impl BedrockClient {
         .await;
         self.set_compression(compression).await;
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_the_current_bedrock_protocol() {
+        assert!(matches!(
+            incompatible_protocol_status(2168),
+            Some(CPlayStatus::OutdatedClient)
+        ));
+        assert!(incompatible_protocol_status(2169).is_none());
+        assert!(matches!(
+            incompatible_protocol_status(2170),
+            Some(CPlayStatus::OutdatedServer)
+        ));
     }
 }

--- a/crates/pumpkin/src/net/chunk_sender.rs
+++ b/crates/pumpkin/src/net/chunk_sender.rs
@@ -303,10 +303,96 @@ impl ChunkSender {
 
         dispatched_positions
     }
+
+    /// Marks a prepared Bedrock batch as dispatched and returns its chunks for encoding.
+    ///
+    /// Bedrock chunks use a different encoder from Java chunks, but they must still move from
+    /// `pending_chunks` to `sent_chunks`. Otherwise the same batch is selected every tick and the
+    /// Bedrock login flow never reaches its minimum-chunk spawn threshold.
+    pub fn commit_bedrock_batch(
+        &mut self,
+        batch: &PreparedBatch,
+        current_epoch: u32,
+    ) -> Vec<SyncChunk> {
+        if current_epoch != batch.epoch_snapshot || batch.chunks.is_empty() {
+            return Vec::new();
+        }
+
+        let mut dispatched_chunks = Vec::with_capacity(batch.chunks.len());
+        for candidate in &batch.chunks {
+            if !self.pending_chunks.remove(&candidate.position) {
+                continue;
+            }
+
+            self.sent_chunks.insert(candidate.position);
+            dispatched_chunks.push(candidate.chunk.clone());
+        }
+
+        self.send_quota -= dispatched_chunks.len() as f32;
+        dispatched_chunks
+    }
 }
 
 impl Default for ChunkSender {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bedrock_batch_moves_pending_chunks_to_sent() {
+        let position = Vector2::new(3, -2);
+        let chunk = ChunkData::empty_sync(position.x, position.y);
+        let batch = PreparedBatch {
+            chunks: vec![PreparedChunk {
+                position,
+                chunk: chunk.clone(),
+            }],
+            epoch_snapshot: 7,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        let mut sender = ChunkSender::new();
+        sender.enqueue_chunk(position);
+        sender.send_quota = 1.0;
+
+        let dispatched = sender.commit_bedrock_batch(&batch, 7);
+
+        assert_eq!(dispatched.len(), 1);
+        assert!(Arc::ptr_eq(&dispatched[0], &chunk));
+        assert!(!sender.pending_chunks.contains(&position));
+        assert!(sender.is_chunk_sent(&position));
+        assert_eq!(sender.sent_chunks_count(), 1);
+        assert_eq!(sender.send_quota, 0.0);
+
+        let repeated = sender.commit_bedrock_batch(&batch, 7);
+
+        assert!(repeated.is_empty());
+        assert_eq!(sender.sent_chunks_count(), 1);
+        assert_eq!(sender.send_quota, 0.0);
+    }
+
+    #[test]
+    fn bedrock_batch_ignores_a_stale_epoch() {
+        let position = Vector2::new(3, -2);
+        let batch = PreparedBatch {
+            chunks: vec![PreparedChunk {
+                position,
+                chunk: ChunkData::empty_sync(position.x, position.y),
+            }],
+            epoch_snapshot: 7,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        let mut sender = ChunkSender::new();
+        sender.enqueue_chunk(position);
+
+        let dispatched = sender.commit_bedrock_batch(&batch, 8);
+
+        assert!(dispatched.is_empty());
+        assert!(sender.pending_chunks.contains(&position));
+        assert_eq!(sender.sent_chunks_count(), 0);
     }
 }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -168,8 +168,8 @@ const fn to_wasm_bedrock_version(
 ) -> pumpkin::plugin::player::BedrockMinecraftVersion {
     match version {
         BedrockMinecraftVersion::V_1_21 => pumpkin::plugin::player::BedrockMinecraftVersion::V121,
-        BedrockMinecraftVersion::V_1_26_40 => {
-            // The v0.1 plugin ABI predates 26.40; do not misreport it as 26.30.
+        BedrockMinecraftVersion::V_1_26_45 => {
+            // The v0.1 plugin ABI predates 26.45; do not misreport it as 26.30.
             pumpkin::plugin::player::BedrockMinecraftVersion::Unknown
         }
         BedrockMinecraftVersion::Unknown => {


### PR DESCRIPTION
## Description
Fixes Bedrock 1.26.45 clients being rejected during network negotiation and remaining stuck on “Locating Server” after connecting because initial chunk batches were never recorded as sent.

## What
- Updates supported Bedrock version from 1.26.40 to 1.26.45.
- Updates the network protocol from 2168 to 2169.
- Correctly records Bedrock chunk batches as sent.
- Prevents the same initial chunks from being encoded and sent repeatedly.
- Allows the server to send `PlayerSpawn` after enough initial chunks have been dispatched.
- Adds regression coverage for protocol negotiation and Bedrock chunk bookkeeping.

## How
- Updates the central Bedrock version, protocol, status advertisement, package metadata, and internal version mapping.
- Keeps the existing packet serializers because protocol 2169 retains the protocol 2168 packet IDs and base layouts.
- Adds `ChunkSender::commit_bedrock_batch` to move dispatched chunks from pending to sent while validating the current chunk-send epoch.
- Uses the committed chunk count to complete the Bedrock spawn sequence.
- Tests current, older, and newer protocol negotiation as well as repeated and stale chunk-batch commits.

## Testing
- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo test -p pumpkin bedrock_batch --lib`
- `cargo test -p pumpkin accepts_only_the_current_bedrock_protocol --lib`
- `cargo test -p pumpkin-util resolves_bedrock_26_45_protocol`
- `cargo test -p pumpkin-protocol formats_vanilla_26_45_advertisement`
- Verified in game that a Bedrock 1.26.45 client can connect, finish locating the server, and enter the world.
