### PR TITLE
feat(block): grow trees from saplings and fix leaf decay drops

### DIFF
--- a/crates/pumpkin-data/src/generated/loot_table.rs
+++ b/crates/pumpkin-data/src/generated/loot_table.rs
@@ -792,7 +792,15 @@ static BLOCKS_ACACIA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::TableBonus {
+                    chances: &[0.05f32, 0.0625f32, 0.083333336f32, 0.1f32],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -801,7 +809,9 @@ static BLOCKS_ACACIA_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 2i32,
-    condition: LootCondition::None,
+    condition: LootCondition::TableBonus {
+        chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_ACACIA_LEAVES_POOLS: &[LootPool] = &[
@@ -1269,7 +1279,15 @@ static BLOCKS_AZALEA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::TableBonus {
+                    chances: &[0.05f32, 0.0625f32, 0.083333336f32, 0.1f32],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -1278,7 +1296,9 @@ static BLOCKS_AZALEA_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 2i32,
-    condition: LootCondition::None,
+    condition: LootCondition::TableBonus {
+        chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_AZALEA_LEAVES_POOLS: &[LootPool] = &[
@@ -1948,7 +1968,15 @@ static BLOCKS_BIRCH_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::TableBonus {
+                    chances: &[0.05f32, 0.0625f32, 0.083333336f32, 0.1f32],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -1957,7 +1985,9 @@ static BLOCKS_BIRCH_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 2i32,
-    condition: LootCondition::None,
+    condition: LootCondition::TableBonus {
+        chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BIRCH_LEAVES_POOLS: &[LootPool] = &[
@@ -2831,7 +2861,10 @@ static BLOCKS_BRAIN_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -3265,7 +3298,10 @@ static BLOCKS_BUBBLE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -3409,7 +3445,10 @@ static BLOCKS_CAMPFIRE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 2i32,
         max_count: 2i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -3691,7 +3730,15 @@ static BLOCKS_CHERRY_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::TableBonus {
+                    chances: &[0.05f32, 0.0625f32, 0.083333336f32, 0.1f32],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -3700,7 +3747,9 @@ static BLOCKS_CHERRY_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 2i32,
-    condition: LootCondition::None,
+    condition: LootCondition::TableBonus {
+        chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_CHERRY_LEAVES_POOLS: &[LootPool] = &[
@@ -4638,7 +4687,10 @@ static BLOCKS_COBWEB_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -5297,7 +5349,10 @@ static BLOCKS_CRIMSON_NYLIUM_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -5991,7 +6046,15 @@ static BLOCKS_DARK_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::TableBonus {
+                    chances: &[0.05f32, 0.0625f32, 0.083333336f32, 0.1f32],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -6000,7 +6063,9 @@ static BLOCKS_DARK_OAK_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 2i32,
-    condition: LootCondition::None,
+    condition: LootCondition::TableBonus {
+        chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_DARK_OAK_LEAVES_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -6008,7 +6073,18 @@ static BLOCKS_DARK_OAK_LEAVES_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::SurvivesExplosion,
+    condition: LootCondition::AllOf(&[
+        LootCondition::SurvivesExplosion,
+        LootCondition::TableBonus {
+            chances: &[
+                0.005f32,
+                0.0055555557f32,
+                0.00625f32,
+                0.008333334f32,
+                0.025f32,
+            ],
+        },
+    ]),
     bonus_formula: None,
 }];
 static BLOCKS_DARK_OAK_LEAVES_POOLS: &[LootPool] = &[
@@ -6619,7 +6695,10 @@ static BLOCKS_DEEPSLATE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -7801,7 +7880,10 @@ static BLOCKS_FERN_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::RandomChance { chance: 0.125f32 },
+        ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(2i32)),
     },
 ];
@@ -7851,7 +7933,10 @@ static BLOCKS_FIRE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -7969,7 +8054,15 @@ static BLOCKS_FLOWERING_AZALEA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::TableBonus {
+                    chances: &[0.05f32, 0.0625f32, 0.083333336f32, 0.1f32],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -7978,7 +8071,9 @@ static BLOCKS_FLOWERING_AZALEA_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry 
     weight: 1i32,
     min_count: 1i32,
     max_count: 2i32,
-    condition: LootCondition::None,
+    condition: LootCondition::TableBonus {
+        chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_FLOWERING_AZALEA_LEAVES_POOLS: &[LootPool] = &[
@@ -8040,7 +8135,12 @@ static BLOCKS_GILDED_BLACKSTONE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 2i32,
         max_count: 5i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[LootCondition::NoSilkTouch, LootCondition::SurvivesExplosion]),
+            LootCondition::TableBonus {
+                chances: &[0.1f32, 0.14285715f32, 0.25f32, 1f32],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -8048,7 +8148,10 @@ static BLOCKS_GILDED_BLACKSTONE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -8294,7 +8397,10 @@ static BLOCKS_GRASS_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -8322,7 +8428,12 @@ static BLOCKS_GRAVEL_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::AllOf(&[LootCondition::NoSilkTouch, LootCondition::SurvivesExplosion]),
+            LootCondition::TableBonus {
+                chances: &[0.1f32, 0.14285715f32, 0.25f32, 1f32],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -8330,7 +8441,10 @@ static BLOCKS_GRAVEL_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -8988,7 +9102,10 @@ static BLOCKS_HORN_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -9422,7 +9539,15 @@ static BLOCKS_JUNGLE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::TableBonus {
+                    chances: &[0.025f32, 0.027777778f32, 0.03125f32, 0.041666668f32, 0.1f32],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -9431,7 +9556,9 @@ static BLOCKS_JUNGLE_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 2i32,
-    condition: LootCondition::None,
+    condition: LootCondition::TableBonus {
+        chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_JUNGLE_LEAVES_POOLS: &[LootPool] = &[
@@ -9783,7 +9910,13 @@ static BLOCKS_LARGE_FERN_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::RandomChance { chance: 0.125f32 },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -9801,7 +9934,13 @@ static BLOCKS_LARGE_FERN_POOL1_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::RandomChance { chance: 0.125f32 },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -11080,7 +11219,12 @@ static BLOCKS_MANGROVE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 2i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::TableBonus {
+                chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+            },
+        ]),
         bonus_formula: None,
     },
 ];
@@ -11676,7 +11820,10 @@ static BLOCKS_MYCELIUM_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -12052,7 +12199,15 @@ static BLOCKS_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::TableBonus {
+                    chances: &[0.05f32, 0.0625f32, 0.083333336f32, 0.1f32],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -12061,7 +12216,9 @@ static BLOCKS_OAK_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 2i32,
-    condition: LootCondition::None,
+    condition: LootCondition::TableBonus {
+        chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_OAK_LEAVES_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
@@ -12069,7 +12226,18 @@ static BLOCKS_OAK_LEAVES_POOL2_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::SurvivesExplosion,
+    condition: LootCondition::AllOf(&[
+        LootCondition::SurvivesExplosion,
+        LootCondition::TableBonus {
+            chances: &[
+                0.005f32,
+                0.0055555557f32,
+                0.00625f32,
+                0.008333334f32,
+                0.025f32,
+            ],
+        },
+    ]),
     bonus_formula: None,
 }];
 static BLOCKS_OAK_LEAVES_POOLS: &[LootPool] = &[
@@ -13084,7 +13252,15 @@ static BLOCKS_PALE_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::TableBonus {
+                    chances: &[0.05f32, 0.0625f32, 0.083333336f32, 0.1f32],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -13093,7 +13269,9 @@ static BLOCKS_PALE_OAK_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 2i32,
-    condition: LootCondition::None,
+    condition: LootCondition::TableBonus {
+        chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PALE_OAK_LEAVES_POOLS: &[LootPool] = &[
@@ -13757,7 +13935,10 @@ static BLOCKS_PODZOL_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -17564,7 +17745,10 @@ static BLOCKS_SHORT_GRASS_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::RandomChance { chance: 0.125f32 },
+        ]),
         bonus_formula: Some(LootBonusFormula::UniformBonusCount(2i32)),
     },
 ];
@@ -18138,7 +18322,10 @@ static BLOCKS_SOUL_CAMPFIRE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -18372,7 +18559,15 @@ static BLOCKS_SPRUCE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::TableBonus {
+                    chances: &[0.05f32, 0.0625f32, 0.083333336f32, 0.1f32],
+                },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -18381,7 +18576,9 @@ static BLOCKS_SPRUCE_LEAVES_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 2i32,
-    condition: LootCondition::None,
+    condition: LootCondition::TableBonus {
+        chances: &[0.02f32, 0.022222223f32, 0.025f32, 0.033333335f32, 0.1f32],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_SPRUCE_LEAVES_POOLS: &[LootPool] = &[
@@ -18615,7 +18812,10 @@ static BLOCKS_STONE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -19478,7 +19678,13 @@ static BLOCKS_TALL_GRASS_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::RandomChance { chance: 0.125f32 },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -19496,7 +19702,13 @@ static BLOCKS_TALL_GRASS_POOL1_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::AllOf(&[
+                LootCondition::SurvivesExplosion,
+                LootCondition::RandomChance { chance: 0.125f32 },
+            ]),
+        ]),
         bonus_formula: None,
     },
 ];
@@ -19753,7 +19965,10 @@ static BLOCKS_TUBE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -19961,7 +20176,12 @@ static BLOCKS_TWISTING_VINES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::TableBonus {
+                chances: &[0.33f32, 0.55f32, 0.77f32, 1f32],
+            },
+        ]),
         bonus_formula: None,
     },
 ];
@@ -19989,7 +20209,12 @@ static BLOCKS_TWISTING_VINES_PLANT_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::TableBonus {
+                chances: &[0.33f32, 0.55f32, 0.77f32, 1f32],
+            },
+        ]),
         bonus_formula: None,
     },
 ];
@@ -20183,7 +20408,10 @@ static BLOCKS_WARPED_NYLIUM_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::SurvivesExplosion,
+        ]),
         bonus_formula: None,
     },
 ];
