### PR TITLE
fix(bedrock): deliver version rejection before disconnect

### DIFF
--- a/crates/pumpkin-protocol/src/bedrock/client/play_status.rs
+++ b/crates/pumpkin-protocol/src/bedrock/client/play_status.rs
@@ -27,3 +27,31 @@ impl PacketWrite for CPlayStatus {
         (*self as i32).write_be(writer)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bedrock::packet_encoder::serialize_packet;
+
+    #[test]
+    fn writes_vanilla_version_rejection_codes() {
+        let mut outdated_client = Vec::new();
+        CPlayStatus::OutdatedClient
+            .write(&mut outdated_client)
+            .unwrap();
+        assert_eq!(outdated_client, [0, 0, 0, 1]);
+
+        let mut outdated_server = Vec::new();
+        CPlayStatus::OutdatedServer
+            .write(&mut outdated_server)
+            .unwrap();
+        assert_eq!(outdated_server, [0, 0, 0, 2]);
+
+        assert_eq!(
+            serialize_packet(&CPlayStatus::OutdatedServer)
+                .unwrap()
+                .as_ref(),
+            [0xfe, 5, 2, 0, 0, 0, 2]
+        );
+    }
+}

--- a/crates/pumpkin/src/net/bedrock/login/request_network_settings.rs
+++ b/crates/pumpkin/src/net/bedrock/login/request_network_settings.rs
@@ -1,6 +1,8 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
 
+const INCOMPATIBLE_PROTOCOL_FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
 fn incompatible_protocol_status(client_network_version: i32) -> Option<CPlayStatus> {
     match client_network_version.cmp(&(CURRENT_BEDROCK_MC_PROTOCOL as i32)) {
         std::cmp::Ordering::Less => Some(CPlayStatus::OutdatedClient),
@@ -18,6 +20,17 @@ impl BedrockClient {
         let status = incompatible_protocol_status(packet.client_network_version);
         if let Some(status) = status {
             self.send_packet(&status).await;
+            if let Err(error) = self
+                .session
+                .flush_reliable(INCOMPATIBLE_PROTOCOL_FLUSH_TIMEOUT)
+                .await
+            {
+                debug!(
+                    address = %self.address,
+                    %error,
+                    "Failed to flush Bedrock version rejection"
+                );
+            }
             self.close().await;
             return false;
         }

--- a/crates/pumpkin/src/net/bedrock/nethernet.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet.rs
@@ -1,5 +1,6 @@
 use std::{
     fs::OpenOptions,
+    future::Future,
     io::{ErrorKind, Write},
     net::{IpAddr, SocketAddr},
     path::Path as FsPath,
@@ -68,8 +69,30 @@ const MAX_FRAGMENT_SIZE: usize = 10_000;
 #[allow(dead_code)]
 const MAX_INBOUND_MESSAGE_SIZE: usize = 262_144;
 const MAX_SDP_SIZE: usize = 1 << 20;
+const RELIABLE_FLUSH_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 type IncomingSession = (Arc<NetherNetSession>, SocketAddr);
+
+async fn wait_for_reliable_delivery<F, Fut>(
+    timeout: Duration,
+    mut outstanding_bytes: F,
+) -> Result<(), String>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<usize, String>>,
+{
+    tokio::time::timeout(timeout, async {
+        loop {
+            match outstanding_bytes().await {
+                Ok(0) => return Ok(()),
+                Ok(_) => tokio::time::sleep(RELIABLE_FLUSH_POLL_INTERVAL).await,
+                Err(error) => return Err(error),
+            }
+        }
+    })
+    .await
+    .map_err(|_| "timed out waiting for reliable messages to be acknowledged".to_string())?
+}
 
 /// Accepts Bedrock `NetherNet` connections negotiated through Mojang's HTTP endpoint.
 pub struct NetherNetListener {
@@ -744,6 +767,31 @@ impl NetherNetSession {
         Ok(())
     }
 
+    /// Waits for every reliable message handed to SCTP to be acknowledged by the peer.
+    ///
+    /// [`DataChannel::send`] only queues data, so closing the peer immediately afterwards can
+    /// discard the final message before it reaches the client. This is intended for terminal
+    /// protocol messages where delivery matters more than keeping the connection alive.
+    pub(super) async fn flush_reliable(&self, timeout: Duration) -> Result<(), String> {
+        let channel = self
+            .reliable
+            .read()
+            .await
+            .clone()
+            .ok_or_else(|| "reliable channel is not open".to_string())?;
+
+        wait_for_reliable_delivery(timeout, || {
+            let channel = channel.clone();
+            async move {
+                channel
+                    .outstanding_bytes()
+                    .await
+                    .map_err(|error| error.to_string())
+            }
+        })
+        .await
+    }
+
     pub const fn client_public_key(&self) -> Option<&PublicKey> {
         self.client_public_key.as_ref()
     }
@@ -1013,6 +1061,7 @@ fn unix_time() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicUsize;
 
     #[test]
     fn fragments_round_trip() {
@@ -1038,6 +1087,32 @@ mod tests {
         assert!(fragments.push(2, b"one").unwrap().is_none());
         assert!(fragments.push(0, b"three").is_err());
         assert_eq!(fragments.push(0, b"complete").unwrap().unwrap(), "complete");
+    }
+
+    #[tokio::test]
+    async fn reliable_delivery_waits_until_no_bytes_are_outstanding() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let result = wait_for_reliable_delivery(Duration::from_secs(1), || {
+            let polls = polls.clone();
+            async move {
+                let poll = polls.fetch_add(1, Ordering::Relaxed);
+                Ok(usize::from(poll == 0))
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(polls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn reliable_delivery_wait_is_bounded() {
+        let result = wait_for_reliable_delivery(Duration::from_millis(1), || async { Ok(1) }).await;
+
+        assert_eq!(
+            result.unwrap_err(),
+            "timed out waiting for reliable messages to be acknowledged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description
Fixes an issue where newer Bedrock clients could receive a generic connection failure instead of Minecraft’s built-in outdated-server message when Pumpkin supports an older Bedrock protocol.

## What
- Ensures newer Bedrock clients receive the vanilla outdated-server screen before being disconnected.
- Preserves the corresponding outdated-client response for clients older than Pumpkin’s supported protocol.
- Prevents the final version-rejection packet from being discarded during NetherNet shutdown.
- Bounds the delivery wait so an unresponsive client cannot stall the login task indefinitely.
- Keeps incompatible connections uncompressed and stops them before the remaining login sequence.

## How
- Uses Bedrock’s existing `PlayStatus::OutdatedServer` response, which causes the client to display its localized outdated-server message.
- Waits for outstanding data on the reliable NetherNet channel to be acknowledged before closing the WebRTC connection.
- Extracts the protocol comparison into a testable helper.
- Tests the older, matching, and newer client protocol cases.
- Verifies the exact vanilla status codes and complete uncompressed outdated-server packet.

## Testing
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo test -p pumpkin --lib`
- `cargo test -p pumpkin-protocol writes_vanilla_version_rejection_codes`
- Verified in game that Bedrock 1.26.45 connecting to Pumpkin with Bedrock 1.26.40 support receives the vanilla message explaining that the host is using an older version of Minecraft.