### PR TITLE
fix(entity): play death sound on lethal hit and send Poof when removing a corpse

### DIFF
--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -237,6 +237,18 @@ impl LivingEntity {
         entity_type.hurt_sound.unwrap_or(Sound::EntityGenericHurt)
     }
 
+    fn death_sound_for_entity(entity_type: &'static EntityType) -> Sound {
+        let name = match entity_type.resource_name {
+            "mooshroom" => "cow",
+            "cave_spider" => "spider",
+            "giant" => "zombie",
+            "pufferfish" => "puffer_fish",
+            "trader_llama" => "llama",
+            other => other,
+        };
+        Sound::from_name(&format!("entity.{name}.death")).unwrap_or(Sound::EntityGenericDeath)
+    }
+
     pub fn new(entity: Entity) -> Self {
         let water_movement_speed_multiplier = if entity.entity_type == &EntityType::POLAR_BEAR {
             0.98
@@ -1847,7 +1859,7 @@ impl LivingEntity {
 
             self.update_death_stats(&*dyn_self, killer);
 
-            // Plays the death sound
+            // Plays the death animation
             world.send_entity_status(&self.entity, EntityStatus::Death, Some(ActorEventID::Death));
             let looting_level;
             let tool = if let Some(cause_ent) = cause {
@@ -2944,6 +2956,7 @@ impl LivingEntity {
             position,
         );
 
+<<<<<<< HEAD
         if play_sound {
             world.play_sound(
                 self.hurt_sound(),
@@ -2960,8 +2973,18 @@ impl LivingEntity {
                 self.entity
                     .apply_knockback(knockback_after_resistance(0.4, resistance), dx, dz);
             }
+=======
+        if play_sound && let Some(source) = source {
+            let source_pos = source.get_entity().pos.load();
+            let target_pos = self.entity.pos.load();
+            let dx = source_pos.x - target_pos.x;
+            let dz = source_pos.z - target_pos.z;
+            let resistance = self.get_attribute_value(&Attributes::KNOCKBACK_RESISTANCE);
+            self.entity
+                .apply_knockback(knockback_after_resistance(0.4, resistance), dx, dz);
+            self.entity.send_velocity();
+>>>>>>> 00287f5c9 (fix(entity): play death sound on lethal hit and send Poof when removing a corpse)
         }
-
         // Vanilla parity: actuallyHurt
         let original_damage = damage_amount;
         let current_abs = self.absorption.load();
@@ -2998,6 +3021,16 @@ impl LivingEntity {
 
         let max_h = self.get_max_health();
         let new_health = (self.health.load() - dmg_to_health).clamp(0.0, max_h);
+
+        if play_sound {
+            let sound = if new_health <= 0.0 {
+                Self::death_sound_for_entity(self.entity.entity_type)
+            } else {
+                self.hurt_sound()
+            };
+
+            world.play_sound(sound, SoundCategory::Players, &self.entity.pos.load());
+        }
 
         if dmg_to_health > 0.0 {
             if let Some(player) = caller.get_player() {
@@ -3359,11 +3392,10 @@ impl EntityBase for LivingEntity {
             // Only send death particles once (on the exact tick death_time reaches 20)
             // and then remove the entity, preventing entity_event spam.
             if time == 20 && !self.entity.removed.swap(true, Ordering::Relaxed) {
-                self.entity.world.load().send_entity_status(
-                    &self.entity,
-                    EntityStatus::Death,
-                    Some(ActorEventID::Death),
-                );
+                self.entity
+                    .world
+                    .load()
+                    .send_entity_status(&self.entity, EntityStatus::Poof, None);
                 self.entity.remove();
             }
         }
@@ -3724,6 +3756,38 @@ mod tests {
         assert_eq!(
             LivingEntity::hurt_sound_for_entity(&EntityType::ENDERMAN),
             Sound::EntityEndermanHurt
+        );
+    }
+
+    #[test]
+    fn death_sound_for_entity_uses_cow_death_sound() {
+        assert_eq!(
+            LivingEntity::death_sound_for_entity(&EntityType::COW),
+            Sound::EntityCowDeath
+        );
+    }
+
+    #[test]
+    fn death_sound_for_entity_uses_mooshroom_death_sound() {
+        assert_eq!(
+            LivingEntity::death_sound_for_entity(&EntityType::MOOSHROOM),
+            Sound::EntityCowDeath
+        );
+    }
+
+    #[test]
+    fn death_sound_for_entity_uses_pufferfish_death_sound() {
+        assert_eq!(
+            LivingEntity::death_sound_for_entity(&EntityType::PUFFERFISH),
+            Sound::EntityPufferFishDeath
+        );
+    }
+
+    #[test]
+    fn death_sound_for_entity_uses_armor_stand_death_sound() {
+        assert_eq!(
+            LivingEntity::death_sound_for_entity(&EntityType::ARMOR_STAND),
+            Sound::EntityGenericDeath
         );
     }
 


### PR DESCRIPTION
## What was changed?
- `LivingEntity::damage_with_context` now plays the entity's death sound instead of its hurt sound when the hit is lethal.
- Added `death_sound_for_entity`, which resolves `entity.<name>.death` by the entity's resource name (with the vanilla aliases: mooshroom→cow, cave_spider→spider, giant→zombie, pufferfish→puffer_fish, trader_llama→llama) and falls back to `entity.generic.death`.
- The corpse removal tick (`death_time == 20`) now sends `EntityStatus::Poof` (60) instead of a second `EntityStatus::Death` (3), matching vanilla `LivingEntity.tickDeath`.
- Unit tests for the new lookup (regular, alias, and fallback cases).

## Why?
Fixes #3121. The issue is titled "death sound plays twice", but on a 26.2 client there is no death sound at all: `ClientLevel.playSeededSound` only plays sounds for the local player, so entity status 3 only triggers the death animation. In vanilla the death sound comes from the server (`LivingEntity.hurtServer` → `makeSound(getDeathSound())`). Pumpkin played the hurt sound on the lethal hit and never the death sound, and sent status 3 twice. On older clients the second status 3 produced the double sound from the report.

## Impact
Mobs play their own death sound once. Corpses now emit the vanilla poof particles on removal.

## Known limitations
Small slimes use the regular slime death sound (no size-aware `death_small` variant yet). Magma cubes are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added entity-specific death sounds, including support for several entity name variants.
  * Added clearer audio feedback when entities are hurt or defeated.

* **Bug Fixes**
  * Corrected the visual effect shown when defeated entities are removed, ensuring the appropriate disappearance effect is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->