### PR TITLE
fix(worldgen): protect nether roof from cave carvers and check replaceables tag

### DIFF
--- a/crates/pumpkin-world/src/generation/carver/cave.rs
+++ b/crates/pumpkin-world/src/generation/carver/cave.rs
@@ -1,5 +1,6 @@
 use super::{CarveRun, Carver, overworld_carve_state, place_carved_block};
 use pumpkin_data::carver::{CarverAdditionalConfig, CarverConfig, HeightProvider};
+use pumpkin_data::tag::{self, Taggable};
 use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::random::{RandomGenerator, RandomImpl};
@@ -280,7 +281,9 @@ impl CaveCarver {
         let x_index_max = ((x + horizontal_radius).floor() as i32 - chunk_min_x).min(15);
 
         let is_overworld = run.ctx.carver_aquifer.is_some();
-        let protected_blocks_on_top = i32::from(!is_overworld);
+        // Vanilla `Carver` excludes the top 7 generation blocks from carving;
+        // only the Nether path applies it here.
+        let protected_blocks_on_top = 7 * i32::from(!is_overworld);
         let max_y = max_y.min(
             (run.chunk.generation_bottom_y() as i32 + run.chunk.generation_height() as i32)
                 - 1
@@ -341,6 +344,7 @@ impl CaveCarver {
     ) -> bool {
         let state = run.chunk.get_block_state(&Vector3::new(x, y, z));
         let block = state.to_block();
+        let overworld = run.ctx.carver_aquifer.is_some();
 
         if block.id == pumpkin_data::Block::GRASS_BLOCK.id
             || block.id == pumpkin_data::Block::MYCELIUM.id
@@ -348,12 +352,14 @@ impl CaveCarver {
             *has_grass = true;
         }
 
+        if !overworld && !block.has_tag(&tag::Block::MINECRAFT_NETHER_CARVER_REPLACEABLES) {
+            return false;
+        }
+
         let Some((state, should_schedule_fluid_update)) = overworld_carve_state(run, x, y, z)
         else {
             return false;
         };
-
-        let overworld = run.ctx.carver_aquifer.is_some();
 
         place_carved_block(
             run,
@@ -427,7 +433,7 @@ pub fn get_height(p: &HeightProvider, random: &mut RandomGenerator, min_y: i8, h
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pumpkin_data::carver::CAVE;
+    use pumpkin_data::carver::{CAVE, NETHER_CAVE};
     use pumpkin_data::{Block, BlockStateId, dimension::Dimension};
 
     type Run<'a, 'b> = super::super::CarveRun<'a, 'b>;
@@ -516,5 +522,58 @@ mod tests {
         }
 
         None
+    }
+
+    #[test]
+    fn nether_roof_blocks_are_protected() {
+        // Production Nether runs have no carver aquifer (the NETHER noise
+        // settings disable aquifers), so mirror that here.
+        super::super::with_carve_run_options(Dimension::THE_NETHER, None, false, |run| {
+            for y in 121..=127 {
+                run.chunk
+                    .set_block_state(8, y, 8, Block::NETHERRACK.default_state);
+            }
+
+            CaveCarver::carve_ellipsoid(run, &NETHER_CAVE, 8.5, 124.0, 8.5, 8.0, 8.0, -1.0);
+
+            for y in 121..=127 {
+                assert_eq!(
+                    block_id(run, 8, y, 8),
+                    Block::NETHERRACK.default_state.id,
+                    "nether roof block at Y={y} should be protected from carving",
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn nether_bedrock_is_not_carved() {
+        // Production Nether runs have no carver aquifer (the NETHER noise
+        // settings disable aquifers), so mirror that here.
+        super::super::with_carve_run_options(Dimension::THE_NETHER, None, false, |run| {
+            // Bedrock sits well inside the carve region, below the protected roof.
+            run.chunk
+                .set_block_state(8, 100, 8, Block::BEDROCK.default_state);
+            for (x, z) in [(7, 8), (9, 8), (8, 7), (8, 9)] {
+                run.chunk
+                    .set_block_state(x, 100, z, Block::NETHERRACK.default_state);
+            }
+
+            CaveCarver::carve_ellipsoid(run, &NETHER_CAVE, 8.5, 100.0, 8.5, 8.0, 8.0, -1.0);
+
+            assert_eq!(
+                block_id(run, 8, 100, 8),
+                Block::BEDROCK.default_state.id,
+                "bedrock is not in the nether carver replaceables tag and must survive",
+            );
+            // Sanity check: the ellipsoid actually reached this spot.
+            for (x, z) in [(7, 8), (9, 8), (8, 7), (8, 9)] {
+                assert_ne!(
+                    block_id(run, x, 100, z),
+                    Block::NETHERRACK.default_state.id,
+                    "neighboring netherrack at ({x}, 100, {z}) should have been carved",
+                );
+            }
+        });
     }
 }


### PR DESCRIPTION
## What was changed?

Two-phase fix, both in `crates/pumpkin-world/src/generation/carver/cave.rs`:

- **Phase 1:** the `protected_blocks_on_top` calculation in `CaveCarver::carve_ellipsoid` changed from `i32::from(!is_overworld)` (0 for Overworld, 1 for Nether) to `7 * i32::from(!is_overworld)` (0 for Overworld, 7 for Nether), matching vanilla's flat 7-block protected boundary for non-Overworld dimensions.
- **Phase 2:** `carve_block` now checks the `minecraft:nether_carver_replaceables` block tag before replacing any block in the Nether — mirroring vanilla's `canAlwaysCarveBlock` check — using the same `has_tag(&tag::...)` pattern already used for the earlier concrete powder fluid-tag fix. Bedrock is not in this tag, so it's now never carved regardless of Y-level.

Fixes #3270

## Why were these changes necessary?

Pumpkin's Nether carver only protected 1 top block (only Y=127) instead of vanilla's 7 (Y=121–127), and had no tag check at all before replacing blocks, meaning bedrock could be carved out entirely wherever a cave's ellipsoid radius reached it. Vanilla's actual logic, confirmed against the 1.21.1 deobfuscated source during investigation: `Carver.carveRegion` computes protected blocks as `chunk.hasBelowZeroRetrogen() ? 0 : 7`, and `canAlwaysCarveBlock` checks `state.isIn(config.replaceable)` before allowing any replacement.

## What is the impact of this change?

This only affects the Nether; Overworld carving behavior is completely unchanged.

## Are there any known issues or limitations?

- Commands run: `cargo fmt` (clean), `cargo clippy --all-targets` (zero warnings), `cargo test --workspace` (all passing, including two new unit tests: `nether_roof_blocks_are_protected` and `nether_bedrock_is_not_carved`). Both tests failed with the exact expected pre-fix behavior (Y=121 carved to air instead of staying netherrack; bedrock carved to air instead of surviving) and pass cleanly after the fix.
- In-game verification was done separately by the author on a live server: fresh Nether chunks show large cave formations near the roof capping out cleanly at the protected boundary with no bedrock exposure (screenshot below).
- Edge cases not specifically tested: multiple overlapping carver runs interacting at the boundary, and carve ellipsoids spanning chunk boundaries near the roof — the unit tests cover a single ellipsoid within one chunk.

## Testing screenshot
<img width="1920" height="1080" alt="Screenshot From 2026-09-06 13-57-29" src="https://github.com/user-attachments/assets/ca75c0af-b2d3-440d-aaff-2c56355ab853" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Nether cave generation now preserves the top seven blocks of the terrain.
  - Nether bedrock and other protected blocks are no longer carved away.
  - Cave carving is limited to blocks designated as replaceable, while neighboring netherrack continues to generate caves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->