### PR TITLE
fix(worldgen): anchor Nether fossils below the bedrock roof

### DIFF
--- a/crates/pumpkin-world/src/chunk_system/generation.rs
+++ b/crates/pumpkin-world/src/chunk_system/generation.rs
@@ -183,6 +183,64 @@ mod tests {
         }
     }
 
+    /// The Nether ceiling is beard-carved around every structure start, so a fossil
+    /// whose start Y was picked from the built chunk anchored itself to its own beard
+    /// pocket and replaced the bedrock roof. This seed/chunk reproduced that.
+    #[test]
+    fn nether_fossils_stay_below_the_bedrock_roof() {
+        let seed = Seed(1_789_192_880_694_109_906);
+        let block_registry = Arc::new(BlockRegistry);
+        let world_gen = get_world_gen(
+            seed,
+            Dimension::THE_NETHER,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+
+        let surface = generate_single_chunk(
+            &world_gen,
+            block_registry.as_ref(),
+            -10,
+            20,
+            StagedChunkEnum::Surface,
+        );
+        let features = generate_single_chunk(
+            &world_gen,
+            block_registry.as_ref(),
+            -10,
+            20,
+            StagedChunkEnum::Features,
+        );
+        let (super::Chunk::Proto(surface), super::Chunk::Proto(features)) = (surface, features)
+        else {
+            panic!("features stage should return a proto chunk");
+        };
+
+        let mut bones = 0;
+        for x in -160..-144 {
+            for z in 320..336 {
+                for y in 0..128 {
+                    let pos = pumpkin_util::math::vector3::Vector3::new(x, y, z);
+                    let surface_block = surface.get_block_state(&pos).to_block_id();
+                    let feature_block = features.get_block_state(&pos).to_block_id();
+                    if feature_block == pumpkin_data::Block::BONE_BLOCK.id {
+                        bones += 1;
+                    }
+                    if surface_block == pumpkin_data::Block::BEDROCK.id {
+                        assert_eq!(
+                            feature_block,
+                            pumpkin_data::Block::BEDROCK.id,
+                            "fossil replaced bedrock at {pos:?}"
+                        );
+                    }
+                }
+            }
+        }
+
+        assert!(bones > 0, "reference chunk contains no fossil");
+    }
+
     #[test]
     fn generate_chunk_should_return() {
         let dimension = Dimension::OVERWORLD;

--- a/crates/pumpkin-world/src/generation/generator/structure_finder.rs
+++ b/crates/pumpkin-world/src/generation/generator/structure_finder.rs
@@ -195,6 +195,7 @@ pub fn find_nearest_structure_start(
                                 random: create_chunk_random(world_seed, chunk_x, chunk_z),
                                 sea_level: settings.sea_level,
                                 min_y: noise_generator.dimension.min_y,
+                                generation_height: settings.shape.height,
                                 height_sampler: Some(&mut height_sampler),
                                 structure_key: Some(key),
                             };

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1442,6 +1442,7 @@ impl ProtoChunk {
         // Constant across every chunk in the dimension, so hoist it out of the loop
         // and out of the (cached) structure-start computation below.
         let chunk_min_y = self.bottom_y() as i32;
+        let generation_height = self.generation_height();
 
         for (set_index, set) in StructureSet::ALL.iter().enumerate() {
             let mut candidate_chunks = Vec::new();
@@ -1520,6 +1521,7 @@ impl ProtoChunk {
                                     ),
                                     sea_level: settings.sea_level,
                                     min_y: chunk_min_y,
+                                    generation_height,
                                     height_sampler: Some(&mut height_sampler),
                                     structure_key: Some(entry.structure),
                                 };

--- a/crates/pumpkin-world/src/generation/structure/height_sampler.rs
+++ b/crates/pumpkin-world/src/generation/structure/height_sampler.rs
@@ -1,4 +1,4 @@
-use pumpkin_data::{Block, BlockId, block_properties::blocks_movement};
+use pumpkin_data::{Block, BlockId, BlockState, block_properties::blocks_movement};
 use pumpkin_util::math::vector3::Vector3;
 use rustc_hash::FxHashMap;
 
@@ -22,8 +22,9 @@ use super::structures::HeightSampler;
 pub struct NoiseHeightSampler<'a> {
     generator: &'a VanillaGenerator,
     preliminary: SurfaceHeightEstimateSampler<'a>,
-    heights: FxHashMap<(i32, i32), i32>,
-    ocean_floor_heights: FxHashMap<(i32, i32), i32>,
+    /// Base noise column per (x, z), bottom-up from `shape.min_y`. The density pass
+    /// that builds it dominates the cost, so one column serves every query about it.
+    columns: FxHashMap<(i32, i32), Vec<&'static BlockState>>,
 }
 
 impl<'a> NoiseHeightSampler<'a> {
@@ -40,12 +41,19 @@ impl<'a> NoiseHeightSampler<'a> {
         Self {
             generator,
             preliminary,
-            heights: FxHashMap::default(),
-            ocean_floor_heights: FxHashMap::default(),
+            columns: FxHashMap::default(),
         }
     }
 
-    fn sample_column(&mut self, x: i32, z: i32, ocean_floor: bool) -> i32 {
+    fn column(&mut self, x: i32, z: i32) -> &[&'static BlockState] {
+        if !self.columns.contains_key(&(x, z)) {
+            let column = self.sample_column(x, z);
+            self.columns.insert((x, z), column);
+        }
+        &self.columns[&(x, z)]
+    }
+
+    fn sample_column(&mut self, x: i32, z: i32) -> Vec<&'static BlockState> {
         let settings = self.generator.settings;
         let shape = &settings.shape;
         let fluid_sampler = StandardChunkFluidLevelSampler::new(
@@ -77,51 +85,62 @@ impl<'a> NoiseHeightSampler<'a> {
         );
 
         let densities = noise.sample_density();
-        for y in (0..volume.size_y).rev() {
-            let block_y = volume.block_y(y);
-            let index = volume.index_unchecked(0, y, 0);
-            let state = noise
-                .sample_block_state(
-                    &self.generator.random_config.ore_random_deriver,
-                    &Vector3::new(x, block_y, z),
-                    densities.density[index],
-                    densities.vein_sample(index).as_ref(),
-                    &mut self.preliminary,
-                )
-                .unwrap_or(self.generator.default_block);
-            if if ocean_floor {
-                blocks_movement(state, BlockId::from_state_id(state.id))
-            } else {
-                !state.is_air()
-            } {
-                return block_y + 1;
-            }
-        }
+        (0..volume.size_y)
+            .map(|y| {
+                let block_y = volume.block_y(y);
+                let index = volume.index_unchecked(0, y, 0);
+                noise
+                    .sample_block_state(
+                        &self.generator.random_config.ore_random_deriver,
+                        &Vector3::new(x, block_y, z),
+                        densities.density[index],
+                        densities.vein_sample(index).as_ref(),
+                        &mut self.preliminary,
+                    )
+                    .unwrap_or(self.generator.default_block)
+            })
+            .collect()
+    }
 
-        i32::from(shape.min_y)
+    /// First Y from the top whose state passes `occupied`, plus one; `min_y` when the
+    /// column is empty.
+    fn top_of(&mut self, x: i32, z: i32, occupied: impl Fn(&BlockState) -> bool) -> i32 {
+        let min_y = i32::from(self.generator.settings.shape.min_y);
+        let column = self.column(x, z);
+        column
+            .iter()
+            .rposition(|state| occupied(state))
+            .map_or(min_y, |index| min_y + index as i32 + 1)
     }
 }
 
 impl HeightSampler for NoiseHeightSampler<'_> {
     fn estimate_height(&mut self, block_x: i32, block_z: i32) -> i32 {
-        let key = (block_x, block_z);
-        if let Some(height) = self.heights.get(&key) {
-            return *height;
-        }
-        let height = self.sample_column(block_x, block_z, false);
-        self.heights.insert(key, height);
-        height
+        self.top_of(block_x, block_z, |state| !state.is_air())
     }
 
     fn estimate_ocean_floor_height(&mut self, block_x: i32, block_z: i32) -> i32 {
-        let key = (block_x, block_z);
-        if let Some(height) = self.ocean_floor_heights.get(&key) {
-            return *height;
-        }
         // Vanilla's structure helper asks for the highest occupied block, while
         // heightmaps store the first free block above it.
-        let height = self.sample_column(block_x, block_z, true) - 1;
-        self.ocean_floor_heights.insert(key, height);
-        height
+        self.top_of(block_x, block_z, |state| {
+            blocks_movement(state, BlockId::from_state_id(state.id))
+        }) - 1
+    }
+
+    fn base_column_state(
+        &mut self,
+        block_x: i32,
+        block_y: i32,
+        block_z: i32,
+    ) -> Option<&'static BlockState> {
+        let min_y = i32::from(self.generator.settings.shape.min_y);
+        let index = block_y - min_y;
+        let column = self.column(block_x, block_z);
+        Some(
+            usize::try_from(index)
+                .ok()
+                .and_then(|index| column.get(index).copied())
+                .unwrap_or(Block::AIR.default_state),
+        )
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/mod.rs
@@ -148,6 +148,7 @@ pub fn try_generate_structure(
         random,
         sea_level,
         min_y: chunk.bottom_y() as i32,
+        generation_height: chunk.generation_height(),
         height_sampler,
         structure_key: Some(*key),
     };
@@ -155,9 +156,8 @@ pub fn try_generate_structure(
 
     if let Some(pos) = structure_pos {
         // Get the biome at the structure's starting position.
-        // Clamp biome Y to the chunk's valid range — structure start_pos.y may exceed
-        // the chunk's logical height (e.g. nether fossils use full height 256 but
-        // ProtoChunk only covers logical_height 128).
+        // Clamp biome Y to the chunk's valid range: a start_pos.y outside it would
+        // index past the biome map.
         let biome_y = biome_coords::from_block(pos.start_pos.0.y);
         let biome_height = (chunk.height() >> 2) as i32;
         let biome_bottom = biome_coords::from_block(chunk.bottom_y() as i32);

--- a/crates/pumpkin-world/src/generation/structure/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     },
 };
 
-pub(crate) mod height_sampler;
+pub mod height_sampler;
 pub mod piece;
 pub mod placement;
 pub mod shiftable_piece;

--- a/crates/pumpkin-world/src/generation/structure/structures/end_city/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/end_city/mod.rs
@@ -341,6 +341,7 @@ mod tests {
                 random: RandomGenerator::Legacy(LegacyRand::from_seed(seed)),
                 sea_level: 63,
                 min_y: 0,
+                generation_height: 128,
                 height_sampler: Some(&mut sampler),
                 structure_key: None,
             })
@@ -374,6 +375,7 @@ mod tests {
                     random: RandomGenerator::Legacy(LegacyRand::from_seed(0)),
                     sea_level: 63,
                     min_y: 0,
+                    generation_height: 128,
                     height_sampler: Some(&mut sampler),
                     structure_key: None,
                 })

--- a/crates/pumpkin-world/src/generation/structure/structures/jigsaw.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/jigsaw.rs
@@ -1012,6 +1012,7 @@ mod tests {
             random: super::super::create_chunk_random(0, 0, 0),
             sea_level: 63,
             min_y: -64,
+            generation_height: 384,
             height_sampler: None,
             structure_key: Some(pumpkin_data::structures::StructureKeys::AncientCity),
         };
@@ -1123,6 +1124,7 @@ mod tests {
             random: super::super::create_chunk_random(SEED, 75, -82),
             sea_level: 63,
             min_y: -64,
+            generation_height: 384,
             height_sampler: Some(&mut height_sampler),
             structure_key: Some(pumpkin_data::structures::StructureKeys::PillagerOutpost),
         };

--- a/crates/pumpkin-world/src/generation/structure/structures/mansion/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mansion/mod.rs
@@ -635,6 +635,7 @@ mod tests {
                 random: RandomGenerator::Legacy(LegacyRand::from_seed(seed)),
                 sea_level: 63,
                 min_y: -64,
+                generation_height: 384,
                 height_sampler: Some(&mut sampler),
                 structure_key: None,
             })

