### PR TITLE
fix: preserve Java chunk batch ordering

### DIFF
--- a/crates/pumpkin/src/net/java/mod.rs
+++ b/crates/pumpkin/src/net/java/mod.rs
@@ -456,20 +456,26 @@ impl JavaClient {
         let Ok(serialized) = rx.await else {
             return;
         };
+        let sent_count = serialized.len();
+        if sent_count == 0 {
+            return;
+        }
 
         if version >= JavaMinecraftVersion::V_1_20_2 {
             self.send_packet(&CChunkBatchStart).await;
         }
 
+        // Keep the whole batch on the priority queue. Otherwise the batch end can overtake chunk
+        // data queued on the normal channel, leaving the client unable to render those chunks.
         for (chunk_data, light_data) in serialized {
-            self.enqueue_packet(chunk_data).await;
+            self.send_packet_now_data(chunk_data).await;
             if let Some(light_data) = light_data {
-                self.enqueue_packet(light_data).await;
+                self.send_packet_now_data(light_data).await;
             }
         }
 
         if version >= JavaMinecraftVersion::V_1_20_2 {
-            self.send_packet(&CChunkBatchEnd::new(chunks.len() as u16))
+            self.send_packet(&CChunkBatchEnd::new(sent_count as u16))
                 .await;
         }
     }


### PR DESCRIPTION
## Description
Fixes a regression where Java players joining a freshly started server could receive an empty initial chunk batch, leaving the spawn terrain invisible and allowing them to fall through the world.

## What
- Ensures the initial spawn chunk is delivered before teleporting the Java player.
- Prevents `ChunkBatchEnd` from overtaking its chunk data.
- Keeps chunk batch boundaries, chunk data, and legacy light data in the correct order.
- Reports the number of successfully serialized chunks in `ChunkBatchEnd`.
- Avoids sending an empty chunk batch when serialization produces no chunks.

## How
- Preserves the earlier client-association fix from [PR #2307](https://github.com/Pumpkin-MC/Pumpkin/pull/2307).
- Sends the complete direct Java chunk batch through the same ordered priority queue.
- Waits for each chunk and light payload to be written before sending the batch end.
- Retains the existing off-thread chunk serialization.
- Prevents the mixed priority/normal queue ordering that could produce `ChunkBatchStart → ChunkBatchEnd → ChunkData`.

## Testing
- `cargo fmt --all -- --check`
- `cargo check -p pumpkin`
- `cargo test -p pumpkin --lib`
- Verified in game after a fresh server start that the Java spawn chunk renders immediately and the player no longer falls through the world.