### PR TITLE
fix(worldgen): clamp the cave ellipsoid floor to the min build height 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-world/src/generation/carver/cave.rs
+++ b/crates/pumpkin-world/src/generation/carver/cave.rs
@@ -272,7 +272,8 @@ impl CaveCarver {
             return;
         }
 
-        let min_y = 1.max((y - vertical_radius).floor() as i32 - 1);
+        let min_y = ((y - vertical_radius).floor() as i32 - 1)
+            .max(run.chunk.generation_bottom_y() as i32 + 1);
         let max_y = (run.chunk.generation_height() as i32 - 1)
             .min((y + vertical_radius).floor() as i32 + 1);
 
@@ -462,6 +463,35 @@ mod tests {
             assert_eq!(run.chunk.fluid_ticks.len(), old_tick_count + 1);
             let pos = run.chunk.fluid_ticks.last().unwrap().position.0;
             assert_eq!((pos.x, pos.y, pos.z), (x, y, z));
+        });
+    }
+
+    /// Vanilla clamps the ellipsoid's lower bound to `getMinGenY() + 1` (-63 in the
+    /// overworld), not to 1, so deepslate-level caves are carved at all.
+    #[test]
+    fn carves_below_y_one() {
+        super::super::with_carve_run(Dimension::OVERWORLD, |run| {
+            let (x, y, z) = (8, -30, 8);
+            let expected = super::super::overworld_carve_state(run, x, y, z)
+                .expect("test position should carve")
+                .0
+                .id;
+            assert_ne!(expected, Block::STONE.default_state.id);
+
+            run.chunk
+                .set_block_state(x, y, z, Block::STONE.default_state);
+            CaveCarver::carve_ellipsoid(
+                run,
+                &CAVE,
+                f64::from(x) + 0.5,
+                f64::from(y) + 0.5,
+                f64::from(z) + 0.5,
+                4.0,
+                4.0,
+                -1.0,
+            );
+
+            assert_eq!(block_id(run, x, y, z), expected);
         });
     }
 


### PR DESCRIPTION

## Description

Independent of #3229 and of #3233 (no overlapping lines); #3229 carries the shared measurement method and tables.

The cave carver's ellipsoid computed its lower bound as

```rust
let min_y = 1.max((y - vertical_radius).floor() as i32 - 1);
```

so nothing at y ≤ 1 was ever carved. Vanilla clamps the ellipsoid's lower bound to one above the dimension's minimum build height — the floor is one above the dimension's minimum build height (−63 in the overworld), not 1. Measured against a real 26.2 server, Pumpkin's carvers changed **zero** blocks below y = 2 in all 256 chunks tested, while vanilla's cave network continues down to at least y = −50.

Fix: `.max(run.chunk.generation_bottom_y() as i32 + 1)`, the same accessor the upper bound already uses a few lines below. `canyon.rs` already had the correct bound and needs no change.

## Measured effect

Against an unmodified Mojang 26.2 server, seed 13579, 256 chunks, solid/non-solid mask, with #3229 and the cave-count fix applied in both columns (method and full tables in #3229):

| | without this fix | with this fix |
|---|---|---|
| mismatch vs vanilla, y < 0 | 83,072 (1.98%) | **8,027 (0.19%)** |
| of which "vanilla open, Pumpkin solid" | 81,684 | **6,103** |
| mismatch vs vanilla, y 2..70 | 14,459 | 14,459 (bit-identical) |

**Known impact:** changes worldgen output; chunks generated after this will not line up with chunks from older builds.

## Testing

`cargo test -p pumpkin-util -p pumpkin-world` green, `cargo clippy --all-targets` clean.

Added `carves_below_y_one` in `cave.rs`: builds a `CarveRun` via the existing `with_carve_run(Dimension::OVERWORLD, …)` helper, places stone at (8, −30, 8), calls `carve_ellipsoid` with radii 4/4, and asserts the block equals `overworld_carve_state`'s result (asserted non-stone first so the test can't pass vacuously). On the old bound it fails with `left: BlockStateId(1)` / `right: BlockStateId(0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

