### PR TITLE
perf(bedrock): prevent Bedrock join-time entity overload

### DIFF
--- a/crates/pumpkin-world/src/chunk/format/mod.rs
+++ b/crates/pumpkin-world/src/chunk/format/mod.rs
@@ -774,6 +774,8 @@ impl ChunkEntityData {
             materialized: AtomicBool::new(false),
             snapshot_needs_rewrite: AtomicBool::new(false),
             dormant_entities: std::sync::Mutex::new(Vec::new()),
+            live_snapshot_uuids: std::sync::Mutex::new(rustc_hash::FxHashSet::default()),
+            pending_materialization_uuids: std::sync::Mutex::new(rustc_hash::FxHashSet::default()),
         })
     }
 

--- a/crates/pumpkin-world/src/chunk/format/mod.rs
+++ b/crates/pumpkin-world/src/chunk/format/mod.rs
@@ -771,6 +771,9 @@ impl ChunkEntityData {
             z: position.y,
             data: std::sync::Mutex::new(entities),
             dirty: AtomicBool::new(false),
+            materialized: AtomicBool::new(false),
+            snapshot_needs_rewrite: AtomicBool::new(false),
+            dormant_entities: std::sync::Mutex::new(Vec::new()),
         })
     }
 

--- a/crates/pumpkin-world/src/chunk/mod.rs
+++ b/crates/pumpkin-world/src/chunk/mod.rs
@@ -9,10 +9,10 @@ use pumpkin_data::{Block, BlockState, BlockStateId};
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::math::position::BlockPos;
 use rustc_hash::{FxHashMap, FxHashSet};
+use uuid::Uuid;
 
 use std::sync::RwLock;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use thiserror::Error;
 
 pub mod format;
