### PR TITLE
feat(java): add HAProxy PROXY v2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,9 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3439,6 +3442,7 @@ dependencies = [
 name = "pumpkin-config"
 version = "0.1.0-dev+26.2-26.45"
 dependencies = [
+ "ipnet",
  "pumpkin-util",
  "serde",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ strip = false
 debug = false
 
 [workspace.dependencies]
+ipnet = { version = "2.12", features = ["serde"] }
 tokio = { version = "1.53", default-features = false }
 syn = { version = "3.0", default-features = false, features = ["full", "parsing", "printing", "proc-macro", "clone-impls", "derive"] }
 

--- a/crates/pumpkin-config/Cargo.toml
+++ b/crates/pumpkin-config/Cargo.toml
@@ -6,13 +6,13 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+ipnet.workspace = true
 pumpkin-util.workspace = true
 serde.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 
 toml.workspace = true
-
 
 [lints]
 workspace = true

--- a/crates/pumpkin-config/src/lib.rs
+++ b/crates/pumpkin-config/src/lib.rs
@@ -87,6 +87,7 @@ impl LoadConfiguration for PumpkinConfig {
     fn validate(&self) {
         self.basic.validate();
         self.advanced.validate();
+        self.advanced.networking.java.proxy_protocol.validate();
 
         let min_vd = NonZero::<u8>::MIN;
         let Some(max_vd) = NonZero::new(64) else {

--- a/crates/pumpkin-config/src/networking/java.rs
+++ b/crates/pumpkin-config/src/networking/java.rs
@@ -1,7 +1,53 @@
 use crate::{AuthenticationConfig, CompressionConfig, PacketLimiterConfig};
+use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::num::NonZero;
+
+/// Java TCP PROXY protocol v2 trust and header deadline settings.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+#[serde(default)]
+pub struct ProxyProtocolConfig {
+    /// Require a v2 header before Minecraft packets when enabled.
+    pub enabled: bool,
+    /// Networks allowed to supply headers, matched against the TCP peer.
+    pub trusted_proxies: Vec<IpNet>,
+    /// Overall header deadline in milliseconds, from 1 through 60000.
+    pub header_timeout_ms: u64,
+}
+
+impl Default for ProxyProtocolConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            trusted_proxies: Vec::new(),
+            header_timeout_ms: 5000,
+        }
+    }
+}
+
+impl ProxyProtocolConfig {
+    /// Validate explicit trust and the finite header deadline.
+    pub fn validate(&self) {
+        assert!(
+            !self.enabled || !self.trusted_proxies.is_empty(),
+            "Java PROXY protocol requires explicit trusted_proxies"
+        );
+        assert!(
+            self.header_timeout_ms > 0 && self.header_timeout_ms <= 60_000,
+            "Java PROXY protocol header_timeout_ms must be between 1 and 60000"
+        );
+    }
+
+    /// Match native addresses and the IPv4 form of IPv4-mapped IPv6 peers.
+    #[must_use]
+    pub fn trusts(&self, peer: IpAddr) -> bool {
+        self.trusted_proxies.iter().any(|network| {
+            network.contains(&peer)
+                || peer.to_canonical() != peer && network.contains(&peer.to_canonical())
+        })
+    }
+}
 
 /// Configuration for Java Edition client connections.
 #[derive(Deserialize, Serialize, Clone)]
@@ -36,6 +82,8 @@ pub struct JavaConfig {
     pub authentication: AuthenticationConfig,
     /// Packet rate limiting settings.
     pub packet_limiter: PacketLimiterConfig,
+    /// Trusted `HAProxy` PROXY protocol v2 connections.
+    pub proxy_protocol: ProxyProtocolConfig,
 }
 
 impl Default for JavaConfig {
@@ -58,6 +106,7 @@ impl Default for JavaConfig {
             motd: "A blazingly fast Pumpkin server!".to_string(),
             authentication: AuthenticationConfig::default(),
             packet_limiter: PacketLimiterConfig::default(),
+            proxy_protocol: ProxyProtocolConfig::default(),
         }
     }
 }
@@ -97,5 +146,62 @@ mod tests {
         ";
         let config: JavaConfig = toml::from_str(toml_interval_kebab).unwrap();
         assert_eq!(config.keep_alive_time, 35);
+    }
+}
+
+#[cfg(test)]
+mod proxy_protocol_tests {
+    use super::*;
+    use crate::PumpkinConfig;
+
+    #[test]
+    fn cidrs_and_mapped_peer_policy() {
+        let config: ProxyProtocolConfig = toml::from_str(
+            "trusted_proxies = ['192.0.2.0/24', '2001:db8::/32', '::ffff:198.51.100.0/120']",
+        )
+        .unwrap();
+        for peer in [
+            "192.0.2.255",
+            "2001:db8::1",
+            "::ffff:192.0.2.42",
+            "::ffff:198.51.100.7",
+        ] {
+            assert!(config.trusts(peer.parse().unwrap()), "{peer}");
+        }
+        for peer in ["192.0.3.0", "2001:db9::1", "::192.0.2.42", "198.51.100.7"] {
+            assert!(!config.trusts(peer.parse().unwrap()), "{peer}");
+        }
+        for cidr in ["192.0.2.1", "192.0.2.0/33", "::/129", "hostname/24"] {
+            assert!(
+                toml::from_str::<ProxyProtocolConfig>(&format!("trusted_proxies = ['{cidr}']"))
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn validation_and_generated_layout() {
+        let mut config = ProxyProtocolConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        assert!(std::panic::catch_unwind(|| config.validate()).is_err());
+        config.trusted_proxies.push("127.0.0.1/32".parse().unwrap());
+        config.validate();
+        for timeout in [0, 60_001, u64::MAX] {
+            config.header_timeout_ms = timeout;
+            assert!(std::panic::catch_unwind(|| config.validate()).is_err());
+        }
+        let generated = toml::to_string(&PumpkinConfig::default()).unwrap();
+        assert!(generated.contains("[networking.java.proxy_protocol]"));
+        let value: toml::Value = toml::from_str(&generated).unwrap();
+        assert_eq!(
+            value["networking"]["java"]["proxy_protocol"]["header_timeout_ms"].as_integer(),
+            Some(5000)
+        );
+        assert_eq!(
+            value["networking"]["java"]["proxy_protocol"]["enabled"].as_bool(),
+            Some(false)
+        );
     }
 }

--- a/crates/pumpkin/Cargo.toml
+++ b/crates/pumpkin/Cargo.toml
@@ -130,6 +130,7 @@ indexmap.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 
 [features]
 console-subscriber = ["dep:console-subscriber"]

--- a/crates/pumpkin/src/lib.rs
+++ b/crates/pumpkin/src/lib.rs
@@ -17,8 +17,8 @@ use crate::net::bedrock::{
     nethernet::{NetherNetListener, load_or_create_identity_key},
     status::{IceSocket, StatusResponder},
 };
-use crate::net::java::JavaClient;
 use crate::net::java::pending::PendingConnection;
+use crate::net::java::{JavaClient, proxy_protocol::accept};
 use crate::net::{ClientPlatform, DisconnectReason, PacketHandlerResult, PacketRateLimiter};
 use crate::net::{lan_broadcast::LANBroadcast, query, rcon::RCONServer};
 use crate::plugin::server::server_command::ServerCommandEvent;
@@ -563,15 +563,27 @@ impl PumpkinServer {
                         let server_clone = self.server.clone();
 
                         tasks.spawn(async move {
+                            let mut connection = connection;
+                            let effective_address = match accept(
+                                &mut connection,
+                                client_addr,
+                                &server_clone.advanced_config.networking.java.proxy_protocol,
+                                &STOP_INTERRUPT,
+                            ).await {
+                                Ok(Some(endpoints)) => endpoints.source,
+                                Ok(None) => client_addr,
+                                Err(error) => {
+                                    debug!("Rejected Java PROXY connection (id {client_id}): {error}");
+                                    return;
+                                }
+                            };
                             let packet_limiter = PacketRateLimiter::from_config(
                                 &server_clone.advanced_config.networking.java.packet_limiter,
                             );
                             let mut pending = PendingConnection::new(
-                                connection,
-                                client_addr,
-                                client_id,
-                                packet_limiter,
+                                connection, client_addr, client_id, packet_limiter,
                             );
+                            pending.address = effective_address;
                             let login_result = pending.handle_login_sequence(&server_clone).await;
 
                             match login_result {

--- a/crates/pumpkin/src/net/java/mod.rs
+++ b/crates/pumpkin/src/net/java/mod.rs
@@ -58,6 +58,7 @@ pub mod handshake;
 pub mod login;
 pub mod pending;
 pub mod play;
+pub mod proxy_protocol;
 pub mod recipe_helper;
 pub mod status;
 
@@ -85,6 +86,7 @@ pub struct JavaClient {
     pub connection_state: AtomicCell<ConnectionState>,
     /// The client's IP address. Direct field (lock-free).
     pub address: SocketAddr,
+    pub transport_peer: SocketAddr,
     /// The client's brand or modpack information. Lock-free `ArcSwap`.
     pub brand: ArcSwap<Option<String>>,
     /// Associated player reference. Lock-free `ArcSwap`.
@@ -233,6 +235,7 @@ impl JavaClient {
             config: ArcSwap::from_pointee(config),
             server_address: pending.server_address,
             address: pending.address,
+            transport_peer: pending.transport_peer,
             connection_state: pending.connection_state,
             close_token: pending.close_token,
             tasks: TaskTracker::new(),

--- a/crates/pumpkin/src/net/java/pending.rs
+++ b/crates/pumpkin/src/net/java/pending.rs
@@ -57,6 +57,7 @@ const HANDSHAKE_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 pub struct PendingConnection {
     pub id: u64,
     pub address: SocketAddr,
+    pub transport_peer: SocketAddr,
     pub server_address: String,
     pub version: AtomicCell<JavaMinecraftVersion>,
     pub connection_state: AtomicCell<ConnectionState>,
@@ -82,6 +83,7 @@ impl PendingConnection {
         Self {
             id,
             address,
+            transport_peer: address,
             server_address: String::new(),
             version: AtomicCell::new(CURRENT_MC_VERSION),
             connection_state: AtomicCell::new(ConnectionState::HandShake),

--- a/crates/pumpkin/src/net/java/proxy_protocol.rs
+++ b/crates/pumpkin/src/net/java/proxy_protocol.rs
@@ -1,0 +1,489 @@
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
+
+use pumpkin_config::networking::java::ProxyProtocolConfig;
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+
+const HEADER_LENGTH: usize = 16;
+const SIGNATURE_LENGTH: usize = 12;
+const VERSION_COMMAND_INDEX: usize = 12;
+const FAMILY_PROTOCOL_INDEX: usize = 13;
+const LENGTH_INDEX: usize = 14;
+const IPV4_ADDRESS_BLOCK_LENGTH: usize = 12;
+const IPV6_ADDRESS_BLOCK_LENGTH: usize = 36;
+const IPV6_BYTES_LENGTH: usize = 16;
+const UNIX_ADDRESS_BLOCK_LENGTH: usize = 216;
+const DISCARD_BUFFER_LENGTH: usize = 512;
+
+const LOCAL_COMMAND: u8 = 0x20;
+const PROXY_COMMAND: u8 = 0x21;
+const UNSPECIFIED: u8 = 0x00;
+const INET_STREAM: u8 = 0x11;
+const INET_DATAGRAM: u8 = 0x12;
+const INET6_STREAM: u8 = 0x21;
+const INET6_DATAGRAM: u8 = 0x22;
+const UNIX_STREAM: u8 = 0x31;
+const UNIX_DATAGRAM: u8 = 0x32;
+
+const SIGNATURE: &[u8; SIGNATURE_LENGTH] = b"\r\n\r\n\0\r\nQUIT\n";
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Endpoints {
+    pub source: SocketAddr,
+    pub destination: SocketAddr,
+}
+
+#[derive(Debug, Error)]
+pub enum ProxyProtocolError {
+    #[error("untrusted TCP peer")]
+    Untrusted,
+    #[error("header deadline exceeded")]
+    Timeout,
+    #[error("server shutting down")]
+    Cancelled,
+    #[error("invalid signature")]
+    Signature,
+    #[error("invalid version or command")]
+    VersionCommand,
+    #[error("reserved address family or transport protocol")]
+    FamilyProtocol,
+    #[error("address payload too short")]
+    Length,
+    #[error("incomplete header or socket read failure")]
+    Read(#[from] std::io::Error),
+}
+
+pub async fn accept<R: AsyncRead + Unpin>(
+    stream: &mut R,
+    peer: SocketAddr,
+    config: &ProxyProtocolConfig,
+    shutdown: &CancellationToken,
+) -> Result<Option<Endpoints>, ProxyProtocolError> {
+    if !config.enabled {
+        return Ok(None);
+    }
+    if !config.trusts(peer.ip()) {
+        return Err(ProxyProtocolError::Untrusted);
+    }
+    tokio::select! {
+        biased;
+        () = shutdown.cancelled() => Err(ProxyProtocolError::Cancelled),
+        result = timeout(
+            Duration::from_millis(config.header_timeout_ms), read_header(stream),
+        ) => result.map_err(|_| ProxyProtocolError::Timeout)?,
+    }
+}
+
+async fn read_header<R: AsyncRead + Unpin>(
+    stream: &mut R,
+) -> Result<Option<Endpoints>, ProxyProtocolError> {
+    let mut header = [0; HEADER_LENGTH];
+    stream.read_exact(&mut header).await?;
+    if &header[..SIGNATURE_LENGTH] != SIGNATURE {
+        return Err(ProxyProtocolError::Signature);
+    }
+    if !matches!(header[VERSION_COMMAND_INDEX], LOCAL_COMMAND | PROXY_COMMAND) {
+        return Err(ProxyProtocolError::VersionCommand);
+    }
+    let length = usize::from(u16::from_be_bytes([
+        header[LENGTH_INDEX],
+        header[LENGTH_INDEX + 1],
+    ]));
+    // Validate the fixed address block for every legal transport, but decode
+    // only TCP/IPv4 and TCP/IPv6. Other valid transports are opaque to Java.
+    let (required_address_length, parsed_address_length) =
+        if header[VERSION_COMMAND_INDEX] == LOCAL_COMMAND {
+            (0, 0)
+        } else {
+            match header[FAMILY_PROTOCOL_INDEX] {
+                UNSPECIFIED => (0, 0),
+                INET_STREAM => (IPV4_ADDRESS_BLOCK_LENGTH, IPV4_ADDRESS_BLOCK_LENGTH),
+                INET_DATAGRAM => (IPV4_ADDRESS_BLOCK_LENGTH, 0),
+                INET6_STREAM => (IPV6_ADDRESS_BLOCK_LENGTH, IPV6_ADDRESS_BLOCK_LENGTH),
+                INET6_DATAGRAM => (IPV6_ADDRESS_BLOCK_LENGTH, 0),
+                UNIX_STREAM | UNIX_DATAGRAM => (UNIX_ADDRESS_BLOCK_LENGTH, 0),
+                _ => return Err(ProxyProtocolError::FamilyProtocol),
+            }
+        };
+    if length < required_address_length {
+        return Err(ProxyProtocolError::Length);
+    }
+    let mut address = [0; IPV6_ADDRESS_BLOCK_LENGTH];
+    stream
+        .read_exact(&mut address[..parsed_address_length])
+        .await?;
+    let endpoints = match parsed_address_length {
+        IPV4_ADDRESS_BLOCK_LENGTH => Some(Endpoints {
+            source: SocketAddr::new(
+                Ipv4Addr::new(address[0], address[1], address[2], address[3]).into(),
+                u16::from_be_bytes([address[8], address[9]]),
+            ),
+            destination: SocketAddr::new(
+                Ipv4Addr::new(address[4], address[5], address[6], address[7]).into(),
+                u16::from_be_bytes([address[10], address[11]]),
+            ),
+        }),
+        IPV6_ADDRESS_BLOCK_LENGTH => {
+            let mut source = [0; IPV6_BYTES_LENGTH];
+            let mut destination = [0; IPV6_BYTES_LENGTH];
+            source.copy_from_slice(&address[..IPV6_BYTES_LENGTH]);
+            destination.copy_from_slice(&address[IPV6_BYTES_LENGTH..2 * IPV6_BYTES_LENGTH]);
+            Some(Endpoints {
+                source: SocketAddr::new(
+                    Ipv6Addr::from(source).into(),
+                    u16::from_be_bytes([address[32], address[33]]),
+                ),
+                destination: SocketAddr::new(
+                    Ipv6Addr::from(destination).into(),
+                    u16::from_be_bytes([address[34], address[35]]),
+                ),
+            })
+        }
+        _ => None,
+    };
+    let mut remaining = length - parsed_address_length;
+    // The length covers the address block and optional TLVs. Consume the
+    // remainder before Minecraft reads from the stream.
+    let mut discard = [0; DISCARD_BUFFER_LENGTH];
+    while remaining > 0 {
+        let count = remaining.min(discard.len());
+        stream.read_exact(&mut discard[..count]).await?;
+        remaining -= count;
+    }
+    Ok(endpoints)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    fn config() -> ProxyProtocolConfig {
+        ProxyProtocolConfig {
+            enabled: true,
+            trusted_proxies: vec!["127.0.0.0/8".parse().unwrap()],
+            header_timeout_ms: 100,
+        }
+    }
+
+    fn peer() -> SocketAddr {
+        "127.0.0.1:40000".parse().unwrap()
+    }
+
+    fn header(command: u8, family: u8, payload: &[u8]) -> Vec<u8> {
+        let mut bytes = SIGNATURE.to_vec();
+        bytes.extend([command, family]);
+        bytes.extend(u16::try_from(payload.len()).unwrap().to_be_bytes());
+        bytes.extend(payload);
+        bytes
+    }
+
+    fn ipv4() -> Vec<u8> {
+        header(
+            PROXY_COMMAND,
+            INET_STREAM,
+            &[192, 0, 2, 42, 203, 0, 113, 5, 0x9c, 0x40, 0x63, 0xdd],
+        )
+    }
+
+    async fn parse(bytes: &[u8]) -> Result<Option<Endpoints>, ProxyProtocolError> {
+        let mut stream = bytes;
+        accept(&mut stream, peer(), &config(), &CancellationToken::new()).await
+    }
+
+    #[tokio::test]
+    async fn ipv4_and_ipv6_endpoints() {
+        assert_eq!(
+            parse(&ipv4()).await.unwrap().unwrap(),
+            Endpoints {
+                source: "192.0.2.42:40000".parse().unwrap(),
+                destination: "203.0.113.5:25565".parse().unwrap(),
+            }
+        );
+        let mut payload = Vec::new();
+        payload.extend("2001:db8::1234".parse::<Ipv6Addr>().unwrap().octets());
+        payload.extend("2001:db8:1::5678".parse::<Ipv6Addr>().unwrap().octets());
+        payload.extend([0xff, 0xff, 0, 0]);
+        assert_eq!(
+            parse(&header(PROXY_COMMAND, INET6_STREAM, &payload))
+                .await
+                .unwrap()
+                .unwrap(),
+            Endpoints {
+                source: "[2001:db8::1234]:65535".parse().unwrap(),
+                destination: "[2001:db8:1::5678]:0".parse().unwrap(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn local_and_unsupported_preserve_stream_boundary() {
+        for (command, family, length) in [
+            (LOCAL_COMMAND, 0xff, 0),
+            (LOCAL_COMMAND, 0xff, 1024),
+            (PROXY_COMMAND, UNSPECIFIED, 0),
+            (PROXY_COMMAND, INET_DATAGRAM, 12),
+            (PROXY_COMMAND, INET6_DATAGRAM, 36),
+            (PROXY_COMMAND, UNIX_STREAM, 216),
+            (PROXY_COMMAND, UNIX_DATAGRAM, 216),
+            (LOCAL_COMMAND, INET_STREAM, 65535),
+        ] {
+            let mut bytes = header(command, family, &vec![0x55; length]);
+            bytes.extend([1, 0]);
+            let mut stream = bytes.as_slice();
+            assert_eq!(
+                accept(&mut stream, peer(), &config(), &CancellationToken::new())
+                    .await
+                    .unwrap(),
+                None
+            );
+            assert_eq!(stream, [1, 0]);
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_and_truncated_headers() {
+        let mut bytes = ipv4();
+        bytes[0] = 0;
+        assert!(matches!(
+            parse(&bytes).await,
+            Err(ProxyProtocolError::Signature)
+        ));
+        for command in [0x11, 0x22, 0x2f, 0x30] {
+            assert!(matches!(
+                parse(&header(command, 0, &[])).await,
+                Err(ProxyProtocolError::VersionCommand)
+            ));
+        }
+        for family in [0x10, 0x01, 0x20, 0x30, 0x40, 0x13, 0x03, 0xf1, 0xff] {
+            assert!(matches!(
+                parse(&header(PROXY_COMMAND, family, &[])).await,
+                Err(ProxyProtocolError::FamilyProtocol)
+            ));
+        }
+        for (family, length) in [
+            (INET_STREAM, 11),
+            (INET_DATAGRAM, 11),
+            (INET6_STREAM, 35),
+            (INET6_DATAGRAM, 35),
+            (UNIX_STREAM, 215),
+            (UNIX_DATAGRAM, 215),
+        ] {
+            assert!(matches!(
+                parse(&header(PROXY_COMMAND, family, &vec![0; length])).await,
+                Err(ProxyProtocolError::Length)
+            ));
+        }
+        let bytes = ipv4();
+        for length in 0..bytes.len() {
+            assert!(
+                matches!(parse(&bytes[..length]).await, Err(ProxyProtocolError::Read(error)) if error.kind() == std::io::ErrorKind::UnexpectedEof)
+            );
+        }
+        let bytes = header(LOCAL_COMMAND, UNSPECIFIED, &[1, 2, 3]);
+        assert!(matches!(
+            parse(&bytes[..18]).await,
+            Err(ProxyProtocolError::Read(_))
+        ));
+        assert!(
+            parse(b"PROXY TCP4 127.0.0.1 127.0.0.1 1 2\r\n")
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn fragmented_header_and_extensions() {
+        let (mut sender, mut receiver) = tokio::io::duplex(1);
+        let mut bytes = ipv4();
+        bytes[15] = 15;
+        bytes.extend([0xea, 0, 0, 1, 0]);
+        let writer = tokio::spawn(async move {
+            for byte in bytes {
+                sender.write_all(&[byte]).await.unwrap();
+                tokio::task::yield_now().await;
+            }
+        });
+        let endpoints = accept(&mut receiver, peer(), &config(), &CancellationToken::new())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            endpoints.source,
+            "192.0.2.42:40000".parse::<SocketAddr>().unwrap()
+        );
+        let mut minecraft = [0; 2];
+        receiver.read_exact(&mut minecraft).await.unwrap();
+        assert_eq!(minecraft, [1, 0]);
+        writer.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn silent_and_trickling_connections_share_one_deadline() {
+        for trickle in [false, true] {
+            let (mut sender, mut receiver) = tokio::io::duplex(64);
+            let writer = tokio::spawn(async move {
+                if trickle {
+                    for byte in ipv4() {
+                        if sender.write_all(&[byte]).await.is_err() {
+                            return;
+                        }
+                        tokio::time::sleep(Duration::from_millis(30)).await;
+                    }
+                } else {
+                    std::future::pending::<()>().await;
+                }
+            });
+            let start = tokio::time::Instant::now();
+            assert!(matches!(
+                accept(&mut receiver, peer(), &config(), &CancellationToken::new()).await,
+                Err(ProxyProtocolError::Timeout)
+            ));
+            assert_eq!(start.elapsed(), Duration::from_millis(100));
+            writer.abort();
+            let _ = writer.await;
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_untrusted_and_cancelled_do_not_read() {
+        let mut stream = &b"ordinary Minecraft bytes"[..];
+        let original = stream;
+        assert_eq!(
+            accept(
+                &mut stream,
+                peer(),
+                &ProxyProtocolConfig::default(),
+                &CancellationToken::new()
+            )
+            .await
+            .unwrap(),
+            None
+        );
+        assert_eq!(stream, original);
+        assert!(matches!(
+            accept(
+                &mut stream,
+                "192.0.2.1:1".parse().unwrap(),
+                &config(),
+                &CancellationToken::new()
+            )
+            .await,
+            Err(ProxyProtocolError::Untrusted)
+        ));
+        assert_eq!(stream, original);
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+        assert!(matches!(
+            accept(&mut stream, peer(), &config(), &shutdown).await,
+            Err(ProxyProtocolError::Cancelled)
+        ));
+        assert_eq!(stream, original);
+        assert!(
+            accept(&mut stream, peer(), &config(), &CancellationToken::new())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn loopback_propagates_address_and_decodes_minecraft() {
+        use crate::data::{banlist_serializer::BannedIpEntry, banned_ip::BannedIpList};
+        use crate::net::{ClientPlatform, java::JavaClient};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mut sender = tokio::net::TcpStream::connect(listener.local_addr().unwrap())
+            .await
+            .unwrap();
+        let (mut receiver, transport_peer) = listener.accept().await.unwrap();
+        let mut bytes = ipv4();
+        bytes.extend([1, 0]);
+        sender.write_all(&bytes).await.unwrap();
+        let forwarded = accept(
+            &mut receiver,
+            transport_peer,
+            &config(),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let mut pending = super::super::pending::PendingConnection::new(
+            receiver,
+            transport_peer,
+            1,
+            crate::net::PacketRateLimiter::from_config(
+                &pumpkin_config::PacketLimiterConfig::default(),
+            ),
+        );
+        pending.address = forwarded.source;
+        let packet = timeout(Duration::from_secs(1), pending.get_packet())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(packet.id, 0);
+        let profile = crate::net::GameProfile {
+            id: uuid::Uuid::nil(),
+            name: "ProxyTest".into(),
+            properties: arc_swap::ArcSwap::from_pointee(Vec::new()),
+            profile_actions: None,
+        };
+        let client =
+            JavaClient::from_pending(pending, profile, crate::net::PlayerConfig::default());
+        assert_eq!(client.transport_peer, transport_peer);
+        let platform = ClientPlatform::Java(client);
+        let address = platform.address();
+        assert_eq!(address, forwarded.source);
+        let mut bans = BannedIpList {
+            banned_ips: vec![BannedIpEntry::new(
+                address.ip(),
+                "test".into(),
+                None,
+                "test".into(),
+            )],
+        };
+        assert!(bans.get_entry(&address.ip()).is_some());
+        assert!(bans.get_entry(&transport_peer.ip()).is_none());
+    }
+
+    #[tokio::test]
+    async fn loopback_direct_connections_require_explicit_disabled_mode() {
+        for enabled in [false, true] {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let mut sender = tokio::net::TcpStream::connect(listener.local_addr().unwrap())
+                .await
+                .unwrap();
+            let (mut receiver, transport_peer) = listener.accept().await.unwrap();
+            sender.write_all(&[1, 0]).await.unwrap();
+            sender.shutdown().await.unwrap();
+            let config = ProxyProtocolConfig {
+                enabled,
+                ..config()
+            };
+            let result = accept(
+                &mut receiver,
+                transport_peer,
+                &config,
+                &CancellationToken::new(),
+            )
+            .await;
+            if enabled {
+                assert!(matches!(result, Err(ProxyProtocolError::Read(_))));
+            } else {
+                assert_eq!(result.unwrap(), None);
+                let mut client = super::super::pending::PendingConnection::new(
+                    receiver,
+                    transport_peer,
+                    1,
+                    crate::net::PacketRateLimiter::from_config(
+                        &pumpkin_config::PacketLimiterConfig::default(),
+                    ),
+                );
+                assert_eq!(client.get_packet().await.unwrap().id, 0);
+                assert_eq!(client.address, transport_peer);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description

Adds opt-in HAProxy PROXY protocol v2 support to Pumpkin's Java TCP listener.

Pumpkin checks the transport peer against configured trusted CIDRs before reading the header, enforces a deadline, validates the protocol fields, and forwards trusted TCP/IPv4 or TCP/IPv6 client addresses. The real TCP peer is retained separately for diagnostics and security checks. Valid unsupported transports and optional TLVs are consumed without being interpreted.

The feature is disabled by default and does not replace Velocity or BungeeCord authentication. Bedrock, RCON, Query, PROXY v1, and TLV interpretation remain outside this change. Configuration and deployment documentation are included.

This fixe issue https://github.com/Pumpkin-MC/Pumpkin/issues/1110
## Testing

- `cargo fmt --all -- --check`
- `cargo test -p pumpkin-config proxy_protocol`
- `cargo test -p pumpkin --lib net::java::proxy_protocol`
- `git diff HEAD --check`