@@ -21759,7 +21987,12 @@ static BLOCKS_WEEPING_VINES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::TableBonus {
+                chances: &[0.33f32, 0.55f32, 0.77f32, 1f32],
+            },
+        ]),
         bonus_formula: None,
     },
 ];
@@ -21787,7 +22020,12 @@ static BLOCKS_WEEPING_VINES_PLANT_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouchOrShears,
+            LootCondition::TableBonus {
+                chances: &[0.33f32, 0.55f32, 0.77f32, 1f32],
+            },
+        ]),
         bonus_formula: None,
     },
 ];

--- a/crates/pumpkin-util/src/loot_table.rs
+++ b/crates/pumpkin-util/src/loot_table.rs
@@ -18,6 +18,9 @@ pub enum LootCondition {
         enchanted_chance_base: f32,
         enchanted_chance_per_level_above_first: f32,
     },
+    TableBonus {
+        chances: &'static [f32],
+    },
     AllOf(&'static [Self]),
 }
 

--- a/crates/pumpkin/src/block/blocks/leaves.rs
+++ b/crates/pumpkin/src/block/blocks/leaves.rs
@@ -113,7 +113,7 @@ impl BlockBehaviour for LeavesBlock {
                 }
             }
             args.world
-                .break_block(args.position, None, BlockFlags::empty());
+                .break_block(args.position, None, BlockFlags::NOTIFY_ALL);
         }
     }
 