--- a/crates/pumpkin-world/src/generation/structure/structures/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mod.rs
@@ -835,6 +835,20 @@ pub trait HeightSampler {
     fn estimate_ocean_floor_height(&mut self, block_x: i32, block_z: i32) -> i32 {
         self.estimate_height(block_x, block_z)
     }
+
+    /// Vanilla `ChunkGenerator::getBaseColumn`: the state raw noise puts at this
+    /// position, before surface rules, carvers, structures and the beardifier touch
+    /// the chunk. Out-of-range Y reads as air, like vanilla's `NoiseColumn`.
+    ///
+    /// `None` means this sampler cannot see the column at all.
+    fn base_column_state(
+        &mut self,
+        _block_x: i32,
+        _block_y: i32,
+        _block_z: i32,
+    ) -> Option<&'static BlockState> {
+        None
+    }
 }
 
 impl HeightSampler

--- a/crates/pumpkin-world/src/generation/structure/structures/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mod.rs
@@ -852,6 +852,10 @@ pub struct StructureGeneratorContext<'a> {
     pub random: RandomGenerator,
     pub sea_level: i32,
     pub min_y: i32,
+    /// Vanilla `WorldGenerationContext::getGenDepth`: the chunk generator's noise
+    /// height clamped to the dimension, *not* the dimension height (128 in the
+    /// Nether, where the dimension is 256 tall).
+    pub generation_height: u16,
     pub height_sampler: Option<&'a mut dyn HeightSampler>,
     pub structure_key: Option<pumpkin_data::structures::StructureKeys>,
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/nether_fossil.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/nether_fossil.rs
@@ -43,12 +43,6 @@ pub const FOSSILS: [&str; 14] = [
     "nether_fossils/fossil_14",
 ];
 
