### PR TITLE
refactor(WASM): Unified resource handling & cleanup

### DIFF
--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
@@ -413,7 +413,7 @@ impl WasmPlugin {
                         store.data_mut().wasi_http_hooks.allow_outbound = allow_http_outbound;
                         store.data_mut().server = Some(server);
                         store.data_mut().name = Some(name);
-                        store.data_mut().add_context(context)
+                        store.data_mut().add(context)
                     })?;
 
                     guest
@@ -455,7 +455,7 @@ impl WasmPlugin {
             .shutdown(move |accessor| {
                 Box::pin(async move {
                     let (context_res, context_rep) = accessor.with(|mut store| {
-                        let resource = store.data_mut().add_context(context)?;
+                        let resource = store.data_mut().add(context)?;
                         let rep = resource.rep();
                         Ok::<_, wasmtime::Error>((resource, rep))
                     })?;
@@ -464,9 +464,9 @@ impl WasmPlugin {
                         .await
                         .map(|(result,)| result);
                     accessor.with(|mut store| {
-                        let _ = store.data_mut().resource_table.delete::<
-                            crate::plugin::loader::wasm::wasm_host::state::ContextResource,
-                        >(wasmtime::component::Resource::new_own(context_rep));
+                        let _ = store.data_mut().resource_table.delete::<Arc<Context>>(
+                            wasmtime::component::Resource::new_own(context_rep),
+                        );
                     });
                     result
                 })
@@ -496,12 +496,6 @@ impl WasmPlugin {
             })
             .await
     }
-}
-
-pub trait DowncastResourceExt<E> {
-    fn downcast_ref<'a>(&'a self, state: &'a mut PluginHostState) -> &'a E;
-    fn downcast_mut<'a>(&'a self, state: &'a mut PluginHostState) -> &'a mut E;
-    fn consume(self, state: &mut PluginHostState) -> E;
 }
 
 #[cfg(test)]

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/state.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/state.rs
@@ -10,11 +10,7 @@ use wasmtime_wasi_http::{
 };
 
 use crate::{
-    entity::player::Player,
-    plugin::
-        loader::wasm::wasm_host::WasmPlugin
-    ,
-    server::Server,
+    entity::player::Player, plugin::loader::wasm::wasm_host::WasmPlugin, server::Server,
     world::World,
 };
 
@@ -184,6 +180,7 @@ impl PluginHostState {
 
     /// take the value of an **owned** [`Resource`] from the resource table
     pub fn take<T: FromResource>(&mut self, res: Resource<T>) -> wasmtime::Result<T::Internal> {
+        debug_assert!(res.owned());
         Ok(self.resource_table.delete(Resource::new_own(res.rep()))?)
     }
 
@@ -199,7 +196,9 @@ impl PluginHostState {
 
     pub fn discard_to_be_removed<T: FromResource>(&mut self, res: &Resource<T>) {
         assert!(res.owned());
-        let _ = self.resource_table.delete::<T::Internal>(Resource::new_own(res.rep()));
+        let _ = self
+            .resource_table
+            .delete::<T::Internal>(Resource::new_own(res.rep()));
     }
 }
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/state.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/state.rs
@@ -179,6 +179,10 @@ impl PluginHostState {
     }
 
     /// take the value of an **owned** [`Resource`] from the resource table
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "Our 'cloning' then deletion of the handle wouldn't be sound if it still exists"
+    )]
     pub fn take<T: FromResource>(&mut self, res: Resource<T>) -> wasmtime::Result<T::Internal> {
         debug_assert!(res.owned());
         Ok(self.resource_table.delete(Resource::new_own(res.rep()))?)

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/state.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/state.rs
@@ -1,27 +1,20 @@
 use std::{
-    collections::HashMap,
     future::Future,
     sync::{Arc, Weak},
 };
 
-use pumpkin_util::text::TextComponent;
-use tokio::sync::Mutex;
-use wasmtime::component::ResourceTable;
+use wasmtime::component::{Resource, ResourceTable};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wasi_http::{
     RequestOptions, WasiBody, WasiHttpCtx, WasiHttpCtxView, WasiHttpHooks, WasiHttpView,
 };
 
 use crate::{
-    command::CommandSender,
-    entity::EntityBase,
     entity::player::Player,
-    plugin::{
-        Context,
-        api::gui::PluginGui,
-        loader::wasm::wasm_host::{WasmPlugin, args::OwnedArg},
-    },
-    server::{RecipeManager, Server},
+    plugin::
+        loader::wasm::wasm_host::WasmPlugin
+    ,
+    server::Server,
     world::World,
 };
 
@@ -101,46 +94,11 @@ impl WasmCommandNode {
     }
 }
 
-pub struct WasmResource<T> {
-    pub provider: T,
-}
-
-pub type ServerResource = WasmResource<Arc<Server>>;
-pub type ContextResource = WasmResource<Arc<Context>>;
-pub type PlayerResource = WasmResource<Arc<Player>>;
-pub type JavaPlayerResource = WasmResource<Arc<Player>>;
-pub type BedrockPlayerResource = WasmResource<Arc<Player>>;
-pub type EntityResource = WasmResource<Arc<dyn EntityBase>>;
-pub type WorldResource = WasmResource<Arc<World>>;
-pub type ChunkResource = WasmResource<(Arc<World>, Weak<pumpkin_world::chunk::ChunkData>)>;
-pub type WorldBorderResource = WasmResource<Arc<World>>;
-
 #[derive(Clone)]
 pub enum ScoreboardProvider {
     World(Arc<World>),
     Player(Arc<Player>),
 }
-
-pub type ScoreboardResource = WasmResource<ScoreboardProvider>;
-pub type BedrockScoreboardResource = WasmResource<Arc<Player>>;
-pub type GuiResource = WasmResource<Arc<Mutex<PluginGui>>>;
-pub type BossBarResource = WasmResource<
-    Arc<Mutex<crate::plugin::loader::wasm::wasm_host::wit::v0_1::boss_bar::PluginBossBar>>,
->;
-pub type TextComponentResource = WasmResource<TextComponent>;
-pub type CommandResource = WasmResource<WasmCommand>;
-pub type CommandSenderResource = WasmResource<CommandSender>;
-pub type ConsumedArgsResource = WasmResource<HashMap<String, OwnedArg>>;
-pub type CommandNodeResource = WasmResource<WasmCommandNode>;
-pub type ItemStackResource = WasmResource<Arc<Mutex<pumpkin_data::item_stack::ItemStack>>>;
-pub type RecipeManagerResource = WasmResource<Arc<RecipeManager>>;
-pub type EnchantmentManagerResource =
-    WasmResource<Arc<crate::server::enchantment::EnchantmentManager>>;
-pub type OpManagerResource = WasmResource<Arc<Server>>;
-pub type BanManagerResource = WasmResource<Arc<Server>>;
-pub type WhitelistManagerResource = WasmResource<Arc<Server>>;
-pub type DatapackManagerResource = WasmResource<Arc<Server>>;
-pub type BlockEntityResource = WasmResource<Arc<dyn crate::block::entities::BlockEntity>>;
 
 #[derive(Clone)]
 pub enum InventoryProvider {
@@ -149,25 +107,11 @@ pub enum InventoryProvider {
     PlayerEnderChest(Arc<Player>),
 }
 
-pub type InventoryResource = WasmResource<InventoryProvider>;
-pub type PlayerInventoryResource = WasmResource<Arc<Player>>;
-
-pub type LivingEntityResource = WasmResource<Arc<dyn EntityBase>>;
-pub type MobResource = WasmResource<Arc<dyn EntityBase>>;
-
 #[derive(Clone)]
 pub struct ContainerBlockEntity {
     pub provider: Arc<dyn crate::block::entities::BlockEntity>,
     pub inventory: Arc<dyn pumpkin_inventory::Inventory>,
 }
-
-pub type ContainerBlockEntityResource = WasmResource<ContainerBlockEntity>;
-
-pub type DisplayEntityResource = WasmResource<Arc<dyn EntityBase>>;
-pub type BlockDisplayEntityResource = WasmResource<Arc<dyn EntityBase>>;
-pub type ItemDisplayEntityResource = WasmResource<Arc<dyn EntityBase>>;
-pub type TextDisplayEntityResource = WasmResource<Arc<dyn EntityBase>>;
-pub type InteractionEntityResource = WasmResource<Arc<dyn EntityBase>>;
 
 #[derive(Clone)]
 pub struct ChunkBuffer {
@@ -177,10 +121,6 @@ pub struct ChunkBuffer {
     pub height: u32,
     pub proto_chunk: Arc<std::sync::Mutex<pumpkin_world::ProtoChunk>>,
 }
-
-pub type ChunkBufferResource = WasmResource<ChunkBuffer>;
-
-pub type OwnedConsumedArgs = HashMap<String, OwnedArg>;
 
 pub struct PluginHostState {
     pub wasi_ctx: WasiCtx,
@@ -223,408 +163,53 @@ impl PluginHostState {
         }
     }
 
-    pub fn add_server<T>(
-        &mut self,
-        provider: Arc<Server>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(ServerResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
+    /// get a **borrowed** (or **owned**) [`Resource`]'s value from the resource table
+    pub fn get<T: FromResource>(&self, res: &Resource<T>) -> wasmtime::Result<&T::Internal> {
+        Ok(self.resource_table.get(&Resource::new_borrow(res.rep()))?)
     }
 
-    pub fn add_context<T>(
+    pub fn get_mut<T: FromResource>(
         &mut self,
-        provider: Arc<Context>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(ContextResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_player<T>(
-        &mut self,
-        provider: Arc<Player>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(PlayerResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_java_player<T>(
-        &mut self,
-        provider: Arc<Player>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(JavaPlayerResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_bedrock_player<T>(
-        &mut self,
-        provider: Arc<Player>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(BedrockPlayerResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_entity<T>(
-        &mut self,
-        provider: Arc<dyn EntityBase>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(EntityResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_living_entity<T>(
-        &mut self,
-        provider: Arc<dyn EntityBase>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(LivingEntityResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_mob<T>(
-        &mut self,
-        provider: Arc<dyn EntityBase>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(MobResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_world<T>(
-        &mut self,
-        provider: Arc<World>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(WorldResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_chunk<T>(
-        &mut self,
-        world: Arc<World>,
-        chunk: Weak<pumpkin_world::chunk::ChunkData>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(ChunkResource {
-            provider: (world, chunk),
-        })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_world_border<T>(
-        &mut self,
-        provider: Arc<World>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(WorldBorderResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_scoreboard<T>(
-        &mut self,
-        provider: ScoreboardProvider,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(ScoreboardResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_bedrock_scoreboard<T>(
-        &mut self,
-        provider: Arc<Player>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(BedrockScoreboardResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_gui<T>(
-        &mut self,
-        provider: Arc<Mutex<PluginGui>>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(GuiResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_boss_bar<T>(
-        &mut self,
-        provider: Arc<
-            Mutex<crate::plugin::loader::wasm::wasm_host::wit::v0_1::boss_bar::PluginBossBar>,
-        >,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(BossBarResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_text_component<T>(
-        &mut self,
-        provider: TextComponent,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(TextComponentResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_command<T>(
-        &mut self,
-        provider: WasmCommand,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(CommandResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_command_sender<T>(
-        &mut self,
-        command_sender: CommandSender,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(CommandSenderResource {
-            provider: command_sender,
-        })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_consumed_args<T>(
-        &mut self,
-        provider: HashMap<String, OwnedArg>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(ConsumedArgsResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_owned_consumed_args<T>(
-        &mut self,
-        provider: OwnedConsumedArgs,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(ConsumedArgsResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_command_node<T>(
-        &mut self,
-        provider: WasmCommandNode,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(CommandNodeResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_item_stack<T>(
-        &mut self,
-        provider: Arc<Mutex<pumpkin_data::item_stack::ItemStack>>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(ItemStackResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_recipe_manager<T>(
-        &mut self,
-        provider: Arc<RecipeManager>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(RecipeManagerResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_enchantment_manager<T>(
-        &mut self,
-        provider: Arc<crate::server::enchantment::EnchantmentManager>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(EnchantmentManagerResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_op_manager<T>(
-        &mut self,
-        provider: Arc<Server>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(OpManagerResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_ban_manager<T>(
-        &mut self,
-        provider: Arc<Server>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(BanManagerResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_whitelist_manager<T>(
-        &mut self,
-        provider: Arc<Server>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(WhitelistManagerResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_datapack_manager<T>(
-        &mut self,
-        provider: Arc<Server>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(DatapackManagerResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_inventory<T>(
-        &mut self,
-        provider: InventoryProvider,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(InventoryResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_player_inventory<T>(
-        &mut self,
-        provider: Arc<Player>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(PlayerInventoryResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_block_entity<T>(
-        &mut self,
-        provider: Arc<dyn crate::block::entities::BlockEntity>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(BlockEntityResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_container_block_entity<T>(
-        &mut self,
-        provider: Arc<dyn crate::block::entities::BlockEntity>,
-        inventory: Arc<dyn pumpkin_inventory::Inventory>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(ContainerBlockEntityResource {
-            provider: ContainerBlockEntity {
-                provider,
-                inventory,
-            },
-        })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn add_display_entity<T>(
-        &mut self,
-        provider: Arc<dyn EntityBase>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(DisplayEntityResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn get_display_entity_res<T>(
-        &self,
-        resource: &wasmtime::component::Resource<T>,
-    ) -> wasmtime::Result<&DisplayEntityResource> {
+        res: &Resource<T>,
+    ) -> wasmtime::Result<&mut T::Internal> {
         Ok(self
             .resource_table
-            .get(&wasmtime::component::Resource::new_borrow(resource.rep()))?)
+            .get_mut(&Resource::new_borrow(res.rep()))?)
     }
 
-    pub fn add_block_display_entity<T>(
-        &mut self,
-        provider: Arc<dyn EntityBase>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(BlockDisplayEntityResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
+    /// always returns an owned [`Resource`]
+    pub fn add<T: FromResource>(&mut self, item: T::Internal) -> wasmtime::Result<Resource<T>> {
+        Ok(Resource::new_own(self.resource_table.push(item)?.rep()))
     }
 
-    pub fn get_block_display_entity_res<T>(
-        &self,
-        resource: &wasmtime::component::Resource<T>,
-    ) -> wasmtime::Result<&BlockDisplayEntityResource> {
-        Ok(self
-            .resource_table
-            .get(&wasmtime::component::Resource::new_borrow(resource.rep()))?)
+    /// take the value of an **owned** [`Resource`] from the resource table
+    pub fn take<T: FromResource>(&mut self, res: Resource<T>) -> wasmtime::Result<T::Internal> {
+        Ok(self.resource_table.delete(Resource::new_own(res.rep()))?)
     }
 
-    pub fn add_item_display_entity<T>(
-        &mut self,
-        provider: Arc<dyn EntityBase>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(ItemDisplayEntityResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
+    /// requires an **owned** [`Resource`]
+    pub fn drop<T: FromResource>(&mut self, res: Resource<T>) -> wasmtime::Result<()> {
+        self.take(res)?;
+        Ok(())
     }
 
-    pub fn get_item_display_entity_res<T>(
-        &self,
-        resource: &wasmtime::component::Resource<T>,
-    ) -> wasmtime::Result<&ItemDisplayEntityResource> {
-        Ok(self
-            .resource_table
-            .get(&wasmtime::component::Resource::new_borrow(resource.rep()))?)
+    pub fn discard<T: FromResource>(&mut self, res: Resource<T>) {
+        let _ = self.drop(res);
     }
 
-    pub fn add_text_display_entity<T>(
-        &mut self,
-        provider: Arc<dyn EntityBase>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(TextDisplayEntityResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
+    pub fn discard_to_be_removed<T: FromResource>(&mut self, res: &Resource<T>) {
+        assert!(res.owned());
+        let _ = self.resource_table.delete::<T::Internal>(Resource::new_own(res.rep()));
     }
+}
 
-    pub fn get_text_display_entity_res<T>(
-        &self,
-        resource: &wasmtime::component::Resource<T>,
-    ) -> wasmtime::Result<&TextDisplayEntityResource> {
-        Ok(self
-            .resource_table
-            .get(&wasmtime::component::Resource::new_borrow(resource.rep()))?)
-    }
-
-    pub fn add_interaction_entity<T>(
-        &mut self,
-        provider: Arc<dyn EntityBase>,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self
-            .resource_table
-            .push(InteractionEntityResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn get_interaction_entity_res<T>(
-        &self,
-        resource: &wasmtime::component::Resource<T>,
-    ) -> wasmtime::Result<&InteractionEntityResource> {
-        Ok(self
-            .resource_table
-            .get(&wasmtime::component::Resource::new_borrow(resource.rep()))?)
-    }
-
-    pub fn add_chunk_buffer<T>(
-        &mut self,
-        provider: ChunkBuffer,
-    ) -> wasmtime::Result<wasmtime::component::Resource<T>> {
-        let resource = self.resource_table.push(ChunkBufferResource { provider })?;
-        Ok(wasmtime::component::Resource::new_own(resource.rep()))
-    }
-
-    pub fn get_chunk_buffer_res<T>(
-        &self,
-        resource: &wasmtime::component::Resource<T>,
-    ) -> wasmtime::Result<&ChunkBufferResource> {
-        Ok(self
-            .resource_table
-            .get(&wasmtime::component::Resource::new_borrow(resource.rep()))?)
-    }
+/// This trait could also be replaced with a bunch of `with: {}` definitions in the-
+/// bindgen! macro. That would however enforce that said macro stays in this crate.
+pub trait FromResource: Sized + 'static
+where
+    Resource<Self>: Send + Sync + 'static,
+{
+    type Internal: Send + Sync + 'static;
 }
 
 pub struct PluginHttpHooks {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/advancement.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/advancement.rs
@@ -30,8 +30,8 @@ pub fn to_wasm_advancement_info(
     advancement: &'static Advancement,
 ) -> wasmtime::Result<WitAdvancementInfo> {
     let display = if let Some(disp) = advancement.display {
-        let title = state.add_text_component(disp.get_title())?;
-        let description = state.add_text_component(disp.get_description())?;
+        let title = state.add(disp.get_title())?;
+        let description = state.add(disp.get_description())?;
         Some(WitAdvancementDisplay {
             title,
             description,

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/block_entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/block_entity.rs
@@ -1,38 +1,11 @@
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use wasmtime::component::Resource;
 
 use crate::block::entities::BlockEntity as InternalBlockEntity;
-use crate::block::entities::banner::BannerBlockEntity as InternalBannerBlockEntity;
-use crate::block::entities::beacon::BeaconBlockEntity as InternalBeaconBlockEntity;
-use crate::block::entities::beehive::BeehiveBlockEntity as InternalBeehiveBlockEntity;
-use crate::block::entities::bell::BellBlockEntity as InternalBellBlockEntity;
-use crate::block::entities::blasting_furnace::BlastingFurnaceBlockEntity as InternalBlastingFurnaceBlockEntity;
-use crate::block::entities::brewing_stand::BrewingStandBlockEntity as InternalBrewingStandBlockEntity;
-use crate::block::entities::chest::ChestBlockEntity as InternalChestBlockEntity;
-use crate::block::entities::chiseled_bookshelf::ChiseledBookshelfBlockEntity as InternalChiseledBookshelfBlockEntity;
-use crate::block::entities::command_block::CommandBlockEntity as InternalCommandBlockEntity;
-use crate::block::entities::comparator::ComparatorBlockEntity as InternalComparatorBlockEntity;
-use crate::block::entities::crafter::CrafterBlockEntity as InternalCrafterBlockEntity;
-use crate::block::entities::creaking_heart::CreakingHeartBlockEntity as InternalCreakingHeartBlockEntity;
-use crate::block::entities::end_gateway::EndGatewayBlockEntity as InternalEndGatewayBlockEntity;
-use crate::block::entities::furnace::FurnaceBlockEntity as InternalFurnaceBlockEntity;
 use crate::block::entities::furnace_like_block_entity::CookingBlockEntityBase;
-use crate::block::entities::hanging_sign::HangingSignBlockEntity as InternalHangingSignBlockEntity;
-use crate::block::entities::hopper::HopperBlockEntity as InternalHopperBlockEntity;
-use crate::block::entities::jigsaw_block::JigsawBlockEntity as InternalJigsawBlockEntity;
-use crate::block::entities::jukebox::JukeboxBlockEntity as InternalJukeboxBlockEntity;
-use crate::block::entities::lectern::LecternBlockEntity as InternalLecternBlockEntity;
-use crate::block::entities::map::MapBlockEntity as InternalMapBlockEntity;
-use crate::block::entities::mob_spawner::MobSpawnerBlockEntity as InternalMobSpawnerBlockEntity;
-use crate::block::entities::piston::PistonBlockEntity as InternalPistonBlockEntity;
-use crate::block::entities::sculk_shrieker::SculkShriekerBlockEntity as InternalSculkShriekerBlockEntity;
-use crate::block::entities::sign::{
-    DyeColor as InternalDyeColor, SignBlockEntity as InternalSignBlockEntity, Text as InternalText,
-};
-use crate::block::entities::skull::SkullBlockEntity as InternalSkullBlockEntity;
-use crate::block::entities::smoker::SmokerBlockEntity as InternalSmokerBlockEntity;
-use crate::block::entities::structure_block::StructureBlockBlockEntity as InternalStructureBlockBlockEntity;
-use crate::plugin::loader::wasm::wasm_host::state;
+use crate::block::entities::sign::{DyeColor as InternalDyeColor, Text as InternalText};
+use crate::plugin::loader::wasm::wasm_host::state::{self, FromResource};
 use crate::plugin::loader::wasm::wasm_host::{
     state::PluginHostState,
     wit::v0_1::pumpkin::{
@@ -86,17 +59,6 @@ use crate::plugin::loader::wasm::wasm_host::{
 
 impl pumpkin::plugin::block_entity::Host for PluginHostState {}
 
-fn block_entity_from_resource(
-    state: &PluginHostState,
-    entity: &Resource<BlockEntity>,
-) -> wasmtime::Result<Arc<dyn InternalBlockEntity>> {
-    state
-        .resource_table
-        .get::<Arc<dyn InternalBlockEntity>>(&Resource::new_own(entity.rep()))
-        .map_err(|_| wasmtime::Error::msg("invalid block entity resource handle"))
-        .map(|resource| resource.clone())
-}
-
 const fn from_wasm_dye_color(color: DyeColor) -> InternalDyeColor {
     match color {
         DyeColor::White => InternalDyeColor::White,
@@ -149,9 +111,7 @@ fn to_wasm_sign_text(text: &InternalText) -> SignText {
             .map(str::into_string)
             .to_vec(),
         color: to_wasm_dye_color(text.get_color()),
-        has_glowing_text: text
-            .has_glowing_text
-            .load(std::sync::atomic::Ordering::Relaxed),
+        has_glowing_text: text.has_glowing_text.load(Ordering::Relaxed),
     }
 }
 
@@ -177,12 +137,12 @@ fn from_wasm_sign_text(text: SignText) -> InternalText {
 
 impl HostBlockEntity for PluginHostState {
     async fn resource_location(&mut self, res: Resource<BlockEntity>) -> wasmtime::Result<String> {
-        let entity = block_entity_from_resource(self, &res)?;
+        let entity = self.get(&res)?;
         Ok(entity.resource_location().to_string())
     }
 
     async fn get_position(&mut self, res: Resource<BlockEntity>) -> wasmtime::Result<WitBlockPos> {
-        let entity = block_entity_from_resource(self, &res)?;
+        let entity = self.get(&res)?;
         let pos = entity.get_position();
         Ok(WitBlockPos {
             x: pos.0.x,
@@ -192,17 +152,17 @@ impl HostBlockEntity for PluginHostState {
     }
 
     async fn get_id(&mut self, res: Resource<BlockEntity>) -> wasmtime::Result<u32> {
-        let entity = block_entity_from_resource(self, &res)?;
+        let entity = self.get(&res)?;
         Ok(entity.get_id())
     }
 
     async fn is_dirty(&mut self, res: Resource<BlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &res)?;
+        let entity = self.get(&res)?;
         Ok(entity.is_dirty())
     }
 
     async fn clear_dirty(&mut self, res: Resource<BlockEntity>) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &res)?;
+        let entity = self.get(&res)?;
         entity.clear_dirty();
         Ok(())
     }
@@ -214,7 +174,7 @@ impl HostBlockEntity for PluginHostState {
         key: String,
         value: super::common::WitNbtTree,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &res)?;
+        let entity = self.get(&res)?;
         let pos = entity.get_position();
         let tag = super::common::from_wit_nbt_tree(&value).map_err(wasmtime::Error::msg)?;
         if let Some(server) = &self.server {
@@ -241,7 +201,7 @@ impl HostBlockEntity for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<Option<super::common::WitNbtTree>> {
-        let entity = block_entity_from_resource(self, &res)?;
+        let entity = self.get(&res)?;
         let pos = entity.get_position();
         if let Some(server) = &self.server {
             for world in server.worlds.load().iter() {
@@ -259,7 +219,7 @@ impl HostBlockEntity for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &res)?;
+        let entity = self.get(&res)?;
         let pos = entity.get_position();
         if let Some(server) = &self.server {
             for world in server.worlds.load().iter() {
@@ -275,7 +235,7 @@ impl HostBlockEntity for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &res)?;
+        let entity = self.get(&res)?;
         let pos = entity.get_position();
         if let Some(server) = &self.server {
             for world in server.worlds.load().iter() {
@@ -292,11 +252,11 @@ impl HostBlockEntity for PluginHostState {
     }
 }
 
-fn get_container_from_be<T>(
+fn get_container_from_be(
     state: &mut PluginHostState,
-    res: &Resource<T>,
+    res: &Resource<impl FromResource<Internal = Arc<impl InternalBlockEntity>>>,
 ) -> wasmtime::Result<Resource<ContainerBlockEntity>> {
-    let entity = block_entity_from_resource(state, &Resource::new_own(res.rep()))?;
+    let entity = state.get(res)?.clone();
     let provider = entity.clone();
     entity.get_inventory().map_or_else(
         || Err(wasmtime::Error::msg("Block entity inventory not available")),
@@ -359,15 +319,11 @@ impl HostContainerBlockEntity for PluginHostState {
         slot: u32,
         stack_res: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let inventory = self.get(&res)?.inventory.clone();
-
         let stack = match stack_res {
-            Some(res) => {
-                let lock = self.get(&res)?;
-                lock.lock().await.clone()
-            }
+            Some(res) => self.take(res)?.lock().await.clone(),
             None => pumpkin_data::item_stack::ItemStack::EMPTY.clone(),
         };
+        let inventory = self.get(&res)?.inventory.clone();
 
         inventory.set_stack(slot as usize, stack);
         Ok(())
@@ -407,92 +363,41 @@ impl HostCommandBlockEntity for PluginHostState {
     }
 
     async fn last_output(&mut self, res: Resource<CommandBlockEntity>) -> wasmtime::Result<String> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalCommandBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a command block entity")),
-                |cmd| {
-                    Ok(cmd
-                        .last_output
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .clone())
-                },
-            )
+        Ok(self
+            .get(&res)?
+            .last_output
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone())
     }
 
     async fn track_output(&mut self, res: Resource<CommandBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalCommandBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a command block entity")),
-                |cmd| Ok(cmd.track_output.load(std::sync::atomic::Ordering::Relaxed)),
-            )
+        Ok(self.get(&res)?.track_output.load(Ordering::Relaxed))
     }
 
     async fn success_count(&mut self, res: Resource<CommandBlockEntity>) -> wasmtime::Result<u32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalCommandBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a command block entity")),
-                |cmd| Ok(cmd.success_count.load(std::sync::atomic::Ordering::Relaxed)),
-            )
+        Ok(self.get(&res)?.success_count.load(Ordering::Relaxed))
     }
 
     async fn command(&mut self, res: Resource<CommandBlockEntity>) -> wasmtime::Result<String> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalCommandBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a command block entity")),
-                |cmd| {
-                    Ok(cmd
-                        .command
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .clone())
-                },
-            )
+        Ok(self
+            .get(&res)?
+            .command
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone())
     }
 
     async fn auto(&mut self, res: Resource<CommandBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalCommandBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a command block entity")),
-                |cmd| Ok(cmd.auto.load(std::sync::atomic::Ordering::Relaxed)),
-            )
+        Ok(self.get(&res)?.auto.load(Ordering::Relaxed))
     }
 
     async fn condition_met(&mut self, res: Resource<CommandBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalCommandBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a command block entity")),
-                |cmd| Ok(cmd.condition_met.load(std::sync::atomic::Ordering::Relaxed)),
-            )
+        Ok(self.get(&res)?.condition_met.load(Ordering::Relaxed))
     }
 
     async fn powered(&mut self, res: Resource<CommandBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalCommandBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a command block entity")),
-                |cmd| Ok(cmd.powered.load(std::sync::atomic::Ordering::Relaxed)),
-            )
+        Ok(self.get(&res)?.powered.load(Ordering::Relaxed))
     }
 
     async fn drop(&mut self, rep: Resource<CommandBlockEntity>) -> wasmtime::Result<()> {
@@ -512,14 +417,7 @@ impl HostSignBlockEntity for PluginHostState {
         &mut self,
         res: Resource<SignBlockEntity>,
     ) -> wasmtime::Result<SignText> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a sign block entity")),
-                |sign| Ok(to_wasm_sign_text(&sign.front_text)),
-            )
+        Ok(to_wasm_sign_text(&self.get(&res)?.front_text))
     }
 
     async fn set_front_text(
@@ -527,49 +425,32 @@ impl HostSignBlockEntity for PluginHostState {
         res: Resource<SignBlockEntity>,
         text: SignText,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a sign block entity")),
-                |sign| {
-                    let new_text = from_wasm_sign_text(text);
-                    sign.front_text.has_glowing_text.store(
-                        new_text
-                            .has_glowing_text
-                            .load(std::sync::atomic::Ordering::Relaxed),
-                        std::sync::atomic::Ordering::Relaxed,
-                    );
-                    sign.front_text.set_color(new_text.get_color());
-                    (*sign
-                        .front_text
-                        .messages
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner))
-                    .clone_from(
-                        &new_text
-                            .messages
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner),
-                    );
-                    Ok(())
-                },
-            )
+        let sign = self.get(&res)?;
+        let new_text = from_wasm_sign_text(text);
+        sign.front_text.has_glowing_text.store(
+            new_text.has_glowing_text.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+        sign.front_text.set_color(new_text.get_color());
+        (*sign
+            .front_text
+            .messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner))
+        .clone_from(
+            &new_text
+                .messages
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+        Ok(())
     }
 
     async fn get_back_text(
         &mut self,
         res: Resource<SignBlockEntity>,
     ) -> wasmtime::Result<SignText> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a sign block entity")),
-                |sign| Ok(to_wasm_sign_text(&sign.back_text)),
-            )
+        Ok(to_wasm_sign_text(&self.get(&res)?.back_text))
     }
 
     async fn set_back_text(
@@ -577,46 +458,29 @@ impl HostSignBlockEntity for PluginHostState {
         res: Resource<SignBlockEntity>,
         text: SignText,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a sign block entity")),
-                |sign| {
-                    let new_text = from_wasm_sign_text(text);
-                    sign.back_text.has_glowing_text.store(
-                        new_text
-                            .has_glowing_text
-                            .load(std::sync::atomic::Ordering::Relaxed),
-                        std::sync::atomic::Ordering::Relaxed,
-                    );
-                    sign.back_text.set_color(new_text.get_color());
-                    (*sign
-                        .back_text
-                        .messages
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner))
-                    .clone_from(
-                        &new_text
-                            .messages
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner),
-                    );
-                    Ok(())
-                },
-            )
+        let sign = self.get(&res)?;
+        let new_text = from_wasm_sign_text(text);
+        sign.back_text.has_glowing_text.store(
+            new_text.has_glowing_text.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+        sign.back_text.set_color(new_text.get_color());
+        (*sign
+            .back_text
+            .messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner))
+        .clone_from(
+            &new_text
+                .messages
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+        Ok(())
     }
 
     async fn is_waxed(&mut self, res: Resource<SignBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a sign block entity")),
-                |sign| Ok(sign.is_waxed.load(std::sync::atomic::Ordering::Relaxed)),
-            )
+        Ok(self.get(&res)?.is_waxed.load(Ordering::Relaxed))
     }
 
     async fn set_waxed(
@@ -624,18 +488,8 @@ impl HostSignBlockEntity for PluginHostState {
         res: Resource<SignBlockEntity>,
         waxed: bool,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a sign block entity")),
-                |sign| {
-                    sign.is_waxed
-                        .store(waxed, std::sync::atomic::Ordering::Relaxed);
-                    Ok(())
-                },
-            )
+        self.get(&res)?.is_waxed.store(waxed, Ordering::Relaxed);
+        Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<SignBlockEntity>) -> wasmtime::Result<()> {
@@ -659,28 +513,12 @@ impl HostJukeboxBlockEntity for PluginHostState {
     }
 
     async fn is_playing(&mut self, res: Resource<JukeboxBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalJukeboxBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a jukebox block entity")),
-                |jukebox| Ok(jukebox.is_playing()),
-            )
+        Ok(self.get(&res)?.is_playing())
     }
 
     async fn stop_playing(&mut self, res: Resource<JukeboxBlockEntity>) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalJukeboxBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a jukebox block entity")),
-                |jukebox| {
-                    jukebox.stop_playing();
-                    Ok(())
-                },
-            )
+        self.get(&res)?.stop_playing();
+        Ok(())
     }
 
     async fn start_playing(
@@ -688,17 +526,8 @@ impl HostJukeboxBlockEntity for PluginHostState {
         res: Resource<JukeboxBlockEntity>,
         length_in_ticks: u64,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalJukeboxBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a jukebox block entity")),
-                |jukebox| {
-                    jukebox.start_playing(length_in_ticks);
-                    Ok(())
-                },
-            )
+        self.get(&res)?.start_playing(length_in_ticks);
+        Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<JukeboxBlockEntity>) -> wasmtime::Result<()> {
@@ -722,14 +551,7 @@ impl HostChestBlockEntity for PluginHostState {
     }
 
     async fn viewer_count(&mut self, res: Resource<ChestBlockEntity>) -> wasmtime::Result<u32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalChestBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a chest block entity")),
-                |chest| Ok(chest.get_viewer_count() as u32),
-            )
+        Ok(self.get(&res)?.get_viewer_count() as u32)
     }
 
     async fn drop(&mut self, rep: Resource<ChestBlockEntity>) -> wasmtime::Result<()> {
@@ -749,39 +571,18 @@ impl HostMobSpawnerBlockEntity for PluginHostState {
         &mut self,
         res: Resource<MobSpawnerBlockEntity>,
     ) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalMobSpawnerBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a mob spawner block entity")),
-                |spawner| Ok(spawner.spawn_count),
-            )
+        Ok(self.get(&res)?.spawn_count)
     }
 
     async fn get_spawn_range(
         &mut self,
         res: Resource<MobSpawnerBlockEntity>,
     ) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalMobSpawnerBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a mob spawner block entity")),
-                |spawner| Ok(spawner.spawn_range),
-            )
+        Ok(self.get(&res)?.spawn_range)
     }
 
     async fn get_delay(&mut self, res: Resource<MobSpawnerBlockEntity>) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalMobSpawnerBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a mob spawner block entity")),
-                |spawner| Ok(spawner.delay.load(std::sync::atomic::Ordering::Relaxed)),
-            )
+        Ok(self.get(&res)?.delay.load(Ordering::Relaxed))
     }
 
     async fn drop(&mut self, rep: Resource<MobSpawnerBlockEntity>) -> wasmtime::Result<()> {
@@ -798,14 +599,7 @@ impl HostMapBlockEntity for PluginHostState {
     }
 
     async fn get_map_id(&mut self, res: Resource<MapBlockEntity>) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalMapBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a map block entity")),
-                |map_be| Ok(map_be.get_map_id()),
-            )
+        Ok(self.get(&res)?.get_map_id())
     }
 
     async fn set_map_id(
@@ -813,22 +607,12 @@ impl HostMapBlockEntity for PluginHostState {
         res: Resource<MapBlockEntity>,
         map_id: i32,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        let map_be = entity
-            .as_any()
-            .downcast_ref::<InternalMapBlockEntity>()
-            .ok_or_else(|| wasmtime::Error::msg("Not a map block entity"))?;
-        map_be.set_map_id(map_id);
+        self.get(&res)?.set_map_id(map_id);
         Ok(())
     }
 
     async fn get_colors(&mut self, res: Resource<MapBlockEntity>) -> wasmtime::Result<Vec<u8>> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        let map_be = entity
-            .as_any()
-            .downcast_ref::<InternalMapBlockEntity>()
-            .ok_or_else(|| wasmtime::Error::msg("Not a map block entity"))?;
-        Ok(map_be.get_colors())
+        Ok(self.get(&res)?.get_colors())
     }
 
     async fn set_colors(
@@ -836,12 +620,7 @@ impl HostMapBlockEntity for PluginHostState {
         res: Resource<MapBlockEntity>,
         colors: Vec<u8>,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        let map_be = entity
-            .as_any()
-            .downcast_ref::<InternalMapBlockEntity>()
-            .ok_or_else(|| wasmtime::Error::msg("Not a map block entity"))?;
-        map_be.set_colors(&colors);
+        self.get(&res)?.set_colors(&colors);
         Ok(())
     }
 
@@ -852,12 +631,7 @@ impl HostMapBlockEntity for PluginHostState {
         y: u32,
         color: u8,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        let map_be = entity
-            .as_any()
-            .downcast_ref::<InternalMapBlockEntity>()
-            .ok_or_else(|| wasmtime::Error::msg("Not a map block entity"))?;
-        map_be.set_pixel(x as usize, y as usize, color);
+        self.get(&res)?.set_pixel(x as usize, y as usize, color);
         Ok(())
     }
 
@@ -867,25 +641,15 @@ impl HostMapBlockEntity for PluginHostState {
         x: u32,
         y: u32,
     ) -> wasmtime::Result<u8> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        let map_be = entity
-            .as_any()
-            .downcast_ref::<InternalMapBlockEntity>()
-            .ok_or_else(|| wasmtime::Error::msg("Not a map block entity"))?;
-        Ok(map_be.get_pixel(x as usize, y as usize))
+        Ok(self.get(&res)?.get_pixel(x as usize, y as usize))
     }
 
     async fn update(&mut self, res: Resource<MapBlockEntity>) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        let map_be = entity
-            .as_any()
-            .downcast_ref::<InternalMapBlockEntity>()
-            .ok_or_else(|| wasmtime::Error::msg("Not a map block entity"))?;
         let server = self
             .server
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server context not set"))?;
-        map_be.broadcast_map_data(server);
+        self.get(&res)?.broadcast_map_data(server);
         Ok(())
     }
 
@@ -894,13 +658,8 @@ impl HostMapBlockEntity for PluginHostState {
         res: Resource<MapBlockEntity>,
         frame_data: Vec<u8>,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        let map_be = entity
-            .as_any()
-            .downcast_ref::<InternalMapBlockEntity>()
-            .ok_or_else(|| wasmtime::Error::msg("Not a map block entity"))?;
         let server_opt = self.server.as_deref();
-        map_be.stream_frame(&frame_data, server_opt);
+        self.get(&res)?.stream_frame(&frame_data, server_opt);
         Ok(())
     }
 
@@ -921,14 +680,7 @@ impl HostHangingSignBlockEntity for PluginHostState {
         &mut self,
         res: Resource<HangingSignBlockEntity>,
     ) -> wasmtime::Result<SignText> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalHangingSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a hanging sign block entity")),
-                |sign| Ok(to_wasm_sign_text(&sign.front_text)),
-            )
+        Ok(to_wasm_sign_text(&self.get(&res)?.front_text))
     }
 
     async fn set_front_text(
@@ -936,49 +688,32 @@ impl HostHangingSignBlockEntity for PluginHostState {
         res: Resource<HangingSignBlockEntity>,
         text: SignText,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalHangingSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a hanging sign block entity")),
-                |sign| {
-                    let new_text = from_wasm_sign_text(text);
-                    sign.front_text.has_glowing_text.store(
-                        new_text
-                            .has_glowing_text
-                            .load(std::sync::atomic::Ordering::Relaxed),
-                        std::sync::atomic::Ordering::Relaxed,
-                    );
-                    sign.front_text.set_color(new_text.get_color());
-                    (*sign
-                        .front_text
-                        .messages
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner))
-                    .clone_from(
-                        &new_text
-                            .messages
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner),
-                    );
-                    Ok(())
-                },
-            )
+        let sign = self.get(&res)?;
+        let new_text = from_wasm_sign_text(text);
+        sign.front_text.has_glowing_text.store(
+            new_text.has_glowing_text.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+        sign.front_text.set_color(new_text.get_color());
+        (*sign
+            .front_text
+            .messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner))
+        .clone_from(
+            &new_text
+                .messages
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+        Ok(())
     }
 
     async fn get_back_text(
         &mut self,
         res: Resource<HangingSignBlockEntity>,
     ) -> wasmtime::Result<SignText> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalHangingSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a hanging sign block entity")),
-                |sign| Ok(to_wasm_sign_text(&sign.back_text)),
-            )
+        Ok(to_wasm_sign_text(&self.get(&res)?.back_text))
     }
 
     async fn set_back_text(
@@ -986,46 +721,29 @@ impl HostHangingSignBlockEntity for PluginHostState {
         res: Resource<HangingSignBlockEntity>,
         text: SignText,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalHangingSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a hanging sign block entity")),
-                |sign| {
-                    let new_text = from_wasm_sign_text(text);
-                    sign.back_text.has_glowing_text.store(
-                        new_text
-                            .has_glowing_text
-                            .load(std::sync::atomic::Ordering::Relaxed),
-                        std::sync::atomic::Ordering::Relaxed,
-                    );
-                    sign.back_text.set_color(new_text.get_color());
-                    (*sign
-                        .back_text
-                        .messages
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner))
-                    .clone_from(
-                        &new_text
-                            .messages
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner),
-                    );
-                    Ok(())
-                },
-            )
+        let sign = self.get(&res)?;
+        let new_text = from_wasm_sign_text(text);
+        sign.back_text.has_glowing_text.store(
+            new_text.has_glowing_text.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+        sign.back_text.set_color(new_text.get_color());
+        (*sign
+            .back_text
+            .messages
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner))
+        .clone_from(
+            &new_text
+                .messages
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+        Ok(())
     }
 
     async fn is_waxed(&mut self, res: Resource<HangingSignBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalHangingSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a hanging sign block entity")),
-                |sign| Ok(sign.is_waxed.load(std::sync::atomic::Ordering::Relaxed)),
-            )
+        Ok(self.get(&res)?.is_waxed.load(Ordering::Relaxed))
     }
 
     async fn set_waxed(
@@ -1033,18 +751,8 @@ impl HostHangingSignBlockEntity for PluginHostState {
         res: Resource<HangingSignBlockEntity>,
         waxed: bool,
     ) -> wasmtime::Result<()> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<InternalHangingSignBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a hanging sign block entity")),
-                |sign| {
-                    sign.is_waxed
-                        .store(waxed, std::sync::atomic::Ordering::Relaxed);
-                    Ok(())
-                },
-            )
+        self.get(&res)?.is_waxed.store(waxed, Ordering::Relaxed);
+        Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<HangingSignBlockEntity>) -> wasmtime::Result<()> {
@@ -1071,14 +779,7 @@ impl HostTrappedChestBlockEntity for PluginHostState {
         &mut self,
         res: Resource<TrappedChestBlockEntity>,
     ) -> wasmtime::Result<u32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        entity
-            .as_any()
-            .downcast_ref::<crate::block::entities::trapped_chest::TrappedChestBlockEntity>()
-            .map_or_else(
-                || Err(wasmtime::Error::msg("Not a trapped chest block entity")),
-                |chest| Ok(chest.get_viewer_count() as u32),
-            )
+        Ok(self.get(&res)?.get_viewer_count() as u32)
     }
 
     async fn drop(&mut self, rep: Resource<TrappedChestBlockEntity>) -> wasmtime::Result<()> {
@@ -1148,55 +849,35 @@ macro_rules! impl_cooking_host_block_entity {
                 &mut self,
                 res: Resource<$resource_name>,
             ) -> wasmtime::Result<u16> {
-                let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-                Ok(entity
-                    .as_any()
-                    .downcast_ref::<$internal_type>()
-                    .map_or(0, |b| b.get_cooking_time_spent()))
+                Ok(self.get(&res)?.get_cooking_time_spent())
             }
 
             async fn get_cooking_total_time(
                 &mut self,
                 res: Resource<$resource_name>,
             ) -> wasmtime::Result<u16> {
-                let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-                Ok(entity
-                    .as_any()
-                    .downcast_ref::<$internal_type>()
-                    .map_or(0, |b| b.get_cooking_total_time()))
+                Ok(self.get(&res)?.get_cooking_total_time())
             }
 
             async fn get_lit_time_remaining(
                 &mut self,
                 res: Resource<$resource_name>,
             ) -> wasmtime::Result<u16> {
-                let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-                Ok(entity
-                    .as_any()
-                    .downcast_ref::<$internal_type>()
-                    .map_or(0, |b| b.get_lit_time_remaining()))
+                Ok(self.get(&res)?.get_lit_time_remaining())
             }
 
             async fn get_lit_total_time(
                 &mut self,
                 res: Resource<$resource_name>,
             ) -> wasmtime::Result<u16> {
-                let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-                Ok(entity
-                    .as_any()
-                    .downcast_ref::<$internal_type>()
-                    .map_or(0, |b| b.get_lit_total_time()))
+                Ok(self.get(&res)?.get_lit_total_time())
             }
 
             async fn is_burning(
                 &mut self,
                 res: Resource<$resource_name>,
             ) -> wasmtime::Result<bool> {
-                let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-                Ok(entity
-                    .as_any()
-                    .downcast_ref::<$internal_type>()
-                    .is_some_and(|b| b.is_burning()))
+                Ok(self.get(&res)?.is_burning())
             }
 
             async fn drop(&mut self, rep: Resource<$resource_name>) -> wasmtime::Result<()> {
@@ -1237,11 +918,12 @@ impl HostBannerBlockEntity for PluginHostState {
         &mut self,
         res: Resource<BannerBlockEntity>,
     ) -> wasmtime::Result<Option<String>> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalBannerBlockEntity>()
-            .and_then(|b| b.custom_name.try_lock().ok().and_then(|g| g.clone())))
+        Ok(self
+            .get(&res)?
+            .custom_name
+            .try_lock()
+            .ok()
+            .and_then(|g| g.clone()))
     }
 
     async fn drop(&mut self, rep: Resource<BannerBlockEntity>) -> wasmtime::Result<()> {
@@ -1292,35 +974,18 @@ impl HostBeaconBlockEntity for PluginHostState {
         &mut self,
         res: Resource<BeaconBlockEntity>,
     ) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalBeaconBlockEntity>()
-            .map_or(-1, |b| {
-                b.primary_effect.load(std::sync::atomic::Ordering::Relaxed)
-            }))
+        Ok(self.get(&res)?.primary_effect.load(Ordering::Relaxed))
     }
 
     async fn get_secondary_effect(
         &mut self,
         res: Resource<BeaconBlockEntity>,
     ) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalBeaconBlockEntity>()
-            .map_or(-1, |b| {
-                b.secondary_effect
-                    .load(std::sync::atomic::Ordering::Relaxed)
-            }))
+        Ok(self.get(&res)?.secondary_effect.load(Ordering::Relaxed))
     }
 
     async fn get_levels(&mut self, res: Resource<BeaconBlockEntity>) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalBeaconBlockEntity>()
-            .map_or(0, |b| b.levels.load(std::sync::atomic::Ordering::Relaxed)))
+        Ok(self.get(&res)?.levels.load(Ordering::Relaxed))
     }
 
     async fn drop(&mut self, rep: Resource<BeaconBlockEntity>) -> wasmtime::Result<()> {
@@ -1337,17 +1002,13 @@ impl HostBeehiveBlockEntity for PluginHostState {
     }
 
     async fn get_bee_count(&mut self, res: Resource<BeehiveBlockEntity>) -> wasmtime::Result<u32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalBeehiveBlockEntity>()
-            .map_or(0, |b| {
-                b.bees
-                    .try_lock()
-                    .ok()
-                    .and_then(|g| g.as_ref().map(|v| v.len() as u32))
-                    .unwrap_or(0)
-            }))
+        Ok(self
+            .get(&res)?
+            .bees
+            .try_lock()
+            .ok()
+            .and_then(|g| g.as_ref().map(|v| v.len() as u32))
+            .unwrap_or(0))
     }
 
     async fn drop(&mut self, rep: Resource<BeehiveBlockEntity>) -> wasmtime::Result<()> {
@@ -1364,19 +1025,11 @@ impl HostBellBlockEntity for PluginHostState {
     }
 
     async fn is_ringing(&mut self, res: Resource<BellBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalBellBlockEntity>()
-            .is_some_and(|b| b.ringing.load()))
+        Ok(self.get(&res)?.ringing.load())
     }
 
     async fn get_ring_ticks(&mut self, res: Resource<BellBlockEntity>) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalBellBlockEntity>()
-            .map_or(0, |b| b.ring_ticks.load()))
+        Ok(self.get(&res)?.ring_ticks.load())
     }
 
     async fn drop(&mut self, rep: Resource<BellBlockEntity>) -> wasmtime::Result<()> {
@@ -1403,21 +1056,11 @@ impl HostBrewingStandBlockEntity for PluginHostState {
         &mut self,
         res: Resource<BrewingStandBlockEntity>,
     ) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalBrewingStandBlockEntity>()
-            .map_or(0, |b| {
-                b.brew_time.load(std::sync::atomic::Ordering::Relaxed)
-            }))
+        Ok(self.get(&res)?.brew_time.load(Ordering::Relaxed))
     }
 
     async fn get_fuel(&mut self, res: Resource<BrewingStandBlockEntity>) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalBrewingStandBlockEntity>()
-            .map_or(0, |b| b.fuel.load(std::sync::atomic::Ordering::Relaxed)))
+        Ok(self.get(&res)?.fuel.load(Ordering::Relaxed))
     }
 
     async fn drop(&mut self, rep: Resource<BrewingStandBlockEntity>) -> wasmtime::Result<()> {
@@ -1444,14 +1087,7 @@ impl HostChiseledBookshelfBlockEntity for PluginHostState {
         &mut self,
         res: Resource<ChiseledBookshelfBlockEntity>,
     ) -> wasmtime::Result<i8> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalChiseledBookshelfBlockEntity>()
-            .map_or(-1, |b| {
-                b.last_interacted_slot
-                    .load(std::sync::atomic::Ordering::Relaxed)
-            }))
+        Ok(self.get(&res)?.last_interacted_slot.load(Ordering::Relaxed))
     }
 
     async fn drop(&mut self, rep: Resource<ChiseledBookshelfBlockEntity>) -> wasmtime::Result<()> {
@@ -1471,13 +1107,7 @@ impl HostComparatorBlockEntity for PluginHostState {
         &mut self,
         res: Resource<ComparatorBlockEntity>,
     ) -> wasmtime::Result<u8> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalComparatorBlockEntity>()
-            .map_or(0, |b| {
-                b.output_signal.load(std::sync::atomic::Ordering::Relaxed)
-            }))
+        Ok(self.get(&res)?.output_signal.load(Ordering::Relaxed))
     }
 
     async fn drop(&mut self, rep: Resource<ComparatorBlockEntity>) -> wasmtime::Result<()> {
@@ -1504,22 +1134,14 @@ impl HostCrafterBlockEntity for PluginHostState {
         &mut self,
         res: Resource<CrafterBlockEntity>,
     ) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalCrafterBlockEntity>()
-            .map_or(0, |b| {
-                b.crafting_ticks_remaining
-                    .load(std::sync::atomic::Ordering::Relaxed)
-            }))
+        Ok(self
+            .get(&res)?
+            .crafting_ticks_remaining
+            .load(Ordering::Relaxed))
     }
 
     async fn is_triggered(&mut self, res: Resource<CrafterBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalCrafterBlockEntity>()
-            .is_some_and(|b| b.triggered.load(std::sync::atomic::Ordering::Relaxed)))
+        Ok(self.get(&res)?.triggered.load(Ordering::Relaxed))
     }
 
     async fn drop(&mut self, rep: Resource<CrafterBlockEntity>) -> wasmtime::Result<()> {
@@ -1539,11 +1161,7 @@ impl HostCreakingHeartBlockEntity for PluginHostState {
         &mut self,
         res: Resource<CreakingHeartBlockEntity>,
     ) -> wasmtime::Result<Option<String>> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalCreakingHeartBlockEntity>()
-            .and_then(|b| b.creaking_uuid.load().map(|u| u.to_string())))
+        Ok(self.get(&res)?.creaking_uuid.load().map(|u| u.to_string()))
     }
 
     async fn drop(&mut self, rep: Resource<CreakingHeartBlockEntity>) -> wasmtime::Result<()> {
@@ -1560,22 +1178,14 @@ impl HostEndGatewayBlockEntity for PluginHostState {
     }
 
     async fn get_age(&mut self, res: Resource<EndGatewayBlockEntity>) -> wasmtime::Result<i64> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalEndGatewayBlockEntity>()
-            .map_or(0, |b| b.age.try_lock().ok().map_or(0, |g| *g)))
+        Ok(self.get(&res)?.age.try_lock().ok().map_or(0, |g| *g))
     }
 
     async fn is_exact_teleport(
         &mut self,
         res: Resource<EndGatewayBlockEntity>,
     ) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalEndGatewayBlockEntity>()
-            .is_some_and(|b| b.exact_teleport.try_lock().is_ok_and(|g| *g)))
+        Ok(self.get(&res)?.exact_teleport.try_lock().is_ok_and(|g| *g))
     }
 
     async fn drop(&mut self, rep: Resource<EndGatewayBlockEntity>) -> wasmtime::Result<()> {
@@ -1646,13 +1256,7 @@ impl HostHopperBlockEntity for PluginHostState {
     }
 
     async fn get_cooldown(&mut self, res: Resource<HopperBlockEntity>) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalHopperBlockEntity>()
-            .map_or(0, |b| {
-                b.cooldown_time.load(std::sync::atomic::Ordering::Relaxed)
-            }))
+        Ok(self.get(&res)?.cooldown_time.load(Ordering::Relaxed))
     }
 
     async fn drop(&mut self, rep: Resource<HopperBlockEntity>) -> wasmtime::Result<()> {
@@ -1669,86 +1273,52 @@ impl HostJigsawBlockEntity for PluginHostState {
     }
 
     async fn get_name(&mut self, res: Resource<JigsawBlockEntity>) -> wasmtime::Result<String> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalJigsawBlockEntity>()
-            .map_or_else(String::new, |b| {
-                b.name
-                    .try_lock()
-                    .ok()
-                    .map_or_else(String::new, |g| g.clone())
-            }))
+        Ok(self
+            .get(&res)?
+            .name
+            .try_lock()
+            .map_or_default(|g| g.clone()))
     }
 
     async fn get_target(&mut self, res: Resource<JigsawBlockEntity>) -> wasmtime::Result<String> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalJigsawBlockEntity>()
-            .map_or_else(String::new, |b| {
-                b.target
-                    .try_lock()
-                    .ok()
-                    .map_or_else(String::new, |g| g.clone())
-            }))
+        Ok(self
+            .get(&res)?
+            .target
+            .try_lock()
+            .map_or_default(|g| g.clone()))
     }
 
     async fn get_pool(&mut self, res: Resource<JigsawBlockEntity>) -> wasmtime::Result<String> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalJigsawBlockEntity>()
-            .map_or_else(String::new, |b| {
-                b.pool
-                    .try_lock()
-                    .ok()
-                    .map_or_else(String::new, |g| g.clone())
-            }))
+        Ok(self
+            .get(&res)?
+            .pool
+            .try_lock()
+            .map_or_default(|g| g.clone()))
     }
 
     async fn get_final_state(
         &mut self,
         res: Resource<JigsawBlockEntity>,
     ) -> wasmtime::Result<String> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalJigsawBlockEntity>()
-            .map_or_else(String::new, |b| {
-                b.final_state
-                    .try_lock()
-                    .ok()
-                    .map_or_else(String::new, |g| g.clone())
-            }))
+        Ok(self
+            .get(&res)?
+            .final_state
+            .try_lock()
+            .map_or_default(|g| g.clone()))
     }
 
     async fn get_selection_priority(
         &mut self,
         res: Resource<JigsawBlockEntity>,
     ) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalJigsawBlockEntity>()
-            .map_or(0, |b| {
-                b.selection_priority
-                    .load(std::sync::atomic::Ordering::Relaxed)
-            }))
+        Ok(self.get(&res)?.selection_priority.load(Ordering::Relaxed))
     }
 
     async fn get_placement_priority(
         &mut self,
         res: Resource<JigsawBlockEntity>,
     ) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalJigsawBlockEntity>()
-            .map_or(0, |b| {
-                b.placement_priority
-                    .load(std::sync::atomic::Ordering::Relaxed)
-            }))
+        Ok(self.get(&res)?.placement_priority.load(Ordering::Relaxed))
     }
 
     async fn drop(&mut self, rep: Resource<JigsawBlockEntity>) -> wasmtime::Result<()> {
@@ -1772,13 +1342,7 @@ impl HostLecternBlockEntity for PluginHostState {
     }
 
     async fn get_page(&mut self, res: Resource<LecternBlockEntity>) -> wasmtime::Result<u32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalLecternBlockEntity>()
-            .map_or(0, |b| {
-                b.page.load(std::sync::atomic::Ordering::Relaxed) as u32
-            }))
+        Ok(self.get(&res)?.page.load(Ordering::Relaxed) as u32)
     }
 
     async fn drop(&mut self, rep: Resource<LecternBlockEntity>) -> wasmtime::Result<()> {
@@ -1795,27 +1359,15 @@ impl HostPistonBlockEntity for PluginHostState {
     }
 
     async fn get_progress(&mut self, res: Resource<PistonBlockEntity>) -> wasmtime::Result<f32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalPistonBlockEntity>()
-            .map_or(0.0, |b| b.current_progress.load()))
+        Ok(self.get(&res)?.current_progress.load())
     }
 
     async fn is_extending(&mut self, res: Resource<PistonBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalPistonBlockEntity>()
-            .is_some_and(|b| b.extending))
+        Ok(self.get(&res)?.extending)
     }
 
     async fn is_source(&mut self, res: Resource<PistonBlockEntity>) -> wasmtime::Result<bool> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalPistonBlockEntity>()
-            .is_some_and(|b| b.source))
+        Ok(self.get(&res)?.source)
     }
 
     async fn drop(&mut self, rep: Resource<PistonBlockEntity>) -> wasmtime::Result<()> {
@@ -1835,11 +1387,7 @@ impl HostSculkShriekerBlockEntity for PluginHostState {
         &mut self,
         res: Resource<SculkShriekerBlockEntity>,
     ) -> wasmtime::Result<i32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalSculkShriekerBlockEntity>()
-            .map_or(0, |b| b.warning_level.try_lock().ok().map_or(0, |g| *g)))
+        Ok(self.get(&res)?.warning_level.try_lock().map_or(0, |g| *g))
     }
 
     async fn drop(&mut self, rep: Resource<SculkShriekerBlockEntity>) -> wasmtime::Result<()> {
@@ -1859,11 +1407,12 @@ impl HostSkullBlockEntity for PluginHostState {
         &mut self,
         res: Resource<SkullBlockEntity>,
     ) -> wasmtime::Result<Option<String>> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalSkullBlockEntity>()
-            .and_then(|b| b.note_block_sound.try_lock().ok().and_then(|g| g.clone())))
+        Ok(self
+            .get(&res)?
+            .note_block_sound
+            .try_lock()
+            .ok()
+            .and_then(|g| g.clone()))
     }
 
     async fn drop(&mut self, rep: Resource<SkullBlockEntity>) -> wasmtime::Result<()> {
@@ -1883,70 +1432,47 @@ impl HostStructureBlockBlockEntity for PluginHostState {
         &mut self,
         res: Resource<StructureBlockBlockEntity>,
     ) -> wasmtime::Result<String> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalStructureBlockBlockEntity>()
-            .map_or_else(String::new, |b| {
-                b.name
-                    .try_lock()
-                    .ok()
-                    .map_or_else(String::new, |g| g.clone())
-            }))
+        Ok(self
+            .get(&res)?
+            .name
+            .try_lock()
+            .map_or_default(|g| g.clone()))
     }
 
     async fn get_author(
         &mut self,
         res: Resource<StructureBlockBlockEntity>,
     ) -> wasmtime::Result<String> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalStructureBlockBlockEntity>()
-            .map_or_else(String::new, |b| {
-                b.author
-                    .try_lock()
-                    .ok()
-                    .map_or_else(String::new, |g| g.clone())
-            }))
+        Ok(self
+            .get(&res)?
+            .author
+            .try_lock()
+            .map_or_default(|g| g.clone()))
     }
 
     async fn get_mode(
         &mut self,
         res: Resource<StructureBlockBlockEntity>,
     ) -> wasmtime::Result<String> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalStructureBlockBlockEntity>()
-            .map_or_else(String::new, |b| {
-                b.mode
-                    .try_lock()
-                    .ok()
-                    .map_or_else(String::new, |g| g.clone())
-            }))
+        Ok(self
+            .get(&res)?
+            .mode
+            .try_lock()
+            .map_or_default(|g| g.clone()))
     }
 
     async fn get_integrity(
         &mut self,
         res: Resource<StructureBlockBlockEntity>,
     ) -> wasmtime::Result<f32> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalStructureBlockBlockEntity>()
-            .map_or(1.0, |b| b.integrity.try_lock().ok().map_or(1.0, |g| *g)))
+        Ok(self.get(&res)?.integrity.try_lock().map_or(1.0, |g| *g))
     }
 
     async fn get_seed(
         &mut self,
         res: Resource<StructureBlockBlockEntity>,
     ) -> wasmtime::Result<i64> {
-        let entity = block_entity_from_resource(self, &Resource::new_own(res.rep()))?;
-        Ok(entity
-            .as_any()
-            .downcast_ref::<InternalStructureBlockBlockEntity>()
-            .map_or(0, |b| b.seed.try_lock().ok().map_or(0, |g| *g)))
+        Ok(self.get(&res)?.seed.try_lock().map_or(0, |g| *g))
     }
 
     async fn drop(&mut self, rep: Resource<StructureBlockBlockEntity>) -> wasmtime::Result<()> {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/block_entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/block_entity.rs
@@ -1277,7 +1277,8 @@ impl HostJigsawBlockEntity for PluginHostState {
             .get(&res)?
             .name
             .try_lock()
-            .map_or_default(|g| g.clone()))
+            .ok()
+            .map_or_else(String::new, |g| g.clone()))
     }
 
     async fn get_target(&mut self, res: Resource<JigsawBlockEntity>) -> wasmtime::Result<String> {
@@ -1285,7 +1286,8 @@ impl HostJigsawBlockEntity for PluginHostState {
             .get(&res)?
             .target
             .try_lock()
-            .map_or_default(|g| g.clone()))
+            .ok()
+            .map_or_else(String::new, |g| g.clone()))
     }
 
     async fn get_pool(&mut self, res: Resource<JigsawBlockEntity>) -> wasmtime::Result<String> {
@@ -1293,7 +1295,8 @@ impl HostJigsawBlockEntity for PluginHostState {
             .get(&res)?
             .pool
             .try_lock()
-            .map_or_default(|g| g.clone()))
+            .ok()
+            .map_or_else(String::new, |g| g.clone()))
     }
 
     async fn get_final_state(
@@ -1304,7 +1307,8 @@ impl HostJigsawBlockEntity for PluginHostState {
             .get(&res)?
             .final_state
             .try_lock()
-            .map_or_default(|g| g.clone()))
+            .ok()
+            .map_or_else(String::new, |g| g.clone()))
     }
 
     async fn get_selection_priority(
@@ -1436,7 +1440,8 @@ impl HostStructureBlockBlockEntity for PluginHostState {
             .get(&res)?
             .name
             .try_lock()
-            .map_or_default(|g| g.clone()))
+            .ok()
+            .map_or_else(String::new, |g| g.clone()))
     }
 
     async fn get_author(
@@ -1447,7 +1452,8 @@ impl HostStructureBlockBlockEntity for PluginHostState {
             .get(&res)?
             .author
             .try_lock()
-            .map_or_default(|g| g.clone()))
+            .ok()
+            .map_or_else(String::new, |g| g.clone()))
     }
 
     async fn get_mode(
@@ -1458,7 +1464,8 @@ impl HostStructureBlockBlockEntity for PluginHostState {
             .get(&res)?
             .mode
             .try_lock()
-            .map_or_default(|g| g.clone()))
+            .ok()
+            .map_or_else(String::new, |g| g.clone()))
     }
 
     async fn get_integrity(

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/block_entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/block_entity.rs
@@ -32,8 +32,9 @@ use crate::block::entities::sign::{
 use crate::block::entities::skull::SkullBlockEntity as InternalSkullBlockEntity;
 use crate::block::entities::smoker::SmokerBlockEntity as InternalSmokerBlockEntity;
 use crate::block::entities::structure_block::StructureBlockBlockEntity as InternalStructureBlockBlockEntity;
+use crate::plugin::loader::wasm::wasm_host::state;
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{BlockEntityResource, ContainerBlockEntityResource, PluginHostState},
+    state::PluginHostState,
     wit::v0_1::pumpkin::{
         self,
         plugin::{
@@ -91,9 +92,9 @@ fn block_entity_from_resource(
 ) -> wasmtime::Result<Arc<dyn InternalBlockEntity>> {
     state
         .resource_table
-        .get::<BlockEntityResource>(&Resource::new_own(entity.rep()))
+        .get::<Arc<dyn InternalBlockEntity>>(&Resource::new_own(entity.rep()))
         .map_err(|_| wasmtime::Error::msg("invalid block entity resource handle"))
-        .map(|resource| resource.provider.clone())
+        .map(|resource| resource.clone())
 }
 
 const fn from_wasm_dye_color(color: DyeColor) -> InternalDyeColor {
@@ -287,10 +288,7 @@ impl HostBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<BlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -302,7 +300,12 @@ fn get_container_from_be<T>(
     let provider = entity.clone();
     entity.get_inventory().map_or_else(
         || Err(wasmtime::Error::msg("Block entity inventory not available")),
-        |inventory| state.add_container_block_entity(provider, inventory),
+        |inventory| {
+            state.add(state::ContainerBlockEntity {
+                provider,
+                inventory,
+            })
+        },
     )
 }
 
@@ -311,12 +314,7 @@ impl HostContainerBlockEntity for PluginHostState {
         &mut self,
         res: Resource<ContainerBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let container = self
-            .resource_table
-            .get::<ContainerBlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid container block entity resource handle"))?;
-        let provider = container.provider.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.provider.clone())
     }
 
     async fn get_inventory(
@@ -327,31 +325,18 @@ impl HostContainerBlockEntity for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::inventory::Inventory,
         >,
     >{
-        let container = self
-            .resource_table
-            .get::<ContainerBlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid container block entity resource handle"))?;
-        let inventory = container.provider.inventory.clone();
-        self.add_inventory(
+        let inventory = self.get(&res)?.inventory.clone();
+        self.add(
             crate::plugin::loader::wasm::wasm_host::state::InventoryProvider::Generic(inventory),
         )
     }
 
     async fn get_size(&mut self, res: Resource<ContainerBlockEntity>) -> wasmtime::Result<u32> {
-        let container = self
-            .resource_table
-            .get::<ContainerBlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid container block entity resource handle"))?;
-        Ok(container.provider.inventory.size() as u32)
+        Ok(self.get(&res)?.inventory.size() as u32)
     }
 
     async fn is_empty(&mut self, res: Resource<ContainerBlockEntity>) -> wasmtime::Result<bool> {
-        let container = self
-            .resource_table
-            .get::<ContainerBlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid container block entity resource handle"))?;
-        let inventory = container.provider.inventory.clone();
-        Ok(inventory.is_empty())
+        Ok(self.get(&res)?.inventory.is_empty())
     }
 
     async fn get_stack(
@@ -359,18 +344,12 @@ impl HostContainerBlockEntity for PluginHostState {
         res: Resource<ContainerBlockEntity>,
         slot: u32,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let container = self
-            .resource_table
-            .get::<ContainerBlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid container block entity resource handle"))?;
-        let inventory = container.provider.inventory.clone();
+        let inventory = self.get(&res)?.inventory.clone();
         let stack = inventory.get_stack(slot as usize);
         if stack.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(
-                tokio::sync::Mutex::new(stack),
-            ))?))
+            Ok(Some(self.add(Arc::new(tokio::sync::Mutex::new(stack)))?))
         }
     }
 
@@ -380,15 +359,11 @@ impl HostContainerBlockEntity for PluginHostState {
         slot: u32,
         stack_res: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let container = self
-            .resource_table
-            .get::<ContainerBlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid container block entity resource handle"))?;
-        let inventory = container.provider.inventory.clone();
+        let inventory = self.get(&res)?.inventory.clone();
 
         let stack = match stack_res {
             Some(res) => {
-                let lock = self.get_item_stack(&res)?;
+                let lock = self.get(&res)?;
                 lock.lock().await.clone()
             }
             None => pumpkin_data::item_stack::ItemStack::EMPTY.clone(),
@@ -403,36 +378,23 @@ impl HostContainerBlockEntity for PluginHostState {
         res: Resource<ContainerBlockEntity>,
         slot: u32,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let container = self
-            .resource_table
-            .get::<ContainerBlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid container block entity resource handle"))?;
-        let inventory = container.provider.inventory.clone();
+        let inventory = self.get(&res)?.inventory.clone();
         let removed = inventory.remove_stack(slot as usize);
         if removed.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(
-                tokio::sync::Mutex::new(removed),
-            ))?))
+            Ok(Some(self.add(Arc::new(tokio::sync::Mutex::new(removed)))?))
         }
     }
 
     async fn clear(&mut self, res: Resource<ContainerBlockEntity>) -> wasmtime::Result<()> {
-        let container = self
-            .resource_table
-            .get::<ContainerBlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid container block entity resource handle"))?;
-        let inventory = container.provider.inventory.clone();
+        let inventory = self.get(&res)?.inventory.clone();
         inventory.clear();
         Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<ContainerBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<ContainerBlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -441,12 +403,7 @@ impl HostCommandBlockEntity for PluginHostState {
         &mut self,
         res: Resource<CommandBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid command block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn last_output(&mut self, res: Resource<CommandBlockEntity>) -> wasmtime::Result<String> {
@@ -539,10 +496,7 @@ impl HostCommandBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<CommandBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -551,12 +505,7 @@ impl HostSignBlockEntity for PluginHostState {
         &mut self,
         res: Resource<SignBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid sign block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_front_text(
@@ -690,10 +639,7 @@ impl HostSignBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<SignBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -702,12 +648,7 @@ impl HostJukeboxBlockEntity for PluginHostState {
         &mut self,
         res: Resource<JukeboxBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid jukebox block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -761,10 +702,7 @@ impl HostJukeboxBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<JukeboxBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -773,12 +711,7 @@ impl HostChestBlockEntity for PluginHostState {
         &mut self,
         res: Resource<ChestBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid chest block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -800,10 +733,7 @@ impl HostChestBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<ChestBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -812,14 +742,7 @@ impl HostMobSpawnerBlockEntity for PluginHostState {
         &mut self,
         res: Resource<MobSpawnerBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid mob spawner block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_spawn_count(
@@ -862,10 +785,7 @@ impl HostMobSpawnerBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<MobSpawnerBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -874,12 +794,7 @@ impl HostMapBlockEntity for PluginHostState {
         &mut self,
         res: Resource<MapBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid map block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_map_id(&mut self, res: Resource<MapBlockEntity>) -> wasmtime::Result<i32> {
@@ -990,10 +905,7 @@ impl HostMapBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<MapBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1002,14 +914,7 @@ impl HostHangingSignBlockEntity for PluginHostState {
         &mut self,
         res: Resource<HangingSignBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid hanging sign block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_front_text(
@@ -1143,10 +1048,7 @@ impl HostHangingSignBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<HangingSignBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1155,14 +1057,7 @@ impl HostTrappedChestBlockEntity for PluginHostState {
         &mut self,
         res: Resource<TrappedChestBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid trapped chest block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -1187,10 +1082,7 @@ impl HostTrappedChestBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<TrappedChestBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1201,21 +1093,11 @@ macro_rules! impl_basic_block_entity {
                 &mut self,
                 res: Resource<$resource_name>,
             ) -> wasmtime::Result<Resource<BlockEntity>> {
-                let entity = self
-                    .resource_table
-                    .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-                    .map_err(|_| {
-                        wasmtime::Error::msg(concat!("invalid ", $name_str, " resource handle"))
-                    })?;
-                let provider = entity.provider.clone();
-                self.add_block_entity(provider)
+                self.add(self.get(&res)?.clone() as _)
             }
 
             async fn drop(&mut self, rep: Resource<$resource_name>) -> wasmtime::Result<()> {
-                let _ = self
-                    .resource_table
-                    .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-                Ok(())
+                self.drop(rep)
             }
         }
     };
@@ -1228,14 +1110,7 @@ macro_rules! impl_container_basic_block_entity {
                 &mut self,
                 res: Resource<$resource_name>,
             ) -> wasmtime::Result<Resource<BlockEntity>> {
-                let entity = self
-                    .resource_table
-                    .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-                    .map_err(|_| {
-                        wasmtime::Error::msg(concat!("invalid ", $name_str, " resource handle"))
-                    })?;
-                let provider = entity.provider.clone();
-                self.add_block_entity(provider)
+                self.add(self.get(&res)?.clone() as _)
             }
 
             async fn get_container(
@@ -1246,10 +1121,7 @@ macro_rules! impl_container_basic_block_entity {
             }
 
             async fn drop(&mut self, rep: Resource<$resource_name>) -> wasmtime::Result<()> {
-                let _ = self
-                    .resource_table
-                    .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-                Ok(())
+                self.drop(rep)
             }
         }
     };
@@ -1262,14 +1134,7 @@ macro_rules! impl_cooking_host_block_entity {
                 &mut self,
                 res: Resource<$resource_name>,
             ) -> wasmtime::Result<Resource<BlockEntity>> {
-                let entity = self
-                    .resource_table
-                    .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-                    .map_err(|_| {
-                        wasmtime::Error::msg(concat!("invalid ", $name_str, " resource handle"))
-                    })?;
-                let provider = entity.provider.clone();
-                self.add_block_entity(provider)
+                self.add(self.get(&res)?.clone() as _)
             }
 
             async fn get_container(
@@ -1335,10 +1200,7 @@ macro_rules! impl_cooking_host_block_entity {
             }
 
             async fn drop(&mut self, rep: Resource<$resource_name>) -> wasmtime::Result<()> {
-                let _ = self
-                    .resource_table
-                    .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-                Ok(())
+                self.drop(rep)
             }
         }
     };
@@ -1368,12 +1230,7 @@ impl HostBannerBlockEntity for PluginHostState {
         &mut self,
         res: Resource<BannerBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid banner block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_custom_name(
@@ -1388,10 +1245,7 @@ impl HostBannerBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<BannerBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1400,12 +1254,7 @@ impl HostBarrelBlockEntity for PluginHostState {
         &mut self,
         res: Resource<BarrelBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid barrel block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -1420,10 +1269,7 @@ impl HostBarrelBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<BarrelBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1432,12 +1278,7 @@ impl HostBeaconBlockEntity for PluginHostState {
         &mut self,
         res: Resource<BeaconBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid beacon block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -1483,10 +1324,7 @@ impl HostBeaconBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<BeaconBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1495,12 +1333,7 @@ impl HostBeehiveBlockEntity for PluginHostState {
         &mut self,
         res: Resource<BeehiveBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid beehive block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_bee_count(&mut self, res: Resource<BeehiveBlockEntity>) -> wasmtime::Result<u32> {
@@ -1518,10 +1351,7 @@ impl HostBeehiveBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<BeehiveBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1530,12 +1360,7 @@ impl HostBellBlockEntity for PluginHostState {
         &mut self,
         res: Resource<BellBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid bell block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn is_ringing(&mut self, res: Resource<BellBlockEntity>) -> wasmtime::Result<bool> {
@@ -1555,10 +1380,7 @@ impl HostBellBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<BellBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1567,14 +1389,7 @@ impl HostBrewingStandBlockEntity for PluginHostState {
         &mut self,
         res: Resource<BrewingStandBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid brewing stand block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -1606,10 +1421,7 @@ impl HostBrewingStandBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<BrewingStandBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1618,14 +1430,7 @@ impl HostChiseledBookshelfBlockEntity for PluginHostState {
         &mut self,
         res: Resource<ChiseledBookshelfBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid chiseled bookshelf block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -1650,10 +1455,7 @@ impl HostChiseledBookshelfBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<ChiseledBookshelfBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1662,12 +1464,7 @@ impl HostComparatorBlockEntity for PluginHostState {
         &mut self,
         res: Resource<ComparatorBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid comparator block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_output_signal(
@@ -1684,10 +1481,7 @@ impl HostComparatorBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<ComparatorBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1696,12 +1490,7 @@ impl HostCrafterBlockEntity for PluginHostState {
         &mut self,
         res: Resource<CrafterBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid crafter block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -1734,10 +1523,7 @@ impl HostCrafterBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<CrafterBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1746,14 +1532,7 @@ impl HostCreakingHeartBlockEntity for PluginHostState {
         &mut self,
         res: Resource<CreakingHeartBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid creaking heart block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_creaking_uuid(
@@ -1768,10 +1547,7 @@ impl HostCreakingHeartBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<CreakingHeartBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1780,14 +1556,7 @@ impl HostEndGatewayBlockEntity for PluginHostState {
         &mut self,
         res: Resource<EndGatewayBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid end gateway block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_age(&mut self, res: Resource<EndGatewayBlockEntity>) -> wasmtime::Result<i64> {
@@ -1810,10 +1579,7 @@ impl HostEndGatewayBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<EndGatewayBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1822,14 +1588,7 @@ impl HostEnderChestBlockEntity for PluginHostState {
         &mut self,
         res: Resource<EnderChestBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid ender chest block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn viewer_count(
@@ -1840,10 +1599,7 @@ impl HostEnderChestBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<EnderChestBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1852,14 +1608,7 @@ impl HostShulkerBoxBlockEntity for PluginHostState {
         &mut self,
         res: Resource<ShulkerBoxBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid shulker box block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -1877,10 +1626,7 @@ impl HostShulkerBoxBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<ShulkerBoxBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1889,12 +1635,7 @@ impl HostHopperBlockEntity for PluginHostState {
         &mut self,
         res: Resource<HopperBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid hopper block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -1915,10 +1656,7 @@ impl HostHopperBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<HopperBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1927,12 +1665,7 @@ impl HostJigsawBlockEntity for PluginHostState {
         &mut self,
         res: Resource<JigsawBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid jigsaw block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_name(&mut self, res: Resource<JigsawBlockEntity>) -> wasmtime::Result<String> {
@@ -2019,10 +1752,7 @@ impl HostJigsawBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<JigsawBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -2031,12 +1761,7 @@ impl HostLecternBlockEntity for PluginHostState {
         &mut self,
         res: Resource<LecternBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid lectern block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_container(
@@ -2057,10 +1782,7 @@ impl HostLecternBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<LecternBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -2069,12 +1791,7 @@ impl HostPistonBlockEntity for PluginHostState {
         &mut self,
         res: Resource<PistonBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid piston block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_progress(&mut self, res: Resource<PistonBlockEntity>) -> wasmtime::Result<f32> {
@@ -2102,10 +1819,7 @@ impl HostPistonBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<PistonBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -2114,14 +1828,7 @@ impl HostSculkShriekerBlockEntity for PluginHostState {
         &mut self,
         res: Resource<SculkShriekerBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid sculk shrieker block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_warning_level(
@@ -2136,10 +1843,7 @@ impl HostSculkShriekerBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<SculkShriekerBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -2148,12 +1852,7 @@ impl HostSkullBlockEntity for PluginHostState {
         &mut self,
         res: Resource<SkullBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid skull block entity resource handle"))?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_note_block_sound(
@@ -2168,10 +1867,7 @@ impl HostSkullBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<SkullBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -2180,14 +1876,7 @@ impl HostStructureBlockBlockEntity for PluginHostState {
         &mut self,
         res: Resource<StructureBlockBlockEntity>,
     ) -> wasmtime::Result<Resource<BlockEntity>> {
-        let entity = self
-            .resource_table
-            .get::<BlockEntityResource>(&Resource::new_own(res.rep()))
-            .map_err(|_| {
-                wasmtime::Error::msg("invalid structure block block entity resource handle")
-            })?;
-        let provider = entity.provider.clone();
-        self.add_block_entity(provider)
+        self.add(self.get(&res)?.clone() as _)
     }
 
     async fn get_name(
@@ -2261,10 +1950,7 @@ impl HostStructureBlockBlockEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<StructureBlockBlockEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/boss_bar.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/boss_bar.rs
@@ -1,5 +1,5 @@
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{BossBarResource, PlayerResource, PluginHostState},
+    state::PluginHostState,
     wit::v0_1::pumpkin::plugin::boss_bar::{
         self, BossBar, BossBarColor as WitColor, BossBarDivision as WitDivision,
         BossBarMetadata as WitMetadata,
@@ -35,11 +35,7 @@ fn player_from_resource(
         crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::Player,
     >,
 ) -> wasmtime::Result<std::sync::Arc<crate::entity::player::Player>> {
-    state
-        .resource_table
-        .get::<PlayerResource>(&Resource::new_own(player.rep()))
-        .map_err(wasmtime::Error::from)
-        .map(|resource| resource.provider.clone())
+    state.get(player).cloned()
 }
 
 const fn to_wit_color(color: BossbarColor) -> WitColor {
@@ -108,13 +104,6 @@ fn from_wit_metadata(metadata: WitMetadata) -> BossbarFlags {
     f
 }
 
-impl PluginHostState {
-    fn get_bossbar_res(&self, res: &Resource<BossBar>) -> wasmtime::Result<&BossBarResource> {
-        self.resource_table
-            .get::<BossBarResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-}
 
 impl boss_bar::Host for PluginHostState {}
 
@@ -127,7 +116,7 @@ impl boss_bar::HostBossBar for PluginHostState {
         color: WitColor,
         division: WitDivision,
     ) -> wasmtime::Result<Resource<BossBar>> {
-        let title = self.get_text_provider(&title)?;
+        let title = self.take(title)?;
         let mut bossbar = Bossbar::new(title);
 
         bossbar.color = from_wit_color(color);
@@ -142,7 +131,7 @@ impl boss_bar::HostBossBar for PluginHostState {
             bossbar,
             Arc::downgrade(&server),
         )));
-        self.add_boss_bar(plugin_bossbar)
+        self.add(plugin_bossbar)
     }
 
     async fn get_title(
@@ -154,10 +143,10 @@ impl boss_bar::HostBossBar for PluginHostState {
         >,
     > {
         let title = {
-            let bossbar = self.get_bossbar_res(&res)?.provider.lock().await;
+            let bossbar = self.get(&res)?.lock().await;
             bossbar.bossbar.title.clone()
         };
-        self.add_text_component(title)
+        self.add(title)
             .map_err(|_| wasmtime::Error::msg("Failed to add text component"))
     }
 
@@ -168,8 +157,8 @@ impl boss_bar::HostBossBar for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::text::TextComponent,
         >,
     ) -> wasmtime::Result<()> {
-        let title = self.get_text_provider(&title)?;
-        let mut pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let title = self.get(&title)?;
+        let mut pbb = self.get(&res)?.lock().await;
         pbb.bossbar.title = title.clone();
         if let Some(server) = pbb.server.upgrade() {
             for uuid in &pbb.players {
@@ -182,12 +171,12 @@ impl boss_bar::HostBossBar for PluginHostState {
     }
 
     async fn get_health(&mut self, res: Resource<BossBar>) -> wasmtime::Result<f32> {
-        let pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let pbb = self.get(&res)?.lock().await;
         Ok(pbb.bossbar.health)
     }
 
     async fn set_health(&mut self, res: Resource<BossBar>, health: f32) -> wasmtime::Result<()> {
-        let mut pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let mut pbb = self.get(&res)?.lock().await;
         pbb.bossbar.health = health;
         if let Some(server) = pbb.server.upgrade() {
             for uuid in &pbb.players {
@@ -200,12 +189,12 @@ impl boss_bar::HostBossBar for PluginHostState {
     }
 
     async fn get_color(&mut self, res: Resource<BossBar>) -> wasmtime::Result<WitColor> {
-        let pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let pbb = self.get(&res)?.lock().await;
         Ok(to_wit_color(pbb.bossbar.color))
     }
 
     async fn set_color(&mut self, res: Resource<BossBar>, color: WitColor) -> wasmtime::Result<()> {
-        let mut pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let mut pbb = self.get(&res)?.lock().await;
         pbb.bossbar.color = from_wit_color(color);
         if let Some(server) = pbb.server.upgrade() {
             for uuid in &pbb.players {
@@ -222,7 +211,7 @@ impl boss_bar::HostBossBar for PluginHostState {
     }
 
     async fn get_division(&mut self, res: Resource<BossBar>) -> wasmtime::Result<WitDivision> {
-        let pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let pbb = self.get(&res)?.lock().await;
         Ok(to_wit_division(pbb.bossbar.division))
     }
 
@@ -231,7 +220,7 @@ impl boss_bar::HostBossBar for PluginHostState {
         res: Resource<BossBar>,
         division: WitDivision,
     ) -> wasmtime::Result<()> {
-        let mut pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let mut pbb = self.get(&res)?.lock().await;
         pbb.bossbar.division = from_wit_division(division);
         if let Some(server) = pbb.server.upgrade() {
             for uuid in &pbb.players {
@@ -248,7 +237,7 @@ impl boss_bar::HostBossBar for PluginHostState {
     }
 
     async fn get_metadata(&mut self, res: Resource<BossBar>) -> wasmtime::Result<WitMetadata> {
-        let pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let pbb = self.get(&res)?.lock().await;
         Ok(to_wit_metadata(pbb.bossbar.flags))
     }
 
@@ -257,7 +246,7 @@ impl boss_bar::HostBossBar for PluginHostState {
         res: Resource<BossBar>,
         metadata: WitMetadata,
     ) -> wasmtime::Result<()> {
-        let mut pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let mut pbb = self.get(&res)?.lock().await;
         pbb.bossbar.flags = from_wit_metadata(metadata);
         if let Some(server) = pbb.server.upgrade() {
             for uuid in &pbb.players {
@@ -280,7 +269,7 @@ impl boss_bar::HostBossBar for PluginHostState {
         >,
     > {
         let players = {
-            let pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+            let pbb = self.get(&res)?.lock().await;
             pbb.players.clone()
         };
 
@@ -292,7 +281,7 @@ impl boss_bar::HostBossBar for PluginHostState {
         let mut wit_players = Vec::new();
         for uuid in players {
             if let Some(player) = server.get_player_by_uuid(uuid) {
-                wit_players.push(self.add_player(player)?);
+                wit_players.push(self.add(player)?);
             }
         }
         Ok(wit_players)
@@ -305,7 +294,7 @@ impl boss_bar::HostBossBar for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::Player,
         >,
     ) -> wasmtime::Result<()> {
-        let mut pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let mut pbb = self.get(&res)?.lock().await;
         let player = player_from_resource(self, &player)?;
         let uuid = player.gameprofile.id;
 
@@ -323,7 +312,7 @@ impl boss_bar::HostBossBar for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::Player,
         >,
     ) -> wasmtime::Result<()> {
-        let mut pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let mut pbb = self.get(&res)?.lock().await;
         let player = player_from_resource(self, &player)?;
         let uuid = player.gameprofile.id;
 
@@ -335,7 +324,7 @@ impl boss_bar::HostBossBar for PluginHostState {
     }
 
     async fn remove_all(&mut self, res: Resource<BossBar>) -> wasmtime::Result<()> {
-        let pbb = self.get_bossbar_res(&res)?.provider.lock().await;
+        let pbb = self.get(&res)?.lock().await;
         if let Some(server) = pbb.server.upgrade() {
             for uuid in &pbb.players {
                 if let Some(player) = server.get_player_by_uuid(*uuid) {
@@ -348,10 +337,7 @@ impl boss_bar::HostBossBar for PluginHostState {
 
     async fn drop(&mut self, res: Resource<BossBar>) -> wasmtime::Result<()> {
         let rep = res.rep();
-        self.remove_all(res).await?;
-        self.resource_table
-            .delete::<BossBarResource>(Resource::new_own(rep))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.remove_all(Resource::new_borrow(rep)).await?;
+        self.drop(res)
     }
 }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/boss_bar.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/boss_bar.rs
@@ -29,15 +29,6 @@ impl PluginBossBar {
     }
 }
 
-fn player_from_resource(
-    state: &PluginHostState,
-    player: &Resource<
-        crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::Player,
-    >,
-) -> wasmtime::Result<std::sync::Arc<crate::entity::player::Player>> {
-    state.get(player).cloned()
-}
-
 const fn to_wit_color(color: BossbarColor) -> WitColor {
     match color {
         BossbarColor::Pink => WitColor::Pink,
@@ -104,7 +95,6 @@ fn from_wit_metadata(metadata: WitMetadata) -> BossbarFlags {
     f
 }
 
-
 impl boss_bar::Host for PluginHostState {}
 
 impl boss_bar::HostBossBar for PluginHostState {
@@ -142,12 +132,8 @@ impl boss_bar::HostBossBar for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::text::TextComponent,
         >,
     > {
-        let title = {
-            let bossbar = self.get(&res)?.lock().await;
-            bossbar.bossbar.title.clone()
-        };
+        let title = self.get(&res)?.lock().await.bossbar.title.clone();
         self.add(title)
-            .map_err(|_| wasmtime::Error::msg("Failed to add text component"))
     }
 
     async fn set_title(
@@ -157,7 +143,7 @@ impl boss_bar::HostBossBar for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::text::TextComponent,
         >,
     ) -> wasmtime::Result<()> {
-        let title = self.get(&title)?;
+        let title = self.take(title)?;
         let mut pbb = self.get(&res)?.lock().await;
         pbb.bossbar.title = title.clone();
         if let Some(server) = pbb.server.upgrade() {
@@ -294,8 +280,8 @@ impl boss_bar::HostBossBar for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::Player,
         >,
     ) -> wasmtime::Result<()> {
+        let player = self.take(player)?;
         let mut pbb = self.get(&res)?.lock().await;
-        let player = player_from_resource(self, &player)?;
         let uuid = player.gameprofile.id;
 
         if !pbb.players.contains(&uuid) {
@@ -312,8 +298,8 @@ impl boss_bar::HostBossBar for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::Player,
         >,
     ) -> wasmtime::Result<()> {
+        let player = self.take(player)?;
         let mut pbb = self.get(&res)?.lock().await;
-        let player = player_from_resource(self, &player)?;
         let uuid = player.gameprofile.id;
 
         if let Some(idx) = pbb.players.iter().position(|&x| x == uuid) {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/executor.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/executor.rs
@@ -172,7 +172,10 @@ impl SuggestionProvider for WasmCommandSuggestionProvider {
                                     let mut builder = builder;
                                     for suggestion in response.values {
                                         if let Some(tooltip) = suggestion.tooltip {
-                                            let text = store.data_mut().take(tooltip).expect("Invalid text component");
+                                            let text = store
+                                                .data_mut()
+                                                .take(tooltip)
+                                                .expect("Invalid text component");
                                             builder = builder
                                                 .suggest_with_tooltip(suggestion.value, text);
                                         } else {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/executor.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/executor.rs
@@ -16,19 +16,13 @@ use crate::{
         },
     },
     plugin::loader::wasm::wasm_host::{
-        DowncastResourceExt, PluginInstance, WasmPlugin,
+        PluginInstance, WasmPlugin,
         args::build_consumed_args_from_context,
-        state::{CommandSenderResource, ConsumedArgsResource, PluginHostState, ServerResource},
+        state::PluginHostState,
         wit::v0_1::pumpkin::plugin::command::{CommandError as CommandErrorWit, SuggestionRequest},
     },
     server::Server,
 };
-
-fn remove_resource<T: 'static>(state: &mut PluginHostState, rep: u32) {
-    let _ = state
-        .resource_table
-        .delete::<T>(wasmtime::component::Resource::new_own(rep));
-}
 
 fn map_command_result(
     state: &mut PluginHostState,
@@ -44,9 +38,12 @@ fn map_command_result(
             .create_without_context(TextComponent::text("Invalid requirement"))),
         Err(CommandErrorWit::PermissionDenied) => Err(DISPATCHER_PARSE_EXCEPTION
             .create_without_context(TextComponent::text("Permission denied"))),
-        Err(CommandErrorWit::CommandFailed(resource)) => {
-            Err(DISPATCHER_PARSE_EXCEPTION.create_without_context(resource.consume(state).provider))
-        }
+        Err(CommandErrorWit::CommandFailed(resource)) => Err(DISPATCHER_PARSE_EXCEPTION
+            .create_without_context(
+                state
+                    .take(resource)
+                    .expect("todo: make this method return a result"),
+            )),
     }
 }
 
@@ -72,44 +69,28 @@ impl CommandExecutor for WasmCommandExecutor {
                     .store
                     .call_guest(move |mut guest| {
                         Box::pin(async move {
-                            let (sender_resource, server_resource, args_resource, reps) = guest
-                                .with(|mut store| {
-                                    let sender_resource =
-                                        store.data_mut().add_command_sender(sender)?;
-                                    let sender_rep = sender_resource.rep();
-                                    let server_resource = match store.data_mut().add_server(server)
-                                    {
+                            let (sender_resource, server_resource, args_resource) =
+                                guest.with(|mut store| {
+                                    let sender_resource = store.data_mut().add(sender)?;
+                                    let server_resource = match store.data_mut().add(server) {
                                         Ok(resource) => resource,
                                         Err(error) => {
-                                            remove_resource::<CommandSenderResource>(
-                                                store.data_mut(),
-                                                sender_rep,
-                                            );
+                                            store.data_mut().discard(sender_resource);
                                             return Err(error);
                                         }
                                     };
-                                    let server_rep = server_resource.rep();
-                                    let args_resource =
-                                        match store.data_mut().add_consumed_args(consumed_args) {
-                                            Ok(resource) => resource,
-                                            Err(error) => {
-                                                remove_resource::<ServerResource>(
-                                                    store.data_mut(),
-                                                    server_rep,
-                                                );
-                                                remove_resource::<CommandSenderResource>(
-                                                    store.data_mut(),
-                                                    sender_rep,
-                                                );
-                                                return Err(error);
-                                            }
-                                        };
-                                    let reps = (sender_rep, server_rep, args_resource.rep());
+                                    let args_resource = match store.data_mut().add(consumed_args) {
+                                        Ok(resource) => resource,
+                                        Err(error) => {
+                                            store.data_mut().discard(sender_resource);
+                                            store.data_mut().discard(server_resource);
+                                            return Err(error);
+                                        }
+                                    };
                                     Ok::<_, wasmtime::Error>((
                                         sender_resource,
                                         server_resource,
                                         args_resource,
-                                        reps,
                                     ))
                                 })?;
 
@@ -121,12 +102,7 @@ impl CommandExecutor for WasmCommandExecutor {
                                 .await;
 
                             guest.with(|mut store| {
-                                let result = result
-                                    .map(|(result,)| map_command_result(store.data_mut(), result));
-                                remove_resource::<CommandSenderResource>(store.data_mut(), reps.0);
-                                remove_resource::<ServerResource>(store.data_mut(), reps.1);
-                                remove_resource::<ConsumedArgsResource>(store.data_mut(), reps.2);
-                                result
+                                result.map(|(result,)| map_command_result(store.data_mut(), result))
                             })
                         })
                     })
@@ -173,29 +149,17 @@ impl SuggestionProvider for WasmCommandSuggestionProvider {
                     .store
                     .call_guest(move |mut guest| {
                         Box::pin(async move {
-                            let (sender_resource, server_resource, reps) =
-                                guest.with(|mut store| {
-                                    let sender_resource =
-                                        store.data_mut().add_command_sender(sender)?;
-                                    let sender_rep = sender_resource.rep();
-                                    let server_resource = match store.data_mut().add_server(server)
-                                    {
-                                        Ok(resource) => resource,
-                                        Err(error) => {
-                                            remove_resource::<CommandSenderResource>(
-                                                store.data_mut(),
-                                                sender_rep,
-                                            );
-                                            return Err(error);
-                                        }
-                                    };
-                                    let reps = (sender_rep, server_resource.rep());
-                                    Ok::<_, wasmtime::Error>((
-                                        sender_resource,
-                                        server_resource,
-                                        reps,
-                                    ))
-                                })?;
+                            let (sender_resource, server_resource) = guest.with(|mut store| {
+                                let sender_resource = store.data_mut().add(sender)?;
+                                let server_resource = match store.data_mut().add(server) {
+                                    Ok(resource) => resource,
+                                    Err(error) => {
+                                        store.data_mut().discard(sender_resource);
+                                        return Err(error);
+                                    }
+                                };
+                                Ok::<_, wasmtime::Error>((sender_resource, server_resource))
+                            })?;
                             let response = guest
                                 .call(
                                     function,
@@ -204,11 +168,11 @@ impl SuggestionProvider for WasmCommandSuggestionProvider {
                                 .await
                                 .map(|(response,)| response);
                             guest.with(|mut store| {
-                                let suggestions = response.map(|response| {
+                                response.map(|response| {
                                     let mut builder = builder;
                                     for suggestion in response.values {
                                         if let Some(tooltip) = suggestion.tooltip {
-                                            let text = tooltip.consume(store.data_mut()).provider;
+                                            let text = store.data_mut().take(tooltip).expect("Invalid text component");
                                             builder = builder
                                                 .suggest_with_tooltip(suggestion.value, text);
                                         } else {
@@ -216,10 +180,7 @@ impl SuggestionProvider for WasmCommandSuggestionProvider {
                                         }
                                     }
                                     builder.build()
-                                });
-                                remove_resource::<CommandSenderResource>(store.data_mut(), reps.0);
-                                remove_resource::<ServerResource>(store.data_mut(), reps.1);
-                                suggestions
+                                })
                             })
                         })
                     })

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/mod.rs
@@ -456,13 +456,13 @@ impl pumpkin::plugin::command::HostCommandSenderWithStore<PluginHostState>
     async fn has_permission(
         mut host: Access<'_, PluginHostState, Self>,
         sender: Resource<CommandSender>,
-        server: Resource<Server>,
+        server: /* borrow */ Resource<Server>,
         node: String,
     ) -> wasmtime::Result<bool> {
         let (sender, server, plugin) = {
             let state = host.get();
             let sender = state.get(&sender)?.clone();
-            let server = state.take(server)?;
+            let server = state.get(&server)?.clone();
             let plugin = state
                 .plugin
                 .as_ref()

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/commands/mod.rs
@@ -26,10 +26,7 @@ use crate::{
         },
     },
     plugin::loader::wasm::wasm_host::{
-        state::{
-            CommandNodeResource, CommandResource, CommandSenderResource, ConsumedArgsResource,
-            PluginHostState, ServerResource, TextComponentResource, WasmCommand, WasmCommandNode,
-        },
+        state::{PluginHostState, WasmCommand, WasmCommandNode},
         wit::v0_1::{
             commands::executor::{WasmCommandExecutor, WasmCommandSuggestionProvider},
             pumpkin::{
@@ -52,46 +49,6 @@ use crate::{
 
 pub mod executor;
 
-impl PluginHostState {
-    fn get_command_mut(
-        &mut self,
-        res: &Resource<Command>,
-    ) -> wasmtime::Result<&mut CommandResource> {
-        self.resource_table
-            .get_mut::<CommandResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-    fn get_node_mut(
-        &mut self,
-        res: &Resource<CommandNode>,
-    ) -> wasmtime::Result<&mut CommandNodeResource> {
-        self.resource_table
-            .get_mut::<CommandNodeResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-    fn take_node(&mut self, res: &Resource<CommandNode>) -> wasmtime::Result<CommandNodeResource> {
-        self.resource_table
-            .delete::<CommandNodeResource>(Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-    fn get_sender_res(
-        &self,
-        res: &Resource<CommandSender>,
-    ) -> wasmtime::Result<&CommandSenderResource> {
-        self.resource_table
-            .get::<CommandSenderResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-    fn get_sender_mut(
-        &mut self,
-        res: &Resource<CommandSender>,
-    ) -> wasmtime::Result<&mut CommandSenderResource> {
-        self.resource_table
-            .get_mut::<CommandSenderResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-}
-
 impl pumpkin::plugin::command::Host for PluginHostState {}
 
 impl pumpkin::plugin::command::HostConsumedArgs for PluginHostState {
@@ -103,12 +60,9 @@ impl pumpkin::plugin::command::HostConsumedArgs for PluginHostState {
     ) -> wasmtime::Result<Arg> {
         use crate::plugin::loader::wasm::wasm_host::args::OwnedArg;
 
-        let resource = self
-            .resource_table
-            .get::<ConsumedArgsResource>(&Resource::new_own(consumed_args.rep()))
-            .map_err(wasmtime::Error::from)?;
+        let resource = self.get(&consumed_args)?;
 
-        let Some(owned_arg) = resource.provider.get(&key).cloned() else {
+        let Some(owned_arg) = resource.get(&key).cloned() else {
             return Ok(Arg::Simple(String::new()));
         };
 
@@ -168,20 +122,14 @@ impl pumpkin::plugin::command::HostConsumedArgs for PluginHostState {
             OwnedArg::Players(players) => {
                 let mut resources = Vec::new();
                 for p in players {
-                    if let Ok(r) = self.add_player(p) {
+                    if let Ok(r) = self.add(p) {
                         resources.push(r);
                     }
                 }
                 Arg::Players(resources)
             }
             OwnedArg::Particle(p) => Arg::Particle(format!("{p:?}")),
-            OwnedArg::TextComponent(t) => {
-                let r = self
-                    .resource_table
-                    .push(TextComponentResource { provider: t })
-                    .map_err(wasmtime::Error::from)?;
-                Arg::TextComponent(wasmtime::component::Resource::new_own(r.rep()))
-            }
+            OwnedArg::TextComponent(t) => Arg::TextComponent(self.add(t)?),
             OwnedArg::BossbarColor(c) => Arg::BossbarColor(match c {
                 crate::world::bossbar::BossbarColor::Pink => {
                     pumpkin::plugin::command::BossbarColor::Pink
@@ -275,10 +223,7 @@ impl pumpkin::plugin::command::HostConsumedArgs for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<ConsumedArgs>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<ConsumedArgsResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -288,7 +233,7 @@ impl pumpkin::plugin::command::HostCommand for PluginHostState {
         names: Vec<String>,
         description: String,
     ) -> wasmtime::Result<Resource<Command>> {
-        self.add_command(WasmCommand::new(names, description))
+        self.add(WasmCommand::new(names, description))
             .map_err(|_| wasmtime::Error::msg("Failed to add command resource"))
     }
 
@@ -297,13 +242,10 @@ impl pumpkin::plugin::command::HostCommand for PluginHostState {
         command: Resource<Command>,
         node: Resource<CommandNode>,
     ) -> wasmtime::Result<()> {
-        let node_data = self.take_node(&node)?;
-        let command_res = self.get_command_mut(&command)?;
-        let cmd = std::mem::replace(
-            &mut command_res.provider,
-            WasmCommand::new(Vec::new(), String::new()),
-        );
-        command_res.provider = cmd.then(node_data.provider);
+        let node_data = self.take(node)?;
+        let command_res = self.get_mut(&command)?;
+        let cmd = std::mem::replace(command_res, WasmCommand::new(Vec::new(), String::new()));
+        *command_res = cmd.then(node_data);
         Ok(())
     }
 
@@ -327,20 +269,14 @@ impl pumpkin::plugin::command::HostCommand for PluginHostState {
             plugin,
             server,
         };
-        let command_res = self.get_command_mut(&command)?;
-        let cmd = std::mem::replace(
-            &mut command_res.provider,
-            WasmCommand::new(Vec::new(), String::new()),
-        );
-        command_res.provider = cmd.executes(executor);
+        let command_res = self.get_mut(&command)?;
+        let cmd = std::mem::replace(command_res, WasmCommand::new(Vec::new(), String::new()));
+        *command_res = cmd.executes(executor);
         Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<Command>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<CommandResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -349,25 +285,22 @@ impl pumpkin::plugin::command::HostCommandSender for PluginHostState {
         &mut self,
         res: Resource<CommandSender>,
     ) -> wasmtime::Result<CommandSenderType> {
-        let sender = self.get_sender_res(&res)?.provider.clone();
+        let sender = self.get(&res)?.clone();
         match sender {
             crate::command::CommandSender::Rcon(_) => Ok(CommandSenderType::Rcon),
             crate::command::CommandSender::Console => Ok(CommandSenderType::Console),
             crate::command::CommandSender::Player(player) => {
-                Ok(CommandSenderType::Player(self.add_player(player)?))
+                Ok(CommandSenderType::Player(self.add(player)?))
             }
-            crate::command::CommandSender::CommandBlock(block_entity, world) => {
-                Ok(CommandSenderType::CommandBlock((
-                    self.add_block_entity(block_entity)?,
-                    self.add_world(world)?,
-                )))
-            }
+            crate::command::CommandSender::CommandBlock(block_entity, world) => Ok(
+                CommandSenderType::CommandBlock((self.add(block_entity)?, self.add(world)?)),
+            ),
             crate::command::CommandSender::Dummy => Ok(CommandSenderType::Dummy),
         }
     }
 
     async fn get_name(&mut self, sender: Resource<CommandSender>) -> wasmtime::Result<String> {
-        Ok(self.get_sender_res(&sender)?.provider.to_string())
+        Ok(self.get(&sender)?.to_string())
     }
 
     async fn send_message(
@@ -375,14 +308,8 @@ impl pumpkin::plugin::command::HostCommandSender for PluginHostState {
         sender: Resource<CommandSender>,
         text: Resource<TextComponent>,
     ) -> wasmtime::Result<()> {
-        let component = self
-            .resource_table
-            .get::<TextComponentResource>(&Resource::new_own(text.rep()))?
-            .provider
-            .clone();
-        self.get_sender_res(&sender)?
-            .provider
-            .send_message(component);
+        let component = self.take(text)?;
+        self.get(&sender)?.send_message(component);
         Ok(())
     }
 
@@ -391,14 +318,8 @@ impl pumpkin::plugin::command::HostCommandSender for PluginHostState {
         sender: Resource<CommandSender>,
         text: Resource<TextComponent>,
     ) -> wasmtime::Result<()> {
-        let component = self
-            .resource_table
-            .get::<TextComponentResource>(&Resource::new_own(text.rep()))?
-            .provider
-            .clone();
-        self.get_sender_res(&sender)?
-            .provider
-            .send_message(component);
+        let component = self.take(text)?;
+        self.get(&sender)?.send_message(component);
         Ok(())
     }
 
@@ -407,13 +328,8 @@ impl pumpkin::plugin::command::HostCommandSender for PluginHostState {
         sender: Resource<CommandSender>,
         text: Resource<TextComponent>,
     ) -> wasmtime::Result<()> {
-        let component = self
-            .resource_table
-            .get::<TextComponentResource>(&Resource::new_own(text.rep()))?
-            .provider
-            .clone();
-        self.get_sender_res(&sender)?
-            .provider
+        let component = self.take(text)?;
+        self.get(&sender)?
             .send_message(component.color(pumpkin_util::text::color::Color::Named(
                 pumpkin_util::text::color::NamedColor::Red,
             )));
@@ -425,22 +341,20 @@ impl pumpkin::plugin::command::HostCommandSender for PluginHostState {
         sender: Resource<CommandSender>,
         count: i32,
     ) -> wasmtime::Result<()> {
-        self.get_sender_mut(&sender)?
-            .provider
-            .set_success_count(count as u32);
+        self.get_mut(&sender)?.set_success_count(count as u32);
         Ok(())
     }
 
     async fn is_player(&mut self, sender: Resource<CommandSender>) -> wasmtime::Result<bool> {
         Ok(matches!(
-            self.get_sender_res(&sender)?.provider,
+            self.get(&sender)?,
             crate::command::CommandSender::Player(_)
         ))
     }
 
     async fn is_console(&mut self, sender: Resource<CommandSender>) -> wasmtime::Result<bool> {
         Ok(matches!(
-            self.get_sender_res(&sender)?.provider,
+            self.get(&sender)?,
             crate::command::CommandSender::Console | crate::command::CommandSender::Rcon(_)
         ))
     }
@@ -449,10 +363,8 @@ impl pumpkin::plugin::command::HostCommandSender for PluginHostState {
         &mut self,
         sender: Resource<CommandSender>,
     ) -> wasmtime::Result<Option<Resource<Player>>> {
-        if let crate::command::CommandSender::Player(player) =
-            &self.get_sender_res(&sender)?.provider
-        {
-            Ok(Some(self.add_player(player.clone()).map_err(|_| {
+        if let crate::command::CommandSender::Player(player) = &self.get(&sender)? {
+            Ok(Some(self.add(player.clone()).map_err(|_| {
                 wasmtime::Error::msg("Failed to add player resource")
             })?))
         } else {
@@ -464,15 +376,13 @@ impl pumpkin::plugin::command::HostCommandSender for PluginHostState {
         &mut self,
         sender: Resource<CommandSender>,
     ) -> wasmtime::Result<PermissionLevel> {
-        Ok(
-            match self.get_sender_res(&sender)?.provider.permission_lvl() {
-                pumpkin_util::PermissionLvl::Zero => PermissionLevel::Zero,
-                pumpkin_util::PermissionLvl::One => PermissionLevel::One,
-                pumpkin_util::PermissionLvl::Two => PermissionLevel::Two,
-                pumpkin_util::PermissionLvl::Three => PermissionLevel::Three,
-                pumpkin_util::PermissionLvl::Four => PermissionLevel::Four,
-            },
-        )
+        Ok(match self.get(&sender)?.permission_lvl() {
+            pumpkin_util::PermissionLvl::Zero => PermissionLevel::Zero,
+            pumpkin_util::PermissionLvl::One => PermissionLevel::One,
+            pumpkin_util::PermissionLvl::Two => PermissionLevel::Two,
+            pumpkin_util::PermissionLvl::Three => PermissionLevel::Three,
+            pumpkin_util::PermissionLvl::Four => PermissionLevel::Four,
+        })
     }
 
     async fn has_permission_level(
@@ -487,26 +397,22 @@ impl pumpkin::plugin::command::HostCommandSender for PluginHostState {
             PermissionLevel::Three => pumpkin_util::PermissionLvl::Three,
             PermissionLevel::Four => pumpkin_util::PermissionLvl::Four,
         };
-        Ok(self.get_sender_res(&sender)?.provider.permission_lvl() >= required)
+        Ok(self.get(&sender)?.permission_lvl() >= required)
     }
 
     async fn position(
         &mut self,
         sender: Resource<CommandSender>,
     ) -> wasmtime::Result<Option<Position>> {
-        Ok(self
-            .get_sender_res(&sender)?
-            .provider
-            .position()
-            .map(|p| (p.x, p.y, p.z)))
+        Ok(self.get(&sender)?.position().map(|p| (p.x, p.y, p.z)))
     }
 
     async fn world(
         &mut self,
         sender: Resource<CommandSender>,
     ) -> wasmtime::Result<Option<Resource<World>>> {
-        if let Some(world) = self.get_sender_res(&sender)?.provider.world() {
-            Ok(Some(self.add_world(world).map_err(|_| {
+        if let Some(world) = self.get(&sender)?.world() {
+            Ok(Some(self.add(world).map_err(|_| {
                 wasmtime::Error::msg("Failed to add world resource")
             })?))
         } else {
@@ -515,43 +421,32 @@ impl pumpkin::plugin::command::HostCommandSender for PluginHostState {
     }
 
     async fn get_locale(&mut self, sender: Resource<CommandSender>) -> wasmtime::Result<Locale> {
-        Ok(map_util_locale_to_wit(
-            self.get_sender_res(&sender)?.provider.get_locale(),
-        ))
+        Ok(map_util_locale_to_wit(self.get(&sender)?.get_locale()))
     }
 
     async fn should_receive_feedback(
         &mut self,
         sender: Resource<CommandSender>,
     ) -> wasmtime::Result<bool> {
-        Ok(self
-            .get_sender_res(&sender)?
-            .provider
-            .should_receive_feedback())
+        Ok(self.get(&sender)?.should_receive_feedback())
     }
 
     async fn should_broadcast_console_to_ops(
         &mut self,
         sender: Resource<CommandSender>,
     ) -> wasmtime::Result<bool> {
-        Ok(self
-            .get_sender_res(&sender)?
-            .provider
-            .should_broadcast_console_to_ops())
+        Ok(self.get(&sender)?.should_broadcast_console_to_ops())
     }
 
     async fn should_track_output(
         &mut self,
         sender: Resource<CommandSender>,
     ) -> wasmtime::Result<bool> {
-        Ok(self.get_sender_res(&sender)?.provider.should_track_output())
+        Ok(self.get(&sender)?.should_track_output())
     }
 
     async fn drop(&mut self, rep: Resource<CommandSender>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<CommandSenderResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -566,12 +461,8 @@ impl pumpkin::plugin::command::HostCommandSenderWithStore<PluginHostState>
     ) -> wasmtime::Result<bool> {
         let (sender, server, plugin) = {
             let state = host.get();
-            let sender = state.get_sender_res(&sender)?.provider.clone();
-            let server = state
-                .resource_table
-                .get::<ServerResource>(&Resource::new_own(server.rep()))?
-                .provider
-                .clone();
+            let sender = state.get(&sender)?.clone();
+            let server = state.take(server)?;
             let plugin = state
                 .plugin
                 .as_ref()
@@ -589,7 +480,7 @@ impl pumpkin::plugin::command::HostCommandSenderWithStore<PluginHostState>
 
 impl pumpkin::plugin::command::HostCommandNode for PluginHostState {
     async fn literal(&mut self, name: String) -> wasmtime::Result<Resource<CommandNode>> {
-        self.add_command_node(WasmCommandNode::Literal(literal(name)))
+        self.add(WasmCommandNode::Literal(literal(name)))
             .map_err(|_| wasmtime::Error::msg("Failed to add literal node"))
     }
 
@@ -685,7 +576,7 @@ impl pumpkin::plugin::command::HostCommandNode for PluginHostState {
                 )));
             }
         };
-        self.add_command_node(node)
+        self.add(node)
             .map_err(|_| wasmtime::Error::msg("Failed to add argument node"))
     }
 
@@ -694,11 +585,10 @@ impl pumpkin::plugin::command::HostCommandNode for PluginHostState {
         self_node: Resource<CommandNode>,
         node: Resource<CommandNode>,
     ) -> wasmtime::Result<()> {
-        let child = self.take_node(&node)?;
-        let parent = self.get_node_mut(&self_node)?;
-        let builder =
-            std::mem::replace(&mut parent.provider, WasmCommandNode::Literal(literal("")));
-        parent.provider = builder.then(child.provider);
+        let child = self.take(node)?;
+        let parent = self.get_mut(&self_node)?;
+        let builder = std::mem::replace(parent, WasmCommandNode::Literal(literal("")));
+        *parent = builder.then(child);
         Ok(())
     }
 
@@ -722,12 +612,9 @@ impl pumpkin::plugin::command::HostCommandNode for PluginHostState {
             plugin,
             server,
         };
-        let resource = self.get_node_mut(&node)?;
-        let builder = std::mem::replace(
-            &mut resource.provider,
-            WasmCommandNode::Literal(literal("")),
-        );
-        resource.provider = builder.executes(executor);
+        let resource = self.get_mut(&node)?;
+        let builder = std::mem::replace(resource, WasmCommandNode::Literal(literal("")));
+        *resource = builder.executes(executor);
         Ok(())
     }
 
@@ -751,12 +638,9 @@ impl pumpkin::plugin::command::HostCommandNode for PluginHostState {
             plugin,
             server,
         };
-        let resource = self.get_node_mut(&node)?;
-        let builder = std::mem::replace(
-            &mut resource.provider,
-            WasmCommandNode::Literal(literal("")),
-        );
-        resource.provider = builder.suggests(provider);
+        let resource = self.get_mut(&node)?;
+        let builder = std::mem::replace(resource, WasmCommandNode::Literal(literal("")));
+        *resource = builder.suggests(provider);
         Ok(())
     }
 
@@ -771,10 +655,7 @@ impl pumpkin::plugin::command::HostCommandNode for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<CommandNode>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<CommandNodeResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/context.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/context.rs
@@ -1,46 +1,35 @@
 use std::{collections::HashMap, sync::Arc};
 use wasmtime::component::Resource;
 
-use crate::plugin::loader::wasm::wasm_host::{
-    DowncastResourceExt,
-    state::{CommandResource, ContextResource, PluginHostState},
+use crate::plugin::{Context, loader::wasm::wasm_host::{
+    state::PluginHostState,
     wit::v0_1::{
         events::{ToFromWasmEvent, WasmPluginEventHandler},
         pumpkin::{
             self,
             plugin::{
                 command::Command,
-                context::{Context, MarketplaceMetadata},
+                context::{Context as WitContext, MarketplaceMetadata},
                 event::{EventPriority, EventType},
                 permission::{Permission, PermissionDefault, PermissionLevel},
                 server::Server,
             },
         },
     },
-};
-
-macro_rules! register_host_event {
-    ($resource:expr, $handler:expr, $priority:expr, $blocking:expr, $event_ty:ty) => {
-        $resource.provider.register_event::<$event_ty, _>(
-            Arc::clone($handler),
-            $priority,
-            $blocking,
-        )
-    };
-}
+}};
 
 fn register_typed_event<E: crate::plugin::Payload + ToFromWasmEvent + Clone + 'static>(
-    resource: &ContextResource,
+    ctx: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
 ) {
-    register_host_event!(resource, handler, priority, blocking, E);
+    ctx.register_event::<E, _>(Arc::clone(handler), priority, blocking);
 }
 
 #[expect(clippy::too_many_lines)]
 fn register_player_event(
-    resource: &ContextResource,
+    ctx: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -68,360 +57,360 @@ fn register_player_event(
 
     match event_type {
         EventType::PlayerJoinEvent => {
-            register_typed_event::<PlayerJoinEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerJoinEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerLeaveEvent => {
-            register_typed_event::<PlayerLeaveEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerLeaveEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerLoginEvent => {
-            register_typed_event::<PlayerLoginEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerLoginEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerChatEvent => {
-            register_typed_event::<PlayerChatEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerChatEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerCommandSendEvent => {
-            register_typed_event::<PlayerCommandSendEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerCommandSendEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerPermissionCheckEvent => {
             register_typed_event::<PlayerPermissionCheckEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::PlayerMoveEvent => {
-            register_typed_event::<PlayerMoveEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerMoveEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerTeleportEvent => {
-            register_typed_event::<PlayerTeleportEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerTeleportEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerChangeWorldEvent => {
-            register_typed_event::<PlayerChangeWorldEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerChangeWorldEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerRespawnEvent => {
-            register_typed_event::<PlayerRespawnEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerRespawnEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerExpChangeEvent => {
-            register_typed_event::<PlayerExpChangeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerExpChangeEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerItemHeldEvent => {
-            register_typed_event::<PlayerItemHeldEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerItemHeldEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerChangedMainHandEvent => {
             register_typed_event::<PlayerChangedMainHandEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::PlayerGamemodeChangeEvent => {
             register_typed_event::<PlayerGamemodeChangeEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::PlayerCustomPayloadEvent => {
-            register_typed_event::<PlayerCustomPayloadEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerCustomPayloadEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerFishEvent => {
-            register_typed_event::<PlayerFishEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerFishEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerEggThrowEvent => {
-            register_typed_event::<PlayerEggThrowEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerEggThrowEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerInteractUnknownEntityEvent => {
             register_typed_event::<PlayerInteractUnknownEntityEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::PlayerInteractEntityEvent => {
             register_typed_event::<PlayerInteractEntityEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::PlayerInteractEvent => {
-            register_typed_event::<PlayerInteractEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerInteractEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerToggleSneakEvent => {
-            register_typed_event::<PlayerToggleSneakEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerToggleSneakEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerToggleFlightEvent => {
-            register_typed_event::<PlayerToggleFlightEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerToggleFlightEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerToggleSprintEvent => {
-            register_typed_event::<PlayerToggleSprintEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerToggleSprintEvent>(ctx, handler, priority, blocking);
         }
         EventType::InventoryClickEvent => {
-            register_typed_event::<InventoryClickEvent>(resource, handler, priority, blocking);
+            register_typed_event::<InventoryClickEvent>(ctx, handler, priority, blocking);
         }
         EventType::InventoryCloseEvent => {
-            register_typed_event::<InventoryCloseEvent>(resource, handler, priority, blocking);
+            register_typed_event::<InventoryCloseEvent>(ctx, handler, priority, blocking);
         }
         EventType::BedrockFormResponseEvent => {
-            register_typed_event::<BedrockFormResponseEvent>(resource, handler, priority, blocking);
+            register_typed_event::<BedrockFormResponseEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerItemConsumeEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_item_consume::PlayerItemConsumeEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerItemDamageEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_item_damage::PlayerItemDamageEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerDropItemEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_drop_item::PlayerDropItemEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerBedEnterEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_bed::PlayerBedEnterEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerBedLeaveEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_bed::PlayerBedLeaveEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerBucketEmptyEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_bucket::PlayerBucketEmptyEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerBucketFillEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_bucket::PlayerBucketFillEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::AsyncPlayerChatEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::async_player_chat::AsyncPlayerChatEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::AsyncPlayerPreLoginEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::async_player_pre_login::AsyncPlayerPreLoginEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerAdvancementDoneEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_advancement_done::PlayerAdvancementDoneEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerAnimationEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_animation::PlayerAnimationEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerArmorStandManipulateEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_armor_stand_manipulate::PlayerArmorStandManipulateEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerBucketEntityEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_bucket_entity::PlayerBucketEntityEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerChangedWorldEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_changed_world::PlayerChangedWorldEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerChannelEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_channel::PlayerChannelEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerCommandPreprocessEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_command_preprocess::PlayerCommandPreprocessEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerEditBookEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_edit_book::PlayerEditBookEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerElytraBoostEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_elytra_boost::PlayerElytraBoostEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerExpCooldownChangeEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_exp_cooldown_change::PlayerExpCooldownChangeEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerHarvestBlockEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_harvest_block::PlayerHarvestBlockEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerHideEntityEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_hide_entity::PlayerHideEntityEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerItemBreakEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_item_break::PlayerItemBreakEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerItemMendEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_item_mend::PlayerItemMendEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerKickEvent => {
             register_typed_event::<crate::plugin::api::events::player::player_kick::PlayerKickEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::PlayerLeashEntityEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_leash_entity::PlayerLeashEntityEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerLevelChangeEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_level_change::PlayerLevelChangeEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerLocaleChangeEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_locale_change::PlayerLocaleChangeEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerNameEntityEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_name_entity::PlayerNameEntityEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerOpenSignEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_open_sign::PlayerOpenSignEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerPortalEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_portal::PlayerPortalEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerPreLoginEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_pre_login::PlayerPreLoginEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerRiptideEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_riptide::PlayerRiptideEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerShearEntityEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_shear_entity::PlayerShearEntityEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerShowEntityEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_show_entity::PlayerShowEntityEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerSpawnChangeEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_spawn_change::PlayerSpawnChangeEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerStatisticIncrementEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_statistic_increment::PlayerStatisticIncrementEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerSwapHandsEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_swap_hands::PlayerSwapHandItemsEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerTakeLecternBookEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_take_lectern_book::PlayerTakeLecternBookEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerUnleashEntityEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_unleash_entity::PlayerUnleashEntityEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerVelocityEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_velocity::PlayerVelocityEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerInputEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_input::PlayerInputEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerInteractAtEntityEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_interact_at_entity::PlayerInteractAtEntityEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerLinksSendEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_links_send::PlayerLinksSendEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerPickupArrowEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_pickup_arrow::PlayerPickupArrowEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerRecipeBookClickEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_recipe_book_click::PlayerRecipeBookClickEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerRecipeBookSettingsChangeEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_recipe_book_settings_change::PlayerRecipeBookSettingsChangeEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerRecipeDiscoverEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_recipe_discover::PlayerRecipeDiscoverEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerRegisterChannelEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_register_channel::PlayerRegisterChannelEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerResourcePackStatusEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_resource_pack_status::PlayerResourcePackStatusEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         EventType::PlayerSpawnLocationEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_spawn_location::PlayerSpawnLocationEvent,
-            >(resource, handler, priority, blocking);
+            >(ctx, handler, priority, blocking);
         }
         EventType::PlayerUnregisterChannelEvent => {
             register_typed_event::<
                 crate::plugin::api::events::player::player_unregister_channel::PlayerUnregisterChannelEvent,
-            >(resource, handler, priority, blocking)
+            >(ctx, handler, priority, blocking)
             ;
         }
         _ => {
@@ -430,24 +419,9 @@ fn register_player_event(
     }
 }
 
-impl PluginHostState {
-    fn get_context(&self, res: &Resource<Context>) -> wasmtime::Result<&ContextResource> {
-        self.resource_table
-            .get::<ContextResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-
-    fn take_command(&mut self, res: &Resource<Command>) -> wasmtime::Result<CommandResource> {
-        self.resource_table
-            .delete::<CommandResource>(Resource::new_own(res.rep()))
-            // Convert ResourceTableError -> wasmtime::Error
-            .map_err(wasmtime::Error::from)
-    }
-}
-
 #[allow(clippy::too_many_lines)]
 fn register_entity_event(
-    resource: &ContextResource,
+    ctx: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -534,262 +508,262 @@ fn register_entity_event(
 
     match event_type {
         EventType::EntityDamageEvent => {
-            register_typed_event::<EntityDamageEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityDamageEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityDeathEvent => {
-            register_typed_event::<EntityDeathEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityDeathEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerDeathEvent => {
-            register_typed_event::<PlayerDeathEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PlayerDeathEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntitySpawnEvent => {
-            register_typed_event::<EntitySpawnEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntitySpawnEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityCombustEvent => {
-            register_typed_event::<EntityCombustEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityCombustEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityRegainHealthEvent => {
-            register_typed_event::<EntityRegainHealthEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityRegainHealthEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityAirChangeEvent => {
-            register_typed_event::<EntityAirChangeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityAirChangeEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityBreedEvent => {
-            register_typed_event::<EntityBreedEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityBreedEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityDismountEvent => {
-            register_typed_event::<EntityDismountEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityDismountEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityDyeEvent => {
-            register_typed_event::<EntityDyeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityDyeEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityEnterLoveModeEvent => {
-            register_typed_event::<EntityEnterLoveModeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityEnterLoveModeEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityExplodeEvent => {
-            register_typed_event::<EntityExplodeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityExplodeEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityMountEvent => {
-            register_typed_event::<EntityMountEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityMountEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityPickupItemEvent => {
-            register_typed_event::<EntityPickupItemEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityPickupItemEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityPortalEvent => {
-            register_typed_event::<EntityPortalEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityPortalEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityResurrectEvent => {
-            register_typed_event::<EntityResurrectEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityResurrectEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityShootBowEvent => {
-            register_typed_event::<EntityShootBowEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityShootBowEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityTameEvent => {
-            register_typed_event::<EntityTameEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityTameEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityTargetEvent => {
-            register_typed_event::<EntityTargetEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityTargetEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityTeleportEvent => {
-            register_typed_event::<EntityTeleportEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityTeleportEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityToggleGlideEvent => {
-            register_typed_event::<EntityToggleGlideEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityToggleGlideEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityTransformEvent => {
-            register_typed_event::<EntityTransformEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityTransformEvent>(ctx, handler, priority, blocking);
         }
         EventType::CreatureSpawnEvent => {
-            register_typed_event::<CreatureSpawnEvent>(resource, handler, priority, blocking);
+            register_typed_event::<CreatureSpawnEvent>(ctx, handler, priority, blocking);
         }
         EventType::EnderDragonChangePhaseEvent => {
             register_typed_event::<EnderDragonChangePhaseEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::EntityBreakDoorEvent => {
-            register_typed_event::<EntityBreakDoorEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityBreakDoorEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityChangeBlockEvent => {
-            register_typed_event::<EntityChangeBlockEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityChangeBlockEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityDamageByBlockEvent => {
-            register_typed_event::<EntityDamageByBlockEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityDamageByBlockEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityDamageByEntityEvent => {
             register_typed_event::<EntityDamageByEntityEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::EntityDropItemEvent => {
-            register_typed_event::<EntityDropItemEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityDropItemEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityEnterBlockEvent => {
-            register_typed_event::<EntityEnterBlockEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityEnterBlockEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityExhaustionEvent => {
-            register_typed_event::<EntityExhaustionEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityExhaustionEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityInteractEvent => {
-            register_typed_event::<EntityInteractEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityInteractEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityKnockbackEvent => {
-            register_typed_event::<EntityKnockbackEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityKnockbackEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityPlaceEvent => {
-            register_typed_event::<EntityPlaceEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityPlaceEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityPoseChangeEvent => {
-            register_typed_event::<EntityPoseChangeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityPoseChangeEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityPotionEffectEvent => {
-            register_typed_event::<EntityPotionEffectEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityPotionEffectEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntitySpellCastEvent => {
-            register_typed_event::<EntitySpellCastEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntitySpellCastEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityTargetLivingEntityEvent => {
             register_typed_event::<EntityTargetLivingEntityEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::EntityToggleSwimEvent => {
-            register_typed_event::<EntityToggleSwimEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityToggleSwimEvent>(ctx, handler, priority, blocking);
         }
         EventType::ExplosionPrimeEvent => {
-            register_typed_event::<ExplosionPrimeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<ExplosionPrimeEvent>(ctx, handler, priority, blocking);
         }
         EventType::FireworkExplodeEvent => {
-            register_typed_event::<FireworkExplodeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<FireworkExplodeEvent>(ctx, handler, priority, blocking);
         }
         EventType::FoodLevelChangeEvent => {
-            register_typed_event::<FoodLevelChangeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<FoodLevelChangeEvent>(ctx, handler, priority, blocking);
         }
         EventType::ItemDespawnEvent => {
-            register_typed_event::<ItemDespawnEvent>(resource, handler, priority, blocking);
+            register_typed_event::<ItemDespawnEvent>(ctx, handler, priority, blocking);
         }
         EventType::ItemMergeEvent => {
-            register_typed_event::<ItemMergeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<ItemMergeEvent>(ctx, handler, priority, blocking);
         }
         EventType::ItemSpawnEvent => {
-            register_typed_event::<ItemSpawnEvent>(resource, handler, priority, blocking);
+            register_typed_event::<ItemSpawnEvent>(ctx, handler, priority, blocking);
         }
         EventType::PiglinBarterEvent => {
-            register_typed_event::<PiglinBarterEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PiglinBarterEvent>(ctx, handler, priority, blocking);
         }
         EventType::ProjectileHitEvent => {
-            register_typed_event::<ProjectileHitEvent>(resource, handler, priority, blocking);
+            register_typed_event::<ProjectileHitEvent>(ctx, handler, priority, blocking);
         }
         EventType::ProjectileLaunchEvent => {
-            register_typed_event::<ProjectileLaunchEvent>(resource, handler, priority, blocking);
+            register_typed_event::<ProjectileLaunchEvent>(ctx, handler, priority, blocking);
         }
         EventType::SheepDyeWoolEvent => {
-            register_typed_event::<SheepDyeWoolEvent>(resource, handler, priority, blocking);
+            register_typed_event::<SheepDyeWoolEvent>(ctx, handler, priority, blocking);
         }
         EventType::SheepRegrowWoolEvent => {
-            register_typed_event::<SheepRegrowWoolEvent>(resource, handler, priority, blocking);
+            register_typed_event::<SheepRegrowWoolEvent>(ctx, handler, priority, blocking);
         }
         EventType::SlimeSplitEvent => {
-            register_typed_event::<SlimeSplitEvent>(resource, handler, priority, blocking);
+            register_typed_event::<SlimeSplitEvent>(ctx, handler, priority, blocking);
         }
         EventType::StriderTemperatureChangeEvent => {
             register_typed_event::<StriderTemperatureChangeEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::VillagerAcquireTradeEvent => {
             register_typed_event::<VillagerAcquireTradeEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::VillagerCareerChangeEvent => {
             register_typed_event::<VillagerCareerChangeEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::VillagerReplenishTradeEvent => {
             register_typed_event::<VillagerReplenishTradeEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::WardenAngerChangeEvent => {
-            register_typed_event::<WardenAngerChangeEvent>(resource, handler, priority, blocking);
+            register_typed_event::<WardenAngerChangeEvent>(ctx, handler, priority, blocking);
         }
         EventType::AreaEffectCloudApplyEvent => {
             register_typed_event::<AreaEffectCloudApplyEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::ArrowBodyCountChangeEvent => {
             register_typed_event::<ArrowBodyCountChangeEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::BatToggleSleepEvent => {
-            register_typed_event::<BatToggleSleepEvent>(resource, handler, priority, blocking);
+            register_typed_event::<BatToggleSleepEvent>(ctx, handler, priority, blocking);
         }
         EventType::CreeperPowerEvent => {
-            register_typed_event::<CreeperPowerEvent>(resource, handler, priority, blocking);
+            register_typed_event::<CreeperPowerEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityCombustByBlockEvent => {
             register_typed_event::<EntityCombustByBlockEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::EntityCombustByEntityEvent => {
             register_typed_event::<EntityCombustByEntityEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::EntityKnockbackByEntityEvent => {
             register_typed_event::<EntityKnockbackByEntityEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::EntityPortalEnterEvent => {
-            register_typed_event::<EntityPortalEnterEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityPortalEnterEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityPortalExitEvent => {
-            register_typed_event::<EntityPortalExitEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityPortalExitEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityRemoveEvent => {
-            register_typed_event::<EntityRemoveEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityRemoveEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityTargetBlockEvent => {
-            register_typed_event::<EntityTargetBlockEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityTargetBlockEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityUnleashEvent => {
-            register_typed_event::<EntityUnleashEvent>(resource, handler, priority, blocking);
+            register_typed_event::<EntityUnleashEvent>(ctx, handler, priority, blocking);
         }
         EventType::ExpBottleEvent => {
-            register_typed_event::<ExpBottleEvent>(resource, handler, priority, blocking);
+            register_typed_event::<ExpBottleEvent>(ctx, handler, priority, blocking);
         }
         EventType::HorseJumpEvent => {
-            register_typed_event::<HorseJumpEvent>(resource, handler, priority, blocking);
+            register_typed_event::<HorseJumpEvent>(ctx, handler, priority, blocking);
         }
         EventType::LingeringPotionSplashEvent => {
             register_typed_event::<LingeringPotionSplashEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::PigZapEvent => {
-            register_typed_event::<PigZapEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PigZapEvent>(ctx, handler, priority, blocking);
         }
         EventType::PigZombieAngerEvent => {
-            register_typed_event::<PigZombieAngerEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PigZombieAngerEvent>(ctx, handler, priority, blocking);
         }
         EventType::PotionSplashEvent => {
-            register_typed_event::<PotionSplashEvent>(resource, handler, priority, blocking);
+            register_typed_event::<PotionSplashEvent>(ctx, handler, priority, blocking);
         }
         EventType::SpawnerSpawnEvent => {
-            register_typed_event::<SpawnerSpawnEvent>(resource, handler, priority, blocking);
+            register_typed_event::<SpawnerSpawnEvent>(ctx, handler, priority, blocking);
         }
         EventType::TrialSpawnerSpawnEvent => {
-            register_typed_event::<TrialSpawnerSpawnEvent>(resource, handler, priority, blocking);
+            register_typed_event::<TrialSpawnerSpawnEvent>(ctx, handler, priority, blocking);
         }
         EventType::VillagerReputationChangeEvent => {
             register_typed_event::<VillagerReputationChangeEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         _ => {
@@ -799,7 +773,7 @@ fn register_entity_event(
 }
 
 fn register_inventory_event(
-    resource: &ContextResource,
+    resource: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -894,7 +868,7 @@ fn register_inventory_event(
 }
 
 fn register_vehicle_event(
-    resource: &ContextResource,
+    resource: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -951,7 +925,7 @@ fn register_vehicle_event(
 }
 
 fn register_enchantment_event(
-    resource: &ContextResource,
+    resource: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -978,7 +952,7 @@ fn register_enchantment_event(
 
 #[allow(clippy::too_many_lines)]
 fn register_world_event(
-    resource: &ContextResource,
+    resource: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -1101,7 +1075,7 @@ fn register_world_event(
 
 #[allow(clippy::too_many_lines)]
 fn register_block_event(
-    resource: &ContextResource,
+    resource: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -1335,7 +1309,7 @@ fn register_block_event(
 }
 
 fn register_raid_event(
-    resource: &ContextResource,
+    resource: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -1366,7 +1340,7 @@ fn register_raid_event(
 }
 
 fn register_dialog_event(
-    resource: &ContextResource,
+    resource: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -1393,7 +1367,7 @@ fn register_dialog_event(
 }
 
 fn register_server_event(
-    resource: &ContextResource,
+    resource: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -1446,7 +1420,7 @@ fn register_server_event(
 }
 
 fn register_hanging_event(
-    resource: &ContextResource,
+    ctx: &Context,
     handler: &Arc<WasmPluginEventHandler>,
     priority: crate::plugin::EventPriority,
     blocking: bool,
@@ -1459,46 +1433,19 @@ fn register_hanging_event(
 
     match event_type {
         EventType::HangingBreakEvent => {
-            register_typed_event::<HangingBreakEvent>(resource, handler, priority, blocking);
+            register_typed_event::<HangingBreakEvent>(ctx, handler, priority, blocking);
         }
         EventType::HangingBreakByEntityEvent => {
             register_typed_event::<HangingBreakByEntityEvent>(
-                resource, handler, priority, blocking,
+                ctx, handler, priority, blocking,
             );
         }
         EventType::HangingPlaceEvent => {
-            register_typed_event::<HangingPlaceEvent>(resource, handler, priority, blocking);
+            register_typed_event::<HangingPlaceEvent>(ctx, handler, priority, blocking);
         }
         _ => {
             tracing::error!("non-hanging event should not be routed to register_hanging_event");
         }
-    }
-}
-
-impl DowncastResourceExt<ContextResource> for Resource<Context> {
-    fn downcast_ref<'a>(&'a self, state: &'a mut PluginHostState) -> &'a ContextResource {
-        state
-            .resource_table
-            .get_any_mut(self.rep())
-            .expect("invalid context resource handle")
-            .downcast_ref()
-            .expect("resource type mismatch")
-    }
-
-    fn downcast_mut<'a>(&'a self, state: &'a mut PluginHostState) -> &'a mut ContextResource {
-        state
-            .resource_table
-            .get_any_mut(self.rep())
-            .expect("invalid context resource handle")
-            .downcast_mut()
-            .expect("resource type mismatch")
-    }
-
-    fn consume(self, state: &mut PluginHostState) -> ContextResource {
-        state
-            .resource_table
-            .delete(Resource::new_own(self.rep()))
-            .expect("invalid context resource handle")
     }
 }
 
@@ -1508,7 +1455,7 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
     #[allow(clippy::too_many_lines)]
     async fn register_event(
         &mut self,
-        context: Resource<Context>,
+        context: Resource<WitContext>,
         handler_id: u32,
         event_type: EventType,
         event_priority: EventPriority,
@@ -1531,7 +1478,7 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             .upgrade()
             .ok_or_else(|| wasmtime::Error::msg("Plugin has been dropped"))?;
 
-        let resource = self.get_context(&context)?;
+        let ctx = self.get(&context)?.as_ref();
         let handler = Arc::new(WasmPluginEventHandler { handler_id, plugin });
 
         match event_type {
@@ -1544,12 +1491,12 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             | EventType::ServerTickEndEvent
             | EventType::ServerTickStartEvent
             | EventType::MapInitializeEvent) => {
-                register_server_event(resource, &handler, priority, blocking, event_type);
+                register_server_event(ctx, &handler, priority, blocking, event_type);
             }
             event_type @ (EventType::HangingBreakEvent
             | EventType::HangingBreakByEntityEvent
             | EventType::HangingPlaceEvent) => {
-                register_hanging_event(resource, &handler, priority, blocking, event_type);
+                register_hanging_event(ctx, &handler, priority, blocking, event_type);
             }
             event_type @ (EventType::SpawnChangeEvent
             | EventType::ChunkLoadEvent
@@ -1573,7 +1520,7 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             | EventType::WorldInitEvent
             | EventType::WorldSaveEvent
             | EventType::LightningStrikeEvent) => {
-                register_world_event(resource, &handler, priority, blocking, event_type);
+                register_world_event(ctx, &handler, priority, blocking, event_type);
             }
             event_type @ (EventType::EntityDamageEvent
             | EventType::EntityDeathEvent
@@ -1652,7 +1599,7 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             | EventType::SpawnerSpawnEvent
             | EventType::TrialSpawnerSpawnEvent
             | EventType::VillagerReputationChangeEvent) => {
-                register_entity_event(resource, &handler, priority, blocking, event_type);
+                register_entity_event(ctx, &handler, priority, blocking, event_type);
             }
             event_type @ (EventType::BlockRedstoneEvent
             | EventType::BlockBreakEvent
@@ -1699,7 +1646,7 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             | EventType::MoistureChangeEvent
             | EventType::SculkBloomEvent
             | EventType::VaultDisplayItemEvent) => {
-                register_block_event(resource, &handler, priority, blocking, event_type);
+                register_block_event(ctx, &handler, priority, blocking, event_type);
             }
             event_type @ (EventType::InventoryOpenEvent
             | EventType::InventoryDragEvent
@@ -1722,10 +1669,10 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             | EventType::PrepareSmithingEvent
             | EventType::SmithItemEvent
             | EventType::TradeSelectEvent) => {
-                register_inventory_event(resource, &handler, priority, blocking, event_type);
+                register_inventory_event(ctx, &handler, priority, blocking, event_type);
             }
             event_type @ (EventType::PrepareItemEnchantEvent | EventType::EnchantItemEvent) => {
-                register_enchantment_event(resource, &handler, priority, blocking, event_type);
+                register_enchantment_event(ctx, &handler, priority, blocking, event_type);
             }
             event_type @ (EventType::VehicleBlockCollisionEvent
             | EventType::VehicleCollisionEvent
@@ -1737,21 +1684,21 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             | EventType::VehicleExitEvent
             | EventType::VehicleMoveEvent
             | EventType::VehicleUpdateEvent) => {
-                register_vehicle_event(resource, &handler, priority, blocking, event_type);
+                register_vehicle_event(ctx, &handler, priority, blocking, event_type);
             }
             event_type @ (EventType::RaidFinishEvent
             | EventType::RaidSpawnWaveEvent
             | EventType::RaidStopEvent
             | EventType::RaidTriggerEvent) => {
-                register_raid_event(resource, &handler, priority, blocking, event_type);
+                register_raid_event(ctx, &handler, priority, blocking, event_type);
             }
             event_type @ (EventType::DialogClickActionEvent
             | EventType::DialogShowEvent
             | EventType::DialogClearEvent) => {
-                register_dialog_event(resource, &handler, priority, blocking, event_type);
+                register_dialog_event(ctx, &handler, priority, blocking, event_type);
             }
             event_type => {
-                register_player_event(resource, &handler, priority, blocking, event_type);
+                register_player_event(ctx, &handler, priority, blocking, event_type);
             }
         }
 
@@ -1760,14 +1707,14 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
 
     async fn register_command(
         &mut self,
-        context: Resource<Context>,
+        context: Resource<WitContext>,
         command: Resource<Command>,
         permission: String,
     ) -> wasmtime::Result<()> {
         use crate::command::argument_builder::ArgumentBuilder;
 
-        let command = self.take_command(&command)?.provider;
-        let context = self.get_context(&context)?.provider.clone();
+        let command = self.take(command)?;
+        let context = self.get(&context)?.clone();
         let aliases = if command.names.len() > 1 {
             command.names[1..].to_vec()
         } else {
@@ -1781,7 +1728,7 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
 
     async fn register_permission(
         &mut self,
-        context: Resource<Context>,
+        context: Resource<WitContext>,
         permission: Permission,
     ) -> wasmtime::Result<Result<(), String>> {
         let mut children = HashMap::with_capacity(permission.children.len());
@@ -1808,36 +1755,31 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             children,
         };
 
-        let context_res = self
-            .resource_table
-            .get_mut::<ContextResource>(&Resource::new_own(context.rep()))?;
-        Ok(context_res.provider.register_permission(util_permission))
+        let context_res = self.get(&context)?;
+        Ok(context_res.register_permission(util_permission))
     }
 
-    async fn get_data_folder(&mut self, _context: Resource<Context>) -> wasmtime::Result<String> {
+    async fn get_data_folder(&mut self, _context: Resource<WitContext>) -> wasmtime::Result<String> {
         Ok("data".to_string())
     }
 
     async fn get_server(
         &mut self,
-        context: Resource<Context>,
+        context: Resource<WitContext>,
     ) -> wasmtime::Result<Resource<Server>> {
-        let server_provider = self.get_context(&context)?.provider.server.clone();
-        self.add_server(server_provider)
+        let server_provider = self.get(&context)?.server.clone();
+        self.add(server_provider)
             .map_err(|_| wasmtime::Error::msg("failed to add server resource"))
     }
 
     async fn get_marketplace_metadata(
         &mut self,
-        _context: Resource<Context>,
+        _context: Resource<WitContext>,
     ) -> wasmtime::Result<Option<MarketplaceMetadata>> {
         Ok(self.marketplace_metadata.clone())
     }
 
-    async fn drop(&mut self, rep: Resource<Context>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<ContextResource>(Resource::new_own(rep.rep()));
-        Ok(())
+    async fn drop(&mut self, rep: Resource<WitContext>) -> wasmtime::Result<()> {
+        self.drop(rep)
     }
 }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/context.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/context.rs
@@ -1,22 +1,25 @@
 use std::{collections::HashMap, sync::Arc};
 use wasmtime::component::Resource;
 
-use crate::plugin::{Context, loader::wasm::wasm_host::{
-    state::PluginHostState,
-    wit::v0_1::{
-        events::{ToFromWasmEvent, WasmPluginEventHandler},
-        pumpkin::{
-            self,
-            plugin::{
-                command::Command,
-                context::{Context as WitContext, MarketplaceMetadata},
-                event::{EventPriority, EventType},
-                permission::{Permission, PermissionDefault, PermissionLevel},
-                server::Server,
+use crate::plugin::{
+    Context,
+    loader::wasm::wasm_host::{
+        state::PluginHostState,
+        wit::v0_1::{
+            events::{ToFromWasmEvent, WasmPluginEventHandler},
+            pumpkin::{
+                self,
+                plugin::{
+                    command::Command,
+                    context::{Context as WitContext, MarketplaceMetadata},
+                    event::{EventPriority, EventType},
+                    permission::{Permission, PermissionDefault, PermissionLevel},
+                    server::Server,
+                },
             },
         },
     },
-}};
+};
 
 fn register_typed_event<E: crate::plugin::Payload + ToFromWasmEvent + Clone + 'static>(
     ctx: &Context,
@@ -72,9 +75,7 @@ fn register_player_event(
             register_typed_event::<PlayerCommandSendEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerPermissionCheckEvent => {
-            register_typed_event::<PlayerPermissionCheckEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<PlayerPermissionCheckEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerMoveEvent => {
             register_typed_event::<PlayerMoveEvent>(ctx, handler, priority, blocking);
@@ -95,14 +96,10 @@ fn register_player_event(
             register_typed_event::<PlayerItemHeldEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerChangedMainHandEvent => {
-            register_typed_event::<PlayerChangedMainHandEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<PlayerChangedMainHandEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerGamemodeChangeEvent => {
-            register_typed_event::<PlayerGamemodeChangeEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<PlayerGamemodeChangeEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerCustomPayloadEvent => {
             register_typed_event::<PlayerCustomPayloadEvent>(ctx, handler, priority, blocking);
@@ -119,9 +116,7 @@ fn register_player_event(
             );
         }
         EventType::PlayerInteractEntityEvent => {
-            register_typed_event::<PlayerInteractEntityEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<PlayerInteractEntityEvent>(ctx, handler, priority, blocking);
         }
         EventType::PlayerInteractEvent => {
             register_typed_event::<PlayerInteractEvent>(ctx, handler, priority, blocking);
@@ -577,9 +572,7 @@ fn register_entity_event(
             register_typed_event::<CreatureSpawnEvent>(ctx, handler, priority, blocking);
         }
         EventType::EnderDragonChangePhaseEvent => {
-            register_typed_event::<EnderDragonChangePhaseEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<EnderDragonChangePhaseEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityBreakDoorEvent => {
             register_typed_event::<EntityBreakDoorEvent>(ctx, handler, priority, blocking);
@@ -591,9 +584,7 @@ fn register_entity_event(
             register_typed_event::<EntityDamageByBlockEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityDamageByEntityEvent => {
-            register_typed_event::<EntityDamageByEntityEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<EntityDamageByEntityEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityDropItemEvent => {
             register_typed_event::<EntityDropItemEvent>(ctx, handler, priority, blocking);
@@ -623,9 +614,7 @@ fn register_entity_event(
             register_typed_event::<EntitySpellCastEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityTargetLivingEntityEvent => {
-            register_typed_event::<EntityTargetLivingEntityEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<EntityTargetLivingEntityEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityToggleSwimEvent => {
             register_typed_event::<EntityToggleSwimEvent>(ctx, handler, priority, blocking);
@@ -667,37 +656,25 @@ fn register_entity_event(
             register_typed_event::<SlimeSplitEvent>(ctx, handler, priority, blocking);
         }
         EventType::StriderTemperatureChangeEvent => {
-            register_typed_event::<StriderTemperatureChangeEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<StriderTemperatureChangeEvent>(ctx, handler, priority, blocking);
         }
         EventType::VillagerAcquireTradeEvent => {
-            register_typed_event::<VillagerAcquireTradeEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<VillagerAcquireTradeEvent>(ctx, handler, priority, blocking);
         }
         EventType::VillagerCareerChangeEvent => {
-            register_typed_event::<VillagerCareerChangeEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<VillagerCareerChangeEvent>(ctx, handler, priority, blocking);
         }
         EventType::VillagerReplenishTradeEvent => {
-            register_typed_event::<VillagerReplenishTradeEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<VillagerReplenishTradeEvent>(ctx, handler, priority, blocking);
         }
         EventType::WardenAngerChangeEvent => {
             register_typed_event::<WardenAngerChangeEvent>(ctx, handler, priority, blocking);
         }
         EventType::AreaEffectCloudApplyEvent => {
-            register_typed_event::<AreaEffectCloudApplyEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<AreaEffectCloudApplyEvent>(ctx, handler, priority, blocking);
         }
         EventType::ArrowBodyCountChangeEvent => {
-            register_typed_event::<ArrowBodyCountChangeEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<ArrowBodyCountChangeEvent>(ctx, handler, priority, blocking);
         }
         EventType::BatToggleSleepEvent => {
             register_typed_event::<BatToggleSleepEvent>(ctx, handler, priority, blocking);
@@ -706,19 +683,13 @@ fn register_entity_event(
             register_typed_event::<CreeperPowerEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityCombustByBlockEvent => {
-            register_typed_event::<EntityCombustByBlockEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<EntityCombustByBlockEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityCombustByEntityEvent => {
-            register_typed_event::<EntityCombustByEntityEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<EntityCombustByEntityEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityKnockbackByEntityEvent => {
-            register_typed_event::<EntityKnockbackByEntityEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<EntityKnockbackByEntityEvent>(ctx, handler, priority, blocking);
         }
         EventType::EntityPortalEnterEvent => {
             register_typed_event::<EntityPortalEnterEvent>(ctx, handler, priority, blocking);
@@ -742,9 +713,7 @@ fn register_entity_event(
             register_typed_event::<HorseJumpEvent>(ctx, handler, priority, blocking);
         }
         EventType::LingeringPotionSplashEvent => {
-            register_typed_event::<LingeringPotionSplashEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<LingeringPotionSplashEvent>(ctx, handler, priority, blocking);
         }
         EventType::PigZapEvent => {
             register_typed_event::<PigZapEvent>(ctx, handler, priority, blocking);
@@ -762,9 +731,7 @@ fn register_entity_event(
             register_typed_event::<TrialSpawnerSpawnEvent>(ctx, handler, priority, blocking);
         }
         EventType::VillagerReputationChangeEvent => {
-            register_typed_event::<VillagerReputationChangeEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<VillagerReputationChangeEvent>(ctx, handler, priority, blocking);
         }
         _ => {
             tracing::error!("non-entity event should not be routed to register_entity_event");
@@ -1436,9 +1403,7 @@ fn register_hanging_event(
             register_typed_event::<HangingBreakEvent>(ctx, handler, priority, blocking);
         }
         EventType::HangingBreakByEntityEvent => {
-            register_typed_event::<HangingBreakByEntityEvent>(
-                ctx, handler, priority, blocking,
-            );
+            register_typed_event::<HangingBreakByEntityEvent>(ctx, handler, priority, blocking);
         }
         EventType::HangingPlaceEvent => {
             register_typed_event::<HangingPlaceEvent>(ctx, handler, priority, blocking);
@@ -1759,7 +1724,10 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
         Ok(context_res.register_permission(util_permission))
     }
 
-    async fn get_data_folder(&mut self, _context: Resource<WitContext>) -> wasmtime::Result<String> {
+    async fn get_data_folder(
+        &mut self,
+        _context: Resource<WitContext>,
+    ) -> wasmtime::Result<String> {
         Ok("data".to_string())
     }
 
@@ -1767,9 +1735,7 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
         &mut self,
         context: Resource<WitContext>,
     ) -> wasmtime::Result<Resource<Server>> {
-        let server_provider = self.get(&context)?.server.clone();
-        self.add(server_provider)
-            .map_err(|_| wasmtime::Error::msg("failed to add server resource"))
+        self.add(self.get(&context)?.server.clone())
     }
 
     async fn get_marketplace_metadata(

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/datapack.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/datapack.rs
@@ -72,12 +72,7 @@ impl HostDatapackManager for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<WitDatapackManager>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<crate::plugin::loader::wasm::wasm_host::state::DatapackManagerResource>(
-            Resource::new_own(rep.rep()),
-        );
-        Ok(())
+        self.drop(rep)
     }
 }
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/display.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/display.rs
@@ -7,13 +7,8 @@ use crate::entity::decoration::display::{
     BlockDisplayEntity as InternalBlockDisplayEntity, DisplayEntity as InternalDisplayEntity,
     ItemDisplayEntity as InternalItemDisplayEntity, TextDisplayEntity as InternalTextDisplayEntity,
 };
-use crate::entity::interaction::InteractionEntity as InternalInteractionEntity;
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{
-        BlockDisplayEntityResource, DisplayEntityResource, EntityResource,
-        InteractionEntityResource, ItemDisplayEntityResource, PluginHostState,
-        TextDisplayEntityResource,
-    },
+    state::PluginHostState,
     wit::v0_1::pumpkin::plugin::{
         display::{
             BillboardMode, BlockDisplayEntity, DisplayEntity, DisplayTransformation, Host,
@@ -113,12 +108,9 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<DisplayEntity>>> {
-        let entity_res = self
-            .resource_table
-            .get::<EntityResource>(&Resource::new_borrow(entity.rep()))?;
-        if get_display_entity(entity_res.provider.as_ref()).is_some() {
-            let res = self.add_display_entity(entity_res.provider.clone())?;
-            Ok(Some(res))
+        let entity = self.take(entity)?;
+        if get_display_entity(entity.as_ref()).is_some() {
+            Ok(Some(self.add(entity.clone())?))
         } else {
             Ok(None)
         }
@@ -128,16 +120,16 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<Resource<Entity>> {
-        let display_res = self.get_display_entity_res(&display)?;
-        self.add_entity(display_res.provider.clone())
+        let display_res = self.get(&display)?;
+        self.add(display_res.clone())
     }
 
     async fn get_transformation(
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<DisplayTransformation> {
-        let display_res = self.get_display_entity_res(&display)?;
-        get_display_entity(display_res.provider.as_ref()).map_or_else(
+        let display_res = self.get(&display)?;
+        get_display_entity(display_res.as_ref()).map_or_else(
             || {
                 Ok(DisplayTransformation {
                     translation: Vector3f {
@@ -203,8 +195,8 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         transformation: DisplayTransformation,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_translation(Vector3::new(
                 transformation.translation.x,
                 transformation.translation.y,
@@ -235,8 +227,8 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<i32> {
-        let display_res = self.get_display_entity_res(&display)?;
-        Ok(get_display_entity(display_res.provider.as_ref()).map_or(
+        let display_res = self.get(&display)?;
+        Ok(get_display_entity(display_res.as_ref()).map_or(
             0,
             crate::entity::decoration::display::DisplayEntity::get_interpolation_duration,
         ))
@@ -247,8 +239,8 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         duration: i32,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_interpolation_duration(duration);
         }
         Ok(())
@@ -258,8 +250,8 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<i32> {
-        let display_res = self.get_display_entity_res(&display)?;
-        Ok(get_display_entity(display_res.provider.as_ref()).map_or(
+        let display_res = self.get(&display)?;
+        Ok(get_display_entity(display_res.as_ref()).map_or(
             0,
             crate::entity::decoration::display::DisplayEntity::get_interpolation_start_delta_ticks,
         ))
@@ -270,8 +262,8 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         delta_ticks: i32,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_interpolation_start_delta_ticks(delta_ticks);
         }
         Ok(())
@@ -281,8 +273,8 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<i32> {
-        let display_res = self.get_display_entity_res(&display)?;
-        Ok(get_display_entity(display_res.provider.as_ref()).map_or(
+        let display_res = self.get(&display)?;
+        Ok(get_display_entity(display_res.as_ref()).map_or(
             0,
             crate::entity::decoration::display::DisplayEntity::get_teleport_duration,
         ))
@@ -293,8 +285,8 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         duration: i32,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_teleport_duration(duration);
         }
         Ok(())
@@ -304,9 +296,9 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<BillboardMode> {
-        let display_res = self.get_display_entity_res(&display)?;
+        let display_res = self.get(&display)?;
         Ok(
-            get_display_entity(display_res.provider.as_ref()).map_or(BillboardMode::Fixed, |d| {
+            get_display_entity(display_res.as_ref()).map_or(BillboardMode::Fixed, |d| {
                 map_billboard_mode(d.get_billboard())
             }),
         )
@@ -317,17 +309,16 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         mode: BillboardMode,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_billboard(map_billboard_mode_rev(mode));
         }
         Ok(())
     }
 
     async fn get_view_range(&mut self, display: Resource<DisplayEntity>) -> wasmtime::Result<f32> {
-        let display_res = self.get_display_entity_res(&display)?;
-        get_display_entity(display_res.provider.as_ref())
-            .map_or_else(|| Ok(1.0), |d| Ok(d.get_view_range()))
+        let display_res = self.get(&display)?;
+        get_display_entity(display_res.as_ref()).map_or_else(|| Ok(1.0), |d| Ok(d.get_view_range()))
     }
 
     async fn set_view_range(
@@ -335,8 +326,8 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         range: f32,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_view_range(range);
         }
         Ok(())
@@ -346,8 +337,8 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<f32> {
-        let display_res = self.get_display_entity_res(&display)?;
-        get_display_entity(display_res.provider.as_ref())
+        let display_res = self.get(&display)?;
+        get_display_entity(display_res.as_ref())
             .map_or_else(|| Ok(0.0), |d| Ok(d.get_shadow_radius()))
     }
 
@@ -356,8 +347,8 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         radius: f32,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_shadow_radius(radius);
         }
         Ok(())
@@ -367,8 +358,8 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<f32> {
-        let display_res = self.get_display_entity_res(&display)?;
-        get_display_entity(display_res.provider.as_ref())
+        let display_res = self.get(&display)?;
+        get_display_entity(display_res.as_ref())
             .map_or_else(|| Ok(1.0), |d| Ok(d.get_shadow_strength()))
     }
 
@@ -377,8 +368,8 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         strength: f32,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_shadow_strength(strength);
         }
         Ok(())
@@ -388,8 +379,8 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<f32> {
-        let display_res = self.get_display_entity_res(&display)?;
-        get_display_entity(display_res.provider.as_ref())
+        let display_res = self.get(&display)?;
+        get_display_entity(display_res.as_ref())
             .map_or_else(|| Ok(0.0), |d| Ok(d.get_display_width()))
     }
 
@@ -398,8 +389,8 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         width: f32,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_display_width(width);
         }
         Ok(())
@@ -409,8 +400,8 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<f32> {
-        let display_res = self.get_display_entity_res(&display)?;
-        get_display_entity(display_res.provider.as_ref())
+        let display_res = self.get(&display)?;
+        get_display_entity(display_res.as_ref())
             .map_or_else(|| Ok(0.0), |d| Ok(d.get_display_height()))
     }
 
@@ -419,8 +410,8 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         height: f32,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_display_height(height);
         }
         Ok(())
@@ -430,8 +421,8 @@ impl HostDisplayEntity for PluginHostState {
         &mut self,
         display: Resource<DisplayEntity>,
     ) -> wasmtime::Result<i32> {
-        let display_res = self.get_display_entity_res(&display)?;
-        Ok(get_display_entity(display_res.provider.as_ref()).map_or(
+        let display_res = self.get(&display)?;
+        Ok(get_display_entity(display_res.as_ref()).map_or(
             -1,
             crate::entity::decoration::display::DisplayEntity::get_glow_color_override,
         ))
@@ -442,16 +433,16 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         color: i32,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_glow_color_override(color);
         }
         Ok(())
     }
 
     async fn get_brightness(&mut self, display: Resource<DisplayEntity>) -> wasmtime::Result<i32> {
-        let display_res = self.get_display_entity_res(&display)?;
-        Ok(get_display_entity(display_res.provider.as_ref()).map_or(
+        let display_res = self.get(&display)?;
+        Ok(get_display_entity(display_res.as_ref()).map_or(
             -1,
             crate::entity::decoration::display::DisplayEntity::get_brightness,
         ))
@@ -462,18 +453,15 @@ impl HostDisplayEntity for PluginHostState {
         display: Resource<DisplayEntity>,
         brightness: i32,
     ) -> wasmtime::Result<()> {
-        let display_res = self.get_display_entity_res(&display)?;
-        if let Some(d) = get_display_entity(display_res.provider.as_ref()) {
+        let display_res = self.get(&display)?;
+        if let Some(d) = get_display_entity(display_res.as_ref()) {
             d.set_brightness(brightness);
         }
         Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<DisplayEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<DisplayEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -482,16 +470,8 @@ impl HostBlockDisplayEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<BlockDisplayEntity>>> {
-        let entity_res = self
-            .resource_table
-            .get::<EntityResource>(&Resource::new_borrow(entity.rep()))?;
-        if entity_res
-            .provider
-            .cast_any()
-            .is::<InternalBlockDisplayEntity>()
-        {
-            let res = self.add_block_display_entity(entity_res.provider.clone())?;
-            Ok(Some(res))
+        if let Ok(entity) = Arc::downcast(self.take(entity)?) {
+            Ok(Some(self.add(entity)?))
         } else {
             Ok(None)
         }
@@ -501,28 +481,21 @@ impl HostBlockDisplayEntity for PluginHostState {
         &mut self,
         block_display: Resource<BlockDisplayEntity>,
     ) -> wasmtime::Result<Resource<DisplayEntity>> {
-        let block_res = self.get_block_display_entity_res(&block_display)?;
-        self.add_display_entity(block_res.provider.clone())
+        self.add(self.get(&block_display)?.clone() as _)
     }
 
     async fn get_entity(
         &mut self,
         block_display: Resource<BlockDisplayEntity>,
     ) -> wasmtime::Result<Resource<Entity>> {
-        let block_res = self.get_block_display_entity_res(&block_display)?;
-        self.add_entity(block_res.provider.clone())
+        self.add(self.get(&block_display)?.clone() as _)
     }
 
     async fn get_block_state_id(
         &mut self,
         block_display: Resource<BlockDisplayEntity>,
     ) -> wasmtime::Result<u16> {
-        let block_res = self.get_block_display_entity_res(&block_display)?;
-        Ok(block_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalBlockDisplayEntity>()
-            .map_or(0, |b| b.get_block_state() as u16))
+        Ok(self.get(&block_display)?.get_block_state() as u16)
     }
 
     async fn set_block_state_id(
@@ -530,22 +503,12 @@ impl HostBlockDisplayEntity for PluginHostState {
         block_display: Resource<BlockDisplayEntity>,
         state_id: u16,
     ) -> wasmtime::Result<()> {
-        let block_res = self.get_block_display_entity_res(&block_display)?;
-        if let Some(b) = block_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalBlockDisplayEntity>()
-        {
-            b.set_block_state(state_id as i32);
-        }
+        self.get(&block_display)?.set_block_state(state_id as i32);
         Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<BlockDisplayEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<BlockDisplayEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -554,16 +517,8 @@ impl HostItemDisplayEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<ItemDisplayEntity>>> {
-        let entity_res = self
-            .resource_table
-            .get::<EntityResource>(&Resource::new_borrow(entity.rep()))?;
-        if entity_res
-            .provider
-            .cast_any()
-            .is::<InternalItemDisplayEntity>()
-        {
-            let res = self.add_item_display_entity(entity_res.provider.clone())?;
-            Ok(Some(res))
+        if let Ok(entity) = Arc::downcast(self.take(entity)?) {
+            Ok(Some(self.add(entity)?))
         } else {
             Ok(None)
         }
@@ -573,37 +528,26 @@ impl HostItemDisplayEntity for PluginHostState {
         &mut self,
         item_display: Resource<ItemDisplayEntity>,
     ) -> wasmtime::Result<Resource<DisplayEntity>> {
-        let item_res = self.get_item_display_entity_res(&item_display)?;
-        self.add_display_entity(item_res.provider.clone())
+        self.add(self.get(&item_display)?.clone() as _)
     }
 
     async fn get_entity(
         &mut self,
         item_display: Resource<ItemDisplayEntity>,
     ) -> wasmtime::Result<Resource<Entity>> {
-        let item_res = self.get_item_display_entity_res(&item_display)?;
-        self.add_entity(item_res.provider.clone())
+        self.add(self.get(&item_display)?.clone() as _)
     }
 
     async fn get_item(
         &mut self,
         item_display: Resource<ItemDisplayEntity>,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let item_res = self.get_item_display_entity_res(&item_display)?;
-        if let Some(i) = item_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalItemDisplayEntity>()
-        {
-            let item = i.get_item();
-            if *item.item == pumpkin_data::item::Item::AIR || item.item_count == 0 {
-                Ok(None)
-            } else {
-                let res = self.add_item_stack(Arc::new(tokio::sync::Mutex::new(item)))?;
-                Ok(Some(res))
-            }
-        } else {
+        let item = self.get(&item_display)?.get_item();
+        if *item.item == pumpkin_data::item::Item::AIR || item.item_count == 0 {
             Ok(None)
+        } else {
+            let res = self.add(Arc::new(tokio::sync::Mutex::new(item)))?;
+            Ok(Some(res))
         }
     }
 
@@ -612,19 +556,13 @@ impl HostItemDisplayEntity for PluginHostState {
         item_display: Resource<ItemDisplayEntity>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let item_res = self.get_item_display_entity_res(&item_display)?;
-        if let Some(i) = item_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalItemDisplayEntity>()
-        {
-            let stack = if let Some(item_res_val) = item {
-                self.get_item_stack(&item_res_val)?.lock().await.clone()
-            } else {
-                pumpkin_data::item_stack::ItemStack::new(0, &pumpkin_data::item::Item::AIR)
-            };
-            i.set_item(stack);
-        }
+        let stack = if let Some(item_res_val) = item {
+            self.get(&item_res_val)?.lock().await.clone()
+        } else {
+            pumpkin_data::item_stack::ItemStack::new(0, &pumpkin_data::item::Item::AIR)
+        };
+
+        self.get(&item_display)?.set_item(stack);
         Ok(())
     }
 
@@ -632,14 +570,9 @@ impl HostItemDisplayEntity for PluginHostState {
         &mut self,
         item_display: Resource<ItemDisplayEntity>,
     ) -> wasmtime::Result<ItemDisplayMode> {
-        let item_res = self.get_item_display_entity_res(&item_display)?;
-        Ok(item_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalItemDisplayEntity>()
-            .map_or(ItemDisplayMode::None, |i| {
-                map_item_display_mode(i.get_item_display_mode())
-            }))
+        Ok(map_item_display_mode(
+            self.get(&item_display)?.get_item_display_mode(),
+        ))
     }
 
     async fn set_item_display_mode(
@@ -647,22 +580,14 @@ impl HostItemDisplayEntity for PluginHostState {
         item_display: Resource<ItemDisplayEntity>,
         mode: ItemDisplayMode,
     ) -> wasmtime::Result<()> {
-        let item_res = self.get_item_display_entity_res(&item_display)?;
-        if let Some(i) = item_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalItemDisplayEntity>()
-        {
-            i.set_item_display_mode(map_item_display_mode_rev(mode));
-        }
+        self.get(&item_display)?
+            .set_item_display_mode(map_item_display_mode_rev(mode));
+
         Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<ItemDisplayEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<ItemDisplayEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -671,16 +596,8 @@ impl HostTextDisplayEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<TextDisplayEntity>>> {
-        let entity_res = self
-            .resource_table
-            .get::<EntityResource>(&Resource::new_borrow(entity.rep()))?;
-        if entity_res
-            .provider
-            .cast_any()
-            .is::<InternalTextDisplayEntity>()
-        {
-            let res = self.add_text_display_entity(entity_res.provider.clone())?;
-            Ok(Some(res))
+        if let Ok(entity) = Arc::downcast(self.take(entity)?) {
+            Ok(Some(self.add(entity)?))
         } else {
             Ok(None)
         }
@@ -690,33 +607,21 @@ impl HostTextDisplayEntity for PluginHostState {
         &mut self,
         text_display: Resource<TextDisplayEntity>,
     ) -> wasmtime::Result<Resource<DisplayEntity>> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        self.add_display_entity(text_res.provider.clone())
+        self.add(self.get(&text_display)?.clone() as _)
     }
 
     async fn get_entity(
         &mut self,
         text_display: Resource<TextDisplayEntity>,
     ) -> wasmtime::Result<Resource<Entity>> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        self.add_entity(text_res.provider.clone())
+        self.add(self.get(&text_display)?.clone() as _)
     }
 
     async fn get_text(
         &mut self,
         text_display: Resource<TextDisplayEntity>,
     ) -> wasmtime::Result<Resource<TextComponent>> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        if let Some(t) = text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-        {
-            let text = t.get_text();
-            self.add_text_component(text)
-        } else {
-            self.add_text_component(pumpkin_util::text::TextComponent::text(""))
-        }
+        self.add(self.get(&text_display)?.get_text())
     }
 
     async fn set_text(
@@ -724,15 +629,8 @@ impl HostTextDisplayEntity for PluginHostState {
         text_display: Resource<TextDisplayEntity>,
         text: Resource<TextComponent>,
     ) -> wasmtime::Result<()> {
-        let text_val = self.get_text_provider(&text)?;
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        if let Some(t) = text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-        {
-            t.set_text(text_val);
-        }
+        let text_val = self.take(text)?;
+        self.get(&text_display)?.set_text(text_val);
         Ok(())
     }
 
@@ -740,12 +638,7 @@ impl HostTextDisplayEntity for PluginHostState {
         &mut self,
         text_display: Resource<TextDisplayEntity>,
     ) -> wasmtime::Result<i32> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        Ok(text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-            .map_or(200, InternalTextDisplayEntity::get_line_width))
+        Ok(self.get(&text_display)?.get_line_width())
     }
 
     async fn set_line_width(
@@ -753,14 +646,7 @@ impl HostTextDisplayEntity for PluginHostState {
         text_display: Resource<TextDisplayEntity>,
         width: i32,
     ) -> wasmtime::Result<()> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        if let Some(t) = text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-        {
-            t.set_line_width(width);
-        }
+        self.get(&text_display)?.set_line_width(width);
         Ok(())
     }
 
@@ -768,15 +654,7 @@ impl HostTextDisplayEntity for PluginHostState {
         &mut self,
         text_display: Resource<TextDisplayEntity>,
     ) -> wasmtime::Result<i32> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        Ok(text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-            .map_or(
-                1_073_741_824,
-                InternalTextDisplayEntity::get_background_color,
-            ))
+        Ok(self.get(&text_display)?.get_background_color())
     }
 
     async fn set_background(
@@ -784,14 +662,7 @@ impl HostTextDisplayEntity for PluginHostState {
         text_display: Resource<TextDisplayEntity>,
         color: i32,
     ) -> wasmtime::Result<()> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        if let Some(t) = text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-        {
-            t.set_background_color(color);
-        }
+        self.get(&text_display)?.set_background_color(color);
         Ok(())
     }
 
@@ -799,12 +670,7 @@ impl HostTextDisplayEntity for PluginHostState {
         &mut self,
         text_display: Resource<TextDisplayEntity>,
     ) -> wasmtime::Result<i8> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        Ok(text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-            .map_or(-1, InternalTextDisplayEntity::get_text_opacity))
+        Ok(self.get(&text_display)?.get_text_opacity())
     }
 
     async fn set_text_opacity(
@@ -812,14 +678,7 @@ impl HostTextDisplayEntity for PluginHostState {
         text_display: Resource<TextDisplayEntity>,
         opacity: i8,
     ) -> wasmtime::Result<()> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        if let Some(t) = text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-        {
-            t.set_text_opacity(opacity);
-        }
+        self.get(&text_display)?.set_text_opacity(opacity);
         Ok(())
     }
 
@@ -827,12 +686,7 @@ impl HostTextDisplayEntity for PluginHostState {
         &mut self,
         text_display: Resource<TextDisplayEntity>,
     ) -> wasmtime::Result<bool> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        Ok(text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-            .is_some_and(InternalTextDisplayEntity::get_shadow))
+        Ok(self.get(&text_display)?.get_shadow())
     }
 
     async fn set_shadow(
@@ -840,14 +694,7 @@ impl HostTextDisplayEntity for PluginHostState {
         text_display: Resource<TextDisplayEntity>,
         shadow: bool,
     ) -> wasmtime::Result<()> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        if let Some(t) = text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-        {
-            t.set_shadow(shadow);
-        }
+        self.get(&text_display)?.set_shadow(shadow);
         Ok(())
     }
 
@@ -855,12 +702,7 @@ impl HostTextDisplayEntity for PluginHostState {
         &mut self,
         text_display: Resource<TextDisplayEntity>,
     ) -> wasmtime::Result<bool> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        Ok(text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-            .is_some_and(InternalTextDisplayEntity::get_see_through))
+        Ok(self.get(&text_display)?.get_see_through())
     }
 
     async fn set_see_through(
@@ -868,14 +710,7 @@ impl HostTextDisplayEntity for PluginHostState {
         text_display: Resource<TextDisplayEntity>,
         see_through: bool,
     ) -> wasmtime::Result<()> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        if let Some(t) = text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-        {
-            t.set_see_through(see_through);
-        }
+        self.get(&text_display)?.set_see_through(see_through);
         Ok(())
     }
 
@@ -883,12 +718,7 @@ impl HostTextDisplayEntity for PluginHostState {
         &mut self,
         text_display: Resource<TextDisplayEntity>,
     ) -> wasmtime::Result<bool> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        Ok(text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-            .is_some_and(InternalTextDisplayEntity::get_use_default_background))
+        Ok(self.get(&text_display)?.get_use_default_background())
     }
 
     async fn set_default_background(
@@ -896,14 +726,8 @@ impl HostTextDisplayEntity for PluginHostState {
         text_display: Resource<TextDisplayEntity>,
         default_background: bool,
     ) -> wasmtime::Result<()> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        if let Some(t) = text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-        {
-            t.set_use_default_background(default_background);
-        }
+        self.get(&text_display)?
+            .set_use_default_background(default_background);
         Ok(())
     }
 
@@ -911,14 +735,7 @@ impl HostTextDisplayEntity for PluginHostState {
         &mut self,
         text_display: Resource<TextDisplayEntity>,
     ) -> wasmtime::Result<TextAlignment> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        Ok(text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-            .map_or(TextAlignment::Center, |t| {
-                map_text_alignment(t.get_alignment())
-            }))
+        Ok(map_text_alignment(self.get(&text_display)?.get_alignment()))
     }
 
     async fn set_alignment(
@@ -926,22 +743,13 @@ impl HostTextDisplayEntity for PluginHostState {
         text_display: Resource<TextDisplayEntity>,
         alignment: TextAlignment,
     ) -> wasmtime::Result<()> {
-        let text_res = self.get_text_display_entity_res(&text_display)?;
-        if let Some(t) = text_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalTextDisplayEntity>()
-        {
-            t.set_alignment(map_text_alignment_rev(alignment));
-        }
+        self.get(&text_display)?
+            .set_alignment(map_text_alignment_rev(alignment));
         Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<TextDisplayEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<TextDisplayEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -950,16 +758,8 @@ impl HostInteractionEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<InteractionEntity>>> {
-        let entity_res = self
-            .resource_table
-            .get::<EntityResource>(&Resource::new_borrow(entity.rep()))?;
-        if entity_res
-            .provider
-            .cast_any()
-            .is::<InternalInteractionEntity>()
-        {
-            let res = self.add_interaction_entity(entity_res.provider.clone())?;
-            Ok(Some(res))
+        if let Ok(entity) = Arc::downcast(self.take(entity)?) {
+            Ok(Some(self.add(entity)?))
         } else {
             Ok(None)
         }
@@ -969,20 +769,14 @@ impl HostInteractionEntity for PluginHostState {
         &mut self,
         interaction: Resource<InteractionEntity>,
     ) -> wasmtime::Result<Resource<Entity>> {
-        let int_res = self.get_interaction_entity_res(&interaction)?;
-        self.add_entity(int_res.provider.clone())
+        self.add(self.get(&interaction)?.clone() as _)
     }
 
     async fn get_width(
         &mut self,
         interaction: Resource<InteractionEntity>,
     ) -> wasmtime::Result<f32> {
-        let int_res = self.get_interaction_entity_res(&interaction)?;
-        int_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalInteractionEntity>()
-            .map_or_else(|| Ok(1.0), |i| Ok(i.get_width()))
+        Ok(self.get(&interaction)?.get_width())
     }
 
     async fn set_width(
@@ -990,14 +784,7 @@ impl HostInteractionEntity for PluginHostState {
         interaction: Resource<InteractionEntity>,
         width: f32,
     ) -> wasmtime::Result<()> {
-        let int_res = self.get_interaction_entity_res(&interaction)?;
-        if let Some(i) = int_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalInteractionEntity>()
-        {
-            i.set_width(width);
-        }
+        self.get(&interaction)?.set_width(width);
         Ok(())
     }
 
@@ -1005,12 +792,7 @@ impl HostInteractionEntity for PluginHostState {
         &mut self,
         interaction: Resource<InteractionEntity>,
     ) -> wasmtime::Result<f32> {
-        let int_res = self.get_interaction_entity_res(&interaction)?;
-        int_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalInteractionEntity>()
-            .map_or_else(|| Ok(1.0), |i| Ok(i.get_height()))
+        Ok(self.get(&interaction)?.get_height())
     }
 
     async fn set_height(
@@ -1018,14 +800,7 @@ impl HostInteractionEntity for PluginHostState {
         interaction: Resource<InteractionEntity>,
         height: f32,
     ) -> wasmtime::Result<()> {
-        let int_res = self.get_interaction_entity_res(&interaction)?;
-        if let Some(i) = int_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalInteractionEntity>()
-        {
-            i.set_height(height);
-        }
+        self.get(&interaction)?.set_height(height);
         Ok(())
     }
 
@@ -1033,12 +808,7 @@ impl HostInteractionEntity for PluginHostState {
         &mut self,
         interaction: Resource<InteractionEntity>,
     ) -> wasmtime::Result<bool> {
-        let int_res = self.get_interaction_entity_res(&interaction)?;
-        Ok(int_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalInteractionEntity>()
-            .is_some_and(InternalInteractionEntity::get_response))
+        Ok(self.get(&interaction)?.get_response())
     }
 
     async fn set_response(
@@ -1046,14 +816,7 @@ impl HostInteractionEntity for PluginHostState {
         interaction: Resource<InteractionEntity>,
         response: bool,
     ) -> wasmtime::Result<()> {
-        let int_res = self.get_interaction_entity_res(&interaction)?;
-        if let Some(i) = int_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalInteractionEntity>()
-        {
-            i.set_response(response);
-        }
+        self.get(&interaction)?.set_response(response);
         Ok(())
     }
 
@@ -1061,42 +824,19 @@ impl HostInteractionEntity for PluginHostState {
         &mut self,
         interaction: Resource<InteractionEntity>,
     ) -> wasmtime::Result<Option<Uuid>> {
-        let int_res = self.get_interaction_entity_res(&interaction)?;
-        int_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalInteractionEntity>()
-            .map_or_else(
-                || Ok(None),
-                |i| {
-                    let action = i.get_last_attacker();
-                    Ok(action.map(|a| Uuid::to_wit(&a.player)))
-                },
-            )
+        let action = self.get(&interaction)?.get_last_attacker();
+        Ok(action.map(|a| Uuid::to_wit(&a.player)))
     }
 
     async fn get_last_interaction(
         &mut self,
         interaction: Resource<InteractionEntity>,
     ) -> wasmtime::Result<Option<Uuid>> {
-        let int_res = self.get_interaction_entity_res(&interaction)?;
-        int_res
-            .provider
-            .cast_any()
-            .downcast_ref::<InternalInteractionEntity>()
-            .map_or_else(
-                || Ok(None),
-                |i| {
-                    let action = i.get_target();
-                    Ok(action.map(|a| Uuid::to_wit(&a.player)))
-                },
-            )
+        let action = self.get(&interaction)?.get_last_attacker();
+        Ok(action.map(|a| Uuid::to_wit(&a.player)))
     }
 
     async fn drop(&mut self, rep: Resource<InteractionEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<InteractionEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/display.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/display.rs
@@ -106,9 +106,9 @@ fn get_display_entity<'a>(
 impl HostDisplayEntity for PluginHostState {
     async fn from_entity(
         &mut self,
-        entity: Resource<Entity>,
+        entity: /* borrow */ Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<DisplayEntity>>> {
-        let entity = self.take(entity)?;
+        let entity = self.get(&entity)?.clone();
         if get_display_entity(entity.as_ref()).is_some() {
             Ok(Some(self.add(entity.clone())?))
         } else {
@@ -468,9 +468,9 @@ impl HostDisplayEntity for PluginHostState {
 impl HostBlockDisplayEntity for PluginHostState {
     async fn from_entity(
         &mut self,
-        entity: Resource<Entity>,
+        entity: /* borrow */ Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<BlockDisplayEntity>>> {
-        if let Ok(entity) = Arc::downcast(self.take(entity)?) {
+        if let Ok(entity) = Arc::downcast(self.get(&entity)?.clone()) {
             Ok(Some(self.add(entity)?))
         } else {
             Ok(None)
@@ -515,9 +515,9 @@ impl HostBlockDisplayEntity for PluginHostState {
 impl HostItemDisplayEntity for PluginHostState {
     async fn from_entity(
         &mut self,
-        entity: Resource<Entity>,
+        entity: /* borrow */ Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<ItemDisplayEntity>>> {
-        if let Ok(entity) = Arc::downcast(self.take(entity)?) {
+        if let Ok(entity) = Arc::downcast(self.get(&entity)?.clone()) {
             Ok(Some(self.add(entity)?))
         } else {
             Ok(None)
@@ -594,9 +594,9 @@ impl HostItemDisplayEntity for PluginHostState {
 impl HostTextDisplayEntity for PluginHostState {
     async fn from_entity(
         &mut self,
-        entity: Resource<Entity>,
+        entity: /* borrow */ Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<TextDisplayEntity>>> {
-        if let Ok(entity) = Arc::downcast(self.take(entity)?) {
+        if let Ok(entity) = Arc::downcast(self.get(&entity)?.clone()) {
             Ok(Some(self.add(entity)?))
         } else {
             Ok(None)
@@ -756,9 +756,9 @@ impl HostTextDisplayEntity for PluginHostState {
 impl HostInteractionEntity for PluginHostState {
     async fn from_entity(
         &mut self,
-        entity: Resource<Entity>,
+        entity: /* borrow */ Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<InteractionEntity>>> {
-        if let Ok(entity) = Arc::downcast(self.take(entity)?) {
+        if let Ok(entity) = Arc::downcast(self.get(&entity)?.clone()) {
             Ok(Some(self.add(entity)?))
         } else {
             Ok(None)

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/display.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/display.rs
@@ -557,7 +557,7 @@ impl HostItemDisplayEntity for PluginHostState {
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
         let stack = if let Some(item_res_val) = item {
-            self.get(&item_res_val)?.lock().await.clone()
+            self.take(item_res_val)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::new(0, &pumpkin_data::item::Item::AIR)
         };
@@ -832,7 +832,7 @@ impl HostInteractionEntity for PluginHostState {
         &mut self,
         interaction: Resource<InteractionEntity>,
     ) -> wasmtime::Result<Option<Uuid>> {
-        let action = self.get(&interaction)?.get_last_attacker();
+        let action = self.get(&interaction)?.get_target();
         Ok(action.map(|a| Uuid::to_wit(&a.player)))
     }
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/enchantment.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/enchantment.rs
@@ -45,7 +45,7 @@ impl HostEnchantmentManager for PluginHostState {
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
 
         if let Some(entry) = server.enchantment_manager.get(&id).await {
-            let description = self.add_text_component(entry.description)?;
+            let description = self.add(entry.description)?;
             return Ok(Some(WitCustomEnchantment {
                 id: entry.id,
                 description,
@@ -59,8 +59,7 @@ impl HostEnchantmentManager for PluginHostState {
         }
 
         if let Some(vanilla) = find_vanilla_enchantment(&id) {
-            let description =
-                self.add_text_component(TextComponent::translate(vanilla.description, []))?;
+            let description = self.add(TextComponent::translate(vanilla.description, []))?;
             return Ok(Some(WitCustomEnchantment {
                 id: vanilla.name.to_string(),
                 description,

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/enchantment.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/enchantment.rs
@@ -14,8 +14,7 @@ impl HostEnchantmentManager for PluginHostState {
         _res: Resource<WitEnchantmentManager>,
         enchantment: WitCustomEnchantment,
     ) -> wasmtime::Result<Result<(), String>> {
-        let description =
-            super::player::text_component_from_resource(self, &enchantment.description);
+        let description = self.take(enchantment.description)?;
         let entry = CustomEnchantmentEntry {
             id: enchantment.id,
             description,
@@ -113,8 +112,8 @@ impl HostEnchantmentManager for PluginHostState {
         Ok(ids)
     }
 
-    async fn drop(&mut self, _rep: Resource<WitEnchantmentManager>) -> wasmtime::Result<()> {
-        Ok(())
+    async fn drop(&mut self, rep: Resource<WitEnchantmentManager>) -> wasmtime::Result<()> {
+        self.drop(rep)
     }
 }
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
@@ -4,7 +4,7 @@ use wasmtime::component::{Access, HasSelf, Resource};
 use pumpkin_util::math::vector3::Vector3;
 
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{EntityResource, PluginHostState},
+    state::PluginHostState,
     wit::v0_1::events::to_wasm_position,
     wit::v0_1::pumpkin::plugin::{
         common::{EntityPose, NbtTree as WitNbtTree, Position},
@@ -32,11 +32,9 @@ pub fn entity_from_resource(
     state: &PluginHostState,
     entity: &Resource<Entity>,
 ) -> wasmtime::Result<std::sync::Arc<dyn crate::entity::EntityBase>> {
-    state
-        .resource_table
-        .get::<EntityResource>(&Resource::new_own(entity.rep()))
+    state.get(entity)
         .map_err(|_| wasmtime::Error::msg("invalid entity resource handle"))
-        .map(|resource| resource.provider.clone())
+        .map(|resource| resource.clone())
 }
 
 fn active_plugin(
@@ -100,7 +98,7 @@ impl HostEntity for PluginHostState {
     async fn get_world(&mut self, entity: Resource<Entity>) -> wasmtime::Result<Resource<World>> {
         let entity = entity_from_resource(self, &entity)?;
         let world = entity.get_entity().world.load_full();
-        self.add_world(world)
+        self.add(world)
             .map_err(|_| wasmtime::Error::msg("failed to add world resource"))
     }
 
@@ -275,7 +273,7 @@ impl HostEntity for PluginHostState {
     ) -> wasmtime::Result<Resource<TextComponent>> {
         let entity = entity_from_resource(self, &entity)?;
         let name = entity.get_name();
-        self.add_text_component(name)
+        self.add(name)
             .map_err(|_| wasmtime::Error::msg("failed to add text component resource"))
     }
 
@@ -284,14 +282,9 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         name: Resource<TextComponent>,
     ) -> wasmtime::Result<()> {
+        let text_res = self.take(name)?;
         let entity_base = entity_from_resource(self, &entity)?;
-        let text_res = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::TextComponentResource>(
-                &Resource::new_own(name.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid text component resource handle"))?;
-        let text = text_res.provider.clone();
+        let text = text_res.clone();
         entity_base.get_entity().set_custom_name(text);
         Ok(())
     }
@@ -303,9 +296,9 @@ impl HostEntity for PluginHostState {
         let entity = entity_from_resource(self, &entity)?;
         let name = entity.get_entity().custom_name.load();
         if let Some(name) = name.as_ref() {
-            Ok(Some(self.add_text_component(name.clone()).map_err(
-                |_| wasmtime::Error::msg("failed to add text component resource"),
-            )?))
+            Ok(Some(self.add(name.clone()).map_err(|_| {
+                wasmtime::Error::msg("failed to add text component resource")
+            })?))
         } else {
             Ok(None)
         }
@@ -447,7 +440,7 @@ impl HostEntity for PluginHostState {
             // Don't include the entity itself
             if e.get_entity().entity_id != entity.get_entity().entity_id {
                 result.push(
-                    self.add_entity(e)
+                    self.add(e)
                         .map_err(|_| wasmtime::Error::msg("failed to add entity resource"))?,
                 );
             }
@@ -466,7 +459,7 @@ impl HostEntity for PluginHostState {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if let Some(v) = vehicle.as_ref() {
-            Ok(Some(self.add_entity(Arc::clone(v)).map_err(|_| {
+            Ok(Some(self.add(Arc::clone(v)).map_err(|_| {
                 wasmtime::Error::msg("failed to add entity resource")
             })?))
         } else {
@@ -487,7 +480,7 @@ impl HostEntity for PluginHostState {
         let mut result = Vec::new();
         for p in passengers.iter() {
             result.push(
-                self.add_entity(Arc::clone(p))
+                self.add(Arc::clone(p))
                     .map_err(|_| wasmtime::Error::msg("failed to add entity resource"))?,
             );
         }
@@ -704,7 +697,7 @@ impl HostEntity for PluginHostState {
         for (hit_entity, hit_pos, distance) in hits {
             if hit_entity.get_entity().entity_id != self_id {
                 let entity_res = self
-                    .add_entity(hit_entity)
+                    .add(hit_entity)
                     .map_err(|_| wasmtime::Error::msg("failed to add entity resource"))?;
                 return Ok(Some(WitRayTraceEntityResult {
                     entity: entity_res,
@@ -781,7 +774,7 @@ impl HostEntity for PluginHostState {
     ) -> wasmtime::Result<Option<Resource<WitLivingEntity>>> {
         let entity = entity_from_resource(self, &this)?;
         if entity.get_living_entity().is_some() {
-            Ok(Some(self.add_living_entity(entity)?))
+            Ok(Some(self.add(entity)?))
         } else {
             Ok(None)
         }
@@ -793,7 +786,7 @@ impl HostEntity for PluginHostState {
     ) -> wasmtime::Result<Option<Resource<WitMob>>> {
         let entity = entity_from_resource(self, &this)?;
         if entity.get_mob().is_some() {
-            Ok(Some(self.add_mob(entity)?))
+            Ok(Some(self.add(entity)?))
         } else {
             Ok(None)
         }
@@ -810,10 +803,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<Entity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<EntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -826,19 +816,12 @@ impl
         mut host: Access<'_, PluginHostState, Self>,
         entity: Resource<Entity>,
         pos: Position,
-        world_ref: Resource<World>,
+        world: Resource<World>,
     ) -> wasmtime::Result<()> {
         let (entity, world, plugin) = {
             let state = host.get();
+            let world = state.take(world)?;
             let entity = entity_from_resource(state, &entity)?;
-            let world = state
-                .resource_table
-                .get::<crate::plugin::loader::wasm::wasm_host::state::WorldResource>(
-                    &Resource::new_own(world_ref.rep()),
-                )
-                .map_err(|_| wasmtime::Error::msg("invalid world resource handle"))?
-                .provider
-                .clone();
             (entity, world, active_plugin(state)?)
         };
         let pos = Vector3::new(pos.0, pos.1, pos.2);

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
@@ -28,15 +28,6 @@ use pumpkin_data::entity::EntityPose as InternalEntityPose;
 impl Host for PluginHostState {}
 impl entity_types::Host for PluginHostState {}
 
-pub fn entity_from_resource(
-    state: &PluginHostState,
-    entity: &Resource<Entity>,
-) -> wasmtime::Result<std::sync::Arc<dyn crate::entity::EntityBase>> {
-    state.get(entity)
-        .map_err(|_| wasmtime::Error::msg("invalid entity resource handle"))
-        .map(|resource| resource.clone())
-}
-
 fn active_plugin(
     state: &PluginHostState,
 ) -> wasmtime::Result<Arc<crate::plugin::loader::wasm::wasm_host::WasmPlugin>> {
@@ -72,12 +63,12 @@ const fn map_entity_pose(pose: InternalEntityPose) -> EntityPose {
 
 impl HostEntity for PluginHostState {
     async fn get_id(&mut self, entity: Resource<Entity>) -> wasmtime::Result<u32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity.get_entity().entity_id as u32)
     }
 
     async fn get_uuid(&mut self, entity: Resource<Entity>) -> wasmtime::Result<Uuid> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(Uuid::to_wit(&entity.get_entity().entity_uuid))
     }
 
@@ -85,40 +76,40 @@ impl HostEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<entity_types::EntityType> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         let original_name = entity.get_entity().entity_type.resource_name;
         to_wit_entity_type(original_name)
     }
 
     async fn get_position(&mut self, entity: Resource<Entity>) -> wasmtime::Result<Position> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(to_wasm_position(entity.get_entity().pos.load()))
     }
 
     async fn get_world(&mut self, entity: Resource<Entity>) -> wasmtime::Result<Resource<World>> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         let world = entity.get_entity().world.load_full();
         self.add(world)
             .map_err(|_| wasmtime::Error::msg("failed to add world resource"))
     }
 
     async fn get_yaw(&mut self, entity: Resource<Entity>) -> wasmtime::Result<f32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity.get_entity().yaw.load())
     }
 
     async fn get_pitch(&mut self, entity: Resource<Entity>) -> wasmtime::Result<f32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity.get_entity().pitch.load())
     }
 
     async fn get_head_yaw(&mut self, entity: Resource<Entity>) -> wasmtime::Result<f32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity.get_entity().head_yaw.load())
     }
 
     async fn is_on_ground(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .on_ground
@@ -126,7 +117,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn is_sneaking(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .sneaking
@@ -134,7 +125,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn is_sprinting(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .sprinting
@@ -142,7 +133,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn is_invisible(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .invisible
@@ -150,7 +141,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn is_glowing(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .glowing
@@ -162,7 +153,7 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         velocity: Position,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity
             .get_entity()
             .velocity
@@ -173,7 +164,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn get_velocity(&mut self, entity: Resource<Entity>) -> wasmtime::Result<Position> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(to_wasm_position(entity.get_entity().velocity.load()))
     }
 
@@ -182,7 +173,7 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         sneaking: bool,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_sneaking(sneaking);
         Ok(())
     }
@@ -192,13 +183,13 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         sprinting: bool,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_sprinting(sprinting);
         Ok(())
     }
 
     async fn is_swimming(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .swimming
@@ -210,7 +201,7 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         invisible: bool,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_invisible(invisible);
         Ok(())
     }
@@ -220,13 +211,13 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         glowing: bool,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_glowing(glowing);
         Ok(())
     }
 
     async fn is_fall_flying(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .fall_flying
@@ -238,13 +229,13 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         fall_flying: bool,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_fall_flying(fall_flying);
         Ok(())
     }
 
     async fn is_on_fire(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .fire_ticks
@@ -257,13 +248,13 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         on_fire: bool,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_on_fire(on_fire);
         Ok(())
     }
 
     async fn get_pose(&mut self, entity: Resource<Entity>) -> wasmtime::Result<EntityPose> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(map_entity_pose(entity.get_entity().pose.load()))
     }
 
@@ -271,7 +262,7 @@ impl HostEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<Resource<TextComponent>> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         let name = entity.get_name();
         self.add(name)
             .map_err(|_| wasmtime::Error::msg("failed to add text component resource"))
@@ -283,7 +274,7 @@ impl HostEntity for PluginHostState {
         name: Resource<TextComponent>,
     ) -> wasmtime::Result<()> {
         let text_res = self.take(name)?;
-        let entity_base = entity_from_resource(self, &entity)?;
+        let entity_base = self.get(&entity)?;
         let text = text_res.clone();
         entity_base.get_entity().set_custom_name(text);
         Ok(())
@@ -293,7 +284,7 @@ impl HostEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<TextComponent>>> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         let name = entity.get_entity().custom_name.load();
         if let Some(name) = name.as_ref() {
             Ok(Some(self.add(name.clone()).map_err(|_| {
@@ -309,13 +300,13 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         visible: bool,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_custom_name_visible(visible);
         Ok(())
     }
 
     async fn is_custom_name_visible(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .custom_name_visible
@@ -323,7 +314,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn is_invulnerable(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .invulnerable
@@ -335,7 +326,7 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         invulnerable: bool,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity
             .get_entity()
             .invulnerable
@@ -344,7 +335,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn get_fire_ticks(&mut self, entity: Resource<Entity>) -> wasmtime::Result<i32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .fire_ticks
@@ -356,7 +347,7 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         ticks: i32,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity
             .get_entity()
             .fire_ticks
@@ -365,7 +356,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn get_fall_distance(&mut self, entity: Resource<Entity>) -> wasmtime::Result<f32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_living_entity()
             .map_or(0.0, |living| living.fall_distance.load()))
@@ -376,7 +367,7 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         distance: f32,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         if let Some(living) = entity.get_living_entity() {
             living.fall_distance.store(distance);
         }
@@ -384,18 +375,18 @@ impl HostEntity for PluginHostState {
     }
 
     async fn is_silent(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity.get_entity().is_silent())
     }
 
     async fn set_silent(&mut self, entity: Resource<Entity>, silent: bool) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_silent(silent);
         Ok(())
     }
 
     async fn has_gravity(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(!entity.get_entity().has_no_gravity())
     }
 
@@ -404,18 +395,18 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         gravity: bool,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_has_no_gravity(!gravity);
         Ok(())
     }
 
     async fn get_eye_height(&mut self, entity: Resource<Entity>) -> wasmtime::Result<f32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity.get_entity().entity_dimension.load().eye_height)
     }
 
     async fn get_eye_position(&mut self, entity: Resource<Entity>) -> wasmtime::Result<Position> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(to_wasm_position(entity.get_eye_pos()))
     }
 
@@ -426,7 +417,7 @@ impl HostEntity for PluginHostState {
         y: f64,
         z: f64,
     ) -> wasmtime::Result<Vec<Resource<Entity>>> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?.clone();
         let pos = entity.get_entity().pos.load();
         let box_range = pumpkin_util::math::boundingbox::BoundingBox::new(
             Vector3::new(pos.x - x, pos.y - y, pos.z - z),
@@ -452,7 +443,7 @@ impl HostEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<Entity>>> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?.clone();
         let vehicle = entity
             .get_entity()
             .vehicle
@@ -471,7 +462,7 @@ impl HostEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<Vec<Resource<Entity>>> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?.clone();
         let passengers = entity
             .get_entity()
             .passengers
@@ -491,7 +482,7 @@ impl HostEntity for PluginHostState {
         &mut self,
         entity: Resource<Entity>,
     ) -> wasmtime::Result<WitBoundingBox> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         let bb = entity.get_entity().bounding_box.load();
         Ok(WitBoundingBox {
             min: to_wasm_position(bb.min),
@@ -500,7 +491,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn is_in_water(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .touching_water
@@ -508,7 +499,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn is_in_lava(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .touching_lava
@@ -516,7 +507,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn get_ticks_lived(&mut self, entity: Resource<Entity>) -> wasmtime::Result<i32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .age
@@ -528,7 +519,7 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         ticks: i32,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity
             .get_entity()
             .age
@@ -537,12 +528,12 @@ impl HostEntity for PluginHostState {
     }
 
     async fn get_width(&mut self, entity: Resource<Entity>) -> wasmtime::Result<f32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity.get_entity().entity_dimension.load().width)
     }
 
     async fn get_height(&mut self, entity: Resource<Entity>) -> wasmtime::Result<f32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity.get_entity().entity_dimension.load().height)
     }
 
@@ -552,13 +543,13 @@ impl HostEntity for PluginHostState {
         yaw: f32,
         pitch: f32,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_rotation(yaw, pitch);
         Ok(())
     }
 
     async fn has_visual_fire(&mut self, entity: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .has_visual_fire
@@ -570,13 +561,13 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         visual_fire: bool,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().set_on_fire(visual_fire);
         Ok(())
     }
 
     async fn get_portal_cooldown(&mut self, entity: Resource<Entity>) -> wasmtime::Result<u32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity
             .get_entity()
             .portal_cooldown
@@ -588,7 +579,7 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         cooldown: u32,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity
             .get_entity()
             .portal_cooldown
@@ -597,7 +588,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn get_remaining_air(&mut self, entity: Resource<Entity>) -> wasmtime::Result<i32> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         Ok(entity.get_player().map_or(0, |player| {
             player
                 .breath_manager
@@ -611,7 +602,7 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         air: i32,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         if let Some(player) = entity.get_player() {
             player
                 .breath_manager
@@ -627,7 +618,7 @@ impl HostEntity for PluginHostState {
     }
 
     async fn remove(&mut self, entity: Resource<Entity>) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         entity.get_entity().remove();
         Ok(())
     }
@@ -638,7 +629,7 @@ impl HostEntity for PluginHostState {
         max_distance: f64,
         fluid_handling: bool,
     ) -> wasmtime::Result<Option<WitRaycastResult>> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         let start = entity.get_eye_pos();
         let direction = entity.get_looking_vector();
         let end = start + direction * max_distance;
@@ -662,7 +653,7 @@ impl HostEntity for PluginHostState {
         max_distance: f64,
         include_fluids: bool,
     ) -> wasmtime::Result<Option<WitRayTraceBlockResult>> {
-        let entity = entity_from_resource(self, &entity)?;
+        let entity = self.get(&entity)?;
         let start = entity.get_eye_pos();
         let direction = entity.get_looking_vector();
         let end = start + direction * max_distance;
@@ -686,7 +677,7 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         max_distance: f64,
     ) -> wasmtime::Result<Option<WitRayTraceEntityResult>> {
-        let entity_base = entity_from_resource(self, &entity)?;
+        let entity_base = self.get(&entity)?;
         let start = entity_base.get_eye_pos();
         let direction = entity_base.get_looking_vector();
         let end = start + direction * max_distance;
@@ -726,7 +717,7 @@ impl HostEntity for PluginHostState {
         key: String,
         value: WitNbtTree,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let base_entity = entity.get_entity();
         let tag = super::common::from_wit_nbt_tree(&value).map_err(wasmtime::Error::msg)?;
         base_entity.set_custom_data(&namespace, &key, tag);
@@ -739,7 +730,7 @@ impl HostEntity for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<Option<WitNbtTree>> {
-        let entity = entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let base_entity = entity.get_entity();
         let tag = base_entity.get_custom_data(&namespace, &key);
         Ok(tag.map(super::common::to_wit_nbt_tree))
@@ -751,7 +742,7 @@ impl HostEntity for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<()> {
-        let entity = entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let base_entity = entity.get_entity();
         base_entity.remove_custom_data(&namespace, &key);
         Ok(())
@@ -763,7 +754,7 @@ impl HostEntity for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let base_entity = entity.get_entity();
         Ok(base_entity.has_custom_data(&namespace, &key))
     }
@@ -772,7 +763,7 @@ impl HostEntity for PluginHostState {
         &mut self,
         this: Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<WitLivingEntity>>> {
-        let entity = entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?.clone();
         if entity.get_living_entity().is_some() {
             Ok(Some(self.add(entity)?))
         } else {
@@ -784,7 +775,7 @@ impl HostEntity for PluginHostState {
         &mut self,
         this: Resource<Entity>,
     ) -> wasmtime::Result<Option<Resource<WitMob>>> {
-        let entity = entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?.clone();
         if entity.get_mob().is_some() {
             Ok(Some(self.add(entity)?))
         } else {
@@ -793,12 +784,12 @@ impl HostEntity for PluginHostState {
     }
 
     async fn is_living(&mut self, this: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_living_entity().is_some())
     }
 
     async fn is_mob(&mut self, this: Resource<Entity>) -> wasmtime::Result<bool> {
-        let entity = entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_mob().is_some())
     }
 
@@ -821,7 +812,7 @@ impl
         let (entity, world, plugin) = {
             let state = host.get();
             let world = state.take(world)?;
-            let entity = entity_from_resource(state, &entity)?;
+            let entity = state.get(&entity)?.clone();
             (entity, world, active_plugin(state)?)
         };
         let pos = Vector3::new(pos.0, pos.1, pos.2);
@@ -838,7 +829,7 @@ impl
     ) -> wasmtime::Result<()> {
         let (entity, plugin) = {
             let state = host.get();
-            (entity_from_resource(state, &entity)?, active_plugin(state)?)
+            (state.get(&entity)?.clone(), active_plugin(state)?)
         };
         plugin
             .store
@@ -855,11 +846,8 @@ impl
     ) -> wasmtime::Result<()> {
         let (entity, vehicle, plugin) = {
             let state = host.get();
-            let entity = entity_from_resource(state, &entity)?;
-            let vehicle = vehicle
-                .as_ref()
-                .map(|vehicle| entity_from_resource(state, vehicle))
-                .transpose()?;
+            let entity = state.get(&entity)?.clone();
+            let vehicle = vehicle.map(|vehicle| state.take(vehicle)).transpose()?;
             (entity, vehicle, active_plugin(state)?)
         };
         plugin
@@ -893,8 +881,8 @@ impl
         let (entity, passenger, plugin) = {
             let state = host.get();
             (
-                entity_from_resource(state, &entity)?,
-                entity_from_resource(state, &passenger)?,
+                state.get(&entity)?.clone(),
+                state.take(passenger)?,
                 active_plugin(state)?,
             )
         };
@@ -915,8 +903,8 @@ impl
     ) -> wasmtime::Result<()> {
         let (entity, passenger_id, plugin) = {
             let state = host.get();
-            let entity = entity_from_resource(state, &entity)?;
-            let passenger = entity_from_resource(state, &passenger)?;
+            let entity = state.get(&entity)?.clone();
+            let passenger = state.take(passenger)?;
             (
                 entity,
                 passenger.get_entity().entity_id,
@@ -937,7 +925,7 @@ impl
     ) -> wasmtime::Result<()> {
         let (entity, plugin) = {
             let state = host.get();
-            (entity_from_resource(state, &entity)?, active_plugin(state)?)
+            (state.get(&entity)?.clone(), active_plugin(state)?)
         };
         plugin
             .store

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
@@ -273,9 +273,8 @@ impl HostEntity for PluginHostState {
         entity: Resource<Entity>,
         name: Resource<TextComponent>,
     ) -> wasmtime::Result<()> {
-        let text_res = self.take(name)?;
+        let text = self.take(name)?;
         let entity_base = self.get(&entity)?;
-        let text = text_res.clone();
         entity_base.get_entity().set_custom_name(text);
         Ok(())
     }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/block.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/block.rs
@@ -81,7 +81,7 @@ use crate::plugin::{
 impl ToFromWasmEvent for BlockRedstoneEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         Event::BlockRedstoneEvent(BlockRedstoneEventData {
@@ -113,7 +113,7 @@ impl ToFromWasmEvent for BlockBreakEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = self.player.as_ref().map(|player| {
             state
-                .add_player(player.clone())
+                .add(player.clone())
                 .expect("failed to add player resource")
         });
 
@@ -166,7 +166,7 @@ impl ToFromWasmEvent for BlockBurnEvent {
 impl ToFromWasmEvent for BlockCanBuildEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::BlockCanBuildEvent(BlockCanBuildEventData {
@@ -195,7 +195,7 @@ impl ToFromWasmEvent for BlockCanBuildEvent {
 impl ToFromWasmEvent for BlockGrowEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         Event::BlockGrowEvent(BlockGrowEventData {
@@ -228,7 +228,7 @@ impl ToFromWasmEvent for BlockGrowEvent {
 impl ToFromWasmEvent for BlockPlaceEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::BlockPlaceEvent(BlockPlaceEventData {
@@ -259,7 +259,7 @@ impl ToFromWasmEvent for BlockPlaceEvent {
 impl ToFromWasmEvent for BlockDamageEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::BlockDamageEvent(BlockDamageEventData {
@@ -498,7 +498,7 @@ impl ToFromWasmEvent for NotePlayEvent {
 impl ToFromWasmEvent for SignChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::SignChangeEvent(SignChangeEventData {
             player,
@@ -564,7 +564,7 @@ impl ToFromWasmEvent for TNTPrimeEvent {
 impl ToFromWasmEvent for BellResonateEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::BellResonateEvent(BellResonateEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -595,7 +595,7 @@ impl ToFromWasmEvent for BellResonateEvent {
 impl ToFromWasmEvent for BellRingEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::BellRingEvent(BellRingEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -624,13 +624,13 @@ impl ToFromWasmEvent for BellRingEvent {
 impl ToFromWasmEvent for BlockBrushEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let item = state
-            .add_item_stack(Arc::new(Mutex::new(self.item.clone())))
+            .add(Arc::new(Mutex::new(self.item.clone())))
             .expect("failed to add item stack resource");
         Event::BlockBrushEvent(BlockBrushEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -659,13 +659,13 @@ impl ToFromWasmEvent for BlockBrushEvent {
 impl ToFromWasmEvent for BlockCookEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         let source = state
-            .add_item_stack(Arc::new(Mutex::new(self.source.clone())))
+            .add(Arc::new(Mutex::new(self.source.clone())))
             .expect("failed to add item stack resource");
         let result = state
-            .add_item_stack(Arc::new(Mutex::new(self.result.clone())))
+            .add(Arc::new(Mutex::new(self.result.clone())))
             .expect("failed to add item stack resource");
         Event::BlockCookEvent(BlockCookEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -694,13 +694,13 @@ impl ToFromWasmEvent for BlockCookEvent {
 impl ToFromWasmEvent for BlockDamageAbortEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         let item_in_hand = state
-            .add_item_stack(Arc::new(Mutex::new(self.item_in_hand.clone())))
+            .add(Arc::new(Mutex::new(self.item_in_hand.clone())))
             .expect("failed to add item stack resource");
         Event::BlockDamageAbortEvent(BlockDamageAbortEventData {
             player,
@@ -723,10 +723,10 @@ impl ToFromWasmEvent for BlockDamageAbortEvent {
 impl ToFromWasmEvent for BlockDispenseArmorEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         let item = state
-            .add_item_stack(Arc::new(Mutex::new(self.item.clone())))
+            .add(Arc::new(Mutex::new(self.item.clone())))
             .expect("failed to add item stack resource");
         Event::BlockDispenseArmorEvent(BlockDispenseArmorEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -757,14 +757,14 @@ impl ToFromWasmEvent for BlockDispenseArmorEvent {
 impl ToFromWasmEvent for BlockDispenseLootEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         let items = self
             .items
             .iter()
             .map(|i| {
                 state
-                    .add_item_stack(Arc::new(Mutex::new(i.clone())))
+                    .add(Arc::new(Mutex::new(i.clone())))
                     .expect("failed to add item stack resource")
             })
             .collect();
@@ -796,19 +796,18 @@ impl ToFromWasmEvent for BlockDispenseLootEvent {
 impl ToFromWasmEvent for BlockDropItemEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
-        let player = self.player.as_ref().map(|p| {
-            state
-                .add_player(p.clone())
-                .expect("failed to add player resource")
-        });
+        let player = self
+            .player
+            .as_ref()
+            .map(|p| state.add(p.clone()).expect("failed to add player resource"));
         let items = self
             .items
             .iter()
             .map(|i| {
                 state
-                    .add_item_stack(Arc::new(Mutex::new(i.clone())))
+                    .add(Arc::new(Mutex::new(i.clone())))
                     .expect("failed to add item stack resource")
             })
             .collect();
@@ -839,7 +838,7 @@ impl ToFromWasmEvent for BlockDropItemEvent {
 impl ToFromWasmEvent for BlockExpEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::BlockExpEvent(BlockExpEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -870,13 +869,12 @@ impl ToFromWasmEvent for BlockExpEvent {
 impl ToFromWasmEvent for BlockFertilizeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
-        let player = self.player.as_ref().map(|p| {
-            state
-                .add_player(p.clone())
-                .expect("failed to add player resource")
-        });
+        let player = self
+            .player
+            .as_ref()
+            .map(|p| state.add(p.clone()).expect("failed to add player resource"));
         let changed_blocks = self
             .changed_blocks
             .iter()
@@ -911,10 +909,10 @@ impl ToFromWasmEvent for BlockFertilizeEvent {
 impl ToFromWasmEvent for BlockMultiPlaceEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         let placed_blocks = self
             .placed_blocks
@@ -949,7 +947,7 @@ impl ToFromWasmEvent for BlockMultiPlaceEvent {
 impl ToFromWasmEvent for BlockReceiveGameEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::BlockReceiveGameEvent(BlockReceiveGameEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -983,10 +981,10 @@ impl ToFromWasmEvent for BlockReceiveGameEvent {
 impl ToFromWasmEvent for BlockShearEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         let item = state
-            .add_item_stack(Arc::new(Mutex::new(self.item.clone())))
+            .add(Arc::new(Mutex::new(self.item.clone())))
             .expect("failed to add item stack resource");
         Event::BlockShearEntityEvent(BlockShearEntityEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -1017,7 +1015,7 @@ impl ToFromWasmEvent for BlockShearEntityEvent {
 impl ToFromWasmEvent for BlockSpreadEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::BlockSpreadEvent(BlockSpreadEventData {
             source_pos: to_wasm_block_position(self.source_pos),
@@ -1053,7 +1051,7 @@ impl ToFromWasmEvent for BlockSpreadEvent {
 impl ToFromWasmEvent for BrewingStartEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::BrewingStartEvent(BrewingStartEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -1087,10 +1085,10 @@ impl ToFromWasmEvent for BrewingStartEvent {
 impl ToFromWasmEvent for CampfireStartEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         let item = state
-            .add_item_stack(Arc::new(Mutex::new(self.item.clone())))
+            .add(Arc::new(Mutex::new(self.item.clone())))
             .expect("failed to add item stack resource");
         Event::CampfireStartEvent(CampfireStartEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -1121,7 +1119,7 @@ impl ToFromWasmEvent for CampfireStartEvent {
 impl ToFromWasmEvent for CauldronLevelChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::CauldronLevelChangeEvent(CauldronLevelChangeEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -1155,10 +1153,10 @@ impl ToFromWasmEvent for CauldronLevelChangeEvent {
 impl ToFromWasmEvent for CrafterCraftEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         let result = state
-            .add_item_stack(Arc::new(Mutex::new(self.result.clone())))
+            .add(Arc::new(Mutex::new(self.result.clone())))
             .expect("failed to add item stack resource");
         Event::CrafterCraftEvent(CrafterCraftEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -1186,7 +1184,7 @@ impl ToFromWasmEvent for CrafterCraftEvent {
 impl ToFromWasmEvent for EntityBlockFormEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::EntityBlockFormEvent(EntityBlockFormEventData {
             entity_id: self.entity.get_entity().entity_id,
@@ -1218,7 +1216,7 @@ impl ToFromWasmEvent for EntityBlockFormEvent {
 impl ToFromWasmEvent for FluidLevelChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::FluidLevelChangeEvent(FluidLevelChangeEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -1252,7 +1250,7 @@ impl ToFromWasmEvent for FluidLevelChangeEvent {
 impl ToFromWasmEvent for InventoryBlockStartEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::InventoryBlockStartEvent(InventoryBlockStartEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -1274,7 +1272,7 @@ impl ToFromWasmEvent for InventoryBlockStartEvent {
 impl ToFromWasmEvent for LeavesDecayEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::LeavesDecayEvent(LeavesDecayEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -1305,7 +1303,7 @@ impl ToFromWasmEvent for LeavesDecayEvent {
 impl ToFromWasmEvent for MoistureChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::MoistureChangeEvent(MoistureChangeEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -1339,7 +1337,7 @@ impl ToFromWasmEvent for MoistureChangeEvent {
 impl ToFromWasmEvent for SculkBloomEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::SculkBloomEvent(SculkBloomEventData {
             block_pos: to_wasm_block_position(self.block_pos),
@@ -1373,10 +1371,10 @@ impl ToFromWasmEvent for SculkBloomEvent {
 impl ToFromWasmEvent for VaultDisplayItemEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         let item = state
-            .add_item_stack(Arc::new(Mutex::new(self.item.clone())))
+            .add(Arc::new(Mutex::new(self.item.clone())))
             .expect("failed to add item stack resource");
         Event::VaultDisplayItemEvent(VaultDisplayItemEventData {
             block_pos: to_wasm_block_position(self.block_pos),

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/cleanup.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/cleanup.rs
@@ -1,8 +1,5 @@
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{
-        EntityResource, ItemStackResource, PlayerResource, PluginHostState, ServerResource,
-        TextComponentResource, WorldResource,
-    },
+    state::PluginHostState,
     wit::v0_1::pumpkin::plugin::{
         entity::Entity, event::Event, item_stack::ItemStack, player::Player, server::Server,
         text::TextComponent, world::World,
@@ -11,39 +8,27 @@ use crate::plugin::loader::wasm::wasm_host::{
 use wasmtime::component::Resource;
 
 fn cleanup_player(state: &mut PluginHostState, player: &Resource<Player>) {
-    let _ = state
-        .resource_table
-        .delete::<PlayerResource>(Resource::new_own(player.rep()));
+    state.discard_to_be_removed(player);
 }
 
 fn cleanup_world(state: &mut PluginHostState, world: &Resource<World>) {
-    let _ = state
-        .resource_table
-        .delete::<WorldResource>(Resource::new_own(world.rep()));
+    state.discard_to_be_removed(world);
 }
 
 fn cleanup_text_component(state: &mut PluginHostState, text_component: &Resource<TextComponent>) {
-    let _ = state
-        .resource_table
-        .delete::<TextComponentResource>(Resource::new_own(text_component.rep()));
+    state.discard_to_be_removed(text_component);
 }
 
 fn cleanup_item_stack(state: &mut PluginHostState, item: &Resource<ItemStack>) {
-    let _ = state
-        .resource_table
-        .delete::<ItemStackResource>(Resource::new_own(item.rep()));
+    state.discard_to_be_removed(item);
 }
 
 pub fn cleanup_entity(state: &mut PluginHostState, entity: &Resource<Entity>) {
-    let _ = state
-        .resource_table
-        .delete::<EntityResource>(Resource::new_own(entity.rep()));
+    state.discard_to_be_removed(entity);
 }
 
 pub fn cleanup_server(state: &mut PluginHostState, server: &Resource<Server>) {
-    let _ = state
-        .resource_table
-        .delete::<ServerResource>(Resource::new_own(server.rep()));
+    state.discard_to_be_removed(server);
 }
 
 #[allow(clippy::too_many_lines, clippy::match_same_arms)]

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/dialog.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/dialog.rs
@@ -161,7 +161,7 @@ pub(crate) fn protocol_dialog_to_wasm(
     dialog: &ProtocolDialog,
 ) -> Dialog {
     let title = state
-        .add_text_component(dialog.title.clone())
+        .add(dialog.title.clone())
         .expect("failed to add text component");
 
     let type_ = match dialog.r#type.as_str() {
@@ -178,13 +178,13 @@ pub(crate) fn protocol_dialog_to_wasm(
         .map(|b| match b {
             ProtocolDialogBody::PlainMessage { contents } => {
                 let comp = state
-                    .add_text_component(contents.clone())
+                    .add(contents.clone())
                     .expect("failed to add text component");
                 DialogBody::PlainMessage(comp)
             }
             ProtocolDialogBody::Item { item: _ } => {
                 let item_res = state
-                    .add_item_stack(Arc::new(Mutex::new(
+                    .add(Arc::new(Mutex::new(
                         pumpkin_data::item_stack::ItemStack::new(0, &pumpkin_data::item::Item::AIR),
                     )))
                     .expect("failed to add item stack resource");
@@ -202,7 +202,7 @@ pub(crate) fn protocol_dialog_to_wasm(
                 default_value,
             } => {
                 let lbl = state
-                    .add_text_component(label.clone())
+                    .add(label.clone())
                     .expect("failed to add text component");
                 DialogInput::Bool(DialogInputBool {
                     label: lbl,
@@ -215,10 +215,10 @@ pub(crate) fn protocol_dialog_to_wasm(
                 default_value,
             } => {
                 let lbl = state
-                    .add_text_component(label.clone())
+                    .add(label.clone())
                     .expect("failed to add text component");
                 let ph = state
-                    .add_text_component(placeholder.clone())
+                    .add(placeholder.clone())
                     .expect("failed to add text component");
                 DialogInput::Text(DialogInputText {
                     label: lbl,
@@ -235,7 +235,7 @@ pub(crate) fn protocol_dialog_to_wasm(
                 label_format,
             } => {
                 let lbl = state
-                    .add_text_component(label.clone())
+                    .add(label.clone())
                     .expect("failed to add text component");
                 DialogInput::NumberRange(DialogInputNumberRange {
                     label: lbl,
@@ -252,15 +252,11 @@ pub(crate) fn protocol_dialog_to_wasm(
                 initial_index,
             } => {
                 let lbl = state
-                    .add_text_component(label.clone())
+                    .add(label.clone())
                     .expect("failed to add text component");
                 let opts = options
                     .iter()
-                    .map(|o| {
-                        state
-                            .add_text_component(o.clone())
-                            .expect("failed to add text component")
-                    })
+                    .map(|o| state.add(o.clone()).expect("failed to add text component"))
                     .collect();
                 DialogInput::SingleOption(DialogInputSingleOption {
                     label: lbl,
@@ -276,13 +272,12 @@ pub(crate) fn protocol_dialog_to_wasm(
         .iter()
         .map(|b| {
             let text = state
-                .add_text_component(b.text.clone())
+                .add(b.text.clone())
                 .expect("failed to add text component");
-            let tooltip = b.tooltip.as_ref().map(|t| {
-                state
-                    .add_text_component(t.clone())
-                    .expect("failed to add text component")
-            });
+            let tooltip = b
+                .tooltip
+                .as_ref()
+                .map(|t| state.add(t.clone()).expect("failed to add text component"));
             let action = match &b.action {
                 DialogAction::OpenUrl { url } => Action::OpenUrl(url.clone()),
                 DialogAction::Custom { id, payload } => Action::CustomClick(CustomClickAction {
@@ -320,7 +315,7 @@ pub(crate) fn protocol_dialog_to_wasm(
                 }),
                 pumpkin_protocol::Label::TextComponent(c) => {
                     let comp = state
-                        .add_text_component((**c).clone())
+                        .add((**c).clone())
                         .expect("failed to add text component");
                     LinkLabel::Custom(comp)
                 }
@@ -332,11 +327,10 @@ pub(crate) fn protocol_dialog_to_wasm(
         })
         .collect();
 
-    let external_title = dialog.external_title.as_ref().map(|t| {
-        state
-            .add_text_component(t.clone())
-            .expect("failed to add text component")
-    });
+    let external_title = dialog
+        .external_title
+        .as_ref()
+        .map(|t| state.add(t.clone()).expect("failed to add text component"));
 
     Dialog {
         title,
@@ -358,7 +352,7 @@ impl ToFromWasmEvent for DialogClickActionEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         Event::DialogClickActionEvent(DialogClickActionEventData {
             player: state
-                .add_player(self.player.clone())
+                .add(self.player.clone())
                 .expect("failed to add player resource"),
             id: self.id.clone(),
             payload: self.payload.as_ref().map(|p| p.to_vec()),
@@ -383,7 +377,7 @@ impl ToFromWasmEvent for DialogClearEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         Event::DialogClearEvent(DialogClearEventData {
             player: state
-                .add_player(self.player.clone())
+                .add(self.player.clone())
                 .expect("failed to add player resource"),
             cancelled: self.cancelled,
         })
@@ -405,7 +399,7 @@ impl ToFromWasmEvent for DialogShowEvent {
         let dialog = protocol_dialog_to_wasm(state, &self.dialog);
         Event::DialogShowEvent(DialogShowEventData {
             player: state
-                .add_player(self.player.clone())
+                .add(self.player.clone())
                 .expect("failed to add player resource"),
             dialog,
             cancelled: self.cancelled,

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/enchantment.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/enchantment.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
+use pumpkin_data::item_stack::ItemStack;
 use tokio::sync::Mutex;
 use wasmtime::component::Resource;
 
 use crate::plugin::{
     enchantment::{enchant_item::EnchantItemEvent, prepare_item_enchant::PrepareItemEnchantEvent},
     loader::wasm::wasm_host::{
-        state::{ItemStackResource, PluginHostState},
+        state::PluginHostState,
         wit::v0_1::{
             events::{ToFromWasmEvent, consume_player},
             item_stack::{from_wit_enchantment, to_wit_enchantment},
@@ -22,22 +23,21 @@ fn consume_item_stack(
     item: &Resource<
         crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::item_stack::ItemStack,
     >,
-) -> pumpkin_data::item_stack::ItemStack {
+) -> ItemStack {
     let mutex = state
         .resource_table
-        .delete::<ItemStackResource>(Resource::new_own(item.rep()))
-        .expect("invalid item stack resource handle")
-        .provider;
+        .delete::<Arc<Mutex<ItemStack>>>(Resource::new_own(item.rep()))
+        .expect("invalid item stack resource handle");
     mutex.try_lock().expect("lock item stack").clone()
 }
 
 impl ToFromWasmEvent for PrepareItemEnchantEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let item = state
-            .add_item_stack(Arc::new(Mutex::new(self.item.clone())))
+            .add(Arc::new(Mutex::new(self.item.clone())))
             .expect("failed to add item stack resource");
 
         let offers = (0..3)
@@ -86,10 +86,10 @@ impl ToFromWasmEvent for PrepareItemEnchantEvent {
 impl ToFromWasmEvent for EnchantItemEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let item = state
-            .add_item_stack(Arc::new(Mutex::new(self.item.clone())))
+            .add(Arc::new(Mutex::new(self.item.clone())))
             .expect("failed to add item stack resource");
 
         let enchantments_to_add = self

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/enchantment.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/enchantment.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use pumpkin_data::item_stack::ItemStack;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use wasmtime::component::Resource;
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/entity.rs
@@ -153,10 +153,10 @@ impl ToFromWasmEvent for EntityDeathEvent {
 impl ToFromWasmEvent for PlayerDeathEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let death_message = state
-            .add_text_component(self.death_message.clone())
+            .add(self.death_message.clone())
             .expect("failed to add text component resource");
 
         Event::PlayerDeathEvent(PlayerDeathEventData {
@@ -185,7 +185,7 @@ impl ToFromWasmEvent for PlayerDeathEvent {
 impl ToFromWasmEvent for EntitySpawnEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         Event::EntitySpawnEvent(EntitySpawnEventData {
@@ -329,10 +329,7 @@ impl ToFromWasmEvent for crate::plugin::api::events::entity::entity_dismount::En
 
 impl ToFromWasmEvent for crate::plugin::api::events::entity::entity_dye::EntityDyeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
-        let player = self
-            .player
-            .as_ref()
-            .and_then(|p| state.add_player(p.clone()).ok());
+        let player = self.player.as_ref().and_then(|p| state.add(p.clone()).ok());
         Event::EntityDyeEvent(EntityDyeEventData {
             entity_id: self.entity_id,
             color: format!("{:?}", self.color),
@@ -520,7 +517,7 @@ impl ToFromWasmEvent for crate::plugin::api::events::entity::entity_shoot_bow::E
 impl ToFromWasmEvent for crate::plugin::api::events::entity::entity_tame::EntityTameEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let owner = state
-            .add_player(self.owner.clone())
+            .add(self.owner.clone())
             .expect("failed to add player resource");
         Event::EntityTameEvent(EntityTameEventData {
             entity_id: self.entity_id,
@@ -644,7 +641,7 @@ impl ToFromWasmEvent
 impl ToFromWasmEvent for CreatureSpawnEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
         Event::CreatureSpawnEvent(CreatureSpawnEventData {
             entity_id: self.entity_id,
@@ -1336,14 +1333,14 @@ impl ToFromWasmEvent for ItemSpawnEvent {
 impl ToFromWasmEvent for PiglinBarterEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let input_item = state
-            .add_item_stack(Arc::new(Mutex::new(self.input_item.clone())))
+            .add(Arc::new(Mutex::new(self.input_item.clone())))
             .expect("failed to add item stack resource");
         let outcome = self
             .outcome
             .iter()
             .map(|i| {
                 state
-                    .add_item_stack(Arc::new(Mutex::new(i.clone())))
+                    .add(Arc::new(Mutex::new(i.clone())))
                     .expect("failed to add item stack resource")
             })
             .collect();

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/hanging.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/hanging.rs
@@ -68,11 +68,10 @@ impl ToFromWasmEvent for HangingBreakByEntityEvent {
 
 impl ToFromWasmEvent for HangingPlaceEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
-        let player = self.player.as_ref().map(|p| {
-            state
-                .add_player(p.clone())
-                .expect("failed to add player resource")
-        });
+        let player = self
+            .player
+            .as_ref()
+            .map(|p| state.add(p.clone()).expect("failed to add player resource"));
 
         Event::HangingPlaceEvent(HangingPlaceEventData {
             entity_id: self.entity.get_entity().entity_id,

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/inventory.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/inventory.rs
@@ -35,7 +35,7 @@ use crate::plugin::{
 impl ToFromWasmEvent for InventoryOpenEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::InventoryOpenEvent(InventoryOpenEventData {
@@ -58,7 +58,7 @@ impl ToFromWasmEvent for InventoryOpenEvent {
 impl ToFromWasmEvent for InventoryDragEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::InventoryDragEvent(InventoryDragEventData {
@@ -81,7 +81,7 @@ impl ToFromWasmEvent for InventoryDragEvent {
 impl ToFromWasmEvent for CraftItemEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::CraftItemEvent(CraftItemEventData {
@@ -194,7 +194,7 @@ impl ToFromWasmEvent for FurnaceBurnEvent {
 impl ToFromWasmEvent for FurnaceExtractEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::FurnaceExtractEvent(FurnaceExtractEventData {
@@ -267,7 +267,7 @@ impl ToFromWasmEvent for HopperInventorySearchEvent {
 impl ToFromWasmEvent for InventoryCreativeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::InventoryCreativeEvent(InventoryCreativeEventData {
@@ -296,7 +296,7 @@ impl ToFromWasmEvent for InventoryCreativeEvent {
 impl ToFromWasmEvent for InventoryInteractEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::InventoryInteractEvent(InventoryInteractEventData {
@@ -367,7 +367,7 @@ impl ToFromWasmEvent for InventoryPickupItemEvent {
 impl ToFromWasmEvent for PrepareAnvilEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PrepareAnvilEvent(PrepareAnvilEventData {
@@ -392,7 +392,7 @@ impl ToFromWasmEvent for PrepareAnvilEvent {
 impl ToFromWasmEvent for PrepareGrindstoneEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PrepareGrindstoneEvent(PrepareGrindstoneEventData {
@@ -415,7 +415,7 @@ impl ToFromWasmEvent for PrepareGrindstoneEvent {
 impl ToFromWasmEvent for PrepareInventoryResultEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PrepareInventoryResultEvent(PrepareInventoryResultEventData {
@@ -438,7 +438,7 @@ impl ToFromWasmEvent for PrepareInventoryResultEvent {
 impl ToFromWasmEvent for PrepareItemCraftEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PrepareItemCraftEvent(PrepareItemCraftEventData {
@@ -463,7 +463,7 @@ impl ToFromWasmEvent for PrepareItemCraftEvent {
 impl ToFromWasmEvent for PrepareSmithingEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PrepareSmithingEvent(PrepareSmithingEventData {
@@ -486,7 +486,7 @@ impl ToFromWasmEvent for PrepareSmithingEvent {
 impl ToFromWasmEvent for SmithItemEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::SmithItemEvent(SmithItemEventData {
@@ -511,7 +511,7 @@ impl ToFromWasmEvent for SmithItemEvent {
 impl ToFromWasmEvent for TradeSelectEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::TradeSelectEvent(TradeSelectEventData {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         BoxFuture, EventHandler, Payload,
         loader::wasm::wasm_host::{
             PluginInstance, WasmPlugin,
-            state::{PlayerResource, PluginHostState, TextComponentResource, WorldResource},
+            state::PluginHostState,
             wit::{self, v0_1::pumpkin},
         },
     },
@@ -203,9 +203,8 @@ pub(super) fn consume_player(
 ) -> Arc<Player> {
     state
         .resource_table
-        .delete::<PlayerResource>(Resource::new_own(player.rep()))
+        .delete::<Arc<Player>>(Resource::new_own(player.rep()))
         .expect("invalid player resource handle")
-        .provider
 }
 
 pub(super) fn consume_text_component(
@@ -214,9 +213,8 @@ pub(super) fn consume_text_component(
 ) -> pumpkin_util::text::TextComponent {
     state
         .resource_table
-        .delete::<TextComponentResource>(Resource::new_own(text_component.rep()))
+        .delete::<pumpkin_util::text::TextComponent>(Resource::new_own(text_component.rep()))
         .expect("invalid text-component resource handle")
-        .provider
 }
 
 pub(super) fn consume_world(
@@ -225,9 +223,8 @@ pub(super) fn consume_world(
 ) -> Arc<World> {
     state
         .resource_table
-        .delete::<WorldResource>(Resource::new_own(world.rep()))
+        .delete::<Arc<World>>(Resource::new_own(world.rep()))
         .expect("invalid world resource handle")
-        .provider
 }
 
 impl<E: Payload + ToFromWasmEvent + Clone + 'static> EventHandler<E> for WasmPluginEventHandler {
@@ -246,7 +243,7 @@ impl<E: Payload + ToFromWasmEvent + Clone + 'static> EventHandler<E> for WasmPlu
                     Box::pin(async move {
                         let (wasm_event, server_res) = guest.with(|mut store| {
                             let wasm_event = event.to_wasm_event(store.data_mut());
-                            match store.data_mut().add_server(server) {
+                            match store.data_mut().add(server) {
                                 Ok(resource) => Ok((wasm_event, resource)),
                                 Err(error) => {
                                     cleanup_event(&wasm_event, store.data_mut());
@@ -294,7 +291,7 @@ impl<E: Payload + ToFromWasmEvent + Clone + 'static> EventHandler<E> for WasmPlu
                     Box::pin(async move {
                         let (wasm_event, server_res) = guest.with(|mut store| {
                             let wasm_event = owned_event.to_wasm_event(store.data_mut());
-                            match store.data_mut().add_server(server) {
+                            match store.data_mut().add(server) {
                                 Ok(resource) => Ok((wasm_event, resource)),
                                 Err(error) => {
                                     cleanup_event(&wasm_event, store.data_mut());

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/player.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/player.rs
@@ -153,7 +153,7 @@ const fn from_wasm_fish_state(state: WasmPlayerFishState) -> PlayerFishState {
 impl ToFromWasmEvent for InventoryCloseEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::InventoryCloseEvent(InventoryCloseEventData {
@@ -176,7 +176,7 @@ impl ToFromWasmEvent for InventoryCloseEvent {
 impl ToFromWasmEvent for InventoryClickEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::InventoryClickEvent(InventoryClickEventData {
@@ -187,12 +187,12 @@ impl ToFromWasmEvent for InventoryClickEvent {
             raw_slot: self.raw_slot,
             clicked_item: self.clicked_item.as_ref().map(|stack| {
                 state
-                    .add_item_stack(Arc::new(Mutex::new(stack.clone())))
+                    .add(Arc::new(Mutex::new(stack.clone())))
                     .expect("failed to add item stack resource")
             }),
             cursor: self.cursor.as_ref().map(|stack| {
                 state
-                    .add_item_stack(Arc::new(Mutex::new(stack.clone())))
+                    .add(Arc::new(Mutex::new(stack.clone())))
                     .expect("failed to add item stack resource")
             }),
             hotbar_button: self.hotbar_button,
@@ -221,10 +221,10 @@ impl ToFromWasmEvent for InventoryClickEvent {
 impl ToFromWasmEvent for PlayerJoinEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let join_message = state
-            .add_text_component(self.join_message.clone())
+            .add(self.join_message.clone())
             .expect("failed to add text-component resource");
 
         Event::PlayerJoinEvent(PlayerJoinEventData {
@@ -249,10 +249,10 @@ impl ToFromWasmEvent for PlayerJoinEvent {
 impl ToFromWasmEvent for PlayerLeaveEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let leave_message = state
-            .add_text_component(self.leave_message.clone())
+            .add(self.leave_message.clone())
             .expect("failed to add text-component resource");
 
         Event::PlayerLeaveEvent(PlayerLeaveEventData {
@@ -277,10 +277,10 @@ impl ToFromWasmEvent for PlayerLeaveEvent {
 impl ToFromWasmEvent for PlayerLoginEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let kick_message = state
-            .add_text_component(self.kick_message.clone())
+            .add(self.kick_message.clone())
             .expect("failed to add text-component resource");
 
         Event::PlayerLoginEvent(PlayerLoginEventData {
@@ -305,17 +305,13 @@ impl ToFromWasmEvent for PlayerLoginEvent {
 impl ToFromWasmEvent for PlayerChatEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let recipients = self
             .recipients
             .iter()
             .cloned()
-            .map(|recipient| {
-                state
-                    .add_player(recipient)
-                    .expect("failed to add player resource")
-            })
+            .map(|recipient| state.add(recipient).expect("failed to add player resource"))
             .collect();
 
         Event::PlayerChatEvent(PlayerChatEventData {
@@ -348,7 +344,7 @@ impl ToFromWasmEvent for PlayerChatEvent {
 impl ToFromWasmEvent for PlayerCommandSendEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerCommandSendEvent(PlayerCommandSendEventData {
@@ -373,7 +369,7 @@ impl ToFromWasmEvent for PlayerCommandSendEvent {
 impl ToFromWasmEvent for PlayerPermissionCheckEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerPermissionCheckEvent(PlayerPermissionCheckEventData {
@@ -398,7 +394,7 @@ impl ToFromWasmEvent for PlayerPermissionCheckEvent {
 impl ToFromWasmEvent for PlayerMoveEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerMoveEvent(PlayerMoveEventData {
@@ -425,7 +421,7 @@ impl ToFromWasmEvent for PlayerMoveEvent {
 impl ToFromWasmEvent for PlayerTeleportEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerTeleportEvent(PlayerTeleportEventData {
@@ -452,13 +448,13 @@ impl ToFromWasmEvent for PlayerTeleportEvent {
 impl ToFromWasmEvent for PlayerChangeWorldEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let previous_world = state
-            .add_world(self.previous_world.clone())
+            .add(self.previous_world.clone())
             .expect("failed to add world resource");
         let new_world = state
-            .add_world(self.new_world.clone())
+            .add(self.new_world.clone())
             .expect("failed to add world resource");
 
         Event::PlayerChangeWorldEvent(PlayerChangeWorldEventData {
@@ -491,13 +487,13 @@ impl ToFromWasmEvent for PlayerChangeWorldEvent {
 impl ToFromWasmEvent for PlayerRespawnEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let previous_world = state
-            .add_world(self.previous_world.clone())
+            .add(self.previous_world.clone())
             .expect("failed to add world resource");
         let respawned_world = state
-            .add_world(self.respawned_world.clone())
+            .add(self.respawned_world.clone())
             .expect("failed to add world resource");
 
         Event::PlayerRespawnEvent(PlayerRespawnEventData {
@@ -530,7 +526,7 @@ impl ToFromWasmEvent for PlayerRespawnEvent {
 impl ToFromWasmEvent for PlayerExpChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerExpChangeEvent(PlayerExpChangeEventData {
@@ -553,7 +549,7 @@ impl ToFromWasmEvent for PlayerExpChangeEvent {
 impl ToFromWasmEvent for PlayerItemHeldEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerItemHeldEvent(PlayerItemHeldEventData {
@@ -580,7 +576,7 @@ impl ToFromWasmEvent for PlayerItemHeldEvent {
 impl ToFromWasmEvent for PlayerChangedMainHandEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerChangedMainHandEvent(PlayerChangedMainHandEventData {
@@ -603,7 +599,7 @@ impl ToFromWasmEvent for PlayerChangedMainHandEvent {
 impl ToFromWasmEvent for PlayerGamemodeChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerGamemodeChangeEvent(PlayerGamemodeChangeEventData {
@@ -630,7 +626,7 @@ impl ToFromWasmEvent for PlayerGamemodeChangeEvent {
 impl ToFromWasmEvent for PlayerCustomPayloadEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerCustomPayloadEvent(PlayerCustomPayloadEventData {
@@ -655,7 +651,7 @@ impl ToFromWasmEvent for PlayerCustomPayloadEvent {
 impl ToFromWasmEvent for PlayerFishEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerFishEvent(PlayerFishEventData {
@@ -690,7 +686,7 @@ impl ToFromWasmEvent for PlayerFishEvent {
 impl ToFromWasmEvent for PlayerEggThrowEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerEggThrowEvent(PlayerEggThrowEventData {
@@ -721,7 +717,7 @@ impl ToFromWasmEvent for PlayerEggThrowEvent {
 impl ToFromWasmEvent for PlayerInteractUnknownEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerInteractUnknownEntityEvent(PlayerInteractUnknownEntityEventData {
@@ -766,7 +762,7 @@ const fn from_wasm_interact_action(action: WasmInteractAction) -> InteractAction
 impl ToFromWasmEvent for PlayerInteractEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerInteractEvent(PlayerInteractEventData {
@@ -795,7 +791,7 @@ impl ToFromWasmEvent for PlayerInteractEvent {
 impl ToFromWasmEvent for PlayerToggleSneakEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerToggleSneakEvent(PlayerToggleSneakEventData {
@@ -820,7 +816,7 @@ impl ToFromWasmEvent for PlayerToggleSneakEvent {
 impl ToFromWasmEvent for PlayerToggleFlightEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerToggleFlightEvent(PlayerToggleFlightEventData {
@@ -845,7 +841,7 @@ impl ToFromWasmEvent for PlayerToggleFlightEvent {
 impl ToFromWasmEvent for PlayerToggleSprintEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerToggleSprintEvent(PlayerToggleSprintEventData {
@@ -870,7 +866,7 @@ impl ToFromWasmEvent for PlayerToggleSprintEvent {
 impl ToFromWasmEvent for BedrockFormResponseEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::BedrockFormResponseEvent(BedrockFormResponseEventData {
@@ -895,7 +891,7 @@ impl ToFromWasmEvent for BedrockFormResponseEvent {
 impl ToFromWasmEvent for PlayerInteractEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerInteractEntityEvent(PlayerInteractEntityEventData {
@@ -934,7 +930,7 @@ impl ToFromWasmEvent
 {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerItemConsumeEvent(PlayerItemConsumeEventData {
@@ -961,7 +957,7 @@ impl ToFromWasmEvent
 {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerItemDamageEvent(PlayerItemDamageEventData {
@@ -988,7 +984,7 @@ impl ToFromWasmEvent
 impl ToFromWasmEvent for crate::plugin::api::events::player::player_drop_item::PlayerDropItemEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerDropItemEvent(PlayerDropItemEventData {
@@ -1015,7 +1011,7 @@ impl ToFromWasmEvent for crate::plugin::api::events::player::player_drop_item::P
 impl ToFromWasmEvent for crate::plugin::api::events::player::player_bed::PlayerBedEnterEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerBedEnterEvent(PlayerBedEnterEventData {
@@ -1040,7 +1036,7 @@ impl ToFromWasmEvent for crate::plugin::api::events::player::player_bed::PlayerB
 impl ToFromWasmEvent for crate::plugin::api::events::player::player_bed::PlayerBedLeaveEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerBedLeaveEvent(PlayerBedLeaveEventData {
@@ -1063,7 +1059,7 @@ impl ToFromWasmEvent for crate::plugin::api::events::player::player_bed::PlayerB
 impl ToFromWasmEvent for crate::plugin::api::events::player::player_bucket::PlayerBucketEmptyEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerBucketEmptyEvent(PlayerBucketEmptyEventData {
@@ -1090,7 +1086,7 @@ impl ToFromWasmEvent for crate::plugin::api::events::player::player_bucket::Play
 impl ToFromWasmEvent for crate::plugin::api::events::player::player_bucket::PlayerBucketFillEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         Event::PlayerBucketFillEvent(PlayerBucketFillEventData {
@@ -1117,10 +1113,10 @@ impl ToFromWasmEvent for crate::plugin::api::events::player::player_bucket::Play
 impl ToFromWasmEvent for AsyncPlayerChatEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let format = state
-            .add_text_component(self.format.clone())
+            .add(self.format.clone())
             .expect("failed to add text-component resource");
         Event::AsyncPlayerChatEvent(AsyncPlayerChatEventData {
             player,
@@ -1158,7 +1154,7 @@ impl ToFromWasmEvent for AsyncPlayerChatEvent {
 impl ToFromWasmEvent for AsyncPlayerPreLoginEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let kick_message = state
-            .add_text_component(self.kick_message.clone())
+            .add(self.kick_message.clone())
             .expect("failed to add text-component resource");
         Event::AsyncPlayerPreLoginEvent(AsyncPlayerPreLoginEventData {
             player_name: self.player_name.clone(),
@@ -1202,7 +1198,7 @@ impl ToFromWasmEvent for AsyncPlayerPreLoginEvent {
 impl ToFromWasmEvent for PlayerAdvancementDoneEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerAdvancementDoneEvent(PlayerAdvancementDoneEventData {
             player,
@@ -1233,7 +1229,7 @@ impl ToFromWasmEvent for PlayerAdvancementDoneEvent {
 impl ToFromWasmEvent for PlayerAnimationEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let animation_type = match self.animation_type {
             PlayerAnimationType::ArmSwingOff => "ArmSwingOff".to_string(),
@@ -1273,7 +1269,7 @@ impl ToFromWasmEvent for PlayerAnimationEvent {
 impl ToFromWasmEvent for PlayerArmorStandManipulateEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerArmorStandManipulateEvent(PlayerArmorStandManipulateEventData {
             player,
@@ -1306,7 +1302,7 @@ impl ToFromWasmEvent for PlayerArmorStandManipulateEvent {
 impl ToFromWasmEvent for PlayerBucketEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerBucketEntityEvent(PlayerBucketEntityEventData {
             player,
@@ -1339,13 +1335,13 @@ impl ToFromWasmEvent for PlayerBucketEntityEvent {
 impl ToFromWasmEvent for PlayerChangedWorldEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let from_world = state
-            .add_world(self.from_world.clone())
+            .add(self.from_world.clone())
             .expect("failed to add world resource");
         let to_world = state
-            .add_world(self.to_world.clone())
+            .add(self.to_world.clone())
             .expect("failed to add world resource");
         Event::PlayerChangedWorldEvent(PlayerChangedWorldEventData {
             player,
@@ -1378,7 +1374,7 @@ impl ToFromWasmEvent for PlayerChangedWorldEvent {
 impl ToFromWasmEvent for PlayerChannelEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerChannelEvent(PlayerChannelEventData {
             player,
@@ -1409,7 +1405,7 @@ impl ToFromWasmEvent for PlayerChannelEvent {
 impl ToFromWasmEvent for PlayerCommandPreprocessEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerCommandPreprocessEvent(PlayerCommandPreprocessEventData {
             player,
@@ -1441,7 +1437,7 @@ impl ToFromWasmEvent for PlayerCommandPreprocessEvent {
 impl ToFromWasmEvent for PlayerEditBookEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerEditBookEvent(PlayerEditBookEventData {
             player,
@@ -1480,7 +1476,7 @@ impl ToFromWasmEvent for PlayerEditBookEvent {
 impl ToFromWasmEvent for PlayerElytraBoostEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerElytraBoostEvent(PlayerElytraBoostEventData {
             player,
@@ -1511,7 +1507,7 @@ impl ToFromWasmEvent for PlayerElytraBoostEvent {
 impl ToFromWasmEvent for PlayerExpCooldownChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerExpCooldownChangeEvent(PlayerExpCooldownChangeEventData {
             player,
@@ -1543,14 +1539,14 @@ impl ToFromWasmEvent for PlayerExpCooldownChangeEvent {
 impl ToFromWasmEvent for PlayerHarvestBlockEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let harvested_items = self
             .harvested_items
             .iter()
             .map(|i| {
                 state
-                    .add_item_stack(Arc::new(Mutex::new(i.clone())))
+                    .add(Arc::new(Mutex::new(i.clone())))
                     .expect("failed to add item stack resource")
             })
             .collect();
@@ -1582,7 +1578,7 @@ impl ToFromWasmEvent for PlayerHarvestBlockEvent {
 impl ToFromWasmEvent for PlayerHideEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerHideEntityEvent(PlayerHideEntityEventData {
             player,
@@ -1613,7 +1609,7 @@ impl ToFromWasmEvent for PlayerHideEntityEvent {
 impl ToFromWasmEvent for PlayerItemBreakEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerItemBreakEvent(PlayerItemBreakEventData {
             player,
@@ -1635,7 +1631,7 @@ impl ToFromWasmEvent for PlayerItemBreakEvent {
 impl ToFromWasmEvent for PlayerItemMendEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerItemMendEvent(PlayerItemMendEventData {
             player,
@@ -1672,7 +1668,7 @@ impl ToFromWasmEvent for PlayerItemMendEvent {
 impl ToFromWasmEvent for PlayerKickEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerKickEvent(PlayerKickEventData {
             player,
@@ -1704,7 +1700,7 @@ impl ToFromWasmEvent for PlayerKickEvent {
 impl ToFromWasmEvent for PlayerLeashEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerLeashEntityEvent(PlayerLeashEntityEventData {
             player,
@@ -1737,7 +1733,7 @@ impl ToFromWasmEvent for PlayerLeashEntityEvent {
 impl ToFromWasmEvent for PlayerLevelChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerLevelChangeEvent(PlayerLevelChangeEventData {
             player,
@@ -1761,7 +1757,7 @@ impl ToFromWasmEvent for PlayerLevelChangeEvent {
 impl ToFromWasmEvent for PlayerLocaleChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerLocaleChangeEvent(PlayerLocaleChangeEventData {
             player,
@@ -1792,10 +1788,10 @@ impl ToFromWasmEvent for PlayerLocaleChangeEvent {
 impl ToFromWasmEvent for PlayerNameEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let name = state
-            .add_text_component(self.name.clone())
+            .add(self.name.clone())
             .expect("failed to add text-component resource");
         Event::PlayerNameEntityEvent(PlayerNameEntityEventData {
             player,
@@ -1832,7 +1828,7 @@ impl ToFromWasmEvent for PlayerNameEntityEvent {
 impl ToFromWasmEvent for PlayerOpenSignEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerOpenSignEvent(PlayerOpenSignEventData {
             player,
@@ -1865,7 +1861,7 @@ impl ToFromWasmEvent for PlayerOpenSignEvent {
 impl ToFromWasmEvent for PlayerPortalEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerPortalEvent(PlayerPortalEventData {
             player,
@@ -1899,7 +1895,7 @@ impl ToFromWasmEvent for PlayerPortalEvent {
 impl ToFromWasmEvent for PlayerPreLoginEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let kick_message = state
-            .add_text_component(self.kick_message.clone())
+            .add(self.kick_message.clone())
             .expect("failed to add text-component resource");
         Event::PlayerPreLoginEvent(PlayerPreLoginEventData {
             player_name: self.player_name.clone(),
@@ -1943,7 +1939,7 @@ impl ToFromWasmEvent for PlayerPreLoginEvent {
 impl ToFromWasmEvent for PlayerRiptideEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerRiptideEvent(PlayerRiptideEventData {
             player,
@@ -1974,7 +1970,7 @@ impl ToFromWasmEvent for PlayerRiptideEvent {
 impl ToFromWasmEvent for PlayerShearEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerShearEntityEvent(PlayerShearEntityEventData {
             player,
@@ -2007,7 +2003,7 @@ impl ToFromWasmEvent for PlayerShearEntityEvent {
 impl ToFromWasmEvent for PlayerShowEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerShowEntityEvent(PlayerShowEntityEventData {
             player,
@@ -2038,7 +2034,7 @@ impl ToFromWasmEvent for PlayerShowEntityEvent {
 impl ToFromWasmEvent for PlayerSpawnChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerSpawnChangeEvent(PlayerSpawnChangeEventData {
             player,
@@ -2072,7 +2068,7 @@ impl ToFromWasmEvent for PlayerSpawnChangeEvent {
 impl ToFromWasmEvent for PlayerStatisticIncrementEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerStatisticIncrementEvent(PlayerStatisticIncrementEventData {
             player,
@@ -2106,7 +2102,7 @@ impl ToFromWasmEvent for PlayerStatisticIncrementEvent {
 impl ToFromWasmEvent for PlayerSwapHandItemsEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerSwapHandsEvent(PlayerSwapHandsEventData {
             player,
@@ -2135,10 +2131,10 @@ impl ToFromWasmEvent for PlayerSwapHandItemsEvent {
 impl ToFromWasmEvent for PlayerTakeLecternBookEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         let book = state
-            .add_item_stack(Arc::new(Mutex::new(self.book.clone())))
+            .add(Arc::new(Mutex::new(self.book.clone())))
             .expect("failed to add item stack resource");
         Event::PlayerTakeLecternBookEvent(PlayerTakeLecternBookEventData {
             player,
@@ -2168,7 +2164,7 @@ impl ToFromWasmEvent for PlayerTakeLecternBookEvent {
 impl ToFromWasmEvent for PlayerUnleashEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerUnleashEntityEvent(PlayerUnleashEntityEventData {
             player,
@@ -2199,7 +2195,7 @@ impl ToFromWasmEvent for PlayerUnleashEntityEvent {
 impl ToFromWasmEvent for PlayerVelocityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerVelocityEvent(PlayerVelocityEventData {
             player,
@@ -2231,7 +2227,7 @@ impl ToFromWasmEvent for PlayerVelocityEvent {
 impl ToFromWasmEvent for PlayerInputEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerInputEvent(PlayerInputEventData {
             player,
@@ -2263,7 +2259,7 @@ impl ToFromWasmEvent for PlayerInputEvent {
 impl ToFromWasmEvent for PlayerInteractAtEntityEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerInteractAtEntityEvent(PlayerInteractAtEntityEventData {
             player,
@@ -2302,7 +2298,7 @@ impl ToFromWasmEvent for PlayerInteractAtEntityEvent {
 impl ToFromWasmEvent for PlayerLinksSendEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerLinksSendEvent(PlayerLinksSendEventData {
             player,
@@ -2334,7 +2330,7 @@ impl ToFromWasmEvent for PlayerLinksSendEvent {
 impl ToFromWasmEvent for PlayerPickupArrowEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerPickupArrowEvent(PlayerPickupArrowEventData {
             player,
@@ -2365,7 +2361,7 @@ impl ToFromWasmEvent for PlayerPickupArrowEvent {
 impl ToFromWasmEvent for PlayerRecipeBookClickEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerRecipeBookClickEvent(PlayerRecipeBookClickEventData {
             player,
@@ -2400,7 +2396,7 @@ impl ToFromWasmEvent for PlayerRecipeBookClickEvent {
 impl ToFromWasmEvent for PlayerRecipeBookSettingsChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerRecipeBookSettingsChangeEvent(PlayerRecipeBookSettingsChangeEventData {
             player,
@@ -2438,7 +2434,7 @@ impl ToFromWasmEvent for PlayerRecipeBookSettingsChangeEvent {
 impl ToFromWasmEvent for PlayerRecipeDiscoverEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerRecipeDiscoverEvent(PlayerRecipeDiscoverEventData {
             player,
@@ -2470,7 +2466,7 @@ impl ToFromWasmEvent for PlayerRecipeDiscoverEvent {
 impl ToFromWasmEvent for PlayerRegisterChannelEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerRegisterChannelEvent(PlayerRegisterChannelEventData {
             player,
@@ -2502,7 +2498,7 @@ impl ToFromWasmEvent for PlayerRegisterChannelEvent {
 impl ToFromWasmEvent for PlayerResourcePackStatusEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerResourcePackStatusEvent(PlayerResourcePackStatusEventData {
             player,
@@ -2536,7 +2532,7 @@ impl ToFromWasmEvent for PlayerResourcePackStatusEvent {
 impl ToFromWasmEvent for PlayerSpawnLocationEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerSpawnLocationEvent(PlayerSpawnLocationEventData {
             player,
@@ -2568,7 +2564,7 @@ impl ToFromWasmEvent for PlayerSpawnLocationEvent {
 impl ToFromWasmEvent for PlayerUnregisterChannelEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
         Event::PlayerUnregisterChannelEvent(PlayerUnregisterChannelEventData {
             player,

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/server.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/server.rs
@@ -29,7 +29,7 @@ use crate::plugin::{
 impl ToFromWasmEvent for PacketReceivedEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player_res = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         let packet = match self.player.client.as_ref() {
@@ -85,7 +85,7 @@ impl ToFromWasmEvent for PacketReceivedEvent {
 impl ToFromWasmEvent for PacketSentEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let player_res = state
-            .add_player(self.player.clone())
+            .add(self.player.clone())
             .expect("failed to add player resource");
 
         let packet = match self.player.client.as_ref() {
@@ -147,10 +147,10 @@ impl ToFromWasmEvent for ServerCommandEvent {
 impl ToFromWasmEvent for ServerBroadcastEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let message = state
-            .add_text_component(self.message.clone())
+            .add(self.message.clone())
             .expect("failed to add text-component resource");
         let sender = state
-            .add_text_component(self.sender.clone())
+            .add(self.sender.clone())
             .expect("failed to add text-component resource");
 
         Event::ServerBroadcastEvent(ServerBroadcastEventData {
@@ -175,7 +175,7 @@ impl ToFromWasmEvent for ServerBroadcastEvent {
 impl ToFromWasmEvent for ServerListPingEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let motd = state
-            .add_text_component(self.motd.clone())
+            .add(self.motd.clone())
             .expect("failed to add text-component resource");
 
         Event::ServerListPingEvent(ServerListPingEventData {
@@ -297,7 +297,6 @@ impl ToFromWasmEvent for MapInitializeEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plugin::loader::wasm::wasm_host::state::TextComponentResource;
     use pumpkin_util::text::TextComponent;
     use wasmtime::component::Resource;
 
@@ -317,7 +316,7 @@ mod tests {
             None,
         );
         let motd = state
-            .add_text_component(returned_motd.clone())
+            .add(returned_motd.clone())
             .expect("text component resource should be inserted");
         let motd_rep = motd.rep();
         let returned = Event::ServerListPingEvent(ServerListPingEventData {
@@ -344,7 +343,7 @@ mod tests {
         assert!(
             state
                 .resource_table
-                .get::<TextComponentResource>(&Resource::new_own(motd_rep))
+                .get::<TextComponent>(&Resource::new_own(motd_rep))
                 .is_err()
         );
     }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/world.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/events/world.rs
@@ -24,7 +24,7 @@ use crate::plugin::{
 impl ToFromWasmEvent for SpawnChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         Event::SpawnChangeEvent(SpawnChangeEventData {
@@ -57,7 +57,7 @@ impl ToFromWasmEvent for SpawnChangeEvent {
 impl ToFromWasmEvent for ChunkLoad {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         let (chunk_x, chunk_z) = self
@@ -110,7 +110,7 @@ impl ToFromWasmEvent for ChunkLoad {
 impl ToFromWasmEvent for ChunkSave {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         let (chunk_x, chunk_z) = self
@@ -163,7 +163,7 @@ impl ToFromWasmEvent for ChunkSave {
 impl ToFromWasmEvent for ChunkSend {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         Event::ChunkSendEvent(ChunkSendEventData {
@@ -212,7 +212,7 @@ impl ToFromWasmEvent for ChunkSend {
 impl ToFromWasmEvent for crate::plugin::api::events::world::weather_change::WeatherChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         Event::WeatherChangeEvent(WeatherChangeEventData {
@@ -237,7 +237,7 @@ impl ToFromWasmEvent for crate::plugin::api::events::world::weather_change::Weat
 impl ToFromWasmEvent for crate::plugin::api::events::world::weather_change::ThunderChangeEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         Event::ThunderChangeEvent(ThunderChangeEventData {
@@ -262,7 +262,7 @@ impl ToFromWasmEvent for crate::plugin::api::events::world::weather_change::Thun
 impl ToFromWasmEvent for crate::plugin::api::events::world::world_load::WorldLoadEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         Event::WorldLoadEvent(WorldLoadEventData { target_world })
@@ -281,7 +281,7 @@ impl ToFromWasmEvent for crate::plugin::api::events::world::world_load::WorldLoa
 impl ToFromWasmEvent for crate::plugin::api::events::world::world_load::WorldUnloadEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         Event::WorldUnloadEvent(WorldUnloadEventData {
@@ -647,7 +647,7 @@ impl ToFromWasmEvent for crate::plugin::api::events::world::time_skip::TimeSkipE
 impl ToFromWasmEvent for crate::plugin::api::events::world::world_init::WorldInitEvent {
     fn to_wasm_event(&self, state: &mut PluginHostState) -> Event {
         let target_world = state
-            .add_world(self.world.clone())
+            .add(self.world.clone())
             .expect("failed to add world resource");
 
         Event::WorldInitEvent(crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::event::WorldInitEventData {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/forms.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/forms.rs
@@ -1,5 +1,4 @@
 use crate::plugin::loader::wasm::wasm_host::state::PluginHostState;
-use crate::plugin::loader::wasm::wasm_host::wit::v0_1::player::text_component_from_resource;
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::forms::{
     CustomForm, CustomFormElement, Host, ImageType, ModalForm, SimpleForm,
 };
@@ -11,22 +10,22 @@ impl Host for PluginHostState {}
 
 impl PluginHostState {
     pub(crate) fn translate_res(
-        &self,
-        res: &Resource<
+        &mut self,
+        res: Resource<
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::text::TextComponent,
         >,
         locale: Locale,
     ) -> String {
-        let component = text_component_from_resource(self, res);
+        let component = self.take(res).expect("Couldn't get text component");
         component.0.get_text(locale)
     }
 
-    pub(crate) fn serialize_simple_form(&self, form: SimpleForm, locale: Locale) -> Value {
+    pub(crate) fn serialize_simple_form(&mut self, form: SimpleForm, locale: Locale) -> Value {
         let buttons: Vec<Value> = form
             .buttons
             .into_iter()
             .map(|b| {
-                let mut obj = json!({ "text": self.translate_res(&b.text, locale) });
+                let mut obj = json!({ "text": self.translate_res(b.text, locale) });
                 if let Some(image) = b.image
                     && let Some(obj) = obj.as_object_mut()
                 {
@@ -47,45 +46,45 @@ impl PluginHostState {
 
         json!({
             "type": "form",
-            "title": self.translate_res(&form.title, locale),
-            "content": self.translate_res(&form.content, locale),
+            "title": self.translate_res(form.title, locale),
+            "content": self.translate_res(form.content, locale),
             "buttons": buttons
         })
     }
 
-    pub(crate) fn serialize_modal_form(&self, form: &ModalForm, locale: Locale) -> Value {
+    pub(crate) fn serialize_modal_form(&mut self, form: ModalForm, locale: Locale) -> Value {
         json!({
             "type": "modal",
-            "title": self.translate_res(&form.title, locale),
-            "content": self.translate_res(&form.content, locale),
-            "button1": self.translate_res(&form.button1, locale),
-            "button2": self.translate_res(&form.button2, locale)
+            "title": self.translate_res(form.title, locale),
+            "content": self.translate_res(form.content, locale),
+            "button1": self.translate_res(form.button1, locale),
+            "button2": self.translate_res(form.button2, locale)
         })
     }
 
-    pub(crate) fn serialize_custom_form(&self, form: CustomForm, locale: Locale) -> Value {
+    pub(crate) fn serialize_custom_form(&mut self, form: CustomForm, locale: Locale) -> Value {
         let elements: Vec<Value> = form.elements.into_iter().map(|e| {
             match e {
-                CustomFormElement::Label(text) => json!({ "type": "label", "text": self.translate_res(&text, locale) }),
-                CustomFormElement::Toggle((text, default)) => json!({ "type": "toggle", "text": self.translate_res(&text, locale), "default": default }),
+                CustomFormElement::Label(text) => json!({ "type": "label", "text": self.translate_res(text, locale) }),
+                CustomFormElement::Toggle((text, default)) => json!({ "type": "toggle", "text": self.translate_res(text, locale), "default": default }),
                 CustomFormElement::Slider((text, min, max, step, default)) => json!({
-                    "type": "slider", "text": self.translate_res(&text, locale), "min": min, "max": max, "step": step, "default": default
+                    "type": "slider", "text": self.translate_res(text, locale), "min": min, "max": max, "step": step, "default": default
                 }),
                 CustomFormElement::StepSlider((text, steps, default)) => json!({
-                    "type": "step_slider", "text": self.translate_res(&text, locale), "steps": steps, "default": default
+                    "type": "step_slider", "text": self.translate_res(text, locale), "steps": steps, "default": default
                 }),
                 CustomFormElement::Dropdown((text, options, default)) => json!({
-                    "type": "dropdown", "text": self.translate_res(&text, locale), "options": options, "default": default
+                    "type": "dropdown", "text": self.translate_res(text, locale), "options": options, "default": default
                 }),
                 CustomFormElement::Input((text, placeholder, default)) => json!({
-                    "type": "input", "text": self.translate_res(&text, locale), "placeholder": placeholder, "default": default
+                    "type": "input", "text": self.translate_res(text, locale), "placeholder": placeholder, "default": default
                 }),
             }
         }).collect();
 
         json!({
             "type": "custom_form",
-            "title": self.translate_res(&form.title, locale),
+            "title": self.translate_res(form.title, locale),
             "content": elements
         })
     }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/gui.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/gui.rs
@@ -4,7 +4,7 @@ use wasmtime::component::Resource;
 
 use crate::plugin::api::gui::{PluginGui, PluginInventory};
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{PluginHostState},
+    state::PluginHostState,
     wit::v0_1::pumpkin::plugin::{
         gui::{self, Gui},
         item_stack::ItemStack as WitHostItemStack,
@@ -131,10 +131,7 @@ impl gui::HostGui for PluginHostState {
         slot: u32,
         item: Resource<WitHostItemStack>,
     ) -> wasmtime::Result<()> {
-        let item_stack = {
-            let item_stack = self.get(&item)?;
-            item_stack.lock().await.clone()
-        };
+        let item_stack = self.take(item)?.lock().await.clone();
         let gui = self.get(&res)?.lock().await;
         let mut slots = gui
             .inventory

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/gui.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/gui.rs
@@ -4,7 +4,7 @@ use wasmtime::component::Resource;
 
 use crate::plugin::api::gui::{PluginGui, PluginInventory};
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{GuiResource, PluginHostState},
+    state::{PluginHostState},
     wit::v0_1::pumpkin::plugin::{
         gui::{self, Gui},
         item_stack::ItemStack as WitHostItemStack,
@@ -75,14 +75,6 @@ pub const fn from_wit_screen(screen: WitScreen) -> WindowType {
     }
 }
 
-impl PluginHostState {
-    fn get_gui_res(&self, res: &Resource<Gui>) -> wasmtime::Result<&GuiResource> {
-        self.resource_table
-            .get::<GuiResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-}
-
 impl gui::Host for PluginHostState {}
 
 impl gui::HostGui for PluginHostState {
@@ -93,7 +85,7 @@ impl gui::HostGui for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::text::TextComponent,
         >,
     ) -> wasmtime::Result<Resource<Gui>> {
-        let title = self.get_text_provider(&title)?;
+        let title = self.take(title)?;
         let window_type = from_wit_screen(screen);
 
         let size = match window_type {
@@ -115,7 +107,7 @@ impl gui::HostGui for PluginHostState {
             allow_put_items: true,
         }));
 
-        self.add_gui(gui)
+        self.add(gui)
     }
 
     async fn get_inventory(
@@ -127,12 +119,10 @@ impl gui::HostGui for PluginHostState {
         >,
     >{
         let inv = {
-            let gui = self.get_gui_res(&res)?.provider.lock().await;
+            let gui = self.get(&res)?.lock().await;
             gui.inventory.clone()
         };
-        self.add_inventory(
-            crate::plugin::loader::wasm::wasm_host::state::InventoryProvider::Generic(inv),
-        )
+        self.add(crate::plugin::loader::wasm::wasm_host::state::InventoryProvider::Generic(inv))
     }
 
     async fn set_item(
@@ -142,10 +132,10 @@ impl gui::HostGui for PluginHostState {
         item: Resource<WitHostItemStack>,
     ) -> wasmtime::Result<()> {
         let item_stack = {
-            let item_stack = self.get_item_stack(&item)?;
+            let item_stack = self.get(&item)?;
             item_stack.lock().await.clone()
         };
-        let gui = self.get_gui_res(&res)?.provider.lock().await;
+        let gui = self.get(&res)?.lock().await;
         let mut slots = gui
             .inventory
             .slots
@@ -163,7 +153,7 @@ impl gui::HostGui for PluginHostState {
         slot: u32,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
         let stack = {
-            let gui = self.get_gui_res(&res)?.provider.lock().await;
+            let gui = self.get(&res)?.lock().await;
             let slots = gui
                 .inventory
                 .slots
@@ -182,14 +172,14 @@ impl gui::HostGui for PluginHostState {
         };
 
         if let Some(stack) = stack {
-            Ok(Some(self.add_item_stack(Arc::new(Mutex::new(stack)))?))
+            Ok(Some(self.add(Arc::new(Mutex::new(stack)))?))
         } else {
             Ok(None)
         }
     }
 
     async fn get_type(&mut self, res: Resource<Gui>) -> wasmtime::Result<WitScreen> {
-        let gui = self.get_gui_res(&res)?.provider.lock().await;
+        let gui = self.get(&res)?.lock().await;
         Ok(to_wit_screen(gui.window_type))
     }
 
@@ -202,22 +192,22 @@ impl gui::HostGui for PluginHostState {
         >,
     > {
         let title = {
-            let gui = self.get_gui_res(&res)?.provider.lock().await;
+            let gui = self.get(&res)?.lock().await;
             gui.title.clone()
         };
-        self.add_text_component(title)
+        self.add(title)
             .map_err(|_| wasmtime::Error::msg("Failed to add text component resource"))
     }
 
     async fn get_size(&mut self, res: Resource<Gui>) -> wasmtime::Result<u32> {
         use pumpkin_inventory::Inventory;
-        let gui = self.get_gui_res(&res)?.provider.lock().await;
+        let gui = self.get(&res)?.lock().await;
         Ok(gui.inventory.size() as u32)
     }
 
     async fn clear_items(&mut self, res: Resource<Gui>) -> wasmtime::Result<()> {
         use pumpkin_inventory::Clearable;
-        let gui = self.get_gui_res(&res)?.provider.lock().await;
+        let gui = self.get(&res)?.lock().await;
         gui.inventory.clear();
         Ok(())
     }
@@ -227,13 +217,13 @@ impl gui::HostGui for PluginHostState {
         res: Resource<Gui>,
         allow: bool,
     ) -> wasmtime::Result<()> {
-        let mut gui = self.get_gui_res(&res)?.provider.lock().await;
+        let mut gui = self.get(&res)?.lock().await;
         gui.allow_grab_items = allow;
         Ok(())
     }
 
     async fn get_allow_grab_items(&mut self, res: Resource<Gui>) -> wasmtime::Result<bool> {
-        let gui = self.get_gui_res(&res)?.provider.lock().await;
+        let gui = self.get(&res)?.lock().await;
         Ok(gui.allow_grab_items)
     }
 
@@ -242,20 +232,17 @@ impl gui::HostGui for PluginHostState {
         res: Resource<Gui>,
         allow: bool,
     ) -> wasmtime::Result<()> {
-        let mut gui = self.get_gui_res(&res)?.provider.lock().await;
+        let mut gui = self.get(&res)?.lock().await;
         gui.allow_put_items = allow;
         Ok(())
     }
 
     async fn get_allow_put_items(&mut self, res: Resource<Gui>) -> wasmtime::Result<bool> {
-        let gui = self.get_gui_res(&res)?.provider.lock().await;
+        let gui = self.get(&res)?.lock().await;
         Ok(gui.allow_put_items)
     }
 
     async fn drop(&mut self, rep: Resource<Gui>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<GuiResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/inventory.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/inventory.rs
@@ -2,9 +2,8 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use wasmtime::component::Resource;
 
-use crate::entity::player::Player;
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{InventoryProvider, InventoryResource, PlayerInventoryResource, PluginHostState},
+    state::{InventoryProvider, PluginHostState},
     wit::v0_1::pumpkin::plugin::{
         common::Hand as WitHand,
         inventory::{
@@ -28,33 +27,9 @@ const fn from_wasm_hand(hand: WitHand) -> pumpkin_util::Hand {
 
 impl InventoryHost for PluginHostState {}
 
-impl PluginHostState {
-    fn get_inventory_provider(
-        &self,
-        res: &Resource<WitInventory>,
-    ) -> wasmtime::Result<InventoryProvider> {
-        let r = self
-            .resource_table
-            .get::<InventoryResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(r.provider.clone())
-    }
-
-    fn get_player_inventory_player(
-        &self,
-        res: &Resource<WitPlayerInventory>,
-    ) -> wasmtime::Result<Arc<Player>> {
-        let r = self
-            .resource_table
-            .get::<PlayerInventoryResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(r.provider.clone())
-    }
-}
-
 impl HostInventory for PluginHostState {
     async fn get_size(&mut self, res: Resource<WitInventory>) -> wasmtime::Result<u32> {
-        let provider = self.get_inventory_provider(&res)?;
+        let provider = self.get(&res)?;
         let size = match provider {
             InventoryProvider::Generic(inv) => inv.size() as u32,
             InventoryProvider::PlayerMain(_) => 36,
@@ -64,7 +39,7 @@ impl HostInventory for PluginHostState {
     }
 
     async fn is_empty(&mut self, res: Resource<WitInventory>) -> wasmtime::Result<bool> {
-        let provider = self.get_inventory_provider(&res)?;
+        let provider = self.get(&res)?;
         let empty = match provider {
             InventoryProvider::Generic(inv) => inv.is_empty(),
             InventoryProvider::PlayerMain(player) => {
@@ -84,7 +59,7 @@ impl HostInventory for PluginHostState {
         res: Resource<WitInventory>,
         slot: u32,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let provider = self.get_inventory_provider(&res)?;
+        let provider = self.get(&res)?;
         let stack = match provider {
             InventoryProvider::Generic(inv) => {
                 let s = inv.get_stack(slot as usize);
@@ -109,7 +84,7 @@ impl HostInventory for PluginHostState {
         };
 
         if let Some(stack) = stack {
-            Ok(Some(self.add_item_stack(Arc::new(Mutex::new(stack)))?))
+            Ok(Some(self.add(Arc::new(Mutex::new(stack)))?))
         } else {
             Ok(None)
         }
@@ -122,12 +97,12 @@ impl HostInventory for PluginHostState {
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
         let stack = if let Some(stack_res) = item {
-            self.get_item_stack(&stack_res)?.lock().await.clone()
+            self.get(&stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
 
-        let provider = self.get_inventory_provider(&res)?;
+        let provider = self.get(&res)?;
         match provider {
             InventoryProvider::Generic(inv) => {
                 inv.set_stack(slot as usize, stack);
@@ -156,7 +131,7 @@ impl HostInventory for PluginHostState {
         res: Resource<WitInventory>,
         slot: u32,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let provider = self.get_inventory_provider(&res)?;
+        let provider = self.get(&res)?;
         let old_stack = match provider {
             InventoryProvider::Generic(inv) => {
                 let s = inv.remove_stack(slot as usize);
@@ -194,14 +169,14 @@ impl HostInventory for PluginHostState {
         };
 
         if let Some(stack) = old_stack {
-            Ok(Some(self.add_item_stack(Arc::new(Mutex::new(stack)))?))
+            Ok(Some(self.add(Arc::new(Mutex::new(stack)))?))
         } else {
             Ok(None)
         }
     }
 
     async fn clear(&mut self, res: Resource<WitInventory>) -> wasmtime::Result<()> {
-        let provider = self.get_inventory_provider(&res)?;
+        let provider = self.get(&res)?;
         match provider {
             InventoryProvider::Generic(inv) => {
                 inv.clear();
@@ -256,7 +231,7 @@ impl HostInventory for PluginHostState {
         res: Resource<WitInventory>,
         item_id: String,
     ) -> wasmtime::Result<u32> {
-        let provider = self.get_inventory_provider(&res)?;
+        let provider = self.get(&res)?;
         let mut total = 0u32;
         let is_matching =
             |key: &str| key == item_id || key.strip_prefix("minecraft:") == Some(&item_id);
@@ -301,10 +276,7 @@ impl HostInventory for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<WitInventory>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<InventoryResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -313,8 +285,8 @@ impl HostPlayerInventory for PluginHostState {
         &mut self,
         res: Resource<WitPlayerInventory>,
     ) -> wasmtime::Result<Resource<WitInventory>> {
-        let player = self.get_player_inventory_player(&res)?;
-        self.add_inventory(InventoryProvider::PlayerMain(player))
+        let player = self.get(&res)?.clone();
+        self.add(InventoryProvider::PlayerMain(player))
     }
 
     async fn get_item_in_hand(
@@ -322,13 +294,13 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         hand: WitHand,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let hand = from_wasm_hand(hand);
         let stack = player.inventory().get_stack_in_hand(hand);
         if stack.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(Mutex::new(stack)))?))
+            Ok(Some(self.add(Arc::new(Mutex::new(stack)))?))
         }
     }
 
@@ -338,9 +310,9 @@ impl HostPlayerInventory for PluginHostState {
         hand: WitHand,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get_item_stack(&stack_res)?.lock().await.clone()
+            self.get(&stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
@@ -365,7 +337,7 @@ impl HostPlayerInventory for PluginHostState {
         &mut self,
         res: Resource<WitPlayerInventory>,
     ) -> wasmtime::Result<u8> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         Ok(player.inventory().get_selected_slot())
     }
 
@@ -374,7 +346,7 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         slot: u8,
     ) -> wasmtime::Result<()> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         if slot < 9 {
             player.inventory().set_selected_slot(slot);
         }
@@ -385,12 +357,12 @@ impl HostPlayerInventory for PluginHostState {
         &mut self,
         res: Resource<WitPlayerInventory>,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = player.inventory().get_slot(39);
         if stack.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(Mutex::new(stack)))?))
+            Ok(Some(self.add(Arc::new(Mutex::new(stack)))?))
         }
     }
 
@@ -399,9 +371,9 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get_item_stack(&stack_res)?.lock().await.clone()
+            self.get(&stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
@@ -416,12 +388,12 @@ impl HostPlayerInventory for PluginHostState {
         &mut self,
         res: Resource<WitPlayerInventory>,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = player.inventory().get_slot(38);
         if stack.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(Mutex::new(stack)))?))
+            Ok(Some(self.add(Arc::new(Mutex::new(stack)))?))
         }
     }
 
@@ -430,9 +402,9 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get_item_stack(&stack_res)?.lock().await.clone()
+            self.get(&stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
@@ -447,12 +419,12 @@ impl HostPlayerInventory for PluginHostState {
         &mut self,
         res: Resource<WitPlayerInventory>,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = player.inventory().get_slot(37);
         if stack.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(Mutex::new(stack)))?))
+            Ok(Some(self.add(Arc::new(Mutex::new(stack)))?))
         }
     }
 
@@ -461,9 +433,9 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get_item_stack(&stack_res)?.lock().await.clone()
+            self.get(&stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
@@ -478,12 +450,12 @@ impl HostPlayerInventory for PluginHostState {
         &mut self,
         res: Resource<WitPlayerInventory>,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = player.inventory().get_slot(36);
         if stack.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(Mutex::new(stack)))?))
+            Ok(Some(self.add(Arc::new(Mutex::new(stack)))?))
         }
     }
 
@@ -492,9 +464,9 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get_item_stack(&stack_res)?.lock().await.clone()
+            self.get(&stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
@@ -509,12 +481,12 @@ impl HostPlayerInventory for PluginHostState {
         &mut self,
         res: Resource<WitPlayerInventory>,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = player.inventory().get_slot(40);
         if stack.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(Mutex::new(stack)))?))
+            Ok(Some(self.add(Arc::new(Mutex::new(stack)))?))
         }
     }
 
@@ -523,9 +495,9 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get_player_inventory_player(&res)?;
+        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get_item_stack(&stack_res)?.lock().await.clone()
+            self.get(&stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
@@ -560,9 +532,6 @@ impl HostPlayerInventory for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<WitPlayerInventory>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<PlayerInventoryResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/inventory.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/inventory.rs
@@ -97,7 +97,7 @@ impl HostInventory for PluginHostState {
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
         let stack = if let Some(stack_res) = item {
-            self.get(&stack_res)?.lock().await.clone()
+            self.take(stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
@@ -200,27 +200,29 @@ impl HostInventory for PluginHostState {
         Ok(())
     }
 
+    // Fixme: this method causes an unnecessary amount of resource table lookups
     async fn get_all_items(
         &mut self,
         res: Resource<WitInventory>,
     ) -> wasmtime::Result<Vec<Option<Resource<WitHostItemStack>>>> {
-        let size = self.get_size(Resource::new_own(res.rep())).await?;
+        let size = self.get_size(Resource::new_borrow(res.rep())).await?;
         let mut items = Vec::with_capacity(size as usize);
         for slot in 0..size {
-            let item = self.get_item(Resource::new_own(res.rep()), slot).await?;
+            let item = self.get_item(Resource::new_borrow(res.rep()), slot).await?;
             items.push(item);
         }
         Ok(items)
     }
 
+    // Fixme: this method causes an unnecessary amount of resource table lookups
     async fn set_all_items(
         &mut self,
         res: Resource<WitInventory>,
         items: Vec<Option<Resource<WitHostItemStack>>>,
     ) -> wasmtime::Result<()> {
-        let size = self.get_size(Resource::new_own(res.rep())).await?;
+        let size = self.get_size(Resource::new_borrow(res.rep())).await?;
         for (slot, item) in items.into_iter().take(size as usize).enumerate() {
-            self.set_item(Resource::new_own(res.rep()), slot as u32, item)
+            self.set_item(Resource::new_borrow(res.rep()), slot as u32, item)
                 .await?;
         }
         Ok(())
@@ -310,12 +312,12 @@ impl HostPlayerInventory for PluginHostState {
         hand: WitHand,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get(&stack_res)?.lock().await.clone()
+            self.take(stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
+        let player = self.get(&res)?;
 
         let hand = from_wasm_hand(hand);
         let slot = match hand {
@@ -371,12 +373,12 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get(&stack_res)?.lock().await.clone()
+            self.take(stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
+        let player = self.get(&res)?;
         player.inventory().set_slot(39, stack.clone());
         let stack_serializer = ItemStackSerializer::from(stack);
         let packet = CSetContainerSlot::new(0, 0, 5, &stack_serializer);
@@ -402,12 +404,12 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get(&stack_res)?.lock().await.clone()
+            self.take(stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
+        let player = self.get(&res)?;
         player.inventory().set_slot(38, stack.clone());
         let stack_serializer = ItemStackSerializer::from(stack);
         let packet = CSetContainerSlot::new(0, 0, 6, &stack_serializer);
@@ -433,12 +435,12 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get(&stack_res)?.lock().await.clone()
+            self.take(stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
+        let player = self.get(&res)?;
         player.inventory().set_slot(37, stack.clone());
         let stack_serializer = ItemStackSerializer::from(stack);
         let packet = CSetContainerSlot::new(0, 0, 7, &stack_serializer);
@@ -464,12 +466,12 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get(&stack_res)?.lock().await.clone()
+            self.take(stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
+        let player = self.get(&res)?;
         player.inventory().set_slot(36, stack.clone());
         let stack_serializer = ItemStackSerializer::from(stack);
         let packet = CSetContainerSlot::new(0, 0, 8, &stack_serializer);
@@ -495,12 +497,12 @@ impl HostPlayerInventory for PluginHostState {
         res: Resource<WitPlayerInventory>,
         item: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = self.get(&res)?;
         let stack = if let Some(stack_res) = item {
-            self.get(&stack_res)?.lock().await.clone()
+            self.take(stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
+        let player = self.get(&res)?;
         player.inventory().set_slot(40, stack.clone());
         let stack_serializer = ItemStackSerializer::from(stack);
         let packet = CSetContainerSlot::new(0, 0, 45, &stack_serializer);
@@ -508,13 +510,16 @@ impl HostPlayerInventory for PluginHostState {
         Ok(())
     }
 
+    // Fixme: this method causes an unnecessary amount of resource table lookups
     async fn clear_armor(&mut self, res: Resource<WitPlayerInventory>) -> wasmtime::Result<()> {
-        self.set_helmet(Resource::new_own(res.rep()), None).await?;
-        self.set_chestplate(Resource::new_own(res.rep()), None)
+        self.set_helmet(Resource::new_borrow(res.rep()), None)
             .await?;
-        self.set_leggings(Resource::new_own(res.rep()), None)
+        self.set_chestplate(Resource::new_borrow(res.rep()), None)
             .await?;
-        self.set_boots(Resource::new_own(res.rep()), None).await?;
+        self.set_leggings(Resource::new_borrow(res.rep()), None)
+            .await?;
+        self.set_boots(Resource::new_borrow(res.rep()), None)
+            .await?;
         Ok(())
     }
 
@@ -523,10 +528,11 @@ impl HostPlayerInventory for PluginHostState {
         self.clear(inv).await
     }
 
+    // Fixme: this method causes an unnecessary amount of resource table lookups
     async fn clear_all(&mut self, res: Resource<WitPlayerInventory>) -> wasmtime::Result<()> {
-        self.clear_main(Resource::new_own(res.rep())).await?;
-        self.clear_armor(Resource::new_own(res.rep())).await?;
-        self.set_off_hand(Resource::new_own(res.rep()), None)
+        self.clear_main(Resource::new_borrow(res.rep())).await?;
+        self.clear_armor(Resource::new_borrow(res.rep())).await?;
+        self.set_off_hand(Resource::new_borrow(res.rep()), None)
             .await?;
         Ok(())
     }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/item_stack.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/item_stack.rs
@@ -1,4 +1,4 @@
-use crate::plugin::loader::wasm::wasm_host::state::{ItemStackResource, PluginHostState};
+use crate::plugin::loader::wasm::wasm_host::state::{PluginHostState};
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::attributes::{
     Attribute as WitAttribute, AttributeModifier as WitAttributeModifier,
     ModifierOperation as WitModifierOperation,
@@ -73,18 +73,6 @@ pub const fn to_wit_item_operation(op: Operation) -> WitModifierOperation {
     }
 }
 
-impl PluginHostState {
-    pub fn get_item_stack(
-        &self,
-        res: &Resource<ItemStackHandle>,
-    ) -> wasmtime::Result<Arc<Mutex<pumpkin_data::item_stack::ItemStack>>> {
-        self.resource_table
-            .get::<ItemStackResource>(&Resource::new_own(res.rep()))
-            .map(|r| r.provider.clone())
-            .map_err(wasmtime::Error::from)
-    }
-}
-
 impl ItemStackInterfaceHost for PluginHostState {}
 
 impl HostItemStack for PluginHostState {
@@ -100,20 +88,20 @@ impl HostItemStack for PluginHostState {
         )
         .unwrap_or(&pumpkin_data::item::Item::AIR);
         let stack = pumpkin_data::item_stack::ItemStack::new(count, item);
-        self.add_item_stack(Arc::new(Mutex::new(stack)))
+        self.add(Arc::new(Mutex::new(stack)))
     }
 
     async fn get_registry_key(
         &mut self,
         res: Resource<ItemStackHandle>,
     ) -> wasmtime::Result<String> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
         Ok(stack.item.registry_key.to_string())
     }
 
     async fn get_count(&mut self, res: Resource<ItemStackHandle>) -> wasmtime::Result<u8> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
         Ok(stack.item_count)
     }
@@ -123,14 +111,14 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         count: u8,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         stack.item_count = count;
         Ok(())
     }
 
     async fn get_max_count(&mut self, res: Resource<ItemStackHandle>) -> wasmtime::Result<u8> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
         // Search in components for MaxStackSize
         if let Some((_, data)) = stack
@@ -151,7 +139,7 @@ impl HostItemStack for PluginHostState {
         &mut self,
         res: Resource<ItemStackHandle>,
     ) -> wasmtime::Result<Vec<WitEnchantmentValue>> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
         let mut enchantments = Vec::new();
         if let Some((_, Some(data))) = stack
@@ -176,7 +164,7 @@ impl HostItemStack for PluginHostState {
         enchantment: WitEnchantment,
         level: u32,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         let enc = from_wit_enchantment(enchantment);
 
@@ -220,7 +208,7 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         enchantment: WitEnchantment,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         let enc = from_wit_enchantment(enchantment);
 
@@ -241,7 +229,7 @@ impl HostItemStack for PluginHostState {
         &mut self,
         res: Resource<ItemStackHandle>,
     ) -> wasmtime::Result<Vec<WitCustomEnchantmentValue>> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
         let mut result = Vec::new();
 
@@ -285,7 +273,7 @@ impl HostItemStack for PluginHostState {
         enchantment_id: String,
         level: u32,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
 
         stack.set_custom_data(
@@ -337,7 +325,7 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         enchantment_id: String,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
 
         stack.remove_custom_data("pumpkin:enchantments", &enchantment_id);
@@ -362,7 +350,7 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         enchantment_id: String,
     ) -> wasmtime::Result<Option<u32>> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
 
         if let Some(NbtTag::Int(level)) =
@@ -393,7 +381,7 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         enchantment_id: String,
     ) -> wasmtime::Result<bool> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
 
         if stack.has_custom_data("pumpkin:enchantments", &enchantment_id) {
@@ -417,7 +405,7 @@ impl HostItemStack for PluginHostState {
         &mut self,
         res: Resource<ItemStackHandle>,
     ) -> wasmtime::Result<Vec<WitItemAttributeModifier>> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
         let mut modifiers = Vec::new();
         if let Some(comp) = stack.get_data_component::<AttributeModifiersImpl>() {
@@ -441,7 +429,7 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         modifier: WitItemAttributeModifier,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         let attr = super::living_entity::from_wit_attribute(modifier.attribute);
         let slot = super::enchantment::to_data_slot(modifier.slot);
@@ -475,7 +463,7 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         attribute: WitAttribute,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         let attr = super::living_entity::from_wit_attribute(attribute);
 
@@ -500,7 +488,7 @@ impl HostItemStack for PluginHostState {
         &mut self,
         res: Resource<ItemStackHandle>,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         stack
             .patch
@@ -512,7 +500,7 @@ impl HostItemStack for PluginHostState {
         &mut self,
         res: Resource<ItemStackHandle>,
     ) -> wasmtime::Result<Vec<Resource<WitTextComponent>>> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let lines = {
             let stack = stack.lock().await;
             stack
@@ -520,10 +508,7 @@ impl HostItemStack for PluginHostState {
                 .map_or_else(Vec::new, |lore| lore.lines.clone())
         };
 
-        lines
-            .into_iter()
-            .map(|line| self.add_text_component(line))
-            .collect()
+        lines.into_iter().map(|line| self.add(line)).collect()
     }
 
     async fn set_lore(
@@ -535,7 +520,7 @@ impl HostItemStack for PluginHostState {
             .iter()
             .map(|line| text_component_from_resource(self, line))
             .collect();
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         stack.lock().await.set_lore(lore);
         Ok(())
     }
@@ -546,7 +531,7 @@ impl HostItemStack for PluginHostState {
         line: Resource<WitTextComponent>,
     ) -> wasmtime::Result<()> {
         let line = text_component_from_resource(self, &line);
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         stack.lock().await.add_lore(line);
         Ok(())
     }
@@ -555,7 +540,7 @@ impl HostItemStack for PluginHostState {
         &mut self,
         res: Resource<ItemStackHandle>,
     ) -> wasmtime::Result<Option<Resource<WitTextComponent>>> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?.clone();
         let stack = stack.lock().await;
         if let Some((_, Some(data))) = stack
             .patch
@@ -563,7 +548,7 @@ impl HostItemStack for PluginHostState {
             .find(|(id, _)| *id == DataComponent::CustomName)
             && let Some(name_impl) = data.as_any().downcast_ref::<CustomNameImpl>()
         {
-            return Ok(Some(self.add_text_component(name_impl.name.clone())?));
+            return Ok(Some(self.add(name_impl.name.clone())?));
         }
         Ok(None)
     }
@@ -573,7 +558,7 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         name: Option<Resource<WitTextComponent>>,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         if let Some(name_res) = name {
             let name = text_component_from_resource(self, &name_res);
@@ -604,7 +589,7 @@ impl HostItemStack for PluginHostState {
         key: String,
         value: WitNbtTree,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         let value = from_wit_nbt_tree(&value).map_err(wasmtime::Error::msg)?;
         stack.set_custom_data(&namespace, &key, value);
@@ -617,7 +602,7 @@ impl HostItemStack for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<Option<WitNbtTree>> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
         Ok(stack.get_custom_data(&namespace, &key).map(to_wit_nbt_tree))
     }
@@ -628,7 +613,7 @@ impl HostItemStack for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         stack.remove_custom_data(&namespace, &key);
         Ok(())
@@ -640,7 +625,7 @@ impl HostItemStack for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<bool> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
         Ok(stack.has_custom_data(&namespace, &key))
     }
@@ -649,7 +634,7 @@ impl HostItemStack for PluginHostState {
         &mut self,
         res: Resource<ItemStackHandle>,
     ) -> wasmtime::Result<Vec<WitDataComponentValue>> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let stack = stack.lock().await;
         let mut components = Vec::new();
         for (id, data) in &stack.patch {
@@ -672,7 +657,7 @@ impl HostItemStack for PluginHostState {
         component: WitDataComponent,
         value: Vec<u8>,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         let id = from_wit_data_component(component);
         let mut cursor = std::io::Cursor::new(value);
@@ -692,7 +677,7 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         component: WitDataComponent,
     ) -> wasmtime::Result<()> {
-        let stack = self.get_item_stack(&res)?;
+        let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
         let id = from_wit_data_component(component);
         stack.patch.retain(|(pid, _)| *pid != id);
@@ -700,9 +685,6 @@ impl HostItemStack for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<ItemStackHandle>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<ItemStackResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/item_stack.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/item_stack.rs
@@ -1,4 +1,4 @@
-use crate::plugin::loader::wasm::wasm_host::state::{PluginHostState};
+use crate::plugin::loader::wasm::wasm_host::state::PluginHostState;
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::attributes::{
     Attribute as WitAttribute, AttributeModifier as WitAttributeModifier,
     ModifierOperation as WitModifierOperation,
@@ -17,7 +17,6 @@ use tokio::sync::Mutex;
 use wasmtime::component::Resource;
 
 use super::common::{WitNbtTree, from_wit_nbt_tree, to_wit_nbt_tree};
-use crate::plugin::loader::wasm::wasm_host::wit::v0_1::player::text_component_from_resource;
 use pumpkin_data::Enchantment;
 use pumpkin_data::attributes::Attributes;
 use pumpkin_data::data_component::DataComponent;
@@ -517,9 +516,9 @@ impl HostItemStack for PluginHostState {
         lore: Vec<Resource<WitTextComponent>>,
     ) -> wasmtime::Result<()> {
         let lore = lore
-            .iter()
-            .map(|line| text_component_from_resource(self, line))
-            .collect();
+            .into_iter()
+            .map(|line| self.take(line))
+            .collect::<Result<_, _>>()?;
         let stack = self.get(&res)?;
         stack.lock().await.set_lore(lore);
         Ok(())
@@ -530,7 +529,7 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         line: Resource<WitTextComponent>,
     ) -> wasmtime::Result<()> {
-        let line = text_component_from_resource(self, &line);
+        let line = self.take(line)?;
         let stack = self.get(&res)?;
         stack.lock().await.add_lore(line);
         Ok(())
@@ -558,10 +557,10 @@ impl HostItemStack for PluginHostState {
         res: Resource<ItemStackHandle>,
         name: Option<Resource<WitTextComponent>>,
     ) -> wasmtime::Result<()> {
+        let name = name.map(|r| self.take(r)).transpose()?;
         let stack = self.get(&res)?;
         let mut stack = stack.lock().await;
-        if let Some(name_res) = name {
-            let name = text_component_from_resource(self, &name_res);
+        if let Some(name) = name {
             if let Some((_, data)) = stack
                 .patch
                 .iter_mut()

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/living_entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/living_entity.rs
@@ -150,29 +150,28 @@ impl HostLivingEntity for PluginHostState {
         &mut self,
         this: Resource<WitLivingEntity>,
     ) -> wasmtime::Result<Resource<Entity>> {
-        let entity = living_entity_from_resource(self, &this)?;
-        self.add(entity)
+        self.add(self.get(&this)?.clone())
     }
 
     async fn as_mob(
         &mut self,
         this: Resource<WitLivingEntity>,
     ) -> wasmtime::Result<Option<Resource<WitMob>>> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if entity.get_mob().is_some() {
-            Ok(Some(self.add(entity)?))
+            Ok(Some(self.add(entity.clone())?))
         } else {
             Ok(None)
         }
     }
 
     async fn is_mob(&mut self, this: Resource<WitLivingEntity>) -> wasmtime::Result<bool> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_mob().is_some())
     }
 
     async fn get_health(&mut self, this: Resource<WitLivingEntity>) -> wasmtime::Result<f32> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity
             .get_living_entity()
             .map_or(0.0, |living| living.health.load()))
@@ -183,7 +182,7 @@ impl HostLivingEntity for PluginHostState {
         this: Resource<WitLivingEntity>,
         health: f32,
     ) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(living) = entity.get_living_entity() {
             living.health.store(health);
         }
@@ -191,7 +190,7 @@ impl HostLivingEntity for PluginHostState {
     }
 
     async fn get_max_health(&mut self, this: Resource<WitLivingEntity>) -> wasmtime::Result<f32> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity
             .get_living_entity()
             .map_or(0.0, crate::entity::living::LivingEntity::get_max_health))
@@ -202,7 +201,7 @@ impl HostLivingEntity for PluginHostState {
         this: Resource<WitLivingEntity>,
         max_health: f32,
     ) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(living) = entity.get_living_entity() {
             living.set_max_health(max_health);
         }
@@ -210,7 +209,7 @@ impl HostLivingEntity for PluginHostState {
     }
 
     async fn is_dead(&mut self, this: Resource<WitLivingEntity>) -> wasmtime::Result<bool> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_living_entity().map_or_else(
             || entity.get_entity().removal_reason.load().is_some(),
             |living| living.dead.load(std::sync::atomic::Ordering::Relaxed),
@@ -218,7 +217,7 @@ impl HostLivingEntity for PluginHostState {
     }
 
     async fn get_absorption(&mut self, this: Resource<WitLivingEntity>) -> wasmtime::Result<f32> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity
             .get_living_entity()
             .map_or(0.0, |living| living.absorption.load()))
@@ -229,7 +228,7 @@ impl HostLivingEntity for PluginHostState {
         this: Resource<WitLivingEntity>,
         amount: f32,
     ) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(living) = entity.get_living_entity() {
             living.absorption.store(amount);
         }
@@ -241,7 +240,7 @@ impl HostLivingEntity for PluginHostState {
         this: Resource<WitLivingEntity>,
         attr: Attribute,
     ) -> wasmtime::Result<f64> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let attribute = from_wit_attribute(attr);
         Ok(entity
             .get_living_entity()
@@ -255,7 +254,7 @@ impl HostLivingEntity for PluginHostState {
         this: Resource<WitLivingEntity>,
         attr: Attribute,
     ) -> wasmtime::Result<f64> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let attribute = from_wit_attribute(attr);
         Ok(entity
             .get_living_entity()
@@ -270,7 +269,7 @@ impl HostLivingEntity for PluginHostState {
         attr: Attribute,
         value: f64,
     ) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let attribute = from_wit_attribute(attr);
         if let Some(living) = entity.get_living_entity() {
             living.set_attribute_base(attribute, value);
@@ -288,7 +287,7 @@ impl HostLivingEntity for PluginHostState {
         attr: Attribute,
         modifier: WitAttributeModifier,
     ) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let attribute = from_wit_attribute(attr);
         if let Some(living) = entity.get_living_entity() {
             let internal_mod = crate::entity::attributes::Modifier {
@@ -311,7 +310,7 @@ impl HostLivingEntity for PluginHostState {
         attr: Attribute,
         id: String,
     ) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let attribute = from_wit_attribute(attr);
         if let Some(living) = entity.get_living_entity() {
             living.update_attribute(attribute, |inst| inst.remove_modifier(&id));
@@ -328,7 +327,7 @@ impl HostLivingEntity for PluginHostState {
         this: Resource<WitLivingEntity>,
         attr: Attribute,
     ) -> wasmtime::Result<Vec<WitAttributeModifier>> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let attribute = from_wit_attribute(attr);
         if let Some(living) = entity.get_living_entity() {
             let map = living
@@ -355,7 +354,7 @@ impl HostLivingEntity for PluginHostState {
         this: Resource<WitLivingEntity>,
         attr: Attribute,
     ) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let attribute = from_wit_attribute(attr);
         if let Some(living) = entity.get_living_entity() {
             {
@@ -377,7 +376,7 @@ impl HostLivingEntity for PluginHostState {
         &mut self,
         this: Resource<WitLivingEntity>,
     ) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(living) = entity.get_living_entity() {
             living.reset_effects_and_attributes();
         }
@@ -389,7 +388,7 @@ impl HostLivingEntity for PluginHostState {
         this: Resource<WitLivingEntity>,
         slot: WitEquipmentSlot,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?.clone();
         if let Some(living) = entity.get_living_entity() {
             let slot = from_wit_equipment_slot(slot);
             let equipment = living
@@ -410,7 +409,7 @@ impl HostLivingEntity for PluginHostState {
         slot: WitEquipmentSlot,
         stack: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(living) = entity.get_living_entity() {
             let slot = from_wit_equipment_slot(slot);
             let item_stack = if let Some(stack_res) = stack {
@@ -433,7 +432,7 @@ impl HostLivingEntity for PluginHostState {
     }
 
     async fn clear_equipment(&mut self, this: Resource<WitLivingEntity>) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(living) = entity.get_living_entity() {
             let mut equipment = living
                 .entity_equipment
@@ -455,14 +454,14 @@ impl HostLivingEntity for PluginHostState {
     }
 
     async fn get_age(&mut self, this: Resource<WitLivingEntity>) -> wasmtime::Result<i32> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_living_entity().map_or(0, |living| {
             living.entity.age.load(std::sync::atomic::Ordering::Relaxed)
         }))
     }
 
     async fn set_age(&mut self, this: Resource<WitLivingEntity>, age: i32) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(living) = entity.get_living_entity() {
             living
                 .entity
@@ -477,9 +476,8 @@ impl HostLivingEntity for PluginHostState {
         this: Resource<WitLivingEntity>,
         message: Resource<TextComponent>,
     ) -> wasmtime::Result<()> {
-        let entity = living_entity_from_resource(self, &this)?;
-        if let Some(player) = entity.get_player() {
-            let text_res = self.take(message)?;
+        let text_res = self.take(message)?;
+        if let Some(player) = self.get(&this)?.get_player() {
             player.send_system_message(&text_res);
         }
         Ok(())

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/living_entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/living_entity.rs
@@ -18,17 +18,6 @@ use crate::plugin::loader::wasm::wasm_host::{
     },
 };
 
-pub fn living_entity_from_resource(
-    state: &PluginHostState,
-    entity: &Resource<WitLivingEntity>,
-) -> wasmtime::Result<std::sync::Arc<dyn crate::entity::EntityBase>> {
-    state
-        .resource_table
-        .get::<Arc<dyn crate::entity::EntityBase>>(&Resource::new_own(entity.rep()))
-        .map_err(|_| wasmtime::Error::msg("invalid living entity resource handle"))
-        .map(|resource| resource.clone())
-}
-
 fn active_plugin(
     state: &PluginHostState,
 ) -> wasmtime::Result<Arc<crate::plugin::loader::wasm::wasm_host::WasmPlugin>> {
@@ -501,7 +490,7 @@ impl crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::world::
         let (entity, plugin) = {
             let state = host.get();
             (
-                living_entity_from_resource(state, &this)?,
+                state.get(&this)?.clone(),
                 active_plugin(state)?,
             )
         };

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/living_entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/living_entity.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use wasmtime::component::{Access, HasSelf, Resource};
 
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{LivingEntityResource, PluginHostState},
+    state::PluginHostState,
     wit::v0_1::pumpkin::plugin::{
         attributes::{
             Attribute, AttributeModifier as WitAttributeModifier,
@@ -24,9 +24,9 @@ pub fn living_entity_from_resource(
 ) -> wasmtime::Result<std::sync::Arc<dyn crate::entity::EntityBase>> {
     state
         .resource_table
-        .get::<LivingEntityResource>(&Resource::new_own(entity.rep()))
+        .get::<Arc<dyn crate::entity::EntityBase>>(&Resource::new_own(entity.rep()))
         .map_err(|_| wasmtime::Error::msg("invalid living entity resource handle"))
-        .map(|resource| resource.provider.clone())
+        .map(|resource| resource.clone())
 }
 
 fn active_plugin(
@@ -151,7 +151,7 @@ impl HostLivingEntity for PluginHostState {
         this: Resource<WitLivingEntity>,
     ) -> wasmtime::Result<Resource<Entity>> {
         let entity = living_entity_from_resource(self, &this)?;
-        self.add_entity(entity)
+        self.add(entity)
     }
 
     async fn as_mob(
@@ -160,7 +160,7 @@ impl HostLivingEntity for PluginHostState {
     ) -> wasmtime::Result<Option<Resource<WitMob>>> {
         let entity = living_entity_from_resource(self, &this)?;
         if entity.get_mob().is_some() {
-            Ok(Some(self.add_mob(entity)?))
+            Ok(Some(self.add(entity)?))
         } else {
             Ok(None)
         }
@@ -398,9 +398,7 @@ impl HostLivingEntity for PluginHostState {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let stack = equipment.get(&slot);
             if !stack.is_empty() {
-                return Ok(Some(
-                    self.add_item_stack(Arc::new(tokio::sync::Mutex::new(stack)))?,
-                ));
+                return Ok(Some(self.add(Arc::new(tokio::sync::Mutex::new(stack)))?));
             }
         }
         Ok(None)
@@ -416,7 +414,7 @@ impl HostLivingEntity for PluginHostState {
         if let Some(living) = entity.get_living_entity() {
             let slot = from_wit_equipment_slot(slot);
             let item_stack = if let Some(stack_res) = stack {
-                self.get_item_stack(&stack_res)?.lock().await.clone()
+                self.get(&stack_res)?.lock().await.clone()
             } else {
                 pumpkin_data::item_stack::ItemStack::EMPTY.clone()
             };
@@ -481,22 +479,14 @@ impl HostLivingEntity for PluginHostState {
     ) -> wasmtime::Result<()> {
         let entity = living_entity_from_resource(self, &this)?;
         if let Some(player) = entity.get_player() {
-            let text_res = self
-                .resource_table
-                .get::<crate::plugin::loader::wasm::wasm_host::state::TextComponentResource>(
-                    &Resource::new_own(message.rep()),
-                )
-                .map_err(|_| wasmtime::Error::msg("invalid text component resource handle"))?;
-            player.send_system_message(&text_res.provider);
+            let text_res = self.take(message)?;
+            player.send_system_message(&text_res);
         }
         Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<WitLivingEntity>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<LivingEntityResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/living_entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/living_entity.rs
@@ -398,15 +398,15 @@ impl HostLivingEntity for PluginHostState {
         slot: WitEquipmentSlot,
         stack: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
+        let item_stack = if let Some(stack_res) = stack {
+            self.take(stack_res)?.lock().await.clone()
+        } else {
+            pumpkin_data::item_stack::ItemStack::EMPTY.clone()
+        };
+
         let entity = self.get(&this)?;
         if let Some(living) = entity.get_living_entity() {
             let slot = from_wit_equipment_slot(slot);
-            let item_stack = if let Some(stack_res) = stack {
-                self.get(&stack_res)?.lock().await.clone()
-            } else {
-                pumpkin_data::item_stack::ItemStack::EMPTY.clone()
-            };
-
             {
                 let mut equipment = living
                     .entity_equipment

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mob.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mob.rs
@@ -3,14 +3,12 @@ use wasmtime::component::{Access, HasSelf, Resource};
 
 use pumpkin_util::math::vector3::Vector3;
 
-use crate::entity::EntityBase;
 use crate::entity::ai::goal::Goal;
 use crate::entity::mob::Mob as InternalMob;
 use crate::entity::passive::tamable::TamableAnimal;
 use crate::plugin::loader::wasm::wasm_host::{
     PluginInstance, WasmPlugin,
     state::PluginHostState,
-    wit::v0_1::entity::entity_from_resource,
     wit::v0_1::pumpkin::plugin::{
         common::Position,
         uuid::Uuid,
@@ -28,17 +26,6 @@ use crate::plugin::loader::wasm::wasm_host::{
     wit::v0_1::uuid::UuidExt,
 };
 use crate::server::Server;
-
-pub fn mob_from_resource(
-    state: &PluginHostState,
-    entity: &Resource<WitMob>,
-) -> wasmtime::Result<std::sync::Arc<dyn crate::entity::EntityBase>> {
-    state
-        .resource_table
-        .get::<Arc<dyn EntityBase>>(&Resource::new_own(entity.rep()))
-        .map_err(|_| wasmtime::Error::msg("invalid mob resource handle"))
-        .map(|resource| resource.clone())
-}
 
 #[must_use]
 pub const fn from_wit_path_node_type(
@@ -243,25 +230,23 @@ impl CustomWasmGoal {
                 .store
                 .call_guest(move |mut guest| {
                     Box::pin(async move {
-                        let (server_resource, entity_resource) =
-                            guest.with(|mut store| {
-                                let server = store.data_mut().server.clone().ok_or_else(|| {
-                                    wasmtime::Error::msg("Wasm plugin server is not available")
-                                })?;
-                                let server_resource = store.data_mut().add(server)?;
-                                let server_rep = server_resource.rep();
-                                let entity_resource = match store.data_mut().add(entity) {
-                                    Ok(resource) => resource,
-                                    Err(error) => {
-                                        let _ =
-                                            store.data_mut().resource_table.delete::<Arc<Server>>(
-                                                wasmtime::component::Resource::new_own(server_rep),
-                                            );
-                                        return Err(error);
-                                    }
-                                };
-                                Ok::<_, wasmtime::Error>((server_resource, entity_resource))
+                        let (server_resource, entity_resource) = guest.with(|mut store| {
+                            let server = store.data_mut().server.clone().ok_or_else(|| {
+                                wasmtime::Error::msg("Wasm plugin server is not available")
                             })?;
+                            let server_resource = store.data_mut().add(server)?;
+                            let server_rep = server_resource.rep();
+                            let entity_resource = match store.data_mut().add(entity) {
+                                Ok(resource) => resource,
+                                Err(error) => {
+                                    let _ = store.data_mut().resource_table.delete::<Arc<Server>>(
+                                        wasmtime::component::Resource::new_own(server_rep),
+                                    );
+                                    return Err(error);
+                                }
+                            };
+                            Ok::<_, wasmtime::Error>((server_resource, entity_resource))
+                        })?;
                         let result = guest
                             .call(function, (goal_id, server_resource, entity_resource))
                             .await;
@@ -306,16 +291,14 @@ impl Goal for CustomWasmGoal {
 
 impl HostMob for PluginHostState {
     async fn as_entity(&mut self, this: Resource<WitMob>) -> wasmtime::Result<Resource<Entity>> {
-        let entity = mob_from_resource(self, &this)?;
-        self.add(entity)
+        self.add(self.get(&this)?.clone())
     }
 
     async fn as_living(
         &mut self,
         this: Resource<WitMob>,
     ) -> wasmtime::Result<Resource<WitLivingEntity>> {
-        let entity = mob_from_resource(self, &this)?;
-        self.add(entity)
+        self.add(self.get(&this)?.clone())
     }
 
     async fn add_ai_goal(
@@ -324,7 +307,7 @@ impl HostMob for PluginHostState {
         priority: u8,
         goal: crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::world::BuiltinAiGoal,
     ) -> wasmtime::Result<()> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(mob) = entity.get_mob() {
             let mob_entity = mob.get_mob_entity();
             match goal {
@@ -367,7 +350,7 @@ impl HostMob for PluginHostState {
         let Some(plugin) = self.plugin.as_ref().and_then(std::sync::Weak::upgrade) else {
             return Err(wasmtime::Error::msg("Plugin not active"));
         };
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(mob) = entity.get_mob() {
             let mob_entity = mob.get_mob_entity();
             mob_entity.add_goal(priority, CustomWasmGoal { plugin, goal_id });
@@ -380,7 +363,7 @@ impl HostMob for PluginHostState {
         this: Resource<WitMob>,
         disabled: bool,
     ) -> wasmtime::Result<()> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(mob) = entity.get_mob() {
             mob.get_mob_entity().set_no_ai(disabled);
         }
@@ -388,7 +371,7 @@ impl HostMob for PluginHostState {
     }
 
     async fn is_ai_disabled(&mut self, this: Resource<WitMob>) -> wasmtime::Result<bool> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity
             .get_mob()
             .is_none_or(|mob| mob.get_mob_entity().is_no_ai()))
@@ -399,8 +382,8 @@ impl HostMob for PluginHostState {
         this: Resource<WitMob>,
         target: Option<Resource<Entity>>,
     ) -> wasmtime::Result<()> {
-        let entity = mob_from_resource(self, &this)?;
-        let target_entity = target.map(|t| entity_from_resource(self, &t)).transpose()?;
+        let entity = self.get(&this)?.clone();
+        let target_entity = target.map(|t| self.take(t)).transpose()?;
         if let Some(mob) = entity.get_mob() {
             mob.get_mob_entity().set_target(target_entity);
         }
@@ -411,7 +394,7 @@ impl HostMob for PluginHostState {
         &mut self,
         this: Resource<WitMob>,
     ) -> wasmtime::Result<Option<Resource<Entity>>> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(target) = entity
             .get_mob()
             .and_then(|mob| mob.get_mob_entity().get_target())
@@ -427,7 +410,7 @@ impl HostMob for PluginHostState {
         pos: Position,
         speed: f64,
     ) -> wasmtime::Result<bool> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_mob().is_some_and(|mob| {
             let mob_pos = entity.get_entity().pos.load();
             let dest = Vector3::new(pos.0, pos.1, pos.2);
@@ -448,8 +431,8 @@ impl HostMob for PluginHostState {
         target: Resource<Entity>,
         speed: f64,
     ) -> wasmtime::Result<bool> {
-        let entity = mob_from_resource(self, &this)?;
-        let target_entity = entity_from_resource(self, &target)?;
+        let entity = self.get(&this)?.clone();
+        let target_entity = self.take(target)?;
         Ok(entity.get_mob().is_some_and(|mob| {
             let mob_pos = entity.get_entity().pos.load();
             let target_pos = target_entity.get_entity().pos.load();
@@ -470,7 +453,7 @@ impl HostMob for PluginHostState {
     }
 
     async fn stop_navigation(&mut self, this: Resource<WitMob>) -> wasmtime::Result<()> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(mob) = entity.get_mob() {
             mob.get_mob_entity()
                 .navigator
@@ -482,7 +465,7 @@ impl HostMob for PluginHostState {
     }
 
     async fn is_navigating(&mut self, this: Resource<WitMob>) -> wasmtime::Result<bool> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_mob().is_some_and(|mob| {
             let is_idle = mob
                 .get_mob_entity()
@@ -495,7 +478,7 @@ impl HostMob for PluginHostState {
     }
 
     async fn has_reached_destination(&mut self, this: Resource<WitMob>) -> wasmtime::Result<bool> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_mob().is_none_or(|mob| {
             mob.get_mob_entity()
                 .navigator
@@ -510,7 +493,7 @@ impl HostMob for PluginHostState {
         this: Resource<WitMob>,
         speed: f64,
     ) -> wasmtime::Result<()> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(mob) = entity.get_mob() {
             mob.get_mob_entity()
                 .navigator
@@ -527,7 +510,7 @@ impl HostMob for PluginHostState {
         pos: Position,
         max_distance: f32,
     ) -> wasmtime::Result<bool> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_mob().is_some_and(|mob| {
             let living = &mob.get_mob_entity().living_entity;
             let dest = Vector3::new(pos.0, pos.1, pos.2);
@@ -545,7 +528,7 @@ impl HostMob for PluginHostState {
         node_type: WitPathNodeType,
         malus: f32,
     ) -> wasmtime::Result<()> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(mob) = entity.get_mob() {
             let internal_type = from_wit_path_node_type(node_type);
             mob.get_mob_entity()
@@ -562,7 +545,7 @@ impl HostMob for PluginHostState {
         this: Resource<WitMob>,
         node_type: WitPathNodeType,
     ) -> wasmtime::Result<f32> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_mob().map_or(0.0, |mob| {
             let internal_type = from_wit_path_node_type(node_type);
             mob.get_mob_entity()
@@ -574,7 +557,7 @@ impl HostMob for PluginHostState {
     }
 
     async fn look_at(&mut self, this: Resource<WitMob>, pos: Position) -> wasmtime::Result<()> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         if let Some(mob) = entity.get_mob() {
             mob.get_mob_entity()
                 .look_control
@@ -590,8 +573,8 @@ impl HostMob for PluginHostState {
         this: Resource<WitMob>,
         target: Resource<Entity>,
     ) -> wasmtime::Result<()> {
-        let entity = mob_from_resource(self, &this)?;
-        let target_entity = entity_from_resource(self, &target)?;
+        let target_entity = self.take(target)?;
+        let entity = self.get(&this)?;
         if let Some(mob) = entity.get_mob() {
             mob.get_mob_entity()
                 .look_control
@@ -604,7 +587,7 @@ impl HostMob for PluginHostState {
 
     #[allow(clippy::too_many_lines)]
     async fn get_mob_data(&mut self, this: Resource<WitMob>) -> wasmtime::Result<WitMobData> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let any = entity.cast_any();
 
         if let Some(sheep) = any.downcast_ref::<crate::entity::passive::sheep::SheepEntity>() {
@@ -726,7 +709,7 @@ impl HostMob for PluginHostState {
         this: Resource<WitMob>,
         data: WitMobData,
     ) -> wasmtime::Result<bool> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         let any = entity.cast_any();
 
         match data {
@@ -872,13 +855,13 @@ impl HostMob for PluginHostState {
         this: Resource<WitMob>,
         ticks: i32,
     ) -> wasmtime::Result<()> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         entity.get_entity().set_frozen_ticks(ticks);
         Ok(())
     }
 
     async fn get_freeze_ticks(&mut self, this: Resource<WitMob>) -> wasmtime::Result<i32> {
-        let entity = mob_from_resource(self, &this)?;
+        let entity = self.get(&this)?;
         Ok(entity.get_entity().get_frozen_ticks())
     }
 
@@ -898,7 +881,7 @@ impl
     ) -> wasmtime::Result<()> {
         let (entity, plugin) = {
             let state = host.get();
-            let entity = mob_from_resource(state, &this)?;
+            let entity = state.get(&this)?.clone();
             let plugin = state
                 .plugin
                 .as_ref()

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mob.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mob.rs
@@ -247,10 +247,9 @@ impl CustomWasmGoal {
                             };
                             Ok::<_, wasmtime::Error>((server_resource, entity_resource))
                         })?;
-                        let result = guest
+                        guest
                             .call(function, (goal_id, server_resource, entity_resource))
-                            .await;
-                        result
+                            .await
                     })
                 })
                 .await

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mob.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mob.rs
@@ -3,12 +3,13 @@ use wasmtime::component::{Access, HasSelf, Resource};
 
 use pumpkin_util::math::vector3::Vector3;
 
+use crate::entity::EntityBase;
 use crate::entity::ai::goal::Goal;
 use crate::entity::mob::Mob as InternalMob;
 use crate::entity::passive::tamable::TamableAnimal;
 use crate::plugin::loader::wasm::wasm_host::{
     PluginInstance, WasmPlugin,
-    state::{MobResource, PluginHostState},
+    state::PluginHostState,
     wit::v0_1::entity::entity_from_resource,
     wit::v0_1::pumpkin::plugin::{
         common::Position,
@@ -26,6 +27,7 @@ use crate::plugin::loader::wasm::wasm_host::{
     },
     wit::v0_1::uuid::UuidExt,
 };
+use crate::server::Server;
 
 pub fn mob_from_resource(
     state: &PluginHostState,
@@ -33,9 +35,9 @@ pub fn mob_from_resource(
 ) -> wasmtime::Result<std::sync::Arc<dyn crate::entity::EntityBase>> {
     state
         .resource_table
-        .get::<MobResource>(&Resource::new_own(entity.rep()))
+        .get::<Arc<dyn EntityBase>>(&Resource::new_own(entity.rep()))
         .map_err(|_| wasmtime::Error::msg("invalid mob resource handle"))
-        .map(|resource| resource.provider.clone())
+        .map(|resource| resource.clone())
 }
 
 #[must_use]
@@ -241,36 +243,28 @@ impl CustomWasmGoal {
                 .store
                 .call_guest(move |mut guest| {
                     Box::pin(async move {
-                        let (server_resource, entity_resource, reps) =
+                        let (server_resource, entity_resource) =
                             guest.with(|mut store| {
                                 let server = store.data_mut().server.clone().ok_or_else(|| {
                                     wasmtime::Error::msg("Wasm plugin server is not available")
                                 })?;
-                                let server_resource = store.data_mut().add_server(server)?;
+                                let server_resource = store.data_mut().add(server)?;
                                 let server_rep = server_resource.rep();
-                                let entity_resource = match store.data_mut().add_entity(entity) {
+                                let entity_resource = match store.data_mut().add(entity) {
                                     Ok(resource) => resource,
                                     Err(error) => {
-                                        let _ = store.data_mut().resource_table.delete::<
-                                            crate::plugin::loader::wasm::wasm_host::state::ServerResource,
-                                        >(wasmtime::component::Resource::new_own(server_rep));
+                                        let _ =
+                                            store.data_mut().resource_table.delete::<Arc<Server>>(
+                                                wasmtime::component::Resource::new_own(server_rep),
+                                            );
                                         return Err(error);
                                     }
                                 };
-                                let reps = (server_rep, entity_resource.rep());
-                                Ok::<_, wasmtime::Error>((server_resource, entity_resource, reps))
+                                Ok::<_, wasmtime::Error>((server_resource, entity_resource))
                             })?;
                         let result = guest
                             .call(function, (goal_id, server_resource, entity_resource))
                             .await;
-                        guest.with(|mut store| {
-                            let _ = store.data_mut().resource_table.delete::<
-                                crate::plugin::loader::wasm::wasm_host::state::ServerResource,
-                            >(wasmtime::component::Resource::new_own(reps.0));
-                            let _ = store.data_mut().resource_table.delete::<
-                                crate::plugin::loader::wasm::wasm_host::state::EntityResource,
-                            >(wasmtime::component::Resource::new_own(reps.1));
-                        });
                         result
                     })
                 })
@@ -313,7 +307,7 @@ impl Goal for CustomWasmGoal {
 impl HostMob for PluginHostState {
     async fn as_entity(&mut self, this: Resource<WitMob>) -> wasmtime::Result<Resource<Entity>> {
         let entity = mob_from_resource(self, &this)?;
-        self.add_entity(entity)
+        self.add(entity)
     }
 
     async fn as_living(
@@ -321,7 +315,7 @@ impl HostMob for PluginHostState {
         this: Resource<WitMob>,
     ) -> wasmtime::Result<Resource<WitLivingEntity>> {
         let entity = mob_from_resource(self, &this)?;
-        self.add_living_entity(entity)
+        self.add(entity)
     }
 
     async fn add_ai_goal(
@@ -422,7 +416,7 @@ impl HostMob for PluginHostState {
             .get_mob()
             .and_then(|mob| mob.get_mob_entity().get_target())
         {
-            return Ok(Some(self.add_entity(target)?));
+            return Ok(Some(self.add(target)?));
         }
         Ok(None)
     }
@@ -889,10 +883,7 @@ impl HostMob for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<WitMob>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<MobResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
@@ -135,6 +135,310 @@ bindgen!({
     exports: { default: async | store | trappable},
 });
 
+mod resource_with {
+    use super::pumpkin::plugin;
+    use crate::{
+        command::CommandSender,
+        entity::EntityBase,
+        entity::player::Player,
+        plugin::{
+            Context,
+            api::gui::PluginGui,
+            loader::wasm::wasm_host::{
+                args::OwnedArg,
+                state::{
+                    ChunkBuffer, FromResource, InventoryProvider, ScoreboardProvider, WasmCommand,
+                    WasmCommandNode,
+                },
+            },
+        },
+        server::{RecipeManager, Server},
+        world::World,
+    };
+    use pumpkin_util::text::TextComponent;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Weak};
+    use tokio::sync::Mutex;
+
+    impl FromResource for plugin::server::Server {
+        type Internal = Arc<Server>;
+    }
+    impl FromResource for plugin::context::Context {
+        type Internal = Arc<Context>;
+    }
+    impl FromResource for plugin::player::Player {
+        type Internal = Arc<Player>;
+    }
+    impl FromResource for plugin::player::JavaPlayer {
+        type Internal = Arc<Player>;
+    }
+    impl FromResource for plugin::player::BedrockPlayer {
+        type Internal = Arc<Player>;
+    }
+    impl FromResource for plugin::world::Entity {
+        type Internal = Arc<dyn EntityBase>;
+    }
+    impl FromResource for plugin::world::World {
+        type Internal = Arc<World>;
+    }
+    impl FromResource for plugin::world::Chunk {
+        type Internal = (Arc<World>, Weak<pumpkin_world::chunk::ChunkData>);
+    }
+    impl FromResource for plugin::world::WorldBorder {
+        type Internal = Arc<World>;
+    }
+
+    impl FromResource for plugin::scoreboard::Scoreboard {
+        type Internal = ScoreboardProvider;
+    }
+    impl FromResource for plugin::scoreboard::BedrockScoreboard {
+        type Internal = Arc<Player>;
+    }
+    impl FromResource for plugin::gui::Gui {
+        type Internal = Arc<Mutex<PluginGui>>;
+    }
+    impl FromResource for plugin::boss_bar::BossBar {
+        type Internal =
+            Arc<Mutex<crate::plugin::loader::wasm::wasm_host::wit::v0_1::boss_bar::PluginBossBar>>;
+    }
+    impl FromResource for plugin::text::TextComponent {
+        type Internal = TextComponent;
+    }
+    impl FromResource for plugin::command::Command {
+        type Internal = WasmCommand;
+    }
+    impl FromResource for plugin::command::CommandSender {
+        type Internal = CommandSender;
+    }
+    impl FromResource for plugin::command::ConsumedArgs {
+        type Internal = HashMap<String, OwnedArg>;
+    }
+    impl FromResource for plugin::command::CommandNode {
+        type Internal = WasmCommandNode;
+    }
+    impl FromResource for plugin::item_stack::ItemStack {
+        type Internal = Arc<Mutex<pumpkin_data::item_stack::ItemStack>>;
+    }
+    impl FromResource for plugin::recipe::RecipeManager {
+        type Internal = Arc<RecipeManager>;
+    }
+    impl FromResource for plugin::enchantments::EnchantmentManager {
+        type Internal = Arc<crate::server::enchantment::EnchantmentManager>;
+    }
+    impl FromResource for plugin::server::OpManager {
+        type Internal = Arc<Server>;
+    }
+    impl FromResource for plugin::server::BanManager {
+        type Internal = Arc<Server>;
+    }
+    impl FromResource for plugin::server::WhitelistManager {
+        type Internal = Arc<Server>;
+    }
+    impl FromResource for plugin::server::DatapackManager {
+        type Internal = Arc<Server>;
+    }
+
+    mod block_entities {
+        use super::super::pumpkin::plugin;
+        use crate::block::entities::*;
+        use crate::plugin::loader::wasm::wasm_host::state::{ContainerBlockEntity, FromResource};
+        use std::sync::Arc;
+
+        impl FromResource for plugin::block_entity::BlockEntity {
+            type Internal = Arc<dyn BlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::BannerBlockEntity {
+            type Internal = Arc<banner::BannerBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::BarrelBlockEntity {
+            type Internal = Arc<barrel::BarrelBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::BeaconBlockEntity {
+            type Internal = Arc<beacon::BeaconBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::BedBlockEntity {
+            type Internal = Arc<bed::BedBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::BeehiveBlockEntity {
+            type Internal = Arc<beehive::BeehiveBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::BellBlockEntity {
+            type Internal = Arc<bell::BellBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::BlastingFurnaceBlockEntity {
+            type Internal = Arc<blasting_furnace::BlastingFurnaceBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::BrewingStandBlockEntity {
+            type Internal = Arc<brewing_stand::BrewingStandBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::BrushableBlockBlockEntity {
+            type Internal = Arc<brushable_block::BrushableBlockBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::CalibratedSculkSensorBlockEntity {
+            type Internal = Arc<calibrated_sculk_sensor::CalibratedSculkSensorBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::CampfireBlockEntity {
+            type Internal = Arc<campfire::CampfireBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::ChestBlockEntity {
+            type Internal = Arc<chest::ChestBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::ChiseledBookshelfBlockEntity {
+            type Internal = Arc<chiseled_bookshelf::ChiseledBookshelfBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::CommandBlockEntity {
+            type Internal = Arc<command_block::CommandBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::ComparatorBlockEntity {
+            type Internal = Arc<comparator::ComparatorBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::ConduitBlockEntity {
+            type Internal = Arc<conduit::ConduitBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::CopperGolemStatueBlockEntity {
+            type Internal = Arc<copper_golem_statue::CopperGolemStatueBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::CrafterBlockEntity {
+            type Internal = Arc<crafter::CrafterBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::CreakingHeartBlockEntity {
+            type Internal = Arc<creaking_heart::CreakingHeartBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::DaylightDetectorBlockEntity {
+            type Internal = Arc<daylight_detector::DaylightDetectorBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::DecoratedPotBlockEntity {
+            type Internal = Arc<decorated_pot::DecoratedPotBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::DispenserBlockEntity {
+            type Internal = Arc<dispenser::DispenserBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::DropperBlockEntity {
+            type Internal = Arc<dropper::DropperBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::EnchantingTableBlockEntity {
+            type Internal = Arc<enchanting_table::EnchantingTableBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::EnderChestBlockEntity {
+            type Internal = Arc<ender_chest::EnderChestBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::EndGatewayBlockEntity {
+            type Internal = Arc<end_gateway::EndGatewayBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::EndPortalBlockEntity {
+            type Internal = Arc<end_portal::EndPortalBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::FurnaceBlockEntity {
+            type Internal = Arc<furnace::FurnaceBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::HangingSignBlockEntity {
+            type Internal = Arc<hanging_sign::HangingSignBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::HopperBlockEntity {
+            type Internal = Arc<hopper::HopperBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::JigsawBlockEntity {
+            type Internal = Arc<jigsaw_block::JigsawBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::JukeboxBlockEntity {
+            type Internal = Arc<jukebox::JukeboxBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::LecternBlockEntity {
+            type Internal = Arc<lectern::LecternBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::MapBlockEntity {
+            type Internal = Arc<map::MapBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::MobSpawnerBlockEntity {
+            type Internal = Arc<mob_spawner::MobSpawnerBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::PistonBlockEntity {
+            type Internal = Arc<piston::PistonBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::PotentSulfurBlockEntity {
+            type Internal = Arc<potent_sulfur::PotentSulfurBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::SculkCatalystBlockEntity {
+            type Internal = Arc<sculk_catalyst::SculkCatalystBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::SculkSensorBlockEntity {
+            type Internal = Arc<sculk_sensor::SculkSensorBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::SculkShriekerBlockEntity {
+            type Internal = Arc<sculk_shrieker::SculkShriekerBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::ShelfBlockEntity {
+            type Internal = Arc<shelf::ShelfBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::ShulkerBoxBlockEntity {
+            type Internal = Arc<shulker_box::ShulkerBoxBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::SignBlockEntity {
+            type Internal = Arc<sign::SignBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::SkullBlockEntity {
+            type Internal = Arc<skull::SkullBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::SmokerBlockEntity {
+            type Internal = Arc<smoker::SmokerBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::StructureBlockBlockEntity {
+            type Internal = Arc<structure_block::StructureBlockBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::TestBlockBlockEntity {
+            type Internal = Arc<test_block::TestBlockBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::TestInstanceBlockBlockEntity {
+            type Internal = Arc<test_instance_block::TestInstanceBlockBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::TrappedChestBlockEntity {
+            type Internal = Arc<trapped_chest::TrappedChestBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::TrialSpawnerBlockEntity {
+            type Internal = Arc<trial_spawner::TrialSpawnerBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::VaultBlockEntity {
+            type Internal = Arc<vault::VaultBlockEntity>;
+        }
+        impl FromResource for plugin::block_entity::ContainerBlockEntity {
+            type Internal = ContainerBlockEntity;
+        }
+    }
+
+    impl FromResource for plugin::inventory::Inventory {
+        type Internal = InventoryProvider;
+    }
+    impl FromResource for plugin::inventory::PlayerInventory {
+        type Internal = Arc<Player>;
+    }
+    impl FromResource for plugin::entity::LivingEntity {
+        type Internal = Arc<dyn EntityBase>;
+    }
+    impl FromResource for plugin::entity::Mob {
+        type Internal = Arc<dyn EntityBase>;
+    }
+
+    impl FromResource for plugin::display::DisplayEntity {
+        type Internal = Arc<dyn EntityBase>;
+    }
+    impl FromResource for plugin::display::BlockDisplayEntity {
+        type Internal = Arc<crate::entity::decoration::display::BlockDisplayEntity>;
+    }
+    impl FromResource for plugin::display::ItemDisplayEntity {
+        type Internal = Arc<crate::entity::decoration::display::ItemDisplayEntity>;
+    }
+    impl FromResource for plugin::display::TextDisplayEntity {
+        type Internal = Arc<crate::entity::decoration::display::TextDisplayEntity>;
+    }
+    impl FromResource for plugin::display::InteractionEntity {
+        type Internal = Arc<crate::entity::interaction::InteractionEntity>;
+    }
+
+    impl FromResource for plugin::world::ChunkBuffer {
+        type Internal = ChunkBuffer;
+    }
+}
+
 impl pumpkin::plugin::java_packets::Host for PluginHostState {}
 impl pumpkin::plugin::bedrock_packets::Host for PluginHostState {}
 impl pumpkin::plugin::data_components::Host for PluginHostState {}

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/mod.rs
@@ -238,6 +238,7 @@ mod resource_with {
         type Internal = Arc<Server>;
     }
 
+    #[allow(clippy::wildcard_imports)]
     mod block_entities {
         use super::super::pumpkin::plugin;
         use crate::block::entities::*;

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -16,10 +16,8 @@ use crate::{
     },
     net::DisconnectReason,
     plugin::loader::wasm::wasm_host::{
-        DowncastResourceExt, WasmPlugin,
-        state::{
-            GuiResource, PlayerResource, PluginHostState, TextComponentResource, WorldResource,
-        },
+        WasmPlugin,
+        state::PluginHostState,
         wit::v0_1::{
             events::{
                 from_wasm_game_mode, from_wasm_position, to_wasm_game_mode, to_wasm_position,
@@ -78,7 +76,7 @@ const fn from_wit_client_game_event(
 }
 
 pub(crate) fn from_wit_server_link(
-    state: &PluginHostState,
+    state: &mut PluginHostState,
     link: pumpkin::plugin::player::ServerLink,
 ) -> wasmtime::Result<(pumpkin_protocol::Label, String)> {
     use pumpkin::plugin::player::{KnownServerLink, ServerLinkLabel};
@@ -101,10 +99,8 @@ pub(crate) fn from_wit_server_link(
             pumpkin_protocol::Label::BuiltIn(link_type)
         }
         ServerLinkLabel::Custom(text) => {
-            let text_res = state
-                .resource_table
-                .get::<TextComponentResource>(&Resource::new_own(text.rep()))?;
-            pumpkin_protocol::Label::TextComponent(Box::new(text_res.provider.clone()))
+            let text_res = state.take(text)?;
+            pumpkin_protocol::Label::TextComponent(Box::new(text_res.clone()))
         }
     };
     Ok((label, link.url))
@@ -562,22 +558,17 @@ pub fn player_from_resource(
     state: &PluginHostState,
     player: &Resource<Player>,
 ) -> wasmtime::Result<std::sync::Arc<crate::entity::player::Player>> {
-    state
-        .resource_table
-        .get::<PlayerResource>(&Resource::new_own(player.rep()))
+    state.get(player)
         .map_err(|_| wasmtime::Error::msg("invalid player resource handle"))
-        .map(|resource| resource.provider.clone())
+        .map(|resource| resource.clone())
 }
 
 pub(crate) fn text_component_from_resource(
     state: &PluginHostState,
     text: &Resource<pumpkin::plugin::text::TextComponent>,
 ) -> pumpkin_util::text::TextComponent {
-    state
-        .resource_table
-        .get::<TextComponentResource>(&Resource::new_own(text.rep()))
+    state.get(text)
         .expect("invalid text-component resource handle")
-        .provider
         .clone()
 }
 
@@ -585,11 +576,8 @@ fn world_from_resource(
     state: &PluginHostState,
     world: &Resource<pumpkin::plugin::world::World>,
 ) -> std::sync::Arc<crate::world::World> {
-    state
-        .resource_table
-        .get::<WorldResource>(&Resource::new_own(world.rep()))
+    state.get(world)
         .expect("invalid world resource handle")
-        .provider
         .clone()
 }
 
@@ -1088,57 +1076,18 @@ const fn from_wasm_bedrock_disconnect_reason(
     }
 }
 
-impl DowncastResourceExt<PlayerResource> for Resource<Player> {
-    fn downcast_ref<'a>(&'a self, state: &'a mut PluginHostState) -> &'a PlayerResource {
-        state
-            .resource_table
-            .get_any_mut(self.rep())
-            .map_err(|_| wasmtime::Error::msg("invalid player resource handle"))
-            .expect("valid player resource handle")
-            .downcast_ref::<PlayerResource>()
-            .ok_or("resource type mismatch")
-            .map_err(wasmtime::Error::msg)
-            .expect("resource type mismatch")
-    }
-
-    fn downcast_mut<'a>(&'a self, state: &'a mut PluginHostState) -> &'a mut PlayerResource {
-        state
-            .resource_table
-            .get_any_mut(self.rep())
-            .map_err(|_| wasmtime::Error::msg("invalid player resource handle"))
-            .expect("valid player resource handle")
-            .downcast_mut::<PlayerResource>()
-            .ok_or("resource type mismatch")
-            .map_err(wasmtime::Error::msg)
-            .expect("resource type mismatch")
-    }
-
-    fn consume(self, state: &mut PluginHostState) -> PlayerResource {
-        state
-            .resource_table
-            .delete::<PlayerResource>(Resource::new_own(self.rep()))
-            .map_err(|_| wasmtime::Error::msg("invalid player resource handle"))
-            .expect("invalid player resource handle")
-    }
-}
-
 impl pumpkin::plugin::player::Host for PluginHostState {
     async fn get_world_players(
         &mut self,
         world_ref: Resource<pumpkin::plugin::world::World>,
     ) -> wasmtime::Result<Vec<Resource<pumpkin::plugin::player::Player>>> {
-        let world = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::WorldResource>(
-                &Resource::new_own(world_ref.rep()),
-            )
+        let world = self.get(&world_ref)
             .map_err(|_| wasmtime::Error::msg("invalid world resource handle"))?
-            .provider
             .clone();
 
         let mut players = Vec::new();
         for player in world.players.load().iter() {
-            players.push(self.add_player(player.clone())?);
+            players.push(self.add(player.clone())?);
         }
 
         Ok(players)
@@ -1162,7 +1111,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<()> {
         let player = player_from_resource(self, &player)?;
         let stack = if let Some(stack_res) = stack {
-            self.get_item_stack(&stack_res)?.lock().await.clone()
+            self.get(&stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
@@ -1191,7 +1140,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<()> {
         let player = player_from_resource(self, &player)?;
         let stack = if let Some(stack_res) = stack {
-            self.get_item_stack(&stack_res)?.lock().await.clone()
+            self.get(&stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
@@ -1215,7 +1164,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         >,
     >{
         let player = player_from_resource(self, &player)?;
-        self.add_player_inventory(player)
+        self.add(player)
     }
 
     async fn get_ender_chest(
@@ -1227,7 +1176,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         >,
     >{
         let player = player_from_resource(self, &player)?;
-        self.add_inventory(
+        self.add(
             crate::plugin::loader::wasm::wasm_host::state::InventoryProvider::PlayerEnderChest(
                 player,
             ),
@@ -1244,9 +1193,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         if stack.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(
-                tokio::sync::Mutex::new(stack),
-            ))?))
+            Ok(Some(self.add(Arc::new(tokio::sync::Mutex::new(stack)))?))
         }
     }
 
@@ -1261,9 +1208,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         if stack.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(
-                tokio::sync::Mutex::new(stack),
-            ))?))
+            Ok(Some(self.add(Arc::new(tokio::sync::Mutex::new(stack)))?))
         }
     }
 
@@ -1275,7 +1220,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<()> {
         let player = player_from_resource(self, &player)?;
         let stack = if let Some(stack_res) = stack {
-            self.get_item_stack(&stack_res)?.lock().await.clone()
+            self.get(&stack_res)?.lock().await.clone()
         } else {
             pumpkin_data::item_stack::ItemStack::EMPTY.clone()
         };
@@ -1361,9 +1306,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         if stack.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(self.add_item_stack(Arc::new(
-                tokio::sync::Mutex::new(stack),
-            ))?))
+            Ok(Some(self.add(Arc::new(tokio::sync::Mutex::new(stack)))?))
         }
     }
 
@@ -1372,7 +1315,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
     ) -> wasmtime::Result<Resource<pumpkin::plugin::world::Entity>> {
         let player = player_from_resource(self, &player)?;
-        self.add_entity(player as Arc<dyn EntityBase>)
+        self.add(player as Arc<dyn EntityBase>)
             .map_err(|_| wasmtime::Error::msg("failed to add entity resource"))
     }
 
@@ -1410,7 +1353,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<wasmtime::component::Resource<pumpkin::plugin::world::World>> {
         let player = player_from_resource(self, &player)?;
         let world = player.world();
-        self.add_world(world)
+        self.add(world)
             .map_err(|_| wasmtime::Error::msg("failed to add world resource"))
     }
 
@@ -1490,7 +1433,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<Resource<pumpkin::plugin::text::TextComponent>> {
         let player = player_from_resource(self, &player)?;
         let display_name = player.get_display_name();
-        self.add_text_component(display_name)
+        self.add(display_name)
             .map_err(|_| wasmtime::Error::msg("failed to add text-component resource"))
     }
 
@@ -1514,7 +1457,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         tab_list_name.map_or_else(
             || Ok(None),
             |name| {
-                self.add_text_component(name)
+                self.add(name)
                     .map(Some)
                     .map_err(|_| wasmtime::Error::msg("failed to add text-component resource"))
             },
@@ -2364,7 +2307,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         for (hit_entity, hit_pos, distance) in hits {
             if hit_entity.get_entity().entity_id != self_id {
                 let entity_res = self
-                    .add_entity(hit_entity)
+                    .add(hit_entity)
                     .map_err(|_| wasmtime::Error::msg("failed to add entity resource"))?;
                 return Ok(Some(pumpkin::plugin::world::RayTraceEntityResult {
                     entity: entity_res,
@@ -2984,7 +2927,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<Option<Resource<pumpkin::plugin::player::JavaPlayer>>> {
         let player = player_from_resource(self, &player)?;
         if let crate::net::ClientPlatform::Java(_) = player.client.as_ref() {
-            Ok(Some(self.add_java_player(player)?))
+            Ok(Some(self.add(player)?))
         } else {
             Ok(None)
         }
@@ -2996,17 +2939,14 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<Option<Resource<pumpkin::plugin::player::BedrockPlayer>>> {
         let player = player_from_resource(self, &player)?;
         if let crate::net::ClientPlatform::Bedrock(_) = player.client.as_ref() {
-            Ok(Some(self.add_bedrock_player(player)?))
+            Ok(Some(self.add(player)?))
         } else {
             Ok(None)
         }
     }
 
     async fn drop(&mut self, rep: Resource<Player>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<PlayerResource>(Resource::new_own(rep.rep()));
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -3268,11 +3208,8 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, gui, plugin) = {
             let state = host.get();
-            let gui = state
-                .resource_table
-                .get::<GuiResource>(&Resource::new_own(gui.rep()))
+            let gui = state.get(&gui)
                 .map_err(|_| wasmtime::Error::msg("invalid gui resource handle"))?
-                .provider
                 .clone();
             (
                 player_from_resource(state, &player)?,
@@ -3626,14 +3563,7 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
         &mut self,
         player: Resource<pumpkin::plugin::player::JavaPlayer>,
     ) -> wasmtime::Result<pumpkin::plugin::player::JavaMinecraftVersion> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let client = player
             .client
@@ -3646,14 +3576,7 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
         &mut self,
         player: Resource<pumpkin::plugin::player::JavaPlayer>,
     ) -> wasmtime::Result<String> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let client = player
             .client
@@ -3666,14 +3589,7 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
         &mut self,
         player: Resource<pumpkin::plugin::player::JavaPlayer>,
     ) -> wasmtime::Result<String> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let client = player
             .client
@@ -3686,14 +3602,7 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
         &mut self,
         player: Resource<pumpkin::plugin::player::JavaPlayer>,
     ) -> wasmtime::Result<pumpkin::plugin::player::JavaPlayerSettings> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let config = player.config.load();
         let mask = config.skin_parts;
@@ -3740,14 +3649,7 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
         player: Resource<pumpkin::plugin::player::JavaPlayer>,
         packet: pumpkin::plugin::java_packets::ClientboundPacket,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let client = player
             .client
@@ -3767,14 +3669,7 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
         channel: String,
         data: Vec<u8>,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         if let crate::net::ClientPlatform::Java(_) = player.client.as_ref() {
             player
@@ -3788,50 +3683,27 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
 
     async fn get_scoreboard(
         &mut self,
-        player_res: Resource<pumpkin::plugin::player::JavaPlayer>,
+        player: Resource<pumpkin::plugin::player::JavaPlayer>,
     ) -> wasmtime::Result<Resource<pumpkin::plugin::scoreboard::Scoreboard>> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player_res.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
-        self.add_scoreboard(
-            crate::plugin::loader::wasm::wasm_host::state::ScoreboardProvider::Player(player),
-        )
+        let player = self.get(&player)?.clone();
+        self.add(crate::plugin::loader::wasm::wasm_host::state::ScoreboardProvider::Player(player))
     }
 
     async fn reset_scoreboard(
         &mut self,
-        player_res: Resource<pumpkin::plugin::player::JavaPlayer>,
+        player: Resource<pumpkin::plugin::player::JavaPlayer>,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player_res.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
         player.reset_scoreboard();
         Ok(())
     }
 
     async fn send_resource_pack(
         &mut self,
-        player_res: Resource<pumpkin::plugin::player::JavaPlayer>,
+        player: Resource<pumpkin::plugin::player::JavaPlayer>,
         pack: pumpkin::plugin::player::JavaResourcePack,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player_res.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let uuid = Uuid::from_wit(&pack.id);
         let prompt_message = pack
@@ -3857,17 +3729,10 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
 
     async fn remove_resource_pack(
         &mut self,
-        player_res: Resource<pumpkin::plugin::player::JavaPlayer>,
+        player: Resource<pumpkin::plugin::player::JavaPlayer>,
         id: pumpkin::plugin::uuid::Uuid,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player_res.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let uuid = Uuid::from_wit(&id);
 
@@ -3883,16 +3748,9 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
 
     async fn clear_resource_packs(
         &mut self,
-        player_res: Resource<pumpkin::plugin::player::JavaPlayer>,
+        player: Resource<pumpkin::plugin::player::JavaPlayer>,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player_res.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         if let crate::net::ClientPlatform::Java(client) = player.client.as_ref() {
             client
@@ -3908,14 +3766,7 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
         event: pumpkin::plugin::player::ClientGameEvent,
         value: f32,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let internal_event = from_wit_client_game_event(event);
         player.send_game_event(internal_event, value);
@@ -3928,14 +3779,7 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
         entity_id: i32,
         status: pumpkin::plugin::entity_statuses::EntityStatus,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         // SAFETY: The WIT enum variants and discriminants are 1:1 generated from entity_statuses.json
         let internal_status: pumpkin_data::entity_status::EntityStatus =
@@ -3952,12 +3796,7 @@ impl pumpkin::plugin::player::HostJavaPlayer for PluginHostState {
         &mut self,
         rep: Resource<pumpkin::plugin::player::JavaPlayer>,
     ) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-            Resource::new_own(rep.rep()),
-        );
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -3972,14 +3811,7 @@ impl pumpkin::plugin::player::HostJavaPlayerWithStore<PluginHostState>
     ) -> wasmtime::Result<()> {
         let (player, protocol_dialog, plugin) = {
             let state = host.get();
-            let player = state
-                .resource_table
-                .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                    &Resource::new_own(player.rep()),
-                )
-                .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-                .provider
-                .clone();
+            let player = state.get(&player)?.clone();
             let protocol_dialog = super::events::dialog::protocol_dialog_from_wasm(state, &dialog);
             let plugin = state
                 .plugin
@@ -4042,14 +3874,7 @@ impl pumpkin::plugin::player::HostJavaPlayerWithStore<PluginHostState>
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            let player = state
-                .resource_table
-                .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                    &Resource::new_own(player.rep()),
-                )
-                .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-                .provider
-                .clone();
+            let player = state.get(&player)?.clone();
             let plugin = state
                 .plugin
                 .as_ref()
@@ -4103,14 +3928,7 @@ impl pumpkin::plugin::player::HostJavaPlayerWithStore<PluginHostState>
     ) -> wasmtime::Result<()> {
         let (player, reason, plugin) = {
             let state = host.get();
-            let player = state
-                .resource_table
-                .get::<crate::plugin::loader::wasm::wasm_host::state::JavaPlayerResource>(
-                    &Resource::new_own(player.rep()),
-                )
-                .map_err(|_| wasmtime::Error::msg("invalid java-player resource handle"))?
-                .provider
-                .clone();
+            let player = state.get(&player)?.clone();
             let reason = text_component_from_resource(state, &options.reason);
             let plugin = state
                 .plugin
@@ -4162,14 +3980,7 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
         &mut self,
         player: Resource<pumpkin::plugin::player::BedrockPlayer>,
     ) -> wasmtime::Result<pumpkin::plugin::player::BedrockMinecraftVersion> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?;
 
         if let crate::net::ClientPlatform::Bedrock(client) = player.client.as_ref() {
             Ok(to_wasm_bedrock_version(client.version.load()))
@@ -4183,14 +3994,7 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
         player: Resource<pumpkin::plugin::player::BedrockPlayer>,
         ability: pumpkin::plugin::player::BedrockAbility,
     ) -> wasmtime::Result<bool> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let ability = from_wasm_bedrock_ability(ability);
         let abilities = player
@@ -4225,14 +4029,7 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
         ability: pumpkin::plugin::player::BedrockAbility,
         value: bool,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let ability = from_wasm_bedrock_ability(ability);
         {
@@ -4269,14 +4066,7 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
         player: Resource<pumpkin::plugin::player::BedrockPlayer>,
         flag: pumpkin::plugin::player::BedrockStatusFlag,
     ) -> wasmtime::Result<bool> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let flag_index = from_wasm_bedrock_status_flag(flag);
         if flag_index < 64 {
@@ -4302,14 +4092,7 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
         flag: pumpkin::plugin::player::BedrockStatusFlag,
         value: bool,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         let flag_index = from_wasm_bedrock_status_flag(flag);
         if flag_index < 64 {
@@ -4389,14 +4172,7 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
         &mut self,
         player: Resource<pumpkin::plugin::player::BedrockPlayer>,
     ) -> wasmtime::Result<pumpkin::plugin::player::BedrockPlayerSettings> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         if let crate::net::ClientPlatform::Bedrock(client) = player.client.as_ref() {
             let data = client.client_data.load();
@@ -4439,14 +4215,7 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
         player: Resource<pumpkin::plugin::player::BedrockPlayer>,
         packet: pumpkin::plugin::bedrock_packets::ClientboundPacket,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         if let Some(bytes) = crate::plugin::loader::wasm::wasm_host::wit::v0_1::generated_packets::serialize_bedrock_packet(
             &packet,
@@ -4458,16 +4227,10 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
 
     async fn open_form(
         &mut self,
-        player_res: Resource<pumpkin::plugin::player::BedrockPlayer>,
+        player: Resource<pumpkin::plugin::player::BedrockPlayer>,
         form: Form,
     ) -> wasmtime::Result<u32> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player_res.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
+        let player = self.get(&player)?
             .clone();
 
         if let crate::net::ClientPlatform::Bedrock(client) = player.client.as_ref() {
@@ -4497,48 +4260,27 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
 
     async fn get_scoreboard(
         &mut self,
-        player_res: Resource<pumpkin::plugin::player::BedrockPlayer>,
+        player: Resource<pumpkin::plugin::player::BedrockPlayer>,
     ) -> wasmtime::Result<Resource<pumpkin::plugin::scoreboard::BedrockScoreboard>> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player_res.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
-            .clone();
-        self.add_bedrock_scoreboard(player)
+        let player = self.get(&player)?.clone();
+        self.add(player)
     }
 
     async fn reset_scoreboard(
         &mut self,
-        player_res: Resource<pumpkin::plugin::player::BedrockPlayer>,
+        player: Resource<pumpkin::plugin::player::BedrockPlayer>,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player_res.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
         player.reset_scoreboard();
         Ok(())
     }
 
     async fn send_resource_packs_info(
         &mut self,
-        player_res: Resource<pumpkin::plugin::player::BedrockPlayer>,
+        player: Resource<pumpkin::plugin::player::BedrockPlayer>,
         info: pumpkin::plugin::player::BedrockResourcePacksInfo,
     ) -> wasmtime::Result<()> {
-        let player = self
-            .resource_table
-            .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                &Resource::new_own(player_res.rep()),
-            )
-            .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-            .provider
-            .clone();
+        let player = self.get(&player)?.clone();
 
         if let crate::net::ClientPlatform::Bedrock(client) = player.client.as_ref() {
             let entries = info
@@ -4585,12 +4327,7 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
         &mut self,
         rep: Resource<pumpkin::plugin::player::BedrockPlayer>,
     ) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-            Resource::new_own(rep.rep()),
-        );
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -4604,14 +4341,7 @@ impl pumpkin::plugin::player::HostBedrockPlayerWithStore<PluginHostState>
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            let player = state
-                .resource_table
-                .get::<crate::plugin::loader::wasm::wasm_host::state::BedrockPlayerResource>(
-                    &Resource::new_own(player.rep()),
-                )
-                .map_err(|_| wasmtime::Error::msg("invalid bedrock-player resource handle"))?
-                .provider
-                .clone();
+            let player = state.get(&player)?.clone();
             let plugin = state
                 .plugin
                 .as_ref()

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -558,7 +558,8 @@ pub fn player_from_resource(
     state: &PluginHostState,
     player: &Resource<Player>,
 ) -> wasmtime::Result<std::sync::Arc<crate::entity::player::Player>> {
-    state.get(player)
+    state
+        .get(player)
         .map_err(|_| wasmtime::Error::msg("invalid player resource handle"))
         .map(|resource| resource.clone())
 }
@@ -567,7 +568,8 @@ pub(crate) fn text_component_from_resource(
     state: &PluginHostState,
     text: &Resource<pumpkin::plugin::text::TextComponent>,
 ) -> pumpkin_util::text::TextComponent {
-    state.get(text)
+    state
+        .get(text)
         .expect("invalid text-component resource handle")
         .clone()
 }
@@ -576,7 +578,8 @@ fn world_from_resource(
     state: &PluginHostState,
     world: &Resource<pumpkin::plugin::world::World>,
 ) -> std::sync::Arc<crate::world::World> {
-    state.get(world)
+    state
+        .get(world)
         .expect("invalid world resource handle")
         .clone()
 }
@@ -1081,7 +1084,8 @@ impl pumpkin::plugin::player::Host for PluginHostState {
         &mut self,
         world_ref: Resource<pumpkin::plugin::world::World>,
     ) -> wasmtime::Result<Vec<Resource<pumpkin::plugin::player::Player>>> {
-        let world = self.get(&world_ref)
+        let world = self
+            .get(&world_ref)
             .map_err(|_| wasmtime::Error::msg("invalid world resource handle"))?
             .clone();
 
@@ -1526,11 +1530,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<()> {
         let player = player_from_resource(self, &player)?;
         if let Some(target_res) = entity {
-            let target =
-                crate::plugin::loader::wasm::wasm_host::wit::v0_1::entity::entity_from_resource(
-                    self,
-                    &target_res,
-                )?;
+            let target = self.take(target_res)?;
             player.set_camera_entity_id(target.get_entity().entity_id);
         } else {
             player.reset_camera();
@@ -3208,7 +3208,8 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, gui, plugin) = {
             let state = host.get();
-            let gui = state.get(&gui)
+            let gui = state
+                .get(&gui)
                 .map_err(|_| wasmtime::Error::msg("invalid gui resource handle"))?
                 .clone();
             (
@@ -4230,8 +4231,7 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
         player: Resource<pumpkin::plugin::player::BedrockPlayer>,
         form: Form,
     ) -> wasmtime::Result<u32> {
-        let player = self.get(&player)?
-            .clone();
+        let player = self.get(&player)?.clone();
 
         if let crate::net::ClientPlatform::Bedrock(client) = player.client.as_ref() {
             let form_id = client.next_form_id.fetch_add(1, Ordering::Relaxed);
@@ -4241,7 +4241,7 @@ impl pumpkin::plugin::player::HostBedrockPlayer for PluginHostState {
 
             let form_json = match form {
                 Form::Simple(simple) => self.serialize_simple_form(simple, locale),
-                Form::Modal(modal) => self.serialize_modal_form(&modal, locale),
+                Form::Modal(modal) => self.serialize_modal_form(modal, locale),
                 Form::Custom(custom) => self.serialize_custom_form(custom, locale),
             };
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -100,7 +100,7 @@ pub(crate) fn from_wit_server_link(
         }
         ServerLinkLabel::Custom(text) => {
             let text_res = state.take(text)?;
-            pumpkin_protocol::Label::TextComponent(Box::new(text_res.clone()))
+            pumpkin_protocol::Label::TextComponent(Box::new(text_res))
         }
     };
     Ok((label, link.url))
@@ -561,7 +561,7 @@ pub fn player_from_resource(
     state
         .get(player)
         .map_err(|_| wasmtime::Error::msg("invalid player resource handle"))
-        .map(|resource| resource.clone())
+        .cloned()
 }
 
 pub(crate) fn text_component_from_resource(
@@ -1113,7 +1113,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         hand: pumpkin::plugin::common::Hand,
         stack: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let stack = if let Some(stack_res) = stack {
             self.get(&stack_res)?.lock().await.clone()
         } else {
@@ -1142,7 +1142,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         slot: u8,
         stack: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let stack = if let Some(stack_res) = stack {
             self.get(&stack_res)?.lock().await.clone()
         } else {
@@ -1167,8 +1167,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::inventory::PlayerInventory,
         >,
     >{
-        let player = player_from_resource(self, &player)?;
-        self.add(player)
+        self.add(self.get(&player)?.clone())
     }
 
     async fn get_ender_chest(
@@ -1179,10 +1178,9 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::inventory::Inventory,
         >,
     >{
-        let player = player_from_resource(self, &player)?;
         self.add(
             crate::plugin::loader::wasm::wasm_host::state::InventoryProvider::PlayerEnderChest(
-                player,
+                self.get(&player)?.clone(),
             ),
         )
     }
@@ -1192,7 +1190,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         slot: u8,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let stack = player.inventory().get_stack(slot as usize);
         if stack.is_empty() {
             Ok(None)
@@ -1206,7 +1204,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         slot: u8,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let ec = player.ender_chest_inventory();
         let stack = ec.get_stack(slot as usize);
         if stack.is_empty() {
@@ -1222,7 +1220,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         slot: u8,
         stack: Option<Resource<WitHostItemStack>>,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let stack = if let Some(stack_res) = stack {
             self.get(&stack_res)?.lock().await.clone()
         } else {
@@ -1262,7 +1260,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     }
 
     async fn clear_ender_chest(&mut self, player: Resource<Player>) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let ec = player.ender_chest_inventory();
         ec.clear();
 
@@ -1304,7 +1302,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         hand: pumpkin::plugin::common::Hand,
     ) -> wasmtime::Result<Option<Resource<WitHostItemStack>>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let hand = from_wasm_hand(hand);
         let stack = player.inventory().get_stack_in_hand(hand);
         if stack.is_empty() {
@@ -1318,18 +1316,16 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<Resource<pumpkin::plugin::world::Entity>> {
-        let player = player_from_resource(self, &player)?;
-        self.add(player as Arc<dyn EntityBase>)
-            .map_err(|_| wasmtime::Error::msg("failed to add entity resource"))
+        self.add(self.get(&player)?.clone() as _)
     }
 
     async fn get_id(&mut self, player: Resource<Player>) -> wasmtime::Result<Uuid> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(Uuid::to_wit(&player.gameprofile.id))
     }
 
     async fn get_name(&mut self, player: Resource<Player>) -> wasmtime::Result<String> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.gameprofile.name.clone())
     }
 
@@ -1337,17 +1333,17 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<pumpkin::plugin::common::Position> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(to_wasm_position(player.position()))
     }
 
     async fn get_yaw(&mut self, player: Resource<Player>) -> wasmtime::Result<f32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_entity().yaw.load())
     }
 
     async fn get_pitch(&mut self, player: Resource<Player>) -> wasmtime::Result<f32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_entity().pitch.load())
     }
 
@@ -1355,7 +1351,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<wasmtime::component::Resource<pumpkin::plugin::world::World>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let world = player.world();
         self.add(world)
             .map_err(|_| wasmtime::Error::msg("failed to add world resource"))
@@ -1365,17 +1361,17 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<pumpkin::plugin::common::GameMode> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(to_wasm_game_mode(player.gamemode.load()))
     }
 
     async fn get_locale(&mut self, player: Resource<Player>) -> wasmtime::Result<String> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.config.load().locale.clone())
     }
 
     async fn get_ping(&mut self, player: Resource<Player>) -> wasmtime::Result<u32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.ping.load(Ordering::Relaxed))
     }
 
@@ -1383,7 +1379,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<pumpkin::plugin::permission::PermissionLevel> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(to_wit_permission_level(player.permission_lvl.load()))
     }
 
@@ -1393,7 +1389,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         node: String,
         value: bool,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let server = self.server.as_ref().expect("server not available");
 
         server
@@ -1408,7 +1404,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         node: String,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let server = self.server.as_ref().expect("server not available");
 
         server
@@ -1423,7 +1419,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         node: String,
     ) -> wasmtime::Result<Option<bool>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let server = self.server.as_ref().expect("server not available");
 
         Ok(server
@@ -1435,7 +1431,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<Resource<pumpkin::plugin::text::TextComponent>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let display_name = player.get_display_name();
         self.add(display_name)
             .map_err(|_| wasmtime::Error::msg("failed to add text-component resource"))
@@ -1447,7 +1443,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         display_name: wasmtime::component::Resource<pumpkin::plugin::text::TextComponent>,
     ) -> wasmtime::Result<()> {
         let display_name = text_component_from_resource(self, &display_name);
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_display_name(Some(display_name));
         Ok(())
     }
@@ -1456,7 +1452,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<Option<Resource<pumpkin::plugin::text::TextComponent>>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let tab_list_name = player.get_tab_list_name();
         tab_list_name.map_or_else(
             || Ok(None),
@@ -1474,7 +1470,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         name: Option<wasmtime::component::Resource<pumpkin::plugin::text::TextComponent>>,
     ) -> wasmtime::Result<()> {
         let name = name.map(|n| text_component_from_resource(self, &n));
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_tab_list_name(name);
         Ok(())
     }
@@ -1486,7 +1482,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         overlay: bool,
     ) -> wasmtime::Result<()> {
         let component = text_component_from_resource(self, &text);
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.send_system_message_raw(&component, overlay);
         Ok(())
     }
@@ -1496,7 +1492,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         signature: Vec<u8>,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         if let Some(client) = player.client.java() {
             let packet =
                 pumpkin_protocol::java::client::play::CDeleteChat::from_signature(&signature);
@@ -1510,7 +1506,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         signature_id: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         if let Some(client) = player.client.java() {
             let packet =
                 pumpkin_protocol::java::client::play::CDeleteChat::from_cache_id(signature_id);
@@ -1528,9 +1524,9 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
             >,
         >,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
-        if let Some(target_res) = entity {
-            let target = self.take(target_res)?;
+        let entity = entity.map(|r| self.take(r)).transpose()?;
+        let player = self.get(&player)?;
+        if let Some(target) = entity {
             player.set_camera_entity_id(target.get_entity().entity_id);
         } else {
             player.reset_camera();
@@ -1543,18 +1539,18 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         entity_id: u32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_camera_entity_id(entity_id as i32);
         Ok(())
     }
 
     async fn get_camera_entity_id(&mut self, player: Resource<Player>) -> wasmtime::Result<u32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_camera_entity_id() as u32)
     }
 
     async fn reset_camera(&mut self, player: Resource<Player>) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.reset_camera();
         Ok(())
     }
@@ -1567,7 +1563,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         volume: f32,
         pitch: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let sound_name = format!("{sound:?}").to_lowercase().replace('_', ".");
         let sound_data = pumpkin_data::sound::Sound::from_name(&sound_name)
             .ok_or_else(|| wasmtime::Error::msg(format!("Unknown sound: {sound_name}")))?;
@@ -1593,7 +1589,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         volume: f32,
         pitch: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let sound_name = format!("{sound:?}").to_lowercase().replace('_', ".");
         let sound_data = pumpkin_data::sound::Sound::from_name(&sound_name)
             .ok_or_else(|| wasmtime::Error::msg(format!("Unknown sound: {sound_name}")))?;
@@ -1615,7 +1611,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         sound: Option<pumpkin::plugin::sounds::Sound>,
         category: Option<pumpkin::plugin::sounds::SoundCategory>,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let sound_rl = sound.and_then(|s| {
             let sound_name = format!("{s:?}").to_lowercase().replace('_', ".");
             pumpkin_data::sound::Sound::from_name(&sound_name).map(|s| s.to_name().into())
@@ -1633,7 +1629,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         volume: f32,
         pitch: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let internal_category = super::world::from_wit_sound_category(category);
         let pos = player.position();
         player.play_custom_sound(&sound_name, internal_category, &pos, volume, pitch);
@@ -1649,7 +1645,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         volume: f32,
         pitch: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let internal_category = super::world::from_wit_sound_category(category);
         player.play_custom_sound(
             &sound_name,
@@ -1667,7 +1663,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         sound_name: Option<String>,
         category: Option<pumpkin::plugin::sounds::SoundCategory>,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let sound_rl = sound_name
             .as_deref()
             .map(pumpkin_util::resource_location::ResourceLocation::from);
@@ -1685,7 +1681,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         offset: pumpkin::plugin::common::Position,
         max_speed: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let particle_data =
             pumpkin_data::particle::Particle::from_id(particle as u16).ok_or_else(|| {
                 wasmtime::Error::msg(format!("Unknown particle ID: {}", particle as u16))
@@ -1710,7 +1706,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         pos: pumpkin::plugin::common::BlockPos,
         block_id: u16,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.send_block_change(
             pumpkin_util::math::position::BlockPos(pumpkin_util::math::vector3::Vector3::new(
                 pos.x, pos.y, pos.z,
@@ -1725,7 +1721,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         pos: pumpkin::plugin::common::BlockPos,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.reset_block_change(pumpkin_util::math::position::BlockPos(
             pumpkin_util::math::vector3::Vector3::new(pos.x, pos.y, pos.z),
         ));
@@ -1737,7 +1733,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         yaw: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.send_hurt_animation(yaw);
         Ok(())
     }
@@ -1747,7 +1743,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         hand: pumpkin::plugin::common::Hand,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let hand = match hand {
             pumpkin::plugin::common::Hand::Right => pumpkin_util::Hand::Right,
             pumpkin::plugin::common::Hand::Left => pumpkin_util::Hand::Left,
@@ -1762,7 +1758,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         pos: pumpkin::plugin::common::BlockPos,
         is_front_text: bool,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.open_sign_editor(
             pumpkin_util::math::position::BlockPos(pumpkin_util::math::vector3::Vector3::new(
                 pos.x, pos.y, pos.z,
@@ -1777,7 +1773,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         velocity: pumpkin::plugin::common::Position,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_velocity(pumpkin_util::math::vector3::Vector3::new(
             velocity.0, velocity.1, velocity.2,
         ));
@@ -1791,7 +1787,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         x: f64,
         z: f64,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.apply_knockback(strength, x, z);
         Ok(())
     }
@@ -1801,13 +1797,13 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         locked: bool,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_movement_locked(locked);
         Ok(())
     }
 
     async fn is_movement_locked(&mut self, player: Resource<Player>) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.is_movement_locked())
     }
 
@@ -1816,13 +1812,13 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         ticks: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_freeze_ticks(ticks);
         Ok(())
     }
 
     async fn get_freeze_ticks(&mut self, player: Resource<Player>) -> wasmtime::Result<i32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_freeze_ticks())
     }
 
@@ -1831,7 +1827,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         links: Vec<pumpkin::plugin::player::ServerLink>,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?.clone();
         let mut converted = Vec::new();
         for link in links {
             converted.push(from_wit_server_link(self, link)?);
@@ -1849,7 +1845,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         effect: pumpkin::plugin::status_effect::StatusEffectType,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let effect_type = super::status_effect::from_wasm_status_effect_type(effect);
         if let Some(status_effect) =
             pumpkin_data::effect::StatusEffect::from_name(effect_type.to_name())
@@ -1860,7 +1856,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     }
 
     async fn clear_effects(&mut self, player: Resource<Player>) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.remove_all_effects();
         Ok(())
     }
@@ -1870,7 +1866,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         effect: pumpkin::plugin::status_effect::StatusEffectType,
     ) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let effect_type = super::status_effect::from_wasm_status_effect_type(effect);
         Ok(
             pumpkin_data::effect::StatusEffect::from_name(effect_type.to_name())
@@ -1883,7 +1879,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         effect: pumpkin::plugin::status_effect::StatusEffectType,
     ) -> wasmtime::Result<Option<pumpkin::plugin::status_effect::StatusEffectInstance>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let effect_type = super::status_effect::from_wasm_status_effect_type(effect);
         if let Some(status_effect) =
             pumpkin_data::effect::StatusEffect::from_name(effect_type.to_name())
@@ -1898,7 +1894,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<Vec<pumpkin::plugin::status_effect::StatusEffectInstance>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let effects = player.get_active_effects();
         let mut list = Vec::with_capacity(effects.len());
         for eff in &effects {
@@ -1915,7 +1911,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         category: WitStatisticCategory,
         stat_id: i32,
     ) -> wasmtime::Result<i32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_stat(from_wit_statistic_category(category), stat_id))
     }
 
@@ -1926,7 +1922,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         stat_id: i32,
         value: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_stat(from_wit_statistic_category(category), stat_id, value);
         Ok(())
     }
@@ -1938,7 +1934,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         stat_id: i32,
         amount: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.increment_stat(from_wit_statistic_category(category), stat_id, amount);
         Ok(())
     }
@@ -1948,7 +1944,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         stat: WitCustomStatistic,
     ) -> wasmtime::Result<i32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_custom_stat(from_wit_custom_statistic(stat)))
     }
 
@@ -1958,7 +1954,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         stat: WitCustomStatistic,
         value: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_custom_stat(from_wit_custom_statistic(stat), value);
         Ok(())
     }
@@ -1969,19 +1965,19 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         stat: WitCustomStatistic,
         amount: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.increment_custom_stat(from_wit_custom_statistic(stat), amount);
         Ok(())
     }
 
     async fn send_stats(&mut self, player: Resource<Player>) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.send_stats();
         Ok(())
     }
 
     async fn get_team(&mut self, player: Resource<Player>) -> wasmtime::Result<Option<String>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let team = player.get_team();
         Ok(team.map(|t| t.name))
     }
@@ -1992,7 +1988,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         group: String,
         duration_ticks: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.start_cooldown(group, duration_ticks);
         Ok(())
     }
@@ -2002,7 +1998,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         group: String,
     ) -> wasmtime::Result<f32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_cooldown(&group))
     }
 
@@ -2011,7 +2007,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         group: String,
     ) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.is_on_cooldown(&group))
     }
 
@@ -2020,7 +2016,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         allowed: bool,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_allow_flight(allowed);
         Ok(())
     }
@@ -2030,7 +2026,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         speed: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_fly_speed(speed);
         Ok(())
     }
@@ -2040,7 +2036,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         speed: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_walk_speed(speed);
         Ok(())
     }
@@ -2050,7 +2046,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         invulnerable: bool,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_invulnerable(invulnerable);
         Ok(())
     }
@@ -2061,19 +2057,19 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         time: u64,
         relative: bool,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_player_time(time, relative);
         Ok(())
     }
 
     async fn reset_player_time(&mut self, player: Resource<Player>) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.reset_player_time();
         Ok(())
     }
 
     async fn get_player_time(&mut self, player: Resource<Player>) -> wasmtime::Result<Option<u64>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_player_time())
     }
 
@@ -2081,7 +2077,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.is_player_time_relative())
     }
 
@@ -2090,7 +2086,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         weather: crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::PlayerWeather,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let w = match weather {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::PlayerWeather::Clear => crate::entity::player::PlayerWeather::Clear,
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::PlayerWeather::Downfall => crate::entity::player::PlayerWeather::Downfall,
@@ -2100,7 +2096,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     }
 
     async fn reset_player_weather(&mut self, player: Resource<Player>) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.reset_player_weather();
         Ok(())
     }
@@ -2109,7 +2105,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<Option<crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::PlayerWeather>>{
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_player_weather().map(|w| match w {
             crate::entity::player::PlayerWeather::Clear => crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::PlayerWeather::Clear,
             crate::entity::player::PlayerWeather::Downfall => crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::player::PlayerWeather::Downfall,
@@ -2121,7 +2117,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         pos: crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::common::Position,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let pos_vec = from_wasm_position(pos);
         let block_pos = pumpkin_util::math::position::BlockPos::new(
             pos_vec.x as i32,
@@ -2138,7 +2134,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<
         crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::common::Position,
     > {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let target = player
             .get_compass_target()
             .unwrap_or(pumpkin_util::math::position::BlockPos::new(0, 0, 0));
@@ -2155,7 +2151,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         pos: crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::common::Position,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let pos_vec = from_wasm_position(pos);
         let block_pos = pumpkin_util::math::position::BlockPos::new(
             pos_vec.x as i32,
@@ -2174,7 +2170,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::common::Position,
         >,
     > {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_respawn_location().map(|p| {
             let vec3 = pumpkin_util::math::vector3::Vector3::new(
                 f64::from(p.0.x),
@@ -2190,8 +2186,8 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         other: Resource<Player>,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
-        let other = player_from_resource(self, &other)?;
+        let player = self.get(&player)?;
+        let other = self.get(&other)?;
         player.hide_player(other.gameprofile.id);
         Ok(())
     }
@@ -2201,8 +2197,8 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         other: Resource<Player>,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
-        let other = player_from_resource(self, &other)?;
+        let player = self.get(&player)?;
+        let other = self.get(&other)?;
         player.show_player(other.gameprofile.id);
         Ok(())
     }
@@ -2212,8 +2208,8 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         other: Resource<Player>,
     ) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
-        let other = player_from_resource(self, &other)?;
+        let player = self.get(&player)?;
+        let other = self.get(&other)?;
         Ok(player.can_see(&other.gameprofile.id))
     }
 
@@ -2222,8 +2218,8 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         other: Resource<Player>,
     ) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
-        let other = player_from_resource(self, &other)?;
+        let player = self.get(&player)?;
+        let other = self.get(&other)?;
         Ok(player.can_see(&other.gameprofile.id))
     }
 
@@ -2232,7 +2228,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         latency_ms: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_tab_list_ping(latency_ms);
         Ok(())
     }
@@ -2243,7 +2239,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         item_id: String,
         ticks: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_item_cooldown(&item_id, ticks);
         Ok(())
     }
@@ -2253,7 +2249,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         item_id: String,
     ) -> wasmtime::Result<Option<i32>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_item_cooldown(&item_id))
     }
 
@@ -2262,7 +2258,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         item_id: String,
     ) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.has_item_cooldown(&item_id))
     }
 
@@ -2272,7 +2268,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         max_distance: f64,
         include_fluids: bool,
     ) -> wasmtime::Result<Option<pumpkin::plugin::world::RayTraceBlockResult>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let start = player.living_entity.entity.get_eye_pos();
         let direction = player.living_entity.entity.get_looking_vector();
         let end = start + direction * max_distance;
@@ -2296,7 +2292,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         max_distance: f64,
     ) -> wasmtime::Result<Option<pumpkin::plugin::world::RayTraceEntityResult>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let start = player.living_entity.entity.get_eye_pos();
         let direction = player.living_entity.entity.get_looking_vector();
         let end = start + direction * max_distance;
@@ -2338,7 +2334,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::common::Position,
         >,
     > {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let res = player.get_target_block(
             &player.living_entity.entity.world.load_full(),
             f64::from(max_distance),
@@ -2385,7 +2381,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<()> {
         let header = text_component_from_resource(self, &header);
         let footer = text_component_from_resource(self, &footer);
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_tab_list_header_footer(&header, &footer);
         Ok(())
     }
@@ -2395,7 +2391,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         order: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_tab_list_order(order);
         Ok(())
     }
@@ -2405,7 +2401,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         latency: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_tab_list_latency(latency);
         Ok(())
     }
@@ -2415,7 +2411,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         listed: bool,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_tab_list_listed(listed);
         Ok(())
     }
@@ -2426,7 +2422,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         text: wasmtime::component::Resource<pumpkin::plugin::text::TextComponent>,
     ) -> wasmtime::Result<()> {
         let component = text_component_from_resource(self, &text);
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.show_title(&component, &TitleMode::Title);
         Ok(())
     }
@@ -2437,7 +2433,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         text: wasmtime::component::Resource<pumpkin::plugin::text::TextComponent>,
     ) -> wasmtime::Result<()> {
         let component = text_component_from_resource(self, &text);
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.show_title(&component, &TitleMode::SubTitle);
         Ok(())
     }
@@ -2448,7 +2444,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         text: wasmtime::component::Resource<pumpkin::plugin::text::TextComponent>,
     ) -> wasmtime::Result<()> {
         let component = text_component_from_resource(self, &text);
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.show_title(&component, &TitleMode::ActionBar);
         Ok(())
     }
@@ -2460,7 +2456,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         stay: i32,
         fade_out: i32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.send_title_animation(fade_in, stay, fade_out);
         Ok(())
     }
@@ -2471,7 +2467,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         host: String,
         port: u16,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         if let crate::net::ClientPlatform::Java(client) = player.client.as_ref() {
             client
                 .send_packet(&pumpkin_protocol::java::client::play::CTransfer::new(
@@ -2484,23 +2480,23 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     }
 
     async fn get_selected_slot(&mut self, player: Resource<Player>) -> wasmtime::Result<u8> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.inventory.get_selected_slot())
     }
 
     async fn get_health(&mut self, player: Resource<Player>) -> wasmtime::Result<f32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.living_entity.health.load())
     }
 
     async fn set_health(&mut self, player: Resource<Player>, health: f32) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_health(health);
         Ok(())
     }
 
     async fn get_max_health(&mut self, player: Resource<Player>) -> wasmtime::Result<f32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.living_entity.get_max_health())
     }
 
@@ -2509,18 +2505,18 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         max_health: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_max_health(max_health);
         Ok(())
     }
 
     async fn get_food_level(&mut self, player: Resource<Player>) -> wasmtime::Result<u8> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.hunger_manager.level.load())
     }
 
     async fn get_saturation(&mut self, player: Resource<Player>) -> wasmtime::Result<f32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.hunger_manager.saturation.load())
     }
 
@@ -2529,13 +2525,13 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         saturation: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_saturation(saturation);
         Ok(())
     }
 
     async fn get_exhaustion(&mut self, player: Resource<Player>) -> wasmtime::Result<f32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_exhaustion())
     }
 
@@ -2544,13 +2540,13 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         exhaustion: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_exhaustion(exhaustion);
         Ok(())
     }
 
     async fn get_absorption(&mut self, player: Resource<Player>) -> wasmtime::Result<f32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_absorption())
     }
 
@@ -2559,33 +2555,33 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         absorption: f32,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         player.set_absorption(absorption);
         Ok(())
     }
 
     async fn get_experience_level(&mut self, player: Resource<Player>) -> wasmtime::Result<i32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.experience_level.load(Ordering::Relaxed))
     }
 
     async fn get_experience_progress(&mut self, player: Resource<Player>) -> wasmtime::Result<f32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.experience_progress.load())
     }
 
     async fn get_experience_points(&mut self, player: Resource<Player>) -> wasmtime::Result<i32> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.experience_points.load(Ordering::Relaxed))
     }
 
     async fn is_flying(&mut self, player: Resource<Player>) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.is_flying())
     }
 
     async fn set_flying(&mut self, player: Resource<Player>, flying: bool) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         {
             let mut abilities = player
                 .abilities
@@ -2601,7 +2597,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<pumpkin::plugin::player::PlayerAbilities> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let abilities = player
             .abilities
             .lock()
@@ -2622,7 +2618,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         abilities: pumpkin::plugin::player::PlayerAbilities,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         {
             let mut a = player
                 .abilities
@@ -2641,12 +2637,12 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     }
 
     async fn get_ip(&mut self, player: Resource<Player>) -> wasmtime::Result<String> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player.get_ip())
     }
 
     async fn get_skin(&mut self, player: Resource<Player>) -> wasmtime::Result<Option<PlayerSkin>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         Ok(player
             .gameprofile
             .properties
@@ -2664,7 +2660,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         skin: PlayerSkin,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let mut properties = (**player.gameprofile.properties.load()).clone();
 
         properties.retain(|p| p.name.as_ref() != "textures");
@@ -2680,7 +2676,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     }
 
     async fn get_skin_parts(&mut self, player: Resource<Player>) -> wasmtime::Result<SkinParts> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let mask = player.config.load().skin_parts;
         let mut parts = SkinParts::empty();
         if mask & 0x01 != 0 {
@@ -2712,7 +2708,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         parts: SkinParts,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let mut mask = 0u8;
         if parts.contains(SkinParts::CAPE) {
             mask |= 0x01;
@@ -2750,7 +2746,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         advancement_id: String,
     ) -> wasmtime::Result<Option<pumpkin::plugin::advancement::AdvancementProgress>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let Some(advancement) =
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::advancement::find_advancement(
                 &advancement_id,
@@ -2795,7 +2791,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         advancement_id: String,
         criterion: String,
     ) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let Some(advancement) =
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::advancement::find_advancement(
                 &advancement_id,
@@ -2809,7 +2805,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let revoked = guard.revoke(advancement, &criterion);
         if revoked {
-            guard.flush_dirty(&player, true);
+            guard.flush_dirty(player, true);
         }
         Ok(revoked)
     }
@@ -2819,7 +2815,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         advancement_id: String,
     ) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let Some(advancement) =
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::advancement::find_advancement(
                 &advancement_id,
@@ -2843,7 +2839,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
             }
         }
         if any_revoked {
-            guard.flush_dirty(&player, true);
+            guard.flush_dirty(player, true);
         }
         Ok(any_revoked)
     }
@@ -2853,7 +2849,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         advancement_id: String,
     ) -> wasmtime::Result<bool> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let Some(advancement) =
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::advancement::find_advancement(
                 &advancement_id,
@@ -2877,7 +2873,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<Vec<String>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let guard = player
             .advancements
             .lock()
@@ -2896,7 +2892,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<Option<String>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let guard = player
             .advancements
             .lock()
@@ -2909,7 +2905,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         player: Resource<Player>,
         tab_id: Option<String>,
     ) -> wasmtime::Result<()> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?;
         let target_adv = tab_id.as_deref().and_then(
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::advancement::find_advancement,
         );
@@ -2925,7 +2921,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<Option<Resource<pumpkin::plugin::player::JavaPlayer>>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?.clone();
         if let crate::net::ClientPlatform::Java(_) = player.client.as_ref() {
             Ok(Some(self.add(player)?))
         } else {
@@ -2937,7 +2933,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         &mut self,
         player: Resource<Player>,
     ) -> wasmtime::Result<Option<Resource<pumpkin::plugin::player::BedrockPlayer>>> {
-        let player = player_from_resource(self, &player)?;
+        let player = self.get(&player)?.clone();
         if let crate::net::ClientPlatform::Bedrock(_) = player.client.as_ref() {
             Ok(Some(self.add(player)?))
         } else {
@@ -2957,10 +2953,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
 
         plugin
@@ -2978,10 +2971,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<bool> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
         let mode = from_wasm_game_mode(mode);
 
@@ -2999,7 +2989,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
         let (player, server, plugin) = {
             let state = host.get();
             (
-                player_from_resource(state, &player)?,
+                state.get(&player)?.clone(),
                 state.server.as_ref().expect("server not available").clone(),
                 plugin_from_state(state)?,
             )
@@ -3023,7 +3013,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
         let (player, server, plugin) = {
             let state = host.get();
             (
-                player_from_resource(state, &player)?,
+                state.get(&player)?.clone(),
                 state.server.as_ref().expect("server not available").clone(),
                 plugin_from_state(state)?,
             )
@@ -3042,10 +3032,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
         let effect_type = super::status_effect::from_wasm_status_effect_type(effect.effect_type);
         let Some(status_effect) =
@@ -3076,10 +3063,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
 
         plugin
@@ -3096,10 +3080,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
         let damage_type = from_wit_damage_type(damage_type);
 
@@ -3117,10 +3098,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
 
         plugin
@@ -3140,7 +3118,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
         let (player, world, plugin) = {
             let state = host.get();
             (
-                player_from_resource(state, &player)?,
+                state.get(&player)?.clone(),
                 world_from_resource(state, &world),
                 plugin_from_state(state)?,
             )
@@ -3166,7 +3144,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
         let (player, world, plugin) = {
             let state = host.get();
             (
-                player_from_resource(state, &player)?,
+                state.get(&player)?.clone(),
                 world_from_resource(state, &world),
                 plugin_from_state(state)?,
             )
@@ -3188,10 +3166,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
         let runtime = tokio::runtime::Handle::current();
 
@@ -3212,11 +3187,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
                 .get(&gui)
                 .map_err(|_| wasmtime::Error::msg("invalid gui resource handle"))?
                 .clone();
-            (
-                player_from_resource(state, &player)?,
-                gui,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), gui, plugin_from_state(state)?)
         };
 
         let (window_type, inventory, allow_grab_items, allow_put_items, title) = plugin
@@ -3268,7 +3239,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
         let (player, server, reason, plugin) = {
             let state = host.get();
             (
-                player_from_resource(state, &player)?,
+                state.get(&player)?.clone(),
                 state.server.as_ref().expect("server not available").clone(),
                 reason
                     .as_ref()
@@ -3309,7 +3280,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
         let (player, server, reason, plugin) = {
             let state = host.get();
             (
-                player_from_resource(state, &player)?,
+                state.get(&player)?.clone(),
                 state.server.as_ref().expect("server not available").clone(),
                 reason
                     .as_ref()
@@ -3341,10 +3312,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
 
         plugin
@@ -3360,10 +3328,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
 
         plugin
@@ -3379,10 +3344,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
 
         plugin
@@ -3404,10 +3366,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
 
         plugin
@@ -3429,10 +3388,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
 
         plugin
@@ -3448,10 +3404,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<()> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
 
         plugin
@@ -3468,10 +3421,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<bool> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
         let Some(advancement) =
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::advancement::find_advancement(
@@ -3512,10 +3462,7 @@ impl pumpkin::plugin::player::HostPlayerWithStore<PluginHostState> for HasSelf<P
     ) -> wasmtime::Result<bool> {
         let (player, plugin) = {
             let state = host.get();
-            (
-                player_from_resource(state, &player)?,
-                plugin_from_state(state)?,
-            )
+            (state.get(&player)?.clone(), plugin_from_state(state)?)
         };
         let Some(advancement) =
             crate::plugin::loader::wasm::wasm_host::wit::v0_1::advancement::find_advancement(

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/recipe.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/recipe.rs
@@ -21,7 +21,7 @@ impl HostRecipeManager for PluginHostState {
         id: String,
         recipe: WitShapedRecipe,
     ) -> wasmtime::Result<()> {
-        let result_stack = self.get(&recipe.output)?;
+        let result_stack = self.take(recipe.output)?;
         let result_stack = result_stack.lock().await;
 
         let category = recipe
@@ -61,7 +61,7 @@ impl HostRecipeManager for PluginHostState {
         id: String,
         recipe: WitShapelessRecipe,
     ) -> wasmtime::Result<()> {
-        let result_stack = self.get(&recipe.output)?;
+        let result_stack = self.take(recipe.output)?;
         let result_stack = result_stack.lock().await;
 
         let category = recipe
@@ -100,7 +100,7 @@ impl HostRecipeManager for PluginHostState {
         station_type: WitCookingType,
         recipe: WitCookingRecipe,
     ) -> wasmtime::Result<()> {
-        let result_stack = self.get(&recipe.output)?;
+        let result_stack = self.take(recipe.output)?;
         let result_stack = result_stack.lock().await;
 
         let category = recipe

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/recipe.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/recipe.rs
@@ -21,7 +21,7 @@ impl HostRecipeManager for PluginHostState {
         id: String,
         recipe: WitShapedRecipe,
     ) -> wasmtime::Result<()> {
-        let result_stack = self.get_item_stack(&recipe.output)?;
+        let result_stack = self.get(&recipe.output)?;
         let result_stack = result_stack.lock().await;
 
         let category = recipe
@@ -61,7 +61,7 @@ impl HostRecipeManager for PluginHostState {
         id: String,
         recipe: WitShapelessRecipe,
     ) -> wasmtime::Result<()> {
-        let result_stack = self.get_item_stack(&recipe.output)?;
+        let result_stack = self.get(&recipe.output)?;
         let result_stack = result_stack.lock().await;
 
         let category = recipe
@@ -100,7 +100,7 @@ impl HostRecipeManager for PluginHostState {
         station_type: WitCookingType,
         recipe: WitCookingRecipe,
     ) -> wasmtime::Result<()> {
-        let result_stack = self.get_item_stack(&recipe.output)?;
+        let result_stack = self.get(&recipe.output)?;
         let result_stack = result_stack.lock().await;
 
         let category = recipe

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/scoreboard.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/scoreboard.rs
@@ -1,7 +1,7 @@
 use wasmtime::component::Resource;
 
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{BedrockScoreboardResource, PluginHostState, ScoreboardProvider, ScoreboardResource},
+    state::{PluginHostState, ScoreboardProvider},
     wit::v0_1::pumpkin::{
         self,
         plugin::scoreboard::{
@@ -22,29 +22,9 @@ fn map_number_format(
         None => Ok(None),
         Some(scoreboard::NumberFormat::Blank) => Ok(Some(NumberFormat::Blank)),
         Some(scoreboard::NumberFormat::Fixed(tc)) => {
-            let text = state.get_text_provider(&tc)?;
+            let text = state.get(&tc)?.clone();
             Ok(Some(NumberFormat::Fixed(text)))
         }
-    }
-}
-
-impl PluginHostState {
-    fn get_scoreboard_res(
-        &self,
-        res: &Resource<scoreboard::Scoreboard>,
-    ) -> wasmtime::Result<&ScoreboardResource> {
-        self.resource_table
-            .get::<ScoreboardResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-
-    fn get_bedrock_scoreboard_res(
-        &self,
-        res: &Resource<scoreboard::BedrockScoreboard>,
-    ) -> wasmtime::Result<&BedrockScoreboardResource> {
-        self.resource_table
-            .get::<BedrockScoreboardResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
     }
 }
 
@@ -59,8 +39,8 @@ impl scoreboard::HostScoreboard for PluginHostState {
         render_type: RenderType,
         number_format: Option<scoreboard::NumberFormat>,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
-        let display_name = self.get_text_provider(&display_name)?;
+        let provider = self.get(&res)?.clone();
+        let display_name = self.get(&display_name)?.clone();
         let nf = map_number_format(number_format, self)?;
 
         let rt = match render_type {
@@ -109,8 +89,8 @@ impl scoreboard::HostScoreboard for PluginHostState {
         render_type: RenderType,
         number_format: Option<scoreboard::NumberFormat>,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
-        let display_name = self.get_text_provider(&display_name)?;
+        let provider = self.get(&res)?.clone();
+        let display_name = self.get(&display_name)?.clone();
         let nf = map_number_format(number_format, self)?;
 
         let rt = match render_type {
@@ -156,7 +136,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         res: Resource<scoreboard::Scoreboard>,
         name: String,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         match provider {
             ScoreboardProvider::World(world) => {
                 world
@@ -186,7 +166,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         slot: DisplaySlot,
         objective_name: String,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         let slot = map_display_slot(slot);
 
         match provider {
@@ -225,7 +205,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         res: Resource<scoreboard::Scoreboard>,
         slot: DisplaySlot,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         let slot = map_display_slot(slot);
 
         match provider {
@@ -259,7 +239,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         value: i32,
         number_format: Option<scoreboard::NumberFormat>,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         let nf = map_number_format(number_format, self)?;
         let score = ScoreboardScore::new(entity_name, objective_name, VarInt(value), None, nf);
         match provider {
@@ -300,7 +280,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         objective_name: String,
         delta: i32,
     ) -> wasmtime::Result<i32> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         let new_val = match provider {
             ScoreboardProvider::World(world) => world
                 .scoreboard
@@ -336,7 +316,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         entity_name: String,
         objective_name: String,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         match provider {
             ScoreboardProvider::World(world) => {
                 world
@@ -365,7 +345,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         res: Resource<scoreboard::Scoreboard>,
         entity_name: String,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         match provider {
             ScoreboardProvider::World(world) => {
                 world
@@ -395,7 +375,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         name: String,
         settings: TeamSettings,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         let team = map_team_settings(name, &settings, self)?;
         match provider {
             ScoreboardProvider::World(world) => {
@@ -433,7 +413,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         res: Resource<scoreboard::Scoreboard>,
         name: String,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         match provider {
             ScoreboardProvider::World(world) => {
                 world
@@ -463,7 +443,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         name: String,
         settings: TeamSettings,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         let team = map_team_settings(name, &settings, self)?;
         match provider {
             ScoreboardProvider::World(world) => {
@@ -494,7 +474,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         team_name: String,
         player_name: String,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         match provider {
             ScoreboardProvider::World(world) => {
                 world
@@ -524,7 +504,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         team_name: String,
         player_name: String,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         match provider {
             ScoreboardProvider::World(world) => {
                 world
@@ -553,7 +533,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         res: Resource<scoreboard::Scoreboard>,
         team_name: String,
     ) -> wasmtime::Result<()> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         match provider {
             ScoreboardProvider::World(world) => {
                 world
@@ -581,7 +561,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         &mut self,
         res: Resource<scoreboard::Scoreboard>,
     ) -> wasmtime::Result<Vec<String>> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         let teams = match provider {
             ScoreboardProvider::World(world) => world
                 .scoreboard
@@ -613,7 +593,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         res: Resource<scoreboard::Scoreboard>,
         name: String,
     ) -> wasmtime::Result<Option<TeamSettings>> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         let team_opt = match provider {
             ScoreboardProvider::World(world) => world
                 .scoreboard
@@ -648,7 +628,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         res: Resource<scoreboard::Scoreboard>,
         team_name: String,
     ) -> wasmtime::Result<Vec<String>> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         let players = match provider {
             ScoreboardProvider::World(world) => world
                 .scoreboard
@@ -681,7 +661,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         res: Resource<scoreboard::Scoreboard>,
         player_name: String,
     ) -> wasmtime::Result<Option<String>> {
-        let provider = self.get_scoreboard_res(&res)?.provider.clone();
+        let provider = self.get(&res)?.clone();
         let team_name = match provider {
             ScoreboardProvider::World(world) => world
                 .scoreboard
@@ -707,10 +687,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<scoreboard::Scoreboard>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<ScoreboardResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -759,9 +736,9 @@ fn map_team_settings(
     settings: &TeamSettings,
     state: &PluginHostState,
 ) -> wasmtime::Result<Team> {
-    let display_name = state.get_text_provider(&settings.display_name)?;
-    let player_prefix = state.get_text_provider(&settings.prefix)?;
-    let player_suffix = state.get_text_provider(&settings.suffix)?;
+    let display_name = state.get(&settings.display_name)?.clone();
+    let player_prefix = state.get(&settings.prefix)?.clone();
+    let player_suffix = state.get(&settings.suffix)?.clone();
 
     let mut options = 0;
     if settings.friendly_fire {
@@ -843,9 +820,9 @@ fn map_team_to_settings(
     team: &Team,
     state: &mut PluginHostState,
 ) -> wasmtime::Result<TeamSettings> {
-    let display_name = state.add_text_component(team.display_name.clone())?;
-    let prefix = state.add_text_component(team.player_prefix.clone())?;
-    let suffix = state.add_text_component(team.player_suffix.clone())?;
+    let display_name = state.add(team.display_name.clone())?;
+    let prefix = state.add(team.player_prefix.clone())?;
+    let suffix = state.add(team.player_suffix.clone())?;
 
     let friendly_fire = (team.options & 0x01) != 0;
     let see_friendly_invisibles = (team.options & 0x02) != 0;
@@ -929,7 +906,7 @@ impl HostBedrockScoreboard for PluginHostState {
         display_name: String,
         sort_order: scoreboard::BedrockSortOrder,
     ) -> wasmtime::Result<()> {
-        let player = self.get_bedrock_scoreboard_res(&res)?.provider.clone();
+        let player = self.get(&res)?.clone();
         let mut custom_guard = player
             .custom_scoreboard
             .lock()
@@ -971,7 +948,7 @@ impl HostBedrockScoreboard for PluginHostState {
         display_name: String,
         sort_order: scoreboard::BedrockSortOrder,
     ) -> wasmtime::Result<()> {
-        let player = self.get_bedrock_scoreboard_res(&res)?.provider.clone();
+        let player = self.get(&res)?.clone();
         let mut custom_guard = player
             .custom_scoreboard
             .lock()
@@ -1011,7 +988,7 @@ impl HostBedrockScoreboard for PluginHostState {
         res: Resource<scoreboard::BedrockScoreboard>,
         name: String,
     ) -> wasmtime::Result<()> {
-        let player = self.get_bedrock_scoreboard_res(&res)?.provider.clone();
+        let player = self.get(&res)?.clone();
         let mut custom_guard = player
             .custom_scoreboard
             .lock()
@@ -1028,7 +1005,7 @@ impl HostBedrockScoreboard for PluginHostState {
         slot: scoreboard::BedrockDisplaySlot,
         objective_name: String,
     ) -> wasmtime::Result<()> {
-        let player = self.get_bedrock_scoreboard_res(&res)?.provider.clone();
+        let player = self.get(&res)?.clone();
         let mut custom_guard = player
             .custom_scoreboard
             .lock()
@@ -1065,7 +1042,7 @@ impl HostBedrockScoreboard for PluginHostState {
         res: Resource<scoreboard::BedrockScoreboard>,
         slot: scoreboard::BedrockDisplaySlot,
     ) -> wasmtime::Result<()> {
-        let player = self.get_bedrock_scoreboard_res(&res)?.provider.clone();
+        let player = self.get(&res)?.clone();
         let mut custom_guard = player
             .custom_scoreboard
             .lock()
@@ -1094,7 +1071,7 @@ impl HostBedrockScoreboard for PluginHostState {
         objective_name: String,
         value: i32,
     ) -> wasmtime::Result<()> {
-        let player = self.get_bedrock_scoreboard_res(&res)?.provider.clone();
+        let player = self.get(&res)?.clone();
         let mut custom_guard = player
             .custom_scoreboard
             .lock()
@@ -1122,7 +1099,7 @@ impl HostBedrockScoreboard for PluginHostState {
         objective_name: String,
         delta: i32,
     ) -> wasmtime::Result<i32> {
-        let player = self.get_bedrock_scoreboard_res(&res)?.provider.clone();
+        let player = self.get(&res)?.clone();
         let mut custom_guard = player
             .custom_scoreboard
             .lock()
@@ -1149,7 +1126,7 @@ impl HostBedrockScoreboard for PluginHostState {
         entity_name: String,
         objective_name: String,
     ) -> wasmtime::Result<()> {
-        let player = self.get_bedrock_scoreboard_res(&res)?.provider.clone();
+        let player = self.get(&res)?.clone();
         let mut custom_guard = player
             .custom_scoreboard
             .lock()
@@ -1165,7 +1142,7 @@ impl HostBedrockScoreboard for PluginHostState {
         res: Resource<scoreboard::BedrockScoreboard>,
         entity_name: String,
     ) -> wasmtime::Result<()> {
-        let player = self.get_bedrock_scoreboard_res(&res)?.provider.clone();
+        let player = self.get(&res)?.clone();
         let mut custom_guard = player
             .custom_scoreboard
             .lock()

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/scoreboard.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/scoreboard.rs
@@ -736,9 +736,9 @@ fn map_team_settings(
     settings: TeamSettings,
     state: &mut PluginHostState,
 ) -> wasmtime::Result<Team> {
-    let display_name = state.take(settings.display_name)?.clone();
-    let player_prefix = state.take(settings.prefix)?.clone();
-    let player_suffix = state.take(settings.suffix)?.clone();
+    let display_name = state.take(settings.display_name)?;
+    let player_prefix = state.take(settings.prefix)?;
+    let player_suffix = state.take(settings.suffix)?;
 
     let mut options = 0;
     if settings.friendly_fire {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/scoreboard.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/scoreboard.rs
@@ -40,7 +40,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         number_format: Option<scoreboard::NumberFormat>,
     ) -> wasmtime::Result<()> {
         let provider = self.get(&res)?.clone();
-        let display_name = self.get(&display_name)?.clone();
+        let display_name = self.take(display_name)?;
         let nf = map_number_format(number_format, self)?;
 
         let rt = match render_type {
@@ -90,7 +90,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         number_format: Option<scoreboard::NumberFormat>,
     ) -> wasmtime::Result<()> {
         let provider = self.get(&res)?.clone();
-        let display_name = self.get(&display_name)?.clone();
+        let display_name = self.take(display_name)?;
         let nf = map_number_format(number_format, self)?;
 
         let rt = match render_type {
@@ -376,7 +376,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         settings: TeamSettings,
     ) -> wasmtime::Result<()> {
         let provider = self.get(&res)?.clone();
-        let team = map_team_settings(name, &settings, self)?;
+        let team = map_team_settings(name, settings, self)?;
         match provider {
             ScoreboardProvider::World(world) => {
                 world
@@ -444,7 +444,7 @@ impl scoreboard::HostScoreboard for PluginHostState {
         settings: TeamSettings,
     ) -> wasmtime::Result<()> {
         let provider = self.get(&res)?.clone();
-        let team = map_team_settings(name, &settings, self)?;
+        let team = map_team_settings(name, settings, self)?;
         match provider {
             ScoreboardProvider::World(world) => {
                 world
@@ -733,12 +733,12 @@ const fn map_display_slot(slot: DisplaySlot) -> pumpkin_data::scoreboard::Scoreb
 
 fn map_team_settings(
     name: String,
-    settings: &TeamSettings,
-    state: &PluginHostState,
+    settings: TeamSettings,
+    state: &mut PluginHostState,
 ) -> wasmtime::Result<Team> {
-    let display_name = state.get(&settings.display_name)?.clone();
-    let player_prefix = state.get(&settings.prefix)?.clone();
-    let player_suffix = state.get(&settings.suffix)?.clone();
+    let display_name = state.take(settings.display_name)?.clone();
+    let player_prefix = state.take(settings.prefix)?.clone();
+    let player_suffix = state.take(settings.suffix)?.clone();
 
     let mut options = 0;
     if settings.friendly_fire {

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
@@ -15,7 +15,7 @@ use super::player::{
 use crate::data::SaveJSONConfiguration;
 use crate::plugin::{
     loader::wasm::wasm_host::{
-        state::{PlayerResource, PluginHostState, ServerResource},
+        state::PluginHostState,
         wit::v0_1::pumpkin::{
             self,
             plugin::{
@@ -33,14 +33,6 @@ use crate::plugin::{
     },
     permissions,
 };
-
-impl PluginHostState {
-    fn get_server_res(&self, res: &Resource<Server>) -> wasmtime::Result<&ServerResource> {
-        self.resource_table
-            .get::<ServerResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-}
 
 impl pumpkin::plugin::server::Host for PluginHostState {}
 
@@ -79,9 +71,9 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
     }
 
     async fn get_difficulty(&mut self, res: Resource<Server>) -> wasmtime::Result<Difficulty> {
-        let resource = self.get_server_res(&res)?;
+        let resource = self.get(&res)?;
 
-        Ok(match resource.provider.get_difficulty() {
+        Ok(match resource.get_difficulty() {
             pumpkin_util::Difficulty::Peaceful => Difficulty::Peaceful,
             pumpkin_util::Difficulty::Easy => Difficulty::Easy,
             pumpkin_util::Difficulty::Normal => Difficulty::Normal,
@@ -125,10 +117,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
         Ok(server
             .get_all_players()
             .into_iter()
-            .map(|player| {
-                self.add_player(player)
-                    .expect("failed to add player resource")
-            })
+            .map(|player| self.add(player).expect("failed to add player resource"))
             .collect())
     }
 
@@ -144,7 +133,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
 
         server
             .get_player_by_name(&name)
-            .map(|player| self.add_player(player))
+            .map(|player| self.add(player))
             .transpose()
     }
 
@@ -162,7 +151,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
 
         server
             .get_player_by_uuid(uuid)
-            .map(|player| self.add_player(player))
+            .map(|player| self.add(player))
             .transpose()
     }
 
@@ -180,7 +169,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .load()
             .iter()
             .map(|world| {
-                self.add_world(world.clone())
+                self.add(world.clone())
                     .expect("failed to add world resource")
             })
             .collect())
@@ -202,7 +191,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .iter()
             .find(|world| world.get_world_name() == name || world.dimension.minecraft_name == name)
             .map(|world| {
-                self.add_world(world.clone())
+                self.add(world.clone())
                     .expect("failed to add world resource")
             }))
     }
@@ -225,11 +214,11 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
         _rep: Resource<Server>,
         world: Resource<pumpkin::plugin::world::World>,
     ) -> wasmtime::Result<Vec<Resource<pumpkin::plugin::player::Player>>> {
-        let world_res = self.get_world_res(&world)?;
-        let players = world_res.provider.players.load();
+        let world_res = self.get(&world)?;
+        let players = world_res.players.load();
         let mut player_resources = Vec::with_capacity(players.len());
         for p in players.iter() {
-            let res = self.add_player(p.clone())?;
+            let res = self.add(p.clone())?;
             player_resources.push(res);
         }
         Ok(player_resources)
@@ -240,8 +229,8 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
         _rep: Resource<Server>,
         world: Resource<pumpkin::plugin::world::World>,
     ) -> wasmtime::Result<u32> {
-        let world_res = self.get_world_res(&world)?;
-        Ok(world_res.provider.players.load().len() as u32)
+        let world_res = self.get(&world)?;
+        Ok(world_res.players.load().len() as u32)
     }
 
     async fn delete_message_by_signature(
@@ -396,7 +385,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .server
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
-        self.add_recipe_manager(server.recipe_manager.clone())
+        self.add(server.recipe_manager.clone())
     }
 
     async fn get_op_manager(
@@ -407,7 +396,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .server
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
-        self.add_op_manager(server.clone())
+        self.add(server.clone())
     }
 
     async fn get_ban_manager(
@@ -418,7 +407,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .server
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
-        self.add_ban_manager(server.clone())
+        self.add(server.clone())
     }
 
     async fn get_whitelist_manager(
@@ -429,7 +418,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .server
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
-        self.add_whitelist_manager(server.clone())
+        self.add(server.clone())
     }
 
     async fn get_advancement(
@@ -468,7 +457,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .server
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
-        self.add_enchantment_manager(server.enchantment_manager.clone())
+        self.add(server.enchantment_manager.clone())
     }
 
     async fn get_enchantment(
@@ -482,7 +471,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
 
         if let Some(entry) = server.enchantment_manager.get(&id).await {
-            let description = self.add_text_component(entry.description)?;
+            let description = self.add(entry.description)?;
             return Ok(Some(WitCustomEnchantment {
                 id: entry.id,
                 description,
@@ -500,8 +489,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
         }
 
         if let Some(vanilla) = super::enchantment::find_vanilla_enchantment(&id) {
-            let description =
-                self.add_text_component(TextComponent::translate(vanilla.description, []))?;
+            let description = self.add(TextComponent::translate(vanilla.description, []))?;
             return Ok(Some(WitCustomEnchantment {
                 id: vanilla.name.to_string(),
                 description,
@@ -552,7 +540,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .server
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
-        self.add_datapack_manager(server.clone())
+        self.add(server.clone())
     }
 
     async fn set_server_links(
@@ -577,10 +565,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<Server>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<ServerResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -616,7 +601,7 @@ impl pumpkin::plugin::server::HostServerWithStore<PluginHostState> for HasSelf<P
             .await?;
 
         host.get()
-            .add_world(world)
+            .add(world)
             .map_err(|_| wasmtime::Error::msg("failed to add world resource"))
     }
 
@@ -713,10 +698,8 @@ impl pumpkin::plugin::server::HostServerWithStore<PluginHostState> for HasSelf<P
             let native_sender = match sender {
                 WasmCommandSender::Console => CommandSender::Console,
                 WasmCommandSender::Player(player_res) => {
-                    let player_resource = state
-                        .resource_table
-                        .get::<PlayerResource>(&Resource::new_own(player_res.rep()))?;
-                    CommandSender::Player(player_resource.provider.clone())
+                    let player_resource = state.take(player_res)?;
+                    CommandSender::Player(player_resource.clone())
                 }
             };
             let plugin = state
@@ -819,12 +802,7 @@ impl pumpkin::plugin::server::HostOpManager for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<WitOpManager>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<crate::plugin::loader::wasm::wasm_host::state::OpManagerResource>(
-                Resource::new_own(rep.rep()),
-            );
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1162,12 +1140,7 @@ impl pumpkin::plugin::server::HostBanManager for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<WitBanManager>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<crate::plugin::loader::wasm::wasm_host::state::BanManagerResource>(
-            Resource::new_own(rep.rep()),
-        );
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1411,12 +1384,7 @@ impl pumpkin::plugin::server::HostWhitelistManager for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<WitWhitelistManager>) -> wasmtime::Result<()> {
-        let _ = self
-            .resource_table
-            .delete::<crate::plugin::loader::wasm::wasm_host::state::WhitelistManagerResource>(
-            Resource::new_own(rep.rep()),
-        );
-        Ok(())
+        self.drop(rep)
     }
 }
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
@@ -698,8 +698,8 @@ impl pumpkin::plugin::server::HostServerWithStore<PluginHostState> for HasSelf<P
             let native_sender = match sender {
                 WasmCommandSender::Console => CommandSender::Console,
                 WasmCommandSender::Player(player_res) => {
-                    let player_resource = state.take(player_res)?;
-                    CommandSender::Player(player_resource.clone())
+                    let player = state.take(player_res)?;
+                    CommandSender::Player(player)
                 }
             };
             let plugin = state

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/server.rs
@@ -214,7 +214,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
         _rep: Resource<Server>,
         world: Resource<pumpkin::plugin::world::World>,
     ) -> wasmtime::Result<Vec<Resource<pumpkin::plugin::player::Player>>> {
-        let world_res = self.get(&world)?;
+        let world_res = self.take(world)?;
         let players = world_res.players.load();
         let mut player_resources = Vec::with_capacity(players.len());
         for p in players.iter() {
@@ -229,7 +229,7 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
         _rep: Resource<Server>,
         world: Resource<pumpkin::plugin::world::World>,
     ) -> wasmtime::Result<u32> {
-        let world_res = self.get(&world)?;
+        let world_res = self.take(world)?;
         Ok(world_res.players.load().len() as u32)
     }
 
@@ -264,11 +264,11 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
     async fn broadcast_tab_list_header_footer(
         &mut self,
         _rep: Resource<Server>,
-        header: wasmtime::component::Resource<pumpkin::plugin::text::TextComponent>,
-        footer: wasmtime::component::Resource<pumpkin::plugin::text::TextComponent>,
+        header: Resource<pumpkin::plugin::text::TextComponent>,
+        footer: Resource<pumpkin::plugin::text::TextComponent>,
     ) -> wasmtime::Result<()> {
-        let header = text_component_from_resource(self, &header);
-        let footer = text_component_from_resource(self, &footer);
+        let header = self.take(header)?;
+        let footer = self.take(footer)?;
         let server = self
             .server
             .as_ref()

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/text.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/text.rs
@@ -170,10 +170,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         &mut self,
         text_component: Resource<TextComponent>,
     ) -> wasmtime::Result<String> {
-        Ok(self
-            .get(&text_component)?
-            .clone()
-            .to_pretty_console())
+        Ok(self.get(&text_component)?.clone().to_pretty_console())
     }
 
     async fn color_named(

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/text.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/text.rs
@@ -3,8 +3,7 @@ use std::str::FromStr;
 use wasmtime::component::Resource;
 
 use crate::plugin::loader::wasm::wasm_host::{
-    DowncastResourceExt,
-    state::{PluginHostState, TextComponentResource},
+    state::PluginHostState,
     wit::v0_1::pumpkin::{
         self,
         plugin::text::{ArgbColor, NamedColor, RgbColor, TextComponent},
@@ -19,69 +18,12 @@ use pumpkin_util::text::{
 };
 use pumpkin_util::translation::Locale;
 
-// --- Trapping Helpers ---
-impl PluginHostState {
-    fn get_text_ref(
-        &self,
-        res: &Resource<TextComponent>,
-    ) -> wasmtime::Result<&TextComponentResource> {
-        self.resource_table
-            .get::<TextComponentResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-
-    fn get_text_mut(
-        &mut self,
-        res: &Resource<TextComponent>,
-    ) -> wasmtime::Result<&mut TextComponentResource> {
-        self.resource_table
-            .get_mut::<TextComponentResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-
-    fn take_text(
-        &mut self,
-        res: &Resource<TextComponent>,
-    ) -> wasmtime::Result<TextComponentResource> {
-        self.resource_table
-            .delete::<TextComponentResource>(Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-}
-
-impl DowncastResourceExt<TextComponentResource> for wasmtime::component::Resource<TextComponent> {
-    fn downcast_ref<'a>(&'a self, state: &'a mut PluginHostState) -> &'a TextComponentResource {
-        state
-            .resource_table
-            .get_any_mut(self.rep())
-            .expect("invalid handle")
-            .downcast_ref()
-            .expect("type mismatch")
-    }
-
-    fn downcast_mut<'a>(&'a self, state: &'a mut PluginHostState) -> &'a mut TextComponentResource {
-        state
-            .resource_table
-            .get_any_mut(self.rep())
-            .expect("invalid handle")
-            .downcast_mut()
-            .expect("type mismatch")
-    }
-
-    fn consume(self, state: &mut PluginHostState) -> TextComponentResource {
-        state
-            .resource_table
-            .delete(wasmtime::component::Resource::new_own(self.rep()))
-            .expect("invalid handle")
-    }
-}
-
 impl pumpkin::plugin::text::Host for PluginHostState {}
 
 impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
     async fn text(&mut self, plain: String) -> wasmtime::Result<Resource<TextComponent>> {
         let tc = InternalTextComponent::text(plain);
-        self.add_text_component(tc)
+        self.add(tc)
             .map_err(|_| wasmtime::Error::msg("Failed to add text component"))
     }
 
@@ -92,11 +34,11 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
     ) -> wasmtime::Result<Resource<TextComponent>> {
         let mut components = Vec::with_capacity(with.len());
         for r in with {
-            components.push(self.take_text(&r)?.provider);
+            components.push(self.take(r)?);
         }
         #[allow(deprecated)]
         let tc = InternalTextComponent::translate(key, components);
-        self.add_text_component(tc)
+        self.add(tc)
             .map_err(|_| wasmtime::Error::msg("Failed to add text component"))
     }
 
@@ -108,11 +50,11 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
     ) -> wasmtime::Result<Resource<TextComponent>> {
         let mut components = Vec::with_capacity(with.len());
         for r in with {
-            components.push(self.take_text(&r)?.provider);
+            components.push(self.take(r)?);
         }
         #[allow(deprecated)]
         let tc = InternalTextComponent::translate_cross(java_key, bedrock_key, components);
-        self.add_text_component(tc)
+        self.add(tc)
             .map_err(|_| wasmtime::Error::msg("Failed to add text component"))
     }
 
@@ -122,13 +64,13 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         separator: Option<String>,
     ) -> wasmtime::Result<Resource<TextComponent>> {
         let tc = InternalTextComponent::entity_names(selector, separator);
-        self.add_text_component(tc)
+        self.add(tc)
             .map_err(|_| wasmtime::Error::msg("Failed to add text component"))
     }
 
     async fn keybind(&mut self, keybind: String) -> wasmtime::Result<Resource<TextComponent>> {
         let tc = InternalTextComponent::keybind(keybind);
-        self.add_text_component(tc)
+        self.add(tc)
             .map_err(|_| wasmtime::Error::msg("Failed to add text component"))
     }
 
@@ -142,10 +84,10 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         let loc = Locale::from_str(&locale).unwrap_or(Locale::EnUs);
         let mut components = Vec::with_capacity(with.len());
         for r in with {
-            components.push(self.take_text(&r)?.provider);
+            components.push(self.take(r)?);
         }
         let tc = InternalTextComponent::custom(namespace, key, loc, components);
-        self.add_text_component(tc)
+        self.add(tc)
             .map_err(|_| wasmtime::Error::msg("Failed to add text component"))
     }
 
@@ -154,7 +96,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         input: String,
     ) -> wasmtime::Result<Resource<TextComponent>> {
         let tc = InternalTextComponent::from_legacy_string(&input);
-        self.add_text_component(tc)
+        self.add(tc)
             .map_err(|_| wasmtime::Error::msg("Failed to add text component"))
     }
 
@@ -164,7 +106,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         code_symbol: char,
     ) -> wasmtime::Result<Resource<TextComponent>> {
         let tc = InternalTextComponent::from_legacy_string_with_code(&input, code_symbol);
-        self.add_text_component(tc)
+        self.add(tc)
             .map_err(|_| wasmtime::Error::msg("Failed to add text component"))
     }
 
@@ -173,7 +115,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         json: String,
     ) -> wasmtime::Result<Result<Resource<TextComponent>, String>> {
         match serde_json::from_str::<InternalTextComponent>(&json) {
-            Ok(tc) => match self.add_text_component(tc) {
+            Ok(tc) => match self.add(tc) {
                 Ok(res) => Ok(Ok(res)),
                 Err(err) => Ok(Err(err.to_string())),
             },
@@ -185,7 +127,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         &mut self,
         text_component: Resource<TextComponent>,
     ) -> wasmtime::Result<String> {
-        let tc = &self.get_text_ref(&text_component)?.provider;
+        let tc = &self.get(&text_component)?;
         Ok(serde_json::to_string(tc).unwrap_or_default())
     }
 
@@ -194,9 +136,9 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         text_component: Resource<TextComponent>,
         child: Resource<TextComponent>,
     ) -> wasmtime::Result<()> {
-        let child_tc = self.take_text(&child)?.provider;
-        let parent = self.get_text_mut(&text_component)?;
-        parent.provider = parent.provider.clone().add_child(child_tc);
+        let child_tc = self.take(child)?;
+        let parent = self.get_mut(&text_component)?;
+        *parent = parent.clone().add_child(child_tc);
         Ok(())
     }
 
@@ -205,8 +147,8 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         text_component: Resource<TextComponent>,
         text: String,
     ) -> wasmtime::Result<()> {
-        let parent = self.get_text_mut(&text_component)?;
-        parent.provider = parent.provider.clone().add_text(text);
+        let parent = self.get_mut(&text_component)?;
+        *parent = parent.clone().add_text(text);
         Ok(())
     }
 
@@ -214,22 +156,14 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         &mut self,
         text_component: Resource<TextComponent>,
     ) -> wasmtime::Result<String> {
-        Ok(self
-            .get_text_ref(&text_component)?
-            .provider
-            .clone()
-            .get_text())
+        Ok(self.get(&text_component)?.clone().get_text())
     }
 
     async fn encode(
         &mut self,
         text_component: Resource<TextComponent>,
     ) -> wasmtime::Result<Vec<u8>> {
-        Ok(self
-            .get_text_ref(&text_component)?
-            .provider
-            .encode()
-            .into_vec())
+        Ok(self.get(&text_component)?.encode().into_vec())
     }
 
     async fn to_pretty_console(
@@ -237,8 +171,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         text_component: Resource<TextComponent>,
     ) -> wasmtime::Result<String> {
         Ok(self
-            .get_text_ref(&text_component)?
-            .provider
+            .get(&text_component)?
             .clone()
             .to_pretty_console())
     }
@@ -248,8 +181,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         color: NamedColor,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.color =
-            Some(Color::Named(map_named_color(color)));
+        self.get_mut(&res)?.0.style.color = Some(Color::Named(map_named_color(color)));
         Ok(())
     }
 
@@ -258,7 +190,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         color: RgbColor,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.color =
+        self.get_mut(&res)?.0.style.color =
             Some(Color::Rgb(color::RGBColor::new(color.r, color.g, color.b)));
         Ok(())
     }
@@ -269,8 +201,8 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         colors: Vec<NamedColor>,
     ) -> wasmtime::Result<()> {
         let mapped: Vec<_> = colors.into_iter().map(map_named_color).collect();
-        let parent = self.get_text_mut(&res)?;
-        parent.provider = parent.provider.clone().gradient_named(&mapped);
+        let parent = self.get_mut(&res)?;
+        *parent = parent.clone().gradient_named(&mapped);
         Ok(())
     }
 
@@ -283,24 +215,24 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
             .into_iter()
             .map(|c| color::RGBColor::new(c.r, c.g, c.b))
             .collect();
-        let parent = self.get_text_mut(&res)?;
-        parent.provider = parent.provider.clone().gradient(&mapped);
+        let parent = self.get_mut(&res)?;
+        *parent = parent.clone().gradient(&mapped);
         Ok(())
     }
 
     async fn rainbow(&mut self, res: Resource<TextComponent>) -> wasmtime::Result<()> {
-        let parent = self.get_text_mut(&res)?;
-        parent.provider = parent.provider.clone().rainbow();
+        let parent = self.get_mut(&res)?;
+        *parent = parent.clone().rainbow();
         Ok(())
     }
 
     async fn bold(&mut self, res: Resource<TextComponent>, value: bool) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.bold = Some(value);
+        self.get_mut(&res)?.0.style.bold = Some(value);
         Ok(())
     }
 
     async fn italic(&mut self, res: Resource<TextComponent>, value: bool) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.italic = Some(value);
+        self.get_mut(&res)?.0.style.italic = Some(value);
         Ok(())
     }
 
@@ -309,7 +241,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         value: bool,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.underlined = Some(value);
+        self.get_mut(&res)?.0.style.underlined = Some(value);
         Ok(())
     }
 
@@ -318,7 +250,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         value: bool,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.strikethrough = Some(value);
+        self.get_mut(&res)?.0.style.strikethrough = Some(value);
         Ok(())
     }
 
@@ -327,7 +259,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         value: bool,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.obfuscated = Some(value);
+        self.get_mut(&res)?.0.style.obfuscated = Some(value);
         Ok(())
     }
 
@@ -336,12 +268,12 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         text: String,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.insertion = Some(text);
+        self.get_mut(&res)?.0.style.insertion = Some(text);
         Ok(())
     }
 
     async fn font(&mut self, res: Resource<TextComponent>, font: String) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.font = Some(font);
+        self.get_mut(&res)?.0.style.font = Some(font);
         Ok(())
     }
 
@@ -350,7 +282,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         color: ArgbColor,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.shadow_color =
+        self.get_mut(&res)?.0.style.shadow_color =
             Some(color::ARGBColor::new(color.a, color.r, color.g, color.b));
         Ok(())
     }
@@ -360,7 +292,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         url: String,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.click_event = Some(ClickEvent::OpenUrl {
+        self.get_mut(&res)?.0.style.click_event = Some(ClickEvent::OpenUrl {
             url: Cow::Owned(url),
         });
         Ok(())
@@ -371,7 +303,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         path: String,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.click_event = Some(ClickEvent::OpenFile {
+        self.get_mut(&res)?.0.style.click_event = Some(ClickEvent::OpenFile {
             path: Cow::Owned(path),
         });
         Ok(())
@@ -382,7 +314,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         command: String,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.click_event = Some(ClickEvent::RunCommand {
+        self.get_mut(&res)?.0.style.click_event = Some(ClickEvent::RunCommand {
             command: Cow::Owned(command),
         });
         Ok(())
@@ -393,7 +325,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         command: String,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.click_event = Some(ClickEvent::SuggestCommand {
+        self.get_mut(&res)?.0.style.click_event = Some(ClickEvent::SuggestCommand {
             command: Cow::Owned(command),
         });
         Ok(())
@@ -404,8 +336,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         page: u32,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.click_event =
-            Some(ClickEvent::ChangePage { page });
+        self.get_mut(&res)?.0.style.click_event = Some(ClickEvent::ChangePage { page });
         Ok(())
     }
 
@@ -414,7 +345,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         text: String,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.click_event = Some(ClickEvent::CopyToClipboard {
+        self.get_mut(&res)?.0.style.click_event = Some(ClickEvent::CopyToClipboard {
             value: Cow::Owned(text),
         });
         Ok(())
@@ -425,8 +356,8 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         text: Resource<TextComponent>,
     ) -> wasmtime::Result<()> {
-        let hover_tc = self.take_text(&text)?.provider;
-        self.get_text_mut(&res)?.provider.0.style.hover_event = Some(HoverEvent::ShowText {
+        let hover_tc = self.take(text)?;
+        self.get_mut(&res)?.0.style.hover_event = Some(HoverEvent::ShowText {
             value: vec![hover_tc.0],
         });
         Ok(())
@@ -437,7 +368,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         res: Resource<TextComponent>,
         item: String,
     ) -> wasmtime::Result<()> {
-        self.get_text_mut(&res)?.provider.0.style.hover_event = Some(HoverEvent::ShowItem {
+        self.get_mut(&res)?.0.style.hover_event = Some(HoverEvent::ShowItem {
             id: Cow::Owned(item),
             count: None,
         });
@@ -452,10 +383,10 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         name: Option<Resource<TextComponent>>,
     ) -> wasmtime::Result<()> {
         let name_val = match name {
-            Some(r) => Some(vec![self.take_text(&r)?.provider.0]),
+            Some(r) => Some(vec![self.take(r)?.0]),
             None => None,
         };
-        self.get_text_mut(&res)?.provider.0.style.hover_event = Some(HoverEvent::ShowEntity {
+        self.get_mut(&res)?.0.style.hover_event = Some(HoverEvent::ShowEntity {
             id: Cow::Owned(entity_type),
             uuid: Cow::Owned(id),
             name: name_val,
@@ -464,10 +395,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<TextComponent>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<TextComponentResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
@@ -702,11 +702,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
     }
 
     async fn get_dimension(&mut self, world: Resource<World>) -> wasmtime::Result<String> {
-        Ok(self
-            .get(&world)?
-            .dimension
-            .minecraft_name
-            .to_string())
+        Ok(self.get(&world)?.dimension.minecraft_name.to_string())
     }
 
     async fn get_top_block_y(
@@ -726,11 +722,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         x: i32,
         z: i32,
     ) -> wasmtime::Result<i32> {
-        Ok(self.get(&world)?.get_heightmap_height(
-            ChunkHeightmapType::MotionBlocking,
-            x,
-            z,
-        ))
+        Ok(self
+            .get(&world)?
+            .get_heightmap_height(ChunkHeightmapType::MotionBlocking, x, z))
     }
 
     async fn is_raining(&mut self, world: Resource<World>) -> wasmtime::Result<bool> {
@@ -747,9 +741,8 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         message: Resource<pumpkin::plugin::text::TextComponent>,
         overlay: bool,
     ) -> wasmtime::Result<()> {
-        let msg = self.get(&message)?;
-        self.get(&world)?
-            .broadcast_system_message(&msg, overlay);
+        let msg = self.take(message)?;
+        self.get(&world)?.broadcast_system_message(&msg, overlay);
         Ok(())
     }
 
@@ -2218,7 +2211,9 @@ impl WasmChunkGenerator {
                             .call(function, (generator_id, phase, buffer_resource))
                             .await;
                         guest.with(|mut store| {
-                            let _ = store.data_mut().resource_table.delete::<ChunkBuffer>(wasmtime::component::Resource::new_own(buffer_rep));
+                            let _ = store.data_mut().resource_table.delete::<ChunkBuffer>(
+                                wasmtime::component::Resource::new_own(buffer_rep),
+                            );
                         });
                         result
                     })

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/world.rs
@@ -59,12 +59,13 @@ use crate::block::entities::test_instance_block::TestInstanceBlockBlockEntity as
 use crate::block::entities::trapped_chest::TrappedChestBlockEntity as InternalTrappedChestBlockEntity;
 use crate::block::entities::trial_spawner::TrialSpawnerBlockEntity as InternalTrialSpawnerBlockEntity;
 use crate::block::entities::vault::VaultBlockEntity as InternalVaultBlockEntity;
+use crate::plugin::loader::wasm::wasm_host::state::ChunkBuffer;
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::common::Position as WitPosition;
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::game_rules::{
     GameRule as WitGameRule, GameRuleValue as WitGameRuleValue,
 };
 use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::world::{
-    Block as WitBlock, BlockDirection as WitBlockDirection, BlockEntity, BlockEntityType,
+    Block as WitBlock, BlockDirection as WitBlockDirection, BlockEntityType,
     BlockFlags as WitBlockFlags, BlockPos as WitBlockPos, BlockState as WitBlockState,
     BlockStateInfo as WitBlockStateInfo, BoundingBox as WitBoundingBox, Chunk as WitChunk,
     Flammable as WitFlammable, NoteblockInstrument as WitNoteblockInstrument,
@@ -73,9 +74,7 @@ use crate::plugin::loader::wasm::wasm_host::wit::v0_1::pumpkin::plugin::world::{
     WorldSpawnLocation as WitWorldSpawnLocation,
 };
 use crate::plugin::loader::wasm::wasm_host::{
-    state::{
-        ChunkResource, PluginHostState, TextComponentResource, WorldBorderResource, WorldResource,
-    },
+    state::PluginHostState,
     wit::v0_1::pumpkin::{self, plugin::world::World},
 };
 use crate::world::explosion::ExplosionInteraction;
@@ -138,7 +137,7 @@ fn world_and_plugin(
     Arc<crate::world::World>,
     Arc<crate::plugin::loader::wasm::wasm_host::WasmPlugin>,
 )> {
-    let world = state.get_world_res(world)?.provider.clone();
+    let world = state.get(world)?.clone();
     let plugin = state
         .plugin
         .as_ref()
@@ -312,56 +311,30 @@ pub(crate) fn to_wit_block_state(
 
 // --- Trapping Helpers ---
 impl PluginHostState {
-    pub(crate) fn get_world_res(&self, res: &Resource<World>) -> wasmtime::Result<&WorldResource> {
-        self.resource_table
-            .get::<WorldResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-
-    fn get_chunk_res(&self, res: &Resource<WitChunk>) -> wasmtime::Result<&ChunkResource> {
-        self.resource_table
-            .get::<ChunkResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-
-    fn get_world_border_res(
-        &self,
-        res: &Resource<WitWorldBorder>,
-    ) -> wasmtime::Result<&WorldBorderResource> {
-        self.resource_table
-            .get::<WorldBorderResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)
-    }
-
-    pub(crate) fn get_text_provider(
-        &self,
-        res: &Resource<pumpkin::plugin::text::TextComponent>,
-    ) -> wasmtime::Result<pumpkin_util::text::TextComponent> {
-        Ok(self
-            .resource_table
-            .get::<TextComponentResource>(&Resource::new_own(res.rep()))
-            .map_err(wasmtime::Error::from)?
-            .provider
-            .clone())
-    }
-
     fn get_wit_biome(
         biome: &pumpkin_data::biome::Biome,
     ) -> wasmtime::Result<pumpkin::plugin::biomes::Biome> {
         to_wit_biome(biome)
     }
 
+    #[expect(
+        unused_assignments,
+        reason = "the tail of the macro output will put the Arc back into the `be` variable"
+    )]
     fn get_wit_block_entity(
         &mut self,
         block_entity: Arc<dyn crate::block::entities::BlockEntity>,
     ) -> wasmtime::Result<Option<BlockEntityType>> {
-        let be = block_entity;
+        let mut be = block_entity as _;
         macro_rules! match_be {
             ($( $internal_type:ty => $variant:ident ),* $(,)?) => {
                 $(
-                    if be.as_any().downcast_ref::<$internal_type>().is_some() {
-                        let res: Resource<BlockEntity> = self.add_block_entity(be)?;
-                        return Ok(Some(BlockEntityType::$variant(Resource::new_own(res.rep()))));
+                    // these kind of chains can be expressed in two different ways, I chose this over
+                    // if (&be as &Any).is::<T>() { unsafe { Arc::downcast::<T>(be).unwrap_unchecked() } }
+                    // eventually it would be great if plugin authors had to manually request a specific be type
+                    match Arc::downcast::<$internal_type>(be) {
+                        Ok(entity) => return Ok(Some(BlockEntityType::$variant(self.add(entity)?))),
+                        Err(entity) => be = entity,
                     }
                 )*
             };
@@ -614,11 +587,7 @@ impl pumpkin::plugin::sounds::Host for PluginHostState {}
 
 impl pumpkin::plugin::world::HostWorld for PluginHostState {
     async fn get_id(&mut self, world: Resource<World>) -> wasmtime::Result<String> {
-        Ok(self
-            .get_world_res(&world)?
-            .provider
-            .get_world_name()
-            .to_string())
+        Ok(self.get(&world)?.get_world_name().to_string())
     }
 
     async fn get_border(
@@ -632,15 +601,15 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         &mut self,
         world: Resource<World>,
     ) -> wasmtime::Result<Resource<WitWorldBorder>> {
-        let world_res = self.get_world_res(&world)?;
-        self.add_world_border(world_res.provider.clone())
+        let world_res = self.get(&world)?;
+        self.add(world_res.clone())
     }
 
     async fn get_spawn_location(
         &mut self,
         world: Resource<World>,
     ) -> wasmtime::Result<WitWorldSpawnLocation> {
-        let (pos, yaw, pitch) = self.get_world_res(&world)?.provider.get_spawn_location();
+        let (pos, yaw, pitch) = self.get(&world)?.get_spawn_location();
         Ok(WitWorldSpawnLocation {
             pos: WitBlockPos {
                 x: pos.0.x,
@@ -658,8 +627,8 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         x: i32,
         z: i32,
     ) -> wasmtime::Result<Option<Resource<WitChunk>>> {
-        let world_res = self.get_world_res(&world)?;
-        let world_provider = world_res.provider.clone();
+        let world_res = self.get(&world)?;
+        let world_provider = world_res.clone();
         let pos = pumpkin_util::math::vector2::Vector2::new(x, z);
 
         let chunk = world_provider
@@ -668,7 +637,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
             .get(&pos)
             .map(|c| c.value().clone());
         if let Some(chunk) = chunk {
-            let res = self.add_chunk(world_provider, std::sync::Arc::downgrade(&chunk))?;
+            let res = self.add((world_provider, std::sync::Arc::downgrade(&chunk)))?;
             Ok(Some(res))
         } else {
             Ok(None)
@@ -680,12 +649,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<u16> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
-        Ok(world_ref
-            .provider
-            .get_block_state_id(&internal_pos)
-            .as_u16())
+        Ok(world_ref.get_block_state_id(&internal_pos).as_u16())
     }
 
     async fn get_block_state(
@@ -693,9 +659,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<WitBlockState> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
-        let state = world_ref.provider.get_block_state(&internal_pos);
+        let state = world_ref.get_block_state(&internal_pos);
         Ok(to_wit_block_state(state, Some(&internal_pos)))
     }
 
@@ -704,9 +670,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<WitBlock> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
-        let state = world_ref.provider.get_block_state(&internal_pos);
+        let state = world_ref.get_block_state(&internal_pos);
         let block = pumpkin_data::Block::from_state_id(state.id);
         Ok(to_wit_block(block))
     }
@@ -716,31 +682,28 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<u16> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
-        let state = world_ref.provider.get_block_state(&internal_pos);
+        let state = world_ref.get_block_state(&internal_pos);
         Ok(pumpkin_data::BlockId::from_state_id(state.id).as_u16())
     }
 
     async fn get_time_of_day(&mut self, world: Resource<World>) -> wasmtime::Result<u64> {
-        Ok(self.get_world_res(&world)?.provider.get_time_of_day() as u64)
+        Ok(self.get(&world)?.get_time_of_day() as u64)
     }
 
     async fn set_time_of_day(&mut self, world: Resource<World>, time: u64) -> wasmtime::Result<()> {
-        self.get_world_res(&world)?
-            .provider
-            .set_time_of_day(time as i64);
+        self.get(&world)?.set_time_of_day(time as i64);
         Ok(())
     }
 
     async fn get_world_age(&mut self, world: Resource<World>) -> wasmtime::Result<u64> {
-        Ok(self.get_world_res(&world)?.provider.get_world_age() as u64)
+        Ok(self.get(&world)?.get_world_age() as u64)
     }
 
     async fn get_dimension(&mut self, world: Resource<World>) -> wasmtime::Result<String> {
         Ok(self
-            .get_world_res(&world)?
-            .provider
+            .get(&world)?
             .dimension
             .minecraft_name
             .to_string())
@@ -753,8 +716,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         z: i32,
     ) -> wasmtime::Result<i32> {
         Ok(self
-            .get_world_res(&world)?
-            .provider
+            .get(&world)?
             .get_top_block(pumpkin_util::math::vector2::Vector2::new(x, z)))
     }
 
@@ -764,7 +726,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         x: i32,
         z: i32,
     ) -> wasmtime::Result<i32> {
-        Ok(self.get_world_res(&world)?.provider.get_heightmap_height(
+        Ok(self.get(&world)?.get_heightmap_height(
             ChunkHeightmapType::MotionBlocking,
             x,
             z,
@@ -772,11 +734,11 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
     }
 
     async fn is_raining(&mut self, world: Resource<World>) -> wasmtime::Result<bool> {
-        Ok(self.get_world_res(&world)?.provider.is_raining())
+        Ok(self.get(&world)?.is_raining())
     }
 
     async fn is_thundering(&mut self, world: Resource<World>) -> wasmtime::Result<bool> {
-        Ok(self.get_world_res(&world)?.provider.is_thundering())
+        Ok(self.get(&world)?.is_thundering())
     }
 
     async fn broadcast_system_message(
@@ -785,9 +747,8 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         message: Resource<pumpkin::plugin::text::TextComponent>,
         overlay: bool,
     ) -> wasmtime::Result<()> {
-        let msg = self.get_text_provider(&message)?;
-        self.get_world_res(&world)?
-            .provider
+        let msg = self.get(&message)?;
+        self.get(&world)?
             .broadcast_system_message(&msg, overlay);
         Ok(())
     }
@@ -796,8 +757,8 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         &mut self,
         world: Resource<World>,
     ) -> wasmtime::Result<Resource<pumpkin::plugin::scoreboard::Scoreboard>> {
-        let world_provider = self.get_world_res(&world)?.provider.clone();
-        self.add_scoreboard(
+        let world_provider = self.get(&world)?.clone();
+        self.add(
             crate::plugin::loader::wasm::wasm_host::state::ScoreboardProvider::World(
                 world_provider,
             ),
@@ -813,14 +774,14 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         volume: f32,
         pitch: f32,
     ) -> wasmtime::Result<()> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let sound_name = format!("{sound:?}").to_lowercase().replace('_', ".");
         let sound_data = pumpkin_data::sound::Sound::from_name(&sound_name)
             .ok_or_else(|| wasmtime::Error::msg(format!("Unknown sound: {sound_name}")))?;
 
         let internal_category = from_wit_sound_category(category);
 
-        world_ref.provider.play_sound_raw(
+        world_ref.play_sound_raw(
             sound_data as u16,
             internal_category,
             &pumpkin_util::math::vector3::Vector3::new(pos.0, pos.1, pos.2),
@@ -839,9 +800,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         volume: f32,
         pitch: f32,
     ) -> wasmtime::Result<()> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let internal_category = from_wit_sound_category(category);
-        world_ref.provider.play_custom_sound(
+        world_ref.play_custom_sound(
             &sound_name,
             internal_category,
             &pumpkin_util::math::vector3::Vector3::new(pos.0, pos.1, pos.2),
@@ -860,13 +821,13 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         max_speed: f32,
         count: i32,
     ) -> wasmtime::Result<()> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let particle_data =
             pumpkin_data::particle::Particle::from_id(particle as u16).ok_or_else(|| {
                 wasmtime::Error::msg(format!("Unknown particle ID: {}", particle as u16))
             })?;
 
-        world_ref.provider.spawn_particle(
+        world_ref.spawn_particle(
             pumpkin_util::math::vector3::Vector3::new(pos.0, pos.1, pos.2),
             pumpkin_util::math::vector3::Vector3::new(
                 offset.0 as f32,
@@ -881,11 +842,11 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
     }
 
     async fn get_sea_level(&mut self, world: Resource<World>) -> wasmtime::Result<i32> {
-        Ok(self.get_world_res(&world)?.provider.sea_level)
+        Ok(self.get(&world)?.sea_level)
     }
 
     async fn get_min_y(&mut self, world: Resource<World>) -> wasmtime::Result<i32> {
-        Ok(self.get_world_res(&world)?.provider.min_y)
+        Ok(self.get(&world)?.min_y)
     }
 
     async fn get_sky_light(
@@ -893,9 +854,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<u8> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
-        Ok(world_ref.provider.get_sky_light_level(&internal_pos))
+        Ok(world_ref.get_sky_light_level(&internal_pos))
     }
 
     async fn set_sky_light(
@@ -904,9 +865,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         pos: WitBlockPos,
         level: u8,
     ) -> wasmtime::Result<()> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
-        world_ref.provider.set_sky_light_level(&internal_pos, level);
+        world_ref.set_sky_light_level(&internal_pos, level);
         Ok(())
     }
 
@@ -915,12 +876,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<u8> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
-        Ok(world_ref
-            .provider
-            .get_block_light_level(&internal_pos)
-            .unwrap_or(0))
+        Ok(world_ref.get_block_light_level(&internal_pos).unwrap_or(0))
     }
 
     async fn set_block_light(
@@ -929,11 +887,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         pos: WitBlockPos,
         level: u8,
     ) -> wasmtime::Result<()> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
-        world_ref
-            .provider
-            .set_block_light_level(&internal_pos, level);
+        world_ref.set_block_light_level(&internal_pos, level);
         Ok(())
     }
 
@@ -942,9 +898,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<pumpkin::plugin::biomes::Biome> {
-        let world_ref = self.get_world_res(&world)?;
+        let world_ref = self.get(&world)?;
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
-        let biome = world_ref.provider.get_biome(&internal_pos);
+        let biome = world_ref.get_biome(&internal_pos);
 
         Self::get_wit_biome(biome)
     }
@@ -953,17 +909,17 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         &mut self,
         world: Resource<World>,
     ) -> wasmtime::Result<Vec<Resource<pumpkin::plugin::entity::Entity>>> {
-        let world_provider = self.get_world_res(&world)?.provider.clone();
+        let world_provider = self.get(&world)?.clone();
         let mut entities = Vec::new();
 
         // Add players as entities
         for player in world_provider.players.load().iter() {
-            entities.push(self.add_entity(player.clone() as Arc<dyn crate::entity::EntityBase>)?);
+            entities.push(self.add(player.clone() as Arc<dyn crate::entity::EntityBase>)?);
         }
 
         // Add other entities
         for entity in world_provider.entities.load().iter() {
-            entities.push(self.add_entity(entity.clone())?);
+            entities.push(self.add(entity.clone())?);
         }
 
         Ok(entities)
@@ -975,7 +931,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         start: WitPosition,
         end: WitPosition,
     ) -> wasmtime::Result<Option<WitPosition>> {
-        let world_provider = self.get_world_res(&world)?.provider.clone();
+        let world_provider = self.get(&world)?.clone();
         let start_pos = super::events::from_wasm_position(start);
         let end_pos = super::events::from_wasm_position(end);
         let res = world_provider.raycast(start_pos, end_pos, |pos, w| {
@@ -997,7 +953,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         end: WitPosition,
         include_fluids: bool,
     ) -> wasmtime::Result<Option<WitRayTraceBlockResult>> {
-        let world_provider = self.get_world_res(&world)?.provider.clone();
+        let world_provider = self.get(&world)?.clone();
         let start_pos = super::events::from_wasm_position(start);
         let end_pos = super::events::from_wasm_position(end);
         let res = world_provider.ray_trace_block(start_pos, end_pos, include_fluids);
@@ -1018,14 +974,14 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         start: WitPosition,
         end: WitPosition,
     ) -> wasmtime::Result<Option<WitRayTraceEntityResult>> {
-        let world_provider = self.get_world_res(&world)?.provider.clone();
+        let world_provider = self.get(&world)?.clone();
         let start_pos = super::events::from_wasm_position(start);
         let end_pos = super::events::from_wasm_position(end);
         if let Some((entity, hit_pos, distance)) =
             world_provider.ray_trace_entity(start_pos, end_pos)
         {
             let entity_res = self
-                .add_entity(entity)
+                .add(entity)
                 .map_err(|_| wasmtime::Error::msg("failed to add entity resource"))?;
             Ok(Some(WitRayTraceEntityResult {
                 entity: entity_res,
@@ -1043,14 +999,14 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         start: WitPosition,
         end: WitPosition,
     ) -> wasmtime::Result<Vec<WitRayTraceEntityResult>> {
-        let world_provider = self.get_world_res(&world)?.provider.clone();
+        let world_provider = self.get(&world)?.clone();
         let start_pos = super::events::from_wasm_position(start);
         let end_pos = super::events::from_wasm_position(end);
         let hits = world_provider.ray_trace_entities(start_pos, end_pos);
         let mut results = Vec::with_capacity(hits.len());
         for (entity, hit_pos, distance) in hits {
             let entity_res = self
-                .add_entity(entity)
+                .add(entity)
                 .map_err(|_| wasmtime::Error::msg("failed to add entity resource"))?;
             results.push(WitRayTraceEntityResult {
                 entity: entity_res,
@@ -1066,7 +1022,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<Option<BlockEntityType>> {
-        let world_provider = self.get_world_res(&world)?.provider.clone();
+        let world_provider = self.get(&world)?.clone();
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
         let block_entity = world_provider.get_block_entity(&internal_pos);
 
@@ -1078,7 +1034,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<Option<Vec<u8>>> {
-        let world_ref = self.get_world_res(&world)?.provider.clone();
+        let world_ref = self.get(&world)?.clone();
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
 
         let Some(entity) = world_ref.get_block_entity(&internal_pos) else {
@@ -1098,7 +1054,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         pos: WitBlockPos,
         nbt_data: Vec<u8>,
     ) -> wasmtime::Result<Result<(), String>> {
-        let world_ref = self.get_world_res(&world)?.provider.clone();
+        let world_ref = self.get(&world)?.clone();
         let internal_pos = BlockPos::new(pos.x, pos.y, pos.z);
 
         let mut cursor = std::io::Cursor::new(&nbt_data[..]);
@@ -1126,7 +1082,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         generator_id: u32,
     ) -> wasmtime::Result<()> {
-        let world_ref = self.get_world_res(&world)?.provider.clone();
+        let world_ref = self.get(&world)?.clone();
         let Some(plugin_weak) = self.plugin.as_ref() else {
             return Ok(());
         };
@@ -1152,11 +1108,7 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
     }
 
     async fn get_name(&mut self, world: Resource<World>) -> wasmtime::Result<String> {
-        Ok(self
-            .get_world_res(&world)?
-            .provider
-            .get_world_name()
-            .to_string())
+        Ok(self.get(&world)?.get_world_name().to_string())
     }
 
     async fn set_custom_data(
@@ -1166,9 +1118,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         key: String,
         value: super::common::WitNbtTree,
     ) -> wasmtime::Result<()> {
-        let world_res = self.get_world_res(&world)?;
+        let world_res = self.get(&world)?;
         let tag = super::common::from_wit_nbt_tree(&value).map_err(wasmtime::Error::msg)?;
-        world_res.provider.set_custom_data(&namespace, &key, tag);
+        world_res.set_custom_data(&namespace, &key, tag);
         Ok(())
     }
 
@@ -1178,8 +1130,8 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<Option<super::common::WitNbtTree>> {
-        let world_res = self.get_world_res(&world)?;
-        let tag = world_res.provider.get_custom_data(&namespace, &key);
+        let world_res = self.get(&world)?;
+        let tag = world_res.get_custom_data(&namespace, &key);
         Ok(tag.map(super::common::to_wit_nbt_tree))
     }
 
@@ -1189,8 +1141,8 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<()> {
-        let world_res = self.get_world_res(&world)?;
-        world_res.provider.remove_custom_data(&namespace, &key);
+        let world_res = self.get(&world)?;
+        world_res.remove_custom_data(&namespace, &key);
         Ok(())
     }
 
@@ -1200,8 +1152,8 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<bool> {
-        let world_res = self.get_world_res(&world)?;
-        Ok(world_res.provider.has_custom_data(&namespace, &key))
+        let world_res = self.get(&world)?;
+        Ok(world_res.has_custom_data(&namespace, &key))
     }
 
     async fn get_game_rule(
@@ -1209,9 +1161,9 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         world: Resource<World>,
         rule: WitGameRule,
     ) -> wasmtime::Result<WitGameRuleValue> {
-        let world_res = self.get_world_res(&world)?;
+        let world_res = self.get(&world)?;
         let internal_rule = from_wit_game_rule(rule);
-        let value = world_res.provider.get_game_rule(&internal_rule);
+        let value = world_res.get_game_rule(&internal_rule);
         Ok(to_wit_game_rule_value(&value))
     }
 
@@ -1221,20 +1173,15 @@ impl pumpkin::plugin::world::HostWorld for PluginHostState {
         rule: WitGameRule,
         value: WitGameRuleValue,
     ) -> wasmtime::Result<()> {
-        let world_res = self.get_world_res(&world)?;
+        let world_res = self.get(&world)?;
         let internal_rule = from_wit_game_rule(rule);
         let internal_value = from_wit_game_rule_value(value);
-        world_res
-            .provider
-            .set_game_rule(&internal_rule, internal_value);
+        world_res.set_game_rule(&internal_rule, internal_value);
         Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<World>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<WorldResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -1303,7 +1250,7 @@ impl pumpkin::plugin::world::HostWorldWithStore<PluginHostState> for HasSelf<Plu
             .store
             .pump_blocking(&mut host, move || world.spawn_entity(spawned_entity))
             .await?;
-        host.get().add_entity(entity)
+        host.get().add(entity)
     }
 
     async fn strike_lightning(
@@ -1389,8 +1336,8 @@ impl pumpkin::plugin::world::HostWorldWithStore<PluginHostState> for HasSelf<Plu
 
 impl pumpkin::plugin::world::HostChunk for PluginHostState {
     async fn get_x(&mut self, chunk: Resource<WitChunk>) -> wasmtime::Result<i32> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1398,8 +1345,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
     }
 
     async fn get_z(&mut self, chunk: Resource<WitChunk>) -> wasmtime::Result<i32> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1411,8 +1358,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         chunk: Resource<WitChunk>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<u16> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1428,8 +1375,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         chunk: Resource<WitChunk>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<WitBlockState> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1447,8 +1394,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         chunk: Resource<WitChunk>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<WitBlock> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1493,8 +1440,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         pos: WitBlockPos,
         state: u16,
     ) -> wasmtime::Result<()> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (world, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (world, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1521,8 +1468,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         chunk: Resource<WitChunk>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<pumpkin::plugin::biomes::Biome> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1541,8 +1488,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         chunk: Resource<WitChunk>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<Option<BlockEntityType>> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (world, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (world, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1559,8 +1506,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         x: i32,
         z: i32,
     ) -> wasmtime::Result<i32> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1581,8 +1528,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         chunk: Resource<WitChunk>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<u8> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1603,8 +1550,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         chunk: Resource<WitChunk>,
         pos: WitBlockPos,
     ) -> wasmtime::Result<u8> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1627,8 +1574,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         key: String,
         value: super::common::WitNbtTree,
     ) -> wasmtime::Result<()> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1643,8 +1590,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<Option<super::common::WitNbtTree>> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1658,8 +1605,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<()> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1673,8 +1620,8 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
         namespace: String,
         key: String,
     ) -> wasmtime::Result<bool> {
-        let chunk_res = self.get_chunk_res(&chunk)?;
-        let (_, chunk_data) = &chunk_res.provider;
+        let chunk_res = self.get(&chunk)?;
+        let (_, chunk_data) = &chunk_res;
         let Some(chunk_data) = chunk_data.upgrade() else {
             return Err(wasmtime::Error::msg("Chunk unloaded"));
         };
@@ -1682,18 +1629,14 @@ impl pumpkin::plugin::world::HostChunk for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<WitChunk>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<ChunkResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 
 impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
     async fn get_center_x(&mut self, border: Resource<WitWorldBorder>) -> wasmtime::Result<f64> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1701,9 +1644,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
     }
 
     async fn get_center_z(&mut self, border: Resource<WitWorldBorder>) -> wasmtime::Result<f64> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1714,9 +1656,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         &mut self,
         border: Resource<WitWorldBorder>,
     ) -> wasmtime::Result<WitPosition> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         let guard = border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -1731,8 +1672,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         x: f64,
         z: f64,
     ) -> wasmtime::Result<()> {
-        let border_res = self.get_world_border_res(&border)?;
-        let world = border_res.provider.clone();
+        let border_res = self.get(&border)?;
+        let world = border_res.clone();
         world
             .worldborder
             .lock()
@@ -1742,9 +1683,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
     }
 
     async fn get_diameter(&mut self, border: Resource<WitWorldBorder>) -> wasmtime::Result<f64> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1761,8 +1701,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         diameter: f64,
         speed: Option<u64>,
     ) -> wasmtime::Result<()> {
-        let border_res = self.get_world_border_res(&border)?;
-        let world = border_res.provider.clone();
+        let border_res = self.get(&border)?;
+        let world = border_res.clone();
         world
             .worldborder
             .lock()
@@ -1794,9 +1734,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         &mut self,
         border: Resource<WitWorldBorder>,
     ) -> wasmtime::Result<f64> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1807,9 +1746,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         &mut self,
         border: Resource<WitWorldBorder>,
     ) -> wasmtime::Result<i64> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1820,9 +1758,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         &mut self,
         border: Resource<WitWorldBorder>,
     ) -> wasmtime::Result<i32> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1834,8 +1771,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         border: Resource<WitWorldBorder>,
         distance: i32,
     ) -> wasmtime::Result<()> {
-        let border_res = self.get_world_border_res(&border)?;
-        let world = border_res.provider.clone();
+        let border_res = self.get(&border)?;
+        let world = border_res.clone();
         world
             .worldborder
             .lock()
@@ -1848,9 +1785,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         &mut self,
         border: Resource<WitWorldBorder>,
     ) -> wasmtime::Result<i32> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1862,8 +1798,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         border: Resource<WitWorldBorder>,
         delay: i32,
     ) -> wasmtime::Result<()> {
-        let border_res = self.get_world_border_res(&border)?;
-        let world = border_res.provider.clone();
+        let border_res = self.get(&border)?;
+        let world = border_res.clone();
         world
             .worldborder
             .lock()
@@ -1891,10 +1827,9 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         &mut self,
         border: Resource<WitWorldBorder>,
     ) -> wasmtime::Result<f64> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(f64::from(
             border_res
-                .provider
                 .worldborder
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1907,9 +1842,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         border: Resource<WitWorldBorder>,
         buffer: f64,
     ) -> wasmtime::Result<()> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1921,10 +1855,9 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         &mut self,
         border: Resource<WitWorldBorder>,
     ) -> wasmtime::Result<f64> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(f64::from(
             border_res
-                .provider
                 .worldborder
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1937,9 +1870,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         border: Resource<WitWorldBorder>,
         damage: f64,
     ) -> wasmtime::Result<()> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1953,9 +1885,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         x: f64,
         z: f64,
     ) -> wasmtime::Result<bool> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1967,9 +1898,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
         border: Resource<WitWorldBorder>,
         pos: WitPosition,
     ) -> wasmtime::Result<bool> {
-        let border_res = self.get_world_border_res(&border)?;
+        let border_res = self.get(&border)?;
         Ok(border_res
-            .provider
             .worldborder
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1977,8 +1907,8 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
     }
 
     async fn reset(&mut self, border: Resource<WitWorldBorder>) -> wasmtime::Result<()> {
-        let border_res = self.get_world_border_res(&border)?;
-        let world = border_res.provider.clone();
+        let border_res = self.get(&border)?;
+        let world = border_res.clone();
         world
             .worldborder
             .lock()
@@ -1988,10 +1918,7 @@ impl pumpkin::plugin::world::HostWorldBorder for PluginHostState {
     }
 
     async fn drop(&mut self, rep: Resource<WitWorldBorder>) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<WorldBorderResource>(Resource::new_own(rep.rep()))
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -2000,32 +1927,32 @@ impl pumpkin::plugin::world::HostChunkBuffer for PluginHostState {
         &mut self,
         this: Resource<pumpkin::plugin::world::ChunkBuffer>,
     ) -> wasmtime::Result<i32> {
-        let res = self.get_chunk_buffer_res(&this)?;
-        Ok(res.provider.x)
+        let res = self.get(&this)?;
+        Ok(res.x)
     }
 
     async fn get_z(
         &mut self,
         this: Resource<pumpkin::plugin::world::ChunkBuffer>,
     ) -> wasmtime::Result<i32> {
-        let res = self.get_chunk_buffer_res(&this)?;
-        Ok(res.provider.z)
+        let res = self.get(&this)?;
+        Ok(res.z)
     }
 
     async fn get_min_y(
         &mut self,
         this: Resource<pumpkin::plugin::world::ChunkBuffer>,
     ) -> wasmtime::Result<i32> {
-        let res = self.get_chunk_buffer_res(&this)?;
-        Ok(res.provider.min_y)
+        let res = self.get(&this)?;
+        Ok(res.min_y)
     }
 
     async fn get_height(
         &mut self,
         this: Resource<pumpkin::plugin::world::ChunkBuffer>,
     ) -> wasmtime::Result<u32> {
-        let res = self.get_chunk_buffer_res(&this)?;
-        Ok(res.provider.height)
+        let res = self.get(&this)?;
+        Ok(res.height)
     }
 
     async fn set_block_state_id(
@@ -2036,16 +1963,13 @@ impl pumpkin::plugin::world::HostChunkBuffer for PluginHostState {
         z: u8,
         state_id: u16,
     ) -> wasmtime::Result<()> {
-        let res = self.get_chunk_buffer_res(&this)?;
+        let res = self.get(&this)?;
         if x < 16 && z < 16 {
             let world_x =
-                pumpkin_world::generation::positions::chunk_pos::start_block_x(res.provider.x)
-                    + x as i32;
+                pumpkin_world::generation::positions::chunk_pos::start_block_x(res.x) + x as i32;
             let world_z =
-                pumpkin_world::generation::positions::chunk_pos::start_block_z(res.provider.z)
-                    + z as i32;
+                pumpkin_world::generation::positions::chunk_pos::start_block_z(res.z) + z as i32;
             let mut proto = res
-                .provider
                 .proto_chunk
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2065,10 +1989,9 @@ impl pumpkin::plugin::world::HostChunkBuffer for PluginHostState {
         y: i32,
         z: u8,
     ) -> wasmtime::Result<u16> {
-        let res = self.get_chunk_buffer_res(&this)?;
+        let res = self.get(&this)?;
         if x < 16 && z < 16 {
             let proto = res
-                .provider
                 .proto_chunk
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2091,16 +2014,13 @@ impl pumpkin::plugin::world::HostChunkBuffer for PluginHostState {
         y: i32,
         state_id: u16,
     ) -> wasmtime::Result<()> {
-        let res = self.get_chunk_buffer_res(&this)?;
-        let start_x =
-            pumpkin_world::generation::positions::chunk_pos::start_block_x(res.provider.x);
-        let start_z =
-            pumpkin_world::generation::positions::chunk_pos::start_block_z(res.provider.z);
+        let res = self.get(&this)?;
+        let start_x = pumpkin_world::generation::positions::chunk_pos::start_block_x(res.x);
+        let start_z = pumpkin_world::generation::positions::chunk_pos::start_block_z(res.z);
         let block_state = pumpkin_data::BlockState::from_id(
             pumpkin_data::BlockStateId::new(state_id).unwrap_or(pumpkin_data::BlockStateId::AIR),
         );
         let mut proto = res
-            .provider
             .proto_chunk
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2121,20 +2041,17 @@ impl pumpkin::plugin::world::HostChunkBuffer for PluginHostState {
         z: u8,
         state_id: u16,
     ) -> wasmtime::Result<()> {
-        let res = self.get_chunk_buffer_res(&this)?;
+        let res = self.get(&this)?;
         if x < 16 && z < 16 {
             let world_x =
-                pumpkin_world::generation::positions::chunk_pos::start_block_x(res.provider.x)
-                    + x as i32;
+                pumpkin_world::generation::positions::chunk_pos::start_block_x(res.x) + x as i32;
             let world_z =
-                pumpkin_world::generation::positions::chunk_pos::start_block_z(res.provider.z)
-                    + z as i32;
+                pumpkin_world::generation::positions::chunk_pos::start_block_z(res.z) + z as i32;
             let block_state = pumpkin_data::BlockState::from_id(
                 pumpkin_data::BlockStateId::new(state_id)
                     .unwrap_or(pumpkin_data::BlockStateId::AIR),
             );
             let mut proto = res
-                .provider
                 .proto_chunk
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2156,16 +2073,13 @@ impl pumpkin::plugin::world::HostChunkBuffer for PluginHostState {
         max_z: u8,
         state_id: u16,
     ) -> wasmtime::Result<()> {
-        let res = self.get_chunk_buffer_res(&this)?;
-        let start_x =
-            pumpkin_world::generation::positions::chunk_pos::start_block_x(res.provider.x);
-        let start_z =
-            pumpkin_world::generation::positions::chunk_pos::start_block_z(res.provider.z);
+        let res = self.get(&this)?;
+        let start_x = pumpkin_world::generation::positions::chunk_pos::start_block_x(res.x);
+        let start_z = pumpkin_world::generation::positions::chunk_pos::start_block_z(res.z);
         let block_state = pumpkin_data::BlockState::from_id(
             pumpkin_data::BlockStateId::new(state_id).unwrap_or(pumpkin_data::BlockStateId::AIR),
         );
         let mut proto = res
-            .provider
             .proto_chunk
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2189,11 +2103,10 @@ impl pumpkin::plugin::world::HostChunkBuffer for PluginHostState {
         z: u8,
         biome: pumpkin::plugin::biomes::Biome,
     ) -> wasmtime::Result<()> {
-        let res = self.get_chunk_buffer_res(&this)?;
+        let res = self.get(&this)?;
         if x < 16 && z < 16 {
             let biome_id = biome as u8;
             let mut proto = res
-                .provider
                 .proto_chunk
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2215,10 +2128,9 @@ impl pumpkin::plugin::world::HostChunkBuffer for PluginHostState {
         this: Resource<pumpkin::plugin::world::ChunkBuffer>,
         biome: pumpkin::plugin::biomes::Biome,
     ) -> wasmtime::Result<()> {
-        let res = self.get_chunk_buffer_res(&this)?;
+        let res = self.get(&this)?;
         let biome_id = biome as u8;
         let mut proto = res
-            .provider
             .proto_chunk
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2230,12 +2142,7 @@ impl pumpkin::plugin::world::HostChunkBuffer for PluginHostState {
         &mut self,
         rep: Resource<pumpkin::plugin::world::ChunkBuffer>,
     ) -> wasmtime::Result<()> {
-        self.resource_table
-            .delete::<crate::plugin::loader::wasm::wasm_host::state::ChunkBufferResource>(
-                Resource::new_own(rep.rep()),
-            )
-            .map_err(wasmtime::Error::from)?;
-        Ok(())
+        self.drop(rep)
     }
 }
 
@@ -2303,7 +2210,7 @@ impl WasmChunkGenerator {
                 .call_guest(move |mut guest| {
                     Box::pin(async move {
                         let (buffer_resource, buffer_rep) = guest.with(|mut store| {
-                            let resource = store.data_mut().add_chunk_buffer(chunk_buffer)?;
+                            let resource = store.data_mut().add(chunk_buffer)?;
                             let rep = resource.rep();
                             Ok::<_, wasmtime::Error>((resource, rep))
                         })?;
@@ -2311,9 +2218,7 @@ impl WasmChunkGenerator {
                             .call(function, (generator_id, phase, buffer_resource))
                             .await;
                         guest.with(|mut store| {
-                            let _ = store.data_mut().resource_table.delete::<
-                                crate::plugin::loader::wasm::wasm_host::state::ChunkBufferResource,
-                            >(wasmtime::component::Resource::new_own(buffer_rep));
+                            let _ = store.data_mut().resource_table.delete::<ChunkBuffer>(wasmtime::component::Resource::new_own(buffer_rep));
                         });
                         result
                     })

--- a/crates/pumpkin/src/server/scheduler.rs
+++ b/crates/pumpkin/src/server/scheduler.rs
@@ -214,7 +214,9 @@ impl TaskScheduler {
                             })?;
                             let result = guest.call(function, (handler_id, server_resource)).await;
                             guest.with(|mut store| {
-                                let _ = store.data_mut().resource_table.delete::<Arc<Server>>(wasmtime::component::Resource::new_own(server_rep));
+                                let _ = store.data_mut().resource_table.delete::<Arc<Server>>(
+                                    wasmtime::component::Resource::new_own(server_rep),
+                                );
                             });
                             result
                         })

--- a/crates/pumpkin/src/server/scheduler.rs
+++ b/crates/pumpkin/src/server/scheduler.rs
@@ -208,15 +208,13 @@ impl TaskScheduler {
                     .call_guest(move |mut guest| {
                         Box::pin(async move {
                             let (server_resource, server_rep) = guest.with(|mut store| {
-                                let resource = store.data_mut().add_server(server_clone)?;
+                                let resource = store.data_mut().add(server_clone)?;
                                 let rep = resource.rep();
                                 Ok::<_, wasmtime::Error>((resource, rep))
                             })?;
                             let result = guest.call(function, (handler_id, server_resource)).await;
                             guest.with(|mut store| {
-                                let _ = store.data_mut().resource_table.delete::<
-                                    crate::plugin::loader::wasm::wasm_host::state::ServerResource,
-                                >(wasmtime::component::Resource::new_own(server_rep));
+                                let _ = store.data_mut().resource_table.delete::<Arc<Server>>(wasmtime::component::Resource::new_own(server_rep));
                             });
                             result
                         })


### PR DESCRIPTION
## Description
Adds a `FromResource` trait that strongly ties `wasmtime::Resource<T>` to an internal type, then refactors all wasm-host impls to go through methods generic over `FromResource`.

This should make it impossible to accidentally create wrongly typed resources, and in the future should prevent deleting non-owned resources.
(That's not the case yet for `wasm_host::wit::v0_1::events`, there will be a follow-up PR for those)

## Changes
- Replaces the separate `get_X`, `get_X_mut`, `add_X` with one generic method `get`, `add`, `take`
- Removes the `ResourceProvider<T>` struct in favor of directly using the `T` as our internal representation
- implements `FromResource` for every WASM resource
  - Changes the internal representation of specific BlockEntities from `Arc<dyn BlockEntity>` to `Arc<T>` for the actual BlockEntity type `T`, removing the need to downcast per-call
- Properly deletes (`take()`s) Resource handles passed back from the guest that said guest can no longer access

Unless explicitly stated in the wit via `borrow<some-resource-type>`, all resources passed back to the host are owned[^1]. When a guest passes an owned resource back to the host, it loses access to said resource. The host has to delete them, otherwise they continue taking up slots in the resource table & ram.

[^1]: the "self/this" parameter on resource-methods is always borrowed, except for `drop()`.

While I did manually go through every single host-trait method to check for missing clean-up, It's possible that I might have missed some Resources embedded in other structs. I can't think of a good way to check against that, other than maybe panicking in `.get<T: FromResource>()` if the passed Resource is owned (which wouldn't be correct, it's fine to access a resource from an owned handle without taking it, but realistically I don't think it happens).

## Todo
As previously mentioned, event cleanup still needs to be migrated to this new system. It currently "cleans" an `&Event`, and for correctness the new methods require an owned Resource handle value (that also was created through `Resource::new_own()`) for Resource deletion.

## Testing

- [x] `cargo check && cargo clippy && cargo fmt --check`
- A very minimal plugin I wrote works just fine. I would appreciate if someone else could test their plugins too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified WASM plugin resource handling across servers, players, entities, inventories, events, forms, displays, and world features.
  - Resource creation, access, transfer, and cleanup now follow consistent lifecycle behavior.
  - Existing plugin operations and event data flows are preserved.
  - Removed legacy typed resource wrappers and specialized lookup methods in favor of generalized resource access.
  - Improved cleanup handling for plugin tasks, events, commands, and host-managed resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->