### PR TITLE
fix(entity): give all living entities an air supply

### DIFF
--- a/crates/pumpkin/src/block/blocks/bubble_column.rs
+++ b/crates/pumpkin/src/block/blocks/bubble_column.rs
@@ -161,6 +161,7 @@ fn bubble_column_velocity(
 }
 
 impl BlockBehaviour for BubbleColumnBlock {
+    /// Moves entities in the column and refills their air.
     fn on_entity_collision(&self, args: OnEntityCollisionArgs<'_>) {
         {
             if args.block != &Block::BUBBLE_COLUMN {
@@ -176,8 +177,8 @@ impl BlockBehaviour for BubbleColumnBlock {
                 at_surface,
             ));
 
-            if let Some(player) = args.entity.get_player() {
-                player.breath_manager.reset(player);
+            if let Some(living) = args.entity.get_living_entity() {
+                living.breath.reset(args.entity);
             }
         }
     }

--- a/crates/pumpkin/src/entity/breath.rs
+++ b/crates/pumpkin/src/entity/breath.rs
@@ -1,20 +1,25 @@
 use crate::entity::EntityBase;
-use crate::entity::player::Player;
+use crate::entity::living::LivingEntity;
+use crate::entity::{Entity, mob::Mob};
+use pumpkin_data::Block;
 use pumpkin_data::damage::DamageType;
 use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::tag;
 use pumpkin_data::tag::Taggable;
+use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_util::GameMode;
 use pumpkin_util::math::position::BlockPos;
 use std::sync::atomic::{AtomicI32, Ordering};
 
+/// `LivingEntity.getMaxAirSupply`.
 pub const MAX_AIR: i32 = 300;
 pub const AIR_RECOVERY_RATE: i32 = 4;
 pub const AIR_DEPLETION_RATE: i32 = 1;
 pub const DROWNING_INTERVAL: i32 = 20;
 pub const DROWNING_DAMAGE: f32 = 2.0;
 
+/// Air supply, from `LivingEntity.baseTick` and `WaterAnimal.baseTick`.
 pub struct BreathManager {
     pub air_supply: AtomicI32,
     pub drowning_tick: AtomicI32,
@@ -30,98 +35,172 @@ impl Default for BreathManager {
 }
 
 impl BreathManager {
-    pub fn tick(&self, player: &Player) {
-        let mode = player.gamemode.load();
+    /// `LivingEntity.getMaxAirSupply`.
+    #[must_use]
+    pub fn max_air_supply(caller: &dyn EntityBase) -> i32 {
+        caller.get_mob().map_or(MAX_AIR, Mob::max_air_supply)
+    }
 
-        if matches!(mode, GameMode::Creative | GameMode::Spectator) {
-            if self.air_supply.load(Ordering::Relaxed) != MAX_AIR {
-                self.air_supply.store(MAX_AIR, Ordering::Relaxed);
-                self.send_air_supply(player);
-            }
-            self.drowning_tick.store(0, Ordering::Relaxed);
-            return;
-        }
+    /// `MobEffectUtil.hasWaterBreathing`.
+    #[must_use]
+    pub fn has_water_breathing(living: &LivingEntity) -> bool {
+        living.has_effect(&StatusEffect::WATER_BREATHING)
+            || living.has_effect(&StatusEffect::CONDUIT_POWER)
+    }
 
-        if !player.world().level_info.load().game_rules.drowning_damage {
-            return;
-        }
+    /// One tick of air change and suffocation damage.
+    pub fn tick(&self, living: &LivingEntity, caller: &dyn EntityBase) {
+        let entity = &living.entity;
+        let mob = caller.get_mob();
+        let max_air = Self::max_air_supply(caller);
 
-        if player
-            .living_entity
-            .has_effect(&StatusEffect::WATER_BREATHING)
+        if let Some(player) = caller.get_player()
+            && matches!(
+                player.gamemode.load(),
+                GameMode::Creative | GameMode::Spectator
+            )
         {
-            if self.air_supply.swap(MAX_AIR, Ordering::Relaxed) != MAX_AIR {
-                self.send_air_supply(player);
+            self.refill(entity, max_air);
+            return;
+        }
+
+        if !entity
+            .world
+            .load()
+            .level_info
+            .load()
+            .game_rules
+            .drowning_damage
+        {
+            return;
+        }
+
+        let breathes_underwater =
+            mob.is_some_and(Mob::can_breathe_underwater) || Self::has_water_breathing(living);
+        let drowning = !breathes_underwater
+            && Self::is_eye_in_water(entity)
+            && !Self::is_eye_in_bubble_column(entity);
+        let dries_out = mob.is_some_and(Mob::dries_out_on_land);
+        let hydrated = if mob.is_some_and(Mob::rehydrates_in_rain) {
+            entity.is_in_water_rain_or_bubble()
+        } else {
+            entity.is_in_water_or_bubble()
+        };
+        let drying_out = dries_out && !hydrated;
+
+        let (suffocating, damage_type) = if drying_out {
+            (true, DamageType::DRY_OUT)
+        } else {
+            (drowning, DamageType::DROWN)
+        };
+
+        if !suffocating {
+            let prev = self.air_supply.load(Ordering::Relaxed);
+            let new_air = if dries_out {
+                max_air
+            } else {
+                mob.map_or_else(
+                    || (prev + AIR_RECOVERY_RATE).min(max_air),
+                    |mob| mob.increase_air_supply(prev),
+                )
+                .clamp(0, max_air)
+            };
+            if new_air != prev {
+                self.set_air(entity, new_air, max_air);
             }
             self.drowning_tick.store(0, Ordering::Relaxed);
             return;
         }
 
-        let in_water = Self::is_eye_in_water(player);
         let prev = self.air_supply.load(Ordering::Relaxed);
+        let new_air = (prev - AIR_DEPLETION_RATE).max(0);
+        if new_air != prev {
+            self.set_air(entity, new_air, max_air);
+        }
 
-        if in_water {
-            let mut new_air = (prev - AIR_DEPLETION_RATE).max(0);
-            if new_air != prev {
-                let server = player.world().server.upgrade();
-                if let Some(server) = server {
-                    let mut event = crate::plugin::api::events::entity::entity_air_change::EntityAirChangeEvent::new(
-                        player.entity_id(),
-                        new_air,
-                    );
-                    server.plugin_manager.fire_blocking(&server, &mut event);
-                    if event.cancelled {
-                        return;
-                    }
-                    new_air = event.amount.clamp(0, MAX_AIR);
-                }
-                self.air_supply.store(new_air, Ordering::Relaxed);
-                self.send_air_supply(player);
+        if self.air_supply.load(Ordering::Relaxed) <= 0 {
+            let t = self.drowning_tick.fetch_add(1, Ordering::Relaxed) + 1;
+            if t >= DROWNING_INTERVAL {
+                self.drowning_tick.store(0, Ordering::Relaxed);
+                living.damage(caller, DROWNING_DAMAGE, damage_type);
             }
-
-            if new_air <= 0 {
-                let t = self.drowning_tick.fetch_add(1, Ordering::Relaxed) + 1;
-
-                if t >= DROWNING_INTERVAL {
-                    self.drowning_tick.store(0, Ordering::Relaxed);
-                    player
-                        .living_entity
-                        .damage(player, DROWNING_DAMAGE, DamageType::DROWN);
-                }
-            }
-        } else {
-            let mut new_air = (prev + AIR_RECOVERY_RATE).min(MAX_AIR);
-            if new_air != prev {
-                let server = player.world().server.upgrade();
-                if let Some(server) = server {
-                    let mut event = crate::plugin::api::events::entity::entity_air_change::EntityAirChangeEvent::new(
-                        player.entity_id(),
-                        new_air,
-                    );
-                    server.plugin_manager.fire_blocking(&server, &mut event);
-                    if event.cancelled {
-                        return;
-                    }
-                    new_air = event.amount.clamp(0, MAX_AIR);
-                }
-                self.air_supply.store(new_air, Ordering::Relaxed);
-                self.send_air_supply(player);
-            }
-            self.drowning_tick.store(0, Ordering::Relaxed);
         }
     }
 
-    fn is_eye_in_water(player: &Player) -> bool {
-        let e = &player.get_entity();
-        let pos = e.pos.load();
-        let eye_y = e.get_eye_y();
+    /// Applies an air change through `EntityAirChangeEvent`.
+    fn set_air(&self, entity: &Entity, new_air: i32, max_air: i32) {
+        let mut new_air = new_air;
+        if let Some(server) = entity.world.load().server.upgrade() {
+            let mut event =
+                crate::plugin::api::events::entity::entity_air_change::EntityAirChangeEvent::new(
+                    entity.entity_id,
+                    new_air,
+                );
+            server.plugin_manager.fire_blocking(&server, &mut event);
+            if event.cancelled {
+                return;
+            }
+            new_air = event.amount.clamp(0, max_air);
+        }
+        self.air_supply.store(new_air, Ordering::Relaxed);
+        self.send_air_supply(entity);
+    }
+
+    /// Sets the air supply, clamped, through `EntityAirChangeEvent`.
+    pub fn set_air_supply(&self, caller: &dyn EntityBase, air: i32) {
+        let max_air = Self::max_air_supply(caller);
+        self.set_air(caller.get_entity(), air.clamp(0, max_air), max_air);
+    }
+
+    /// Writes `Air`, `AirSupply` and `DrowningTick`.
+    pub fn write_nbt(&self, nbt: &mut NbtCompound) {
+        let air = self.air_supply.load(Ordering::Relaxed);
+        nbt.put_short("Air", air.clamp(0, i32::from(i16::MAX)) as i16);
+        nbt.put_int("AirSupply", air.max(0));
+        nbt.put_int(
+            "DrowningTick",
+            self.drowning_tick
+                .load(Ordering::Relaxed)
+                .clamp(0, DROWNING_INTERVAL - 1),
+        );
+    }
+
+    /// Reads [`Self::write_nbt`] tags, clamped to `max_air`.
+    pub fn read_nbt(&self, nbt: &NbtCompound, max_air: i32) {
+        if let Some(air) = nbt
+            .get_short("Air")
+            .map(i32::from)
+            .or_else(|| nbt.get_int("AirSupply"))
+        {
+            self.air_supply
+                .store(air.clamp(0, max_air), Ordering::Relaxed);
+        }
+        if let Some(tick) = nbt.get_int("DrowningTick") {
+            self.drowning_tick
+                .store(tick.clamp(0, DROWNING_INTERVAL - 1), Ordering::Relaxed);
+        }
+    }
+
+    /// Sets the air to `max_air` without the event.
+    pub fn refill(&self, entity: &Entity, max_air: i32) {
+        if self.air_supply.swap(max_air, Ordering::Relaxed) != max_air {
+            self.send_air_supply(entity);
+        }
+        self.drowning_tick.store(0, Ordering::Relaxed);
+    }
+
+    /// `Entity.isEyeInFluid(FluidTags.WATER)`.
+    #[must_use]
+    pub fn is_eye_in_water(entity: &Entity) -> bool {
+        let pos = entity.pos.load();
+        let eye_y = entity.get_eye_y();
 
         let bp = BlockPos::new(
             pos.x.floor() as i32,
             eye_y.floor() as i32,
             pos.z.floor() as i32,
         );
-        let world = player.world();
+        let world = entity.world.load();
 
         let (fluid, state) = world.get_fluid_and_fluid_state(&bp);
 
@@ -164,8 +243,20 @@ impl BreathManager {
         surface_y > eye_y
     }
 
-    pub fn send_air_supply(&self, player: &Player) {
-        let air = self.air_supply.load(Ordering::Relaxed).clamp(0, MAX_AIR);
+    /// Eye block is a bubble column.
+    fn is_eye_in_bubble_column(entity: &Entity) -> bool {
+        let pos = entity.pos.load();
+        let bp = BlockPos::new(
+            pos.x.floor() as i32,
+            entity.get_eye_y().floor() as i32,
+            pos.z.floor() as i32,
+        );
+        entity.world.load().get_block(&bp) == &Block::BUBBLE_COLUMN
+    }
+
+    /// Syncs the air supply to clients.
+    pub fn send_air_supply(&self, entity: &Entity) {
+        let air = self.air_supply.load(Ordering::Relaxed).max(0);
 
         let mut bedrock_meta =
             pumpkin_protocol::bedrock::client::set_actor_data::SyncedActorDataList::new();
@@ -174,16 +265,15 @@ impl BreathManager {
             pumpkin_protocol::bedrock::client::set_actor_data::MetadataValue::Short(air as i16),
         );
 
-        player.get_entity().set_synced_data(
+        entity.set_synced_data(
             pumpkin_data::tracked_data::entity::DATA_AIR_SUPPLY_ID,
             VarInt(air),
         );
-        player.get_entity().send_bedrock_actor_data(&bedrock_meta);
+        entity.send_bedrock_actor_data(&bedrock_meta);
     }
 
-    pub fn reset(&self, player: &Player) {
-        self.air_supply.store(MAX_AIR, Ordering::Relaxed);
-        self.send_air_supply(player);
-        self.drowning_tick.store(0, Ordering::Relaxed);
+    /// Refills the air to the maximum.
+    pub fn reset(&self, caller: &dyn EntityBase) {
+        self.refill(caller.get_entity(), Self::max_air_supply(caller));
     }
 }

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::{
 };
 use tracing::warn;
 
+use super::breath::BreathManager;
 use super::experience_orb::ExperienceOrbEntity;
 use super::{Entity, EntityBase, NBTStorageInit};
 use crate::block::OnLandedUponArgs;
@@ -73,6 +74,8 @@ use std::sync::RwLock;
 pub struct LivingEntity {
     /// The underlying entity object, providing basic entity information and functionality.
     pub entity: Entity,
+    /// Air supply, drowning and dry-out damage (`LivingEntity.baseTick`).
+    pub breath: BreathManager,
     /// Tracks the remaining time until the entity can regenerate health.
     pub hurt_cooldown: AtomicI32,
     /// Stores the amount of damage the entity last received.
@@ -191,6 +194,7 @@ impl LivingEntity {
         entity_type.hurt_sound.unwrap_or(Sound::EntityGenericHurt)
     }
 
+    /// New living entity with default attributes.
     pub fn new(entity: Entity) -> Self {
         let water_movement_speed_multiplier = if entity.entity_type == &EntityType::POLAR_BEAR {
             0.98
@@ -246,6 +250,7 @@ impl LivingEntity {
             movement_input: AtomicCell::new(Vector3::default()),
             water_movement_speed_multiplier,
             last_block_pos: AtomicCell::new(None),
+            breath: BreathManager::default(),
         }
     }
 
@@ -2318,6 +2323,7 @@ impl LivingEntity {
 }
 
 impl LivingEntity {
+    /// Writes living-entity tags.
     pub fn write_living_nbt(&self, nbt: &mut NbtCompound) {
         nbt.put("Health", NbtTag::Float(self.health.load()));
         // Avoid persisting a lethal fall distance when the entity is dead to prevent death loops
@@ -2332,6 +2338,7 @@ impl LivingEntity {
         nbt.put_short("HurtTime", self.hurt_cooldown.load(Relaxed).max(0) as i16);
         nbt.put_short("DeathTime", i16::from(self.death_time.load(Relaxed)));
         nbt.put_bool("FallFlying", self.entity.is_fall_flying());
+        self.breath.write_nbt(nbt);
         {
             let effects_vec: Vec<pumpkin_data::potion::Effect> = {
                 let effects = self
@@ -2985,6 +2992,7 @@ impl EntityBase for LivingEntity {
         self.get_attribute_value(&Attributes::GRAVITY)
     }
 
+    /// `LivingEntity.tick`.
     #[allow(clippy::too_many_lines)]
     fn tick(&self, caller: &dyn EntityBase, server: &Server) {
         self.entity.tick(caller, server);
@@ -3005,6 +3013,10 @@ impl EntityBase for LivingEntity {
                 caller.damage(caller, 1.0, DamageType::IN_WALL);
             }
             self.entity.tick_frozen(caller);
+        }
+
+        if is_alive {
+            self.breath.tick(self, caller);
         }
 
         // TODO

--- a/crates/pumpkin/src/entity/mob/elder_guardian.rs
+++ b/crates/pumpkin/src/entity/mob/elder_guardian.rs
@@ -65,6 +65,11 @@ impl ElderGuardianEntity {
 }
 
 impl Mob for ElderGuardianEntity {
+    /// Elder guardians never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }

--- a/crates/pumpkin/src/entity/mob/guardian.rs
+++ b/crates/pumpkin/src/entity/mob/guardian.rs
@@ -69,6 +69,11 @@ impl GuardianEntity {
 }
 
 impl Mob for GuardianEntity {
+    /// Guardians never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }

--- a/crates/pumpkin/src/entity/mob/mod.rs
+++ b/crates/pumpkin/src/entity/mob/mod.rs
@@ -677,6 +677,31 @@ pub trait Mob: EntityBase + Send + Sync {
         None
     }
 
+    /// `LivingEntity.canBreatheUnderwater`: no air is lost while submerged.
+    fn can_breathe_underwater(&self) -> bool {
+        false
+    }
+
+    /// `WaterAnimal.handleAirSupply`: lose air out of water.
+    fn dries_out_on_land(&self) -> bool {
+        false
+    }
+
+    /// `LivingEntity.getMaxAirSupply`.
+    fn max_air_supply(&self) -> i32 {
+        crate::entity::breath::MAX_AIR
+    }
+
+    /// `LivingEntity.increaseAirSupply`.
+    fn increase_air_supply(&self, current: i32) -> i32 {
+        (current + crate::entity::breath::AIR_RECOVERY_RATE).min(self.max_air_supply())
+    }
+
+    /// Rain counts as water for [`Mob::dries_out_on_land`].
+    fn rehydrates_in_rain(&self) -> bool {
+        false
+    }
+
     /// Metadata which must accompany this mob whenever it is spawned for a Java client.
     fn mob_java_spawn_metadata(&self, _version: JavaMinecraftVersion) -> Option<Box<[u8]>> {
         None

--- a/crates/pumpkin/src/entity/mob/zombie/drowned.rs
+++ b/crates/pumpkin/src/entity/mob/zombie/drowned.rs
@@ -43,6 +43,11 @@ impl DrownedEntity {
 }
 
 impl Mob for DrownedEntity {
+    /// Drowned never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.entity.mob_entity
     }

--- a/crates/pumpkin/src/entity/mob/zombie/mod.rs
+++ b/crates/pumpkin/src/entity/mob/zombie/mod.rs
@@ -128,6 +128,11 @@ impl ZombieEntityBase {
 }
 
 impl Mob for ZombieEntityBase {
+    /// Zombies do not drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }

--- a/crates/pumpkin/src/entity/mob/zombified_piglin.rs
+++ b/crates/pumpkin/src/entity/mob/zombified_piglin.rs
@@ -77,6 +77,11 @@ impl ZombifiedPiglinEntity {
 }
 
 impl Mob for ZombifiedPiglinEntity {
+    /// Zombified piglins are zombies and do not take drowning damage.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -141,10 +141,15 @@ pub trait EntityBase: Send + Sync + std::any::Any {
 
     fn write_custom_nbt(&self, _nbt: &mut NbtCompound) {}
 
+    /// Reads base, living and custom tags.
     fn read_nbt_non_mut(&self, nbt: &NbtCompound) {
         self.get_entity().read_nbt_non_mut(nbt);
         if let Some(living) = self.get_living_entity() {
             living.read_living_nbt_non_mut(nbt);
+            let max_air = self
+                .get_mob()
+                .map_or(breath::MAX_AIR, mob::Mob::max_air_supply);
+            living.breath.read_nbt(nbt, max_air);
         }
         self.read_custom_nbt(nbt);
     }
@@ -2767,6 +2772,42 @@ impl Entity {
     #[must_use]
     pub fn is_under_water(&self) -> bool {
         self.is_in_water() && self.is_submerged_in_water()
+    }
+
+    /// `Entity.isInBubbleColumn`.
+    #[must_use]
+    pub fn is_in_bubble_column(&self) -> bool {
+        self.world.load().get_block(&self.block_pos.load()) == &Block::BUBBLE_COLUMN
+    }
+
+    /// `Entity.isInRain`.
+    #[must_use]
+    pub fn is_in_rain(&self) -> bool {
+        let world = self.world.load();
+        let feet = self.block_pos.load();
+        if world.is_raining_at(&feet) {
+            return true;
+        }
+        let top_y = self.bounding_box.load().max.y.floor() as i32;
+        world.is_raining_at(&BlockPos::new(feet.0.x, top_y, feet.0.z))
+    }
+
+    /// `Entity.isInWaterOrRain`.
+    #[must_use]
+    pub fn is_in_water_or_rain(&self) -> bool {
+        self.is_in_water() || self.is_in_rain()
+    }
+
+    /// `Entity.isInWaterOrBubble`.
+    #[must_use]
+    pub fn is_in_water_or_bubble(&self) -> bool {
+        self.is_in_water() || self.is_in_bubble_column()
+    }
+
+    /// `Entity.isInWaterRainOrBubble`.
+    #[must_use]
+    pub fn is_in_water_rain_or_bubble(&self) -> bool {
+        self.is_in_water_or_rain() || self.is_in_bubble_column()
     }
 
     #[must_use]

--- a/crates/pumpkin/src/entity/passive/axolotl.rs
+++ b/crates/pumpkin/src/entity/passive/axolotl.rs
@@ -233,6 +233,26 @@ impl Animal for AxolotlEntity {
 }
 
 impl Mob for AxolotlEntity {
+    /// Axolotls never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
+    /// `Axolotl.handleAirSupply`.
+    fn dries_out_on_land(&self) -> bool {
+        true
+    }
+
+    /// Rain counts as water.
+    fn rehydrates_in_rain(&self) -> bool {
+        true
+    }
+
+    /// `Axolotl.getMaxAirSupply`.
+    fn max_air_supply(&self) -> i32 {
+        6000
+    }
+
     fn as_ageable(&self) -> Option<&dyn AgeableMob> {
         Some(self)
     }

--- a/crates/pumpkin/src/entity/passive/cod.rs
+++ b/crates/pumpkin/src/entity/passive/cod.rs
@@ -49,6 +49,16 @@ impl CodEntity {
 }
 
 impl Mob for CodEntity {
+    /// Water animals never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
+    /// `WaterAnimal.handleAirSupply`.
+    fn dries_out_on_land(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }

--- a/crates/pumpkin/src/entity/passive/dolphin.rs
+++ b/crates/pumpkin/src/entity/passive/dolphin.rs
@@ -89,6 +89,16 @@ impl DolphinEntity {
 }
 
 impl Mob for DolphinEntity {
+    /// `Dolphin.getMaxAirSupply`.
+    fn max_air_supply(&self) -> i32 {
+        4800
+    }
+
+    /// `Dolphin.increaseAirSupply`.
+    fn increase_air_supply(&self, _current: i32) -> i32 {
+        4800
+    }
+
     fn mob_write_nbt(&self, nbt: &mut NbtCompound) {
         nbt.put_bool("GotFish", self.got_fish());
         nbt.put_int("Moistness", self.moistness_level.load(Ordering::Relaxed));

--- a/crates/pumpkin/src/entity/passive/glow_squid.rs
+++ b/crates/pumpkin/src/entity/passive/glow_squid.rs
@@ -49,6 +49,16 @@ impl GlowSquidEntity {
 }
 
 impl Mob for GlowSquidEntity {
+    /// Water animals never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
+    /// `WaterAnimal.handleAirSupply`.
+    fn dries_out_on_land(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }

--- a/crates/pumpkin/src/entity/passive/nautilus.rs
+++ b/crates/pumpkin/src/entity/passive/nautilus.rs
@@ -221,6 +221,16 @@ impl Animal for NautilusEntity {
 }
 
 impl Mob for NautilusEntity {
+    /// Water animals never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
+    /// `WaterAnimal.handleAirSupply`.
+    fn dries_out_on_land(&self) -> bool {
+        true
+    }
+
     fn as_animal(&self) -> Option<&dyn Animal> {
         Some(self)
     }

--- a/crates/pumpkin/src/entity/passive/pufferfish.rs
+++ b/crates/pumpkin/src/entity/passive/pufferfish.rs
@@ -49,6 +49,16 @@ impl PufferfishEntity {
 }
 
 impl Mob for PufferfishEntity {
+    /// Water animals never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
+    /// `WaterAnimal.handleAirSupply`.
+    fn dries_out_on_land(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }

--- a/crates/pumpkin/src/entity/passive/salmon.rs
+++ b/crates/pumpkin/src/entity/passive/salmon.rs
@@ -46,6 +46,16 @@ impl SalmonEntity {
 }
 
 impl Mob for SalmonEntity {
+    /// Water animals never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
+    /// `WaterAnimal.handleAirSupply`.
+    fn dries_out_on_land(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }

--- a/crates/pumpkin/src/entity/passive/squid.rs
+++ b/crates/pumpkin/src/entity/passive/squid.rs
@@ -48,6 +48,16 @@ impl SquidEntity {
 }
 
 impl Mob for SquidEntity {
+    /// Water animals never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
+    /// `WaterAnimal.handleAirSupply`.
+    fn dries_out_on_land(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }

--- a/crates/pumpkin/src/entity/passive/tadpole.rs
+++ b/crates/pumpkin/src/entity/passive/tadpole.rs
@@ -76,6 +76,16 @@ impl AgeableMob for TadpoleEntity {
 }
 
 impl Mob for TadpoleEntity {
+    /// Water animals never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
+    /// `WaterAnimal.handleAirSupply`.
+    fn dries_out_on_land(&self) -> bool {
+        true
+    }
+
     fn as_ageable(&self) -> Option<&dyn AgeableMob> {
         Some(self)
     }

--- a/crates/pumpkin/src/entity/passive/tropical_fish.rs
+++ b/crates/pumpkin/src/entity/passive/tropical_fish.rs
@@ -46,6 +46,16 @@ impl TropicalFishEntity {
 }
 
 impl Mob for TropicalFishEntity {
+    /// Water animals never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
+    /// `WaterAnimal.handleAirSupply`.
+    fn dries_out_on_land(&self) -> bool {
+        true
+    }
+
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
     }

--- a/crates/pumpkin/src/entity/passive/turtle.rs
+++ b/crates/pumpkin/src/entity/passive/turtle.rs
@@ -107,6 +107,11 @@ impl Animal for TurtleEntity {
 }
 
 impl Mob for TurtleEntity {
+    /// Turtles never drown.
+    fn can_breathe_underwater(&self) -> bool {
+        true
+    }
+
     fn as_ageable(&self) -> Option<&dyn AgeableMob> {
         Some(self)
     }

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -306,7 +306,6 @@ use crate::server::Server;
 use crate::world::{BlockBreakingProgress, World};
 use bytes::Bytes;
 
-use super::breath::BreathManager;
 use super::combat::{self, AttackType, player_attack_sound};
 use super::hunger::HungerManager;
 use super::item::ItemEntity;
@@ -411,8 +410,6 @@ pub struct Player {
     pub respawn_point: std::sync::Mutex<Option<RespawnPoint>>,
     /// The player's sleep status
     pub sleeping_since: AtomicCell<Option<u8>>,
-    /// Manages the player's breath level
-    pub breath_manager: BreathManager,
     /// Manages the player's hunger level.
     pub hunger_manager: HungerManager,
     /// The ID of the currently open container (if any).
@@ -619,6 +616,7 @@ impl Player {
         Some(skin)
     }
 
+    /// New player for a connected client.
     #[expect(clippy::too_many_lines, clippy::items_after_statements)]
     pub fn new(
         client: Arc<ClientPlatform>,
@@ -718,7 +716,6 @@ impl Player {
             gameprofile,
             client,
             awaiting_teleport: Mutex::new(None),
-            breath_manager: BreathManager::default(),
             // TODO: Load this from previous instance
             hunger_manager: HungerManager::default(),
             current_block_destroy_stage: AtomicI32::new(-1),
@@ -2486,6 +2483,7 @@ impl Player {
         }
     }
 
+    /// `ServerPlayer.tick`.
     #[expect(clippy::too_many_lines)]
     pub fn tick<'a>(&'a self, server: &'a Server) {
         self.process_inbound_packets();
@@ -2705,7 +2703,6 @@ impl Player {
 
         self.living_entity.tick(self, server);
 
-        self.breath_manager.tick(self);
         self.hunger_manager.tick(self);
 
         // Vanilla updates pose in PlayerEntity#tick after super.tick().
@@ -4483,6 +4480,7 @@ impl Player {
         );
     }
 
+    /// Handles player death.
     pub fn handle_killed(&self, death_msg: &TextComponent) {
         self.trigger_advancement(
             crate::entity::player::advancement::trigger::AdvancementTrigger::PlayerKilled,
@@ -4515,7 +4513,7 @@ impl Player {
         }
 
         // Reset air supply & drowning ticks on death
-        self.breath_manager.reset(self);
+        self.living_entity.breath.reset(self.get_entity());
 
         if matches!(self.client.as_ref(), ClientPlatform::Java(_)) {
             self.set_client_loaded(false);
@@ -6574,6 +6572,7 @@ impl EntityBase for Player {
         self
     }
 
+    /// Writes player-only tags.
     fn write_custom_nbt(&self, nbt: &mut NbtCompound) {
         nbt.put_int("DataVersion", DATA_VERSION);
         self.inventory.write_nbt(nbt);
@@ -6611,20 +6610,7 @@ impl EntityBase for Player {
         // Store food level, saturation, exhaustion, and tick timer
         self.hunger_manager.write_nbt(nbt);
 
-        let air_supply = self
-            .breath_manager
-            .air_supply
-            .load(Ordering::Relaxed)
-            .clamp(0, super::breath::MAX_AIR);
-        nbt.put_short("Air", air_supply as i16);
-        nbt.put_int("AirSupply", air_supply);
-        nbt.put_int(
-            "DrowningTick",
-            self.breath_manager
-                .drowning_tick
-                .load(Ordering::Relaxed)
-                .clamp(0, super::breath::DROWNING_INTERVAL - 1),
-        );
+        self.living_entity.breath.write_nbt(nbt);
 
         nbt.put_string(
             "Dimension",
@@ -6679,6 +6665,7 @@ impl EntityBase for Player {
             .write_nbt(nbt);
     }
 
+    /// Reads player-only tags.
     #[expect(clippy::too_many_lines)]
     fn read_custom_nbt(&self, nbt: &NbtCompound) {
         self.inventory.read_nbt_non_mut(nbt);
@@ -6778,21 +6765,9 @@ impl EntityBase for Player {
 
         self.hunger_manager.read_nbt_non_mut(nbt);
 
-        if let Some(air) = nbt
-            .get_short("Air")
-            .map(i32::from)
-            .or_else(|| nbt.get_int("AirSupply"))
-        {
-            self.breath_manager
-                .air_supply
-                .store(air.clamp(0, super::breath::MAX_AIR), Ordering::Relaxed);
-        }
-        if let Some(tick) = nbt.get_int("DrowningTick") {
-            self.breath_manager.drowning_tick.store(
-                tick.clamp(0, super::breath::DROWNING_INTERVAL - 1),
-                Ordering::Relaxed,
-            );
-        }
+        self.living_entity
+            .breath
+            .read_nbt(nbt, super::breath::MAX_AIR);
 
         // Load any saved spawnpoint data (both vanilla "respawn" compound and legacy SpawnX/SpawnY/SpawnZ)
         if let Some(respawn_compound) = nbt.get_compound("respawn") {

--- a/crates/pumpkin/src/entity/type.rs
+++ b/crates/pumpkin/src/entity/type.rs
@@ -128,6 +128,7 @@ use crate::world::World;
 use pumpkin_data::Block;
 use std::sync::atomic::AtomicBool;
 
+/// Builds the entity for `entity_type` at `position`.
 #[expect(clippy::too_many_lines)]
 pub fn from_type(
     entity_type: &'static EntityType,
@@ -339,6 +340,13 @@ pub fn from_type(
             }
         }
     };
+
+    if let (Some(living), Some(mob_impl)) = (mob.get_living_entity(), mob.get_mob()) {
+        living.breath.air_supply.store(
+            mob_impl.max_air_supply(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
 
     mob
 }

--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/entity.rs
@@ -603,34 +603,36 @@ impl HostEntity for PluginHostState {
         Ok(())
     }
 
+    /// Air supply, `0` for non-living entities.
     async fn get_remaining_air(&mut self, entity: Resource<Entity>) -> wasmtime::Result<i32> {
         let entity = entity_from_resource(self, &entity)?;
-        Ok(entity.get_player().map_or(0, |player| {
-            player
-                .breath_manager
+        Ok(entity.get_living_entity().map_or(0, |living| {
+            living
+                .breath
                 .air_supply
                 .load(std::sync::atomic::Ordering::Relaxed)
         }))
     }
 
+    /// Sets the air supply, clamped, through `EntityAirChangeEvent`.
     async fn set_remaining_air(
         &mut self,
         entity: Resource<Entity>,
         air: i32,
     ) -> wasmtime::Result<()> {
         let entity = entity_from_resource(self, &entity)?;
-        if let Some(player) = entity.get_player() {
-            player
-                .breath_manager
-                .air_supply
-                .store(air, std::sync::atomic::Ordering::Relaxed);
-            player.breath_manager.send_air_supply(player);
+        if let Some(living) = entity.get_living_entity() {
+            living.breath.set_air_supply(entity.as_ref(), air);
         }
         Ok(())
     }
 
-    async fn get_max_air(&mut self, _entity: Resource<Entity>) -> wasmtime::Result<i32> {
-        Ok(crate::entity::breath::MAX_AIR)
+    /// Maximum air supply.
+    async fn get_max_air(&mut self, entity: Resource<Entity>) -> wasmtime::Result<i32> {
+        let entity = entity_from_resource(self, &entity)?;
+        Ok(crate::entity::breath::BreathManager::max_air_supply(
+            entity.as_ref(),
+        ))
     }
 
     async fn remove(&mut self, entity: Resource<Entity>) -> wasmtime::Result<()> {

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -3334,6 +3334,7 @@ impl World {
         }
     }
 
+    /// Finishes the Java login.
     #[expect(clippy::too_many_lines)]
     pub async fn spawn_java_player(
         &self,
@@ -4009,7 +4010,10 @@ impl World {
         player.on_screen_handler_opened(&player.player_screen_handler);
 
         player.send_active_effects();
-        player.breath_manager.send_air_supply(player);
+        player
+            .living_entity
+            .breath
+            .send_air_supply(player.get_entity());
         self.send_player_equipment(player);
 
         if let crate::net::ClientPlatform::Java(java_client) = player.client.as_ref()


### PR DESCRIPTION
Closes #1674

## Description

Air supply and drowning only existed on `Player`. Mobs never lost air.

- `BreathManager` moved from `Player` to `LivingEntity`. Ticks for every living entity (`LivingEntity.baseTick`, `WaterAnimal.baseTick`).
- `Mob` hooks:
  - `can_breathe_underwater`: guardian, elder guardian, turtle, drowned, zombies, axolotl
  - `dries_out_on_land`: cod, salmon, pufferfish, tropical fish, tadpole, squid, glow squid, nautilus, axolotl
  - `rehydrates_in_rain`: axolotl
  - `max_air_supply`: dolphin 4800, axolotl 6000
  - `increase_air_supply`: dolphin refills at once at the surface
- Water animals refill air at once when wet.
- Conduit Power counts as water breathing (`MobEffectUtil.hasWaterBreathing`).
- Bubble columns do not drain air.
- `Air`, `AirSupply` and `DrowningTick` saved and loaded for every living entity, clamped to the entity maximum. Mobs spawn with full air.
- Player behaviour unchanged: constants, creative and spectator refill, `drowningDamage` game rule, `EntityAirChangeEvent`.
- Plugin API: `get_remaining_air` and `set_remaining_air` work for any living entity. `set_remaining_air` clamps and fires `EntityAirChangeEvent`. `get_max_air` returns the entity maximum.
- New `Entity` helpers: `is_in_bubble_column`, `is_in_rain`, `is_in_water_or_rain`, `is_in_water_or_bubble`, `is_in_water_rain_or_bubble`.

Split out: dolphin moisture #3291, zombie conversion #3289, conduit #3287.

## Testing

- `cargo fmt --all --check`, `cargo clippy -p pumpkin --all-targets`, `cargo test -p pumpkin` pass.
- In game:
  - Cod and salmon on land die after 15 to 20 s.
  - Pig under water drowns after 20 to 40 s.
  - Zombie and drowned under water survive.
  - Player air bar drains and refills as before.
- Not yet verified in game: instant refill for fish, dolphin drowning after 4 min, air persistence across chunk reload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended air-supply and drowning mechanics to all living entities and mobs.
  * Added mob-specific air limits, underwater breathing, land drying, rain rehydration, and recovery behaviors.
  * Preserved breathing state across entity saves and loads.
  * Bubble columns now reset breathing for any living entity.
  * Added support for entity-specific air updates through integrations.
* **Bug Fixes**
  * Corrected initial air supplies to use each mob’s configured maximum.
  * Guardians, zombies, zombified piglins, and aquatic mobs now correctly avoid drowning where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->