### PR TITLE
feat(entity): convert zombies to drowned and husks to zombies under water

### DIFF
--- a/crates/pumpkin/src/entity/mob/mod.rs
+++ b/crates/pumpkin/src/entity/mob/mod.rs
@@ -12,6 +12,7 @@ use pumpkin_data::damage::DamageType;
 use pumpkin_data::data_component_impl::EquipmentSlot;
 use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
+use pumpkin_data::potion::Effect;
 use pumpkin_data::tag::{self, Taggable};
 use pumpkin_data::tracked_data;
 use pumpkin_data::{Block, BlockDirection};
@@ -221,6 +222,119 @@ impl MobEntity {
 
     pub fn set_no_ai(&self, no_ai: bool) {
         self.set_mob_flag(Self::AI_DISABLED_FLAG, no_ai);
+    }
+
+    /// `ConversionType.convertCommon`. Call before spawn. Health is not copied.
+    pub fn copy_conversion_state(&self, converted: &dyn EntityBase) {
+        let living = &self.living_entity;
+        let entity = &living.entity;
+        let target = converted.get_entity();
+
+        target.set_rotation(entity.yaw.load(), entity.pitch.load());
+        target.head_yaw.store(entity.head_yaw.load());
+        target.velocity.store(entity.velocity.load());
+        target.age.store(entity.age.load(Relaxed), Relaxed);
+        target.silent.store(entity.is_silent(), Relaxed);
+        target
+            .invulnerable
+            .store(entity.invulnerable.load(Relaxed), Relaxed);
+        target
+            .has_no_gravity
+            .store(entity.has_no_gravity(), Relaxed);
+        target
+            .portal_cooldown
+            .store(entity.portal_cooldown.load(Relaxed), Relaxed);
+        target
+            .fire_ticks
+            .store(entity.fire_ticks.load(Relaxed), Relaxed);
+        if let Some(custom_name) = &**entity.custom_name.load() {
+            target.set_custom_name(custom_name.clone());
+            target
+                .custom_name_visible
+                .store(entity.custom_name_visible.load(Relaxed), Relaxed);
+        }
+        let tags = entity
+            .scoreboard_tags
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        *target
+            .scoreboard_tags
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = tags;
+
+        if let Some(target_living) = converted.get_living_entity() {
+            target_living.set_absorption(living.absorption.load());
+            let effects: Vec<Effect> = living
+                .active_effects
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .values()
+                .cloned()
+                .collect();
+            for effect in effects {
+                target_living.add_effect(effect);
+            }
+        }
+
+        if let Some(target_mob) = converted.get_mob() {
+            let target_mob_entity = target_mob.get_mob_entity();
+            target_mob_entity.set_no_ai(self.is_no_ai());
+            target_mob_entity
+                .persistence_required
+                .store(self.persistence_required.load(Relaxed), Relaxed);
+            target_mob_entity.set_can_pick_up_loot(self.can_pick_up_loot());
+        }
+    }
+
+    /// `ConversionParams.keepEquipment`. Call after spawn; replaces rolled gear.
+    pub fn copy_conversion_equipment(&self, converted: &dyn EntityBase) {
+        let Some(target_living) = converted.get_living_entity() else {
+            return;
+        };
+        let living = &self.living_entity;
+
+        let src: Vec<(EquipmentSlot, ItemStack)> = living
+            .entity_equipment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .equipment
+            .iter()
+            .map(|(slot, item)| (slot.clone(), item.clone()))
+            .collect();
+        let src_drop_chances = living
+            .equipment_drop_chances
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+
+        let mut changes = Vec::new();
+        let mut dst = target_living
+            .entity_equipment
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut dst_drop_chances = target_living
+            .equipment_drop_chances
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let stale: Vec<EquipmentSlot> = dst
+            .equipment
+            .keys()
+            .filter(|slot| !src.iter().any(|(s, _)| s == *slot))
+            .cloned()
+            .collect();
+        for slot in stale {
+            dst.put(&slot, ItemStack::EMPTY.clone());
+            changes.push((slot, ItemStack::EMPTY.clone()));
+        }
+        for (slot, item) in src {
+            dst.put(&slot, item.clone());
+            changes.push((slot, item));
+        }
+        *dst_drop_chances = src_drop_chances;
+        drop(dst);
+        drop(dst_drop_chances);
+        target_living.send_equipment_changes(&changes);
     }
 
     pub fn is_no_ai(&self) -> bool {

--- a/crates/pumpkin/src/entity/mob/zombie/husk.rs
+++ b/crates/pumpkin/src/entity/mob/zombie/husk.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 
 use crate::entity::mob::zombie::ZombieEntityBase;
 use crate::entity::{
-    Entity,
+    Entity, EntityBase,
     mob::{Mob, MobEntity},
 };
+use pumpkin_data::entity::EntityType;
+use pumpkin_data::world::WorldEvent;
 use pumpkin_nbt::compound::NbtCompound;
 
 pub struct HuskEntity {
@@ -29,6 +31,12 @@ impl HuskEntity {
 impl Mob for HuskEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.entity.mob_entity
+    }
+
+    /// `Husk.doUnderWaterConversion`.
+    fn mob_tick(&self, _caller: &dyn EntityBase) {
+        self.entity
+            .tick_water_conversion(&EntityType::ZOMBIE, WorldEvent::SoundHuskToZombie);
     }
 
     fn mob_write_nbt(&self, nbt: &mut NbtCompound) {

--- a/crates/pumpkin/src/entity/mob/zombie/mod.rs
+++ b/crates/pumpkin/src/entity/mob/zombie/mod.rs
@@ -16,9 +16,10 @@ use pumpkin_data::data_component_impl::EquipmentSlot;
 use pumpkin_data::entity::EntityType;
 use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
+use pumpkin_data::world::WorldEvent;
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::Difficulty;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Weak};
 
 pub mod drowned;
@@ -30,18 +31,28 @@ pub mod zombie_villager;
 pub struct ZombieEntityBase {
     pub mob_entity: MobEntity,
     pub can_break_doors: AtomicBool,
+    /// `Zombie.inWaterTime`, `-1` when dry.
+    pub in_water_time: AtomicI32,
+    /// `Zombie.conversionTime`, `-1` when not converting.
+    pub drowned_conversion_time: AtomicI32,
 }
 
 impl ZombieEntityBase {
+    pub const IN_WATER_CONVERSION_DELAY: i32 = 600;
+    pub const UNDER_WATER_CONVERSION_TIME: i32 = 300;
+
     pub fn new(entity: Entity) -> Arc<Self> {
         Self::with_can_break_doors(entity, false)
     }
 
+    /// Shared zombie AI, optionally with door breaking.
     pub fn with_can_break_doors(entity: Entity, can_break_doors: bool) -> Arc<Self> {
         let mob_entity = MobEntity::new(entity);
         let zombie = Self {
             mob_entity,
             can_break_doors: AtomicBool::new(can_break_doors),
+            in_water_time: AtomicI32::new(-1),
+            drowned_conversion_time: AtomicI32::new(-1),
         };
         let mob_arc = Arc::new(zombie);
         let mob_weak: Weak<dyn Mob> = {
@@ -99,6 +110,76 @@ impl ZombieEntityBase {
     #[must_use]
     pub fn can_break_doors(&self) -> bool {
         self.can_break_doors.load(Ordering::Relaxed)
+    }
+
+    /// `Zombie.isUnderWaterConverting`.
+    #[must_use]
+    pub fn is_under_water_converting(&self) -> bool {
+        self.drowned_conversion_time.load(Ordering::Relaxed) >= 0
+    }
+
+    /// `Zombie.startUnderWaterConversion`.
+    pub fn start_under_water_conversion(&self, ticks: i32) {
+        self.drowned_conversion_time
+            .store(ticks.max(0), Ordering::Relaxed);
+        self.mob_entity.living_entity.entity.set_synced_data(
+            pumpkin_data::tracked_data::zombie::DATA_DROWNED_CONVERSION_ID,
+            true,
+        );
+    }
+
+    /// `Zombie.tick` water conversion. Becomes `target` after the timers expire.
+    pub fn tick_water_conversion(&self, target: &'static EntityType, sound_event: WorldEvent) {
+        let entity = &self.mob_entity.living_entity.entity;
+        if !entity.is_alive() || self.mob_entity.is_no_ai() {
+            return;
+        }
+
+        if self.is_under_water_converting() {
+            let remaining = self.drowned_conversion_time.fetch_sub(1, Ordering::Relaxed) - 1;
+            if remaining < 0 {
+                self.convert_to_zombie_type(target);
+                if !entity.is_silent() {
+                    entity
+                        .world
+                        .load()
+                        .sync_world_event(sound_event, entity.block_pos.load(), 0);
+                }
+            }
+        } else if entity.is_submerged_in_water() {
+            let time = self.in_water_time.fetch_add(1, Ordering::Relaxed) + 1;
+            if time >= Self::IN_WATER_CONVERSION_DELAY {
+                self.start_under_water_conversion(Self::UNDER_WATER_CONVERSION_TIME);
+            }
+        } else {
+            self.in_water_time.store(-1, Ordering::Relaxed);
+        }
+    }
+
+    /// `Zombie.convertToZombieType`.
+    fn convert_to_zombie_type(&self, target: &'static EntityType) {
+        let entity = &self.mob_entity.living_entity.entity;
+        let world = entity.world.load();
+
+        let converted = crate::entity::r#type::from_type(
+            target,
+            entity.pos.load(),
+            &world,
+            uuid::Uuid::new_v4(),
+        );
+        self.mob_entity.copy_conversion_state(converted.as_ref());
+        if self.can_break_doors()
+            && let Some(converted_mob) = converted.get_mob()
+        {
+            let mut nbt = NbtCompound::new();
+            nbt.put_bool("CanBreakDoors", true);
+            converted_mob.mob_read_nbt(&nbt);
+        }
+
+        world.spawn_entity(converted.clone());
+        self.mob_entity
+            .copy_conversion_equipment(converted.as_ref());
+        entity.remove();
     }
 
     pub fn set_can_break_doors(&self, can_break_doors: bool, mob: &dyn Mob) {
@@ -196,15 +277,35 @@ impl Mob for ZombieEntityBase {
         }
     }
 
+    /// Writes `CanBreakDoors`, `InWaterTime`, `DrownedConversionTime`.
     fn mob_write_nbt(&self, nbt: &mut NbtCompound) {
         if self.can_break_doors() {
             nbt.put_bool("CanBreakDoors", true);
         }
+        let in_water_time = if self.mob_entity.living_entity.entity.is_in_water() {
+            self.in_water_time.load(Ordering::Relaxed)
+        } else {
+            -1
+        };
+        nbt.put_int("InWaterTime", in_water_time);
+        nbt.put_int(
+            "DrownedConversionTime",
+            self.drowned_conversion_time.load(Ordering::Relaxed),
+        );
     }
 
+    /// Reads `CanBreakDoors`, `InWaterTime`, `DrownedConversionTime`.
     fn mob_read_nbt(&self, nbt: &NbtCompound) {
         if let Some(can_break_doors) = nbt.get_bool("CanBreakDoors") {
             self.set_can_break_doors(can_break_doors, self);
+        }
+        if let Some(in_water_time) = nbt.get_int("InWaterTime") {
+            self.in_water_time.store(in_water_time, Ordering::Relaxed);
+        }
+        if let Some(conversion_time) = nbt.get_int("DrownedConversionTime")
+            && conversion_time > -1
+        {
+            self.start_under_water_conversion(conversion_time);
         }
     }
 }

--- a/crates/pumpkin/src/entity/mob/zombie/zombie.rs
+++ b/crates/pumpkin/src/entity/mob/zombie/zombie.rs
@@ -1,8 +1,10 @@
-use crate::entity::Entity;
 use crate::entity::mob::equipment::RegionalDifficulty;
 use crate::entity::mob::zombie::ZombieEntityBase;
 use crate::entity::mob::{Mob, MobEntity};
+use crate::entity::{Entity, EntityBase};
 use crate::world::World;
+use pumpkin_data::entity::EntityType;
+use pumpkin_data::world::WorldEvent;
 use pumpkin_nbt::compound::NbtCompound;
 use std::sync::Arc;
 
@@ -28,6 +30,12 @@ impl ZombieEntity {
 impl Mob for ZombieEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.entity.mob_entity
+    }
+
+    /// `Zombie.tick`.
+    fn mob_tick(&self, _caller: &dyn EntityBase) {
+        self.entity
+            .tick_water_conversion(&EntityType::DROWNED, WorldEvent::SoundZombieToDrowned);
     }
 
     fn populate_default_equipment_slots(


### PR DESCRIPTION
Closes #3288

## Description

- `Zombie.tick` water conversion: 600 ticks with the eyes under water, then 300 ticks shaking (`DATA_DROWNED_CONVERSION_ID`), then the mob becomes a drowned. Husks become zombies. Level event sound on conversion.
- `MobEntity::copy_conversion_state` mirrors `ConversionType.convertCommon`: rotation, motion, baby age, silent, invulnerable, gravity, portal cooldown, fire, custom name and visibility, scoreboard tags, absorption, active effects, NoAI, persistence, loot pickup. Health is not copied (24w37a).
- `MobEntity::copy_conversion_equipment` runs after spawn and replaces the spawn-time gear roll with the source equipment and drop chances.
- `CanBreakDoors` carries over.
- `InWaterTime` and `DrownedConversionTime` NBT saved and loaded.
- Uses `Entity::is_submerged_in_water` for the eye check.

Not included: leash and passenger transfer.

## Testing

- `cargo fmt --all --check`, `cargo clippy -p pumpkin --all-targets`, `cargo test -p pumpkin` pass.
- Not yet verified in game.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Zombies now convert into drowned after remaining submerged for the required duration.
  - Husks now convert into zombies when exposed to water.
  - Conversion progress is saved and restored when entities are reloaded.
  - Converted entities retain relevant equipment, drop chances, names, tags, active effects, and other state.
  - Conversion progress is synchronized, and appropriate conversion sound effects are played.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->