@@ -92,6 +92,131 @@ pub struct ChunkEntityData {
     pub data: std::sync::Mutex<Vec<NbtCompound>>,
 
     pub dirty: AtomicBool,
+    /// Whether the serialized entities have been moved into the live world.
+    ///
+    /// Entity chunk data must not be treated as an authoritative snapshot until
+    /// this transition has happened. A chunk can be fetched just as its final
+    /// watcher leaves, in which case its persisted data must remain untouched.
+    materialized: AtomicBool,
+    /// Records that non-empty persisted data was consumed and therefore must be
+    /// rewritten even if the eventual authoritative live snapshot is empty.
+    snapshot_needs_rewrite: AtomicBool,
+    /// Persisted records Pumpkin cannot currently materialize (for example an entity
+    /// type supplied by a missing mod). These must survive authoritative live snapshots.
+    dormant_entities: std::sync::Mutex<Vec<NbtCompound>>,
+}
+
+impl ChunkEntityData {
+    #[must_use]
+    pub const fn empty(x: i32, z: i32) -> Self {
+        Self {
+            x,
+            z,
+            data: std::sync::Mutex::new(Vec::new()),
+            dirty: AtomicBool::new(false),
+            materialized: AtomicBool::new(false),
+            snapshot_needs_rewrite: AtomicBool::new(false),
+            dormant_entities: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Takes the persisted entities exactly once when the entity chunk becomes
+    /// live. Later watchers observe `None` and use the world's live entities.
+    pub fn take_entities_for_materialization(&self) -> Option<Vec<NbtCompound>> {
+        let mut data = self
+            .data
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self
+            .materialized
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return None;
+        }
+
+        let entities = std::mem::take(&mut *data);
+        if !entities.is_empty() {
+            self.snapshot_needs_rewrite.store(true, Ordering::Release);
+        }
+        Some(entities)
+    }
+
+    #[must_use]
+    pub fn entities_are_materialized(&self) -> bool {
+        self.materialized.load(Ordering::Acquire)
+    }
+
+    /// Retains records which could not be turned into live entities. They remain in
+    /// `data` for serialization and are also kept separately so later live snapshot
+    /// replacements cannot erase them.
+    pub fn retain_dormant_entities(&self, entities: Vec<NbtCompound>) {
+        if entities.is_empty() {
+            return;
+        }
+
+        let mut dormant = self
+            .dormant_entities
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut data = self
+            .data
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        dormant.extend(entities.iter().cloned());
+        data.extend(entities);
+    }
+
+    /// Replaces the serialized snapshot for a materialized entity chunk.
+    /// Replacing rather than appending makes repeated autosaves idempotent.
+    pub fn replace_entities(&self, mut entities: Vec<NbtCompound>) {
+        let dormant = self
+            .dormant_entities
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !dormant.is_empty() {
+            let mut combined = Vec::with_capacity(dormant.len() + entities.len());
+            combined.extend(dormant.iter().cloned());
+            combined.append(&mut entities);
+            entities = combined;
+        }
+        let mut data = self
+            .data
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let snapshot_needs_rewrite = self.snapshot_needs_rewrite.swap(false, Ordering::AcqRel);
+        if !snapshot_needs_rewrite && *data == entities {
+            return;
+        }
+        *data = entities;
+        self.dirty.store(true, Ordering::Release);
+    }
+
+    /// Reconciles a chunk whose persisted contents have not been materialized
+    /// with live entity snapshots. Dormant entities are retained, while any old
+    /// occurrence of a live UUID is removed before the current chunk's snapshots
+    /// are appended.
+    pub fn reconcile_entities(&self, entities: Vec<NbtCompound>, live_uuids: &FxHashSet<Uuid>) {
+        if entities.is_empty() && live_uuids.is_empty() {
+            return;
+        }
+
+        let mut data = self
+            .data
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous_len = data.len();
+        data.retain(|entity| {
+            entity
+                .get_uuid("UUID")
+                .is_none_or(|uuid| !live_uuids.contains(&uuid))
+        });
+        let changed = data.len() != previous_len || !entities.is_empty();
+        data.extend(entities);
+        if changed {
+            self.dirty.store(true, Ordering::Release);
+        }
+    }
 }
 
 /// Represents pure block data for a chunk.
@@ -936,9 +1061,143 @@ pub enum ChunkSerializingError {
 
 #[cfg(test)]
 mod tests {
-    use super::ChunkSections;
+    use super::{ChunkEntityData, ChunkSections};
     use crate::chunk::palette::BlockPalette;
     use pumpkin_data::{Block, block_properties::has_random_ticks};
+    use pumpkin_nbt::compound::NbtCompound;
+    use uuid::Uuid;
+
+    fn entity_nbt(marker: i32, uuid: Uuid) -> NbtCompound {
+        let mut nbt = NbtCompound::new();
+        nbt.put_int("marker", marker);
+        nbt.put_uuid("UUID", uuid);
+        nbt
+    }
+
+    #[test]
+    fn materialized_entity_snapshots_replace_instead_of_append() {
+        let chunk = ChunkEntityData::empty(4, -2);
+        chunk
+            .data
+            .lock()
+            .unwrap()
+            .push(entity_nbt(1, Uuid::from_u128(1)));
+
+        let persisted = chunk
+            .take_entities_for_materialization()
+            .expect("first materialization should consume persisted entities");
+        assert_eq!(persisted.len(), 1);
+        assert!(chunk.entities_are_materialized());
+        assert!(chunk.take_entities_for_materialization().is_none());
+
+        chunk.replace_entities(vec![entity_nbt(2, Uuid::from_u128(1))]);
+        chunk.replace_entities(vec![entity_nbt(3, Uuid::from_u128(1))]);
+
+        let saved = chunk.data.lock().unwrap();
+        assert_eq!(saved.len(), 1);
+        assert_eq!(saved[0].get_int("marker"), Some(3));
+    }
+
+    #[test]
+    fn consumed_entity_snapshot_rewrites_an_authoritative_empty_snapshot() {
+        let chunk = ChunkEntityData::empty(4, -2);
+        chunk
+            .data
+            .lock()
+            .unwrap()
+            .push(entity_nbt(1, Uuid::from_u128(1)));
+
+        assert_eq!(
+            chunk
+                .take_entities_for_materialization()
+                .expect("chunk should materialize")
+                .len(),
+            1
+        );
+        assert!(!chunk.dirty.load(std::sync::atomic::Ordering::Acquire));
+
+        chunk.replace_entities(Vec::new());
+
+        assert!(chunk.dirty.load(std::sync::atomic::Ordering::Acquire));
+        assert!(chunk.data.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn generated_empty_entity_chunk_stays_clean_after_empty_snapshot() {
+        let chunk = ChunkEntityData::empty(4, -2);
+        assert!(
+            chunk
+                .take_entities_for_materialization()
+                .expect("chunk should materialize")
+                .is_empty()
+        );
+
+        chunk.replace_entities(Vec::new());
+
+        assert!(!chunk.dirty.load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    #[test]
+    fn dormant_entity_records_survive_repeated_live_snapshot_replacement() {
+        let dormant_uuid = Uuid::from_u128(1);
+        let live_uuid = Uuid::from_u128(2);
+        let chunk = ChunkEntityData::empty(4, -2);
+        chunk.data.lock().unwrap().push(entity_nbt(1, dormant_uuid));
+
+        let persisted = chunk
+            .take_entities_for_materialization()
+            .expect("chunk should materialize");
+        chunk.retain_dormant_entities(persisted);
+        chunk.replace_entities(vec![entity_nbt(2, live_uuid)]);
+        chunk.replace_entities(vec![entity_nbt(3, live_uuid)]);
+
+        let saved = chunk.data.lock().unwrap();
+        assert_eq!(saved.len(), 2);
+        assert_eq!(saved[0].get_int("marker"), Some(1));
+        assert_eq!(saved[1].get_int("marker"), Some(3));
+    }
+
+    #[test]
+    fn dormant_only_entity_chunk_survives_repeated_empty_live_snapshots() {
+        let dormant_uuid = Uuid::from_u128(1);
+        let chunk = ChunkEntityData::empty(4, -2);
+        chunk.data.lock().unwrap().push(entity_nbt(1, dormant_uuid));
+
+        let persisted = chunk
+            .take_entities_for_materialization()
+            .expect("chunk should materialize");
+        chunk.retain_dormant_entities(persisted);
+        chunk.replace_entities(Vec::new());
+        chunk.replace_entities(Vec::new());
+
+        let saved = chunk.data.lock().unwrap();
+        assert_eq!(saved.len(), 1);
+        assert_eq!(saved[0].get_uuid("UUID"), Some(dormant_uuid));
+        assert_eq!(saved[0].get_int("marker"), Some(1));
+    }
+
+    #[test]
+    fn unmaterialized_entity_merge_preserves_dormant_entities_and_is_idempotent() {
+        let dormant_uuid = Uuid::from_u128(1);
+        let moving_uuid = Uuid::from_u128(2);
+        let chunk = ChunkEntityData::empty(4, -2);
+        chunk
+            .data
+            .lock()
+            .unwrap()
+            .extend([entity_nbt(1, dormant_uuid), entity_nbt(2, moving_uuid)]);
+
+        let moving_snapshot = vec![entity_nbt(20, moving_uuid)];
+        let live_uuids = rustc_hash::FxHashSet::from_iter([moving_uuid]);
+        chunk.reconcile_entities(moving_snapshot.clone(), &live_uuids);
+        chunk.reconcile_entities(moving_snapshot, &live_uuids);
+
+        let saved = chunk.data.lock().unwrap();
+        assert_eq!(saved.len(), 2);
+        assert_eq!(saved[0].get_int("marker"), Some(1));
+        assert_eq!(saved[1].get_int("marker"), Some(20));
+        assert!(!chunk.entities_are_materialized());
+    }
 
     #[test]
     fn random_tick_cache_initializes_from_palette_contents() {

--- a/crates/pumpkin-world/src/chunk/mod.rs
+++ b/crates/pumpkin-world/src/chunk/mod.rs
@@ -101,9 +101,15 @@ pub struct ChunkEntityData {
     /// Records that non-empty persisted data was consumed and therefore must be
     /// rewritten even if the eventual authoritative live snapshot is empty.
     snapshot_needs_rewrite: AtomicBool,
-    /// Persisted records Pumpkin cannot currently materialize (for example an entity
-    /// type supplied by a missing mod). These must survive authoritative live snapshots.
+    /// Records which are not live: unsupported entities, and entities unloaded
+    /// into a chunk which remains cached. Both survive authoritative live snapshots.
     dormant_entities: std::sync::Mutex<Vec<NbtCompound>>,
+    /// UUIDs added by live snapshots before this chunk was materialized. Unlike
+    /// untouched disk records, these must be replaced even after the entity dies.
+    live_snapshot_uuids: std::sync::Mutex<FxHashSet<Uuid>>,
+    /// Newly unloaded records which can be materialized, unlike unsupported
+    /// dormant records. These are consumed once even if the chunk was already live.
+    pending_materialization_uuids: std::sync::Mutex<FxHashSet<Uuid>>,
 }
 
 impl ChunkEntityData {
@@ -117,28 +123,81 @@ impl ChunkEntityData {
             materialized: AtomicBool::new(false),
             snapshot_needs_rewrite: AtomicBool::new(false),
             dormant_entities: std::sync::Mutex::new(Vec::new()),
+            live_snapshot_uuids: std::sync::Mutex::new(FxHashSet::with_hasher(
+                rustc_hash::FxBuildHasher,
+            )),
+            pending_materialization_uuids: std::sync::Mutex::new(FxHashSet::with_hasher(
+                rustc_hash::FxBuildHasher,
+            )),
         }
     }
 
-    /// Takes the persisted entities exactly once when the entity chunk becomes
-    /// live. Later watchers observe `None` and use the world's live entities.
+    /// Takes persisted or newly unloaded entities exactly once. Later watchers
+    /// observe `None` and use the world's live entities unless more entities have
+    /// since been transferred back to this chunk by an unload.
     pub fn take_entities_for_materialization(&self) -> Option<Vec<NbtCompound>> {
+        let mut dormant = self
+            .dormant_entities
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut live_snapshot_uuids = self
+            .live_snapshot_uuids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut pending_uuids = self
+            .pending_materialization_uuids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut data = self
             .data
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if self
-            .materialized
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return None;
+        if self.materialized.swap(true, Ordering::AcqRel) {
+            if pending_uuids.is_empty() {
+                return None;
+            }
+            let mut pending = Vec::new();
+            dormant.retain(|entity| {
+                if entity
+                    .get_uuid("UUID")
+                    .is_some_and(|uuid| pending_uuids.contains(&uuid))
+                {
+                    pending.push(entity.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            data.retain(|entity| {
+                entity
+                    .get_uuid("UUID")
+                    .is_none_or(|uuid| !pending_uuids.contains(&uuid))
+            });
+            pending_uuids.clear();
+            self.snapshot_needs_rewrite.store(true, Ordering::Release);
+            return Some(pending);
         }
 
-        let entities = std::mem::take(&mut *data);
+        let mut entities = std::mem::take(&mut *data);
         if !entities.is_empty() {
             self.snapshot_needs_rewrite.store(true, Ordering::Release);
         }
+        // Reconciled records are snapshots of entities already owned by the live
+        // world, not entities waiting to spawn. They may since have moved or died.
+        entities.retain(|entity| {
+            entity
+                .get_uuid("UUID")
+                .is_none_or(|uuid| !live_snapshot_uuids.contains(&uuid))
+        });
+        live_snapshot_uuids.clear();
+        // Pending records were included in `data`; drop their preservation copies
+        // now that ownership is handed back to the live world.
+        dormant.retain(|entity| {
+            entity
+                .get_uuid("UUID")
+                .is_none_or(|uuid| !pending_uuids.contains(&uuid))
+        });
+        pending_uuids.clear();
         Some(entities)
     }
 
@@ -193,25 +252,110 @@ impl ChunkEntityData {
     }
 
     /// Reconciles a chunk whose persisted contents have not been materialized
-    /// with live entity snapshots. Dormant entities are retained, while any old
-    /// occurrence of a live UUID is removed before the current chunk's snapshots
-    /// are appended.
+    /// with its complete live entity snapshot. Untouched disk records are retained,
+    /// but previously reconciled live records are replaced even if their UUID is no
+    /// longer live. Otherwise removing an entity would leave its last NBT behind.
     pub fn reconcile_entities(&self, entities: Vec<NbtCompound>, live_uuids: &FxHashSet<Uuid>) {
-        if entities.is_empty() && live_uuids.is_empty() {
-            return;
-        }
-
+        let mut dormant = self
+            .dormant_entities
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut live_snapshot_uuids = self
+            .live_snapshot_uuids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut pending_uuids = self
+            .pending_materialization_uuids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut data = self
             .data
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let previous_len = data.len();
-        data.retain(|entity| {
+        dormant.retain(|entity| {
             entity
                 .get_uuid("UUID")
                 .is_none_or(|uuid| !live_uuids.contains(&uuid))
         });
+        pending_uuids.retain(|uuid| !live_uuids.contains(uuid));
+        data.retain(|entity| {
+            entity.get_uuid("UUID").is_none_or(|uuid| {
+                !live_uuids.contains(&uuid) && !live_snapshot_uuids.contains(&uuid)
+            })
+        });
         let changed = data.len() != previous_len || !entities.is_empty();
+        live_snapshot_uuids.clear();
+        live_snapshot_uuids.extend(entities.iter().filter_map(|entity| entity.get_uuid("UUID")));
+        data.extend(entities);
+        if changed {
+            self.dirty.store(true, Ordering::Release);
+        }
+    }
+
+    /// Transfers a complete chunk snapshot from the live world back to persistence.
+    /// These entities are no longer world-owned and must be eligible to spawn again.
+    pub fn replace_unloaded_entities(&self, entities: Vec<NbtCompound>, uuids: &FxHashSet<Uuid>) {
+        self.transfer_unloaded_entities(entities, uuids, true);
+    }
+
+    /// Transfers only the supplied UUIDs, preserving unrelated live records. An
+    /// entity may have crossed out of the unloading chunks before being serialized.
+    pub fn merge_unloaded_entities(&self, entities: Vec<NbtCompound>, uuids: &FxHashSet<Uuid>) {
+        self.transfer_unloaded_entities(entities, uuids, false);
+    }
+
+    fn transfer_unloaded_entities(
+        &self,
+        entities: Vec<NbtCompound>,
+        uuids: &FxHashSet<Uuid>,
+        complete: bool,
+    ) {
+        if !complete && uuids.is_empty() && entities.is_empty() {
+            return;
+        }
+
+        let mut dormant = self
+            .dormant_entities
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut live_snapshot_uuids = self
+            .live_snapshot_uuids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut pending_uuids = self
+            .pending_materialization_uuids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut data = self
+            .data
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let keep = |entity: &NbtCompound| {
+            entity
+                .get_uuid("UUID")
+                .is_none_or(|uuid| !uuids.contains(&uuid))
+        };
+        dormant.retain(keep);
+        pending_uuids.retain(|uuid| !uuids.contains(uuid));
+        let previous_len = data.len();
+        if complete && self.entities_are_materialized() {
+            data.clone_from(&dormant);
+        } else {
+            data.retain(|entity| {
+                keep(entity)
+                    && (!complete
+                        || entity
+                            .get_uuid("UUID")
+                            .is_none_or(|uuid| !live_snapshot_uuids.contains(&uuid)))
+            });
+        }
+        let snapshot_needs_rewrite =
+            complete && self.snapshot_needs_rewrite.swap(false, Ordering::AcqRel);
+        let changed = snapshot_needs_rewrite || data.len() != previous_len || !entities.is_empty();
+        live_snapshot_uuids.retain(|uuid| !complete && !uuids.contains(uuid));
+        pending_uuids.extend(entities.iter().filter_map(|entity| entity.get_uuid("UUID")));
+        dormant.extend(entities.iter().cloned());
         data.extend(entities);
         if changed {
             self.dirty.store(true, Ordering::Release);
@@ -1138,6 +1282,22 @@ mod tests {
     }
 
     #[test]
+    fn empty_unload_rewrites_a_consumed_entity_snapshot() {
+        let chunk = ChunkEntityData::empty(4, -2);
+        chunk
+            .data
+            .lock()
+            .unwrap()
+            .push(entity_nbt(1, Uuid::from_u128(1)));
+        assert_eq!(chunk.take_entities_for_materialization().unwrap().len(), 1);
+
+        chunk.replace_unloaded_entities(Vec::new(), &rustc_hash::FxHashSet::default());
+
+        assert!(chunk.dirty.load(std::sync::atomic::Ordering::Acquire));
+        assert!(chunk.data.lock().unwrap().is_empty());
+    }
+
+    #[test]
     fn dormant_entity_records_survive_repeated_live_snapshot_replacement() {
         let dormant_uuid = Uuid::from_u128(1);
         let live_uuid = Uuid::from_u128(2);
@@ -1197,6 +1357,75 @@ mod tests {
         assert_eq!(saved[0].get_int("marker"), Some(1));
         assert_eq!(saved[1].get_int("marker"), Some(20));
         assert!(!chunk.entities_are_materialized());
+    }
+
+    #[test]
+    fn materialization_does_not_respawn_previously_reconciled_live_entities() {
+        let dormant_uuid = Uuid::from_u128(1);
+        let live_uuid = Uuid::from_u128(2);
+        let chunk = ChunkEntityData::empty(4, -2);
+        chunk.data.lock().unwrap().push(entity_nbt(1, dormant_uuid));
+        chunk.reconcile_entities(
+            vec![entity_nbt(2, live_uuid)],
+            &rustc_hash::FxHashSet::from_iter([live_uuid]),
+        );
+
+        // The live entity may have died since the last autosave. Its old snapshot
+        // must not be mistaken for an untouched disk entity waiting to spawn.
+        let pending = chunk.take_entities_for_materialization().unwrap();
+        assert_eq!(pending, vec![entity_nbt(1, dormant_uuid)]);
+        assert!(chunk.take_entities_for_materialization().is_none());
+    }
+
+    #[test]
+    fn partial_unload_updates_only_the_supplied_entity_uuids() {
+        let dormant_uuid = Uuid::from_u128(1);
+        let moving_uuid = Uuid::from_u128(2);
+        let staying_uuid = Uuid::from_u128(3);
+        let chunk = ChunkEntityData::empty(4, -2);
+        chunk.data.lock().unwrap().push(entity_nbt(1, dormant_uuid));
+        chunk.reconcile_entities(
+            vec![entity_nbt(2, moving_uuid), entity_nbt(3, staying_uuid)],
+            &rustc_hash::FxHashSet::from_iter([moving_uuid, staying_uuid]),
+        );
+
+        chunk.merge_unloaded_entities(Vec::new(), &rustc_hash::FxHashSet::from_iter([moving_uuid]));
+        assert_eq!(
+            *chunk.data.lock().unwrap(),
+            vec![entity_nbt(1, dormant_uuid), entity_nbt(3, staying_uuid)]
+        );
+
+        chunk.merge_unloaded_entities(
+            vec![entity_nbt(20, moving_uuid)],
+            &rustc_hash::FxHashSet::from_iter([moving_uuid]),
+        );
+        assert_eq!(
+            *chunk.data.lock().unwrap(),
+            vec![
+                entity_nbt(1, dormant_uuid),
+                entity_nbt(3, staying_uuid),
+                entity_nbt(20, moving_uuid)
+            ]
+        );
+
+        chunk.reconcile_entities(Vec::new(), &rustc_hash::FxHashSet::default());
+        assert_eq!(
+            *chunk.data.lock().unwrap(),
+            vec![entity_nbt(1, dormant_uuid), entity_nbt(20, moving_uuid)]
+        );
+
+        let pending = chunk.take_entities_for_materialization().unwrap();
+        assert_eq!(
+            pending,
+            vec![entity_nbt(1, dormant_uuid), entity_nbt(20, moving_uuid)]
+        );
+        assert!(chunk.take_entities_for_materialization().is_none());
+        chunk.retain_dormant_entities(vec![entity_nbt(1, dormant_uuid)]);
+        chunk.replace_entities(Vec::new());
+        assert_eq!(
+            *chunk.data.lock().unwrap(),
+            vec![entity_nbt(1, dormant_uuid)]
+        );
     }
 
     #[test]

--- a/crates/pumpkin-world/src/level.rs
+++ b/crates/pumpkin-world/src/level.rs
@@ -24,9 +24,10 @@ use pumpkin_config::{chunk::ChunkConfig, lighting::LightingEngineConfig, world::
 use pumpkin_data::biome::Biome;
 use pumpkin_data::dimension::Dimension;
 use pumpkin_data::{Block, BlockStateId, block_properties::has_random_ticks, fluid::Fluid};
+use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::math::{position::BlockPos, vector2::Vector2};
 use pumpkin_util::world_seed::Seed;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 use std::{
@@ -47,6 +48,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_util::task::TaskTracker;
+use uuid::Uuid;
 
 pub type SyncChunk = Arc<ChunkData>;
 pub type SyncEntityChunk = Arc<ChunkEntityData>;
@@ -925,6 +927,52 @@ impl Level {
             .collect()
     }
 
+    /// Applies live snapshots for an autosave (`authoritative_chunks = None`) or
+    /// for just the chunks being unloaded. An unload transfers ownership back to
+    /// persistence; other chunks only update the supplied UUIDs, preserving their
+    /// unrelated live records if an entity crossed a boundary before serialization.
+    ///
+    /// The world must serialize this with entity materialization and other saves.
+    pub async fn update_entity_chunk_snapshots(
+        self: &Arc<Self>,
+        mut snapshots: FxHashMap<Vector2<i32>, Vec<NbtCompound>>,
+        snapshot_uuids: &FxHashSet<Uuid>,
+        authoritative_chunks: Option<&FxHashSet<Vector2<i32>>>,
+    ) {
+        for (chunk_pos, chunk) in self.entity_chunks() {
+            let entities = snapshots.remove(&chunk_pos).unwrap_or_default();
+            if let Some(chunks) = authoritative_chunks {
+                if chunks.contains(&chunk_pos) {
+                    chunk.replace_unloaded_entities(entities, snapshot_uuids);
+                } else {
+                    chunk.merge_unloaded_entities(entities, snapshot_uuids);
+                }
+            } else if chunk.entities_are_materialized() {
+                // Retained pending records are no longer authoritative if their
+                // UUID is now live (or removed) elsewhere in the world snapshot.
+                chunk.merge_unloaded_entities(Vec::new(), snapshot_uuids);
+                chunk.replace_entities(entities);
+            } else {
+                chunk.reconcile_entities(entities, snapshot_uuids);
+            }
+        }
+
+        // A live entity can enter an entity chunk which has not yet been fetched.
+        // Load its untouched disk records before merging the live snapshot.
+        for (chunk_pos, entities) in snapshots {
+            let chunk = self.get_entity_chunk(chunk_pos).await;
+            if let Some(chunks) = authoritative_chunks {
+                if chunks.contains(&chunk_pos) {
+                    chunk.replace_unloaded_entities(entities, snapshot_uuids);
+                } else {
+                    chunk.merge_unloaded_entities(entities, snapshot_uuids);
+                }
+            } else {
+                chunk.reconcile_entities(entities, snapshot_uuids);
+            }
+        }
+    }
+
     pub async fn get_or_fetch_entity_chunk<R, F: Fn(&SyncEntityChunk) -> R>(
         self: &Arc<Self>,
         pos: Vector2<i32>,
@@ -1018,6 +1066,233 @@ mod tests {
     use super::*;
     use pumpkin_config::world::LevelConfig;
     use tempfile::TempDir;
+
+    fn persisted_entity(id: &str, uuid: u128, marker: i32) -> NbtCompound {
+        let mut nbt = NbtCompound::new();
+        nbt.put_string("id", id.to_owned());
+        nbt.put_uuid("UUID", Uuid::from_u128(uuid));
+        nbt.put_int("marker", marker);
+        nbt
+    }
+
+    fn snapshot_uuids(snapshots: &FxHashMap<Vector2<i32>, Vec<NbtCompound>>) -> FxHashSet<Uuid> {
+        snapshots
+            .values()
+            .flatten()
+            .map(|nbt| nbt.get_uuid("UUID").unwrap())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn entity_persistence_flow_preserves_dormant_records_without_reviving_removed_entities() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = LevelConfig::default();
+        let level = Level::from_root_folder(
+            &config,
+            temp_dir.path().to_path_buf(),
+            0,
+            Dimension::OVERWORLD,
+        );
+        let source_pos = Vector2::new(0, 0);
+        let target_pos = Vector2::new(1, 0);
+        let dormant_source = persisted_entity("missing_mod:source", 1, 10);
+        let dormant_target = persisted_entity("missing_mod:target", 2, 20);
+        let moving = persisted_entity("minecraft:pig", 3, 30);
+        let survivor = persisted_entity("minecraft:pig", 4, 40);
+
+        // Begin with real on-disk entity chunks, before either chunk is live.
+        for (pos, data) in [
+            (source_pos, vec![dormant_source.clone(), moving.clone()]),
+            (target_pos, vec![dormant_target.clone()]),
+        ] {
+            let chunk = Arc::new(ChunkEntityData::empty(pos.x, pos.y));
+            *chunk.data.lock().unwrap() = data;
+            chunk.mark_dirty(true);
+            level.write_entity_chunks(vec![(pos, chunk)]).await;
+        }
+        let source = level.get_entity_chunk(source_pos).await;
+        let pending = source.take_entities_for_materialization().unwrap();
+        assert_eq!(pending, vec![dormant_source.clone(), moving.clone()]);
+        source.retain_dormant_entities(vec![dormant_source.clone()]);
+
+        // The pig crosses into a chunk whose persisted records have not spawned.
+        // Repeated autosaves replace its snapshot rather than accumulating copies.
+        let mut snapshots = FxHashMap::from_iter([(target_pos, vec![moving, survivor.clone()])]);
+        for marker in [31, 32] {
+            snapshots.get_mut(&target_pos).unwrap()[0].put_int("marker", marker);
+            level
+                .update_entity_chunk_snapshots(snapshots.clone(), &snapshot_uuids(&snapshots), None)
+                .await;
+            level.write_entity_chunks(level.entity_chunks()).await;
+        }
+        let target = level.get_entity_chunk(target_pos).await;
+        assert!(!target.entities_are_materialized());
+        assert_eq!(target.data.lock().unwrap().len(), 3);
+        assert_eq!(target.data.lock().unwrap()[1].get_int("marker"), Some(32));
+
+        // Unloading another chunk provides only a partial snapshot. It must not
+        // erase live snapshots in the still-loaded, unmaterialized destination.
+        level
+            .update_entity_chunk_snapshots(
+                FxHashMap::default(),
+                &FxHashSet::default(),
+                Some(&FxHashSet::from_iter([source_pos])),
+            )
+            .await;
+        level.clean_entity_chunks([source_pos]);
+        assert_eq!(target.data.lock().unwrap().len(), 3);
+
+        // Remove the pig, then the final survivor. Neither UUID is present in its
+        // next autosave, including the entirely empty live set from the review.
+        snapshots.insert(target_pos, vec![survivor.clone()]);
+        level
+            .update_entity_chunk_snapshots(snapshots.clone(), &snapshot_uuids(&snapshots), None)
+            .await;
+        assert_eq!(
+            *target.data.lock().unwrap(),
+            vec![dormant_target.clone(), survivor]
+        );
+        level.write_entity_chunks(level.entity_chunks()).await;
+        level
+            .update_entity_chunk_snapshots(FxHashMap::default(), &FxHashSet::default(), None)
+            .await;
+        assert!(target.is_dirty());
+        level.shutdown().await;
+
+        // A fresh Level and file manager force a disk read, not an in-memory cache
+        // hit. Only the genuinely dormant records may be materialized on restart.
+        let restarted = Level::from_root_folder(
+            &config,
+            temp_dir.path().to_path_buf(),
+            0,
+            Dimension::OVERWORLD,
+        );
+        for (pos, dormant) in [(source_pos, dormant_source), (target_pos, dormant_target)] {
+            let chunk = restarted.get_entity_chunk(pos).await;
+            let pending = chunk.take_entities_for_materialization().unwrap();
+            assert_eq!(pending, vec![dormant]);
+            assert!(chunk.take_entities_for_materialization().is_none());
+            chunk.retain_dormant_entities(pending);
+            chunk.replace_entities(Vec::new());
+        }
+        restarted.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn unload_transfers_ownership_to_cached_chunks_without_losing_or_duplicating_entities() {
+        let temp_dir = TempDir::new().unwrap();
+        let level = Level::from_root_folder(
+            &LevelConfig::default(),
+            temp_dir.path().to_path_buf(),
+            0,
+            Dimension::OVERWORLD,
+        );
+
+        // A destination may be untouched, or already materialized but still cached
+        // because a watcher arrived during unload. Exercise both authoritative and
+        // out-of-scope destinations: the snapshots are no longer world-owned.
+        for (index, (materialized, in_scope)) in
+            [(false, false), (true, false), (false, true), (true, true)]
+                .into_iter()
+                .enumerate()
+        {
+            let destination = Vector2::new(index as i32, 0);
+            let chunk = level.get_entity_chunk(destination).await;
+            if materialized {
+                assert!(
+                    chunk
+                        .take_entities_for_materialization()
+                        .unwrap()
+                        .is_empty()
+                );
+            }
+            let detached = persisted_entity("minecraft:pig", 10 + index as u128, 1);
+            let other_live = persisted_entity("minecraft:pig", 20 + index as u128, 2);
+            let remaining = if in_scope {
+                Vec::new()
+            } else {
+                vec![other_live]
+            };
+            let mut initial = remaining.clone();
+            initial.push(detached.clone());
+            let snapshots = FxHashMap::from_iter([(destination, initial)]);
+            level
+                .update_entity_chunk_snapshots(snapshots.clone(), &snapshot_uuids(&snapshots), None)
+                .await;
+
+            let snapshots = FxHashMap::from_iter([(destination, vec![detached.clone()])]);
+            let unloading = FxHashSet::from_iter([if in_scope {
+                destination
+            } else {
+                Vector2::new(-1, 0)
+            }]);
+            level
+                .update_entity_chunk_snapshots(
+                    snapshots.clone(),
+                    &snapshot_uuids(&snapshots),
+                    Some(&unloading),
+                )
+                .await;
+
+            // Autosaving the remaining live world must retain the transferred
+            // entity until materialization actually takes ownership of it.
+            let snapshots = FxHashMap::from_iter([(destination, remaining.clone())]);
+            level
+                .update_entity_chunk_snapshots(snapshots.clone(), &snapshot_uuids(&snapshots), None)
+                .await;
+            assert!(chunk.data.lock().unwrap().contains(&detached));
+            assert_eq!(
+                chunk.take_entities_for_materialization().unwrap(),
+                vec![detached]
+            );
+            assert!(chunk.take_entities_for_materialization().is_none());
+
+            // If it then dies, no preservation copy may survive the next save.
+            level
+                .update_entity_chunk_snapshots(snapshots.clone(), &snapshot_uuids(&snapshots), None)
+                .await;
+            assert_eq!(*chunk.data.lock().unwrap(), remaining);
+        }
+        level.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn live_entity_elsewhere_supersedes_pending_nbt_in_a_materialized_chunk() {
+        let temp_dir = TempDir::new().unwrap();
+        let level = Level::from_root_folder(
+            &LevelConfig::default(),
+            temp_dir.path().to_path_buf(),
+            0,
+            Dimension::OVERWORLD,
+        );
+        let source_pos = Vector2::new(0, 0);
+        let destination = Vector2::new(1, 0);
+        let source = level.get_entity_chunk(source_pos).await;
+        assert!(
+            source
+                .take_entities_for_materialization()
+                .unwrap()
+                .is_empty()
+        );
+        let entity = persisted_entity("minecraft:pig", 1, 10);
+        let snapshots = FxHashMap::from_iter([(source_pos, vec![entity.clone()])]);
+        level
+            .update_entity_chunk_snapshots(
+                snapshots.clone(),
+                &snapshot_uuids(&snapshots),
+                Some(&FxHashSet::from_iter([source_pos])),
+            )
+            .await;
+        assert_eq!(*source.data.lock().unwrap(), vec![entity.clone()]);
+
+        let snapshots = FxHashMap::from_iter([(destination, vec![entity])]);
+        level
+            .update_entity_chunk_snapshots(snapshots.clone(), &snapshot_uuids(&snapshots), None)
+            .await;
+        assert!(source.data.lock().unwrap().is_empty());
+        assert!(source.take_entities_for_materialization().is_none());
+        level.shutdown().await;
+    }
 
     #[tokio::test]
     async fn dimension_paths_26_2() {

--- a/crates/pumpkin-world/src/level.rs
+++ b/crates/pumpkin-world/src/level.rs
@@ -317,14 +317,14 @@ impl Level {
     pub fn spawn_entity_generation(self: &Arc<Self>, pos: Vector2<i32>) {
         let level = self.clone();
         rayon::spawn(move || {
-            let arc_chunk = Arc::new(ChunkEntityData {
-                x: pos.x,
-                z: pos.y,
-                data: std::sync::Mutex::new(Vec::new()),
-                dirty: AtomicBool::new(false),
-            });
-
-            level.loaded_entity_chunks.insert(pos, arc_chunk.clone());
+            let generated_chunk = Arc::new(ChunkEntityData::empty(pos.x, pos.y));
+            let arc_chunk = match level.loaded_entity_chunks.entry(pos) {
+                Entry::Occupied(entry) => entry.get().clone(),
+                Entry::Vacant(entry) => {
+                    entry.insert(generated_chunk.clone());
+                    generated_chunk
+                }
+            };
 
             if let Some((_, waiters)) = level.pending_entity_generations.remove(&pos) {
                 for tx in waiters {
@@ -734,8 +734,15 @@ impl Level {
                         match data {
                             LoadedData::Loaded(chunk) => {
                                 let pos = Vector2::new(chunk.x, chunk.z);
-                                level.loaded_entity_chunks.insert(pos, chunk.clone());
-                                let _ = sender.send((Arc::downgrade(&chunk), true)).await;
+                                let (chunk, first_load) =
+                                    match level.loaded_entity_chunks.entry(pos) {
+                                        Entry::Occupied(entry) => (entry.get().clone(), false),
+                                        Entry::Vacant(entry) => {
+                                            entry.insert(chunk.clone());
+                                            (chunk, true)
+                                        }
+                                    };
+                                let _ = sender.send((Arc::downgrade(&chunk), first_load)).await;
                             }
                             LoadedData::Missing(pos) | LoadedData::Error((pos, _)) => {
                                 let (tx, rx) = oneshot::channel();
@@ -776,8 +783,13 @@ impl Level {
         }
 
         if let Ok((chunk, _)) = self.load_single_entity_chunk(pos).await {
-            self.loaded_entity_chunks.insert(pos, chunk.clone());
-            chunk
+            match self.loaded_entity_chunks.entry(pos) {
+                Entry::Occupied(entry) => entry.get().clone(),
+                Entry::Vacant(entry) => {
+                    entry.insert(chunk.clone());
+                    chunk
+                }
+            }
         } else {
             let (tx, rx) = oneshot::channel();
             match self.pending_entity_generations.entry(pos) {
@@ -789,14 +801,8 @@ impl Level {
                     self.spawn_entity_generation(pos);
                 }
             }
-            rx.await.unwrap_or_else(|_| {
-                Arc::new(ChunkEntityData {
-                    x: pos.x,
-                    z: pos.y,
-                    data: std::sync::Mutex::new(Vec::new()),
-                    dirty: AtomicBool::new(false),
-                })
-            })
+            rx.await
+                .unwrap_or_else(|_| Arc::new(ChunkEntityData::empty(pos.x, pos.y)))
         }
     }
 
@@ -908,6 +914,15 @@ impl Level {
         self.loaded_entity_chunks
             .get(pos)
             .map(|x| x.value().clone())
+    }
+
+    /// Returns stable references to the currently loaded entity chunks. Callers
+    /// must inspect each chunk's materialization state before replacing data.
+    pub fn entity_chunks(&self) -> Vec<(Vector2<i32>, SyncEntityChunk)> {
+        self.loaded_entity_chunks
+            .iter()
+            .map(|entry| (*entry.key(), entry.value().clone()))
+            .collect()
     }
 
     pub async fn get_or_fetch_entity_chunk<R, F: Fn(&SyncEntityChunk) -> R>(

--- a/crates/pumpkin/src/entity/attributes.rs
+++ b/crates/pumpkin/src/entity/attributes.rs
@@ -177,9 +177,7 @@ pub fn send_attribute_updates_for_living(
 
     living
         .entity
-        .world
-        .load()
-        .broadcast_editioned(&je_packet, &be_packet);
+        .send_tracked_editioned(living.entity.chunk_pos.load(), &je_packet, &be_packet);
 }
 
 impl Clone for AttributeInstance {

--- a/crates/pumpkin/src/entity/item.rs
+++ b/crates/pumpkin/src/entity/item.rs
@@ -638,7 +638,7 @@ impl EntityBase for ItemEntity {
         self
     }
 
-    fn send_bedrock_spawn_packet(&self, client: &crate::net::bedrock::BedrockClient) {
+    fn try_send_bedrock_spawn_packet(&self, client: &crate::net::bedrock::BedrockClient) -> bool {
         let entity = &self.entity;
         let runtime_id = entity.entity_id as u64;
         let data = {
@@ -657,9 +657,7 @@ impl EntityBase for ItemEntity {
             };
             client.serialize_packet(&packet).ok()
         };
-        if let Some(data) = data {
-            client.try_enqueue_packet(data);
-        }
+        data.is_some_and(|data| client.try_enqueue_packet_data_checked(data))
     }
 
     fn send_java_spawn_packet(&self, client: &crate::net::java::JavaClient) {

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -462,19 +462,30 @@ impl LivingEntity {
             }
         }
 
-        let chunk_pos = self.entity.chunk_pos.load();
-        self.entity.world.load().broadcast_to_chunk_editioned(
-            chunk_pos,
+        let world = self.entity.world.load();
+        world.broadcast_to_chunk(
+            self.entity.chunk_pos.load(),
             &CTakeItemEntity::new(
                 item.entity_id.into(),
                 self.entity.entity_id.into(),
                 VarInt(stack_amount as i32),
             ),
-            &CTakeItemActor {
-                item_runtime_id: VarULong(item.entity_id as u64),
-                actor_runtime_id: VarULong(self.entity.entity_id as u64),
-            },
         );
+        if let (Some(collector), Some(tracked_item)) = (
+            world
+                .entity_tracker
+                .get_tracked_entity(self.entity.entity_id),
+            world.entity_tracker.get_tracked_entity(item.entity_id),
+        ) {
+            collector.send_to_tracking_players_and_self_bedrock_filtered(
+                &CTakeItemActor {
+                    item_runtime_id: VarULong(item.entity_id as u64),
+                    actor_runtime_id: VarULong(self.entity.entity_id as u64),
+                },
+                &world,
+                |player| tracked_item.has_active_bedrock_pairing(&player.gameprofile.id),
+            );
+        }
     }
 
     /// Sends the Hand animation to all others, used when Eating for example
@@ -907,11 +918,8 @@ impl LivingEntity {
             ambient: effect.ambient,
         };
 
-        let chunk_pos = self.entity.chunk_pos.load();
         self.entity
-            .world
-            .load()
-            .broadcast_to_chunk_editioned(chunk_pos, &je_packet, &be_packet);
+            .send_tracked_editioned(self.entity.chunk_pos.load(), &je_packet, &be_packet);
         if effect.effect_type != &StatusEffect::INSTANT_HEALTH
             && effect.effect_type != &StatusEffect::INSTANT_DAMAGE
         {
@@ -1140,7 +1148,6 @@ impl LivingEntity {
     }
 
     pub fn swing_hand(&self) {
-        let world = self.entity.world.load();
         let entity_id = self.entity_id();
 
         let je_packet = pumpkin_protocol::java::client::play::CEntityAnimation::new(
@@ -1154,7 +1161,8 @@ impl LivingEntity {
             swing_source: None,
         };
 
-        world.broadcast_editioned(&je_packet, &be_packet);
+        self.entity
+            .send_tracked_editioned(self.entity.chunk_pos.load(), &je_packet, &be_packet);
     }
 
     fn tick_movement(&self, caller: &dyn EntityBase) {

--- a/crates/pumpkin/src/entity/marker.rs
+++ b/crates/pumpkin/src/entity/marker.rs
@@ -90,5 +90,7 @@ impl EntityBase for MarkerEntity {
 
     fn send_java_spawn_packet(&self, _client: &JavaClient) {}
 
-    fn send_bedrock_spawn_packet(&self, _client: &BedrockClient) {}
+    fn try_send_bedrock_spawn_packet(&self, _client: &BedrockClient) -> bool {
+        true
+    }
 }

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -35,7 +35,7 @@ use pumpkin_protocol::bedrock::client::{CAddActor, CSetActorMotion};
 use pumpkin_protocol::codec::var_long::VarLong;
 use pumpkin_protocol::java::client::play::{CUpdateEntityPos, CUpdateEntityPosRot};
 use pumpkin_protocol::{
-    PositionFlag,
+    BClientPacket, ClientPacket, PositionFlag,
     bedrock::client::{
         move_actor_delta::{
             CMoveActorDelta, MOVE_ACTOR_DELTA_FLAG_HAS_HEAD_YAW, MOVE_ACTOR_DELTA_FLAG_HAS_PITCH,
@@ -333,6 +333,24 @@ pub trait EntityBase: Send + Sync + std::any::Any {
     }
 
     fn send_bedrock_spawn_packet(&self, client: &BedrockClient) {
+        let _ = self.try_send_bedrock_spawn_packet(client);
+    }
+
+    /// Attempts to enqueue this entity's Bedrock spawn lifecycle packets atomically.
+    /// Implementations with custom spawn packets should override this checked hook.
+    fn try_send_bedrock_spawn_packet(&self, client: &BedrockClient) -> bool {
+        if let Some(player) = self.get_player() {
+            let Ok(player_list) = client.serialize_packet(&player.bedrock_player_list_add_packet())
+            else {
+                return false;
+            };
+            let Ok(add_player) = client.serialize_packet(&player.bedrock_add_player_packet())
+            else {
+                return false;
+            };
+            return client.try_enqueue_packet_batch_checked(vec![player_list, add_player]);
+        }
+
         let entity = self.get_entity();
         let runtime_id = entity.entity_id as u64;
         let identifier = self
@@ -362,9 +380,9 @@ pub trait EntityBase: Send + Sync + std::any::Any {
             },
             actor_links: Vec::new(),
         };
-        if let Ok(data) = client.serialize_packet(&packet) {
-            client.try_enqueue_packet(data);
-        }
+        client
+            .serialize_packet(&packet)
+            .is_ok_and(|data| client.try_enqueue_packet_data_checked(data))
     }
 
     fn send_java_spawn_packet(&self, client: &JavaClient) {
@@ -1198,10 +1216,45 @@ impl Entity {
         self.set_synced_data(tracked_data::entity::DATA_NO_GRAVITY, no_gravity);
     }
 
+    /// Sends a Bedrock actor packet only to clients which have been paired with this entity.
+    pub(crate) fn send_tracked_bedrock<P: BClientPacket + Sync>(&self, packet: &P) {
+        let world = self.world.load();
+        if let Some(tracked) = world.entity_tracker.get_tracked_entity(self.entity_id) {
+            tracked.send_to_tracking_players_bedrock(packet, &world);
+        }
+        self.send_tracked_bedrock_to_self(packet, &world);
+    }
+
+    /// The tracker intentionally excludes an entity's own player. Server-authored
+    /// movement such as knockback must still reach that Bedrock client.
+    fn send_tracked_bedrock_to_self<P: BClientPacket>(&self, packet: &P, world: &World) {
+        if self.entity_type == &EntityType::PLAYER
+            && let Some(player) = world.get_player_by_id(self.entity_id)
+            && let ClientPlatform::Bedrock(client) = player.client.as_ref()
+        {
+            client.try_enqueue_client_packet(packet);
+        }
+    }
+
+    /// Preserves Java's chunk broadcast while routing Bedrock through entity pairings.
+    pub(crate) fn send_tracked_editioned<J: ClientPacket, B: BClientPacket + Sync>(
+        &self,
+        chunk_pos: Vector2<i32>,
+        java_packet: &J,
+        bedrock_packet: &B,
+    ) {
+        let world = self.world.load();
+        world.broadcast_to_chunk(chunk_pos, java_packet);
+        if let Some(tracked) = world.entity_tracker.get_tracked_entity(self.entity_id) {
+            tracked.send_to_tracking_players_bedrock(bedrock_packet, &world);
+        }
+        self.send_tracked_bedrock_to_self(bedrock_packet, &world);
+    }
+
     pub fn send_velocity(&self) {
         let velocity = self.velocity.load();
         let chunk_pos = self.chunk_pos.load();
-        self.world.load().broadcast_to_chunk_editioned(
+        self.send_tracked_editioned(
             chunk_pos,
             &CEntityVelocity::new(self.entity_id.into(), velocity),
             &CSetActorMotion {
@@ -1710,7 +1763,7 @@ impl Entity {
                 self.on_ground.load(Relaxed),
             );
             if self.entity_type == &EntityType::PLAYER {
-                self.world.load().broadcast_to_chunk_editioned(
+                self.send_tracked_editioned(
                     chunk_pos,
                     &je_packet,
                     &CMovePlayer::new(
@@ -1737,7 +1790,7 @@ impl Entity {
                 if self.on_ground.load(Relaxed) {
                     flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
                 }
-                self.world.load().broadcast_to_chunk_editioned(
+                self.send_tracked_editioned(
                     chunk_pos,
                     &je_packet,
                     &CMoveActorDelta::new(
@@ -1759,7 +1812,7 @@ impl Entity {
                 self.on_ground.load(Relaxed),
             );
             if self.entity_type == &EntityType::PLAYER {
-                self.world.load().broadcast_to_chunk_editioned(
+                self.send_tracked_editioned(
                     chunk_pos,
                     &je_packet,
                     &CMovePlayer::new(
@@ -1784,7 +1837,7 @@ impl Entity {
                     flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
                 }
 
-                self.world.load().broadcast_to_chunk_editioned(
+                self.send_tracked_editioned(
                     chunk_pos,
                     &je_packet,
                     &CMoveActorDelta::new(
@@ -1807,7 +1860,7 @@ impl Entity {
                 self.on_ground.load(Relaxed),
             );
             if self.entity_type == &EntityType::PLAYER {
-                self.world.load().broadcast_to_chunk_editioned(
+                self.send_tracked_editioned(
                     chunk_pos,
                     &je_packet,
                     &CMovePlayer::new(
@@ -1831,7 +1884,7 @@ impl Entity {
                 if self.on_ground.load(Relaxed) {
                     flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
                 }
-                self.world.load().broadcast_to_chunk_editioned(
+                self.send_tracked_editioned(
                     chunk_pos,
                     &je_packet,
                     &CMoveActorDelta::new(
@@ -1852,7 +1905,6 @@ impl Entity {
 
     pub fn send_bedrock_pos(&self) {
         let position = self.pos.load();
-        let chunk_pos = self.chunk_pos.load();
         let mut flags =
             MOVE_ACTOR_DELTA_FLAG_HAS_X | MOVE_ACTOR_DELTA_FLAG_HAS_Y | MOVE_ACTOR_DELTA_FLAG_HAS_Z;
         if self.on_ground.load(Relaxed) {
@@ -1868,8 +1920,7 @@ impl Entity {
             0,
             0,
         );
-        let world = self.world.load();
-        world.broadcast_to_chunk_bedrock(chunk_pos, &packet);
+        self.send_tracked_bedrock(&packet);
     }
 
     pub fn update_last_pos(&self) -> Vector3<f64> {
@@ -1905,7 +1956,7 @@ impl Entity {
         );
 
         if self.entity_type == &EntityType::PLAYER {
-            self.world.load().broadcast_to_chunk_editioned(
+            self.send_tracked_editioned(
                 chunk_pos,
                 &je_packet,
                 &CMovePlayer::new(
@@ -1930,7 +1981,7 @@ impl Entity {
                 flags |= MOVE_ACTOR_DELTA_FLAG_ON_GROUND;
             }
 
-            self.world.load().broadcast_to_chunk_editioned(
+            self.send_tracked_editioned(
                 chunk_pos,
                 &je_packet,
                 &CMoveActorDelta::new(
@@ -2982,8 +3033,6 @@ impl Entity {
                 }
             }
 
-            let world = self.world.load();
-            let chunk_pos = self.chunk_pos.load();
             let mut metadata = SyncedActorDataList(std::collections::HashMap::new());
             metadata.set(
                 entity_data_key::FLAGS,
@@ -3002,7 +3051,7 @@ impl Entity {
                 },
                 tick: VarULong(0),
             };
-            world.broadcast_to_chunk_bedrock(chunk_pos, &packet);
+            self.send_tracked_bedrock(&packet);
         }
     }
 
@@ -3027,33 +3076,6 @@ impl Entity {
     }
 
     pub fn send_bedrock_actor_data(&self, bedrock_meta: &SyncedActorDataList) {
-        let world = self.world.load();
-        let players = world.players.load();
-        let mut bedrock_recipients = Vec::new();
-
-        if let Some(tracked) = world.entity_tracker.get_tracked_entity(self.entity_id) {
-            for player in players.iter() {
-                if (tracked.seen_by.contains(&player.gameprofile.id)
-                    || player.entity_id() == self.entity_id)
-                    && let ClientPlatform::Bedrock(client) = player.client.as_ref()
-                {
-                    bedrock_recipients.push(client);
-                }
-            }
-        } else {
-            let chunk_pos = self.chunk_pos.load();
-            for player in players.iter() {
-                let center = player.get_entity().chunk_pos.load();
-                let view_distance = crate::world::chunker::get_view_distance(player).get() as i32;
-
-                if is_within_view_distance(chunk_pos, center, view_distance)
-                    && let ClientPlatform::Bedrock(client) = player.client.as_ref()
-                {
-                    bedrock_recipients.push(client);
-                }
-            }
-        }
-
         let packet = CSetActorData {
             target_runtime_id: VarULong(self.entity_id as u64),
             actor_data: SyncedActorDataList(bedrock_meta.0.clone()),
@@ -3063,11 +3085,9 @@ impl Entity {
             },
             tick: VarULong(0),
         };
-        for recipient in bedrock_recipients {
-            if let Ok(packet_data) = recipient.serialize_packet(&packet) {
-                recipient.try_enqueue_packet(packet_data);
-            }
-        }
+        // A not-yet-tracked entity has no valid Bedrock recipients. Its current metadata is
+        // included in AddActor/AddPlayer when the terrain-gated pairing is eventually created.
+        self.send_tracked_bedrock(&packet);
     }
 
     pub fn send_dirty_entity_data(&self) {
@@ -3407,11 +3427,7 @@ impl Entity {
             },
         };
 
-        self.world.load().broadcast_to_chunk_editioned(
-            self.chunk_pos.load(),
-            &je_packet,
-            &be_packet,
-        );
+        self.send_tracked_editioned(self.chunk_pos.load(), &je_packet, &be_packet);
     }
 
     pub fn unleash(&self) {
@@ -3463,11 +3479,7 @@ impl Entity {
             },
         };
 
-        self.world.load().broadcast_to_chunk_editioned(
-            self.chunk_pos.load(),
-            &je_packet,
-            &be_packet,
-        );
+        self.send_tracked_editioned(self.chunk_pos.load(), &je_packet, &be_packet);
     }
 
     pub fn tick_leash(&self) {

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -388,6 +388,38 @@ pub enum PlayerWeather {
     Downfall,
 }
 
+struct BedrockEntityChunkBatch {
+    world: Arc<World>,
+    chunks: Vec<Vector2<i32>>,
+    center_chunk: Vector2<i32>,
+    epoch: u32,
+}
+
+#[derive(Default)]
+struct BedrockEntityChunkQueue {
+    pending: VecDeque<BedrockEntityChunkBatch>,
+    worker_running: bool,
+}
+
+struct ChunkWatcherTransition {
+    world: Arc<World>,
+    loading_chunks: Vec<Vector2<i32>>,
+    unloading_chunks: Vec<Vector2<i32>>,
+    completion: Option<tokio::sync::oneshot::Sender<Vec<Vector2<i32>>>>,
+}
+
+#[derive(Default)]
+struct ChunkWatcherTransitionQueue {
+    pending: VecDeque<ChunkWatcherTransition>,
+    worker_running: bool,
+}
+
+pub(crate) struct HeldChunkTickets {
+    pub(crate) center: Vector2<i32>,
+    pub(crate) view_level: Option<i8>,
+    pub(crate) simulation_level: Option<i8>,
+}
+
 pub struct Player {
     /// The underlying living entity object that represents the player.
     pub living_entity: LivingEntity,
@@ -467,6 +499,7 @@ pub struct Player {
     /// Whether the client has reported that it has loaded.
     pub client_loaded: AtomicBool,
     pub bedrock_spawned: AtomicBool,
+    bedrock_entity_chunks: Mutex<BedrockEntityChunkQueue>,
     /// Whether the player is frozen in place (movement locked for dialogues/cutscenes).
     pub is_movement_locked: AtomicBool,
     /// The amount of time (in ticks) the client has to report having finished loading before being timed out.
@@ -487,8 +520,12 @@ pub struct Player {
     pub experience_pick_up_delay: Mutex<u32>,
     pub chunk_sender: Mutex<crate::net::ChunkSender>,
     pub chunk_listener: Mutex<Receiver<(Vector2<i32>, Weak<ChunkData>)>>,
-    pub held_chunk_tickets: Mutex<Option<(Option<i8>, Option<i8>)>>,
+    pub(crate) held_chunk_tickets: Mutex<Option<HeldChunkTickets>>,
+    chunk_watcher_transitions: Mutex<ChunkWatcherTransitionQueue>,
     pub chunk_send_epoch: AtomicU32,
+    /// Prevents stale player ticks from streaming either world's chunks during a world transfer.
+    chunk_streaming_paused: AtomicBool,
+    client_movement_lock: Mutex<()>,
     pub has_played_before: AtomicBool,
     root_vehicle_uuid: AtomicCell<Option<Uuid>>,
     pub chat_session: Arc<Mutex<ChatSession>>,
@@ -758,6 +795,7 @@ impl Player {
             last_attacked_ticks: AtomicU32::new(0),
             client_loaded: AtomicBool::new(initially_loaded),
             bedrock_spawned: AtomicBool::new(false),
+            bedrock_entity_chunks: Mutex::new(BedrockEntityChunkQueue::default()),
             client_loaded_timeout: AtomicU32::new(if initially_loaded { 0 } else { 60 }),
             chat_spam_tick_count: AtomicU32::new(0),
             // Item usage tracking
@@ -785,7 +823,10 @@ impl Player {
             chunk_sender: Mutex::new(crate::net::ChunkSender::new()),
             chunk_listener: Mutex::new(world.level.chunk_listener.add_global_chunk_listener()),
             held_chunk_tickets: Mutex::new(None),
+            chunk_watcher_transitions: Mutex::new(ChunkWatcherTransitionQueue::default()),
             chunk_send_epoch: AtomicU32::new(0),
+            chunk_streaming_paused: AtomicBool::new(false),
+            client_movement_lock: Mutex::new(()),
             last_sent_xp: AtomicI32::new(-1),
             last_sent_health: AtomicI32::new(-1),
             last_sent_food: AtomicU8::new(0),
@@ -978,6 +1019,250 @@ impl Player {
         self.client.spawn_task(task)
     }
 
+    /// Queues a completed Bedrock chunk batch for entity loading. The single worker is held until
+    /// each entity-load task finishes, preventing successive network batches from creating
+    /// overlapping actor bursts.
+    fn queue_bedrock_entity_chunks(
+        self: &Arc<Self>,
+        world: Arc<World>,
+        chunks: Vec<Vector2<i32>>,
+        center_chunk: Vector2<i32>,
+        epoch: u32,
+    ) {
+        if chunks.is_empty() {
+            return;
+        }
+
+        let should_start = {
+            let mut queue = self
+                .bedrock_entity_chunks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            queue.pending.push_back(BedrockEntityChunkBatch {
+                world,
+                chunks,
+                center_chunk,
+                epoch,
+            });
+            if self.bedrock_spawned.load(Ordering::Acquire) && !queue.worker_running {
+                queue.worker_running = true;
+                true
+            } else {
+                false
+            }
+        };
+
+        if should_start {
+            self.start_bedrock_entity_chunk_worker();
+        }
+    }
+
+    /// Atomically validates the chunk generation and publishes `PlayerSpawn`. World changes and
+    /// teleports advance the same generation while holding `bedrock_entity_chunks`, so a stale
+    /// tick cannot unlock actors for a destination whose terrain has not arrived.
+    fn try_finish_bedrock_spawn(
+        self: &Arc<Self>,
+        client: &crate::net::bedrock::BedrockClient,
+        expected_world: &Arc<World>,
+        expected_epoch: u32,
+    ) -> bool {
+        let should_start = {
+            let mut queue = self
+                .bedrock_entity_chunks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if self.bedrock_spawned.load(Ordering::Acquire)
+                || self.is_chunk_streaming_paused()
+                || self.chunk_send_epoch.load(Ordering::Acquire) != expected_epoch
+                || !Arc::ptr_eq(&self.world(), expected_world)
+                || self
+                    .chunk_sender
+                    .lock()
+                    .map_or(0, |sender| sender.bedrock_completed_chunks_count())
+                    <= 4
+            {
+                return false;
+            }
+
+            let spawn_queued = client
+                .serialize_packet(&CPlayStatus::PlayerSpawn)
+                .is_ok_and(|data| client.try_enqueue_packet_data_checked(data));
+            if !spawn_queued {
+                return false;
+            }
+
+            self.bedrock_spawned.store(true, Ordering::Release);
+            if !queue.pending.is_empty() && !queue.worker_running {
+                queue.worker_running = true;
+                true
+            } else {
+                false
+            }
+        };
+
+        if should_start {
+            self.start_bedrock_entity_chunk_worker();
+        }
+        true
+    }
+
+    fn start_bedrock_entity_chunk_worker(self: &Arc<Self>) {
+        let worker_player = Arc::clone(self);
+        let handle = self.spawn_task(async move {
+            worker_player.run_bedrock_entity_chunk_worker().await;
+        });
+        if handle.is_none() {
+            self.bedrock_entity_chunks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .worker_running = false;
+        }
+    }
+
+    async fn run_bedrock_entity_chunk_worker(self: Arc<Self>) {
+        loop {
+            let batch = {
+                let mut queue = self
+                    .bedrock_entity_chunks
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if !self.bedrock_spawned.load(Ordering::Acquire) {
+                    queue.worker_running = false;
+                    return;
+                }
+                let Some(batch) = queue.pending.pop_front() else {
+                    queue.worker_running = false;
+                    return;
+                };
+                batch
+            };
+
+            if self.chunk_send_epoch.load(Ordering::Acquire) != batch.epoch
+                || !Arc::ptr_eq(&self.world(), &batch.world)
+            {
+                continue;
+            }
+
+            if let Some(handle) = batch.world.spawn_world_entity_chunks(
+                Arc::clone(&self),
+                batch.chunks,
+                batch.center_chunk,
+                batch.epoch,
+            ) {
+                let _ = handle.await;
+            }
+        }
+    }
+
+    pub(crate) fn queue_chunk_watcher_transition(
+        self: &Arc<Self>,
+        world: Arc<World>,
+        loading_chunks: Vec<Vector2<i32>>,
+        unloading_chunks: Vec<Vector2<i32>>,
+    ) {
+        self.enqueue_chunk_watcher_transition(world, loading_chunks, unloading_chunks, None);
+    }
+
+    async fn queue_chunk_watcher_transition_and_wait(
+        self: &Arc<Self>,
+        world: Arc<World>,
+        loading_chunks: Vec<Vector2<i32>>,
+        unloading_chunks: Vec<Vector2<i32>>,
+    ) -> Vec<Vector2<i32>> {
+        let (completion, completed) = tokio::sync::oneshot::channel();
+        self.enqueue_chunk_watcher_transition(
+            world,
+            loading_chunks,
+            unloading_chunks,
+            Some(completion),
+        );
+        completed.await.unwrap_or_default()
+    }
+
+    fn enqueue_chunk_watcher_transition(
+        self: &Arc<Self>,
+        world: Arc<World>,
+        loading_chunks: Vec<Vector2<i32>>,
+        unloading_chunks: Vec<Vector2<i32>>,
+        completion: Option<tokio::sync::oneshot::Sender<Vec<Vector2<i32>>>>,
+    ) {
+        if loading_chunks.is_empty() && unloading_chunks.is_empty() {
+            if let Some(completion) = completion {
+                let _ = completion.send(Vec::new());
+            }
+            return;
+        }
+
+        let Some(server) = world.server.upgrade() else {
+            if let Some(completion) = completion {
+                let _ = completion.send(Vec::new());
+            }
+            return;
+        };
+
+        let should_start = {
+            let mut queue = self
+                .chunk_watcher_transitions
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            queue.pending.push_back(ChunkWatcherTransition {
+                world,
+                loading_chunks,
+                unloading_chunks,
+                completion,
+            });
+            if queue.worker_running {
+                false
+            } else {
+                queue.worker_running = true;
+                true
+            }
+        };
+
+        if should_start {
+            let player = Arc::clone(self);
+            server.spawn_task(async move {
+                player.run_chunk_watcher_transition_worker().await;
+            });
+        }
+    }
+
+    async fn run_chunk_watcher_transition_worker(self: Arc<Self>) {
+        loop {
+            let transition = {
+                let mut queue = self
+                    .chunk_watcher_transitions
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let Some(transition) = queue.pending.pop_front() else {
+                    queue.worker_running = false;
+                    return;
+                };
+                transition
+            };
+
+            transition
+                .world
+                .level
+                .mark_chunks_as_newly_watched(&transition.loading_chunks)
+                .await;
+            let chunks_to_clean = transition
+                .world
+                .level
+                .mark_chunks_as_not_watched(&transition.unloading_chunks)
+                .await;
+            if !chunks_to_clean.is_empty() {
+                transition
+                    .world
+                    .remove_entities_in_chunks(&chunks_to_clean)
+                    .await;
+            }
+            if let Some(completion) = transition.completion {
+                let _ = completion.send(chunks_to_clean);
+            }
+        }
+    }
+
     pub const fn inventory(&self) -> &Arc<PlayerInventory> {
         &self.inventory
     }
@@ -1037,17 +1322,15 @@ impl Player {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .increment_custom(statistics::CustomStatistic::LeaveGame, 1);
         let world = self.world();
+        self.pause_chunk_streaming_for_transfer();
         world.remove_player(self, true).await;
 
         let cylindrical = self.watched_section.load();
         self.clean_up_chunk_tickets(&world.level);
-        if let Ok(mut sender) = self.chunk_sender.lock() {
-            sender.reset();
-        }
 
         // Radial chunks are all of the chunks the player is theoretically viewing.
         // Given enough time, all of these chunks will be in memory.
-        let radial_chunks = cylindrical.all_chunks_within();
+        let radial_chunks: Vec<_> = cylindrical.all_chunks_within().collect();
 
         debug!(
             "Removing player {}, unwatching {} chunks",
@@ -1057,18 +1340,14 @@ impl Player {
 
         let level = &world.level;
 
-        // Decrement the value of watched chunks
-        let chunks_to_clean = level.mark_chunks_as_not_watched(radial_chunks).await;
-        // Remove chunks with no watchers from the cache
-        if !chunks_to_clean.is_empty() {
-            world.remove_entities_in_chunks(&chunks_to_clean).await;
-            level.clean_entity_chunks(&chunks_to_clean);
-        }
+        // Serialize the final unwatch behind every movement transition published before the
+        // disconnect pause. The worker also removes entities from chunks with no remaining views.
+        self.queue_chunk_watcher_transition_and_wait(world.clone(), Vec::new(), radial_chunks)
+            .await;
         // Remove left over entries from all possiblily loaded chunks
         let cleaned_chunks = level.clean_memory();
         if !cleaned_chunks.is_empty() {
             world.remove_entities_in_chunks(&cleaned_chunks).await;
-            level.clean_entity_chunks(&cleaned_chunks);
         }
 
         debug!(
@@ -1096,22 +1375,21 @@ impl Player {
     }
 
     pub fn clean_up_chunk_tickets(&self, level: &Arc<pumpkin_world::level::Level>) {
-        let mut lock = level
-            .chunk_loading
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let held = self
             .held_chunk_tickets
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take();
-        if let Some((view_level, sim_level)) = held {
-            let center = self.get_entity().chunk_pos.load();
-            if let Some(view) = view_level {
-                lock.remove_ticket(center, view);
+        let mut lock = level
+            .chunk_loading
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(held) = held {
+            if let Some(view) = held.view_level {
+                lock.remove_ticket(held.center, view);
             }
-            if let Some(sim) = sim_level {
-                lock.remove_ticket(center, sim);
+            if let Some(sim) = held.simulation_level {
+                lock.remove_ticket(held.center, sim);
             }
         }
         lock.send_change();
@@ -1132,10 +1410,60 @@ impl Player {
         if let Ok(mut listener) = self.chunk_listener.lock() {
             *listener = new_world.level.chunk_listener.add_global_chunk_listener();
         }
-        self.chunk_send_epoch.fetch_add(1, Ordering::Relaxed);
+        if !self.is_chunk_streaming_paused() {
+            self.reset_chunk_send_generation();
+        }
+    }
+
+    fn reset_chunk_send_generation(&self) {
+        let mut bedrock_entity_chunks = self
+            .bedrock_entity_chunks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.chunk_send_epoch.fetch_add(1, Ordering::AcqRel);
         if let Ok(mut sender) = self.chunk_sender.lock() {
             sender.reset();
         }
+        if matches!(self.client.as_ref(), ClientPlatform::Bedrock(_)) {
+            self.bedrock_spawned.store(false, Ordering::Release);
+            self.set_client_loaded(false);
+            bedrock_entity_chunks.pending.clear();
+        }
+    }
+
+    pub(crate) fn pause_chunk_streaming_for_transfer(&self) {
+        self.chunk_streaming_paused.store(true, Ordering::Release);
+        // A packet handler which passed the loaded-state check before the flag changed must
+        // finish its old-world transform before the transfer applies its destination transform.
+        let _movement_guard = self
+            .client_movement_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Reset while holding the same locks used by spawn completion. Besides invalidating
+        // asynchronous encoders, acquiring `chunk_sender` is a barrier for a tick which entered
+        // chunk streaming immediately before the pause flag changed.
+        self.reset_chunk_send_generation();
+    }
+
+    pub(crate) fn is_chunk_streaming_paused(&self) -> bool {
+        self.chunk_streaming_paused.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn lock_client_movement_if_loaded(&self) -> Option<std::sync::MutexGuard<'_, ()>> {
+        let guard = self.lock_client_movement_if_unpaused()?;
+        self.has_client_loaded().then_some(guard)
+    }
+
+    pub(crate) fn lock_client_movement_if_unpaused(&self) -> Option<std::sync::MutexGuard<'_, ()>> {
+        let guard = self
+            .client_movement_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (!self.is_chunk_streaming_paused()).then_some(guard)
+    }
+
+    pub(crate) fn resume_chunk_streaming_after_transfer(&self) {
+        self.chunk_streaming_paused.store(false, Ordering::Release);
     }
 
     #[expect(clippy::too_many_lines)]
@@ -2558,8 +2886,11 @@ impl Player {
         {
             *xp -= 1;
         }
-        if let Ok(listener) = self.chunk_listener.try_lock()
+        let chunk_streaming_paused = self.is_chunk_streaming_paused();
+        if !chunk_streaming_paused
+            && let Ok(listener) = self.chunk_listener.try_lock()
             && let Ok(mut sender) = self.chunk_sender.try_lock()
+            && !self.is_chunk_streaming_paused()
         {
             let center = self.get_entity().chunk_pos.load();
             let view_dist =
@@ -2573,66 +2904,144 @@ impl Player {
 
         let world = self.world();
         let player_chunk = self.get_entity().chunk_pos.load();
-        let epoch = self.chunk_send_epoch.load(Ordering::Relaxed);
+        let epoch = self.chunk_send_epoch.load(Ordering::Acquire);
         let version = match self.client.as_ref() {
             ClientPlatform::Java(java_client) => java_client.version.load(),
             ClientPlatform::Bedrock(_) => JavaMinecraftVersion::V_1_20_2,
         };
 
-        let prepared_batch = self.chunk_sender.try_lock().ok().and_then(|mut sender| {
-            sender.prepare_batch(&world.level, player_chunk, epoch, version)
-        });
+        let prepared_batch = if chunk_streaming_paused {
+            None
+        } else {
+            self.chunk_sender.try_lock().ok().and_then(|mut sender| {
+                if self.is_chunk_streaming_paused()
+                    || self.chunk_send_epoch.load(Ordering::Acquire) != epoch
+                    || !Arc::ptr_eq(&self.world(), &world)
+                {
+                    None
+                } else {
+                    sender.prepare_batch(&world.level, player_chunk, epoch, version)
+                }
+            })
+        };
 
-        let total_sent_chunks = prepared_batch.map_or_else(
-            || {
-                self.chunk_sender
-                    .try_lock()
-                    .map_or(0, |s| s.sent_chunks_count())
-            },
-            |batch| match self.client.as_ref() {
-                ClientPlatform::Java(_) => {
-                    let mut per_player_cache = rustc_hash::FxHashMap::default();
-                    let encoded =
-                        crate::net::ChunkSender::encode_batch(&batch, &mut per_player_cache);
-                    let current_epoch = self.chunk_send_epoch.load(Ordering::Relaxed);
-                    self.chunk_sender.try_lock().map_or(0, |mut sender| {
-                        sender.commit_batch(&batch, &encoded, &self.client, current_epoch);
-                        sender.sent_chunks_count()
+        let total_sent_chunks = if chunk_streaming_paused {
+            0
+        } else {
+            prepared_batch.map_or_else(
+                || {
+                    self.chunk_sender.try_lock().map_or(0, |sender| {
+                        if self.is_chunk_streaming_paused() {
+                            0
+                        } else if matches!(self.client.as_ref(), ClientPlatform::Bedrock(_)) {
+                            sender.bedrock_completed_chunks_count()
+                        } else {
+                            sender.sent_chunks_count()
+                        }
                     })
-                }
-                ClientPlatform::Bedrock(_) => {
-                    let current_epoch = self.chunk_send_epoch.load(Ordering::Relaxed);
-                    let (chunks, total_sent_chunks) = self.chunk_sender.try_lock().map_or_else(
-                        |_| (Vec::new(), 0),
-                        |mut sender| {
-                            let chunks = sender.commit_bedrock_batch(&batch, current_epoch);
-                            let total_sent_chunks = sender.sent_chunks_count();
-                            (chunks, total_sent_chunks)
-                        },
-                    );
-                    if !chunks.is_empty() {
-                        let client = self.client.clone();
-                        self.spawn_task(async move {
-                            client.send_chunks(&chunks).await;
-                        });
+                },
+                |batch| match self.client.as_ref() {
+                    ClientPlatform::Java(_) => {
+                        let mut per_player_cache = rustc_hash::FxHashMap::default();
+                        let encoded =
+                            crate::net::ChunkSender::encode_batch(&batch, &mut per_player_cache);
+                        self.chunk_sender.try_lock().map_or(0, |mut sender| {
+                            if self.is_chunk_streaming_paused()
+                                || !Arc::ptr_eq(&self.world(), &world)
+                            {
+                                return 0;
+                            }
+                            let current_epoch = self.chunk_send_epoch.load(Ordering::Acquire);
+                            sender.commit_batch(&batch, &encoded, &self.client, current_epoch);
+                            sender.sent_chunks_count()
+                        })
                     }
-                    total_sent_chunks
-                }
-            },
-        );
+                    ClientPlatform::Bedrock(bedrock_client) => {
+                        let committed_batch =
+                            self.chunk_sender.try_lock().ok().and_then(|mut sender| {
+                                if self.is_chunk_streaming_paused()
+                                    || !Arc::ptr_eq(&self.world(), &world)
+                                {
+                                    None
+                                } else {
+                                    let current_epoch =
+                                        self.chunk_send_epoch.load(Ordering::Acquire);
+                                    sender.commit_bedrock_batch(&batch, current_epoch)
+                                }
+                            });
+                        if let Some(committed_batch) = committed_batch {
+                            let bedrock_client = Arc::clone(bedrock_client);
+                            let player = bedrock_client.player.load_full().as_ref().clone();
+                            let batch_world = Arc::clone(&world);
+                            self.spawn_task(async move {
+                                let Some(player) = player else {
+                                    return;
+                                };
+                                let send_result = bedrock_client
+                                    .send_chunks_for_batch(
+                                        &committed_batch.chunks,
+                                        &player,
+                                        &batch_world,
+                                        committed_batch.epoch_snapshot,
+                                    )
+                                    .await;
+
+                                let current_epoch = player.chunk_send_epoch.load(Ordering::Acquire);
+                                let expected_world_is_current =
+                                    Arc::ptr_eq(&player.world(), &batch_world);
+                                let ready_entity_chunks = player.chunk_sender.lock().map_or_else(
+                                    |_| Vec::new(),
+                                    |mut sender| {
+                                        sender.on_bedrock_batch_completed(
+                                            &committed_batch,
+                                            &send_result.queued_positions,
+                                            &send_result.cancelled_positions,
+                                            current_epoch,
+                                            expected_world_is_current,
+                                        )
+                                    },
+                                );
+
+                                // Entity chunks depend on their Bedrock level-chunk packets. Do not
+                                // hold the chunk-sender lock while queueing world/entity work. The
+                                // per-player worker also keeps actors behind PlayerSpawn and processes
+                                // one completed chunk batch at a time.
+                                if !ready_entity_chunks.is_empty() {
+                                    let center_chunk = player.get_entity().chunk_pos.load();
+                                    player.queue_bedrock_entity_chunks(
+                                        batch_world,
+                                        ready_entity_chunks,
+                                        center_chunk,
+                                        committed_batch.epoch_snapshot,
+                                    );
+                                }
+                            });
+                        }
+                        self.chunk_sender
+                            .try_lock()
+                            .map_or(0, |sender| sender.bedrock_completed_chunks_count())
+                    }
+                },
+            )
+        };
 
         if let ClientPlatform::Bedrock(bedrock_client) = self.client.as_ref()
             && !self.bedrock_spawned.load(Ordering::Relaxed)
             && total_sent_chunks > 4
         {
-            if let Ok(data) = bedrock_client.serialize_packet(&CPlayStatus::PlayerSpawn) {
-                bedrock_client.try_enqueue_packet(data);
-            }
-            self.bedrock_spawned.store(true, Ordering::Relaxed);
-            self.set_client_loaded(true);
-            self.send_health();
-            if self.living_entity.health.load() <= 0.0 {
-                self.send_bedrock_respawn_state(RespawnState::SearchingForSpawn);
+            let client_player = bedrock_client.player.load_full();
+            if client_player
+                .as_ref()
+                .as_ref()
+                .is_some_and(|client_player| {
+                    client_player.try_finish_bedrock_spawn(bedrock_client, &world, epoch)
+                })
+            {
+                self.set_client_loaded(true);
+                self.send_health();
+                if self.living_entity.health.load() <= 0.0 {
+                    self.send_bedrock_respawn_state(RespawnState::SearchingForSpawn);
+                }
             }
         }
         self.tick_counter.fetch_add(1, Ordering::Relaxed);
@@ -2842,6 +3251,12 @@ impl Player {
 
     #[must_use]
     pub fn has_client_loaded(&self) -> bool {
+        if self.is_chunk_streaming_paused()
+            || (matches!(self.client.as_ref(), ClientPlatform::Bedrock(_))
+                && !self.bedrock_spawned.load(Ordering::Acquire))
+        {
+            return false;
+        }
         if !self.supports_player_loaded() {
             return true;
         }
@@ -2909,6 +3324,94 @@ impl Player {
 
     pub const fn entity_id(&self) -> i32 {
         self.living_entity.entity.entity_id
+    }
+
+    pub(crate) fn bedrock_add_player_packet(
+        &self,
+    ) -> pumpkin_protocol::bedrock::client::add_player::CAddPlayer {
+        let entity = self.get_entity();
+        let position = entity.pos.load();
+        let velocity = entity.velocity.load();
+        let held_item = self.inventory().held_item();
+        pumpkin_protocol::bedrock::client::add_player::CAddPlayer {
+            uuid: self.gameprofile.id,
+            player_name: self.gameprofile.name.clone(),
+            target_runtime_id: VarULong(self.entity_id() as u64),
+            platform_chat_id: String::new(),
+            position: Vector3::new(position.x as f32, position.y as f32, position.z as f32),
+            velocity: Vector3::new(velocity.x as f32, velocity.y as f32, velocity.z as f32),
+            rotation: Vector2::new(entity.pitch.load(), entity.yaw.load()),
+            y_head_rotation: entity.head_yaw.load(),
+            carried_item: (&held_item).into(),
+            player_game_type: self.gamemode.load().into(),
+            entity_data: entity.bedrock_metadata(),
+            synced_properties:
+                pumpkin_protocol::bedrock::client::set_actor_data::PropertySyncData::default(),
+            abilities_data: SerializedAbilitiesData {
+                target_player_raw_id: i64::from(self.entity_id()),
+                player_permissions: PlayerPermissionLevel::Visitor,
+                command_permissions: CommandPermissionLevel::Any,
+                layers: vec![SerializedAbilitiesDataSerializedLayer {
+                    serialized_layer: 0,
+                    abilities_set: 0,
+                    ability_value: 0,
+                    fly_speed: 0.05,
+                    vertical_fly_speed: 0.05,
+                    walk_speed: 0.1,
+                }],
+            },
+            actor_links: Vec::new(),
+            device_id: String::new(),
+            build_platform: pumpkin_protocol::bedrock::client::common::BuildPlatform::Unknown,
+        }
+    }
+
+    pub(crate) fn bedrock_player_list_add_packet(
+        &self,
+    ) -> pumpkin_protocol::bedrock::client::player_list::CPlayerList {
+        pumpkin_protocol::bedrock::client::player_list::CPlayerList {
+            action: pumpkin_protocol::bedrock::client::player_list::CPlayerList::ACTION_ADD,
+            entries: vec![
+                pumpkin_protocol::bedrock::client::player_list::PlayerListEntry {
+                    uuid: self.gameprofile.id,
+                    entity_unique_id: VarLong(i64::from(self.entity_id())),
+                    username: self.gameprofile.name.clone(),
+                    xuid: String::new(),
+                    platform_chat_id: String::new(),
+                    build_platform:
+                        pumpkin_protocol::bedrock::client::common::BuildPlatform::Unknown,
+                    skin: (**self.bedrock_skin.load()).clone(),
+                    is_teacher: false,
+                    is_host: false,
+                    is_sub_client: false,
+                    player_color: [0; 4],
+                },
+            ],
+        }
+    }
+
+    pub(crate) fn bedrock_player_list_remove_packet(
+        &self,
+    ) -> pumpkin_protocol::bedrock::client::player_list::CPlayerList {
+        pumpkin_protocol::bedrock::client::player_list::CPlayerList {
+            action: pumpkin_protocol::bedrock::client::player_list::CPlayerList::ACTION_REMOVE,
+            entries: vec![
+                pumpkin_protocol::bedrock::client::player_list::PlayerListEntry {
+                    uuid: self.gameprofile.id,
+                    entity_unique_id: VarLong(i64::from(self.entity_id())),
+                    username: self.gameprofile.name.clone(),
+                    xuid: String::new(),
+                    platform_chat_id: String::new(),
+                    build_platform:
+                        pumpkin_protocol::bedrock::client::common::BuildPlatform::Unknown,
+                    skin: pumpkin_protocol::bedrock::client::player_list::Skin::steve(),
+                    is_teacher: false,
+                    is_host: false,
+                    is_sub_client: false,
+                    player_color: [0; 4],
+                },
+            ],
+        }
     }
 
     /// Sets the player's camera target entity ID.
@@ -3667,14 +4170,11 @@ impl Player {
         res.map(|(pos, _)| pos)
     }
 
-    pub async fn unload_watched_chunks(&self, world: &World) {
-        let radial_chunks = self.watched_section.load().all_chunks_within();
-        let level = &world.level;
-        let chunks_to_clean = level.mark_chunks_as_not_watched(radial_chunks).await;
-        if !chunks_to_clean.is_empty() {
-            world.remove_entities_in_chunks(&chunks_to_clean).await;
-            level.clean_entity_chunks(&chunks_to_clean);
-        }
+    pub async fn unload_watched_chunks(self: &Arc<Self>, world: &Arc<World>) {
+        let radial_chunks: Vec<_> = self.watched_section.load().all_chunks_within().collect();
+        let chunks_to_clean = self
+            .queue_chunk_watcher_transition_and_wait(world.clone(), Vec::new(), radial_chunks)
+            .await;
         for chunk in &chunks_to_clean {
             self.send_client_packet(&CUnloadChunk::new(chunk.x, chunk.y))
                 .await;
@@ -3723,18 +4223,27 @@ impl Player {
                 let new_world = event.new_world;
 
                 self.set_client_loaded(false);
+                self.pause_chunk_streaming_for_transfer();
                 let Some(player) = current_world.remove_player(self, false).await else {
+                    self.resume_chunk_streaming_after_transfer();
                     return;
                 };
-               new_world.players.rcu(|current_list| {
-                    let mut new_list = (**current_list).clone();
-                    new_list.push(player.clone());
-                    new_list
-                });
                 self.unload_watched_chunks(&current_world).await;
+
+                let last_pos = self.living_entity.entity.last_pos.load();
+                let death_dimension =
+                    ResourceLocation::from(current_world.dimension.minecraft_name);
+                let death_location = BlockPos(Vector3::new(
+                    last_pos.x.round() as i32,
+                    last_pos.y.round() as i32,
+                    last_pos.z.round() as i32,
+                ));
 
                 self.change_world_chunks(&current_world.level, &new_world);
                 self.living_entity.entity.set_world(new_world.clone());
+                player.get_entity().set_pos(position);
+                player.get_entity().set_rotation(yaw, pitch);
+                player.get_entity().last_pos.store(position);
 
                 if new_world.dimension == pumpkin_data::dimension::Dimension::THE_NETHER {
                     self.trigger_advancement(crate::entity::player::advancement::trigger::AdvancementTrigger::EnterDimension {
@@ -3746,13 +4255,6 @@ impl Player {
                     });
                 }
 
-                let last_pos = self.living_entity.entity.last_pos.load();
-                let death_dimension = ResourceLocation::from(self.world().dimension.minecraft_name);
-                let death_location = BlockPos(Vector3::new(
-                    last_pos.x.round() as i32,
-                    last_pos.y.round() as i32,
-                    last_pos.z.round() as i32,
-                ));
                 match self.client.as_ref() {
                     ClientPlatform::Java(java) => {
                         let packet = CRespawn::new(
@@ -3793,15 +4295,21 @@ impl Player {
                         if let Ok(data) = bedrock.serialize_packet(&change_dim_packet) {
                             bedrock.enqueue_packet(data).await;
                         }
-                        self.bedrock_spawned.store(false, Ordering::Relaxed);
                     }
                 }
 
                 self.send_permission_lvl_update();
 
-                player.get_entity().set_pos(position);
-                player.get_entity().set_rotation(yaw, pitch);
-                player.get_entity().last_pos.store(position);
+                new_world.players.rcu(|current_list| {
+                    let mut new_list = (**current_list).clone();
+                    new_list.push(player.clone());
+                    new_list
+                });
+                let tracked_player = player.clone() as Arc<dyn EntityBase>;
+                new_world
+                    .entity_tracker
+                    .add_entity(&tracked_player, &new_world);
+                new_world.sync_bedrock_player_lists_on_join(&player).await;
 
                 self.send_abilities_update();
 
@@ -3813,6 +4321,7 @@ impl Player {
 
                 self.send_health();
 
+                self.resume_chunk_streaming_after_transfer();
                 new_world.send_world_info(&player, position, yaw, pitch);
 
                 if let ClientPlatform::Java(java_client) = player.client.as_ref() {
@@ -3824,7 +4333,7 @@ impl Player {
                     java_client.send_chunks(&[chunk]).await;
                 }
 
-                player.request_teleport(position, yaw, pitch);
+                player.request_teleport_in_current_chunk_epoch(position, yaw, pitch);
 
                 let mut changed_world_event = crate::plugin::api::events::player::player_changed_world::PlayerChangedWorldEvent {
                     player: player.clone(),
@@ -3841,6 +4350,37 @@ impl Player {
     /// Rarly used, for example when waking up the player from a bed or their first time spawn. Otherwise, the `teleport` method should be used.
     /// The player should respond with the `SConfirmTeleport` packet.
     pub fn request_teleport(&self, position: Vector3<f64>, yaw: f32, pitch: f32) {
+        self.request_teleport_inner(position, yaw, pitch, true);
+    }
+
+    pub(crate) fn request_teleport_in_current_chunk_epoch(
+        &self,
+        position: Vector3<f64>,
+        yaw: f32,
+        pitch: f32,
+    ) {
+        self.request_teleport_inner(position, yaw, pitch, false);
+    }
+
+    pub(crate) fn advance_chunk_send_epoch(&self) {
+        let _spawn_guard = self
+            .bedrock_entity_chunks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _chunk_sender_guard = self
+            .chunk_sender
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.chunk_send_epoch.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn request_teleport_inner(
+        &self,
+        position: Vector3<f64>,
+        yaw: f32,
+        pitch: f32,
+        advance_chunk_epoch: bool,
+    ) {
         // This is the ultra special magic code used to create the teleport id
         // This returns the old value
         // This operation wraps around on overflow.
@@ -3861,7 +4401,9 @@ impl Player {
         }
 
         let i = self.teleport_id_count.fetch_add(1, Ordering::Relaxed);
-        self.chunk_send_epoch.fetch_add(1, Ordering::Relaxed);
+        if advance_chunk_epoch {
+            self.advance_chunk_send_epoch();
+        }
         let teleport_id = i + 1;
         self.living_entity.entity.set_pos(position);
         let entity = &self.living_entity.entity;
@@ -6036,9 +6578,16 @@ impl Player {
         };
 
         if all {
-            world.broadcast_editioned(&je_packet, &be_packet);
+            self.get_entity().send_tracked_editioned(
+                self.get_entity().chunk_pos.load(),
+                &je_packet,
+                &be_packet,
+            );
         } else {
-            world.broadcast_packet_except_editioned(&[self.gameprofile.id], &je_packet, &be_packet);
+            world.broadcast_packet_except(&[self.gameprofile.id], &je_packet);
+            if let Some(tracked) = world.entity_tracker.get_tracked_entity(entity_id) {
+                tracked.send_to_tracking_players_bedrock(&be_packet, &world);
+            }
         }
     }
 

--- a/crates/pumpkin/src/lib.rs
+++ b/crates/pumpkin/src/lib.rs
@@ -62,6 +62,9 @@ pub mod plugin;
 pub mod server;
 pub mod world;
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 pub struct LoggingConfig {
     pub color: bool,
     pub threads: bool,

--- a/crates/pumpkin/src/net/bedrock/mod.rs
+++ b/crates/pumpkin/src/net/bedrock/mod.rs
@@ -61,11 +61,18 @@ use crate::{
     net::{DisconnectReason, PacketHandlerResult, PacketRateLimiter},
     plugin::api::events::world::chunk_send::ChunkSend,
     server::Server,
+    world::World,
 };
 use arc_swap::ArcSwap;
 use pumpkin_protocol::bedrock::server::login::ClientData;
-use pumpkin_util::version::BedrockMinecraftVersion;
+use pumpkin_util::{math::vector2::Vector2, version::BedrockMinecraftVersion};
 use pumpkin_world::level::SyncChunk;
+
+#[derive(Default)]
+pub(crate) struct BedrockChunkSendResult {
+    pub queued_positions: Vec<Vector2<i32>>,
+    pub cancelled_positions: Vec<Vector2<i32>>,
+}
 
 pub struct OutgoingPacket {
     pub data: Bytes,
@@ -305,51 +312,102 @@ impl BedrockClient {
         self.close().await;
     }
 
-    pub async fn send_chunks(&self, chunks: &[SyncChunk]) {
-        let player = self.player.load_full();
-        let Some(player) = player.as_ref() else {
+    pub async fn send_chunks(&self, chunks: &[SyncChunk]) -> Vec<Vector2<i32>> {
+        let player_snapshot = self.player.load_full();
+        let Some(player) = player_snapshot.as_ref() else {
             debug!(
                 "send_chunks: player not set yet, dropping {} chunks",
                 chunks.len()
             );
-            return;
+            return Vec::new();
         };
-        let Some(server) = player.world().server.upgrade() else {
-            return;
+        let world = player.world();
+        self.send_chunks_in_world(chunks, player, &world, None)
+            .await
+            .queued_positions
+    }
+
+    pub(crate) async fn send_chunks_for_batch(
+        &self,
+        chunks: &[SyncChunk],
+        player: &Arc<Player>,
+        world: &Arc<World>,
+        expected_epoch: u32,
+    ) -> BedrockChunkSendResult {
+        self.send_chunks_in_world(chunks, player, world, Some(expected_epoch))
+            .await
+    }
+
+    fn chunk_send_context_is_current(
+        player: &Player,
+        world: &Arc<World>,
+        expected_epoch: Option<u32>,
+    ) -> bool {
+        !player.is_chunk_streaming_paused()
+            && Arc::ptr_eq(&player.world(), world)
+            && expected_epoch.is_none_or(|expected_epoch| {
+                player.chunk_send_epoch.load(Ordering::Acquire) == expected_epoch
+            })
+    }
+
+    #[allow(clippy::too_many_lines)]
+    async fn send_chunks_in_world(
+        &self,
+        chunks: &[SyncChunk],
+        player: &Arc<Player>,
+        world: &Arc<World>,
+        expected_epoch: Option<u32>,
+    ) -> BedrockChunkSendResult {
+        let mut result = BedrockChunkSendResult::default();
+        if !Self::chunk_send_context_is_current(player, world, expected_epoch) {
+            return result;
+        }
+        let Some(server) = world.server.upgrade() else {
+            return result;
         };
 
         let mut valid_chunks = Vec::with_capacity(chunks.len());
         for chunk in chunks {
-            let mut event = ChunkSend::new(player.world(), chunk.clone());
+            if !Self::chunk_send_context_is_current(player, world, expected_epoch) {
+                return result;
+            }
+            let mut event = ChunkSend::new(Arc::clone(world), chunk.clone());
             server.plugin_manager.fire(&server, &mut event).await;
-            if !event.cancelled {
+            if !Self::chunk_send_context_is_current(player, world, expected_epoch) {
+                return result;
+            }
+            if event.cancelled {
+                result
+                    .cancelled_positions
+                    .push(Vector2::new(chunk.x, chunk.z));
+            } else {
                 valid_chunks.push(chunk.clone());
             }
         }
 
         if valid_chunks.is_empty() {
-            return;
+            return result;
         }
 
-        let bedrock_dimension =
-            if player.world().dimension == pumpkin_data::dimension::Dimension::THE_NETHER {
-                1
-            } else if player.world().dimension == pumpkin_data::dimension::Dimension::THE_END {
-                2
-            } else {
-                0
-            };
+        let bedrock_dimension = if world.dimension == pumpkin_data::dimension::Dimension::THE_NETHER
+        {
+            1
+        } else if world.dimension == pumpkin_data::dimension::Dimension::THE_END {
+            2
+        } else {
+            0
+        };
 
         let cache_enabled = server.advanced_config.networking.bedrock.chunk_caching
             && self.client_cache_supported.load(Ordering::Relaxed);
 
-        let world = player.world();
+        let encoding_world = Arc::clone(world);
         let (tx, rx) = tokio::sync::oneshot::channel();
         rayon::spawn(move || {
             let mut encoded_payloads = Vec::with_capacity(valid_chunks.len());
             let mut new_blobs = Vec::new();
             for chunk in valid_chunks {
-                let block_actors = world.bedrock_chunk_block_actors(&chunk);
+                let block_actors = encoding_world.bedrock_chunk_block_actors(&chunk);
                 match CLevelChunk::encode_chunk(
                     &chunk,
                     bedrock_dimension,
@@ -357,7 +415,7 @@ impl BedrockClient {
                     &block_actors,
                 ) {
                     Ok((payload, blobs)) => {
-                        encoded_payloads.push(payload);
+                        encoded_payloads.push((Vector2::new(chunk.x, chunk.z), payload));
                         new_blobs.extend(blobs);
                     }
                     Err(e) => error!("Failed to serialize Bedrock chunk: {:?}", e),
@@ -367,8 +425,11 @@ impl BedrockClient {
         });
 
         let Ok((encoded_payloads, new_blobs)) = rx.await else {
-            return;
+            return result;
         };
+        if !Self::chunk_send_context_is_current(player, world, expected_epoch) {
+            return result;
+        }
 
         if !new_blobs.is_empty() {
             let mut cache = self
@@ -383,7 +444,10 @@ impl BedrockClient {
         let mut packets_to_enqueue = Vec::with_capacity(encoded_payloads.len());
         {
             let encoder = self.network_writer.read().await;
-            for payload in encoded_payloads {
+            if !Self::chunk_send_context_is_current(player, world, expected_epoch) {
+                return result;
+            }
+            for (position, payload) in encoded_payloads {
                 let mut packet_buf = Vec::new();
                 match encoder.write_game_packet(
                     CLevelChunk::PACKET_ID as u16,
@@ -392,14 +456,28 @@ impl BedrockClient {
                     &payload,
                     &mut packet_buf,
                 ) {
-                    Ok(()) => packets_to_enqueue.push(packet_buf),
+                    Ok(()) => packets_to_enqueue.push((position, packet_buf)),
                     Err(err) => error!("Failed to write game packet wrapper: {err}"),
                 }
             }
         }
-        for packet_buf in packets_to_enqueue {
-            self.enqueue_packet_data(packet_buf.into()).await;
+        for (position, packet_buf) in packets_to_enqueue {
+            if !Self::chunk_send_context_is_current(player, world, expected_epoch) {
+                break;
+            }
+            let queued = if expected_epoch.is_some() {
+                // A full normal queue is a transient failure for a tracked batch. Retrying on a
+                // later tick is preferable to waiting here and enqueueing an obsolete packet
+                // after a teleport changes the batch epoch.
+                self.try_enqueue_packet_data_checked(packet_buf.into())
+            } else {
+                self.queue_packet_data(packet_buf.into()).await
+            };
+            if queued {
+                result.queued_positions.push(position);
+            }
         }
+        result
     }
 
     pub fn set_player(&self, player: Arc<Player>) {
@@ -421,6 +499,10 @@ impl BedrockClient {
     ///
     /// * `packet_data`: A `Bytes` payload representing the encoded packet.
     pub async fn enqueue_packet_data(&self, packet_data: Bytes) {
+        self.queue_packet_data(packet_data).await;
+    }
+
+    async fn queue_packet_data(&self, packet_data: Bytes) -> bool {
         if let Err(err) = self
             .outgoing_packet_queue_send
             .send(OutgoingPacket::normal(packet_data))
@@ -430,10 +512,17 @@ impl BedrockClient {
             if !self.is_closed() {
                 error!("Failed to add packet to the outgoing packet queue for client: {err}");
             }
+            false
+        } else {
+            true
         }
     }
 
     pub fn try_enqueue_packet_data(&self, packet_data: Bytes) {
+        self.try_enqueue_packet_data_checked(packet_data);
+    }
+
+    pub(crate) fn try_enqueue_packet_data_checked(&self, packet_data: Bytes) -> bool {
         if let Err(err) = self
             .outgoing_packet_queue_send
             .try_send(OutgoingPacket::normal(packet_data))
@@ -452,7 +541,45 @@ impl BedrockClient {
                     }
                 }
             }
+            false
+        } else {
+            true
         }
+    }
+
+    /// Atomically reserves normal-queue capacity for an ordered packet group. Either every
+    /// packet is queued in order or none are, which is required for `PlayerList` + `AddPlayer`.
+    pub(crate) fn try_enqueue_packet_batch_checked(&self, packets: Vec<Bytes>) -> bool {
+        if packets.is_empty() {
+            return true;
+        }
+
+        let permits = match self
+            .outgoing_packet_queue_send
+            .try_reserve_many(packets.len())
+        {
+            Ok(permits) => permits,
+            Err(tokio::sync::mpsc::error::TrySendError::Full(())) => {
+                debug!("Failed to reserve outgoing Bedrock packet batch: channel full");
+                return false;
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(())) => {
+                if !self.is_closed() {
+                    error!("Failed to reserve outgoing Bedrock packet batch: channel closed");
+                }
+                return false;
+            }
+        };
+
+        for (permit, packet) in permits.zip(packets) {
+            permit.send(OutgoingPacket::normal(packet));
+        }
+        true
+    }
+
+    #[must_use]
+    pub(crate) fn has_outgoing_packet_capacity(&self) -> bool {
+        self.outgoing_packet_queue_send.capacity() > 0
     }
 
     pub fn write_raw_packet<P: BClientPacket>(

--- a/crates/pumpkin/src/net/bedrock/mod.rs
+++ b/crates/pumpkin/src/net/bedrock/mod.rs
@@ -484,6 +484,26 @@ impl BedrockClient {
         self.player.store(Arc::new(Some(player)));
     }
 
+    /// Observes the real normal FIFO without starting the network writer in integration tests.
+    #[cfg(test)]
+    pub(crate) async fn drain_outgoing_packets_for_test(&self) -> Vec<Bytes> {
+        let mut receiver = self.outgoing_packet_queue_recv.lock().await;
+        let receiver = receiver.as_mut().expect("test owns outgoing queue");
+        let mut packets = Vec::new();
+        while let Ok(packet) = receiver.try_recv() {
+            packets.push(packet.data);
+            if let Some(completion) = packet.completion {
+                let _ = completion.send(());
+            }
+        }
+        packets
+    }
+
+    #[cfg(test)]
+    pub(crate) fn outgoing_packet_capacity_for_test(&self) -> usize {
+        self.outgoing_packet_queue_send.capacity()
+    }
+
     pub async fn enqueue_packet(&self, packet_data: Bytes) {
         self.enqueue_packet_data(packet_data).await;
     }

--- a/crates/pumpkin/src/net/bedrock/nethernet.rs
+++ b/crates/pumpkin/src/net/bedrock/nethernet.rs
@@ -534,6 +534,29 @@ pub struct NetherNetSession {
 }
 
 impl NetherNetSession {
+    /// Creates an unnegotiated loopback-only transport for server integration tests.
+    /// No remote offer, discovery, authentication, or external ICE server is used.
+    #[cfg(test)]
+    pub(crate) async fn new_for_test() -> Self {
+        struct TestPeerEventHandler;
+
+        #[async_trait]
+        impl PeerConnectionEventHandler for TestPeerEventHandler {}
+
+        let address = SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0));
+        let peer = Box::pin(
+            PeerConnectionBuilder::new()
+                .with_configuration(RTCConfigurationBuilder::default().build())
+                .with_handler(Arc::new(TestPeerEventHandler))
+                .with_udp_addrs(vec![address])
+                .build(),
+        )
+        .await
+        .expect("unconnected loopback test peer");
+        let (incoming, _) = mpsc::channel(1);
+        Self::new(Arc::new(peer), None, address, incoming)
+    }
+
     fn new(
         peer: Arc<dyn PeerConnection>,
         client_public_key: Option<PublicKey>,

--- a/crates/pumpkin/src/net/bedrock/play/actor_event.rs
+++ b/crates/pumpkin/src/net/bedrock/play/actor_event.rs
@@ -17,14 +17,11 @@ impl BedrockClient {
         }
 
         let entity = player.get_entity();
-        entity.world.load().broadcast_to_chunk_bedrock(
-            entity.chunk_pos.load(),
-            &SActorEvent {
-                target_runtime_id: VarULong(entity.entity_id as u64),
-                event_id: ActorEventID::Feed,
-                data: packet.data,
-                fire_at_position: None,
-            },
-        );
+        entity.send_tracked_bedrock(&SActorEvent {
+            target_runtime_id: VarULong(entity.entity_id as u64),
+            event_id: ActorEventID::Feed,
+            data: packet.data,
+            fire_at_position: None,
+        });
     }
 }

--- a/crates/pumpkin/src/net/bedrock/play/animate.rs
+++ b/crates/pumpkin/src/net/bedrock/play/animate.rs
@@ -8,7 +8,6 @@ impl BedrockClient {
         }
 
         let entity = &player.get_entity();
-        let world = entity.world.load();
 
         let java_animation = match packet.action {
             AnimateAction::NoAction => None,
@@ -26,7 +25,7 @@ impl BedrockClient {
                 data: 0.0,
                 swing_source: None,
             };
-            world.broadcast_editioned(&je_packet, &be_packet);
+            entity.send_tracked_editioned(entity.chunk_pos.load(), &je_packet, &be_packet);
         }
     }
 }

--- a/crates/pumpkin/src/net/bedrock/play/emote.rs
+++ b/crates/pumpkin/src/net/bedrock/play/emote.rs
@@ -20,13 +20,13 @@ impl BedrockClient {
         broadcast_packet.actor_runtime_id = VarULong(entity.entity_id as u64);
         broadcast_packet.flags |= pumpkin_protocol::bedrock::server::emote::EMOTE_FLAG_SERVER_SIDE;
 
-        world.broadcast_packet_except_editioned(
-            &[player.gameprofile.id],
-            &CEntityAnimation::new(
-                VarInt(entity.entity_id),
-                Animation::SwingMainArm, // Fallback for Java? Or just ignore
-            ),
-            &broadcast_packet,
+        let je_packet = CEntityAnimation::new(
+            VarInt(entity.entity_id),
+            Animation::SwingMainArm, // Fallback for Java? Or just ignore
         );
+        world.broadcast_packet_except(&[player.gameprofile.id], &je_packet);
+        if let Some(tracked) = world.entity_tracker.get_tracked_entity(entity.entity_id) {
+            tracked.send_to_tracking_players_bedrock(&broadcast_packet, &world);
+        }
     }
 }

--- a/crates/pumpkin/src/net/bedrock/play/player_auth_input.rs
+++ b/crates/pumpkin/src/net/bedrock/play/player_auth_input.rs
@@ -10,9 +10,9 @@ impl BedrockClient {
         packet: SPlayerAuthInput,
         server: &Arc<Server>,
     ) {
-        if !player.has_client_loaded() {
+        let Some(movement_guard) = player.lock_client_movement_if_loaded() else {
             return;
-        }
+        };
         if player.living_entity.dead.load(Ordering::Relaxed)
             || player.living_entity.health.load() <= 0.0
         {
@@ -38,6 +38,11 @@ impl BedrockClient {
 
         let pos_changed = new_pos != old_pos;
         let rot_changed = new_pitch != old_pitch || new_yaw != old_yaw;
+        let delta = pumpkin_util::math::vector3::Vector3::new(
+            new_pos.x - old_pos.x,
+            new_pos.y - old_pos.y,
+            new_pos.z - old_pos.z,
+        );
 
         if pos_changed || rot_changed {
             let world = player.world();
@@ -52,12 +57,6 @@ impl BedrockClient {
 
             let je_yaw = (new_yaw * 256.0 / 360.0).rem_euclid(256.0);
             let je_pitch = (new_pitch * 256.0 / 360.0).rem_euclid(256.0);
-
-            let delta = pumpkin_util::math::vector3::Vector3::new(
-                new_pos.x - old_pos.x,
-                new_pos.y - old_pos.y,
-                new_pos.z - old_pos.z,
-            );
 
             let bedrock_move_packet = pumpkin_protocol::bedrock::client::CMovePlayer::new(
                 pumpkin_protocol::codec::var_ulong::VarULong(player.entity_id() as u64),
@@ -90,7 +89,7 @@ impl BedrockClient {
                     ),
                 );
             } else if pos_changed && rot_changed {
-                world.broadcast_packet_except_editioned(
+                world.broadcast_packet_except(
                     &[player.gameprofile.id],
                     &pumpkin_protocol::java::client::play::CUpdateEntityPosRot::new(
                         player.entity_id().into(),
@@ -103,10 +102,9 @@ impl BedrockClient {
                         je_pitch as u8, // Use converted Java byte
                         on_ground,
                     ),
-                    &bedrock_move_packet,
                 );
             } else if pos_changed {
-                world.broadcast_packet_except_editioned(
+                world.broadcast_packet_except(
                     &[player.gameprofile.id],
                     &pumpkin_protocol::java::client::play::CUpdateEntityPos::new(
                         player.entity_id().into(),
@@ -117,10 +115,9 @@ impl BedrockClient {
                         ),
                         on_ground,
                     ),
-                    &bedrock_move_packet,
                 );
             } else if rot_changed {
-                world.broadcast_packet_except_editioned(
+                world.broadcast_packet_except(
                     &[player.gameprofile.id],
                     &pumpkin_protocol::java::client::play::CUpdateEntityRot::new(
                         player.entity_id().into(),
@@ -128,9 +125,11 @@ impl BedrockClient {
                         je_pitch as u8, // Use converted Java byte
                         on_ground,
                     ),
-                    &bedrock_move_packet,
                 );
             }
+
+            // Bedrock must only receive movement for actors whose spawn packet was accepted.
+            world.send_to_tracking_players_bedrock(entity, &bedrock_move_packet);
 
             if rot_changed {
                 world.broadcast_packet_except(
@@ -144,10 +143,14 @@ impl BedrockClient {
             }
 
             if pos_changed {
-                chunker::update_position(player);
                 player.check_location_enchantments(new_pos, on_ground);
                 player.progress_motion(delta);
             }
+        }
+        drop(movement_guard);
+
+        if pos_changed {
+            chunker::update_position(player);
         }
 
         let input_data = packet.input_data;

--- a/crates/pumpkin/src/net/chunk_sender.rs
+++ b/crates/pumpkin/src/net/chunk_sender.rs
@@ -20,6 +20,9 @@ const MIN_CHUNKS_PER_TICK: f32 = 0.1;
 const MAX_CHUNKS_PER_TICK: f32 = 500.0;
 const INITIAL_CHUNKS_PER_TICK: f32 = 9.0;
 const MAX_CONCURRENT_BATCHES: u16 = 10;
+/// Bedrock decodes a complete vertical column for every level-chunk packet. Keep initial
+/// delivery deliberately smaller than Java's adaptive batch and never overlap these batches.
+const BEDROCK_CHUNKS_PER_BATCH: usize = 4;
 
 pub struct PreparedChunk {
     pub position: Vector2<i32>,
@@ -30,6 +33,13 @@ pub struct PreparedBatch {
     pub chunks: Vec<PreparedChunk>,
     pub epoch_snapshot: u32,
     pub target_version: JavaMinecraftVersion,
+}
+
+pub struct BedrockChunkBatch {
+    pub chunks: Vec<SyncChunk>,
+    pub positions: Vec<Vector2<i32>>,
+    pub epoch_snapshot: u32,
+    token: u64,
 }
 
 #[derive(Clone)]
@@ -55,6 +65,10 @@ impl EncodedChunk {
 pub struct ChunkSender {
     pub pending_chunks: FxHashSet<Vector2<i32>>,
     sent_chunks: FxHashSet<Vector2<i32>>,
+    bedrock_ready_chunks: FxHashSet<Vector2<i32>>,
+    bedrock_completed_chunks: FxHashSet<Vector2<i32>>,
+    bedrock_in_flight_token: Option<u64>,
+    next_bedrock_batch_token: u64,
     pub in_flight_batches: u16,
     pub desired_rate: f32,
     pub send_quota: f32,
@@ -67,6 +81,10 @@ impl ChunkSender {
         Self {
             pending_chunks: FxHashSet::default(),
             sent_chunks: FxHashSet::default(),
+            bedrock_ready_chunks: FxHashSet::default(),
+            bedrock_completed_chunks: FxHashSet::default(),
+            bedrock_in_flight_token: None,
+            next_bedrock_batch_token: 0,
             in_flight_batches: 0,
             desired_rate: INITIAL_CHUNKS_PER_TICK,
             send_quota: 0.0,
@@ -77,6 +95,9 @@ impl ChunkSender {
     pub fn reset(&mut self) {
         self.pending_chunks.clear();
         self.sent_chunks.clear();
+        self.bedrock_ready_chunks.clear();
+        self.bedrock_completed_chunks.clear();
+        self.bedrock_in_flight_token = None;
         self.in_flight_batches = 0;
         self.send_quota = 0.0;
     }
@@ -89,6 +110,25 @@ impl ChunkSender {
     #[must_use]
     pub fn sent_chunks_count(&self) -> usize {
         self.sent_chunks.len()
+    }
+
+    /// Returns whether the Bedrock level-chunk packet has been queued for this position.
+    #[must_use]
+    pub fn is_bedrock_chunk_ready(&self, pos: &Vector2<i32>) -> bool {
+        self.bedrock_ready_chunks.contains(pos)
+    }
+
+    #[must_use]
+    pub fn bedrock_ready_chunks_count(&self) -> usize {
+        self.bedrock_ready_chunks.len()
+    }
+
+    /// Returns chunks whose Bedrock send hook reached a terminal result. This includes
+    /// successfully queued chunks and plugin-cancelled chunks, so cancellation cannot
+    /// leave login waiting forever. Only `bedrock_ready_chunks` may unlock actors.
+    #[must_use]
+    pub fn bedrock_completed_chunks_count(&self) -> usize {
+        self.bedrock_completed_chunks.len()
     }
 
     pub const fn on_batch_acknowledged(&mut self, client_requested_rate: f32) -> bool {
@@ -113,11 +153,15 @@ impl ChunkSender {
 
     pub fn enqueue_chunk(&mut self, pos: Vector2<i32>) {
         self.sent_chunks.remove(&pos);
+        self.bedrock_ready_chunks.remove(&pos);
+        self.bedrock_completed_chunks.remove(&pos);
         self.pending_chunks.insert(pos);
     }
 
     pub fn unload_chunk(&mut self, client: &ClientPlatform, pos: Vector2<i32>) {
         self.pending_chunks.remove(&pos);
+        self.bedrock_ready_chunks.remove(&pos);
+        self.bedrock_completed_chunks.remove(&pos);
         if self.sent_chunks.remove(&pos)
             && let ClientPlatform::Java(java_client) = client
             && !java_client.is_closed()
@@ -313,23 +357,103 @@ impl ChunkSender {
         &mut self,
         batch: &PreparedBatch,
         current_epoch: u32,
-    ) -> Vec<SyncChunk> {
-        if current_epoch != batch.epoch_snapshot || batch.chunks.is_empty() {
-            return Vec::new();
+    ) -> Option<BedrockChunkBatch> {
+        if current_epoch != batch.epoch_snapshot
+            || batch.chunks.is_empty()
+            || self.bedrock_in_flight_token.is_some()
+        {
+            return None;
         }
 
-        let mut dispatched_chunks = Vec::with_capacity(batch.chunks.len());
+        let capacity = batch.chunks.len().min(BEDROCK_CHUNKS_PER_BATCH);
+        let mut dispatched_chunks = Vec::with_capacity(capacity);
+        let mut dispatched_positions = Vec::with_capacity(capacity);
         for candidate in &batch.chunks {
+            if dispatched_chunks.len() >= BEDROCK_CHUNKS_PER_BATCH {
+                break;
+            }
             if !self.pending_chunks.remove(&candidate.position) {
                 continue;
             }
 
             self.sent_chunks.insert(candidate.position);
             dispatched_chunks.push(candidate.chunk.clone());
+            dispatched_positions.push(candidate.position);
+        }
+
+        if dispatched_chunks.is_empty() {
+            return None;
         }
 
         self.send_quota -= dispatched_chunks.len() as f32;
-        dispatched_chunks
+        self.in_flight_batches = self.in_flight_batches.saturating_add(1);
+        let token = self.next_bedrock_batch_token;
+        self.next_bedrock_batch_token = self.next_bedrock_batch_token.wrapping_add(1);
+        self.bedrock_in_flight_token = Some(token);
+        Some(BedrockChunkBatch {
+            chunks: dispatched_chunks,
+            positions: dispatched_positions,
+            epoch_snapshot: batch.epoch_snapshot,
+            token,
+        })
+    }
+
+    /// Releases a Bedrock batch and returns the successfully queued positions which became ready
+    /// for dependent packets. Failed positions are put back in the pending queue for retry, while
+    /// plugin-cancelled positions are treated as terminal for this watch cycle.
+    ///
+    /// A stale completion must not release a newer batch started after a teleport or world
+    /// change. Positions unloaded while encoding are likewise not marked as ready.
+    pub fn on_bedrock_batch_completed(
+        &mut self,
+        batch: &BedrockChunkBatch,
+        queued_positions: &[Vector2<i32>],
+        cancelled_positions: &[Vector2<i32>],
+        current_epoch: u32,
+        expected_world_is_current: bool,
+    ) -> Vec<Vector2<i32>> {
+        if self.bedrock_in_flight_token != Some(batch.token) {
+            return Vec::new();
+        }
+
+        self.bedrock_in_flight_token = None;
+        self.in_flight_batches = self.in_flight_batches.saturating_sub(1);
+        if current_epoch != batch.epoch_snapshot || !expected_world_is_current {
+            for position in &batch.positions {
+                if self.sent_chunks.remove(position) {
+                    self.bedrock_ready_chunks.remove(position);
+                    self.bedrock_completed_chunks.remove(position);
+                    self.pending_chunks.insert(*position);
+                }
+            }
+            return Vec::new();
+        }
+
+        let mut ready_positions = Vec::with_capacity(batch.positions.len());
+        for position in &batch.positions {
+            if !self.sent_chunks.contains(position) {
+                continue;
+            }
+
+            if queued_positions.contains(position) {
+                self.bedrock_completed_chunks.insert(*position);
+                if self.bedrock_ready_chunks.insert(*position) {
+                    ready_positions.push(*position);
+                }
+            } else if cancelled_positions.contains(position) {
+                // Cancellation means the plugin deliberately suppressed this chunk. Keep it out
+                // of the pending queue so the closest cancelled chunk cannot be retried every
+                // tick and starve chunks behind it.
+                self.bedrock_ready_chunks.remove(position);
+                self.bedrock_completed_chunks.insert(*position);
+            } else {
+                self.sent_chunks.remove(position);
+                self.bedrock_ready_chunks.remove(position);
+                self.bedrock_completed_chunks.remove(position);
+                self.pending_chunks.insert(*position);
+            }
+        }
+        ready_positions
     }
 }
 
@@ -359,20 +483,34 @@ mod tests {
         sender.enqueue_chunk(position);
         sender.send_quota = 1.0;
 
-        let dispatched = sender.commit_bedrock_batch(&batch, 7);
+        let dispatched = sender
+            .commit_bedrock_batch(&batch, 7)
+            .expect("current Bedrock batch should be dispatched");
 
-        assert_eq!(dispatched.len(), 1);
-        assert!(Arc::ptr_eq(&dispatched[0], &chunk));
+        assert_eq!(dispatched.chunks.len(), 1);
+        assert!(Arc::ptr_eq(&dispatched.chunks[0], &chunk));
+        assert_eq!(dispatched.positions, vec![position]);
         assert!(!sender.pending_chunks.contains(&position));
         assert!(sender.is_chunk_sent(&position));
+        assert!(!sender.is_bedrock_chunk_ready(&position));
         assert_eq!(sender.sent_chunks_count(), 1);
         assert_eq!(sender.send_quota, 0.0);
+        assert_eq!(sender.in_flight_batches, 1);
 
         let repeated = sender.commit_bedrock_batch(&batch, 7);
 
-        assert!(repeated.is_empty());
+        assert!(repeated.is_none());
         assert_eq!(sender.sent_chunks_count(), 1);
         assert_eq!(sender.send_quota, 0.0);
+
+        assert_eq!(
+            sender.on_bedrock_batch_completed(&dispatched, &dispatched.positions, &[], 7, true,),
+            vec![position]
+        );
+        assert!(sender.is_bedrock_chunk_ready(&position));
+        assert_eq!(sender.bedrock_completed_chunks_count(), 1);
+        assert!(sender.bedrock_completed_chunks.contains(&position));
+        assert_eq!(sender.in_flight_batches, 0);
     }
 
     #[test]
@@ -391,8 +529,330 @@ mod tests {
 
         let dispatched = sender.commit_bedrock_batch(&batch, 8);
 
-        assert!(dispatched.is_empty());
+        assert!(dispatched.is_none());
         assert!(sender.pending_chunks.contains(&position));
         assert_eq!(sender.sent_chunks_count(), 0);
+        assert_eq!(sender.in_flight_batches, 0);
+    }
+
+    #[test]
+    fn bedrock_batches_are_bounded_and_do_not_overlap() {
+        let positions: Vec<_> = (0..6).map(|x| Vector2::new(x, 0)).collect();
+        let batch = PreparedBatch {
+            chunks: positions
+                .iter()
+                .map(|position| PreparedChunk {
+                    position: *position,
+                    chunk: ChunkData::empty_sync(position.x, position.y),
+                })
+                .collect(),
+            epoch_snapshot: 3,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        let mut sender = ChunkSender::new();
+        for position in &positions {
+            sender.enqueue_chunk(*position);
+        }
+        sender.send_quota = positions.len() as f32;
+
+        let first = sender
+            .commit_bedrock_batch(&batch, 3)
+            .expect("first batch should be dispatched");
+
+        assert_eq!(first.chunks.len(), BEDROCK_CHUNKS_PER_BATCH);
+        assert_eq!(sender.pending_chunks.len(), 2);
+        assert!(sender.commit_bedrock_batch(&batch, 3).is_none());
+
+        assert_eq!(
+            sender.on_bedrock_batch_completed(&first, &first.positions, &[], 3, true),
+            first.positions
+        );
+        let second = sender
+            .commit_bedrock_batch(&batch, 3)
+            .expect("remaining chunks should be dispatched after completion");
+
+        assert_eq!(second.chunks.len(), 2);
+        assert!(sender.pending_chunks.is_empty());
+    }
+
+    #[test]
+    fn bedrock_batch_requeues_chunks_that_were_not_queued() {
+        let queued_position = Vector2::new(1, 0);
+        let failed_position = Vector2::new(2, 0);
+        let batch = PreparedBatch {
+            chunks: [queued_position, failed_position]
+                .into_iter()
+                .map(|position| PreparedChunk {
+                    position,
+                    chunk: ChunkData::empty_sync(position.x, position.y),
+                })
+                .collect(),
+            epoch_snapshot: 3,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        let mut sender = ChunkSender::new();
+        sender.enqueue_chunk(queued_position);
+        sender.enqueue_chunk(failed_position);
+        sender.send_quota = 2.0;
+        let committed = sender
+            .commit_bedrock_batch(&batch, 3)
+            .expect("batch should be dispatched");
+
+        let became_ready =
+            sender.on_bedrock_batch_completed(&committed, &[queued_position], &[], 3, true);
+
+        assert_eq!(became_ready, vec![queued_position]);
+        assert!(sender.is_bedrock_chunk_ready(&queued_position));
+        assert_eq!(sender.bedrock_completed_chunks_count(), 1);
+        assert!(sender.bedrock_completed_chunks.contains(&queued_position));
+        assert!(sender.is_chunk_sent(&queued_position));
+        assert!(sender.pending_chunks.contains(&failed_position));
+        assert!(!sender.is_chunk_sent(&failed_position));
+        assert!(!sender.is_bedrock_chunk_ready(&failed_position));
+        assert!(!sender.bedrock_completed_chunks.contains(&failed_position));
+        assert_eq!(sender.in_flight_batches, 0);
+    }
+
+    #[test]
+    fn bedrock_batch_does_not_retry_plugin_cancelled_chunks() {
+        let cancelled_position = Vector2::new(1, 0);
+        let failed_position = Vector2::new(2, 0);
+        let batch = PreparedBatch {
+            chunks: [cancelled_position, failed_position]
+                .into_iter()
+                .map(|position| PreparedChunk {
+                    position,
+                    chunk: ChunkData::empty_sync(position.x, position.y),
+                })
+                .collect(),
+            epoch_snapshot: 3,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        let mut sender = ChunkSender::new();
+        sender.enqueue_chunk(cancelled_position);
+        sender.enqueue_chunk(failed_position);
+        sender.send_quota = 2.0;
+        let committed = sender
+            .commit_bedrock_batch(&batch, 3)
+            .expect("batch should be dispatched");
+
+        let became_ready =
+            sender.on_bedrock_batch_completed(&committed, &[], &[cancelled_position], 3, true);
+
+        assert!(became_ready.is_empty());
+        assert!(sender.is_chunk_sent(&cancelled_position));
+        assert!(!sender.is_bedrock_chunk_ready(&cancelled_position));
+        assert_eq!(sender.bedrock_completed_chunks_count(), 1);
+        assert!(
+            sender
+                .bedrock_completed_chunks
+                .contains(&cancelled_position)
+        );
+        assert!(!sender.bedrock_completed_chunks.contains(&failed_position));
+        assert!(!sender.pending_chunks.contains(&cancelled_position));
+        assert!(sender.pending_chunks.contains(&failed_position));
+
+        sender.send_quota = 2.0;
+        let retried = sender
+            .commit_bedrock_batch(&batch, 3)
+            .expect("only the failed chunk should be retried");
+        assert_eq!(retried.positions, vec![failed_position]);
+    }
+
+    #[test]
+    fn bedrock_completion_distinguishes_outcomes_and_clears_terminal_state() {
+        let queued = Vector2::new(1, 0);
+        let cancelled = Vector2::new(2, 0);
+        let failed = Vector2::new(3, 0);
+        let batch = PreparedBatch {
+            chunks: [queued, cancelled, failed]
+                .into_iter()
+                .map(|position| PreparedChunk {
+                    position,
+                    chunk: ChunkData::empty_sync(position.x, position.y),
+                })
+                .collect(),
+            epoch_snapshot: 12,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        let mut sender = ChunkSender::new();
+        for position in [queued, cancelled, failed] {
+            sender.enqueue_chunk(position);
+        }
+        sender.send_quota = 3.0;
+        let committed = sender
+            .commit_bedrock_batch(&batch, 12)
+            .expect("mixed batch should be dispatched");
+
+        let ready =
+            sender.on_bedrock_batch_completed(&committed, &[queued], &[cancelled], 12, true);
+
+        assert_eq!(ready, vec![queued]);
+        assert_eq!(sender.bedrock_completed_chunks_count(), 2);
+        assert!(sender.bedrock_completed_chunks.contains(&queued));
+        assert!(sender.bedrock_completed_chunks.contains(&cancelled));
+        assert!(!sender.bedrock_completed_chunks.contains(&failed));
+        assert!(sender.is_bedrock_chunk_ready(&queued));
+        assert!(!sender.is_bedrock_chunk_ready(&cancelled));
+        assert!(!sender.is_bedrock_chunk_ready(&failed));
+        assert!(!sender.pending_chunks.contains(&queued));
+        assert!(!sender.pending_chunks.contains(&cancelled));
+        assert!(sender.pending_chunks.contains(&failed));
+
+        sender.enqueue_chunk(cancelled);
+        assert_eq!(sender.bedrock_completed_chunks_count(), 1);
+        assert!(sender.bedrock_completed_chunks.contains(&queued));
+        assert!(!sender.bedrock_completed_chunks.contains(&cancelled));
+        assert!(sender.is_bedrock_chunk_ready(&queued));
+        assert!(sender.pending_chunks.contains(&cancelled));
+
+        sender.reset();
+        assert_eq!(sender.bedrock_completed_chunks_count(), 0);
+        assert_eq!(sender.bedrock_ready_chunks_count(), 0);
+        assert!(sender.pending_chunks.is_empty());
+        assert_eq!(sender.sent_chunks_count(), 0);
+    }
+
+    #[test]
+    fn bedrock_completion_from_a_different_world_is_requeued() {
+        let position = Vector2::new(1, 1);
+        let batch = PreparedBatch {
+            chunks: vec![PreparedChunk {
+                position,
+                chunk: ChunkData::empty_sync(position.x, position.y),
+            }],
+            epoch_snapshot: 4,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        let mut sender = ChunkSender::new();
+        sender.enqueue_chunk(position);
+        sender.send_quota = 1.0;
+        let committed = sender
+            .commit_bedrock_batch(&batch, 4)
+            .expect("batch should be dispatched");
+
+        assert!(
+            sender
+                .on_bedrock_batch_completed(&committed, &committed.positions, &[], 4, false)
+                .is_empty()
+        );
+        assert!(sender.pending_chunks.contains(&position));
+        assert!(!sender.is_chunk_sent(&position));
+        assert!(!sender.is_bedrock_chunk_ready(&position));
+        assert_eq!(sender.bedrock_completed_chunks_count(), 0);
+        assert_eq!(sender.in_flight_batches, 0);
+    }
+
+    #[test]
+    fn stale_bedrock_completion_does_not_release_a_new_batch() {
+        let old_position = Vector2::new(1, 1);
+        let old_batch = PreparedBatch {
+            chunks: vec![PreparedChunk {
+                position: old_position,
+                chunk: ChunkData::empty_sync(old_position.x, old_position.y),
+            }],
+            epoch_snapshot: 4,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        let mut sender = ChunkSender::new();
+        sender.enqueue_chunk(old_position);
+        sender.send_quota = 1.0;
+        let old_committed = sender
+            .commit_bedrock_batch(&old_batch, 4)
+            .expect("old batch should be dispatched");
+
+        sender.reset();
+        let new_position = Vector2::new(2, 2);
+        let new_batch = PreparedBatch {
+            chunks: vec![PreparedChunk {
+                position: new_position,
+                chunk: ChunkData::empty_sync(new_position.x, new_position.y),
+            }],
+            epoch_snapshot: 5,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        sender.enqueue_chunk(new_position);
+        sender.send_quota = 1.0;
+        let new_committed = sender
+            .commit_bedrock_batch(&new_batch, 5)
+            .expect("new batch should be dispatched");
+
+        assert!(
+            sender
+                .on_bedrock_batch_completed(&old_committed, &old_committed.positions, &[], 5, true,)
+                .is_empty()
+        );
+        assert_eq!(sender.in_flight_batches, 1);
+        assert!(!sender.is_bedrock_chunk_ready(&old_position));
+        assert!(!sender.is_bedrock_chunk_ready(&new_position));
+        assert_eq!(sender.bedrock_completed_chunks_count(), 0);
+
+        assert_eq!(
+            sender.on_bedrock_batch_completed(
+                &new_committed,
+                &new_committed.positions,
+                &[],
+                5,
+                true,
+            ),
+            vec![new_position]
+        );
+        assert_eq!(sender.in_flight_batches, 0);
+        assert!(sender.is_bedrock_chunk_ready(&new_position));
+        assert_eq!(sender.bedrock_completed_chunks_count(), 1);
+        assert!(sender.bedrock_completed_chunks.contains(&new_position));
+    }
+
+    #[test]
+    fn stale_bedrock_completion_releases_its_own_batch_after_epoch_advance() {
+        let old_position = Vector2::new(1, 1);
+        let old_batch = PreparedBatch {
+            chunks: vec![PreparedChunk {
+                position: old_position,
+                chunk: ChunkData::empty_sync(old_position.x, old_position.y),
+            }],
+            epoch_snapshot: 10,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        let mut sender = ChunkSender::new();
+        sender.enqueue_chunk(old_position);
+        sender.send_quota = 1.0;
+        let old_committed = sender
+            .commit_bedrock_batch(&old_batch, 10)
+            .expect("old batch should be dispatched");
+
+        // A same-world teleport advances the epoch without resetting the sender. The old send
+        // still owns the in-flight slot and must release it, but its chunks must not become ready.
+        assert!(
+            sender
+                .on_bedrock_batch_completed(
+                    &old_committed,
+                    &old_committed.positions,
+                    &[],
+                    11,
+                    true,
+                )
+                .is_empty()
+        );
+        assert_eq!(sender.in_flight_batches, 0);
+        assert!(!sender.is_bedrock_chunk_ready(&old_position));
+        assert_eq!(sender.bedrock_completed_chunks_count(), 0);
+        assert!(sender.pending_chunks.contains(&old_position));
+        assert!(!sender.is_chunk_sent(&old_position));
+
+        let new_position = Vector2::new(2, 2);
+        let new_batch = PreparedBatch {
+            chunks: vec![PreparedChunk {
+                position: new_position,
+                chunk: ChunkData::empty_sync(new_position.x, new_position.y),
+            }],
+            epoch_snapshot: 11,
+            target_version: JavaMinecraftVersion::V_1_20_2,
+        };
+        sender.enqueue_chunk(new_position);
+        sender.send_quota = 1.0;
+
+        assert!(sender.commit_bedrock_batch(&new_batch, 11).is_some());
+        assert_eq!(sender.in_flight_batches, 1);
     }
 }

--- a/crates/pumpkin/src/net/java/play/confirm_teleport.rs
+++ b/crates/pumpkin/src/net/java/play/confirm_teleport.rs
@@ -1,14 +1,17 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
 
+enum TeleportResult {
+    Success,
+    WrongId,
+    NotTeleporting,
+}
+
 impl JavaClient {
     pub fn handle_confirm_teleport(&self, player: &Player, confirm_teleport: &SConfirmTeleport) {
-        enum TeleportResult {
-            Success,
-            WrongId,
-            NotTeleporting,
-        }
-
+        let Some(_movement_guard) = player.lock_client_movement_if_unpaused() else {
+            return;
+        };
         let result = {
             let mut awaiting_teleport = player
                 .awaiting_teleport

--- a/crates/pumpkin/src/net/java/play/move_vehicle.rs
+++ b/crates/pumpkin/src/net/java/play/move_vehicle.rs
@@ -3,6 +3,9 @@ use super::*;
 
 impl JavaClient {
     pub fn handle_move_vehicle(&self, player: &Arc<Player>, packet: &SMoveVehicle) {
+        let Some(movement_guard) = player.lock_client_movement_if_loaded() else {
+            return;
+        };
         let entity = player.get_entity();
         let last_pos = entity.pos.load();
         let pos = Vector3::new(packet.x, packet.y, packet.z);
@@ -27,6 +30,7 @@ impl JavaClient {
                 cm,
             );
         }
+        drop(movement_guard);
         chunker::update_position(player);
     }
 }

--- a/crates/pumpkin/src/net/java/play/player_position.rs
+++ b/crates/pumpkin/src/net/java/play/player_position.rs
@@ -1,6 +1,44 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
 
+struct ClientMovementSnapshot {
+    chunk_send_epoch: u32,
+    teleport_id: i32,
+}
+
+impl ClientMovementSnapshot {
+    fn capture(player: &Player) -> Option<Self> {
+        let _movement_guard = player.lock_client_movement_if_loaded()?;
+        // Vanilla ignores movement while a teleport still awaits confirmation.
+        if player
+            .awaiting_teleport
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some()
+        {
+            return None;
+        }
+        Some(Self {
+            chunk_send_epoch: player.chunk_send_epoch.load(Ordering::Acquire),
+            teleport_id: player.teleport_id_count.load(Ordering::Relaxed),
+        })
+    }
+
+    fn lock_if_current<'a>(&self, player: &'a Player) -> Option<std::sync::MutexGuard<'a, ()>> {
+        let movement_guard = player.lock_client_movement_if_loaded()?;
+        // A move-event plugin can complete a transfer or even confirm a same-world teleport
+        // before returning. Loaded state and the pending teleport alone cannot detect that.
+        (self.chunk_send_epoch == player.chunk_send_epoch.load(Ordering::Acquire)
+            && self.teleport_id == player.teleport_id_count.load(Ordering::Relaxed)
+            && player
+                .awaiting_teleport
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_none())
+        .then_some(movement_guard)
+    }
+}
+
 impl JavaClient {
     const fn clamp_horizontal(pos: f64) -> f64 {
         pos.clamp(-3.0E7, 3.0E7)
@@ -49,23 +87,14 @@ impl JavaClient {
         server: &Arc<Server>,
         packet: &SPlayerPosition,
     ) {
-        if !player.has_client_loaded() {
+        let Some(movement) = ClientMovementSnapshot::capture(player) else {
             return;
-        }
+        };
         if player.get_entity().has_vehicle() {
             return;
         }
-        // Ignore movement packets while awaiting a teleport confirmation (vanilla behavior)
-        if player
-            .awaiting_teleport
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .is_some()
-        {
-            return;
-        }
         if player.is_movement_locked.load(Ordering::Relaxed) {
-            let Some(_movement_guard) = player.lock_client_movement_if_loaded() else {
+            let Some(_movement_guard) = movement.lock_if_current(player) else {
                 return;
             };
             self.force_tp(player, player.get_entity().pos.load());
@@ -97,7 +126,7 @@ impl JavaClient {
             };
 
             'after: {
-                let Some(movement_guard) = player.lock_client_movement_if_loaded() else {
+                let Some(movement_guard) = movement.lock_if_current(player) else {
                     return;
                 };
                 let pos = event.to;
@@ -187,7 +216,7 @@ impl JavaClient {
             }
 
             'cancelled: {
-                let Some(_movement_guard) = player.lock_client_movement_if_loaded() else {
+                let Some(_movement_guard) = movement.lock_if_current(player) else {
                     return;
                 };
                 self.force_tp(player, player.get_entity().pos.load());
@@ -202,23 +231,14 @@ impl JavaClient {
         server: &Arc<Server>,
         packet: &SPlayerPositionRotation,
     ) {
-        if !player.has_client_loaded() {
+        let Some(movement) = ClientMovementSnapshot::capture(player) else {
             return;
-        }
+        };
         if player.get_entity().has_vehicle() {
             return;
         }
-        // Ignore movement packets while awaiting a teleport confirmation (vanilla behavior)
-        if player
-            .awaiting_teleport
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .is_some()
-        {
-            return;
-        }
         if player.is_movement_locked.load(Ordering::Relaxed) {
-            let Some(_movement_guard) = player.lock_client_movement_if_loaded() else {
+            let Some(_movement_guard) = movement.lock_if_current(player) else {
                 return;
             };
             let entity = player.get_entity();
@@ -257,7 +277,7 @@ impl JavaClient {
             );
 
             'after: {
-                let Some(movement_guard) = player.lock_client_movement_if_loaded() else {
+                let Some(movement_guard) = movement.lock_if_current(player) else {
                     return;
                 };
                 let pos = event.to;
@@ -365,7 +385,7 @@ impl JavaClient {
             }
 
             'cancelled: {
-                let Some(_movement_guard) = player.lock_client_movement_if_loaded() else {
+                let Some(_movement_guard) = movement.lock_if_current(player) else {
                     return;
                 };
                 self.force_tp(player, position);
@@ -388,5 +408,164 @@ impl JavaClient {
             player.get_entity().pitch.load(),
             Vec::new(),
         ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, atomic::AtomicU32};
+
+    use super::*;
+    use crate::{
+        net::ClientPlatform,
+        plugin::{BoxFuture, EventHandler, EventPriority},
+        test_support::TestServer,
+    };
+
+    const TELEPORT_POSITION: Vector3<f64> = Vector3::new(256.0, 120.0, -256.0);
+    const EVENT_POSITION: Vector3<f64> = Vector3::new(3.0, 100.0, 4.0);
+
+    #[derive(Clone, Copy)]
+    enum MoveAction {
+        Rewrite,
+        Teleport { confirm: bool, advance_epoch: bool },
+    }
+
+    struct MovePlugin {
+        action: Mutex<(MoveAction, bool)>,
+        calls: AtomicU32,
+    }
+
+    impl EventHandler<PlayerMoveEvent> for MovePlugin {
+        fn handle_blocking<'a>(
+            &'a self,
+            _server: &'a Arc<Server>,
+            event: &'a mut PlayerMoveEvent,
+        ) -> BoxFuture<'a, ()> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::Relaxed);
+                let (action, cancelled) = *self.action.lock().unwrap();
+                event.cancelled = cancelled;
+                event.to = EVENT_POSITION;
+                if let MoveAction::Teleport {
+                    confirm,
+                    advance_epoch,
+                } = action
+                {
+                    if advance_epoch {
+                        event.player.request_teleport(TELEPORT_POSITION, 90.0, 30.0);
+                    } else {
+                        event.player.request_teleport_in_current_chunk_epoch(
+                            TELEPORT_POSITION,
+                            90.0,
+                            30.0,
+                        );
+                    }
+                    if confirm {
+                        confirm_teleport(&event.player);
+                    }
+                }
+            })
+        }
+    }
+
+    fn java_client(player: &Player) -> &JavaClient {
+        let ClientPlatform::Java(client) = player.client.as_ref() else {
+            panic!("expected a Java player");
+        };
+        client
+    }
+
+    fn confirm_teleport(player: &Player) {
+        java_client(player).handle_confirm_teleport(
+            player,
+            &SConfirmTeleport {
+                teleport_id: player.teleport_id_count.load(Ordering::Relaxed).into(),
+            },
+        );
+    }
+
+    fn send_movement(player: &Arc<Player>, server: &Arc<Server>, include_rotation: bool) {
+        let position = Vector3::new(1.0, 100.0, 1.0);
+        if include_rotation {
+            java_client(player).handle_position_rotation(
+                player,
+                server,
+                &SPlayerPositionRotation {
+                    position,
+                    yaw: 12.0,
+                    pitch: 24.0,
+                    collision: FLAG_ON_GROUND,
+                },
+            );
+        } else {
+            java_client(player).handle_position(
+                player,
+                server,
+                &SPlayerPosition {
+                    position,
+                    collision: FLAG_ON_GROUND,
+                },
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn java_move_event_teleports_are_not_overwritten() {
+        let fixture = TestServer::new().await;
+        let player = fixture.new_java_player().await;
+        let plugin = Arc::new(MovePlugin {
+            action: Mutex::new((MoveAction::Rewrite, false)),
+            calls: AtomicU32::new(0),
+        });
+        fixture
+            .server
+            .plugin_manager
+            .register::<PlayerMoveEvent, _>(plugin.clone(), EventPriority::Normal, true);
+
+        for include_rotation in [false, true] {
+            for cancelled in [false, true] {
+                // Cover a pending teleport, one already confirmed by the plugin, and a
+                // confirmed teleport that deliberately leaves the chunk epoch unchanged.
+                for (confirm, advance_epoch) in [(false, true), (true, true), (true, false)] {
+                    *plugin.action.lock().unwrap() = (
+                        MoveAction::Teleport {
+                            confirm,
+                            advance_epoch,
+                        },
+                        cancelled,
+                    );
+                    player.get_entity().set_pos(Vector3::new(0.0, 100.0, 0.0));
+                    player.get_entity().set_rotation(0.0, 0.0);
+                    let previous_id = player.teleport_id_count.load(Ordering::Relaxed);
+
+                    send_movement(&player, &fixture.server, include_rotation);
+
+                    assert_eq!(player.get_entity().pos.load(), TELEPORT_POSITION);
+                    assert_eq!(player.get_entity().yaw.load(), 90.0);
+                    assert_eq!(player.get_entity().pitch.load(), 30.0);
+                    assert_eq!(
+                        player.teleport_id_count.load(Ordering::Relaxed),
+                        previous_id + 1,
+                        "cancelling the move must not send a second correction teleport"
+                    );
+                    assert_eq!(player.awaiting_teleport.lock().unwrap().is_none(), confirm);
+                    if !confirm {
+                        confirm_teleport(&player);
+                        assert_eq!(player.get_entity().pos.load(), TELEPORT_POSITION);
+                    }
+                }
+            }
+
+            // Rejecting stale events must not prevent a plugin from changing an ordinary
+            // movement destination when no teleport or transfer occurred.
+            *plugin.action.lock().unwrap() = (MoveAction::Rewrite, false);
+            player.get_entity().set_pos(Vector3::new(0.0, 100.0, 0.0));
+            send_movement(&player, &fixture.server, include_rotation);
+            assert_eq!(player.get_entity().pos.load(), EVENT_POSITION);
+        }
+        assert_eq!(plugin.calls.load(Ordering::Relaxed), 14);
+        assert!(!java_client(&player).is_closed());
+        fixture.shutdown().await;
     }
 }

--- a/crates/pumpkin/src/net/java/play/player_position.rs
+++ b/crates/pumpkin/src/net/java/play/player_position.rs
@@ -65,6 +65,9 @@ impl JavaClient {
             return;
         }
         if player.is_movement_locked.load(Ordering::Relaxed) {
+            let Some(_movement_guard) = player.lock_client_movement_if_loaded() else {
+                return;
+            };
             self.force_tp(player, player.get_entity().pos.load());
             return;
         }
@@ -94,6 +97,9 @@ impl JavaClient {
             };
 
             'after: {
+                let Some(movement_guard) = player.lock_client_movement_if_loaded() else {
+                    return;
+                };
                 let pos = event.to;
                 let entity = &player.get_entity();
                 let last_pos = entity.pos.load();
@@ -121,7 +127,24 @@ impl JavaClient {
                 // TODO: Warn when player moves to quickly
                 if !Self::sync_position(player, world, pos, last_pos, entity.yaw.load(), entity.pitch.load(), packet.collision & FLAG_ON_GROUND != 0) {
                     // Send the new position to all other players.
-                    world.broadcast_packet_except_editioned(
+                    let bedrock_move_packet = CMovePlayer::new(
+                        VarULong(player.entity_id() as u64),
+                        Vector3::new(
+                            pos.x as f32,
+                            pos.y as f32 + player.get_entity().entity_type.eye_height,
+                            pos.z as f32,
+                        ),
+                        entity.pitch.load(),
+                        entity.yaw.load(),
+                        entity.yaw.load(),
+                        CMovePlayer::MODE_NORMAL,
+                        (packet.collision & FLAG_ON_GROUND) != 0,
+                        VarULong(0),
+                        0,
+                        0,
+                        VarULong(0),
+                    );
+                    world.broadcast_packet_except(
                         &[player.gameprofile.id],
                         &CUpdateEntityPos::new(
                             player.entity_id().into(),
@@ -132,20 +155,8 @@ impl JavaClient {
                             ),
                             packet.collision & FLAG_ON_GROUND != 0,
                         ),
-                        &CMovePlayer::new(
-                            VarULong(player.entity_id() as u64),
-                            Vector3::new(pos.x as f32, pos.y as f32 + player.get_entity().entity_type.eye_height, pos.z as f32),
-                            entity.pitch.load(),
-                            entity.yaw.load(),
-                            entity.yaw.load(),
-                            CMovePlayer::MODE_NORMAL,
-                            (packet.collision & FLAG_ON_GROUND) != 0,
-                            VarULong(0),
-                            0,
-                            0,
-                            VarULong(0),
-                        ),
                     );
+                    world.send_to_tracking_players_bedrock(entity, &bedrock_move_packet);
                 }
 
                 // Only process fall damage if player is alive
@@ -160,7 +171,6 @@ impl JavaClient {
                         player.gamemode.load() == GameMode::Creative,
                     );
                 }
-                chunker::update_position(player);
                 let delta = Vector3::new(
                     pos.x - last_pos.x,
                     pos.y - last_pos.y,
@@ -172,9 +182,14 @@ impl JavaClient {
                     player.check_location_enchantments(pos, packet.collision & FLAG_ON_GROUND != 0);
                 }
                 player.progress_motion(delta);
+                drop(movement_guard);
+                chunker::update_position(player);
             }
 
             'cancelled: {
+                let Some(_movement_guard) = player.lock_client_movement_if_loaded() else {
+                    return;
+                };
                 self.force_tp(player, player.get_entity().pos.load());
             }
         }}
@@ -203,6 +218,9 @@ impl JavaClient {
             return;
         }
         if player.is_movement_locked.load(Ordering::Relaxed) {
+            let Some(_movement_guard) = player.lock_client_movement_if_loaded() else {
+                return;
+            };
             let entity = player.get_entity();
             entity.set_rotation(packet.yaw, packet.pitch);
             self.force_tp(player, entity.pos.load());
@@ -239,6 +257,9 @@ impl JavaClient {
             );
 
             'after: {
+                let Some(movement_guard) = player.lock_client_movement_if_loaded() else {
+                    return;
+                };
                 let pos = event.to;
                 let entity = &player.get_entity();
                 let last_pos = entity.pos.load();
@@ -276,7 +297,24 @@ impl JavaClient {
                     sync_position(player, &world, pos, last_pos, yaw, pitch, (packet.collision & FLAG_ON_GROUND) != 0)
                 {
                     // Send the new position to all other players.
-                    world.broadcast_packet_except_editioned(
+                    let bedrock_move_packet = CMovePlayer::new(
+                        VarULong(entity_id as u64),
+                        Vector3::new(
+                            pos.x as f32,
+                            pos.y as f32 + player.get_entity().entity_type.eye_height,
+                            pos.z as f32,
+                        ),
+                        entity.pitch.load(),
+                        entity.yaw.load(),
+                        entity.yaw.load(),
+                        CMovePlayer::MODE_NORMAL,
+                        (packet.collision & FLAG_ON_GROUND) != 0,
+                        VarULong(0),
+                        0,
+                        0,
+                        VarULong(0),
+                    );
+                    world.broadcast_packet_except(
                         &[player.gameprofile.id],
                         &CUpdateEntityPosRot::new(
                             entity_id.into(),
@@ -289,20 +327,8 @@ impl JavaClient {
                             pitch as u8,
                             (packet.collision & FLAG_ON_GROUND) != 0,
                         ),
-                        &CMovePlayer::new(
-                            VarULong(entity_id as u64),
-                            Vector3::new(pos.x as f32, pos.y as f32 + player.get_entity().entity_type.eye_height, pos.z as f32),
-                            entity.pitch.load(),
-                            entity.yaw.load(),
-                            entity.yaw.load(),
-                            CMovePlayer::MODE_NORMAL,
-                            (packet.collision & FLAG_ON_GROUND) != 0,
-                            VarULong(0),
-                            0,
-                            0,
-                            VarULong(0),
-                        ),
                     );
+                    world.send_to_tracking_players_bedrock(entity, &bedrock_move_packet);
                 }
 
                 world
@@ -323,7 +349,6 @@ impl JavaClient {
                         player.gamemode.load() == GameMode::Creative,
                     );
                 }
-                chunker::update_position(player);
                 let delta = Vector3::new(
                     pos.x - last_pos.x,
                     pos.y - last_pos.y,
@@ -335,9 +360,14 @@ impl JavaClient {
                     player.check_location_enchantments(pos, (packet.collision & FLAG_ON_GROUND) != 0);
                 }
                 player.progress_motion(delta);
+                drop(movement_guard);
+                chunker::update_position(player);
             }
 
             'cancelled: {
+                let Some(_movement_guard) = player.lock_client_movement_if_loaded() else {
+                    return;
+                };
                 self.force_tp(player, position);
             }
         }}

--- a/crates/pumpkin/src/net/java/play/player_rotation.rs
+++ b/crates/pumpkin/src/net/java/play/player_rotation.rs
@@ -3,9 +3,9 @@ use super::*;
 
 impl JavaClient {
     pub fn handle_rotation(&self, player: &Player, rotation: &SPlayerRotation) {
-        if !player.has_client_loaded() {
+        let Some(_movement_guard) = player.lock_client_movement_if_loaded() else {
             return;
-        }
+        };
         if !rotation.yaw.is_finite() || !rotation.pitch.is_finite() {
             self.try_kick(&TextComponent::translate_cross(
                 translation::java::MULTIPLAYER_DISCONNECT_INVALID_PLAYER_MOVEMENT,
@@ -50,7 +50,8 @@ impl JavaClient {
             VarULong(0),
         );
 
-        world.broadcast_packet_except_editioned(&[player.gameprofile.id], &je_packet, &be_packet);
+        world.broadcast_packet_except(&[player.gameprofile.id], &je_packet);
+        world.send_to_tracking_players_bedrock(entity, &be_packet);
 
         let je_packet = CHeadRot::new(entity_id.into(), yaw as u8);
         world.broadcast_packet_except(&[player.gameprofile.id], &je_packet);

--- a/crates/pumpkin/src/net/mod.rs
+++ b/crates/pumpkin/src/net/mod.rs
@@ -253,21 +253,38 @@ impl ClientPlatform {
         }
     }
 
-    pub fn try_enqueue_spawn_packet(&self, entity: &Arc<dyn crate::entity::EntityBase>) {
-        self.enqueue_spawn_packet(entity);
+    /// Attempts to queue an entity's spawn packet.
+    ///
+    /// Java retains its existing fire-and-forget behavior. Bedrock reports whether the actor
+    /// packet was accepted by its bounded outgoing queue so entity tracking can retry safely.
+    pub fn try_enqueue_spawn_packet(&self, entity: &Arc<dyn crate::entity::EntityBase>) -> bool {
+        match self {
+            Self::Java(java) => {
+                entity.send_java_spawn_packet(java);
+                true
+            }
+            Self::Bedrock(bedrock) => {
+                bedrock.has_outgoing_packet_capacity()
+                    && entity.try_send_bedrock_spawn_packet(bedrock)
+            }
+        }
     }
 
     pub fn enqueue_spawn_packet(&self, entity: &Arc<dyn crate::entity::EntityBase>) {
         match self {
             Self::Java(java) => entity.send_java_spawn_packet(java),
-            Self::Bedrock(bedrock) => entity.send_bedrock_spawn_packet(bedrock),
+            Self::Bedrock(bedrock) => {
+                entity.send_bedrock_spawn_packet(bedrock);
+            }
         }
     }
 
     pub async fn send_chunks(&self, chunks: &[SyncChunk]) {
         match self {
             Self::Java(java) => java.send_chunks(chunks).await,
-            Self::Bedrock(bedrock) => bedrock.send_chunks(chunks).await,
+            Self::Bedrock(bedrock) => {
+                bedrock.send_chunks(chunks).await;
+            }
         }
     }
 

--- a/crates/pumpkin/src/server/mod.rs
+++ b/crates/pumpkin/src/server/mod.rs
@@ -1091,6 +1091,7 @@ impl Server {
                 let _guard = player_handle.enter();
                 player.tick(self);
             });
+            world.entity_tracker.update_bedrock_lifecycles(world);
         }
     }
 

--- a/crates/pumpkin/src/test_support.rs
+++ b/crates/pumpkin/src/test_support.rs
@@ -1,0 +1,184 @@
+//! Isolated real server/player fixtures for tests spanning packet handlers and world state.
+//!
+//! No server listener or ticker is started. Tests drive the production operations explicitly,
+//! and must call `shutdown` before dropping the temporary world to join its chunk workers.
+
+use std::num::NonZeroU8;
+use std::sync::{Arc, Mutex, RwLock};
+
+use arc_swap::ArcSwap;
+use pumpkin_config::{AdvancedConfiguration, BasicConfiguration};
+use pumpkin_data::dimension::Dimension;
+use pumpkin_util::GameMode;
+use tempfile::TempDir;
+use tokio::net::{TcpListener, TcpStream};
+use uuid::Uuid;
+
+use crate::data::VanillaData;
+use crate::entity::player::Player;
+use crate::net::bedrock::{BedrockClient, nethernet::NetherNetSession};
+use crate::net::java::{JavaClient, pending::PendingConnection};
+use crate::net::{ClientPlatform, GameProfile, PacketRateLimiter, PlayerConfig};
+use crate::server::Server;
+use crate::world::World;
+
+pub struct TestServer {
+    pub(crate) server: Arc<Server>,
+    pub(crate) world: Arc<World>,
+    // Keep the peer endpoints alive, but do not start socket readers/writers: tests inspect
+    // state and the real outgoing queues without depending on wall-clock network scheduling.
+    java_peers: Mutex<Vec<TcpStream>>,
+    _directory: TempDir,
+}
+
+impl TestServer {
+    pub(crate) async fn new() -> Self {
+        let directory = tempfile::tempdir().expect("temporary test world");
+        let basic = BasicConfiguration {
+            seed: pumpkin_util::world_seed::Seed(0),
+            default_level_name: directory
+                .path()
+                .join("world")
+                .to_string_lossy()
+                .into_owned(),
+            allow_nether: false,
+            allow_end: false,
+            allow_chat_reports: false,
+            use_favicon: false,
+            ..BasicConfiguration::default()
+        };
+        let mut advanced = AdvancedConfiguration::default();
+        advanced.networking.java.online_mode = false;
+        advanced.networking.java.authentication.enabled = false;
+        advanced.networking.bedrock.online_mode = false;
+        advanced.networking.bedrock.authentication.enabled = false;
+        advanced.networking.java.view_distance = NonZeroU8::new(2).unwrap();
+        advanced.networking.java.simulation_distance = NonZeroU8::new(2).unwrap();
+        advanced.networking.bedrock.view_distance = NonZeroU8::new(2).unwrap();
+        advanced.networking.bedrock.simulation_distance = NonZeroU8::new(2).unwrap();
+        advanced.world.autosave_ticks = 0;
+        advanced.player_data.save_player_data = false;
+        advanced.advancement.save_advancements = false;
+
+        // Loading VanillaData would touch the user's data/ files. Empty real stores are enough
+        // for these isolated players, and still exercise the normal Server constructor.
+        let vanilla_data = VanillaData {
+            banned_ip_list: RwLock::default(),
+            banned_player_list: RwLock::default(),
+            operator_config: RwLock::default(),
+            user_cache: RwLock::default(),
+            whitelist_config: RwLock::default(),
+        };
+        let server = Server::new(basic, advanced, vanilla_data).await;
+        let world = server.get_world_from_dimension(&Dimension::OVERWORLD);
+        Self {
+            server,
+            world,
+            java_peers: Mutex::new(Vec::new()),
+            _directory: directory,
+        }
+    }
+
+    pub(crate) async fn new_java_player(&self) -> Arc<Player> {
+        let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("local test listener");
+        let address = listener.local_addr().unwrap();
+        let (peer, accepted) = tokio::join!(TcpStream::connect(address), listener.accept());
+        let peer = peer.expect("local test peer");
+        let (stream, address) = accepted.expect("accepted test client");
+        let profile = Self::profile();
+        let config = Self::player_config();
+        let pending =
+            PendingConnection::new(stream, address, 0, PacketRateLimiter::new(false, 0.0, 0.0));
+        let client = JavaClient::from_pending(pending, profile.clone(), config.clone());
+        client
+            .connection_state
+            .store(pumpkin_protocol::ConnectionState::Play);
+        let client = Arc::new(ClientPlatform::Java(client));
+        let player = Arc::new(Player::new(
+            client,
+            profile,
+            config,
+            &self.world,
+            GameMode::Creative,
+        ));
+        player.set_client_loaded(true);
+        player.client.java().unwrap().set_player(player.clone());
+        self.java_peers.lock().unwrap().push(peer);
+        self.add_player(&player);
+        player
+    }
+
+    pub(crate) async fn new_bedrock_player(&self) -> Arc<Player> {
+        let session = Arc::new(NetherNetSession::new_for_test().await);
+        let client = Arc::new(BedrockClient::new(
+            session,
+            (std::net::Ipv4Addr::LOCALHOST, 0).into(),
+            Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            PacketRateLimiter::new(false, 0.0, 0.0),
+        ));
+        client
+            .version
+            .store(pumpkin_util::version::BedrockMinecraftVersion::V_1_26_45);
+        let player = Arc::new(Player::new(
+            Arc::new(ClientPlatform::Bedrock(client.clone())),
+            Self::profile(),
+            Self::player_config(),
+            &self.world,
+            GameMode::Creative,
+        ));
+        player
+            .bedrock_spawned
+            .store(true, std::sync::atomic::Ordering::Release);
+        player.set_client_loaded(true);
+        client.set_player(player.clone());
+        self.add_player(&player);
+        player
+    }
+
+    fn profile() -> GameProfile {
+        let id = Uuid::new_v4();
+        GameProfile {
+            id,
+            name: format!("test_{}", &id.simple().to_string()[..8]),
+            properties: ArcSwap::from_pointee(Vec::new()),
+            profile_actions: None,
+        }
+    }
+
+    fn player_config() -> PlayerConfig {
+        PlayerConfig {
+            view_distance: NonZeroU8::new(2).unwrap(),
+            ..PlayerConfig::default()
+        }
+    }
+
+    fn add_player(&self, player: &Arc<Player>) {
+        self.world.players.rcu(|players| {
+            let mut players = (**players).clone();
+            players.push(player.clone());
+            players
+        });
+    }
+
+    pub(crate) async fn shutdown(self) {
+        for player in self.world.players.load().iter() {
+            match player.client.as_ref() {
+                ClientPlatform::Java(client) => {
+                    client.close();
+                    client.await_tasks().await;
+                    client.player.store(Arc::new(None));
+                }
+                ClientPlatform::Bedrock(client) => {
+                    client.close().await;
+                    client.await_tasks().await;
+                    client.player.store(Arc::new(None));
+                }
+            }
+        }
+        self.world.players.store(Arc::new(Vec::new()));
+        self.java_peers.lock().unwrap().clear();
+        self.server.shutdown().await;
+    }
+}

--- a/crates/pumpkin/src/world/chunker.rs
+++ b/crates/pumpkin/src/world/chunker.rs
@@ -1,5 +1,8 @@
 use pumpkin_util::math::vector2::Vector2;
-use std::{num::NonZero, sync::Arc};
+use std::{
+    num::NonZero,
+    sync::{Arc, atomic::Ordering},
+};
 
 use pumpkin_protocol::{
     bedrock::client::network_chunk_publisher_update::CNetworkChunkPublisherUpdate,
@@ -8,7 +11,10 @@ use pumpkin_protocol::{
 use pumpkin_world::cylindrical_chunk_iterator::Cylindrical;
 
 use crate::{
-    entity::{EntityBase, player::Player},
+    entity::{
+        EntityBase,
+        player::{HeldChunkTickets, Player},
+    },
     net::ClientPlatform,
 };
 
@@ -42,6 +48,15 @@ pub fn is_within_view_distance(
 
 #[allow(clippy::too_many_lines)]
 pub fn update_position(player: &Arc<Player>) {
+    let mut sender = player
+        .chunk_sender
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if player.is_chunk_streaming_paused() {
+        return;
+    }
+    let expected_epoch = player.chunk_send_epoch.load(Ordering::Acquire);
+
     let entity = &player.get_entity();
     let new_chunk_center = entity.chunk_pos.load();
     let old_cylindrical = player.watched_section.load();
@@ -58,22 +73,6 @@ pub fn update_position(player: &Arc<Player>) {
         return;
     }
 
-    match player.client.as_ref() {
-        ClientPlatform::Java(java_client) => {
-            java_client.try_send_packet(&CCenterChunk {
-                chunk_x: new_chunk_center.x.into(),
-                chunk_z: new_chunk_center.y.into(),
-            });
-        }
-        ClientPlatform::Bedrock(bedrock_client) => {
-            if let Ok(data) = bedrock_client.serialize_packet(&CNetworkChunkPublisherUpdate::new(
-                player.get_entity().block_pos.load(),
-                u32::from(view_distance.get()) * 16,
-            )) {
-                bedrock_client.try_enqueue_packet(data);
-            }
-        }
-    }
     let (loading_iter, unloading_iter) =
         Cylindrical::changed_chunks(old_cylindrical, new_cylindrical);
     let loading_chunks: Vec<_> = loading_iter.collect();
@@ -119,61 +118,62 @@ pub fn update_position(player: &Arc<Player>) {
             lock.add_ticket(new_chunk_center, sim);
         }
 
-        if let Some((held_view, held_sim)) = held_tickets.replace((new_view_level, new_sim_level)) {
-            if let Some(view) = held_view {
-                lock.remove_ticket(old_cylindrical.center, view);
+        if let Some(held) = held_tickets.replace(HeldChunkTickets {
+            center: new_chunk_center,
+            view_level: new_view_level,
+            simulation_level: new_sim_level,
+        }) {
+            if let Some(view) = held.view_level {
+                lock.remove_ticket(held.center, view);
             }
-            if let Some(sim) = held_sim {
-                lock.remove_ticket(old_cylindrical.center, sim);
+            if let Some(sim) = held.simulation_level {
+                lock.remove_ticket(held.center, sim);
             }
         }
         lock.send_change();
     };
     drop(held_tickets);
 
-    {
-        let mut sender = player
-            .chunk_sender
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        for pos in &unloading_chunks {
-            sender.unload_chunk(&player.client, *pos);
+    match player.client.as_ref() {
+        ClientPlatform::Java(java_client) => {
+            java_client.try_send_packet(&CCenterChunk {
+                chunk_x: new_chunk_center.x.into(),
+                chunk_z: new_chunk_center.y.into(),
+            });
         }
-        for pos in &loading_chunks {
-            sender.enqueue_chunk(*pos);
+        ClientPlatform::Bedrock(bedrock_client) => {
+            if let Ok(data) = bedrock_client.serialize_packet(&CNetworkChunkPublisherUpdate::new(
+                player.get_entity().block_pos.load(),
+                u32::from(view_distance.get()) * 16,
+            )) {
+                bedrock_client.try_enqueue_packet(data);
+            }
         }
+    }
+
+    for pos in &unloading_chunks {
+        sender.unload_chunk(&player.client, *pos);
+    }
+    for pos in &loading_chunks {
+        sender.enqueue_chunk(*pos);
     }
     player.watched_section.store(new_cylindrical);
 
-    // Make sure the watched section and the chunk watcher updates are async atomic. We want to
-    // ensure what we unload when the player disconnects is correct.
-    if !loading_chunks.is_empty() || !unloading_chunks.is_empty() {
-        let level = world.level.clone();
-        let world_clone = world.clone();
-        let loading_chunks_clone = loading_chunks.clone();
-        let unloading_chunks_clone = unloading_chunks;
+    // Queue watcher counts before releasing `chunk_sender`. Transfer pause acquires the same
+    // lock, so its full-radius unwatch is guaranteed to follow every published movement update.
+    player.queue_chunk_watcher_transition(world.clone(), loading_chunks.clone(), unloading_chunks);
+    drop(sender);
 
-        if let Some(server) = world.server.upgrade() {
-            server.spawn_task(async move {
-                level
-                    .mark_chunks_as_newly_watched(&loading_chunks_clone)
-                    .await;
-                let chunks_to_clean = level
-                    .mark_chunks_as_not_watched(&unloading_chunks_clone)
-                    .await;
-
-                if !chunks_to_clean.is_empty() {
-                    world_clone
-                        .remove_entities_in_chunks(&chunks_to_clean)
-                        .await;
-                    world_clone.level.clean_entity_chunks(&chunks_to_clean);
-                }
-            });
-        }
-    }
-
-    if !loading_chunks.is_empty() {
-        world.spawn_world_entity_chunks(player.clone(), loading_chunks, new_chunk_center);
+    // Bedrock entity chunks are activated only after their corresponding level-chunk packets
+    // have been queued. This keeps a large persisted entity population from racing terrain and
+    // arriving as one unbounded join-time burst.
+    if !loading_chunks.is_empty() && matches!(player.client.as_ref(), ClientPlatform::Java(_)) {
+        let _ = world.spawn_world_entity_chunks(
+            player.clone(),
+            loading_chunks,
+            new_chunk_center,
+            expected_epoch,
+        );
     }
     world.entity_tracker.update_player_position(player, &world);
 }

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -31,18 +31,23 @@ use crate::net::java::JavaClient;
 use crate::world::World;
 use crate::world::chunker::{get_view_distance, is_within_view_distance};
 
-/// Actor packets share Bedrock's bounded normal queue with terrain. A small per-player
-/// budget prevents a dense entity chunk from filling that queue in a single world tick.
-const BEDROCK_ACTOR_PAIRINGS_PER_TICK: usize = 64;
+/// Pumpkin's transport budget for actor lifecycle packets sharing the normal queue with
+/// terrain. This limits packets, not actors: a player spawn costs two packets (`PlayerList`
+/// and `AddPlayer`), other spawns and removals cost one. Deferred actors remain pending.
+const BEDROCK_ACTOR_PACKETS_PER_TICK: usize = 64;
 
-fn take_bedrock_pairing_budget(budgets: &mut FxHashMap<Uuid, usize>, player_id: Uuid) -> bool {
+fn take_bedrock_packet_budget(
+    budgets: &mut FxHashMap<Uuid, usize>,
+    player_id: Uuid,
+    packet_count: usize,
+) -> bool {
     let Some(remaining) = budgets.get_mut(&player_id) else {
         return false;
     };
-    if *remaining == 0 {
+    let Some(next) = remaining.checked_sub(packet_count) else {
         return false;
-    }
-    *remaining -= 1;
+    };
+    *remaining = next;
     true
 }
 
@@ -315,7 +320,15 @@ impl TrackedEntity {
 
         for player in players {
             if self.pending_pairings.contains(&player.gameprofile.id)
-                && take_bedrock_pairing_budget(bedrock_budgets, player.gameprofile.id)
+                && take_bedrock_packet_budget(
+                    bedrock_budgets,
+                    player.gameprofile.id,
+                    if self.entity.get_player().is_some() {
+                        2
+                    } else {
+                        1
+                    },
+                )
             {
                 self.update_player(player, world);
             }
@@ -335,7 +348,7 @@ impl TrackedEntity {
         for player in players {
             let player_id = player.gameprofile.id;
             if self.pending_removals.contains(&player_id)
-                && take_bedrock_pairing_budget(bedrock_budgets, player_id)
+                && take_bedrock_packet_budget(bedrock_budgets, player_id, 1)
                 && self.remove_pairing(player)
             {
                 self.seen_by.remove(&player_id);
@@ -938,11 +951,11 @@ impl EntityTracker {
     /// runs while game ticks are frozen so chunk streaming cannot leave joins or despawns stuck.
     pub fn update_bedrock_lifecycles(&self, world: &World) {
         let players = world.players.load();
-        let mut bedrock_pairing_budgets = players
+        let mut bedrock_packet_budgets = players
             .iter()
             .filter_map(|player| {
                 matches!(player.client.as_ref(), ClientPlatform::Bedrock(_))
-                    .then_some((player.gameprofile.id, BEDROCK_ACTOR_PAIRINGS_PER_TICK))
+                    .then_some((player.gameprofile.id, BEDROCK_ACTOR_PACKETS_PER_TICK))
             })
             .collect::<FxHashMap<_, _>>();
         let mut completed_removals = Vec::new();
@@ -951,7 +964,7 @@ impl EntityTracker {
         // new pairings. This prevents a large spawn backlog from delaying despawns for seconds.
         for entry in &self.entity_map {
             let tracked = entry.value();
-            tracked.retry_pending_removals(players.as_ref(), world, &mut bedrock_pairing_budgets);
+            tracked.retry_pending_removals(players.as_ref(), world, &mut bedrock_packet_budgets);
             if tracked.removing.load(Ordering::Acquire) && tracked.removal_complete() {
                 completed_removals.push(tracked.entity_id);
             }
@@ -966,7 +979,7 @@ impl EntityTracker {
             if tracked.removing.load(Ordering::Acquire) {
                 continue;
             }
-            tracked.retry_pending_pairings(players.as_ref(), world, &mut bedrock_pairing_budgets);
+            tracked.retry_pending_pairings(players.as_ref(), world, &mut bedrock_packet_budgets);
         }
     }
 
@@ -1022,20 +1035,271 @@ impl EntityTracker {
 
 #[cfg(test)]
 mod tests {
-    use super::{BEDROCK_ACTOR_PAIRINGS_PER_TICK, take_bedrock_pairing_budget};
+    use super::*;
+    use crate::net::bedrock::BedrockClient;
+    use crate::test_support::TestServer;
+    use pumpkin_protocol::Packet;
+    use pumpkin_protocol::bedrock::client::{
+        add_player::CAddPlayer, level_chunk::CLevelChunk, player_list::CPlayerList,
+    };
+    use pumpkin_protocol::bedrock::packet_decoder::BedrockBatchDecoder;
+    use pumpkin_world::chunk::ChunkData;
     use rustc_hash::FxHashMap;
+    use std::io::Cursor;
     use uuid::Uuid;
 
-    #[test]
-    fn bedrock_actor_pairing_budget_is_strictly_bounded_per_tick() {
-        let player_id = Uuid::from_u128(1);
-        let mut budgets = FxHashMap::from_iter([(player_id, BEDROCK_ACTOR_PAIRINGS_PER_TICK)]);
+    async fn decode_packets(client: &BedrockClient) -> Vec<pumpkin_protocol::RawPacket> {
+        let mut decoder = BedrockBatchDecoder::new();
+        let mut packets = Vec::new();
+        for data in client.drain_outgoing_packets_for_test().await {
+            let payload = decoder.get_packet_payload(data.to_vec()).await.unwrap();
+            let mut reader = Cursor::new(payload);
+            let packet = decoder.get_game_packet(&mut reader).unwrap();
+            assert_eq!(reader.position() as usize, reader.get_ref().len());
+            packets.push(packet);
+        }
+        packets
+    }
 
-        let accepted = (0..BEDROCK_ACTOR_PAIRINGS_PER_TICK + 10)
-            .filter(|_| take_bedrock_pairing_budget(&mut budgets, player_id))
+    async fn send_entity_chunk(fixture: &TestServer, player: &Arc<Player>) {
+        let position = player.get_entity().chunk_pos.load();
+        let chunk = ChunkData::empty_sync(position.x, position.y);
+        fixture.world.level.loaded_chunks.insert(position, chunk);
+        let epoch = player.chunk_send_epoch.load(Ordering::Acquire);
+        let batch = {
+            let mut sender = player.chunk_sender.lock().unwrap();
+            sender.enqueue_chunk(position);
+            let prepared = sender
+                .prepare_batch(
+                    &fixture.world.level,
+                    position,
+                    epoch,
+                    JavaMinecraftVersion::V_1_20_2,
+                )
+                .unwrap();
+            sender.commit_bedrock_batch(&prepared, epoch).unwrap()
+        };
+        let ClientPlatform::Bedrock(client) = player.client.as_ref() else {
+            panic!("Bedrock test player");
+        };
+        // Exercise the production plugin hook, chunk encoder and bounded queue before
+        // completing the sender state; no fabricated chunk-ready flag is used.
+        let result = client
+            .send_chunks_for_batch(&batch.chunks, player, &fixture.world, epoch)
+            .await;
+        assert_eq!(result.queued_positions, vec![position]);
+        let ready = player
+            .chunk_sender
+            .lock()
+            .unwrap()
+            .on_bedrock_batch_completed(
+                &batch,
+                &result.queued_positions,
+                &result.cancelled_positions,
+                epoch,
+                true,
+            );
+        fixture.world.entity_tracker.update_player_for_chunks(
+            player,
+            &fixture.world,
+            &ready.into_iter().collect(),
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bedrock_join_queues_terrain_before_packet_budgeted_player_spawns() {
+        let fixture = TestServer::new().await;
+        let watcher = fixture.new_bedrock_player().await;
+        let ClientPlatform::Bedrock(client) = watcher.client.as_ref() else {
+            panic!("Bedrock test player");
+        };
+        let mut actors = Vec::new();
+        // Each real player pairing emits PlayerList and AddPlayer, so this backlog
+        // crosses a 64-packet budget but not the old 64-pairing budget.
+        for _ in 0..33 {
+            let actor: Arc<dyn EntityBase> = fixture.new_java_player().await;
+            fixture
+                .world
+                .entity_tracker
+                .add_entity(&actor, &fixture.world);
+            actors.push(actor);
+        }
+        fixture
+            .world
+            .entity_tracker
+            .update_bedrock_lifecycles(&fixture.world);
+        assert!(
+            decode_packets(client).await.is_empty(),
+            "actors need terrain first"
+        );
+
+        send_entity_chunk(&fixture, &watcher).await;
+        fixture
+            .world
+            .entity_tracker
+            .update_bedrock_lifecycles(&fixture.world);
+        let packets = decode_packets(client).await;
+        assert_eq!(packets[0].id, CLevelChunk::PACKET_ID);
+        assert_eq!(
+            packets.len(),
+            65,
+            "terrain followed by at most 64 actor packets"
+        );
+        for pair in packets[1..].chunks_exact(2) {
+            assert_eq!(pair[0].id, CPlayerList::PACKET_ID);
+            assert_eq!(pair[1].id, CAddPlayer::PACKET_ID);
+        }
+
+        fixture
+            .world
+            .entity_tracker
+            .update_bedrock_lifecycles(&fixture.world);
+        let packets = decode_packets(client).await;
+        assert_eq!(packets.len(), 2, "the final actor is deferred, not dropped");
+        assert_eq!(packets[0].id, CPlayerList::PACKET_ID);
+        assert_eq!(packets[1].id, CAddPlayer::PACKET_ID);
+        for actor in &actors {
+            let tracked = fixture
+                .world
+                .entity_tracker
+                .get_tracked_entity(actor.get_entity().entity_id)
+                .unwrap();
+            assert!(tracked.has_active_bedrock_pairing(&watcher.gameprofile.id));
+        }
+        fixture
+            .world
+            .entity_tracker
+            .update_bedrock_lifecycles(&fixture.world);
+        assert!(
+            decode_packets(client).await.is_empty(),
+            "no duplicate pairings"
+        );
+
+        for actor in actors {
+            fixture
+                .world
+                .entity_tracker
+                .remove_entity(actor.as_ref(), &fixture.world);
+        }
+        fixture
+            .world
+            .entity_tracker
+            .update_bedrock_lifecycles(&fixture.world);
+        let packets = decode_packets(client).await;
+        assert_eq!(packets.len(), 33);
+        assert!(
+            packets
+                .iter()
+                .all(|packet| packet.id == CRemoveActor::PACKET_ID)
+        );
+        assert!(fixture.world.entity_tracker.entity_map.is_empty());
+        fixture.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn bedrock_pairing_retries_full_queue_and_orders_removal_after_spawn() {
+        let fixture = TestServer::new().await;
+        let watcher = fixture.new_bedrock_player().await;
+        let ClientPlatform::Bedrock(client) = watcher.client.as_ref() else {
+            panic!("Bedrock test player");
+        };
+        send_entity_chunk(&fixture, &watcher).await;
+        assert_eq!(decode_packets(client).await.len(), 1);
+        let actor: Arc<dyn EntityBase> = fixture.new_java_player().await;
+        fixture
+            .world
+            .entity_tracker
+            .add_entity(&actor, &fixture.world);
+        let tracked = fixture
+            .world
+            .entity_tracker
+            .get_tracked_entity(actor.get_entity().entity_id)
+            .unwrap();
+        let filler = client
+            .serialize_packet(&CRemoveActor::new(VarLong(-1)))
+            .unwrap();
+        let capacity = client.outgoing_packet_capacity_for_test();
+        for _ in 0..capacity - 1 {
+            assert!(client.try_enqueue_packet_data_checked(filler.clone()));
+        }
+        fixture
+            .world
+            .entity_tracker
+            .update_bedrock_lifecycles(&fixture.world);
+        assert!(!tracked.seen_by.contains(&watcher.gameprofile.id));
+        assert!(tracked.pending_pairings.contains(&watcher.gameprofile.id));
+        let packets = decode_packets(client).await;
+        assert_eq!(packets.len(), capacity - 1, "no partial player spawn");
+        assert!(
+            packets
+                .iter()
+                .all(|packet| packet.id == CRemoveActor::PACKET_ID)
+        );
+
+        fixture
+            .world
+            .entity_tracker
+            .update_bedrock_lifecycles(&fixture.world);
+        assert!(tracked.has_active_bedrock_pairing(&watcher.gameprofile.id));
+        // Leave the accepted spawn queued, then saturate the queue before despawning.
+        for _ in 0..client.outgoing_packet_capacity_for_test() {
+            assert!(client.try_enqueue_packet_data_checked(filler.clone()));
+        }
+        fixture
+            .world
+            .entity_tracker
+            .remove_entity(actor.as_ref(), &fixture.world);
+        fixture
+            .world
+            .entity_tracker
+            .update_bedrock_lifecycles(&fixture.world);
+        assert!(tracked.pending_removals.contains(&watcher.gameprofile.id));
+        assert!(!tracked.has_active_bedrock_pairing(&watcher.gameprofile.id));
+        let packets = decode_packets(client).await;
+        assert_eq!(packets.len(), capacity);
+        assert_eq!(packets[0].id, CPlayerList::PACKET_ID);
+        assert_eq!(packets[1].id, CAddPlayer::PACKET_ID);
+
+        fixture
+            .world
+            .entity_tracker
+            .update_bedrock_lifecycles(&fixture.world);
+        let packets = decode_packets(client).await;
+        assert_eq!(
+            packets.len(),
+            1,
+            "despawn is retried after the queued spawn"
+        );
+        assert_eq!(packets[0].id, CRemoveActor::PACKET_ID);
+        assert!(
+            !fixture
+                .world
+                .entity_tracker
+                .has_entity_with_id(tracked.entity_id)
+        );
+        fixture
+            .world
+            .entity_tracker
+            .update_bedrock_lifecycles(&fixture.world);
+        assert!(decode_packets(client).await.is_empty());
+        fixture.shutdown().await;
+    }
+
+    #[test]
+    fn bedrock_actor_packet_budget_keeps_player_spawns_atomic() {
+        let player_id = Uuid::from_u128(1);
+        let mut budgets = FxHashMap::from_iter([(player_id, BEDROCK_ACTOR_PACKETS_PER_TICK)]);
+
+        // One removal leaves an odd budget. A player spawn must reserve both of its packets.
+        assert!(take_bedrock_packet_budget(&mut budgets, player_id, 1));
+        let accepted = (0..BEDROCK_ACTOR_PACKETS_PER_TICK)
+            .filter(|_| take_bedrock_packet_budget(&mut budgets, player_id, 2))
             .count();
 
-        assert_eq!(accepted, BEDROCK_ACTOR_PAIRINGS_PER_TICK);
+        assert_eq!(accepted, 31);
+        assert_eq!(budgets[&player_id], 1);
+        assert!(take_bedrock_packet_budget(&mut budgets, player_id, 1));
+        assert!(!take_bedrock_packet_budget(&mut budgets, player_id, 1));
         assert_eq!(budgets[&player_id], 0);
     }
 }

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use bytes::BufMut;
 use crossbeam::atomic::AtomicCell;
@@ -15,8 +18,10 @@ use pumpkin_protocol::java::client::play::{
 use pumpkin_protocol::{BClientPacket, ClientPacket};
 use pumpkin_util::GameMode;
 use pumpkin_util::math::get_section_cord;
+use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::version::JavaMinecraftVersion;
+use rustc_hash::{FxHashMap, FxHashSet};
 use uuid::Uuid;
 
 use crate::entity::EntityBase;
@@ -26,6 +31,62 @@ use crate::net::java::JavaClient;
 use crate::world::World;
 use crate::world::chunker::{get_view_distance, is_within_view_distance};
 
+/// Actor packets share Bedrock's bounded normal queue with terrain. A small per-player
+/// budget prevents a dense entity chunk from filling that queue in a single world tick.
+const BEDROCK_ACTOR_PAIRINGS_PER_TICK: usize = 64;
+
+fn take_bedrock_pairing_budget(budgets: &mut FxHashMap<Uuid, usize>, player_id: Uuid) -> bool {
+    let Some(remaining) = budgets.get_mut(&player_id) else {
+        return false;
+    };
+    if *remaining == 0 {
+        return false;
+    }
+    *remaining -= 1;
+    true
+}
+
+fn player_is_in_world(player: &Player, world: &World) -> bool {
+    let current_world = player.world();
+    std::ptr::eq(Arc::as_ptr(&current_world), world)
+}
+
+fn is_entity_visible_to_player(
+    entity: &dyn EntityBase,
+    player: &Player,
+    effective_range: u32,
+) -> bool {
+    let player_entity = player.get_entity();
+    let player_pos = player_entity.pos.load();
+    let entity_pos = entity.get_entity().pos.load();
+    let dx = player_pos.x - entity_pos.x;
+    let dz = player_pos.z - entity_pos.z;
+    let dist_sq = dx.mul_add(dx, dz * dz);
+
+    let player_vd = get_view_distance(player).get() as i32;
+    let visible_range_blocks = f64::from((effective_range as i32).min(player_vd) * 16);
+    let range_sq = visible_range_blocks * visible_range_blocks;
+    let entity_chunk = entity.get_entity().chunk_pos.load();
+    let player_chunk = player_entity.chunk_pos.load();
+    let in_view = is_within_view_distance(entity_chunk, player_chunk, player_vd);
+    let spectator_visible = entity.get_player().is_none_or(|target_player| {
+        player.gamemode.load() == GameMode::Spectator
+            || target_player.gamemode.load() != GameMode::Spectator
+    });
+    let chunk_ready = match player.client.as_ref() {
+        ClientPlatform::Java(_) => true,
+        ClientPlatform::Bedrock(_) => {
+            player.bedrock_spawned.load(Ordering::Acquire)
+                && player
+                    .chunk_sender
+                    .lock()
+                    .is_ok_and(|sender| sender.is_bedrock_chunk_ready(&entity_chunk))
+        }
+    };
+
+    dist_sq <= range_sq && spectator_visible && in_view && chunk_ready
+}
+
 pub struct TrackedEntity {
     pub entity: Arc<dyn EntityBase>,
     pub entity_id: i32,
@@ -33,6 +94,16 @@ pub struct TrackedEntity {
     pub update_interval: u32,
     pub track_deltas: bool,
     pub seen_by: DashSet<Uuid>,
+    /// Bedrock pairings whose spawn packet could not fit in the bounded outgoing queue.
+    pending_pairings: DashSet<Uuid>,
+    /// Prevents concurrent chunk/entity tasks from queueing the same actor spawn twice.
+    pairings_in_progress: DashSet<Uuid>,
+    /// Bedrock removals which could not yet enter the normal FIFO behind their spawn.
+    pending_removals: DashSet<Uuid>,
+    /// Temporarily hides this actor from Bedrock clients, for example while a Java player is dead.
+    bedrock_suspended: AtomicBool,
+    /// Keeps a removed entity's tracker alive until all accepted Bedrock actors are removed.
+    removing: AtomicBool,
     pub last_section_pos: AtomicCell<Vector3<i32>>,
 }
 
@@ -58,6 +129,11 @@ impl TrackedEntity {
             update_interval,
             track_deltas,
             seen_by: DashSet::new(),
+            pending_pairings: DashSet::new(),
+            pairings_in_progress: DashSet::new(),
+            pending_removals: DashSet::new(),
+            bedrock_suspended: AtomicBool::new(false),
+            removing: AtomicBool::new(false),
             last_section_pos: AtomicCell::new(last_section_pos),
         }
     }
@@ -88,54 +164,196 @@ impl TrackedEntity {
         effective_range
     }
 
-    fn broadcast_to_player(&self, player: &Player) -> bool {
-        self.entity.get_player().is_none_or(|target_player| {
-            player.gamemode.load() == GameMode::Spectator
-                || target_player.gamemode.load() != GameMode::Spectator
-        })
-    }
-
-    pub fn update_player(&self, player: &Arc<Player>, _world: &World) {
-        if player.get_entity().entity_id == self.entity_id {
+    pub fn update_player(&self, player: &Arc<Player>, world: &World) {
+        if self.removing.load(Ordering::Acquire)
+            || player.get_entity().entity_id == self.entity_id
+            || !player_is_in_world(player, world)
+        {
             return;
         }
 
-        let player_entity = player.get_entity();
-        let player_pos = player_entity.pos.load();
-        let entity_pos = self.entity.get_entity().pos.load();
-        let dx = player_pos.x - entity_pos.x;
-        let dz = player_pos.z - entity_pos.z;
-        let dist_sq = dx.mul_add(dx, dz * dz);
+        let player_id = player.gameprofile.id;
+        if matches!(player.client.as_ref(), ClientPlatform::Bedrock(_))
+            && self.bedrock_suspended.load(Ordering::Acquire)
+        {
+            self.pending_pairings.remove(&player_id);
+            if self.seen_by.contains(&player_id) {
+                self.pending_removals.insert(player_id);
+            }
+            return;
+        }
 
-        let player_vd = get_view_distance(player).get() as i32;
         let effective_range = self.get_effective_range();
-        let visible_range_blocks = f64::from((effective_range as i32).min(player_vd) * 16);
-        let range_sq = visible_range_blocks * visible_range_blocks;
-
-        let entity_chunk = self.entity.get_entity().chunk_pos.load();
-        let player_chunk = player_entity.chunk_pos.load();
-        let in_view = is_within_view_distance(entity_chunk, player_chunk, player_vd);
-
-        let is_visible = dist_sq <= range_sq && self.broadcast_to_player(player) && in_view;
+        let is_visible = is_entity_visible_to_player(self.entity.as_ref(), player, effective_range);
 
         if is_visible {
-            if self.seen_by.insert(player.gameprofile.id) {
-                self.add_pairing(player);
+            // Once a removal is pending, preserve FIFO ordering even if the actor becomes visible
+            // again. The accepted removal will re-evaluate visibility and enqueue a fresh spawn.
+            if self.pending_removals.contains(&player_id) {
+                return;
             }
-        } else if self.seen_by.remove(&player.gameprofile.id).is_some() {
-            self.remove_pairing(player);
+            match player.client.as_ref() {
+                ClientPlatform::Java(_) => {
+                    // Preserve Java's existing pairing and fire-and-forget queue behavior.
+                    if self.seen_by.insert(player_id) {
+                        let _ = self.add_pairing(player);
+                    }
+                }
+                ClientPlatform::Bedrock(_) => {
+                    if !self.seen_by.contains(&player_id)
+                        && self.pairings_in_progress.insert(player_id)
+                    {
+                        if self.removing.load(Ordering::Acquire) {
+                            self.pairings_in_progress.remove(&player_id);
+                            return;
+                        }
+                        if self.add_pairing(player) {
+                            self.seen_by.insert(player_id);
+                            self.pending_pairings.remove(&player_id);
+                            if self.removing.load(Ordering::Acquire)
+                                || self.bedrock_suspended.load(Ordering::Acquire)
+                                || !player_is_in_world(player, world)
+                                || !is_entity_visible_to_player(
+                                    self.entity.as_ref(),
+                                    player,
+                                    effective_range,
+                                )
+                            {
+                                // A lifecycle transition may race the synchronous enqueue above.
+                                // Keep the accepted spawn ordered before its required removal.
+                                self.pending_removals.insert(player_id);
+                            }
+                        } else {
+                            // The Bedrock outgoing queue is deliberately bounded. Leave the actor
+                            // unseen and retry later instead of silently losing its spawn.
+                            if !self.removing.load(Ordering::Acquire)
+                                && !self.bedrock_suspended.load(Ordering::Acquire)
+                            {
+                                self.pending_pairings.insert(player_id);
+                            }
+                        }
+                        self.pairings_in_progress.remove(&player_id);
+                    }
+                }
+            }
+        } else {
+            let player_id = player.gameprofile.id;
+            self.pending_pairings.remove(&player_id);
+            match player.client.as_ref() {
+                ClientPlatform::Java(_) => {
+                    if self.seen_by.remove(&player_id).is_some() {
+                        let _ = self.remove_pairing(player);
+                    }
+                }
+                ClientPlatform::Bedrock(_) => {
+                    if self.seen_by.contains(&player_id) {
+                        self.pending_removals.insert(player_id);
+                    }
+                }
+            }
         }
     }
 
     pub fn update_players(&self, players: &[Arc<Player>], world: &World) {
         for player in players {
-            self.update_player(player, world);
+            match player.client.as_ref() {
+                ClientPlatform::Java(_) => self.update_player(player, world),
+                ClientPlatform::Bedrock(_) => self.update_player_deferred(player, world),
+            }
+        }
+    }
+
+    /// Applies visibility changes for a Bedrock player without immediately enqueueing a spawn.
+    /// Bulk scans use this path; the world-tick retry path is the sole actor-spawn rate limiter.
+    fn update_player_deferred(&self, player: &Arc<Player>, world: &World) {
+        if self.removing.load(Ordering::Acquire)
+            || player.get_entity().entity_id == self.entity_id
+            || !player_is_in_world(player, world)
+        {
+            return;
+        }
+
+        let player_id = player.gameprofile.id;
+        if self.bedrock_suspended.load(Ordering::Acquire) {
+            self.pending_pairings.remove(&player_id);
+            if self.seen_by.contains(&player_id) {
+                self.pending_removals.insert(player_id);
+            }
+            return;
+        }
+
+        if is_entity_visible_to_player(self.entity.as_ref(), player, self.get_effective_range()) {
+            if !self.pending_removals.contains(&player_id) && !self.seen_by.contains(&player_id) {
+                self.pending_pairings.insert(player_id);
+            }
+        } else {
+            self.pending_pairings.remove(&player_id);
+            match player.client.as_ref() {
+                ClientPlatform::Java(_) => {
+                    if self.seen_by.remove(&player_id).is_some() {
+                        let _ = self.remove_pairing(player);
+                    }
+                }
+                ClientPlatform::Bedrock(_) => {
+                    if self.seen_by.contains(&player_id) {
+                        self.pending_removals.insert(player_id);
+                    }
+                }
+            }
+        }
+    }
+
+    fn retry_pending_pairings(
+        &self,
+        players: &[Arc<Player>],
+        world: &World,
+        bedrock_budgets: &mut FxHashMap<Uuid, usize>,
+    ) {
+        if self.pending_pairings.is_empty() {
+            return;
+        }
+
+        for player in players {
+            if self.pending_pairings.contains(&player.gameprofile.id)
+                && take_bedrock_pairing_budget(bedrock_budgets, player.gameprofile.id)
+            {
+                self.update_player(player, world);
+            }
+        }
+    }
+
+    fn retry_pending_removals(
+        &self,
+        players: &[Arc<Player>],
+        world: &World,
+        bedrock_budgets: &mut FxHashMap<Uuid, usize>,
+    ) {
+        if self.pending_removals.is_empty() {
+            return;
+        }
+
+        for player in players {
+            let player_id = player.gameprofile.id;
+            if self.pending_removals.contains(&player_id)
+                && take_bedrock_pairing_budget(bedrock_budgets, player_id)
+                && self.remove_pairing(player)
+            {
+                self.seen_by.remove(&player_id);
+                self.pending_removals.remove(&player_id);
+                if !self.removing.load(Ordering::Acquire) {
+                    // Visibility may have changed while the full queue delayed this removal.
+                    // Re-evaluate now so a visible actor is respawned after the accepted remove.
+                    self.update_player_deferred(player, world);
+                }
+            }
         }
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn add_pairing(&self, player: &Arc<Player>) {
-        player.client.try_enqueue_spawn_packet(&self.entity);
+    pub fn add_pairing(&self, player: &Arc<Player>) -> bool {
+        if !player.client.try_enqueue_spawn_packet(&self.entity) {
+            return false;
+        }
 
         if let Some(target_player) = self.entity.get_player() {
             let skin_parts = target_player.config.load().skin_parts;
@@ -271,9 +489,11 @@ impl TrackedEntity {
                 client.try_enqueue_packet(data);
             }
         }
+
+        true
     }
 
-    pub fn remove_pairing(&self, player: &Arc<Player>) {
+    pub fn remove_pairing(&self, player: &Arc<Player>) -> bool {
         let entity_ids = [self.entity_id.into()];
         match player.client.as_ref() {
             ClientPlatform::Java(client) => {
@@ -281,51 +501,101 @@ impl TrackedEntity {
                 if let Ok(data) = client.serialize_packet(&packet) {
                     client.try_enqueue_packet(data);
                 }
+                true
             }
             ClientPlatform::Bedrock(client) => {
                 let packet = CRemoveActor::new(VarLong(i64::from(self.entity_id)));
-                if let Ok(data) = client.serialize_packet(&packet) {
-                    client.try_enqueue_packet(data);
+                client
+                    .serialize_packet(&packet)
+                    .is_ok_and(|data| client.try_enqueue_packet_data_checked(data))
+            }
+        }
+    }
+
+    fn suspend_bedrock(&self, world: &World) {
+        if self.removing.load(Ordering::Acquire) {
+            return;
+        }
+        self.bedrock_suspended.store(true, Ordering::Release);
+        self.pending_pairings.clear();
+        let players = world.players.load();
+        for player in players.iter() {
+            let player_id = player.gameprofile.id;
+            if matches!(player.client.as_ref(), ClientPlatform::Bedrock(_))
+                && self.seen_by.contains(&player_id)
+            {
+                self.pending_removals.insert(player_id);
+            }
+        }
+    }
+
+    fn resume_bedrock(&self, world: &World) {
+        if self.removing.load(Ordering::Acquire) {
+            return;
+        }
+        self.bedrock_suspended.store(false, Ordering::Release);
+        let players = world.players.load();
+        for player in players.iter() {
+            if matches!(player.client.as_ref(), ClientPlatform::Bedrock(_)) {
+                if self.seen_by.contains(&player.gameprofile.id) {
+                    // Respawn may be requested before the delayed death-time suspension ran.
+                    // Always refresh an already-paired actor so the client cannot retain its
+                    // non-interactable death state.
+                    self.pending_removals.insert(player.gameprofile.id);
+                }
+                self.update_player_deferred(player, world);
+            }
+        }
+    }
+
+    pub fn begin_removal(&self, world: &World) {
+        self.removing.store(true, Ordering::Release);
+        self.pending_pairings.clear();
+        let players = world.players.load();
+        for player in players.iter() {
+            let player_id = player.gameprofile.id;
+            if !self.seen_by.contains(&player_id) {
+                continue;
+            }
+            match player.client.as_ref() {
+                ClientPlatform::Java(_) => {
+                    let _ = self.remove_pairing(player);
+                    self.seen_by.remove(&player_id);
+                }
+                ClientPlatform::Bedrock(_) => {
+                    self.pending_removals.insert(player_id);
                 }
             }
         }
     }
 
-    pub fn broadcast_removed(&self, world: &World) {
-        let entity_ids = [self.entity_id.into()];
-        let je_packet = CRemoveEntities::new(&entity_ids);
-        let be_packet = CRemoveActor::new(VarLong(i64::from(self.entity_id)));
-
-        let players = world.players.load();
-        let recipients = players
-            .iter()
-            .filter(|p| self.seen_by.contains(&p.gameprofile.id));
-
-        let mut java_recipients = Vec::new();
-        let mut bedrock_recipients = Vec::new();
-        for p in recipients {
-            match p.client.as_ref() {
-                ClientPlatform::Java(_) => java_recipients.push(p),
-                ClientPlatform::Bedrock(be_client) => bedrock_recipients.push(be_client),
-            }
-        }
-        let recipients_by_version =
-            World::collect_java_recipients_by_version(java_recipients.into_iter());
-        World::broadcast_java_grouped(&je_packet, recipients_by_version);
-        World::broadcast_bedrock_grouped(&be_packet, bedrock_recipients.into_iter());
-
-        self.seen_by.clear();
+    fn removal_complete(&self) -> bool {
+        self.removing.load(Ordering::Acquire)
+            && self.seen_by.is_empty()
+            && self.pending_removals.is_empty()
+            && self.pairings_in_progress.is_empty()
     }
 
     pub fn remove_player(&self, player_uuid: &Uuid) {
         self.seen_by.remove(player_uuid);
+        self.pending_pairings.remove(player_uuid);
+        self.pairings_in_progress.remove(player_uuid);
+        self.pending_removals.remove(player_uuid);
+    }
+
+    #[must_use]
+    pub fn has_active_bedrock_pairing(&self, player_uuid: &Uuid) -> bool {
+        !self.removing.load(Ordering::Acquire)
+            && !self.bedrock_suspended.load(Ordering::Acquire)
+            && self.seen_by.contains(player_uuid)
+            && !self.pending_removals.contains(player_uuid)
     }
 
     pub fn send_to_tracking_players<P: ClientPacket + Sync>(&self, packet: &P, world: &World) {
         let players = world.players.load();
         let recipients = players
             .iter()
-            .filter(|p| self.seen_by.contains(&p.gameprofile.id));
+            .filter(|p| player_is_in_world(p, world) && self.seen_by.contains(&p.gameprofile.id));
         let recipients_by_version = World::collect_java_recipients_by_version(recipients);
         World::broadcast_java_grouped(packet, recipients_by_version);
     }
@@ -335,10 +605,44 @@ impl TrackedEntity {
         packet: &P,
         world: &World,
     ) {
+        if self.removing.load(Ordering::Acquire) || self.bedrock_suspended.load(Ordering::Acquire) {
+            return;
+        }
         let players = world.players.load();
         let recipients = players.iter().filter_map(|p| {
-            if self.seen_by.contains(&p.gameprofile.id)
+            if player_is_in_world(p, world)
+                && self.seen_by.contains(&p.gameprofile.id)
+                && !self.pending_removals.contains(&p.gameprofile.id)
                 && let ClientPlatform::Bedrock(client) = p.client.as_ref()
+            {
+                return Some(client);
+            }
+            None
+        });
+        World::broadcast_bedrock_grouped(packet, recipients);
+    }
+
+    pub fn send_to_tracking_players_and_self_bedrock_filtered<
+        P: BClientPacket + Sync,
+        F: Fn(&Player) -> bool,
+    >(
+        &self,
+        packet: &P,
+        world: &World,
+        filter: F,
+    ) {
+        if self.removing.load(Ordering::Acquire) || self.bedrock_suspended.load(Ordering::Acquire) {
+            return;
+        }
+        let players = world.players.load();
+        let recipients = players.iter().filter_map(|player| {
+            let tracks_entity = self.seen_by.contains(&player.gameprofile.id)
+                || player.entity_id() == self.entity_id;
+            if player_is_in_world(player, world)
+                && tracks_entity
+                && !self.pending_removals.contains(&player.gameprofile.id)
+                && filter(player)
+                && let ClientPlatform::Bedrock(client) = player.client.as_ref()
             {
                 return Some(client);
             }
@@ -356,14 +660,21 @@ impl TrackedEntity {
         let players = world.players.load();
         let recipients = players
             .iter()
-            .filter(|p| self.seen_by.contains(&p.gameprofile.id));
+            .filter(|p| player_is_in_world(p, world) && self.seen_by.contains(&p.gameprofile.id));
 
         let mut java_recipients = Vec::new();
         let mut bedrock_recipients = Vec::new();
         for p in recipients {
             match p.client.as_ref() {
                 ClientPlatform::Java(_) => java_recipients.push(p),
-                ClientPlatform::Bedrock(be_client) => bedrock_recipients.push(be_client),
+                ClientPlatform::Bedrock(be_client) => {
+                    if !self.removing.load(Ordering::Acquire)
+                        && !self.bedrock_suspended.load(Ordering::Acquire)
+                        && !self.pending_removals.contains(&p.gameprofile.id)
+                    {
+                        bedrock_recipients.push(be_client);
+                    }
+                }
             }
         }
         let recipients_by_version =
@@ -405,9 +716,9 @@ impl TrackedEntity {
         filter: F,
     ) {
         let players = world.players.load();
-        let recipients = players
-            .iter()
-            .filter(|p| self.seen_by.contains(&p.gameprofile.id) && filter(p));
+        let recipients = players.iter().filter(|p| {
+            player_is_in_world(p, world) && self.seen_by.contains(&p.gameprofile.id) && filter(p)
+        });
         let recipients_by_version = World::collect_java_recipients_by_version(recipients);
         World::broadcast_java_grouped(packet, recipients_by_version);
     }
@@ -424,16 +735,23 @@ impl TrackedEntity {
         filter: F,
     ) {
         let players = world.players.load();
-        let recipients = players
-            .iter()
-            .filter(|p| self.seen_by.contains(&p.gameprofile.id) && filter(p));
+        let recipients = players.iter().filter(|p| {
+            player_is_in_world(p, world) && self.seen_by.contains(&p.gameprofile.id) && filter(p)
+        });
 
         let mut java_recipients = Vec::new();
         let mut bedrock_recipients = Vec::new();
         for p in recipients {
             match p.client.as_ref() {
                 ClientPlatform::Java(_) => java_recipients.push(p),
-                ClientPlatform::Bedrock(be_client) => bedrock_recipients.push(be_client),
+                ClientPlatform::Bedrock(be_client) => {
+                    if !self.removing.load(Ordering::Acquire)
+                        && !self.bedrock_suspended.load(Ordering::Acquire)
+                        && !self.pending_removals.contains(&p.gameprofile.id)
+                    {
+                        bedrock_recipients.push(be_client);
+                    }
+                }
             }
         }
         let recipients_by_version =
@@ -509,7 +827,12 @@ impl EntityTracker {
         self.entity_map.insert(entity_id, tracked.clone());
 
         let players = world.players.load();
-        tracked.update_players(players.as_ref(), world);
+        for player in players.iter() {
+            match player.client.as_ref() {
+                ClientPlatform::Java(_) => tracked.update_player(player, world),
+                ClientPlatform::Bedrock(_) => tracked.update_player_deferred(player, world),
+            }
+        }
     }
 
     /// Must only be called after the player's own `CLogin` packet has been sent.
@@ -517,7 +840,12 @@ impl EntityTracker {
         let entity_id = player_arc.get_entity().entity_id;
         for entry in &self.entity_map {
             if *entry.key() != entity_id {
-                entry.value().update_player(player_arc, world);
+                match player_arc.client.as_ref() {
+                    ClientPlatform::Java(_) => entry.value().update_player(player_arc, world),
+                    ClientPlatform::Bedrock(_) => {
+                        entry.value().update_player_deferred(player_arc, world);
+                    }
+                }
             }
         }
     }
@@ -531,8 +859,23 @@ impl EntityTracker {
             }
         }
 
-        if let Some((_, tracked)) = self.entity_map.remove(&entity_id) {
-            tracked.broadcast_removed(world);
+        if let Some(tracked) = self.get_tracked_entity(entity_id) {
+            tracked.begin_removal(world);
+            if tracked.removal_complete() {
+                self.entity_map.remove(&entity_id);
+            }
+        }
+    }
+
+    pub fn suspend_bedrock_entity(&self, entity_id: i32, world: &World) {
+        if let Some(tracked) = self.get_tracked_entity(entity_id) {
+            tracked.suspend_bedrock(world);
+        }
+    }
+
+    pub fn resume_bedrock_entity(&self, entity_id: i32, world: &World) {
+        if let Some(tracked) = self.get_tracked_entity(entity_id) {
+            tracked.resume_bedrock(world);
         }
     }
 
@@ -551,7 +894,28 @@ impl EntityTracker {
                 let players = world.players.load();
                 entry.value().update_players(players.as_ref(), world);
             } else {
-                entry.value().update_player(player, world);
+                match player.client.as_ref() {
+                    ClientPlatform::Java(_) => entry.value().update_player(player, world),
+                    ClientPlatform::Bedrock(_) => {
+                        entry.value().update_player_deferred(player, world);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Re-evaluates one player's entity pairings for a newly available set of chunks.
+    /// This is used after Bedrock level-chunk delivery, so actor packets cannot overtake terrain.
+    pub fn update_player_for_chunks(
+        &self,
+        player: &Arc<Player>,
+        world: &World,
+        chunks: &FxHashSet<Vector2<i32>>,
+    ) {
+        for entry in &self.entity_map {
+            if chunks.contains(&entry.value().entity.get_entity().chunk_pos.load()) {
+                player.try_restore_vehicle(&entry.value().entity);
+                entry.value().update_player_deferred(player, world);
             }
         }
     }
@@ -570,12 +934,52 @@ impl EntityTracker {
         }
     }
 
-    pub fn update_all(&self, world: &World) {
+    /// Advances Bedrock actor spawn/removal queues without ticking entity simulation. This also
+    /// runs while game ticks are frozen so chunk streaming cannot leave joins or despawns stuck.
+    pub fn update_bedrock_lifecycles(&self, world: &World) {
         let players = world.players.load();
-        let mut moved_players = Vec::new();
+        let mut bedrock_pairing_budgets = players
+            .iter()
+            .filter_map(|player| {
+                matches!(player.client.as_ref(), ClientPlatform::Bedrock(_))
+                    .then_some((player.gameprofile.id, BEDROCK_ACTOR_PAIRINGS_PER_TICK))
+            })
+            .collect::<FxHashMap<_, _>>();
+        let mut completed_removals = Vec::new();
+
+        // Drain lifecycle removals before spending any of the shared per-player budget on
+        // new pairings. This prevents a large spawn backlog from delaying despawns for seconds.
+        for entry in &self.entity_map {
+            let tracked = entry.value();
+            tracked.retry_pending_removals(players.as_ref(), world, &mut bedrock_pairing_budgets);
+            if tracked.removing.load(Ordering::Acquire) && tracked.removal_complete() {
+                completed_removals.push(tracked.entity_id);
+            }
+        }
+
+        for entity_id in completed_removals {
+            self.entity_map.remove(&entity_id);
+        }
 
         for entry in &self.entity_map {
             let tracked = entry.value();
+            if tracked.removing.load(Ordering::Acquire) {
+                continue;
+            }
+            tracked.retry_pending_pairings(players.as_ref(), world, &mut bedrock_pairing_budgets);
+        }
+    }
+
+    pub fn update_all(&self, world: &World) {
+        self.update_bedrock_lifecycles(world);
+
+        let players = world.players.load();
+        let mut moved_players = Vec::new();
+        for entry in &self.entity_map {
+            let tracked = entry.value();
+            if tracked.removing.load(Ordering::Acquire) {
+                continue;
+            }
             let pos = tracked.entity.get_entity().pos.load();
             let new_pos = Vector3::new(
                 get_section_cord(pos.x.floor() as i32),
@@ -596,7 +1000,14 @@ impl EntityTracker {
 
         if !moved_players.is_empty() {
             for entry in &self.entity_map {
-                entry.value().update_players(&moved_players, world);
+                for player in &moved_players {
+                    match player.client.as_ref() {
+                        ClientPlatform::Java(_) => entry.value().update_player(player, world),
+                        ClientPlatform::Bedrock(_) => {
+                            entry.value().update_player_deferred(player, world);
+                        }
+                    }
+                }
             }
         }
 
@@ -606,5 +1017,25 @@ impl EntityTracker {
                 tracked.entity.get_entity().send_dirty_entity_data();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BEDROCK_ACTOR_PAIRINGS_PER_TICK, take_bedrock_pairing_budget};
+    use rustc_hash::FxHashMap;
+    use uuid::Uuid;
+
+    #[test]
+    fn bedrock_actor_pairing_budget_is_strictly_bounded_per_tick() {
+        let player_id = Uuid::from_u128(1);
+        let mut budgets = FxHashMap::from_iter([(player_id, BEDROCK_ACTOR_PAIRINGS_PER_TICK)]);
+
+        let accepted = (0..BEDROCK_ACTOR_PAIRINGS_PER_TICK + 10)
+            .filter(|_| take_bedrock_pairing_budget(&mut budgets, player_id))
+            .count();
+
+        assert_eq!(accepted, BEDROCK_ACTOR_PAIRINGS_PER_TICK);
+        assert_eq!(budgets[&player_id], 0);
     }
 }

--- a/crates/pumpkin/src/world/entity_tracker.rs
+++ b/crates/pumpkin/src/world/entity_tracker.rs
@@ -1145,7 +1145,7 @@ mod tests {
             65,
             "terrain followed by at most 64 actor packets"
         );
-        for pair in packets[1..].chunks_exact(2) {
+        for pair in packets[1..].as_chunks::<2>().0 {
             assert_eq!(pair[0].id, CPlayerList::PACKET_ID);
             assert_eq!(pair[1].id, CAddPlayer::PACKET_ID);
         }

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1,5 +1,5 @@
 use crate::block::entities::{BlockEntity, block_entity_from_nbt};
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use pumpkin_data::chunk::Biome;
 use pumpkin_data::item::{BedrockItem, BedrockItemVersion};
 use pumpkin_protocol::bedrock::client::item_registry::{CItemRegistry, ItemData};
@@ -109,8 +109,7 @@ use pumpkin_protocol::{
                 CreativeItemEntryPayload,
             },
             level_sound_event::CLevelSoundEvent,
-            player_list::{CPlayerList, PlayerListEntry, Skin},
-            remove_actor::CRemoveActor,
+            player_list::{CPlayerList, PlayerListEntry},
             start_game::{Experiments, GamePublishSetting, LevelSettings},
             update_attributes::{AttributeData, CUpdateAttributes},
         },
@@ -124,8 +123,8 @@ use pumpkin_protocol::{
         self,
         client::play::{
             CBlockEntityData, CDamageEvent, CEntityStatus, CGameEvent, CLogin, CMultiBlockUpdate,
-            CPlayerInfoUpdate, CRemoveEntities, CRemovePlayerInfo, CSetSelectedSlot, CSoundEffect,
-            CSpawnEntity, GameEvent, InitChat, PlayerAction, PlayerInfoFlags,
+            CPlayerInfoUpdate, CRemovePlayerInfo, CSetSelectedSlot, CSoundEffect, CSpawnEntity,
+            GameEvent, InitChat, PlayerAction, PlayerInfoFlags,
         },
         server::play::SChatMessage,
     },
@@ -219,6 +218,47 @@ fn bedrock_chest_block_actor(state_id: BlockStateId, position: BlockPos) -> Opti
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+/// Removes duplicate persisted UUIDs within one entity chunk while preserving the relative file
+/// order of retained entries. The last occurrence wins because the historical bug appended newer
+/// snapshots after older ones. Entries without a usable UUID remain distinct and receive a fresh
+/// one for the live entity.
+fn deduplicate_entity_nbts_by_uuid(
+    entity_nbts: Vec<NbtCompound>,
+    mut fresh_uuid: impl FnMut() -> Uuid,
+) -> Vec<(NbtCompound, Uuid)> {
+    // Reserve every valid persisted UUID up front so a generated UUID cannot steal the identity
+    // of a later entry in the same chunk.
+    let mut reserved_uuids: FxHashSet<_> = entity_nbts
+        .iter()
+        .filter_map(|entity_nbt| entity_nbt.get_uuid("UUID"))
+        .collect();
+    let last_persisted_occurrence: FxHashMap<_, _> = entity_nbts
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entity_nbt)| entity_nbt.get_uuid("UUID").map(|uuid| (uuid, index)))
+        .collect();
+    let mut unique_entities = Vec::with_capacity(entity_nbts.len());
+
+    for (index, entity_nbt) in entity_nbts.into_iter().enumerate() {
+        let uuid = if let Some(uuid) = entity_nbt.get_uuid("UUID") {
+            if last_persisted_occurrence.get(&uuid) != Some(&index) {
+                continue;
+            }
+            uuid
+        } else {
+            loop {
+                let uuid = fresh_uuid();
+                if reserved_uuids.insert(uuid) {
+                    break uuid;
+                }
+            }
+        };
+        unique_entities.push((entity_nbt, uuid));
+    }
+
+    unique_entities
+}
+
 impl PumpkinError for GetBlockError {
     fn is_kick(&self) -> bool {
         false
@@ -253,6 +293,8 @@ pub struct World {
     /// A map of active entities within the world, keyed by their unique UUID.
     /// This does not include players.
     pub entities: ArcSwap<Vec<Arc<dyn EntityBase>>>,
+    /// Atomically reserves UUIDs before entities are admitted to the live list.
+    entity_uuids: DashSet<Uuid>,
     /// The world's scoreboard, used for tracking scores, objectives, and display information.
     pub scoreboard: std::sync::Mutex<Scoreboard>,
     /// The world's worldborder, defining the playable area and controlling its expansion or contraction.
@@ -293,6 +335,9 @@ pub struct World {
     pub custom_block_entity_data: DashMap<BlockPos, NbtCompound>,
     /// Entity tracker responsible for tracking entity visibility and sending delta/status packets to watchers.
     pub entity_tracker: entity_tracker::EntityTracker,
+    /// Serializes entity chunk materialization, autosave snapshots, and unload
+    /// snapshots so none of those transitions can observe a half-updated world.
+    entity_persistence_lock: tokio::sync::Mutex<()>,
 }
 
 #[derive(Clone, Copy)]
@@ -388,6 +433,7 @@ impl World {
             level_info,
             players: ArcSwap::new(Arc::new(Vec::new())),
             entities: ArcSwap::new(Arc::new(Vec::new())),
+            entity_uuids: DashSet::new(),
             scoreboard: std::sync::Mutex::new(Scoreboard::default()),
             worldborder: std::sync::Mutex::new(Worldborder::new(
                 0.0,
@@ -419,6 +465,7 @@ impl World {
             custom_data: std::sync::Mutex::new(custom_data),
             custom_block_entity_data: DashMap::new(),
             entity_tracker: entity_tracker::EntityTracker::new(),
+            entity_persistence_lock: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -542,9 +589,11 @@ impl World {
     }
 
     pub async fn shutdown(&self) {
-        for entity in self.entities.load().iter() {
-            self.save_entity(entity).await;
-        }
+        {
+            let _persistence_guard = self.entity_persistence_lock.lock().await;
+            let entities = self.entities.load_full();
+            self.rebuild_all_entity_chunk_snapshots(&entities).await;
+        };
 
         let chunks: Vec<Vector2<i32>> = self
             .block_entities
@@ -568,26 +617,81 @@ impl World {
         self.level.shutdown().await;
     }
 
-    /// Serializes a live entity into its current chunk's entity data. The live
-    /// entity list is the source of truth while a chunk is loaded (its saved NBT
-    /// is consumed on load), so this simply appends the entity to the chunk it is
-    /// currently in; the chunk is rewritten from scratch every unload cycle, so
-    /// there is nothing stale to deduplicate.
-    async fn save_entity(&self, entity: &Arc<dyn EntityBase>) {
-        let base_entity = entity.get_entity();
-        if base_entity.is_removed() {
-            return;
+    fn entity_chunk_snapshots(
+        entities: &[Arc<dyn EntityBase>],
+    ) -> (FxHashMap<Vector2<i32>, Vec<NbtCompound>>, FxHashSet<Uuid>) {
+        let mut snapshots: FxHashMap<Vector2<i32>, Vec<NbtCompound>> = FxHashMap::default();
+        let mut saved_uuids = FxHashSet::default();
+        for entity in entities {
+            let base_entity = entity.get_entity();
+            if base_entity.is_removed() || !saved_uuids.insert(base_entity.entity_uuid) {
+                continue;
+            }
+
+            let chunk_pos = base_entity.chunk_pos.load();
+            let mut nbt = NbtCompound::new();
+            entity.write_nbt(&mut nbt);
+            snapshots.entry(chunk_pos).or_default().push(nbt);
         }
-        let current_chunk = base_entity.block_pos.load().chunk_position();
-        let mut nbt = NbtCompound::new();
-        entity.write_nbt(&mut nbt);
-        let chunk = self.level.get_entity_chunk(current_chunk).await;
-        chunk
-            .data
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .push(nbt);
-        chunk.mark_dirty(true);
+        (snapshots, saved_uuids)
+    }
+
+    /// Rebuilds every materialized entity chunk from the live entity list.
+    ///
+    /// A complete replacement is important here: appending one NBT record per
+    /// entity makes every autosave add another copy of the same entities. Empty
+    /// materialized chunks are replaced too, which removes snapshots of entities
+    /// that moved away or were discarded.
+    async fn rebuild_all_entity_chunk_snapshots(&self, entities: &[Arc<dyn EntityBase>]) {
+        let (mut snapshots, live_uuids) = Self::entity_chunk_snapshots(entities);
+
+        for (chunk_pos, chunk) in self.level.entity_chunks() {
+            let entities = snapshots.remove(&chunk_pos).unwrap_or_default();
+            if chunk.entities_are_materialized() {
+                chunk.replace_entities(entities);
+            } else {
+                chunk.reconcile_entities(entities, &live_uuids);
+            }
+        }
+
+        // An entity can cross into a chunk before that chunk's persisted entities
+        // are materialized. Preserve those untouched entities while replacing any
+        // prior snapshot of the live UUID.
+        for (chunk_pos, entities) in snapshots {
+            self.level
+                .get_entity_chunk(chunk_pos)
+                .await
+                .reconcile_entities(entities, &live_uuids);
+        }
+    }
+
+    /// Rebuilds the chunks being unloaded from the entities removed from the live
+    /// world. The caller holds `entity_persistence_lock`, preventing an autosave
+    /// or another unload from rebuilding the same chunks concurrently.
+    async fn rebuild_unloaded_entity_chunk_snapshots(
+        &self,
+        entities: &[Arc<dyn EntityBase>],
+        chunks: &FxHashSet<Vector2<i32>>,
+    ) {
+        let (mut snapshots, live_uuids) = Self::entity_chunk_snapshots(entities);
+
+        // Also remove stale occurrences of these live UUIDs from other loaded
+        // chunks (for example after an entity crossed a boundary).
+        for (chunk_pos, chunk) in self.level.entity_chunks() {
+            let entities = snapshots.remove(&chunk_pos).unwrap_or_default();
+            if chunks.contains(&chunk_pos) && chunk.entities_are_materialized() {
+                chunk.replace_entities(entities);
+            } else {
+                chunk.reconcile_entities(entities, &live_uuids);
+            }
+        }
+
+        for (chunk_pos, entities) in snapshots {
+            self.level
+                .get_entity_chunk(chunk_pos)
+                .await
+                .reconcile_entities(entities, &live_uuids);
+        }
     }
 
     /// Serializes the live block entities of a chunk back into that chunk's block
@@ -1144,16 +1248,9 @@ impl World {
 
     /// Broadcasts the skin layers of a player, encoding the metadata for each Java client's own
     /// protocol version since the tracked data index differs between versions.
-    fn broadcast_skin_parts<B: BClientPacket>(
-        &self,
-        except: &[uuid::Uuid],
-        entity_id: i32,
-        skin_parts: u8,
-        be_packet: &B,
-    ) {
+    fn broadcast_skin_parts(&self, except: &[uuid::Uuid], entity_id: i32, skin_parts: u8) {
         let players = self.players.load();
         let mut java_recipients = Vec::new();
-        let mut bedrock_recipients = Vec::new();
 
         for p in players.iter() {
             if except.contains(&p.gameprofile.id) {
@@ -1161,7 +1258,7 @@ impl World {
             }
             match p.client.as_ref() {
                 ClientPlatform::Java(_) => java_recipients.push(p),
-                ClientPlatform::Bedrock(be_client) => bedrock_recipients.push(be_client),
+                ClientPlatform::Bedrock(_) => {}
             }
         }
 
@@ -1193,8 +1290,6 @@ impl World {
                 }
             }
         }
-
-        Self::broadcast_bedrock_grouped(be_packet, bedrock_recipients.into_iter());
     }
 
     /// Broadcasts a packet to all connected players within the world, excluding the specified players.
@@ -1815,7 +1910,6 @@ impl World {
                     if let Some(server) = self.server.upgrade() {
                         server.spawn_task(async move {
                             world_clone.remove_entities_in_chunks(&cleaned_chunks).await;
-                            world_clone.level.clean_entity_chunks(&cleaned_chunks);
                         });
                     }
                 }
@@ -3120,26 +3214,10 @@ impl World {
         let gameprofile = &player.gameprofile;
         let velocity = player.get_entity().velocity.load();
 
-        // 1. Broadcast the new Bedrock player to everyone else (Java + Bedrock)
-        let bedrock_player_list = CPlayerList {
-            action: CPlayerList::ACTION_ADD,
-            entries: vec![PlayerListEntry {
-                uuid: gameprofile.id,
-                entity_unique_id: VarLong(runtime_id as i64),
-                username: gameprofile.name.clone(),
-                xuid: String::new(),
-                platform_chat_id: String::new(),
-                build_platform: BuildPlatform::Unknown,
-                skin: (**player.bedrock_skin.load()).clone(),
-                is_teacher: false,
-                is_host: false,
-                is_sub_client: false,
-                player_color: [0, 0, 0, 0],
-            }],
-        };
-
+        // 1. Broadcast the new Bedrock player to Java clients. Bedrock recipients receive the
+        // player-list entry atomically with the actor once their terrain barrier is satisfied.
         let gamemode = player.gamemode.load();
-        self.broadcast_packet_except_editioned(
+        self.broadcast_packet_except(
             &[gameprofile.id],
             &CPlayerInfoUpdate::new(
                 (PlayerInfoFlags::ADD_PLAYER
@@ -3164,44 +3242,13 @@ impl World {
                     ],
                 }],
             ),
-            &bedrock_player_list,
         );
 
-        let bedrock_add_player = CAddPlayer {
-            uuid: gameprofile.id,
-            player_name: gameprofile.name.clone(),
-            target_runtime_id: VarULong(runtime_id),
-            platform_chat_id: String::new(),
-            position: Vector3::new(position.x as f32, position.y as f32, position.z as f32),
-            velocity: Vector3::new(velocity.x as f32, velocity.y as f32, velocity.z as f32),
-            rotation: Vector2::new(pitch, yaw),
-            y_head_rotation: yaw,
-            carried_item: NetworkItemStackDescriptor::default(),
-            player_game_type: player.gamemode.load().into(),
-            entity_data: entity.bedrock_metadata(),
-            synced_properties: PropertySyncData::default(),
-            abilities_data: pumpkin_protocol::bedrock::client::SerializedAbilitiesData {
-                target_player_raw_id: runtime_id as i64,
-                player_permissions:
-                    pumpkin_protocol::bedrock::client::PlayerPermissionLevel::Visitor,
-                command_permissions: pumpkin_protocol::bedrock::client::CommandPermissionLevel::Any,
-                layers: vec![
-                    pumpkin_protocol::bedrock::client::SerializedAbilitiesDataSerializedLayer {
-                        serialized_layer: 0,
-                        abilities_set: 0,
-                        ability_value: 0,
-                        fly_speed: 0.05,
-                        vertical_fly_speed: 0.05,
-                        walk_speed: 0.1,
-                    },
-                ],
-            },
-            actor_links: Vec::new(),
-            device_id: String::new(),
-            build_platform: BuildPlatform::Unknown,
-        };
+        self.sync_bedrock_player_lists_on_join(&player).await;
 
-        self.broadcast_packet_except_editioned(
+        // Java can receive the actor immediately. Bedrock actor creation is deferred through
+        // EntityTracker until terrain and PlayerSpawn are ready for each recipient.
+        self.broadcast_packet_except(
             &[gameprofile.id],
             &CSpawnEntity::new(
                 (runtime_id as i32).into(),
@@ -3214,7 +3261,6 @@ impl World {
                 0.into(),
                 velocity,
             ),
-            &bedrock_add_player,
         );
 
         self.send_player_equipment(&player);
@@ -3222,97 +3268,11 @@ impl World {
         // Broadcast metadata to Java players so they can correctly interact with the new player
         let skin_parts = player.config.load().skin_parts;
 
-        self.broadcast_skin_parts(
-            &[gameprofile.id],
-            runtime_id as i32,
-            skin_parts,
-            &actor_data,
-        );
-
-        // 2. Spawn existing players for our new Bedrock client
-        let players = self.players.load();
-
-        for existing_player in players
-            .iter()
-            .filter(|p| p.gameprofile.id != gameprofile.id)
-        {
-            let ex_profile = &existing_player.gameprofile;
-            let ex_entity = &existing_player.get_entity();
-            let ex_pos = ex_entity.pos.load();
-            let ex_vel = ex_entity.velocity.load();
-
-            let ex_player_list = CPlayerList {
-                action: CPlayerList::ACTION_ADD,
-                entries: vec![PlayerListEntry {
-                    uuid: ex_profile.id,
-                    entity_unique_id: VarLong(existing_player.entity_id() as i64),
-                    username: ex_profile.name.clone(),
-                    xuid: String::new(),
-                    platform_chat_id: String::new(),
-                    build_platform: BuildPlatform::Unknown,
-                    skin: (**existing_player.bedrock_skin.load()).clone(),
-                    is_teacher: false,
-                    is_host: false,
-                    is_sub_client: false,
-                    player_color: [0, 0, 0, 0],
-                }],
-            };
-            // Send PlayerList FIRST
-            client.send_packet(&ex_player_list).await;
-
-            let ex_add_player = CAddPlayer {
-                uuid: ex_profile.id,
-                player_name: ex_profile.name.clone(),
-                target_runtime_id: VarULong(existing_player.entity_id() as u64),
-                platform_chat_id: String::new(),
-                position: Vector3::new(ex_pos.x as f32, ex_pos.y as f32, ex_pos.z as f32),
-                velocity: Vector3::new(ex_vel.x as f32, ex_vel.y as f32, ex_vel.z as f32),
-                rotation: Vector2::new(ex_entity.pitch.load(), ex_entity.yaw.load()),
-                y_head_rotation: ex_entity.head_yaw.load(),
-                carried_item: NetworkItemStackDescriptor::default(),
-                player_game_type: existing_player.gamemode.load().into(),
-                entity_data: ex_entity.bedrock_metadata(),
-                synced_properties: PropertySyncData::default(),
-                abilities_data: pumpkin_protocol::bedrock::client::SerializedAbilitiesData {
-                    target_player_raw_id: existing_player.entity_id() as i64,
-                    player_permissions:
-                        pumpkin_protocol::bedrock::client::PlayerPermissionLevel::Visitor,
-                    command_permissions:
-                        pumpkin_protocol::bedrock::client::CommandPermissionLevel::Any,
-                    layers: vec![
-                        pumpkin_protocol::bedrock::client::SerializedAbilitiesDataSerializedLayer {
-                            serialized_layer: 0,
-                            abilities_set: 0,
-                            ability_value: 0,
-                            fly_speed: 0.05,
-                            vertical_fly_speed: 0.05,
-                            walk_speed: 0.1,
-                        },
-                    ],
-                },
-                actor_links: Vec::new(),
-                device_id: String::new(),
-                build_platform: BuildPlatform::Unknown,
-            };
-
-            client.send_packet(&ex_add_player).await;
-
-            let ex_held_item = existing_player.inventory().held_item();
-
-            let ex_be_mob_equipment = pumpkin_protocol::bedrock::client::CMobEquipment {
-                target_runtime_id: (existing_player.entity_id() as u64).into(),
-                item: (&ex_held_item).into(),
-                slot: 0,
-                selected_slot: 0,
-                container_id: 0,
-            };
-
-            client.send_packet(&ex_be_mob_equipment).await;
-        }
+        self.broadcast_skin_parts(&[gameprofile.id], runtime_id as i32, skin_parts);
 
         player.has_played_before.store(true, Ordering::Relaxed);
 
-        // 3. Trigger Join Event and Broadcast Join Message
+        // 2. Trigger Join Event and Broadcast Join Message
         let msg_comp = TextComponent::translate_cross(
             translation::java::MULTIPLAYER_PLAYER_JOINED,
             translation::bedrock::MULTIPLAYER_PLAYER_JOINED,
@@ -3490,23 +3450,6 @@ impl World {
         player.request_teleport(position, yaw, pitch);
 
         let gameprofile = &player.gameprofile;
-        let bedrock_player_list = CPlayerList {
-            action: CPlayerList::ACTION_ADD,
-            entries: vec![PlayerListEntry {
-                uuid: gameprofile.id,
-                entity_unique_id: VarLong(entity_id as i64),
-                username: gameprofile.name.clone(),
-                xuid: String::new(),
-                platform_chat_id: String::new(),
-                build_platform: BuildPlatform::Unknown,
-                skin: (**player.bedrock_skin.load()).clone(),
-                is_teacher: false,
-                is_host: false,
-                is_sub_client: false,
-                player_color: [0, 0, 0, 0],
-            }],
-        };
-
         let player_actions = [
             PlayerAction::AddPlayer {
                 name: &gameprofile.name,
@@ -3533,7 +3476,8 @@ impl World {
             &java_player,
         );
 
-        self.broadcast_editioned(&player_info_update, &bedrock_player_list);
+        self.broadcast_packet_all(&player_info_update);
+        self.sync_bedrock_player_lists_on_join(player).await;
 
         // If the player has a custom tab_list_name, send an update for it
         if let Some(tab_list_name) = player.get_tab_list_name() {
@@ -3652,41 +3596,8 @@ impl World {
 
         let gameprofile = &player.gameprofile;
 
-        let bedrock_add_player = CAddPlayer {
-            uuid: gameprofile.id,
-            player_name: gameprofile.name.clone(),
-            target_runtime_id: VarULong(entity_id as u64),
-            platform_chat_id: String::new(),
-            position: Vector3::new(position.x as f32, position.y as f32, position.z as f32),
-            velocity: Vector3::new(velocity.x as f32, velocity.y as f32, velocity.z as f32),
-            rotation: Vector2::new(pitch, yaw),
-            y_head_rotation: yaw,
-            carried_item: NetworkItemStackDescriptor::default(),
-            player_game_type: player.gamemode.load().into(),
-            entity_data: player.get_entity().bedrock_metadata(),
-            synced_properties: PropertySyncData::default(),
-            abilities_data: pumpkin_protocol::bedrock::client::SerializedAbilitiesData {
-                target_player_raw_id: entity_id as i64,
-                player_permissions:
-                    pumpkin_protocol::bedrock::client::PlayerPermissionLevel::Visitor,
-                command_permissions: pumpkin_protocol::bedrock::client::CommandPermissionLevel::Any,
-                layers: vec![
-                    pumpkin_protocol::bedrock::client::SerializedAbilitiesDataSerializedLayer {
-                        serialized_layer: 0,
-                        abilities_set: 0,
-                        ability_value: 0,
-                        fly_speed: 0.05,
-                        vertical_fly_speed: 0.05,
-                        walk_speed: 0.1,
-                    },
-                ],
-            },
-            actor_links: Vec::new(),
-            device_id: String::new(),
-            build_platform: BuildPlatform::Unknown,
-        };
-
-        // Spawn the player for every client.
+        // Java can receive the actor immediately. Bedrock actor creation is deferred through
+        // EntityTracker until that recipient has terrain ready for the player's chunk.
         let spawn_entity = CSpawnEntity::new(
             entity_id.into(),
             gameprofile.id,
@@ -3699,29 +3610,12 @@ impl World {
             velocity,
         );
 
-        self.broadcast_packet_except_editioned(
-            &[player.gameprofile.id],
-            &spawn_entity,
-            &bedrock_add_player,
-        );
+        self.broadcast_packet_except(&[player.gameprofile.id], &spawn_entity);
 
         // Broadcast metadata to Java players so they can correctly interact with the new player
         let skin_parts = player.config.load().skin_parts;
 
-        self.broadcast_skin_parts(
-            &[gameprofile.id],
-            entity_id,
-            skin_parts,
-            &CSetActorData {
-                target_runtime_id: VarULong(entity_id as u64),
-                actor_data: player.get_entity().bedrock_metadata(),
-                synced_properties: PropertySyncData {
-                    int_entries_list: HashMap::new(),
-                    float_entries_list: HashMap::new(),
-                },
-                tick: VarULong(0),
-            },
-        );
+        self.broadcast_skin_parts(&[gameprofile.id], entity_id, skin_parts);
 
         // Spawn players for our client.
         let id = player.gameprofile.id;
@@ -4220,80 +4114,17 @@ impl World {
             return;
         };
         if matches!(player.client.as_ref(), ClientPlatform::Java(_)) {
-            self.broadcast_to_chunk_bedrock(
-                subject.chunk_pos.load(),
-                &CRemoveActor::new(VarLong(subject.entity_id.into())),
-            );
+            self.entity_tracker
+                .suspend_bedrock_entity(subject.entity_id, self);
         }
     }
 
-    async fn refresh_java_player_for_bedrock(&self, subject: &Player) {
+    fn refresh_java_player_for_bedrock(&self, subject: &Player) {
         if !matches!(subject.client.as_ref(), ClientPlatform::Java(_)) {
             return;
         }
-
-        let entity = subject.get_entity();
-        let entity_id = subject.entity_id();
-        let position = entity.pos.load();
-        let velocity = entity.velocity.load();
-        let player_list = CPlayerList {
-            action: CPlayerList::ACTION_ADD,
-            entries: vec![PlayerListEntry {
-                uuid: subject.gameprofile.id,
-                entity_unique_id: VarLong(entity_id.into()),
-                username: subject.gameprofile.name.clone(),
-                xuid: String::new(),
-                platform_chat_id: String::new(),
-                build_platform: BuildPlatform::Unknown,
-                skin: (**subject.bedrock_skin.load()).clone(),
-                is_teacher: false,
-                is_host: false,
-                is_sub_client: false,
-                player_color: [0; 4],
-            }],
-        };
-        let add_player = CAddPlayer {
-            uuid: subject.gameprofile.id,
-            player_name: subject.gameprofile.name.clone(),
-            target_runtime_id: VarULong(entity_id as u64),
-            platform_chat_id: String::new(),
-            position: Vector3::new(position.x as f32, position.y as f32, position.z as f32),
-            velocity: Vector3::new(velocity.x as f32, velocity.y as f32, velocity.z as f32),
-            rotation: Vector2::new(entity.pitch.load(), entity.yaw.load()),
-            y_head_rotation: entity.head_yaw.load(),
-            carried_item: NetworkItemStackDescriptor::default(),
-            player_game_type: subject.gamemode.load().into(),
-            entity_data: entity.bedrock_metadata(),
-            synced_properties: PropertySyncData::default(),
-            abilities_data: pumpkin_protocol::bedrock::client::SerializedAbilitiesData {
-                target_player_raw_id: entity_id as i64,
-                player_permissions:
-                    pumpkin_protocol::bedrock::client::PlayerPermissionLevel::Visitor,
-                command_permissions: pumpkin_protocol::bedrock::client::CommandPermissionLevel::Any,
-                layers: vec![
-                    pumpkin_protocol::bedrock::client::SerializedAbilitiesDataSerializedLayer {
-                        serialized_layer: 0,
-                        abilities_set: 0,
-                        ability_value: 0,
-                        fly_speed: 0.05,
-                        vertical_fly_speed: 0.05,
-                        walk_speed: 0.1,
-                    },
-                ],
-            },
-            actor_links: Vec::new(),
-            device_id: String::new(),
-            build_platform: BuildPlatform::Unknown,
-        };
-        let remove = CRemoveActor::new(VarLong(entity_id.into()));
-
-        for recipient in self.players.load().iter() {
-            if let ClientPlatform::Bedrock(client) = recipient.client.as_ref() {
-                client.send_packet(&remove).await;
-                client.send_packet(&player_list).await;
-                client.send_packet(&add_player).await;
-            }
-        }
+        self.entity_tracker
+            .resume_bedrock_entity(subject.entity_id(), self);
     }
 
     #[allow(clippy::too_many_lines)]
@@ -4446,15 +4277,11 @@ impl World {
 
                         // Detach from the old world before publishing into the new one, so no
                         // observer sees the player in a world whose chunk manager doesn't match.
+                        player.pause_chunk_streaming_for_transfer();
                         self.remove_player(player, false).await;
                         player.unload_watched_chunks(self).await;
                         player.change_world_chunks(&self.level, &destination);
                         player.living_entity.entity.set_world(destination.clone());
-                        destination.players.rcu(|current_list| {
-                            let mut new_list = (**current_list).clone();
-                            new_list.push(player.clone());
-                            new_list
-                        });
                     }
 
                     (Some(destination), position, yaw, pitch)
@@ -4564,10 +4391,29 @@ impl World {
         player.get_entity().set_pos(position);
         player.get_entity().set_rotation(yaw, pitch);
         player.get_entity().last_pos.store(position);
+        if target_world.uuid != self.uuid {
+            target_world.players.rcu(|current_list| {
+                let mut new_list = (**current_list).clone();
+                new_list.push(player.clone());
+                new_list
+            });
+            let tracked_player = player.clone() as Arc<dyn EntityBase>;
+            target_world
+                .entity_tracker
+                .add_entity(&tracked_player, &target_world);
+            target_world.sync_bedrock_player_lists_on_join(player).await;
+        }
 
         // TODO: difficulty, exp bar, status effect
 
+        if target_world.uuid == self.uuid {
+            // Cross-world transfers already advanced/reset this generation in
+            // `change_world_chunks`; same-world respawns must do it before scheduling chunks.
+            player.advance_chunk_send_epoch();
+        }
+
         // Load chunks and send world info FIRST (before teleport packet)
+        player.resume_chunk_streaming_after_transfer();
         target_world.send_world_info(player, position, yaw, pitch);
 
         // Ensure at least the center chunk is sent synchronously before teleport.
@@ -4581,9 +4427,9 @@ impl World {
         }
 
         // Send teleport packet after at least the center chunk was delivered
-        player.request_teleport(position, yaw, pitch);
+        player.request_teleport_in_current_chunk_epoch(position, yaw, pitch);
 
-        target_world.refresh_java_player_for_bedrock(player).await;
+        target_world.refresh_java_player_for_bedrock(player);
     }
 
     /// Returns true if enough players are sleeping and we should skip the night.
@@ -4619,14 +4465,16 @@ impl World {
         sleeping_player_count >= required_sleeping
     }
 
-    // NOTE: This function doesn't actually await on anything, it just spawns two tokio tasks
+    // NOTE: This function doesn't actually await on anything; it spawns one player-owned task.
     /// IMPORTANT: Chunks have to be non-empty
-    fn spawn_world_entity_chunks(
+    #[allow(clippy::too_many_lines)]
+    pub(crate) fn spawn_world_entity_chunks(
         self: &Arc<Self>,
         player: Arc<Player>,
         chunks: Vec<Vector2<i32>>,
         center_chunk: Vector2<i32>,
-    ) {
+        expected_epoch: u32,
+    ) -> Option<tokio::task::JoinHandle<()>> {
         #[cfg(debug_assertions)]
         let inst = std::time::Instant::now();
 
@@ -4638,6 +4486,7 @@ impl World {
             rel_x * rel_x + rel_z * rel_z
         });
 
+        let requested_chunks: FxHashSet<_> = chunks.iter().copied().collect();
         let mut entity_receiver = self.level.receive_entity_chunks(chunks);
         let level = self.level.clone();
         let world = self.clone();
@@ -4654,15 +4503,28 @@ impl World {
                     }
                 };
 
-                let Some((chunk_weak, first_load)) = recv_result else {
+                let Some((chunk_weak, _first_load)) = recv_result else {
                     break;
                 };
+
+                if player.chunk_send_epoch.load(Ordering::Acquire) != expected_epoch
+                    || !Arc::ptr_eq(&player.world(), &world)
+                {
+                    break;
+                }
 
                 let Some(chunk) = chunk_weak.upgrade() else {
                     continue;
                 };
 
                 let position = Vector2::new(chunk.x, chunk.z);
+                let _persistence_guard = world.entity_persistence_lock.lock().await;
+
+                if player.chunk_send_epoch.load(Ordering::Acquire) != expected_epoch
+                    || !Arc::ptr_eq(&player.world(), &world)
+                {
+                    break;
+                }
 
                 if !level.is_chunk_watched(&position) {
                     // No longer watched: don't make its entities live. Leave the
@@ -4675,40 +4537,40 @@ impl World {
                     continue 'main;
                 }
 
-                if first_load {
-                    // First watcher: consume the serialized entities and make them
-                    // live. The live entity list becomes the single source of
-                    // truth, so the chunk's NBT is taken (cleared) to avoid keeping
-                    // a duplicate copy that would be re-appended on the next unload
-                    // and doubled on every reload.
-                    let entity_nbts = std::mem::take(
-                        &mut *chunk
-                            .data
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner),
-                    );
+                if let Some(entity_nbts) = chunk.take_entities_for_materialization() {
+                    // The watcher that atomically materializes this chunk consumes
+                    // its serialized entities. Later watchers use the live entity
+                    // tracker, even if two fetches for this position raced.
+                    let original_entity_count = entity_nbts.len();
+                    let entity_nbts =
+                        deduplicate_entity_nbts_by_uuid(entity_nbts, Uuid::new_v4);
+                    let duplicate_count = original_entity_count - entity_nbts.len();
+                    if duplicate_count > 0 {
+                        warn!(
+                            "Discarded {duplicate_count} duplicate UUID entries while loading entity chunk {position:?}"
+                        );
+                    }
                     let mut entities_to_add: Vec<Arc<dyn EntityBase>> =
                         Vec::with_capacity(entity_nbts.len());
-                    for entity_nbt in &entity_nbts {
+                    let mut dormant_entity_nbts = Vec::new();
+                    for (entity_nbt, uuid) in entity_nbts {
                         let Some(id) = entity_nbt.get_string("id") else {
                             debug!("Entity has no ID");
+                            dormant_entity_nbts.push(entity_nbt);
                             continue;
                         };
                         let Some(entity_type) =
                             EntityType::from_name(id.strip_prefix("minecraft:").unwrap_or(id))
                         else {
                             warn!("Entity has no valid Entity Type {id}");
+                            dormant_entity_nbts.push(entity_nbt);
                             continue;
                         };
 
-                        // Keep the persisted UUID so the entity keeps its identity
-                        // across reloads (matching vanilla); only fall back to a
-                        // fresh one if it is missing/corrupt.
-                        let uuid = entity_nbt.get_uuid("UUID").unwrap_or_else(Uuid::new_v4);
                         // Pos is zero since it will be read from nbt.
                         let entity =
                             from_type(entity_type, Vector3::new(0.0, 0.0, 0.0), &world, uuid);
-                        entity.read_nbt_non_mut(entity_nbt);
+                        entity.read_nbt_non_mut(&entity_nbt);
                         entity.init_data_tracker();
 
                         let base_entity = entity.get_entity();
@@ -4717,9 +4579,24 @@ impl World {
                         // stale data.
                         base_entity.velocity.store(Vector3::default());
 
-                        player.client.enqueue_spawn_packet(&entity);
-                        player.try_restore_vehicle(&entity);
                         entities_to_add.push(entity);
+                    }
+                    chunk.retain_dormant_entities(dormant_entity_nbts);
+
+                    // Corrupt saves can contain the same UUID in different entity
+                    // chunks. Materialization is serialized, so filter against the
+                    // live world before admitting this batch as well.
+                    let before_global_dedup = entities_to_add.len();
+                    entities_to_add.retain(|entity| {
+                        world
+                            .entity_uuids
+                            .insert(entity.get_entity().entity_uuid)
+                    });
+                    let globally_duplicated = before_global_dedup - entities_to_add.len();
+                    if globally_duplicated > 0 {
+                        warn!(
+                            "Discarded {globally_duplicated} duplicate UUID entries already live while loading entity chunk {position:?}"
+                        );
                     }
 
                     if !entities_to_add.is_empty() {
@@ -4728,24 +4605,34 @@ impl World {
                             new_entities.extend(entities_to_add.iter().cloned());
                             new_entities
                         });
-                    }
-                } else {
-                    // The chunk's entities are already live (another watcher loaded
-                    // them). Just send this player the spawn packets for the live
-                    // entities currently in this chunk.
-                    for entity in world.entities.load().iter() {
-                        let base_entity = entity.get_entity();
-                        if base_entity.chunk_pos.load() == position {
-                            player.client.enqueue_spawn_packet(entity);
-                            player.try_restore_vehicle(entity);
+
+                        for entity in &entities_to_add {
+                            world
+                                .spawn_state
+                                .load()
+                                .add_entity(&world, entity.as_ref());
+                            world.entity_tracker.add_entity(entity, &world);
                         }
                     }
                 }
             }
 
+            // Existing live entities and newly loaded entities share the normal visibility
+            // predicate (including type tracking range and Bedrock chunk readiness). Scan the
+            // tracker once for this batch instead of scanning every live entity for every chunk.
+            if player.chunk_send_epoch.load(Ordering::Acquire) == expected_epoch
+                && Arc::ptr_eq(&player.world(), &world)
+            {
+                world.entity_tracker.update_player_for_chunks(
+                    &player,
+                    &world,
+                    &requested_chunks,
+                );
+            }
+
             #[cfg(debug_assertions)]
             debug!("Chunks queued after {}ms", inst.elapsed().as_millis());
-        });
+        })
     }
 
     /// Gets a `Player` by an entity id
@@ -5066,6 +4953,34 @@ impl World {
         Ok(())
     }
 
+    /// Synchronizes Bedrock's global player/skin list without coupling it to actor visibility.
+    /// Actor creation itself remains terrain-gated by `EntityTracker`.
+    pub(crate) async fn sync_bedrock_player_lists_on_join(&self, player: &Arc<Player>) {
+        let existing_players = self
+            .players
+            .load()
+            .iter()
+            .filter(|existing| existing.gameprofile.id != player.gameprofile.id)
+            .cloned()
+            .collect::<Vec<_>>();
+        let joining_client = match player.client.as_ref() {
+            ClientPlatform::Bedrock(client) => Some(Arc::clone(client)),
+            ClientPlatform::Java(_) => None,
+        };
+        let new_player_list = player.bedrock_player_list_add_packet();
+
+        for existing in existing_players {
+            if let ClientPlatform::Bedrock(recipient) = existing.client.as_ref() {
+                recipient.enqueue_client_packet(&new_player_list).await;
+            }
+            if let Some(client) = joining_client.as_ref() {
+                client
+                    .enqueue_client_packet(&existing.bedrock_player_list_add_packet())
+                    .await;
+            }
+        }
+    }
+
     /// Must only be called after the player's own `CLogin` packet has been sent.
     pub fn pair_new_player_with_tracked_entities(&self, player: &Arc<Player>) {
         self.entity_tracker
@@ -5113,31 +5028,22 @@ impl World {
             self.entity_tracker
                 .remove_entity(player.as_ref() as &dyn EntityBase, self);
             let uuid = player.gameprofile.id;
-            let entity_id = player.entity_id();
-
-            let bedrock_remove_player = CPlayerList {
-                action: CPlayerList::ACTION_REMOVE,
-                entries: vec![PlayerListEntry {
-                    uuid,
-                    entity_unique_id: VarLong(entity_id as i64),
-                    username: player.gameprofile.name.clone(),
-                    xuid: String::new(),
-                    platform_chat_id: String::new(),
-                    build_platform: BuildPlatform::Unknown,
-                    skin: Skin::steve(),
-                    is_teacher: false,
-                    is_host: false,
-                    is_sub_client: false,
-                    player_color: [0, 0, 0, 0],
-                }],
-            };
-
-            self.broadcast_editioned(&CRemovePlayerInfo::new(&[uuid]), &bedrock_remove_player);
-
-            self.broadcast_editioned(
-                &CRemoveEntities::new(&[entity_id.into()]),
-                &CRemoveActor::new(VarLong(entity_id as i64)),
-            );
+            // EntityTracker reliably queues actor removal for clients which had the actor. Player
+            // lists are global, so remove the entry independently for every Bedrock recipient.
+            self.broadcast_packet_all(&CRemovePlayerInfo::new(&[uuid]));
+            let bedrock_recipients = self
+                .players
+                .load()
+                .iter()
+                .filter_map(|recipient| match recipient.client.as_ref() {
+                    ClientPlatform::Bedrock(client) => Some(Arc::clone(client)),
+                    ClientPlatform::Java(_) => None,
+                })
+                .collect::<Vec<_>>();
+            let bedrock_player_list = player.bedrock_player_list_remove_packet();
+            for recipient in bedrock_recipients {
+                recipient.enqueue_client_packet(&bedrock_player_list).await;
+            }
 
             if fire_event {
                 let msg_comp = TextComponent::translate_cross(
@@ -5165,7 +5071,10 @@ impl World {
 
     #[expect(clippy::needless_pass_by_value)]
     pub fn spawn_entity_non_save(&self, entity: Arc<dyn EntityBase>) {
-        let _base_entity = entity.get_entity();
+        let base_entity = entity.get_entity();
+        if !self.entity_uuids.insert(base_entity.entity_uuid) {
+            return;
+        }
         self.entity_tracker.add_entity(&entity, self);
         self.spawn_state.load().add_entity(self, entity.as_ref());
 
@@ -5213,21 +5122,14 @@ impl World {
     pub fn add_entity_silent(&self, entity: Arc<dyn EntityBase>) {
         let base_entity = entity.get_entity();
 
-        // Guard against duplicate entities with the same UUID.
-        // This can happen when chunk entity data is loaded while the entity
-        // already exists in the world (e.g. another player is still tracking it).
-        let already_exists = self
-            .entities
-            .load()
-            .iter()
-            .any(|e| e.get_entity().entity_uuid == base_entity.entity_uuid);
-        if already_exists {
+        // Reserve the UUID atomically before publishing the entity. This also
+        // coordinates synchronous spawns with asynchronous chunk materialization.
+        if !self.entity_uuids.insert(base_entity.entity_uuid) {
             return;
         }
 
-        // The entity stays live-only: it is written to its chunk's saved data on
-        // unload (see `save_entity`), never at spawn, so it can't be both live and
-        // serialized at once (which would double it on the next reload).
+        // The entity stays live-only until the next snapshot rebuild, so spawning
+        // cannot append a second serialized copy immediately.
         self.spawn_state.load().add_entity(self, entity.as_ref());
         self.entity_tracker.add_entity(&entity, self);
 
@@ -5256,6 +5158,7 @@ impl World {
             new_entities.retain(|e| e.get_entity().entity_uuid != base_entity.entity_uuid);
             new_entities
         });
+        self.entity_uuids.remove(&base_entity.entity_uuid);
     }
 
     pub async fn remove_entities_in_chunks(
@@ -5266,9 +5169,13 @@ impl World {
         if chunks_set.is_empty() {
             return;
         }
+        let _persistence_guard = self.entity_persistence_lock.lock().await;
         let mut entities_to_remove = Vec::new();
 
         self.entities.rcu(|current_entities| {
+            // ArcSwap may retry this closure if another entity update wins the race.
+            // Keep only the entities selected by the successful iteration.
+            entities_to_remove.clear();
             let mut new_entities = (**current_entities).clone();
             new_entities.retain(|entity| {
                 let base_entity = entity.get_entity();
@@ -5283,15 +5190,25 @@ impl World {
             new_entities
         });
 
-        for entity in entities_to_remove {
+        for entity in &entities_to_remove {
             self.entity_tracker.remove_entity(entity.as_ref(), self);
-            self.save_entity(&entity).await;
             self.spawn_state.load().remove_entity(self, entity.as_ref());
         }
+
+        self.rebuild_unloaded_entity_chunk_snapshots(&entities_to_remove, &chunks_set)
+            .await;
 
         for chunk_pos in &chunks_set {
             self.save_block_entities(*chunk_pos);
             self.block_entities.remove(chunk_pos);
+        }
+
+        // Remove and enqueue the entity chunks for writing while the persistence
+        // lock is still held. Callers historically repeat this cleanup; those
+        // calls are harmless no-ops once these entries have been removed.
+        self.level.clean_entity_chunks(&chunks_set);
+        for entity in &entities_to_remove {
+            self.entity_uuids.remove(&entity.get_entity().entity_uuid);
         }
     }
 
@@ -6952,9 +6869,11 @@ impl World {
     }
 
     pub async fn save(&self) {
-        for entity in self.entities.load().iter() {
-            self.save_entity(entity).await;
-        }
+        {
+            let _persistence_guard = self.entity_persistence_lock.lock().await;
+            let entities = self.entities.load_full();
+            self.rebuild_all_entity_chunk_snapshots(&entities).await;
+        };
 
         let chunks: Vec<Vector2<i32>> = self
             .block_entities
@@ -7359,7 +7278,11 @@ mod tests {
     };
     use pumpkin_util::math::position::BlockPos;
 
-    use super::{bedrock_block_breaking_rate, bedrock_chest_block_actor};
+    use super::{
+        bedrock_block_breaking_rate, bedrock_chest_block_actor, deduplicate_entity_nbts_by_uuid,
+    };
+    use pumpkin_nbt::compound::NbtCompound;
+    use uuid::Uuid;
 
     #[test]
     fn bedrock_block_breaking_rate_uses_progress_per_tick() {
@@ -7382,6 +7305,54 @@ mod tests {
         assert_eq!(actor.get_int("pairx"), Some(4));
         assert_eq!(actor.get_int("pairz"), Some(7));
         assert_eq!(actor.get_bool("pairlead"), Some(true));
+    }
+
+    #[test]
+    fn persisted_entity_uuid_dedup_keeps_latest_and_assigns_missing_uuids() {
+        fn entity_nbt(marker: i32, uuid: Option<Uuid>) -> NbtCompound {
+            let mut nbt = NbtCompound::new();
+            nbt.put_int("marker", marker);
+            if let Some(uuid) = uuid {
+                nbt.put_uuid("UUID", uuid);
+            }
+            nbt
+        }
+
+        let duplicate_uuid = Uuid::from_u128(1);
+        let other_uuid = Uuid::from_u128(2);
+        let first_generated_uuid = Uuid::from_u128(3);
+        let second_generated_uuid = Uuid::from_u128(4);
+        let mut generated_uuids =
+            [duplicate_uuid, first_generated_uuid, second_generated_uuid].into_iter();
+
+        let entities = deduplicate_entity_nbts_by_uuid(
+            vec![
+                entity_nbt(10, Some(duplicate_uuid)),
+                entity_nbt(20, None),
+                entity_nbt(30, Some(duplicate_uuid)),
+                entity_nbt(40, Some(other_uuid)),
+                entity_nbt(50, None),
+            ],
+            || generated_uuids.next().expect("test UUIDs exhausted"),
+        );
+
+        assert_eq!(entities.len(), 4);
+        assert_eq!(
+            entities
+                .iter()
+                .map(|(nbt, _)| nbt.get_int("marker").expect("marker should be present"))
+                .collect::<Vec<_>>(),
+            vec![20, 30, 40, 50]
+        );
+        assert_eq!(
+            entities.iter().map(|(_, uuid)| *uuid).collect::<Vec<_>>(),
+            vec![
+                first_generated_uuid,
+                duplicate_uuid,
+                other_uuid,
+                second_generated_uuid
+            ]
+        );
     }
 
     #[test]

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -622,8 +622,12 @@ impl World {
     ) -> (FxHashMap<Vector2<i32>, Vec<NbtCompound>>, FxHashSet<Uuid>) {
         let mut snapshots: FxHashMap<Vector2<i32>, Vec<NbtCompound>> = FxHashMap::default();
         let mut saved_uuids = FxHashSet::default();
+        let mut snapshot_uuids = FxHashSet::default();
         for entity in entities {
             let base_entity = entity.get_entity();
+            // Removed entities still identify obsolete snapshots in other chunks,
+            // especially when this is only the subset being unloaded.
+            snapshot_uuids.insert(base_entity.entity_uuid);
             if base_entity.is_removed() || !saved_uuids.insert(base_entity.entity_uuid) {
                 continue;
             }
@@ -633,7 +637,7 @@ impl World {
             entity.write_nbt(&mut nbt);
             snapshots.entry(chunk_pos).or_default().push(nbt);
         }
-        (snapshots, saved_uuids)
+        (snapshots, snapshot_uuids)
     }
 
     /// Rebuilds every materialized entity chunk from the live entity list.
@@ -643,26 +647,10 @@ impl World {
     /// materialized chunks are replaced too, which removes snapshots of entities
     /// that moved away or were discarded.
     async fn rebuild_all_entity_chunk_snapshots(&self, entities: &[Arc<dyn EntityBase>]) {
-        let (mut snapshots, live_uuids) = Self::entity_chunk_snapshots(entities);
-
-        for (chunk_pos, chunk) in self.level.entity_chunks() {
-            let entities = snapshots.remove(&chunk_pos).unwrap_or_default();
-            if chunk.entities_are_materialized() {
-                chunk.replace_entities(entities);
-            } else {
-                chunk.reconcile_entities(entities, &live_uuids);
-            }
-        }
-
-        // An entity can cross into a chunk before that chunk's persisted entities
-        // are materialized. Preserve those untouched entities while replacing any
-        // prior snapshot of the live UUID.
-        for (chunk_pos, entities) in snapshots {
-            self.level
-                .get_entity_chunk(chunk_pos)
-                .await
-                .reconcile_entities(entities, &live_uuids);
-        }
+        let (snapshots, snapshot_uuids) = Self::entity_chunk_snapshots(entities);
+        self.level
+            .update_entity_chunk_snapshots(snapshots, &snapshot_uuids, None)
+            .await;
     }
 
     /// Rebuilds the chunks being unloaded from the entities removed from the live
@@ -673,25 +661,10 @@ impl World {
         entities: &[Arc<dyn EntityBase>],
         chunks: &FxHashSet<Vector2<i32>>,
     ) {
-        let (mut snapshots, live_uuids) = Self::entity_chunk_snapshots(entities);
-
-        // Also remove stale occurrences of these live UUIDs from other loaded
-        // chunks (for example after an entity crossed a boundary).
-        for (chunk_pos, chunk) in self.level.entity_chunks() {
-            let entities = snapshots.remove(&chunk_pos).unwrap_or_default();
-            if chunks.contains(&chunk_pos) && chunk.entities_are_materialized() {
-                chunk.replace_entities(entities);
-            } else {
-                chunk.reconcile_entities(entities, &live_uuids);
-            }
-        }
-
-        for (chunk_pos, entities) in snapshots {
-            self.level
-                .get_entity_chunk(chunk_pos)
-                .await
-                .reconcile_entities(entities, &live_uuids);
-        }
+        let (snapshots, snapshot_uuids) = Self::entity_chunk_snapshots(entities);
+        self.level
+            .update_entity_chunk_snapshots(snapshots, &snapshot_uuids, Some(chunks))
+            .await;
     }
 
     /// Serializes the live block entities of a chunk back into that chunk's block
@@ -7283,6 +7256,37 @@ mod tests {
     };
     use pumpkin_nbt::compound::NbtCompound;
     use uuid::Uuid;
+
+    #[tokio::test]
+    async fn entity_snapshots_prefer_live_duplicates_and_keep_removed_uuid_cleanup() {
+        let fixture = crate::test_support::TestServer::new().await;
+        let uuid = Uuid::from_u128(1);
+        let position = pumpkin_util::math::vector3::Vector3::new(1.0, 64.0, 1.0);
+        let removed = super::from_type(
+            &pumpkin_data::entity::EntityType::PIG,
+            position,
+            &fixture.world,
+            uuid,
+        );
+        removed
+            .get_entity()
+            .removal_reason
+            .store(Some(super::RemovalReason::Discarded));
+        let live = super::from_type(
+            &pumpkin_data::entity::EntityType::PIG,
+            position,
+            &fixture.world,
+            uuid,
+        );
+        let (snapshots, uuids) = super::World::entity_chunk_snapshots(&[removed.clone(), live]);
+        assert_eq!(snapshots.values().map(Vec::len).sum::<usize>(), 1);
+        assert!(uuids.contains(&uuid));
+
+        let (snapshots, uuids) = super::World::entity_chunk_snapshots(&[removed]);
+        assert!(snapshots.is_empty());
+        assert!(uuids.contains(&uuid));
+        fixture.shutdown().await;
+    }
 
     #[test]
     fn bedrock_block_breaking_rate_uses_progress_per_tick() {


### PR DESCRIPTION
## Description
Fixes severe Bedrock join-time slowdowns caused by duplicate persisted entity records and unbounded initial terrain and actor synchronization. Existing affected worlds are repaired through normal chunk loading and saving without requiring manual save edits.

## What
- Replaces persisted chunk entity snapshots instead of appending another copy during every save.
- Deduplicates entity UUIDs within and across chunks while preserving unknown entity data.
- Limits Bedrock terrain delivery to four chunks per batch with one batch in flight.
- Limits actor lifecycle synchronization to 64 packets per player per tick.
- Retries terrain and actor packets when the outbound queue is full.
- Waits for terrain and PlayerSpawn completion before sending actors.
- Prevents stale chunk and actor data after movement, teleportation, or dimension transfers.

## How
- Tracks whether chunk entity data has been materialized and whether its persisted snapshot requires rewriting.
- Rebuilds authoritative entity snapshots from the current live state.
- Uses per-chunk and world-level UUID tracking to discard duplicate persisted records.
- Adds completion-aware Bedrock chunk batching with generation tokens and world epochs.
- Uses ordered packet reservations for packet groups that must remain atomic.
- Queues actor spawns and removals in bounded FIFO lifecycle queues, prioritizing removals.
- Serializes chunk tickets, watcher transitions, and client movement during world transfers.

## Testing
- `cargo check -p pumpkin --tests`
- `cargo test -p pumpkin --lib`
- `cargo test -p pumpkin-world --lib`
- `cargo fmt --all -- --check`
- Started Pumpkin with the affected world and confirmed that duplicate UUID records were discarded during chunk loading while a client connected successfully.