### PR TITLE
feat(entity): dolphin moisture

### DIFF
--- a/crates/pumpkin/src/entity/mod.rs
+++ b/crates/pumpkin/src/entity/mod.rs
@@ -2769,6 +2769,36 @@ impl Entity {
         self.is_in_water() && self.is_submerged_in_water()
     }
 
+    /// `Entity.isInBubbleColumn`.
+    #[must_use]
+    pub fn is_in_bubble_column(&self) -> bool {
+        self.world.load().get_block(&self.block_pos.load()) == &Block::BUBBLE_COLUMN
+    }
+
+    /// `Entity.isInRain`.
+    #[must_use]
+    pub fn is_in_rain(&self) -> bool {
+        let world = self.world.load();
+        let feet = self.block_pos.load();
+        if world.is_raining_at(&feet) {
+            return true;
+        }
+        let top_y = self.bounding_box.load().max.y.floor() as i32;
+        world.is_raining_at(&BlockPos::new(feet.0.x, top_y, feet.0.z))
+    }
+
+    /// `Entity.isInWaterOrRain`.
+    #[must_use]
+    pub fn is_in_water_or_rain(&self) -> bool {
+        self.is_in_water() || self.is_in_rain()
+    }
+
+    /// `Entity.isInWaterRainOrBubble`.
+    #[must_use]
+    pub fn is_in_water_rain_or_bubble(&self) -> bool {
+        self.is_in_water_or_rain() || self.is_in_bubble_column()
+    }
+
     #[must_use]
     pub fn is_visually_crawling(&self) -> bool {
         self.is_visually_swimming() && !self.is_in_water()

--- a/crates/pumpkin/src/entity/passive/dolphin.rs
+++ b/crates/pumpkin/src/entity/passive/dolphin.rs
@@ -3,12 +3,14 @@ use std::sync::{
     atomic::{AtomicBool, AtomicI32, Ordering},
 };
 
+use pumpkin_data::damage::DamageType;
 use pumpkin_data::entity::EntityType;
 use pumpkin_data::item::Item;
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::particle::Particle;
 use pumpkin_data::sound::{Sound, SoundCategory};
 use pumpkin_nbt::compound::NbtCompound;
+use pumpkin_protocol::codec::var_int::VarInt;
 use pumpkin_util::math::vector3::Vector3;
 
 use crate::entity::{
@@ -25,6 +27,8 @@ use crate::entity::{
 
 const TEMPT_ITEMS: &[&Item] = &[&Item::COD, &Item::SALMON, &Item::TROPICAL_FISH];
 
+const MAX_MOISTNESS: i32 = 2400;
+
 pub struct DolphinEntity {
     pub mob_entity: MobEntity,
     pub got_fish: AtomicBool,
@@ -32,12 +36,13 @@ pub struct DolphinEntity {
 }
 
 impl DolphinEntity {
+    /// New dolphin with vanilla goals.
     pub fn new(entity: Entity) -> Arc<Self> {
         let mob_entity = MobEntity::new(entity);
         let dolphin = Self {
             mob_entity,
             got_fish: AtomicBool::new(false),
-            moistness_level: AtomicI32::new(2400),
+            moistness_level: AtomicI32::new(MAX_MOISTNESS),
         };
         let mob_arc = Arc::new(dolphin);
         let mob_weak: Weak<dyn Mob> = {
@@ -78,28 +83,82 @@ impl DolphinEntity {
         mob_arc
     }
 
+    /// `Dolphin.gotFish`.
     #[must_use]
     pub fn got_fish(&self) -> bool {
         self.got_fish.load(Ordering::Relaxed)
     }
 
+    /// Sets and syncs `GotFish`.
     pub fn set_got_fish(&self, val: bool) {
         self.got_fish.store(val, Ordering::Relaxed);
+        self.get_entity()
+            .set_synced_data(pumpkin_data::tracked_data::dolphin::GOT_FISH, val);
+    }
+
+    /// `Dolphin.moistnessLevel`.
+    #[must_use]
+    pub fn moistness_level(&self) -> i32 {
+        self.moistness_level.load(Ordering::Relaxed)
+    }
+
+    /// Sets and syncs `Moistness`.
+    pub fn set_moistness_level(&self, level: i32) {
+        if self.moistness_level.swap(level, Ordering::Relaxed) != level {
+            self.get_entity().set_synced_data(
+                pumpkin_data::tracked_data::dolphin::MOISTNESS_LEVEL,
+                VarInt(level),
+            );
+        }
     }
 }
 
 impl Mob for DolphinEntity {
-    fn mob_write_nbt(&self, nbt: &mut NbtCompound) {
-        nbt.put_bool("GotFish", self.got_fish());
-        nbt.put_int("Moistness", self.moistness_level.load(Ordering::Relaxed));
+    /// `Dolphin.tick` moisture.
+    fn mob_tick(&self, caller: &dyn EntityBase) {
+        let living = &self.mob_entity.living_entity;
+        let entity = &living.entity;
+        if !entity.is_alive() || self.mob_entity.is_no_ai() {
+            return;
+        }
+
+        if entity.is_in_water_rain_or_bubble() {
+            self.set_moistness_level(MAX_MOISTNESS);
+        } else {
+            let moistness = self.moistness_level() - 1;
+            self.set_moistness_level(moistness);
+            if moistness <= 0 {
+                living.damage(caller, 1.0, DamageType::DRY_OUT);
+            }
+        }
     }
 
+    /// Syncs `GotFish` and `Moistness` on spawn.
+    fn mob_init_data_tracker(&self) {
+        let entity = self.get_entity();
+        entity.set_synced_data(
+            pumpkin_data::tracked_data::dolphin::GOT_FISH,
+            self.got_fish(),
+        );
+        entity.set_synced_data(
+            pumpkin_data::tracked_data::dolphin::MOISTNESS_LEVEL,
+            VarInt(self.moistness_level()),
+        );
+    }
+
+    /// Writes `GotFish` and `Moistness`.
+    fn mob_write_nbt(&self, nbt: &mut NbtCompound) {
+        nbt.put_bool("GotFish", self.got_fish());
+        nbt.put_int("Moistness", self.moistness_level());
+    }
+
+    /// Reads `GotFish` and `Moistness`.
     fn mob_read_nbt(&self, nbt: &NbtCompound) {
         if let Some(got_fish) = nbt.get_bool("GotFish") {
             self.set_got_fish(got_fish);
         }
         if let Some(moistness) = nbt.get_int("Moistness") {
-            self.moistness_level.store(moistness, Ordering::Relaxed);
+            self.set_moistness_level(moistness);
         }
     }
 


### PR DESCRIPTION
Closes #3290

## Description

- `Dolphin.tick` moisture: 2400 ticks, refills in water, rain or a bubble column, drops 1 per tick otherwise. At 0 the dolphin takes 1 dry-out damage per tick. NoAI dolphins skip it.
- `GotFish` and `Moistness` synced to clients on spawn and change.
- New `Entity` helpers: `is_in_bubble_column`, `is_in_rain`, `is_in_water_or_rain`, `is_in_water_rain_or_bubble`.

Related: #3275 (air supply, gives dolphins 4800 air and drowning). #3287 adds the same helpers.

## Testing

- `cargo fmt --all --check`, `cargo clippy -p pumpkin --all-targets`, `cargo test -p pumpkin` pass.
- Not yet verified in game.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment awareness for entities, including bubble columns, rain, and water conditions.
  * Rain detection now accounts for both an entity’s feet and the top of its bounding area.
  * Dolphins now track moisture levels and gradually dry out over time.
  * Dolphins may take damage when they become completely dry.
  * Dolphin moisture and feeding-related state remains synchronized and persists correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->