### PR TITLE
fix(worldgen): stop regenerating chunks around single chunk fetches

### DIFF
--- a/crates/pumpkin-world/src/chunk_system/schedule.rs
+++ b/crates/pumpkin-world/src/chunk_system/schedule.rs
@@ -901,10 +901,10 @@ impl GenerationSchedule {
                             chunks.push((pos, Chunk::Level(chunk)));
                         }
                     }
-                    Chunk::Proto(_) => {
-                        // ProtoChunks are in-memory intermediate generation stages
-                        // (e.g. temporary border dependencies). Do not convert and save
-                        // incomplete chunks to disk during runtime unloads.
+                    Chunk::Proto(proto) => {
+                        if !matches!(proto.stage, StagedChunkEnum::Empty | StagedChunkEnum::None) {
+                            chunks.push((pos, Chunk::Proto(proto)));
+                        }
                     }
                 }
             }

--- a/crates/pumpkin-world/src/chunk_system/schedule.rs
+++ b/crates/pumpkin-world/src/chunk_system/schedule.rs
@@ -622,6 +622,7 @@ impl GenerationSchedule {
                             for dz in -radius..=radius {
                                 let new_pos = pos.add_raw(dx, dz);
                                 let req_stage = dependency[dx.abs().max(dz.abs()) as usize];
+                                self.unload_chunks.remove(&new_pos);
                                 if new_pos == pos {
                                     let newly_created = Self::ensure_dependency_chain(
                                         &mut self.graph,
@@ -674,6 +675,7 @@ impl GenerationSchedule {
         }
 
         while let Some((pos, req_stage, dep_task)) = worklist.pop_front() {
+            self.unload_chunks.remove(&pos);
             let mut holder = self.chunk_map.remove(&pos).unwrap_or_default();
             let newly_created = Self::ensure_dependency_chain(
                 &mut self.graph,
@@ -861,7 +863,12 @@ impl GenerationSchedule {
             let Some(mut holder) = self.chunk_map.remove(&pos) else {
                 continue;
             };
-            debug_assert_eq!(holder.target_stage, StagedChunkEnum::None);
+            if holder.target_stage != StagedChunkEnum::None
+                || holder.dependency_stage != StagedChunkEnum::None
+            {
+                self.chunk_map.insert(pos, holder);
+                continue;
+            }
             if !holder.occupied.is_null() {
                 self.chunk_map.insert(pos, holder);
                 self.unload_chunks.insert(pos);

--- a/crates/pumpkin-world/src/level.rs
+++ b/crates/pumpkin-world/src/level.rs
@@ -662,7 +662,7 @@ impl Level {
                 .chunk_loading
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            lock.add_ticket(pos, 31);
+            lock.add_ticket(pos, ChunkLoading::FULL_CHUNK_LEVEL);
             lock.send_change();
         };
 
@@ -675,7 +675,7 @@ impl Level {
                 .chunk_loading
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            lock.remove_ticket(pos, 31);
+            lock.remove_ticket(pos, ChunkLoading::FULL_CHUNK_LEVEL);
             lock.send_change();
         };
 


### PR DESCRIPTION
## Description

Chunk generation was repeating a lot of work it had already done.

I put a temporary counter in `run_generation` and left one bot standing in a fresh world for 8.5 minutes. It ran 62,817 chunk stages, and 39,738 of those were stages that had already been generated once. Teleporting the bot back and forth over terrain it had already visited made every stage run in that window a repeat. The counter also kept going up while the bot was standing still.

The problem comes from `Level::fetch_chunk` adding a single chunk ticket at level 31. Our full chunk level is 43, so a level 31 ticket spreads out to a 37x37 pyramid and makes 625 chunks full for a single chunk request. That ticket is removed one tick later.

Every add/remove runs `resort_work`. `recompute_dependency_stages` then drops dependency holders outside the player's area, and `process_unload_queue` throws those proto chunks away without saving them. The next fetch generates them again.

Any tick path that reads a block from a chunk that isn't full yet ends up going through `fetch_chunk`, so this was happening constantly.

In 26.3, `ServerChunkCache.getChunkFutureMainThread` uses `ChunkLevel.byStatus` for a one-off chunk fetch, which gives it the full chunk level. Level 31 is `ENTITY_TICKING_LEVEL` and seems to be left over from before FULL moved to 43.

`fetch_chunk` now uses `ChunkLoading::FULL_CHUNK_LEVEL`. That cuts the ticket range from 17 chunks to 5.

`process_unload_queue` also sends proto chunks to the IO writer instead of dropping them. Full chunks already go through that path, and the IO side can already round-trip proto chunks for the shutdown save. Vanilla persists every chunk status too, so there isn't a reason to throw these away during normal unloads.

The first commit also stops chunks from being unloaded while they're still needed as generation dependencies.

## Testing
I measured this with the temporary run_generation counter, which is not part of the PR.

With a stationary bot on a fresh world for 150 seconds, repeated stage runs dropped from 2,474 to 78 with the ticket change alone, and to 0 with both fixes.

In the longer movement test, the old code ran 62,817 stages, 39,738 of them repeats. With this PR it ran 22,974 stages with 0 repeats while covering the same unique chunk stages. So the extra ~40k stage runs in the old result were entirely regenerated work.

These were debug builds, so the absolute timings are not useful here. The stage counts are what I was measuring.