### PR TITLE
chore(item): drop stale tool break TODOs

### DIFF
--- a/crates/pumpkin/src/entity/mob/creeper.rs
+++ b/crates/pumpkin/src/entity/mob/creeper.rs
@@ -228,7 +228,6 @@ impl Mob for CreeperEntity {
         entity.set_synced_data(pumpkin_data::tracked_data::creeper::IS_IGNITED, true);
 
         if player.gamemode.load() != pumpkin_util::GameMode::Creative {
-            // TODO: Handle DamageResult::Broken to broadcast item break and update player slot.
             let _ = item_stack.damage_item(1);
         }
 

--- a/crates/pumpkin/src/item/items/axe.rs
+++ b/crates/pumpkin/src/item/items/axe.rs
@@ -77,7 +77,6 @@ impl ItemBehaviour for AxeItem {
             world.set_block_state(&location, result.new_state_id, BlockFlags::NOTIFY_ALL);
 
             if player.gamemode.load() != GameMode::Creative {
-                // TODO: Handle DamageResult::Broken to broadcast item break and update player slot.
                 let _ = item.damage_item(i32::from(result.entry.item_damage_per_use));
             }
         }

--- a/crates/pumpkin/src/item/items/hoe.rs
+++ b/crates/pumpkin/src/item/items/hoe.rs
@@ -63,7 +63,6 @@ impl ItemBehaviour for HoeItem {
             }
 
             if player.gamemode.load() != GameMode::Creative {
-                // TODO: Handle DamageResult::Broken to broadcast item break and update player slot.
                 let _ = item.damage_item(i32::from(result.entry.item_damage_per_use));
             }
         }

--- a/crates/pumpkin/src/item/items/ignite/flint_and_steel.rs
+++ b/crates/pumpkin/src/item/items/ignite/flint_and_steel.rs
@@ -67,7 +67,6 @@ impl ItemBehaviour for FlintAndSteelItem {
         );
 
         if ignited && player.gamemode.load() != pumpkin_util::GameMode::Creative {
-            // TODO: Handle DamageResult::Broken to broadcast item break and update player slot.
             let _ = item.damage_item(1);
         }
     }

--- a/crates/pumpkin/src/item/items/shovel.rs
+++ b/crates/pumpkin/src/item/items/shovel.rs
@@ -78,7 +78,6 @@ impl ItemBehaviour for ShovelItem {
         }
 
         if changed && player.gamemode.load() != GameMode::Creative {
-            // TODO: Handle DamageResult::Broken to broadcast item break and update player slot.
             let _ = item.damage_item(i32::from(damage));
         }
     }


### PR DESCRIPTION
## Problem

Five sites carry the same marker above a `let _ = ...damage_item(...)`:

```rust
// TODO: Handle DamageResult::Broken to broadcast item break and update player slot.
```

The work it asks for is already done, one level up. Every path that reaches these
handlers clones the stack, calls the handler, and compares afterwards:

- `use_item_on.rs` covers `shovel`, `axe`, `hoe` and `flint_and_steel`
- the Bedrock `inventory_action.rs` path covers the same four
- `interact.rs` covers the creeper

Each one increments the `Broken` statistic, sends the entity status that plays the break
particles, and syncs the slot back to the client. The marker describes exactly that, so it
now reads as a known gap when nothing is missing, and the next person to look will
re-derive the same conclusion I did.

## Change

Delete the five comments. No code moves.

## Note

There is a real inconsistency nearby, left alone here because it is a design call rather
than a cleanup: `PlayerItemDamageEvent` and `PlayerItemBreakEvent` fire only from
`Player::damage_item_in_slot`, which these paths do not use. A plugin sees shears break on
a sheep but not an axe wear out stripping logs. Happy to open an issue for that if it is
worth tracking.