-/// Vanilla height provider bounds for nether fossils.
-/// From `nether_fossil.json`: uniform(absolute=32, `below_top=2`).
-/// Vanilla `BelowTop`: height - 1 + `min_y` - offset = 256 - 1 + 0 - 2 = 253.
-const HEIGHT_MIN: i32 = 32;
-const HEIGHT_MAX: i32 = 253;
-
 pub struct NetherFossilGenerator;
 
 impl StructureGenerator for NetherFossilGenerator {
@@ -67,16 +61,20 @@ impl StructureGenerator for NetherFossilGenerator {
         let x = start_block_x(context.chunk_x) + context.random.next_bounded_i32(16);
         let z = start_block_z(context.chunk_z) + context.random.next_bounded_i32(16);
 
-        let structure = context
+        // `nether_fossil.json`: uniform(absolute=32, `below_top=2`). `BelowTop` resolves
+        // against the generation height, which in the Nether is the noise height (128,
+        // giving max y 125), not the 256-block dimension height. Sampling up to 253 put
+        // the start above the bedrock roof, where the downward scan stopped on the roof
+        // and buried the fossil in it.
+        let initial_y = context
             .structure_key
-            .map(|key| pumpkin_data::structures::Structure::get(&key));
-
-        let initial_y = if let Some(hp) = structure.and_then(|s| s.start_height) {
-            hp.get(&mut context.random, context.min_y as i8, 256)
-        } else {
-            let height_range = HEIGHT_MAX - HEIGHT_MIN + 1;
-            HEIGHT_MIN + context.random.next_bounded_i32(height_range)
-        };
+            .map(|key| pumpkin_data::structures::Structure::get(&key))
+            .and_then(|s| s.start_height)?
+            .get(
+                &mut context.random,
+                context.min_y as i8,
+                context.generation_height,
+            );
 
         let rotation_index = context.random.next_bounded_i32(4) as u8;
         let rotation = Rotation::from_index(rotation_index);
@@ -310,4 +308,40 @@ fn make_settings(rotation: Rotation) -> StructurePlaceSettings {
                 properties: None,
             },
         ]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generation::structure::structures::{
+        StructureGeneratorContext, create_chunk_random,
+    };
+    use pumpkin_data::structures::StructureKeys;
+
+    /// The Nether is 256 blocks tall but only generates 128, so `below_top=2`
+    /// resolves to y=125. Sampling above that used to start the fossil over the
+    /// bedrock roof, where the downward scan stopped on the roof itself.
+    #[test]
+    fn start_height_stays_below_the_nether_roof() {
+        for chunk_x in 0..64 {
+            let context = StructureGeneratorContext {
+                seed: 0,
+                chunk_x,
+                chunk_z: 0,
+                random: create_chunk_random(0, chunk_x, 0),
+                sea_level: 32,
+                min_y: 0,
+                generation_height: 128,
+                height_sampler: None,
+                structure_key: Some(StructureKeys::NetherFossil),
+            };
+            let y = NetherFossilGenerator
+                .get_structure_position(context)
+                .expect("nether fossil template should load")
+                .start_pos
+                .0
+                .y;
+            assert!((32..=125).contains(&y), "fossil start out of range: {y}");
+        }
+    }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/nether_fossil.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/nether_fossil.rs
@@ -15,8 +15,8 @@ use crate::{
         structure::{
             piece::StructurePieceType,
             structures::{
-                StructureGenerator, StructureGeneratorContext, StructurePiece, StructurePieceBase,
-                StructurePiecesCollector, StructurePosition, WorldPortalExt,
+                HeightSampler, StructureGenerator, StructureGeneratorContext, StructurePiece,
+                StructurePieceBase, StructurePiecesCollector, StructurePosition, WorldPortalExt,
             },
             template::{
                 BlockStateResolver, StructurePlaceSettings, StructureTemplate, get_template,
@@ -76,6 +76,20 @@ impl StructureGenerator for NetherFossilGenerator {
                 context.generation_height,
             );
 
+        // Vanilla decides the fossil's Y right here, scanning the *base* noise column:
+        // surface rules, carvers and the beardifier (this structure is `beard_thin`)
+        // have not run yet. Deciding it later, from the built chunk, anchors the fossil
+        // to the beard pocket its own start box carved into the Nether ceiling.
+        let anchor_y = match context.height_sampler.as_deref_mut() {
+            // Samplers without base-column access keep the sampled height.
+            Some(sampler) => match find_anchor(sampler, x, z, initial_y, context.sea_level) {
+                ColumnScan::NoSampler => initial_y,
+                ColumnScan::Anchor(y) => y,
+                ColumnScan::NoSpot => return None,
+            },
+            None => initial_y,
+        };
+
         let rotation_index = context.random.next_bounded_i32(4) as u8;
         let rotation = Rotation::from_index(rotation_index);
 
@@ -83,25 +97,59 @@ impl StructureGenerator for NetherFossilGenerator {
         let template_name = FOSSILS[template_index];
 
         let template = get_template(template_name)?;
-        let position = Vector3::new(x, initial_y, z);
+        let position = Vector3::new(x, anchor_y, z);
 
         let mut collector = StructurePiecesCollector::default();
 
-        let piece = NetherFossilPiece::new(
-            template,
-            template_name.to_string(),
-            position,
-            rotation,
-            initial_y,
-            context.sea_level,
-        );
+        let piece = NetherFossilPiece::new(template, template_name.to_string(), position, rotation);
 
         collector.add_piece(Box::new(piece));
 
         Some(StructurePosition {
-            start_pos: BlockPos::new(x, initial_y, z),
+            start_pos: BlockPos::new(x, anchor_y, z),
             collector: Arc::new(collector.into()),
         })
+    }
+}
+
+enum ColumnScan {
+    /// The sampler cannot see the base column, so the caller keeps its own height.
+    NoSampler,
+    Anchor(i32),
+    /// The scan reached sea level: vanilla generates no fossil here.
+    NoSpot,
+}
+
+/// Vanilla's downward scan for a spot to drop a fossil on: the first air block sitting
+/// on soul sand or an upward-solid face.
+fn find_anchor(
+    sampler: &mut dyn HeightSampler,
+    x: i32,
+    z: i32,
+    start_y: i32,
+    sea_level: i32,
+) -> ColumnScan {
+    let mut y = start_y;
+    while y > sea_level {
+        let (Some(upper), Some(lower)) = (
+            sampler.base_column_state(x, y, z),
+            sampler.base_column_state(x, y - 1, z),
+        ) else {
+            return ColumnScan::NoSampler;
+        };
+        y -= 1;
+        if upper.is_air()
+            && (Block::from_state_id(lower.id) == &Block::SOUL_SAND
+                || lower.is_side_solid(BlockDirection::Up))
+        {
+            break;
+        }
+    }
+
+    if y > sea_level {
+        ColumnScan::Anchor(y)
+    } else {
+        ColumnScan::NoSpot
     }
 }
 
@@ -111,8 +159,6 @@ pub struct NetherFossilPiece {
     pub template_name: String,
     pub place_settings: StructurePlaceSettings,
     pub template_position: Vector3<i32>,
-    pub initial_y: i32,
-    pub sea_level: i32,
 }
 
 impl NetherFossilPiece {
@@ -122,8 +168,6 @@ impl NetherFossilPiece {
         template_name: String,
         template_position: Vector3<i32>,
         rotation: Rotation,
-        initial_y: i32,
-        sea_level: i32,
     ) -> Self {
         let place_settings = make_settings(rotation);
         let bounding_box = template.get_bounding_box(&place_settings, template_position);
@@ -134,34 +178,7 @@ impl NetherFossilPiece {
             template_name,
             place_settings,
             template_position,
-            initial_y,
-            sea_level,
         }
-    }
-
-    /// Vanilla column scan: search downward from `initial_y` for air above (soul sand OR solid block).
-    /// Returns the Y of the support block, or None if no valid position found above sea level.
-    fn find_placement_y(&self, chunk: &ProtoChunk) -> Option<i32> {
-        let origin = self.template_position;
-        let mut y = self.initial_y;
-
-        while y > self.sea_level {
-            let upper = chunk.get_block_state(&Vector3::new(origin.x, y, origin.z));
-            y -= 1;
-            let lower = chunk.get_block_state(&Vector3::new(origin.x, y, origin.z));
-
-            let upper_state = BlockState::from_id(upper);
-            let lower_state = BlockState::from_id(lower);
-
-            if upper_state.is_air()
-                && (Block::from_state_id(lower) == &Block::SOUL_SAND
-                    || lower_state.is_side_solid(BlockDirection::Up))
-            {
-                break;
-            }
-        }
-
-        if y <= self.sea_level { None } else { Some(y) }
     }
 
     fn place_blocks(&self, chunk: &mut ProtoChunk, chunk_box: &BlockBox) {
@@ -276,15 +293,6 @@ impl StructurePieceBase for NetherFossilPiece {
         seed: i64,
         chunk_box: &BlockBox,
     ) {
-        let Some(placement_y) = self.find_placement_y(chunk) else {
-            return;
-        };
-
-        self.template_position.y = placement_y;
-        self.piece.bounding_box = self
-            .template
-            .get_bounding_box(&self.place_settings, self.template_position);
-
         let fossil_bb = self.piece.bounding_box;
         let mut enlarged_box = *chunk_box;
         enlarged_box.encompass(&fossil_bb);

--- a/crates/pumpkin-world/src/generation/structure/structures/ocean_monument/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/ocean_monument/mod.rs
@@ -545,6 +545,7 @@ mod tests {
             random: RandomGenerator::Legacy(LegacyRand::from_seed(0)),
             sea_level: 63,
             min_y: -64,
+            generation_height: 384,
             height_sampler: Some(&mut height_sampler),
             structure_key: None,
         };

--- a/crates/pumpkin/src/block/entities/jigsaw_block.rs
+++ b/crates/pumpkin/src/block/entities/jigsaw_block.rs
@@ -100,6 +100,7 @@ impl JigsawBlockEntity {
                 random: RandomGenerator::Xoroshiro(Xoroshiro::from_seed(rand::rng().next_u64())),
                 sea_level: 63,
                 min_y: -64,
+                generation_height: 384,
                 height_sampler: None,
                 structure_key: None,
             };

--- a/crates/pumpkin/src/command/commands/place.rs
+++ b/crates/pumpkin/src/command/commands/place.rs
@@ -27,13 +27,15 @@ use crate::command::node::{CommandExecutor, CommandExecutorResult};
 use crate::world::block_placer::WorldBlockPlacer;
 use pumpkin_world::generation::feature::configured_features::CONFIGURED_FEATURES;
 use pumpkin_world::generation::feature::placed_features::{Feature, PLACED_FEATURES};
-use pumpkin_world::generation::structure::structures::StructureGeneratorContext;
+use pumpkin_world::generation::generator::WorldGenerator;
+use pumpkin_world::generation::structure::height_sampler::NoiseHeightSampler;
 use pumpkin_world::generation::structure::structures::jigsaw::{
     PoolElementStructurePiece, place_pool_element_templates,
 };
 use pumpkin_world::generation::structure::structures::jigsaw_placement::{
     DimensionPadding, JigsawPlacement, LiquidSettings, MaxDistance, PoolAliasLookup,
 };
+use pumpkin_world::generation::structure::structures::{HeightSampler, StructureGeneratorContext};
 use pumpkin_world::generation::structure::template::BlockPlacer;
 
 use pumpkin_util::PermissionLvl;
@@ -347,6 +349,12 @@ impl CommandExecutor for PlaceStructureExecutor {
                 (piece_count, placer)
             } else {
                 let random = RandomGenerator::Legacy(LegacyRand::from_seed(seed));
+                // Structures that pick their own Y (nether fossils) need the base noise
+                // column to scan, the same one worldgen hands them.
+                let mut height_sampler = match world_gen.as_ref() {
+                    WorldGenerator::Noise(noise_gen) => Some(NoiseHeightSampler::new(noise_gen)),
+                    _ => None,
+                };
 
                 let position = pumpkin_world::generation::structure::generate_structure_position(
                     &key,
@@ -359,7 +367,9 @@ impl CommandExecutor for PlaceStructureExecutor {
                         sea_level: settings.sea_level,
                         min_y: world_gen.dimension().min_y,
                         generation_height: settings.shape.height,
-                        height_sampler: None,
+                        height_sampler: height_sampler
+                            .as_mut()
+                            .map(|sampler| sampler as &mut dyn HeightSampler),
                         structure_key: Some(key),
                     },
                 )

--- a/crates/pumpkin/src/command/commands/place.rs
+++ b/crates/pumpkin/src/command/commands/place.rs
@@ -201,6 +201,7 @@ impl CommandExecutor for PlaceJigsawExecutor {
                 random,
                 sea_level: settings.sea_level,
                 min_y: world_gen.dimension().min_y,
+                generation_height: settings.shape.height,
                 height_sampler: None,
                 structure_key: None,
             };
@@ -308,6 +309,7 @@ impl CommandExecutor for PlaceStructureExecutor {
                         random,
                         sea_level: settings.sea_level,
                         min_y: world_gen.dimension().min_y,
+                        generation_height: settings.shape.height,
                         height_sampler: None,
                         structure_key: Some(key),
                     },
@@ -356,6 +358,7 @@ impl CommandExecutor for PlaceStructureExecutor {
                         random,
                         sea_level: settings.sea_level,
                         min_y: world_gen.dimension().min_y,
+                        generation_height: settings.shape.height,
                         height_sampler: None,
                         structure_key: Some(key),
                     },


### PR DESCRIPTION
## Description

Nether fossils could generate in or above the bedrock ceiling. Resolve their initial height against the Nether's 128-block generation depth, giving the vanilla range of Y=32 through Y=125, instead of the 256-block dimension height.

Determine the final anchor during structure-start generation by scanning the raw base-noise column, matching vanilla's `ChunkGenerator.getBaseColumn`. Remove the later scan of generated terrain, which could anchor a fossil to the ceiling pocket created around its own provisional bounding box by the beardifier. Structure bounds and biome validation now use the resolved anchor, and noise-world `/place structure` receives the same base-column sampler.

Addresses the fossil-generation portion of #3255. The mob-spawning portion is separate.

## Testing

- `cargo test --offline -p pumpkin-world --lib nether_fossil -j 2`: 2 passed.
- Height-range test checks initial fossil Y stays within 32 through 125.
- Generated-chunk regression uses seed `1789192880694109906`, chunk `(-10, 20)`, and verifies that fossils are present while every bedrock block from the Surface stage survives the Features stage.
- Compared placement logic with the local decompiled vanilla 26.2 sources.
- Merge compatibility checked against upstream master `786e2fbf7`; no conflicts. Tests ran on the PR branch.

Assisted by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved structure placement across different world heights and dimensions.
  - Nether fossils now generate at valid terrain locations and remain within the intended height range.
  - Structure placement in noise-generated worlds now accounts for surrounding terrain.
  - Fixed Nether feature generation so existing roof bedrock is preserved.
  - Improved terrain-state sampling for more consistent structure generation.
- **Tests**
  - Added regression coverage for Nether fossils, terrain generation, and bedrock preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->