### PR TITLE
fix(inventory): swap stacks between hovered slot and hotbar when hovered slot is occupied

### DIFF
--- a/crates/pumpkin-inventory/src/screen_handler.rs
+++ b/crates/pumpkin-inventory/src/screen_handler.rs
@@ -1175,6 +1175,11 @@ pub trait ScreenHandler: Send + Sync {
                             .set_stack(button as usize, ItemStack::EMPTY.clone());
                         source_slot.set_stack(button_stack);
                     }
+                } else if source_slot.can_insert(&button_stack) {
+                    player
+                        .get_inventory()
+                        .set_stack(button as usize, source_stack);
+                    source_slot.set_stack(button_stack);
                 }
             }
         }


### PR DESCRIPTION
Adds support for swapping an occupied, hovered inventory slot with an occupied hotbar slot using the corresponding number key.

Previously, swapping only worked when either the inventory slot or the hotbar slot was empty. Now, when both slots contain an item, their stacks are exchanged if the target slot accepts the hotbar stack.

This matches vanilla Minecraft's inventory behavior.

