### PR TITLE
fix(worldgen): treat trapezoid float plateau as an absolute width 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-util/src/math/float_provider.rs
+++ b/crates/pumpkin-util/src/math/float_provider.rs
@@ -357,7 +357,9 @@ pub struct TrapezoidFloatProvider {
     min: f32,
     /// The maximum value (inclusive) that can be generated.
     max: f32,
-    /// The width of the flat plateau as a fraction of the total range (0.0 to 1.0).
+    /// The absolute width of the flat plateau, in the same units as `min`/`max`.
+    /// Must not exceed `max - min`; a plateau of `0.0` yields a triangular
+    /// distribution, a plateau of `max - min` a uniform one.
     plateau: f32,
 }
 
@@ -383,7 +385,8 @@ impl TrapezoidFloatProvider {
     /// # Arguments
     /// - `min` – The minimum value (inclusive).
     /// - `max` – The maximum value (inclusive).
-    /// - `plateau` – The width of the flat plateau as a fraction of the total range (0.0 to 1.0).
+    /// - `plateau` – The absolute width of the flat plateau, in the same units as
+    ///   `min`/`max` (not a fraction of the range). Must not exceed `max - min`.
     ///
     /// # Returns
     /// A new `TrapezoidFloatProvider` instance.
@@ -409,29 +412,18 @@ impl TrapezoidFloatProvider {
     /// # Returns
     /// A random float from the trapezoidal distribution in the range [min, max].
     pub fn get(&self, random: &mut impl RandomImpl) -> f32 {
-        // NOTE: Trapezoid distribution: flat plateau in the middle, linear ramps on the sides.
+        // NOTE: A trapezoid is the sum of two uniform variables of differing width, mirroring
+        // `TrapezoidIntProvider::get`. Both draws are mandatory: the RNG stream is shared
+        // with the rest of the carver, so consuming a different amount desyncs everything
+        // drawn afterwards. Kept as plain adds and multiplies rather than `mul_add`, since
+        // each intermediate product has to round to f32 the way the vanilla expression does.
         let range = self.max - self.min;
-        let plateau_range = range * self.plateau;
-        let ramp_range = (range - plateau_range) * 0.5;
+        // NOTE: `max(0.0)` only guards a malformed `plateau > range`, which vanilla rejects
+        // while decoding; for valid inputs this is the plain half-difference.
+        let plateau_start = ((range - self.plateau) * 0.5).max(0.0);
+        let plateau_end = range - plateau_start;
 
-        let random_value = random.next_f32();
-
-        if random_value < self.plateau.mul_add(-0.5, 0.5) {
-            // NOTE: Left ramp: quadratic distribution biased toward plateau
-            let scaled = random_value / self.plateau.mul_add(-0.5, 0.5);
-            let sqrt_scaled = scaled.sqrt();
-            self.min + ramp_range * sqrt_scaled
-        } else if random_value > self.plateau.mul_add(0.5, 0.5) {
-            // NOTE: Right ramp: quadratic distribution biased toward plateau
-            let scaled =
-                (random_value - self.plateau.mul_add(0.5, 0.5)) / self.plateau.mul_add(-0.5, 0.5);
-            let sqrt_scaled = (1.0 - scaled).sqrt();
-            self.max - ramp_range * sqrt_scaled
-        } else {
-            // NOTE: Plateau: uniform distribution
-            let plateau_pos = (random_value - self.plateau.mul_add(-0.5, 0.5)) / self.plateau;
-            self.min + ramp_range + plateau_pos * plateau_range
-        }
+        self.min + random.next_f32() * plateau_end + random.next_f32() * plateau_start
     }
 
     /// Returns the maximum inclusive value.
@@ -508,7 +500,7 @@ mod tests {
         let mut random = RandomGenerator::Xoroshiro(
             crate::random::xoroshiro128::Xoroshiro::from_seed(get_seed()),
         );
-        let provider = TrapezoidFloatProvider::new(0.0, 10.0, 0.5);
+        let provider = TrapezoidFloatProvider::new(0.0, 10.0, 4.0);
 
         assert_eq!(provider.get_min(), 0.0);
         assert_eq!(provider.get_max(), 10.0);
@@ -521,6 +513,66 @@ mod tests {
                 "Value {value} is outside range [0.0, 10.0]"
             );
         }
+    }
+
+    /// `plateau` is an absolute width, not a fraction of the range, and the distribution is
+    /// the sum of two uniform draws. Expected values come from vanilla's `TrapezoidFloat`
+    /// (`min + nextFloat() * h + nextFloat() * g`) on the same seed, for the two shapes the
+    /// carvers actually use: canyon/nether cave `0..6` plateau `2`, and cave `0..3` plateau `1`.
+    #[test]
+    fn trapezoid_float_provider_matches_vanilla() {
+        let mut random =
+            RandomGenerator::Xoroshiro(crate::random::xoroshiro128::Xoroshiro::from_seed(1));
+        assert_eq!(
+            TrapezoidFloatProvider::new(0.0, 6.0, 2.0).get(&mut random),
+            4.475_350_4
+        );
+
+        let mut random =
+            RandomGenerator::Xoroshiro(crate::random::xoroshiro128::Xoroshiro::from_seed(1));
+        assert_eq!(
+            TrapezoidFloatProvider::new(0.0, 3.0, 1.0).get(&mut random),
+            2.237_675_2
+        );
+    }
+
+    /// The carvers draw the trapezoid from the middle of a shared per-chunk stream, so
+    /// consuming the wrong number of floats desyncs every value drawn after it.
+    #[test]
+    fn trapezoid_float_provider_consumes_two_floats() {
+        let mut provider_random =
+            RandomGenerator::Xoroshiro(crate::random::xoroshiro128::Xoroshiro::from_seed(1));
+        TrapezoidFloatProvider::new(0.0, 6.0, 2.0).get(&mut provider_random);
+
+        let mut reference =
+            RandomGenerator::Xoroshiro(crate::random::xoroshiro128::Xoroshiro::from_seed(1));
+        reference.next_f32();
+        reference.next_f32();
+
+        assert_eq!(provider_random.next_f32(), reference.next_f32());
+    }
+
+    /// A zero plateau degenerates to a triangular distribution, a full-range plateau to a
+    /// uniform one. Both still take two draws, matching vanilla.
+    #[test]
+    fn trapezoid_float_provider_degenerate_plateaus() {
+        let mut random =
+            RandomGenerator::Xoroshiro(crate::random::xoroshiro128::Xoroshiro::from_seed(1));
+        let triangular = TrapezoidFloatProvider::new(-6.0, 6.0, 0.0).get(&mut random);
+        assert!(
+            (-6.0..=6.0).contains(&triangular),
+            "Value {triangular} is outside range [-6.0, 6.0]"
+        );
+
+        let mut random =
+            RandomGenerator::Xoroshiro(crate::random::xoroshiro128::Xoroshiro::from_seed(1));
+        let uniform = TrapezoidFloatProvider::new(0.0, 6.0, 6.0).get(&mut random);
+        let mut reference =
+            RandomGenerator::Xoroshiro(crate::random::xoroshiro128::Xoroshiro::from_seed(1));
+        assert_eq!(uniform, reference.next_f32() * 6.0);
+        // NOTE: the second draw is scaled by a zero-width ramp, but is still consumed.
+        reference.next_f32();
+        assert_eq!(reference.next_f32(), random.next_f32());
     }
 
     #[test]

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -191,6 +191,18 @@ impl LivingEntity {
         entity_type.hurt_sound.unwrap_or(Sound::EntityGenericHurt)
     }
 
+    fn death_sound_for_entity(entity_type: &'static EntityType) -> Sound {
+        let name = match entity_type.resource_name {
+            "mooshroom" => "cow",
+            "cave_spider" => "spider",
+            "giant" => "zombie",
+            "pufferfish" => "puffer_fish",
+            "trader_llama" => "llama",
+            other => other,
+        };
+        Sound::from_name(&format!("entity.{name}.death")).unwrap_or(Sound::EntityGenericDeath)
+    }
+
     pub fn new(entity: Entity) -> Self {
         let water_movement_speed_multiplier = if entity.entity_type == &EntityType::POLAR_BEAR {
             0.98
@@ -1727,7 +1739,7 @@ impl LivingEntity {
 
             self.update_death_stats(&*dyn_self, killer);
 
-            // Plays the death sound
+            // Plays the death animation
             world.send_entity_status(&self.entity, EntityStatus::Death, Some(ActorEventID::Death));
             let looting_level;
             let tool = if let Some(cause_ent) = cause {
@@ -2824,25 +2836,16 @@ impl LivingEntity {
             position,
         );
 
-        if play_sound {
-            world.play_sound(
-                self.hurt_sound(),
-                SoundCategory::Players,
-                &self.entity.pos.load(),
-            );
-
-            if let Some(source) = source {
-                let source_pos = source.get_entity().pos.load();
-                let target_pos = self.entity.pos.load();
-                let dx = source_pos.x - target_pos.x;
-                let dz = source_pos.z - target_pos.z;
-                let resistance = self.get_attribute_value(&Attributes::KNOCKBACK_RESISTANCE);
-                self.entity
-                    .apply_knockback(knockback_after_resistance(0.4, resistance), dx, dz);
-                self.entity.send_velocity();
-            }
+        if play_sound && let Some(source) = source {
+            let source_pos = source.get_entity().pos.load();
+            let target_pos = self.entity.pos.load();
+            let dx = source_pos.x - target_pos.x;
+            let dz = source_pos.z - target_pos.z;
+            let resistance = self.get_attribute_value(&Attributes::KNOCKBACK_RESISTANCE);
+            self.entity
+                .apply_knockback(knockback_after_resistance(0.4, resistance), dx, dz);
+            self.entity.send_velocity();
         }
-
         // Vanilla parity: actuallyHurt
         let original_damage = damage_amount;
         let current_abs = self.absorption.load();
@@ -2879,6 +2882,16 @@ impl LivingEntity {
 
         let max_h = self.get_max_health();
         let new_health = (self.health.load() - dmg_to_health).clamp(0.0, max_h);
+
+        if play_sound {
+            let sound = if new_health <= 0.0 {
+                Self::death_sound_for_entity(self.entity.entity_type)
+            } else {
+                self.hurt_sound()
+            };
+
+            world.play_sound(sound, SoundCategory::Players, &self.entity.pos.load());
+        }
 
         if dmg_to_health > 0.0 {
             if let Some(player) = caller.get_player() {
@@ -3222,11 +3235,10 @@ impl EntityBase for LivingEntity {
             // Only send death particles once (on the exact tick death_time reaches 20)
             // and then remove the entity, preventing entity_event spam.
             if time == 20 && !self.entity.removed.swap(true, Ordering::Relaxed) {
-                self.entity.world.load().send_entity_status(
-                    &self.entity,
-                    EntityStatus::Death,
-                    Some(ActorEventID::Death),
-                );
+                self.entity
+                    .world
+                    .load()
+                    .send_entity_status(&self.entity, EntityStatus::Poof, None);
                 self.entity.remove();
             }
         }
@@ -3587,6 +3599,38 @@ mod tests {
         assert_eq!(
             LivingEntity::hurt_sound_for_entity(&EntityType::ENDERMAN),
             Sound::EntityEndermanHurt
+        );
+    }
+
+    #[test]
+    fn death_sound_for_entity_uses_cow_death_sound() {
+        assert_eq!(
+            LivingEntity::death_sound_for_entity(&EntityType::COW),
+            Sound::EntityCowDeath
+        );
+    }
+
+    #[test]
+    fn death_sound_for_entity_uses_mooshroom_death_sound() {
+        assert_eq!(
+            LivingEntity::death_sound_for_entity(&EntityType::MOOSHROOM),
+            Sound::EntityCowDeath
+        );
+    }
+
+    #[test]
+    fn death_sound_for_entity_uses_pufferfish_death_sound() {
+        assert_eq!(
+            LivingEntity::death_sound_for_entity(&EntityType::PUFFERFISH),
+            Sound::EntityPufferFishDeath
+        );
+    }
+
+    #[test]
+    fn death_sound_for_entity_uses_armor_stand_death_sound() {
+        assert_eq!(
+            LivingEntity::death_sound_for_entity(&EntityType::ARMOR_STAND),
+            Sound::EntityGenericDeath
         );
     }
 


### PR DESCRIPTION
## Description

One of three independent PRs against the same measurement — #3233 (cave count) and #3234 (cave floor) are the other two; this one carries the shared method and tables.

`TrapezoidFloatProvider::get` treated `plateau` as a *fraction* of the range and sampled from a hand-rolled inverse CDF using a single `next_f32()`. In vanilla, `plateau` is an *absolute* width and `TrapezoidFloat.sample` is the sum of two uniform draws: the range minus the plateau, halved, is one ramp width, the rest of the range is the other, and the result is `min` plus a `nextFloat` scaled by each of the two.

Two things went wrong as a result.

**The distribution collapsed to uniform.** Every trapezoid float in the tree has `plateau >= 1`, so the branch thresholds `0.5 ± plateau/2` fall outside `[0, 1)` and both ramp branches are unreachable. For the canyon carver (`min=0, max=6, plateau=2`) the remaining branch simplifies to exactly `6 * next_f32()`. All four affected configs — `CANYON`, `CAVE`, `CAVE_EXTRA_UNDERGROUND`, `NETHER_CAVE` — were sampling `thickness` uniformly instead of trapezoidally:

| `0..6`, plateau `2` | before | after |
|---|---|---|
| mean | 3.0 | 3.0 |
| σ | 1.73 | 1.29 |
| `P(thickness < 1)` | 16.7% | 6.25% |
| `P(thickness > 5)` | 16.7% | 6.25% |

`thickness` feeds the tunnel radius directly (`1.5 + sin(progress) * thickness`), so pencil-thin and cavernous carves were roughly 2.7× more common than they should be.

**The RNG stream desynced.** The old code drew one float where vanilla draws two. `thickness` is sampled from the middle of the shared per-chunk carver stream, so everything drawn after it shifted by one: the weird-thickness roll, `distance`, `start_vertical_radius_multiplier`, the per-tunnel `next_i64()` seed, and every subsequent tunnel and carver in that chunk. The fix restores the stream, so the two draws are kept even in the degenerate cases where the second one is scaled by a zero-width ramp.

The shape now mirrors `TrapezoidIntProvider::get`, which already had this right. The only deviation from vanilla is `max(0.0)` on the ramp width, which bounds a malformed `plateau > max - min`; vanilla rejects that while decoding, and for every valid input the expression is identical. `TrapezoidIntProvider` is untouched, so ore, flower and grass placement is unaffected.

## Measured effect

Measured against an unmodified Mojang 26.2 server on seed 13579, 256 chunks, solid/non-solid mask (method below):

- **On its own this fix is partial**: mismatch vs vanilla 336,722 → 312,657 (−7%), carved-volume precision 6% → 15%. Per chunk it is close to a coin flip (128 better / 124 worse), because the cave carver's stream is already desynced by its *first* draw (the cave count — separate PR). Where the stream happens to be aligned — canyons, which have no count draw — it reproduces vanilla's tunnel almost exactly.

- Together with the count and floor fixes: 336,722 → 23,476 (−92.5%), precision 99.6%, 252 of 256 chunks improve and none regress.

**Known impact:** this changes worldgen output. Chunks generated after this lands will not line up with chunks already generated by an older build, so existing worlds will show carver discontinuities at the boundary.

## Measurement method

- **Reference:** official `server.jar` 26.2 (sha1 `823e2250…`), unmodified, `level-seed=13579`, `pause-when-empty-seconds=-1`, `forceload add -256 0 -1 255`. All 256 chunks (`x ∈ [-16,-1]`, `z ∈ [0,15]`) verified `Status == minecraft:full`. Region files read with a plain MCA/NBT reader (DataVersion 4903; 26.2 keeps overworld regions under `world/dimensions/minecraft/overworld/region/`).
- **Pumpkin:** the same 256 chunks through `generate_single_chunk_with_radius(…, StagedChunkEnum::Carvers, 1)` — i.e. stopped after `step_to_carvers`, no feature step. Variants built from one binary with the fixes toggled, so nothing else differs.
- **Comparison:** every block reduced to solid / non-solid (`air`, `cave_air`, `void_air`, `water`, `lava`, `bubble_column` = non-solid). Y −64…100. "Carved set" = blocks vanilla has open that Pumpkin's *pre-carver* chunk still has solid (103,329 blocks) — the set the carvers are supposed to open.

Seed 13579 was chosen because `assets/tests/` already holds vanilla noise/surface dumps for it, so pre-carver parity there is known (~1.8% off, within the existing tests' `allowed_mismatches = 6000`).

## Results across the three PRs — mismatching blocks vs vanilla, 256 chunks

| band | pre-carver | master | + #1 trapezoid | + #1 + #3 count | **+ #1 + #3 + #4 floor** |
|---|---|---|---|---|---|
| all (−64..100) | 194,590 (1.80%) | 336,722 (3.11%) | 312,657 (2.89%) | 101,542 (0.94%) | **23,476 (0.22%)** |
| y 2..70 (carver band) | 106,548 | 248,513 | 223,513 | 14,459 | **14,459** |
| y < 0 | 83,072 | 83,072 | 83,072 | 83,072 | **8,027** |

| variant | carved-set precision | recall |
|---|---|---|
| master | 6.3% | 9.9% |
| + #1 | 14.7% | 23.7% |
| + #1 + #3 | **99.6%** | **89.5%** |
| + #1 + #3 + #4 | **99.6%** | **89.5%** |

Per chunk, bundle vs #1 alone: **252 improve, 0 regress, 4 unchanged**. Median per-chunk carver-band mismatch: pre-carver 162 → master 622 → bundle **12**. The attribution is clean and additive: #3 changes nothing below y=2, #4 changes nothing above it, and the carver band is bit-identical between the last two columns.

## A strip, for the impatient

<details><summary>Z=84, X −160…−97 — vanilla vs Pumpkin with all three fixes (row mismatch 1,378 → 22)</summary>

```
Z=84, X -160..-97, Y 20..-50   # solid   . open

VANILLA 26.2 (real server)
  20 ###############################################.......##########
  19 ###############################################.......##########
  18 ###############################################.......##########
  17 ################################......#########.......##########
  16 #########################...............#######.......##########
  15 #######################..................#######......##########
  14 ######################...................#######......##..######
  13 #####################...................########......##...#####
  12 #####################..........###.....#########......##...#####
  11 #####################........####################.....##..######
  10 #####################.....##################....##....##########
   9 ########################################..............##########
   8 #######################################...............##########
   7 #######################################................#########
   6 ########################################.................#######
   5 ##########################################................######
   4 ###########################################.................####
   3 #############################################................###
   2 ################################....############..............##
   1 #############################..........###########............##
   0 #############################..........#############..........##
  -1 #####################################################.........##
  -2 #######################################################......###
  -3 #########################################################...####
  -4 ################################################################
  -5 ################################################################
  -6 ################################################################
  -7 ################################################################
  -8 ################################################################
  -9 ..##############################################################
 -10 .....###########################################################
 -11 .......#########################################################
 -12 ........########################################################
 -13 .........#######################################################
 -14 ..........######################################################
 -15 ..........####......############################################
 -16 ...........##........###########################################
 -17 ..........###.................##################################
 -18 ..........###..................###############...###############
 -19 .........#####.................############........#######..####
 -20 .........######...............############.........#####....####

PUMPKIN #1+#3+#4
  20 ###############################################.......##########
  19 ###############################################.......##########
  18 ###############################################.......##########
  17 ################################......#########.......##########
  16 #########################...............#######.......##########
  15 #######################..................#######......##########
  14 ######################...................#######......##..######
  13 #####################...................########......##...#####
  12 #####################..........###.....#########......##...#####
  11 #####################........####################.....##..######
  10 #####################.....##################....##....##########
   9 ########################################..............##########
   8 #######################################...............##########
   7 #######################################................#########
   6 ########################################.................#######
   5 ##########################################................######
   4 ###########################################.................####
   3 #############################################................###
   2 ################################....############..............##
   1 #############################..........###########............##
   0 #############################..........#############..........##
  -1 #####################################################.........##
  -2 #######################################################......###
  -3 #########################################################...####
  -4 ################################################################
  -5 ################################################################
  -6 ################################################################
  -7 ################################################################
  -8 ################################################################
  -9 ..##############################################################
 -10 .....###########################################################
 -11 .......#########################################################
 -12 ........########################################################
 -13 .........#######################################################
 -14 ..........######################################################
 -15 ..........####......############################################
 -16 ...........##........###########################################
 -17 ..........###.................##################################
 -18 ..........###..................###############...###############
 -19 .........#####.................############........#######..####
 -20 .........######...............############.........#####....####
```

</details>

Everything else is in the numbers above; the method section is enough to reproduce them.

## Caveats

- Vanilla chunks are `full` (feature step included); Pumpkin stops at carvers. This inflates every "vs vanilla" number. With the three fixes in, the residual is now *dominated* by this: of the 23,476 remaining mismatches, ~4,500 are feature blocks Pumpkin never places (`dead_bush`, `seagrass`, `glow_lichen`, geodes) and half sit at y ≥ 55. A vanilla run with carvers/features disabled via datapack would give a clean per-stage reference; I can produce one if useful.
- One seed, one 256-chunk area, overworld only. Nether/End carvers untested (the audit also flags the nether carver using Xoroshiro where vanilla always uses `LegacyRandomSource` — not measured here).
- All three fixes change worldgen output; chunks generated after them will not line up with chunks from older builds.

## What remains

- [ ] cave carver `protected_blocks_on_top` is 0/1, vanilla 7 (canyon already 7) — `cave.rs`
- [ ] cave carver ignores `replaceable` and carves bedrock — `cave.rs` `carve_block`
- [ ] nether carver RNG source (`legacy_random_source` flag selects Xoroshiro) — `carver/mod.rs`
- [ ] residual recall: ~10,900 blocks vanilla opens in the carver band that Pumpkin still leaves solid, concentrated around y ≈ −42…−39
- [ ] a carver parity test in `proto_chunk_test.rs` against a vanilla dump in `assets/tests/` — `step_to_carvers` currently has no test at all, which is why these three lived as long as they did

## Testing

`cargo test -p pumpkin-util -p pumpkin-world` and `cargo clippy -p pumpkin-util --all-targets` are clean.

Three tests added in `float_provider.rs`:

- `trapezoid_float_provider_matches_vanilla` — pins the output of both carver shapes on seed `1` against values produced by vanilla's `TrapezoidFloat`. Pumpkin's `Xoroshiro` already matches vanilla's stream bit-for-bit, so `0..6` plateau `2` on seed `1` yields exactly `4.4753504` (the old code returned `5.663788`).
- `trapezoid_float_provider_consumes_two_floats` — asserts the generator advances by exactly two draws, which is what guards the desync described above.
- `trapezoid_float_provider_degenerate_plateaus` — covers `plateau = 0` (triangular) and `plateau = max - min` (uniform), both still two draws.

Note that no existing test could have caught this: `proto_chunk_test.rs` compares against vanilla dumps only through `step_to_noise` / `step_to_surface`, with 6,000 allowed mismatches per chunk; `step_to_carvers` has no test. A carver parity test is on the list below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

