### PR TITLE
fix(worldgen): draw the cave count with vanilla's three nested ints 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-util/src/math/int_provider.rs
+++ b/crates/pumpkin-util/src/math/int_provider.rs
@@ -360,6 +360,12 @@ impl VeryBiasedToBottomIntProvider {
         self.min_inclusive
     }
 
+    /// Samples the provider, matching vanilla's nested `nextInt` expression.
+    ///
+    /// Vanilla's cave carver picks its count with
+    /// `random.nextInt(random.nextInt(random.nextInt(bound) + 1) + 1)`, i.e. `inner + 2`
+    /// draws in total, returning the innermost-last one. The loop performs the `inner + 1`
+    /// draws that narrow the bound, and the final draw produces the value itself.
     pub fn get(&self, random: &mut impl RandomImpl) -> i32 {
         if self.min_inclusive >= self.max_inclusive {
             return self.min_inclusive;
@@ -369,7 +375,7 @@ impl VeryBiasedToBottomIntProvider {
         for _ in 0..=self.inner {
             bound = random.next_bounded_i32(bound) + 1;
         }
-        self.min_inclusive + bound - 1
+        self.min_inclusive + random.next_bounded_i32(bound)
     }
 
     #[must_use]
@@ -862,6 +868,75 @@ mod tests {
             assert!(
                 (1..=20).contains(&value),
                 "Value {value} is outside range [1, 20]"
+            );
+        }
+    }
+
+    /// Vanilla's `CaveWorldCarver.carve` picks its cave count with
+    /// `random.nextInt(random.nextInt(random.nextInt(getCaveBound()) + 1) + 1)` —
+    /// three nested draws returning the innermost-last one, where `getCaveBound()` is
+    /// `15` in the overworld (`(0, 14, 1)`) and `10` in the nether (`(0, 9, 1)`).
+    #[test]
+    fn very_biased_to_bottom_int_provider_matches_vanilla() {
+        for bound in [15, 10] {
+            let provider = VeryBiasedToBottomIntProvider::new(0, bound - 1, 1);
+
+            let mut random =
+                RandomGenerator::Xoroshiro(crate::random::xoroshiro128::Xoroshiro::from_seed(2));
+            let mut reference =
+                RandomGenerator::Xoroshiro(crate::random::xoroshiro128::Xoroshiro::from_seed(2));
+            // Java evaluates the nested `nextInt` calls inside out.
+            let inner = reference.next_bounded_i32(bound);
+            let middle = reference.next_bounded_i32(inner + 1);
+            let expected = reference.next_bounded_i32(middle + 1);
+            assert_eq!(provider.get(&mut random), expected);
+
+            // The carvers use the legacy random source, so check that stream too.
+            let mut random =
+                RandomGenerator::Legacy(crate::random::legacy_rand::LegacyRand::from_seed(2));
+            let mut reference =
+                RandomGenerator::Legacy(crate::random::legacy_rand::LegacyRand::from_seed(2));
+            let inner = reference.next_bounded_i32(bound);
+            let middle = reference.next_bounded_i32(inner + 1);
+            let expected = reference.next_bounded_i32(middle + 1);
+            assert_eq!(provider.get(&mut random), expected);
+        }
+    }
+
+    /// The cave count is the first value drawn from every chunk's carver stream, so
+    /// consuming the wrong number of ints desyncs everything carved after it.
+    #[test]
+    fn very_biased_to_bottom_int_provider_consumes_three_ints() {
+        for bound in [15, 10] {
+            let mut provider_random =
+                RandomGenerator::Legacy(crate::random::legacy_rand::LegacyRand::from_seed(2));
+            VeryBiasedToBottomIntProvider::new(0, bound - 1, 1).get(&mut provider_random);
+
+            let mut reference =
+                RandomGenerator::Legacy(crate::random::legacy_rand::LegacyRand::from_seed(2));
+            let first = reference.next_bounded_i32(bound);
+            let second = reference.next_bounded_i32(first + 1);
+            reference.next_bounded_i32(second + 1);
+
+            assert_eq!(provider_random.next_i32(), reference.next_i32());
+        }
+    }
+
+    #[test]
+    fn very_biased_to_bottom_int_provider() {
+        let mut random = RandomGenerator::Xoroshiro(
+            crate::random::xoroshiro128::Xoroshiro::from_seed(get_seed()),
+        );
+        let provider = VeryBiasedToBottomIntProvider::new(0, 14, 1);
+
+        assert_eq!(provider.get_min(), 0);
+        assert_eq!(provider.get_max(), 14);
+
+        for _ in 0..100 {
+            let value = provider.get(&mut random);
+            assert!(
+                (0..=14).contains(&value),
+                "Value {value} is outside range [0, 14]"
             );
         }
     }


### PR DESCRIPTION

## Description

Independent of #3229 (different crate, no overlapping lines) and of #3234, but the three only show their full effect together; #3229 carries the shared measurement method and tables.

`VeryBiasedToBottomIntProvider::get` ran its narrowing loop `inner + 1` times and returned the last narrowing draw itself:

```rust
for _ in 0..=self.inner { bound = random.next_bounded_i32(bound) + 1; }
self.min_inclusive + bound - 1
```

With the carver config `(0, 14, 1)` that is two `next_bounded_i32` calls, returning the second. Vanilla's `CaveWorldCarver.carve` computes the cave count as

Vanilla nests three `nextInt` draws, feeding each result plus one in as the bound of the next and keeping the last; the outermost bound is 15 in the overworld.

— three nested draws, returning the innermost-last. The fix keeps the loop and returns `self.min_inclusive + random.next_bounded_i32(bound)`, which for `(0, 14, 1)` is exactly `a = next(15); b = next(a+1); c = next(b+1); c`. Same shape for the nether's `(0, 9, 1)`.

Both the value and the RNG consumption were wrong, and this is the **first** draw of every chunk's carver stream (`cave.rs`, `cave_config.count.get(random)`), so every value after it — cave positions, radii, per-tunnel seeds, later carvers in the same chunk — was shifted. That made it the dominant cause of Pumpkin's cave divergence. LegacyRand seed 2, bound 15: old code 8 caves, vanilla 2.

The int provider is used in exactly three places, all carver `count` fields (`CAVE`, `CAVE_EXTRA_UNDERGROUND`, `NETHER_CAVE`). The identically named `VeryBiasedToBottomHeightProvider` is a different type and is untouched; its parity test still passes.

## Measured effect

Against an unmodified Mojang 26.2 server, seed 13579, 256 chunks, solid/non-solid mask, with #3229 applied in both columns (method and full tables in #3229):

| | without this fix | with this fix |
|---|---|---|
| mismatch vs vanilla, carver band y 2..70 | 223,513 (4.94%) | **14,459 (0.32%)** |
| carved-volume precision / recall | 14.7% / 23.7% | **99.6% / 89.5%** |
| median per-chunk carver-band mismatch | 620 | **12** |

Below y = 2 it changes nothing (that's the floor fix, separate PR).

**Known impact:** changes worldgen output; chunks generated after this will not line up with chunks from older builds.

## Testing

`cargo test -p pumpkin-util -p pumpkin-world` green, `cargo clippy --all-targets` clean.

Added in `int_provider.rs`, anchored on an explicit reference expression rather than magic numbers:

- `very_biased_to_bottom_int_provider_matches_vanilla` — for bounds 15 and 10, on both `Xoroshiro::from_seed(2)` and `LegacyRand::from_seed(2)` (the carver uses legacy rand), asserts `provider.get()` equals the written-out `next_bounded_i32` / `+1` / `+1` nesting on a fresh generator with the same seed.
- `very_biased_to_bottom_int_provider_consumes_three_ints` — the generator advances by exactly three draws.
- `very_biased_to_bottom_int_provider` — range smoke test in the style of the neighbouring providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

