### PR TITLE
fix(plugin): fix context drop outside of on_load

### DIFF
--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/mod.rs
@@ -400,7 +400,7 @@ impl WasmPlugin {
         self.store
             .call_guest(move |mut guest| {
                 Box::pin(async move {
-                    let (context_res, context_rep) = guest.with(|mut store| {
+                    let context_res = guest.with(|mut store| {
                         if let Some(mb) = max_memory_mb {
                             let limit_bytes = (mb as usize).saturating_mul(1024 * 1024);
                             store.data_mut().limits = wasmtime::StoreLimitsBuilder::new()
@@ -413,23 +413,13 @@ impl WasmPlugin {
                         store.data_mut().wasi_http_hooks.allow_outbound = allow_http_outbound;
                         store.data_mut().server = Some(server);
                         store.data_mut().name = Some(name);
-
-                        let resource = store.data_mut().add_context(context)?;
-                        let rep = resource.rep();
-                        Ok::<_, wasmtime::Error>((resource, rep))
+                        store.data_mut().add_context(context)
                     })?;
 
-                    let result = guest
+                    guest
                         .call(function, (context_res,))
                         .await
-                        .map(|(result,)| result);
-
-                    guest.with(|mut store| {
-                        let _ = store.data_mut().resource_table.delete::<
-                            crate::plugin::loader::wasm::wasm_host::state::ContextResource,
-                        >(wasmtime::component::Resource::new_own(context_rep));
-                    });
-                    result
+                        .map(|(result,)| result)
                 })
             })
             .await


### PR DESCRIPTION
## Description

This PR fixes an issue where the context store was not being saved after returning outside of `on_load` so registered commands from plugins would cause the plugin WASM component to become trapped. 

## Validation

`cargo clippy`, `cargo test` and manually tested in game against the previously failing plugin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebAssembly plugin loading by ensuring initialization context resources are passed and managed consistently.
  - Reduced the risk of resource-handling issues during plugin startup.

- **Compatibility**
  - No changes were made to exported or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->