--- a/crates/pumpkin/src/block/blocks/plant/mangrove_propagule.rs
+++ b/crates/pumpkin/src/block/blocks/plant/mangrove_propagule.rs
@@ -5,8 +5,10 @@ use pumpkin_data::{
 };
 use pumpkin_macros::pumpkin_block;
 use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::random::{RandomGenerator, xoroshiro128::Xoroshiro};
 use pumpkin_world::world::{BlockAccessor, BlockFlags};
 
+use crate::block::blocks::plant::tree_grower::TreeGrower;
 use crate::block::{
     BlockBehaviour, BonemealArgs, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, OnPlaceArgs,
     RandomTickArgs,
@@ -68,7 +70,19 @@ impl MangrovePropaguleBlock {
             let mut event = StructureGrowEvent::new(*pos, TreeType::Mangrove, false);
             if let Some(server) = world.server.upgrade() {
                 server.plugin_manager.fire_blocking(&server, &mut event);
+                if event.cancelled {
+                    return;
+                }
             }
+            let mut random =
+                RandomGenerator::Xoroshiro(Xoroshiro::from_seed(rand::random::<u64>()));
+            TreeGrower::MANGROVE.grow_tree(
+                world,
+                pos,
+                block,
+                props.to_state_id(block),
+                &mut random,
+            );
         }
     }
 }

--- a/crates/pumpkin/src/block/blocks/plant/mod.rs
+++ b/crates/pumpkin/src/block/blocks/plant/mod.rs
@@ -38,6 +38,7 @@ pub mod spore_blossom;
 pub mod sugar_cane;
 pub mod tall_plant;
 pub mod tall_seagrass;
+pub mod tree_grower;
 pub mod twisting_vines;
 pub mod weeping_vines;
 pub mod wither_rose;

--- a/crates/pumpkin/src/block/blocks/plant/sapling.rs
+++ b/crates/pumpkin/src/block/blocks/plant/sapling.rs
@@ -5,10 +5,12 @@ use pumpkin_data::{
     block_properties::{BlockProperties, OakSaplingLikeProperties},
 };
 use pumpkin_macros::pumpkin_block_from_tag;
-use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::{position::BlockPos, vector3::Vector3};
+use pumpkin_util::random::{RandomGenerator, xoroshiro128::Xoroshiro};
 use pumpkin_world::world::BlockFlags;
 
 use crate::block::blocks::plant::PlantBlockBase;
+use crate::block::blocks::plant::tree_grower::TreeGrower;
 use crate::block::{
     BlockBehaviour, BonemealArgs, CanPlaceAtArgs, GetStateForNeighborUpdateArgs, RandomTickArgs,
 };
@@ -55,7 +57,15 @@ impl SaplingBlock {
         let mut event = StructureGrowEvent::new(*pos, tree_type, bone_meal);
         if let Some(server) = world.server.upgrade() {
             server.plugin_manager.fire_blocking(&server, &mut event);
+            if event.cancelled {
+                return;
+            }
         }
+        let Some(grower) = TreeGrower::for_block(block) else {
+            return;
+        };
+        let mut random = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(rand::random::<u64>()));
+        grower.grow_tree(world, pos, block, state_id, &mut random);
     }
 }
 
