### PR TITLE
fix: prevent java door flicker

### DIFF
--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -2416,6 +2416,17 @@ impl Player {
     pub fn process_inbound_packets(&self) {
         const MAX_PACKETS_PER_TICK: usize = 64;
 
+        // Player::tick runs after the world's block-update flush. Acknowledge the previous tick's
+        // predictions here so Java clients receive the authoritative block states before resolving
+        // those predictions. Sending the ACK from the packet loop would make doors and other
+        // predicted blocks briefly revert because their updates are not flushed until the next tick.
+        if let ClientPlatform::Java(client) = self.client.as_ref() {
+            let seq = client.packet_sequence.swap(-1, Ordering::Relaxed);
+            if seq != -1 {
+                client.try_send_packet(&CAcknowledgeBlockChange::new(seq.into()));
+            }
+        }
+
         let Some(player_arc) = self.world().get_player_by_uuid(self.gameprofile.id) else {
             return;
         };
@@ -2448,11 +2459,6 @@ impl Player {
                             packet.payload.len(),
                             e
                         );
-                    }
-
-                    let seq = client.packet_sequence.swap(-1, Ordering::Relaxed);
-                    if seq != -1 {
-                        client.try_send_packet(&CAcknowledgeBlockChange::new(seq.into()));
                     }
                 }
                 ClientPlatform::Bedrock(client) => {


### PR DESCRIPTION
## Description
Fixes an issue where doors flickered between their open and closed states when interacted with by Java clients.
Resolves: https://github.com/Pumpkin-MC/Pumpkin/issues/3052

## What
- Prevents Java clients from briefly restoring the previous block state after an interaction.
- Ensures authoritative block updates are sent before acknowledging client-side predictions.
- Fixes flickering when opening and closing doors.
- Applies the corrected ordering to other predicted Java block interactions as well.

## How
- Retains the highest pending Java block-change sequence after processing inbound packets.
- Defers the acknowledgment until the next player tick.
- Uses Pumpkin’s existing world-tick ordering, which flushes queued block updates before ticking players.
- Leaves door state handling and block-update batching unchanged.

## Testing
- `cargo fmt --all -- --check`
- `cargo check -p pumpkin`
- `cargo test -p pumpkin --lib`
- Verified in game that opening and closing doors from Java no longer causes them to flicker between states.