### PR TITLE
fix: install a rustls CryptoProvider at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,6 +3497,7 @@ dependencies = [
  "rsa",
  "rustc-hash",
  "rustc_version_runtime",
+ "rustls",
  "rustyline",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,7 @@ arc-swap = { version = "1.9", default-features = false }
 tokio-util = { version = "0.7.19", default-features = false }
 toml = { version = "1.1", default-features = false, features = ["parse", "display", "serde"] }
 reqwest = { version = "0.13.4", features = ["json"] }
+rustls = { version = "0.23.43" }
 notify = { version = "8.2.0", default-features = false, features = ["macos_fsevent"] }
 
 sysinfo = { version = "0.39", default-features = false, features = ["system"] }

--- a/crates/pumpkin/Cargo.toml
+++ b/crates/pumpkin/Cargo.toml
@@ -78,6 +78,7 @@ wasm-encoder = "0.258"
 
 # authentication
 reqwest = { workspace = true, features = ["json"] }
+rustls.workspace = true
 
 sha1.workspace = true
 

--- a/crates/pumpkin/src/main.rs
+++ b/crates/pumpkin/src/main.rs
@@ -49,6 +49,15 @@ static MAIN_THREAD: OnceLock<ThreadId> = OnceLock::new();
 async fn main() {
     let _ = MAIN_THREAD.set(thread::current().id());
 
+    // Both `ring` and `aws-lc-rs` end up enabled in the dependency graph
+    // (different dependents each pull in one), which rustls refuses to
+    // auto-resolve on its own — the first TLS connection anywhere in the
+    // process (including one made through a plugin's outbound-HTTP
+    // capability) panics with "Could not automatically determine the
+    // process-level CryptoProvider" otherwise. This has to run before
+    // anything in the process can possibly need TLS.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Initialize global Rayon thread pool with named worker threads
     let _ = rayon::ThreadPoolBuilder::new()
         .thread_name(|i| format!("Rayon-Worker-{i}"))


### PR DESCRIPTION
Ran into a server crash while building a plugin that makes outbound HTTPS requests — the very first request anywhere in the process brings the whole server down, not just the plugin.

Turns out both `ring` and `aws-lc-rs` end up enabled in the dependency graph (different things pull in each one), and rustls won't pick a default crypto backend on its own when that happens. Nothing in the codebase was ever calling `CryptoProvider::install_default()`, so whatever hits TLS first is gambling on it.

The annoying part is it's timing-dependent, which is probably why it hasn't been super obvious: if a `reqwest` client happens to get built somewhere else first (like Mojang session auth when a player joins in online-mode), that path resolves the ambiguity as a side effect and everything's fine from then on. But if a plugin's outbound HTTP call is the first thing in the process that ever needs TLS — say, nobody's joined yet and a plugin tries to reach an API right after boot — the process just panics and dies.

This installs the `aws-lc-rs` provider explicitly at the very top of `main()`, before anything else in the server can possibly touch TLS, so it's no longer a race.

Built this locally and actually tested it before opening this — spun up an isolated server with the patched binary, zero players online (the exact conditions that used to crash it), and fired off a couple of real outbound HTTPS calls through a plugin. Both went through clean, server stayed up the whole time. Confirmed fixed, not just theorized.