@@ -77,14 +87,26 @@ impl BlockBehaviour for SaplingBlock {
     }
 
     fn random_tick(&self, args: RandomTickArgs<'_>) {
-        if rand::random::<u8>().is_multiple_of(7) {
+        if args.world.get_max_local_raw_brightness(&args.position.up()) >= 9
+            && rand::random_range(0..7) == 0
+        {
             let state_id = args.world.get_block_state_id(args.position);
             Self::advance_tree(args.world, args.position, args.block, state_id, false);
         }
     }
 
-    fn is_valid_bonemeal_target(&self, _args: BonemealArgs<'_>) -> bool {
-        true
+    fn is_valid_bonemeal_target(&self, args: BonemealArgs<'_>) -> bool {
+        let Some(grower) = TreeGrower::for_block(args.block) else {
+            return false;
+        };
+        let mut random = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(rand::random::<u64>()));
+        grower.can_grow(args.world, args.position, args.block, &mut random)
+            && args
+                .world
+                .is_in_build_limit(
+                    args.position
+                        .offset(Vector3::new(0, grower.min_height(), 0)),
+                )
     }
 
     fn is_bonemeal_success(&self, _args: BonemealArgs<'_>) -> bool {

--- a/crates/pumpkin/src/block/blocks/plant/tree_grower.rs
+++ b/crates/pumpkin/src/block/blocks/plant/tree_grower.rs
@@ -1,0 +1,284 @@
+use std::sync::Arc;
+
+use pumpkin_data::{
+    Block, BlockStateId, configured_feature::ConfiguredFeature as FeatureKey, tag, tag::Taggable,
+};
+use pumpkin_util::{
+    math::{position::BlockPos, vector3::Vector3},
+    random::{RandomGenerator, RandomImpl},
+};
+use pumpkin_world::{
+    generation::feature::configured_features::{CONFIGURED_FEATURES, ConfiguredFeature},
+    world::BlockFlags,
+};
+
+use crate::world::{World, generation_cache::WorldGenerationCache};
+
+struct TwoByTwoSaplingPos {
+    offset_x: i32,
+    offset_z: i32,
+    saplings: Vec<(BlockPos, BlockStateId)>,
+}
+
+pub struct TreeGrower {
+    trees: &'static [(FeatureKey, i32)],
+    mega_trees: &'static [(FeatureKey, i32)],
+    flower_trees: &'static [(FeatureKey, i32)],
+    shortest: Option<FeatureKey>,
+}
+
+impl TreeGrower {
+    pub const OAK: Self = Self {
+        trees: &[(FeatureKey::Oak, 9), (FeatureKey::FancyOak, 1)],
+        mega_trees: &[],
+        flower_trees: &[
+            (FeatureKey::OakBees005, 9),
+            (FeatureKey::FancyOakBees005, 1),
+        ],
+        shortest: Some(FeatureKey::Oak),
+    };
+    pub const SPRUCE: Self = Self {
+        trees: &[(FeatureKey::Spruce, 1)],
+        mega_trees: &[(FeatureKey::MegaSpruce, 1), (FeatureKey::MegaPine, 1)],
+        flower_trees: &[],
+        shortest: Some(FeatureKey::Spruce),
+    };
+    pub const MANGROVE: Self = Self {
+        trees: &[(FeatureKey::Mangrove, 15), (FeatureKey::TallMangrove, 85)],
+        mega_trees: &[],
+        flower_trees: &[],
+        shortest: Some(FeatureKey::Mangrove),
+    };
+    pub const AZALEA: Self = Self {
+        trees: &[(FeatureKey::AzaleaTree, 1)],
+        mega_trees: &[],
+        flower_trees: &[],
+        shortest: Some(FeatureKey::AzaleaTree),
+    };
+    pub const BIRCH: Self = Self {
+        trees: &[(FeatureKey::Birch, 1)],
+        mega_trees: &[],
+        flower_trees: &[(FeatureKey::BirchBees005, 1)],
+        shortest: Some(FeatureKey::Birch),
+    };
+    pub const JUNGLE: Self = Self {
+        trees: &[(FeatureKey::JungleTreeNoVine, 1)],
+        mega_trees: &[(FeatureKey::MegaJungleTree, 1)],
+        flower_trees: &[],
+        shortest: Some(FeatureKey::JungleTreeNoVine),
+    };
+    pub const ACACIA: Self = Self {
+        trees: &[(FeatureKey::Acacia, 1)],
+        mega_trees: &[],
+        flower_trees: &[],
+        shortest: Some(FeatureKey::Acacia),
+    };
+    pub const CHERRY: Self = Self {
+        trees: &[(FeatureKey::Cherry, 1)],
+        mega_trees: &[],
+        flower_trees: &[(FeatureKey::CherryBees005, 1)],
+        shortest: Some(FeatureKey::Cherry),
+    };
+    pub const DARK_OAK: Self = Self {
+        trees: &[],
+        mega_trees: &[(FeatureKey::DarkOak, 1)],
+        flower_trees: &[],
+        shortest: None,
+    };
+    pub const PALE_OAK: Self = Self {
+        trees: &[],
+        mega_trees: &[(FeatureKey::PaleOakBonemeal, 1)],
+        flower_trees: &[],
+        shortest: None,
+    };
+
+    #[must_use]
+    pub fn for_block(block: &Block) -> Option<&'static Self> {
+        match block.name {
+            "oak_sapling" => Some(&Self::OAK),
+            "spruce_sapling" => Some(&Self::SPRUCE),
+            "birch_sapling" => Some(&Self::BIRCH),
+            "jungle_sapling" => Some(&Self::JUNGLE),
+            "acacia_sapling" => Some(&Self::ACACIA),
+            "dark_oak_sapling" => Some(&Self::DARK_OAK),
+            "pale_oak_sapling" => Some(&Self::PALE_OAK),
+            "cherry_sapling" => Some(&Self::CHERRY),
+            "azalea" | "flowering_azalea" => Some(&Self::AZALEA),
+            "mangrove_propagule" => Some(&Self::MANGROVE),
+            _ => None,
+        }
+    }
+
+    fn pick(list: &[(FeatureKey, i32)], random: &mut RandomGenerator) -> Option<FeatureKey> {
+        let total: i32 = list.iter().map(|(_, weight)| *weight).sum();
+        if total <= 0 {
+            return None;
+        }
+        let mut roll = random.next_bounded_i32(total);
+        for (key, weight) in list {
+            roll -= weight;
+            if roll < 0 {
+                return Some(*key);
+            }
+        }
+        None
+    }
+
+    fn has_flowers(world: &World, pos: &BlockPos) -> bool {
+        for x in -2..=2 {
+            for y in -1..=1 {
+                for z in -2..=2 {
+                    let block = world.get_block(&pos.offset(Vector3::new(x, y, z)));
+                    if block.has_tag(&tag::Block::MINECRAFT_FLOWERS) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    fn surrounding(
+        world: &World,
+        pos: &BlockPos,
+        dx: i32,
+        dz: i32,
+    ) -> Vec<(BlockPos, BlockStateId)> {
+        [(dx, dz), (dx + 1, dz), (dx, dz + 1), (dx + 1, dz + 1)]
+            .into_iter()
+            .map(|(x, z)| {
+                let position = pos.offset(Vector3::new(x, 0, z));
+                (position, world.get_block_state_id(&position))
+            })
+            .collect()
+    }
+
+    fn find_two_by_two(world: &World, block: &Block, pos: &BlockPos) -> Option<TwoByTwoSaplingPos> {
+        for dx in [0, -1] {
+            for dz in [0, -1] {
+                let saplings = Self::surrounding(world, pos, dx, dz);
+                if saplings
+                    .iter()
+                    .all(|(_, state_id)| Block::from_state_id(*state_id) == block)
+                {
+                    return Some(TwoByTwoSaplingPos {
+                        offset_x: dx,
+                        offset_z: dz,
+                        saplings,
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    fn remove_saplings(world: &Arc<World>, saplings: &[(BlockPos, BlockStateId)]) {
+        for (pos, _) in saplings {
+            world.set_block_state(
+                pos,
+                Block::AIR.default_state.id,
+                BlockFlags::NOTIFY_LISTENERS,
+            );
+        }
+    }
+
+    fn reset_saplings(world: &Arc<World>, saplings: &[(BlockPos, BlockStateId)]) {
+        for (pos, state_id) in saplings {
+            world.set_block_state(pos, *state_id, BlockFlags::NOTIFY_LISTENERS);
+        }
+    }
+
+    fn place(
+        world: &Arc<World>,
+        key: FeatureKey,
+        pos: BlockPos,
+        random: &mut RandomGenerator,
+    ) -> bool {
+        let Some(ConfiguredFeature::Tree(tree)) = CONFIGURED_FEATURES.get(&key) else {
+            return false;
+        };
+        let portal = world.level.world_portal.load_full();
+        let Some(portal) = portal.as_ref() else {
+            return false;
+        };
+        let mut cache = WorldGenerationCache::new(world.clone(), &pos);
+        if !tree.generate(&**portal, &mut cache, random, pos) {
+            return false;
+        }
+        cache.apply();
+        true
+    }
+
+    #[must_use]
+    pub fn min_height(&self) -> i32 {
+        self.shortest
+            .and_then(|key| match CONFIGURED_FEATURES.get(&key) {
+                Some(ConfiguredFeature::Tree(tree)) => {
+                    Some(i32::from(tree.trunk_placer.base_height))
+                }
+                _ => None,
+            })
+            .unwrap_or(0)
+    }
+
+    #[must_use]
+    pub fn can_grow(
+        &self,
+        world: &World,
+        pos: &BlockPos,
+        block: &Block,
+        random: &mut RandomGenerator,
+    ) -> bool {
+        let has_flowers = Self::has_flowers(world, pos);
+        let list = if has_flowers && !self.flower_trees.is_empty() {
+            self.flower_trees
+        } else {
+            self.trees
+        };
+        let single = Self::pick(list, random);
+        let mega = Self::pick(self.mega_trees, random);
+        if single.is_none() && mega.is_some() {
+            Self::find_two_by_two(world, block, pos).is_some()
+        } else {
+            true
+        }
+    }
+
+    pub fn grow_tree(
+        &self,
+        world: &Arc<World>,
+        pos: &BlockPos,
+        block: &Block,
+        state_id: BlockStateId,
+        random: &mut RandomGenerator,
+    ) -> bool {
+        if let Some(mega) = Self::pick(self.mega_trees, random)
+            && let Some(two_by_two) = Self::find_two_by_two(world, block, pos)
+        {
+            Self::remove_saplings(world, &two_by_two.saplings);
+            let origin = pos.offset(Vector3::new(two_by_two.offset_x, 0, two_by_two.offset_z));
+            if Self::place(world, mega, origin, random) {
+                return true;
+            }
+            Self::reset_saplings(world, &two_by_two.saplings);
+            return false;
+        }
+
+        let has_flowers = Self::has_flowers(world, pos);
+        let list = if has_flowers && !self.flower_trees.is_empty() {
+            self.flower_trees
+        } else {
+            self.trees
+        };
+        let Some(key) = Self::pick(list, random) else {
+            return false;
+        };
+        let sapling = [(*pos, state_id)];
+        Self::remove_saplings(world, &sapling);
+        if Self::place(world, key, *pos, random) {
+            return true;
+        }
+        Self::reset_saplings(world, &sapling);
+        false
+    }
+}

--- a/crates/pumpkin/src/world/generation_cache.rs
+++ b/crates/pumpkin/src/world/generation_cache.rs
@@ -1,0 +1,196 @@
+use std::sync::Arc;
+
+use pumpkin_data::{
+    Block, BlockState, BlockStateId,
+    biome::Biome,
+    fluid::{Fluid, FluidState},
+};
+use pumpkin_nbt::compound::NbtCompound;
+use pumpkin_util::{
+    HeightMap,
+    math::{position::BlockPos, vector2::Vector2, vector3::Vector3},
+};
+use pumpkin_world::{
+    ProtoChunk,
+    chunk::ChunkHeightmapType,
+    generation::{
+        blender::blending_data::BlendingData, height_limit::HeightLimitView,
+        proto_chunk::GenerationCache,
+    },
+    world::{BlockAccessor, BlockFlags},
+};
+use rustc_hash::FxHashMap;
+
+use crate::block::entities::block_entity_from_nbt;
+use crate::world::World;
+
+pub struct WorldGenerationCache {
+    world: Arc<World>,
+    center: ProtoChunk,
+    pending: Vec<(BlockPos, BlockStateId)>,
+    overlay: FxHashMap<BlockPos, BlockStateId>,
+    block_entities: Vec<NbtCompound>,
+}
+
+impl WorldGenerationCache {
+    #[must_use]
+    pub fn new(world: Arc<World>, pos: &BlockPos) -> Self {
+        let generator = world.level.world_gen.load();
+        let center = ProtoChunk::new(pos.0.x >> 4, pos.0.z >> 4, &generator);
+        Self {
+            world,
+            center,
+            pending: Vec::new(),
+            overlay: FxHashMap::default(),
+            block_entities: Vec::new(),
+        }
+    }
+
+    fn read(&self, pos: &BlockPos) -> BlockStateId {
+        self.overlay
+            .get(pos)
+            .copied()
+            .unwrap_or_else(|| self.world.get_block_state_id(pos))
+    }
+
+    fn heightmap(&self, heightmap: ChunkHeightmapType, x: i32, z: i32) -> i32 {
+        let min_y = self.world.dimension.min_y;
+        self.world
+            .level
+            .loaded_chunks
+            .get(&Vector2::new(x >> 4, z >> 4))
+            .map_or(min_y, |chunk| {
+                chunk
+                    .heightmap
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .get(heightmap, x & 15, z & 15, min_y)
+                    + 1
+            })
+    }
+
+    pub fn apply(self) {
+        for (pos, state_id) in self.pending {
+            self.world
+                .set_block_state(&pos, state_id, BlockFlags::NOTIFY_ALL);
+        }
+        for nbt in self.block_entities {
+            if let Some(block_entity) = block_entity_from_nbt(&nbt) {
+                self.world.add_block_entity(block_entity);
+            }
+        }
+    }
+}
+
+impl HeightLimitView for WorldGenerationCache {
+    fn height(&self) -> u16 {
+        self.world.dimension.height as u16
+    }
+
+    fn bottom_y(&self) -> i8 {
+        self.world.dimension.min_y as i8
+    }
+}
+
+impl BlockAccessor for WorldGenerationCache {
+    fn get_block(&self, position: &BlockPos) -> &'static Block {
+        Block::from_state_id(self.read(position))
+    }
+
+    fn get_block_state(&self, position: &BlockPos) -> &'static BlockState {
+        BlockState::from_id(self.read(position))
+    }
+
+    fn get_block_state_id(&self, position: &BlockPos) -> BlockStateId {
+        self.read(position)
+    }
+
+    fn get_block_and_state(&self, position: &BlockPos) -> (&'static Block, &'static BlockState) {
+        BlockState::from_id_with_block(self.read(position))
+    }
+}
+
+impl GenerationCache for WorldGenerationCache {
+    fn get_center_chunk_mut(&mut self) -> &mut ProtoChunk {
+        &mut self.center
+    }
+
+    fn get_center_chunk(&self) -> &ProtoChunk {
+        &self.center
+    }
+
+    fn get_chunk_mut(&mut self, _chunk_x: i32, _chunk_z: i32) -> Option<&mut ProtoChunk> {
+        None
+    }
+
+    fn get_chunk(&self, _chunk_x: i32, _chunk_z: i32) -> Option<&ProtoChunk> {
+        None
+    }
+
+    fn try_get_proto_chunk(&self, _chunk_x: i32, _chunk_z: i32) -> Option<&ProtoChunk> {
+        None
+    }
+
+    fn get_block_state(&self, pos: &Vector3<i32>) -> BlockStateId {
+        self.read(&BlockPos(*pos))
+    }
+
+    fn get_fluid_and_fluid_state(&self, position: &Vector3<i32>) -> (Fluid, FluidState) {
+        let (fluid, state) = self.world.get_fluid_and_fluid_state(&BlockPos(*position));
+        (fluid.clone(), state.clone())
+    }
+
+    fn set_block_state(&mut self, pos: &Vector3<i32>, block_state: &BlockState) {
+        let position = BlockPos(*pos);
+        self.overlay.insert(position, block_state.id);
+        self.pending.push((position, block_state.id));
+    }
+
+    fn add_block_entity(&mut self, pos: &Vector3<i32>, mut nbt: NbtCompound) {
+        nbt.put_int("x", pos.x);
+        nbt.put_int("y", pos.y);
+        nbt.put_int("z", pos.z);
+        self.block_entities.push(nbt);
+    }
+
+    fn top_motion_blocking_block_height_exclusive(&self, x: i32, z: i32) -> i32 {
+        self.heightmap(ChunkHeightmapType::MotionBlocking, x, z)
+    }
+
+    fn top_motion_blocking_block_no_leaves_height_exclusive(&self, x: i32, z: i32) -> i32 {
+        self.heightmap(ChunkHeightmapType::MotionBlockingNoLeaves, x, z)
+    }
+
+    fn get_top_y(&self, heightmap: &HeightMap, x: i32, z: i32) -> i32 {
+        match heightmap {
+            HeightMap::WorldSurfaceWg
+            | HeightMap::WorldSurface
+            | HeightMap::OceanFloorWg
+            | HeightMap::OceanFloor => self.top_block_height_exclusive(x, z),
+            HeightMap::MotionBlocking => self.top_motion_blocking_block_height_exclusive(x, z),
+            HeightMap::MotionBlockingNoLeaves => {
+                self.top_motion_blocking_block_no_leaves_height_exclusive(x, z)
+            }
+        }
+    }
+
+    fn top_block_height_exclusive(&self, x: i32, z: i32) -> i32 {
+        self.heightmap(ChunkHeightmapType::WorldSurface, x, z)
+    }
+
+    fn ocean_floor_height_exclusive(&self, x: i32, z: i32) -> i32 {
+        self.heightmap(ChunkHeightmapType::WorldSurface, x, z)
+    }
+
+    fn is_air(&self, local_pos: &Vector3<i32>) -> bool {
+        BlockState::from_id(self.read(&BlockPos(*local_pos))).is_air()
+    }
+
+    fn get_biome_for_terrain_gen(&self, x: i32, y: i32, z: i32) -> &'static Biome {
+        self.world.get_biome(&BlockPos::new(x, y, z))
+    }
+
+    fn get_blending_data(&self, _chunk_x: i32, _chunk_z: i32) -> Option<&BlendingData> {
+        None
+    }
+}

--- a/crates/pumpkin/src/world/loot.rs
+++ b/crates/pumpkin/src/world/loot.rs
@@ -59,6 +59,12 @@ fn check_condition(
             };
             rng.next_f32() < chance
         }
+        LootCondition::TableBonus { chances } => {
+            let index = (fortune_level.max(0) as usize).min(chances.len().saturating_sub(1));
+            chances
+                .get(index)
+                .is_some_and(|chance| rng.next_f32() < *chance)
+        }
         LootCondition::AllOf(conditions) => conditions
             .iter()
             .all(|c| check_condition(*c, has_silk_touch, has_shears, fortune_level, params, rng)),

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -20,6 +20,7 @@ use tracing::{debug, error, info, trace, warn};
 mod active_chunks;
 pub mod chunker;
 pub mod explosion;
+pub mod generation_cache;
 pub mod loot;
 pub mod map;
 pub mod portal;

--- a/tools/pumpkin-codegen/src/loot_table.rs
+++ b/tools/pumpkin-codegen/src/loot_table.rs
@@ -104,7 +104,6 @@ struct ConditionStruct {
     unenchanted_chance: Option<f32>,
     #[serde(default)]
     enchanted_chance: Option<EnchantedChanceStruct>,
-    #[allow(dead_code)]
     #[serde(default)]
     chances: Option<Vec<f32>>,
     #[serde(default)]
@@ -142,6 +141,16 @@ fn parse_condition(cond: &ConditionStruct) -> LootCondition {
                 unenchanted_chance,
                 enchanted_chance_base,
                 enchanted_chance_per_level_above_first,
+            }
+        }
+        "minecraft:table_bonus" => {
+            let chances = cond.chances.clone().unwrap_or_default();
+            if chances.is_empty() {
+                LootCondition::None
+            } else {
+                LootCondition::TableBonus {
+                    chances: Box::leak(chances.into_boxed_slice()),
+                }
             }
         }
         "minecraft:all_of" => {
@@ -328,18 +337,11 @@ fn extract_entries_with_depth(
         return;
     }
 
-    let mut entry_cond = inherited_condition;
-    for c in &entry.conditions {
-        let parsed = parse_condition(c);
-        if parsed != LootCondition::None {
-            if entry_cond == LootCondition::NoSilkTouch
-                || entry_cond == LootCondition::NoSilkTouchOrShears
-            {
-            } else {
-                entry_cond = parsed;
-            }
-        }
-    }
+    let entry_cond = match (inherited_condition, combine_conditions(&entry.conditions)) {
+        (LootCondition::None, cond) | (cond, LootCondition::None) => cond,
+        (first, second) if first == second => first,
+        (first, second) => LootCondition::AllOf(Box::leak(vec![first, second].into_boxed_slice())),
+    };
 
     match entry.entry_type.as_str() {
         "minecraft:empty" => {
@@ -515,13 +517,7 @@ fn extract_entries_with_depth(
             let mut saw_shears = false;
 
             for child in &entry.children {
-                let mut child_cond = LootCondition::None;
-                for c in &child.conditions {
-                    let parsed = parse_condition(c);
-                    if parsed != LootCondition::None {
-                        child_cond = parsed;
-                    }
-                }
+                let child_cond = combine_conditions(&child.conditions);
 
                 let effective_cond = if child_cond == LootCondition::SilkTouch {
                     saw_silk = true;
@@ -580,6 +576,10 @@ fn condition_to_tokens(cond: LootCondition) -> TokenStream {
                     enchanted_chance_per_level_above_first: #enchanted_chance_per_level_above_first,
                 }
             }
+        }
+        LootCondition::TableBonus { chances } => {
+            let values = chances.iter();
+            quote! { LootCondition::TableBonus { chances: &[#(#values),*] } }
         }
         LootCondition::AllOf(list) => {
             let tokens: Vec<TokenStream> = list.iter().copied().map(condition_to_tokens).collect();


### PR DESCRIPTION
## Description

There were three separate problems around trees: saplings never grew, decayed leaves stayed visible on the client after being removed on the server, and leaf drops always gave the same items instead of using the loot table chances.

The leaf decay issue was just the update flags. `LeavesBlock::random_tick` called `break_block` with `BlockFlags::empty()`, so the block disappeared server side without sending an update to the client. Vanilla removes the block with a normal update, so this now uses `NOTIFY_ALL`.

The drop issue came from loot table codegen. Leaf loot tables use `minecraft:table_bonus` for saplings, sticks, and apples, but the codegen didn't handle that condition and emitted `LootCondition::None` instead. I added `LootCondition::TableBonus`, including its fortune chance list, and implemented the same `chances[min(level, len - 1)]` vs `nextFloat` check vanilla uses.

I also fixed two condition folding bugs while working on this. Children of `alternatives` entries could lose their own conditions when a tool negation was added, and multiple entry conditions were effectively last-wins and could disappear under the same tool handling. They now fold into `AllOf`, so the generated oak sapling condition keeps the silk/shears check, explosion survival, and table bonus together. `loot_table.rs` is the only regenerated file in this PR.

Sapling growth now reuses the existing worldgen tree features at runtime. `WorldGenerationCache` implements `GenerationCache` over a live `World`, with an overlay and buffered writes, then applies the generated blocks with `NOTIFY_ALL` and adds any block entities.

`TreeGrower` follows vanilla's grower table and selection rules: oak with the 9:1 normal/fancy split, flower-based bee variants, mega spruce and jungle trees, 2x2-only dark and pale oak, mangrove with the 15:85 normal/tall split, cherry and birch bee variants, and azalea. Mega trees use the same 2x2 search order, remove the saplings before placement, and restore them if generation fails.

`SaplingBlock` random ticking now requires light level 9 above the sapling and uses the vanilla 1-in-7 growth roll. Bonemeal checks `canGrow` and build height, and mangrove propagules and azalea use the same grower path.

## Testing

Play tested on a release build.

Bone meal grows oak, spruce, birch, 2x2 dark oak, and occasional fancy oak. A single dark oak sapling refuses bone meal, and saplings in the dark do not grow.

After cutting a tree, decaying leaves disappear correctly on the client. Most leaves drop nothing, saplings show up around the expected one-in-twenty range, and sticks drop occasionally instead of every time.
