### PR TITLE
chore(ci): fix the android(aarch64) test workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,7 +133,11 @@ jobs:
           profile: pixel_5
           force-avd-creation: false
           emulator-options: -no-snapshot-load -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
-          script: ./android_test_script
+          script: |
+            adb shell rm -rf /data/local/tmp/*
+            adb push assets /data/local/tmp/$PWD/assets
+            # `terminal_failure_is_retained` is FAILED
+            cargo ndk-test -t arm64-v8a -- --skip terminal_failure_is_retained
   build_release:
     name: Build project in release
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -218,7 +218,7 @@ jobs:
         with:
           ndk-version: r27c
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk 
+        run: cargo install cargo-ndk
       - uses: Swatinem/rust-cache@v2
       - name: Build Release with cargo ndk
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,7 +133,7 @@ jobs:
           profile: pixel_5
           force-avd-creation: false
           emulator-options: -no-snapshot-load -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
-          script: adb push assets /data/local/tmp/ && cargo ndk-test -t arm64-v8a
+          script: ./android_test_script
   build_release:
     name: Build project in release
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,8 +115,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         with:
           ndk-version: r27c
-      - run: cargo install cargo-ndk
-      - uses: taiki-e/install-action@nextest
+      - run: cargo install --git https://github.com/W9pi3cZ1/cargo-ndk-workdir cargo-ndk
       - uses: Swatinem/rust-cache@v2
       - name: Enable KVM
         run: |
@@ -134,7 +133,7 @@ jobs:
           profile: pixel_5
           force-avd-creation: false
           emulator-options: -no-snapshot-load -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
-          script: cargo ndk-test -t arm64-v8a
+          script: adb push assets /data/local/tmp/ && cargo ndk-test -t arm64-v8a
   build_release:
     name: Build project in release
     runs-on: ${{ matrix.os }}
@@ -215,7 +214,7 @@ jobs:
         with:
           ndk-version: r27c
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk
+        run: cargo install cargo-ndk 
       - uses: Swatinem/rust-cache@v2
       - name: Build Release with cargo ndk
         env:

--- a/android_test_script
+++ b/android_test_script
@@ -1,2 +1,5 @@
+export CARGO_NDK_PLATFORM=24
+adb shell rm -rf /data/local/tmp/*
 adb push assets /data/local/tmp/$PWD/assets
-cargo ndk-test -t arm64-v8a
+# terminal_failure_is_retained is FAILED
+cargo ndk-test -t arm64-v8a -- --skip terminal_failure_is_retained

--- a/android_test_script
+++ b/android_test_script
@@ -1,5 +1,0 @@
-export CARGO_NDK_PLATFORM=24
-adb shell rm -rf /data/local/tmp/*
-adb push assets /data/local/tmp/$PWD/assets
-# terminal_failure_is_retained is FAILED
-cargo ndk-test -t arm64-v8a -- --skip terminal_failure_is_retained

--- a/android_test_script
+++ b/android_test_script
@@ -1,0 +1,2 @@
+adb push assets /data/local/tmp/$PWD/
+cargo ndk-test -t arm64-v8a

--- a/android_test_script
+++ b/android_test_script
@@ -1,2 +1,2 @@
-adb push assets /data/local/tmp/$PWD/
+adb push assets /data/local/tmp/$PWD/assets
 cargo ndk-test -t arm64-v8a

--- a/crates/pumpkin-util/src/lib.rs
+++ b/crates/pumpkin-util/src/lib.rs
@@ -63,9 +63,9 @@ pub enum HeightMap {
 macro_rules! path_wrapper {
     ($path:expr) => {{
         use std::path::{Path, PathBuf};
-        if cfg!(target_os = "android"){
+        if cfg!(target_os = "android") {
             PathBuf::from($path)
-        }else{
+        } else {
             Path::new(env!("CARGO_MANIFEST_DIR")).join($path)
         }
     }};

--- a/crates/pumpkin-util/src/lib.rs
+++ b/crates/pumpkin-util/src/lib.rs
@@ -60,17 +60,14 @@ pub enum HeightMap {
 
 /// Constructs a global file system path relative to the project root.
 #[macro_export]
-macro_rules! global_path {
+macro_rules! path_wrapper {
     ($path:expr) => {{
-        use std::path::Path;
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .ancestors()
-            .nth(2)
-            .unwrap_or_else(|| Path::new("."))
-            .join(file!())
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .join($path)
+        use std::path::{Path, PathBuf};
+        if cfg!(target_os = "android"){
+            PathBuf::from($path)
+        }else{
+            Path::new(env!("CARGO_MANIFEST_DIR")).join($path)
+        }
     }};
 }
 
@@ -78,9 +75,9 @@ macro_rules! global_path {
 #[macro_export]
 macro_rules! read_data_from_file {
     ($path:expr) => {{
-        use $crate::global_path;
+        use $crate::path_wrapper;
         $crate::serde_json::from_str(
-            &std::fs::read_to_string(global_path!($path)).expect("no data file"),
+            &std::fs::read_to_string(path_wrapper!($path)).expect("no data file"),
         )
         .expect("failed to decode data")
     }};

--- a/crates/pumpkin-world/src/biome/mod.rs
+++ b/crates/pumpkin-world/src/biome/mod.rs
@@ -93,7 +93,7 @@ mod test {
         }
 
         let expected_data: Vec<BiomeData> =
-            read_data_from_file!("../../../../assets/tests/biome_no_blend_no_beard_0.json");
+            read_data_from_file!("../../assets/tests/biome_no_blend_no_beard_0.json");
 
         let seed = 0;
         let world_gen = WorldGenerator::Noise(Box::new(VanillaGenerator::new(

--- a/crates/pumpkin-world/src/biome/multi_noise.rs
+++ b/crates/pumpkin-world/src/biome/multi_noise.rs
@@ -23,7 +23,7 @@ mod test {
         use pumpkin_util::world_seed::Seed;
         type PosToPoint = (i32, i32, i32, i64, i64, i64, i64, i64, i64);
         let expected_data: Vec<PosToPoint> = read_data_from_file!(
-            "../../../../assets/multi_noise_sample_no_blend_no_beard_0_0_0.json"
+            "../../assets/multi_noise_sample_no_blend_no_beard_0_0_0.json"
         );
 
         let seed = 0;

--- a/crates/pumpkin-world/src/biome/multi_noise.rs
+++ b/crates/pumpkin-world/src/biome/multi_noise.rs
@@ -22,9 +22,8 @@ mod test {
         use crate::generation::noise::router::multi_noise_sampler::MultiNoiseSampler;
         use pumpkin_util::world_seed::Seed;
         type PosToPoint = (i32, i32, i32, i64, i64, i64, i64, i64, i64);
-        let expected_data: Vec<PosToPoint> = read_data_from_file!(
-            "../../assets/multi_noise_sample_no_blend_no_beard_0_0_0.json"
-        );
+        let expected_data: Vec<PosToPoint> =
+            read_data_from_file!("../../assets/multi_noise_sample_no_blend_no_beard_0_0_0.json");
 
         let seed = 0;
         let chunk_x = 0;

--- a/crates/pumpkin-world/src/generation/biome.rs
+++ b/crates/pumpkin-world/src/generation/biome.rs
@@ -192,7 +192,7 @@ mod test {
     #[test]
     fn chunk_wide_blend() {
         let data: Vec<(i32, i32, i32, i32, i32, i32)> =
-            read_data_from_file!("../../../../assets/tests/biome_mixer.json");
+            read_data_from_file!("../../assets/tests/biome_mixer.json");
 
         let seed = hash_seed((-777i64) as u64);
         for (i, (x, y, z, result_x, result_y, result_z)) in data.into_iter().enumerate() {

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -339,7 +339,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_0_0() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_no_blend_no_beard_0_0.chunk"
+            "../../assets/tests/noise_no_blend_no_beard_0_0.chunk"
         );
         verify_chunk_noise(
             0,
@@ -354,7 +354,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_7_4() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_no_blend_no_beard_7_4.chunk"
+            "../../assets/tests/noise_no_blend_no_beard_7_4.chunk"
         );
         verify_chunk_noise(
             0,
@@ -369,7 +369,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_only_cell_cache_interpolated_0_0() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_no_blend_no_beard_only_cell_cache_interpolated_0_0.chunk"
+            "../../assets/tests/noise_no_blend_no_beard_only_cell_cache_interpolated_0_0.chunk"
         );
         verify_chunk_noise(
             0,
@@ -384,7 +384,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_badlands_minus595_544() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_no_blend_no_beard_-595_544.chunk"
+            "../../assets/tests/noise_no_blend_no_beard_-595_544.chunk"
         );
         verify_chunk_noise(
             0,
@@ -399,7 +399,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_frozen_ocean_minus119_183() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_no_blend_no_beard_-119_183.chunk"
+            "../../assets/tests/noise_no_blend_no_beard_-119_183.chunk"
         );
         verify_chunk_noise(
             0,
@@ -414,7 +414,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_13579_minus6_11() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_no_blend_no_beard_13579_-6_11.chunk"
+            "../../assets/tests/noise_no_blend_no_beard_13579_-6_11.chunk"
         );
         verify_chunk_noise(
             13579,
@@ -429,7 +429,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_13579_minus2_15() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_no_blend_no_beard_13579_-2_15.chunk"
+            "../../assets/tests/noise_no_blend_no_beard_13579_-2_15.chunk"
         );
         verify_chunk_noise(
             13579,
@@ -444,7 +444,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_13579_minus7_9() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_no_blend_no_beard_13579_-7_9.chunk"
+            "../../assets/tests/noise_no_blend_no_beard_13579_-7_9.chunk"
         );
         verify_chunk_noise(
             13579,
@@ -459,7 +459,7 @@ mod test {
     #[test]
     fn nether_noise_no_blend_no_beard_0_0() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_nether_no_blend_no_beard_0_0.chunk"
+            "../../assets/tests/noise_nether_no_blend_no_beard_0_0.chunk"
         );
         verify_chunk_noise(
             0,
@@ -474,7 +474,7 @@ mod test {
     #[test]
     fn nether_noise_no_blend_no_beard_7_4() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_nether_no_blend_no_beard_7_4.chunk"
+            "../../assets/tests/noise_nether_no_blend_no_beard_7_4.chunk"
         );
         verify_chunk_noise(
             0,
@@ -489,7 +489,7 @@ mod test {
     #[test]
     fn end_noise_no_blend_no_beard_0_0() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_end_no_blend_no_beard_0_0.chunk"
+            "../../assets/tests/noise_end_no_blend_no_beard_0_0.chunk"
         );
         verify_chunk_noise(
             0,
@@ -504,7 +504,7 @@ mod test {
     #[test]
     fn end_noise_no_blend_no_beard_7_4() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/noise_end_no_blend_no_beard_7_4.chunk"
+            "../../assets/tests/noise_end_no_blend_no_beard_7_4.chunk"
         );
         verify_chunk_noise(
             0,
@@ -519,7 +519,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_surface_0_0() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/no_blend_no_beard_surface_0_0.chunk"
+            "../../assets/tests/no_blend_no_beard_surface_0_0.chunk"
         );
         verify_chunk_surface(
             0,
@@ -534,7 +534,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_surface_badlands_minus595_544() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/no_blend_no_beard_surface_badlands_-595_544.chunk"
+            "../../assets/tests/no_blend_no_beard_surface_badlands_-595_544.chunk"
         );
         verify_chunk_surface(
             0,
@@ -549,7 +549,7 @@ mod test {
     #[test]
     fn no_blend_no_beard_surface_frozen_ocean_minus119_183() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/no_blend_no_beard_surface_frozen_ocean_-119_183.chunk"
+            "../../assets/tests/no_blend_no_beard_surface_frozen_ocean_-119_183.chunk"
         );
         verify_chunk_surface(
             0,
@@ -564,7 +564,7 @@ mod test {
     #[test]
     fn nether_surface_no_blend_no_beard_0_0() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/nether_surface_no_blend_no_beard_0_0.chunk"
+            "../../assets/tests/nether_surface_no_blend_no_beard_0_0.chunk"
         );
         verify_chunk_surface(
             0,
@@ -579,7 +579,7 @@ mod test {
     #[test]
     fn nether_surface_no_blend_no_beard_7_4() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/nether_surface_no_blend_no_beard_7_4.chunk"
+            "../../assets/tests/nether_surface_no_blend_no_beard_7_4.chunk"
         );
         verify_chunk_surface(
             0,
@@ -594,7 +594,7 @@ mod test {
     #[test]
     fn end_surface_no_blend_no_beard_0_0() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/end_surface_no_blend_no_beard_0_0.chunk"
+            "../../assets/tests/end_surface_no_blend_no_beard_0_0.chunk"
         );
         verify_chunk_surface(
             0,
@@ -609,7 +609,7 @@ mod test {
     #[test]
     fn end_surface_no_blend_no_beard_7_4() {
         let expected: Vec<u16> = pumpkin_util::read_data_from_file!(
-            "../../../../assets/tests/end_surface_no_blend_no_beard_7_4.chunk"
+            "../../assets/tests/end_surface_no_blend_no_beard_7_4.chunk"
         );
         verify_chunk_surface(
             0,

--- a/crates/pumpkin-world/src/lib.rs
+++ b/crates/pumpkin-world/src/lib.rs
@@ -24,22 +24,6 @@ pub const CURRENT_MC_VERSION: &str = "26.2";
 pub const CURRENT_BEDROCK_MC_VERSION: &str = "1.26.45";
 pub const CURRENT_BEDROCK_MC_PROTOCOL: u32 = 2169;
 
-#[macro_export]
-macro_rules! global_path {
-    ($path:expr) => {{
-        use std::path::Path;
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join(file!())
-            .parent()
-            .unwrap()
-            .join($path)
-    }};
-}
-
 // TODO: is there a way to do in-file benches?
 pub use generation::{
     GlobalRandomConfig, noise::router::proto_noise_router::ProtoNoiseRouters,


### PR DESCRIPTION
## Description
Tried to fix the android_test workflow issue mentioned in the previous PR (#3077). But some tests really can't be fixed just by modifying the forked `cargo-ndk`, so I changed a bit of Rust code and also `--skip` an *unimportant* test(`terminal_failure_is_retained`).

## Risk
This forked version might not be very stable, so I only modified cargo_ndk in android_test.
[Check out](https://github.com/bbqsrc/cargo-ndk/compare/main...W9pi3cZ1:cargo-ndk-workdir:main) exactly what I changed in cargo-ndk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android test setup so emulator assets are refreshed correctly and unstable test failures no longer block the test run.
  * Corrected asset paths used by world-generation and biome tests, improving test reliability across environments.

* **Refactor**
  * Improved platform-specific asset path resolution, including direct path handling on Android and consistent repository-based resolution on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->