### PR TITLE
fix(worldgen): stop overworld biomes leaking into other dimensions

### DIFF
--- a/crates/pumpkin-world/src/biome/mod.rs
+++ b/crates/pumpkin-world/src/biome/mod.rs
@@ -17,8 +17,14 @@ pub use pumpkin_data::chunk::{
 };
 
 thread_local! {
-    /// A shortcut; check if last used biome is what we should use
-    static LAST_RESULT_NODE: RefCell<Option<&'static BiomeTree>> = const {RefCell::new(None) };
+    /// A shortcut; check if last used biome is what we should use.
+    ///
+    /// Keyed by the tree the leaf came from. `BiomeTree::get` seeds its search distance from
+    /// this leaf and only accepts strictly closer nodes, so a leaf cached from one dimension's
+    /// tree would otherwise beat every node of another's and be returned unchanged. Vanilla
+    /// stores `lastResult` on the `RTree` itself rather than sharing one across all of them.
+    static LAST_RESULT_NODE: RefCell<Option<(&'static BiomeTree, &'static BiomeTree)>> =
+        const { RefCell::new(None) };
 }
 
 pub trait BiomeSupplier {
@@ -53,7 +59,13 @@ impl BiomeSupplier for MultiNoiseBiomeSupplier {
     fn biome(&self, x: i32, y: i32, z: i32, noise: &mut MultiNoiseSampler<'_>) -> &'static Biome {
         let point = noise.sample(x, y, z);
         let point_list = point.convert_to_list();
-        LAST_RESULT_NODE.with_borrow_mut(|last_result| self.source.get(&point_list, last_result))
+        LAST_RESULT_NODE.with_borrow_mut(|last_result| {
+            let mut node = last_result
+                .and_then(|(tree, node)| std::ptr::eq(tree, self.source).then_some(node));
+            let biome = self.source.get(&point_list, &mut node);
+            *last_result = node.map(|node| (self.source, node));
+            biome
+        })
     }
 }
 
@@ -248,6 +260,61 @@ mod test {
         assert!(
             Biome::from_id(id_to_test).is_none(),
             "We need to update our constants!"
+        );
+    }
+
+    /// A leaf cached from one dimension's biome tree must never seed another dimension's
+    /// search, or the Nether fills with overworld biomes (and their mobs and features).
+    #[test]
+    fn nether_chunks_only_contain_nether_biomes() {
+        use crate::generation::generator::{GeneratorInit, VanillaGenerator, WorldGenerator};
+        use crate::generation::noise::router::multi_noise_sampler::MultiNoiseSampler;
+        use pumpkin_util::world_seed::Seed;
+
+        let fill = |dimension: Dimension, chunk_x: i32, chunk_z: i32| -> Vec<u8> {
+            let world_gen =
+                WorldGenerator::Noise(Box::new(VanillaGenerator::new(Seed(0), dimension)));
+            let WorldGenerator::Noise(generator) = &world_gen else {
+                unreachable!()
+            };
+            let mut chunk = ProtoChunk::new(chunk_x, chunk_z, &world_gen);
+            let mut sampler = MultiNoiseSampler::generate(&generator.base_router.multi_noise);
+            chunk.populate_biomes(generator, &mut sampler);
+            let mut biomes = Vec::new();
+            for y in 0..8 {
+                for x in 0..4 {
+                    for z in 0..4 {
+                        biomes.push(chunk.get_biome(x, y, z).id);
+                    }
+                }
+            }
+            biomes
+        };
+
+        // Warm the thread-local leaf cache with overworld leaves, then generate a Nether
+        // chunk on the same thread.
+        let _ = fill(Dimension::OVERWORLD, 0, 0);
+        let nether = fill(Dimension::THE_NETHER, 0, 0);
+
+        let nether_ids: Vec<u8> = [
+            "nether_wastes",
+            "soul_sand_valley",
+            "crimson_forest",
+            "warped_forest",
+            "basalt_deltas",
+        ]
+        .iter()
+        .map(|name| Biome::from_name(name).unwrap().id)
+        .collect();
+
+        let leaked: Vec<&str> = nether
+            .iter()
+            .filter(|id| !nether_ids.contains(id))
+            .filter_map(|id| Biome::from_id(*id).map(|biome| biome.registry_id))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "non-Nether biomes generated in a Nether chunk: {leaked:?}"
         );
     }
 }


### PR DESCRIPTION
## Problem

`LAST_RESULT_NODE` is a thread-local shortcut holding the last matched biome-tree leaf, but it was shared by every dimension's tree. `BiomeTree::get` seeds its search distance from that leaf and `search` only accepts strictly closer nodes, so a leaf cached from the overworld tree can beat every node of the Nether tree and be returned unchanged.

A worker thread that generates an overworld chunk then hands the next Nether chunk overworld biomes, and with them overworld surface rules, features and mob spawns: rivers and plains in the Nether, and zombies, skeletons and creepers spawning there.

## Fix

Key the cache by its source tree, so a leaf is only ever reused for the tree it came from. This matches vanilla, where `lastResult` lives on the `RTree` itself rather than being shared across all of them.

## Testing

- New regression test `nether_chunks_only_contain_nether_biomes`: warms the thread-local cache with an overworld chunk, then generates a Nether chunk on the same thread and asserts every biome is one of the five Nether biomes. Fails on `master`, passes here.
- Rebased onto master after df983f84, which already moved the ocean monument check onto `generator.biome_supplier`, so that hunk is dropped here.
- `cargo clippy -p pumpkin-world --lib --tests` clean, `cargo test -p pumpkin-world --lib` 188 passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed biome generation across dimensions so cached biome data from one dimension cannot affect another.
  * Nether chunks now consistently contain only Nether biomes, even after generating overworld terrain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->