### PR TITLE
feat(block): tick conduit block entity

### DIFF
--- a/crates/pumpkin/src/block/entities/conduit.rs
+++ b/crates/pumpkin/src/block/entities/conduit.rs
@@ -1,13 +1,35 @@
 use super::BlockEntity;
+use crate::entity::EntityBase;
+use crate::world::World;
+use pumpkin_data::damage::DamageType;
+use pumpkin_data::effect::StatusEffect;
+use pumpkin_data::entity::MobCategory;
+use pumpkin_data::potion::Effect;
+use pumpkin_data::sound::{Sound, SoundCategory};
+use pumpkin_data::tag::{self, Taggable};
+use pumpkin_data::{Block, BlockId};
 use pumpkin_nbt::compound::NbtCompound;
-use pumpkin_nbt::tag::NbtTag;
+use pumpkin_util::math::boundingbox::BoundingBox;
 use pumpkin_util::math::position::BlockPos;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
 
+/// `ConduitBlockEntity`.
+///
+/// Every 2 seconds the conduit re-scans its frame. With at least 16 frame blocks
+/// (prismarine, prismarine bricks, dark prismarine or sea lantern) on the edges of
+/// the 5x5x5 shell around it, and water in the full 3x3x3 core, it activates and
+/// grants Conduit Power to wet players in range. With 42 or more frame blocks it
+/// also attacks one hostile mob within 8 blocks.
 pub struct ConduitBlockEntity {
     pub position: BlockPos,
-    pub active: Mutex<bool>,
-    pub target: Mutex<Option<NbtTag>>,
+    pub active: AtomicBool,
+    /// `destroyTarget`: the hostile mob currently being zapped, synced to clients
+    /// as the `Target` NBT tag so they can render the beam.
+    pub target: Mutex<Option<Uuid>>,
+    /// `effectBlocks`: frame blocks found by the last shape scan.
+    pub effect_blocks: Mutex<Vec<BlockPos>>,
 }
 
 impl BlockEntity for ConduitBlockEntity {
@@ -19,38 +41,71 @@ impl BlockEntity for ConduitBlockEntity {
         self.position
     }
 
-    fn from_nbt(nbt: &pumpkin_nbt::compound::NbtCompound, position: BlockPos) -> Self
+    /// Reads `Active` and `Target`.
+    fn from_nbt(nbt: &NbtCompound, position: BlockPos) -> Self
     where
         Self: Sized,
     {
         let active = nbt.get_bool("Active").unwrap_or(false);
-        let target = nbt.get("Target").cloned();
+        let target = nbt.get_uuid("Target");
         Self {
             position,
-            active: Mutex::new(active),
+            active: AtomicBool::new(active),
             target: Mutex::new(target),
+            effect_blocks: Mutex::new(Vec::new()),
         }
     }
 
+    /// Writes `Active` and `Target`.
     fn write_nbt(&self, nbt: &mut NbtCompound) {
-        if let Ok(active) = self.active.lock() {
-            nbt.put_bool("Active", *active);
-        }
-        if let Ok(target) = self.target.lock()
-            && let Some(tgt) = target.as_ref()
+        nbt.put_bool("Active", self.active.load(Ordering::Relaxed));
+        if let Some(target) = *self
+            .target
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
         {
-            nbt.put("Target", tgt.clone());
+            nbt.put_uuid("Target", target);
         }
     }
 
+    /// `ConduitBlockEntity.serverTick`.
+    fn tick(&self, world: &Arc<World>) {
+        let game_time = world.get_world_age();
+
+        if game_time % Self::SHAPE_UPDATE_INTERVAL == 0 {
+            let active = self.update_shape(world);
+            if self.active.swap(active, Ordering::Relaxed) != active {
+                let sound = if active {
+                    Sound::BlockConduitActivate
+                } else {
+                    Sound::BlockConduitDeactivate
+                };
+                world.play_sound(sound, SoundCategory::Blocks, &self.center());
+            }
+        }
+
+        if !self.active.load(Ordering::Relaxed) {
+            return;
+        }
+
+        if game_time % Self::EFFECT_INTERVAL == 0 {
+            self.apply_effects(world);
+            world.play_sound(
+                Sound::BlockConduitAmbient,
+                SoundCategory::Blocks,
+                &self.center(),
+            );
+        }
+
+        if game_time % Self::ATTACK_INTERVAL == 0 {
+            self.update_destroy_target(world);
+        }
+    }
+
+    /// Same as [`Self::write_nbt`].
     fn chunk_data_nbt(&self) -> Option<NbtCompound> {
         let mut nbt = NbtCompound::new();
-        nbt.put_bool("Active", *self.active.try_lock().ok()?);
-        if let Ok(target) = self.target.try_lock()
-            && let Some(ref tgt) = *target
-        {
-            nbt.put("Target", tgt.clone());
-        }
+        self.write_nbt(&mut nbt);
         Some(nbt)
     }
 
@@ -61,12 +116,210 @@ impl BlockEntity for ConduitBlockEntity {
 
 impl ConduitBlockEntity {
     pub const ID: &'static str = "minecraft:conduit";
+
+    const SHAPE_UPDATE_INTERVAL: i64 = 40;
+    const EFFECT_INTERVAL: i64 = 80;
+    const ATTACK_INTERVAL: i64 = 40;
+    const MIN_ACTIVE_SIZE: usize = 16;
+    const MIN_HUNTING_SIZE: usize = 42;
+    const BLOCKS_PER_RANGE_STEP: i32 = 7;
+    const RANGE_PER_STEP: i32 = 16;
+    const DESTROY_RANGE: f64 = 8.0;
+    const DESTROY_DAMAGE: f32 = 4.0;
+    const EFFECT_DURATION: i32 = 260;
+
+    /// Inactive until the first scan.
     #[must_use]
     pub const fn new(position: BlockPos) -> Self {
         Self {
             position,
-            active: Mutex::new(false),
+            active: AtomicBool::new(false),
             target: Mutex::new(None),
+            effect_blocks: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Result of the last frame scan.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+
+    /// `isHunting`.
+    #[must_use]
+    pub fn is_hunting(&self) -> bool {
+        self.effect_block_count() >= Self::MIN_HUNTING_SIZE
+    }
+
+    /// Frame blocks from the last scan.
+    fn effect_block_count(&self) -> usize {
+        self.effect_blocks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+
+    /// Block centre.
+    fn center(&self) -> pumpkin_util::math::vector3::Vector3<f64> {
+        self.position.to_centered_f64()
+    }
+
+    /// `ConduitBlockEntity.VALID_BLOCKS`.
+    fn is_frame_block(block: &Block) -> bool {
+        block.id == BlockId::PRISMARINE
+            || block.id == BlockId::PRISMARINE_BRICKS
+            || block.id == BlockId::DARK_PRISMARINE
+            || block.id == BlockId::SEA_LANTERN
+    }
+
+    /// `updateShape`.
+    fn update_shape(&self, world: &World) -> bool {
+        let mut blocks = Vec::new();
+        let origin = self.position.0;
+
+        let mut core_flooded = true;
+        'core: for dx in -1..=1 {
+            for dy in -1..=1 {
+                for dz in -1..=1 {
+                    let pos = BlockPos::new(origin.x + dx, origin.y + dy, origin.z + dz);
+                    if !world.get_fluid(&pos).has_tag(&tag::Fluid::MINECRAFT_WATER) {
+                        core_flooded = false;
+                        break 'core;
+                    }
+                }
+            }
+        }
+
+        if core_flooded {
+            for dx in -2i32..=2 {
+                for dy in -2i32..=2 {
+                    for dz in -2i32..=2 {
+                        let (ax, ay, az) = (dx.abs(), dy.abs(), dz.abs());
+                        let on_shell = ax > 1 || ay > 1 || az > 1;
+                        let on_edge_line = (dx == 0 && (ay == 2 || az == 2))
+                            || (dy == 0 && (ax == 2 || az == 2))
+                            || (dz == 0 && (ax == 2 || ay == 2));
+                        if !(on_shell && on_edge_line) {
+                            continue;
+                        }
+                        let pos = BlockPos::new(origin.x + dx, origin.y + dy, origin.z + dz);
+                        if Self::is_frame_block(world.get_block(&pos)) {
+                            blocks.push(pos);
+                        }
+                    }
+                }
+            }
+        }
+
+        let active = core_flooded && blocks.len() >= Self::MIN_ACTIVE_SIZE;
+        *self
+            .effect_blocks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = blocks;
+        active
+    }
+
+    /// `applyEffects`.
+    fn apply_effects(&self, world: &World) {
+        let count = self.effect_block_count() as i32;
+        let range = count / Self::BLOCKS_PER_RANGE_STEP * Self::RANGE_PER_STEP;
+        if range <= 0 {
+            return;
+        }
+        let range_squared = range * range;
+
+        for player in world.players.load().iter() {
+            let entity = &player.living_entity.entity;
+            if self.position.squared_distance(&entity.block_pos.load()) >= range_squared {
+                continue;
+            }
+            if !entity.is_in_water_rain_or_bubble() {
+                continue;
+            }
+            player.add_effect(Effect {
+                effect_type: &StatusEffect::CONDUIT_POWER,
+                duration: Self::EFFECT_DURATION,
+                amplifier: 0,
+                ambient: true,
+                show_particles: true,
+                show_icon: true,
+                blend: false,
+            });
+        }
+    }
+
+    /// `updateDestroyTarget`.
+    fn update_destroy_target(&self, world: &Arc<World>) {
+        let previous = *self
+            .target
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let target = if self.is_hunting() {
+            let current = previous
+                .and_then(|uuid| world.get_entity_by_uuid(uuid))
+                .filter(|entity| self.is_valid_target(entity, false));
+            current.or_else(|| self.find_destroy_target(world))
+        } else {
+            None
+        };
+
+        if let Some(target) = &target {
+            world.play_sound(
+                Sound::BlockConduitAttackTarget,
+                SoundCategory::Blocks,
+                &self.center(),
+            );
+            target.damage(target.as_ref(), Self::DESTROY_DAMAGE, DamageType::MAGIC);
+        }
+
+        let target_uuid = target.map(|entity| entity.get_entity().entity_uuid);
+        if target_uuid != previous {
+            *self
+                .target
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = target_uuid;
+            if let Some(block_entity) = world.get_block_entity(&self.position) {
+                world.update_block_entity(&block_entity);
+            }
+        }
+    }
+
+    /// Hostile, alive, within range; new targets must be in water or rain.
+    fn is_valid_target(&self, entity: &Arc<dyn EntityBase>, require_wet: bool) -> bool {
+        let base = entity.get_entity();
+        if !base.is_alive() || entity.get_living_entity().is_none() {
+            return false;
+        }
+        if base.entity_type.category != &MobCategory::MONSTER {
+            return false;
+        }
+        if require_wet && !base.is_in_water_or_rain() {
+            return false;
+        }
+        let range = Self::DESTROY_RANGE as i32;
+        self.position.squared_distance(&base.block_pos.load()) < range * range
+    }
+
+    /// Random valid target in the destroy range.
+    fn find_destroy_target(&self, world: &World) -> Option<Arc<dyn EntityBase>> {
+        let area = BoundingBox::from_block(&self.position).expand(
+            Self::DESTROY_RANGE,
+            Self::DESTROY_RANGE,
+            Self::DESTROY_RANGE,
+        );
+        let candidates: Vec<Arc<dyn EntityBase>> = world
+            .get_nearby_entities(self.center(), Self::DESTROY_RANGE * 2.0)
+            .into_values()
+            .filter(|entity| {
+                entity.get_entity().bounding_box.load().intersects(&area)
+                    && self.is_valid_target(entity, true)
+            })
+            .collect();
+        if candidates.is_empty() {
+            return None;
+        }
+        let index = rand::random_range(0..candidates.len());
+        candidates.into_iter().nth(index)
     }
 }

--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -2769,6 +2769,36 @@ impl Entity {
         self.is_in_water() && self.is_submerged_in_water()
     }
 
+    /// `Entity.isInBubbleColumn`.
+    #[must_use]
+    pub fn is_in_bubble_column(&self) -> bool {
+        self.world.load().get_block(&self.block_pos.load()) == &Block::BUBBLE_COLUMN
+    }
+
+    /// `Entity.isInRain`.
+    #[must_use]
+    pub fn is_in_rain(&self) -> bool {
+        let world = self.world.load();
+        let feet = self.block_pos.load();
+        if world.is_raining_at(&feet) {
+            return true;
+        }
+        let top_y = self.bounding_box.load().max.y.floor() as i32;
+        world.is_raining_at(&BlockPos::new(feet.0.x, top_y, feet.0.z))
+    }
+
+    /// `Entity.isInWaterOrRain`.
+    #[must_use]
+    pub fn is_in_water_or_rain(&self) -> bool {
+        self.is_in_water() || self.is_in_rain()
+    }
+
+    /// `Entity.isInWaterRainOrBubble`.
+    #[must_use]
+    pub fn is_in_water_rain_or_bubble(&self) -> bool {
+        self.is_in_water_or_rain() || self.is_in_bubble_column()
+    }
+
     #[must_use]
     pub fn is_visually_crawling(&self) -> bool {
         self.is_visually_swimming() && !self.is_in_water()


### PR DESCRIPTION
Closes #3286

## Description

- Conduit block entity now ticks (`ConduitBlockEntity.serverTick`).
- Every 40 ticks: scan frame. Active with water in the 3x3x3 core and 16+ prismarine, prismarine bricks, dark prismarine or sea lantern blocks on the 5x5x5 shell edges. Activate and deactivate sounds.
- Every 80 ticks: Conduit Power (260 ticks) to players in water, rain or a bubble column within 16 blocks per 7 frame blocks. Ambient sound.
- With 42+ frame blocks: one random hostile mob in water or rain within 8 blocks takes 4 magic damage every 40 ticks. Attack sound. Target UUID synced as `Target` so the client renders the beam.
- New `Entity` helpers: `is_in_bubble_column`, `is_in_rain`, `is_in_water_or_rain`, `is_in_water_rain_or_bubble`.

Related: #3275 (air supply, uses the same helpers).

## Testing

- `cargo fmt --all --check`, `cargo clippy -p pumpkin --all-targets`, `cargo test -p pumpkin` pass.
- Not yet verified in game.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functional conduit activation based on surrounding water and frame structures.
  - Active conduits now grant Conduit Power to players in suitable conditions.
  - Fully powered conduits can attack nearby hostile mobs.
  - Added activation, deactivation, ambient, and attack sound effects.
  - Conduit status and target updates are now reflected in block-entity data.
  - Improved detection of entities in water, rain, and bubble columns to support environmental effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->