### PR TITLE
fix(worldgen): respect the carver replaceable tag and lava_level 🤖🤖🤖

### DIFF
--- a/assets/datapacks/26_2/data/minecraft/worldgen/carver/canyon.json
+++ b/assets/datapacks/26_2/data/minecraft/worldgen/carver/canyon.json
@@ -1,5 +1,8 @@
 {
   "type": "minecraft:canyon",
+  "lava_level": {
+    "above_bottom": 8
+  },
   "probability": 0.01,
   "replaceable": "#minecraft:overworld_carver_replaceables",
   "shape": {

--- a/assets/datapacks/26_2/data/minecraft/worldgen/carver/canyon.json
+++ b/assets/datapacks/26_2/data/minecraft/worldgen/carver/canyon.json
@@ -1,6 +1,7 @@
 {
   "type": "minecraft:canyon",
   "probability": 0.01,
+  "replaceable": "#minecraft:overworld_carver_replaceables",
   "shape": {
     "distance_factor": {
       "type": "minecraft:uniform",

--- a/assets/datapacks/26_2/data/minecraft/worldgen/carver/cave.json
+++ b/assets/datapacks/26_2/data/minecraft/worldgen/carver/cave.json
@@ -15,6 +15,9 @@
     "max_exclusive": 1.4,
     "min_inclusive": 0.7
   },
+  "lava_level": {
+    "above_bottom": 8
+  },
   "probability": 0.15,
   "replaceable": "#minecraft:overworld_carver_replaceables",
   "room_vertical_radius_multiplier": {

--- a/assets/datapacks/26_2/data/minecraft/worldgen/carver/cave.json
+++ b/assets/datapacks/26_2/data/minecraft/worldgen/carver/cave.json
@@ -16,6 +16,7 @@
     "min_inclusive": 0.7
   },
   "probability": 0.15,
+  "replaceable": "#minecraft:overworld_carver_replaceables",
   "room_vertical_radius_multiplier": {
     "type": "minecraft:uniform",
     "max_exclusive": 0.9,

--- a/assets/datapacks/26_2/data/minecraft/worldgen/carver/cave_extra_underground.json
+++ b/assets/datapacks/26_2/data/minecraft/worldgen/carver/cave_extra_underground.json
@@ -15,6 +15,9 @@
     "max_exclusive": 1.4,
     "min_inclusive": 0.7
   },
+  "lava_level": {
+    "above_bottom": 8
+  },
   "probability": 0.07,
   "replaceable": "#minecraft:overworld_carver_replaceables",
   "room_vertical_radius_multiplier": {

--- a/assets/datapacks/26_2/data/minecraft/worldgen/carver/cave_extra_underground.json
+++ b/assets/datapacks/26_2/data/minecraft/worldgen/carver/cave_extra_underground.json
@@ -16,6 +16,7 @@
     "min_inclusive": 0.7
   },
   "probability": 0.07,
+  "replaceable": "#minecraft:overworld_carver_replaceables",
   "room_vertical_radius_multiplier": {
     "type": "minecraft:uniform",
     "max_exclusive": 0.9,

--- a/assets/datapacks/26_2/data/minecraft/worldgen/carver/nether_cave.json
+++ b/assets/datapacks/26_2/data/minecraft/worldgen/carver/nether_cave.json
@@ -7,6 +7,9 @@
   },
   "floor_level": -0.7,
   "horizontal_radius_multiplier": 1.0,
+  "lava_level": {
+    "above_bottom": 10
+  },
   "probability": 0.2,
   "replaceable": "#minecraft:nether_carver_replaceables",
   "room_vertical_radius_multiplier": 0.5,

--- a/assets/datapacks/26_2/data/minecraft/worldgen/carver/nether_cave.json
+++ b/assets/datapacks/26_2/data/minecraft/worldgen/carver/nether_cave.json
@@ -8,6 +8,7 @@
   "floor_level": -0.7,
   "horizontal_radius_multiplier": 1.0,
   "probability": 0.2,
+  "replaceable": "#minecraft:nether_carver_replaceables",
   "room_vertical_radius_multiplier": 0.5,
   "start_vertical_radius_multiplier": 5.0,
   "thickness": {

--- a/crates/pumpkin-data/src/generated/carver.rs
+++ b/crates/pumpkin-data/src/generated/carver.rs
@@ -74,6 +74,8 @@ pub struct CarverConfig {
     pub y: HeightProvider,
     #[doc = r" Vanilla `CarverConfiguration.replaceable`: blocks this carver may replace."]
     pub replaceable: crate::tag::Tag,
+    #[doc = r" Vanilla `CarverConfiguration.lavaLevel`: below this anchor the carver emits lava."]
+    pub lava_level: YOffset,
     pub additional: CarverAdditionalConfig,
 }
 use super::*;
@@ -84,6 +86,7 @@ pub const CANYON: CarverConfig = CarverConfig {
         max_inclusive: YOffset::Absolute(Absolute { absolute: 67i16 }),
     }),
     replaceable: crate::tag::Block::MINECRAFT_OVERWORLD_CARVER_REPLACEABLES,
+    lava_level: YOffset::AboveBottom(AboveBottom { above_bottom: 8i8 }),
     additional: CarverAdditionalConfig::Canyon(CanyonCarverConfig {
         vertical_rotation: FloatProvider::Object(NormalFloatProvider::Uniform(
             UniformFloatProvider::new(-0.125f32, 0.125f32),
@@ -112,6 +115,7 @@ pub const CAVE: CarverConfig = CarverConfig {
         max_inclusive: YOffset::Absolute(Absolute { absolute: 180i16 }),
     }),
     replaceable: crate::tag::Block::MINECRAFT_OVERWORLD_CARVER_REPLACEABLES,
+    lava_level: YOffset::AboveBottom(AboveBottom { above_bottom: 8i8 }),
     additional: CarverAdditionalConfig::Cave(CaveCarverConfig {
         count: IntProvider::Object(NormalIntProvider::VeryBiasedToBottom(
             VeryBiasedToBottomIntProvider::new(0i32, 14i32, 1i32),
@@ -142,6 +146,7 @@ pub const CAVE_EXTRA_UNDERGROUND: CarverConfig = CarverConfig {
         max_inclusive: YOffset::Absolute(Absolute { absolute: 47i16 }),
     }),
     replaceable: crate::tag::Block::MINECRAFT_OVERWORLD_CARVER_REPLACEABLES,
+    lava_level: YOffset::AboveBottom(AboveBottom { above_bottom: 8i8 }),
     additional: CarverAdditionalConfig::Cave(CaveCarverConfig {
         count: IntProvider::Object(NormalIntProvider::VeryBiasedToBottom(
             VeryBiasedToBottomIntProvider::new(0i32, 14i32, 1i32),
@@ -172,6 +177,7 @@ pub const NETHER_CAVE: CarverConfig = CarverConfig {
         max_inclusive: YOffset::BelowTop(BelowTop { below_top: 1i8 }),
     }),
     replaceable: crate::tag::Block::MINECRAFT_NETHER_CARVER_REPLACEABLES,
+    lava_level: YOffset::AboveBottom(AboveBottom { above_bottom: 10i8 }),
     additional: CarverAdditionalConfig::Cave(CaveCarverConfig {
         count: IntProvider::Object(NormalIntProvider::VeryBiasedToBottom(
             VeryBiasedToBottomIntProvider::new(0i32, 9i32, 1i32),

--- a/crates/pumpkin-data/src/generated/carver.rs
+++ b/crates/pumpkin-data/src/generated/carver.rs
@@ -72,6 +72,8 @@ pub enum CarverAdditionalConfig {
 pub struct CarverConfig {
     pub probability: f32,
     pub y: HeightProvider,
+    #[doc = r" Vanilla `CarverConfiguration.replaceable`: blocks this carver may replace."]
+    pub replaceable: crate::tag::Tag,
     pub additional: CarverAdditionalConfig,
 }
 use super::*;
@@ -81,6 +83,7 @@ pub const CANYON: CarverConfig = CarverConfig {
         min_inclusive: YOffset::Absolute(Absolute { absolute: 10i16 }),
         max_inclusive: YOffset::Absolute(Absolute { absolute: 67i16 }),
     }),
+    replaceable: crate::tag::Block::MINECRAFT_OVERWORLD_CARVER_REPLACEABLES,
     additional: CarverAdditionalConfig::Canyon(CanyonCarverConfig {
         vertical_rotation: FloatProvider::Object(NormalFloatProvider::Uniform(
             UniformFloatProvider::new(-0.125f32, 0.125f32),
@@ -108,6 +111,7 @@ pub const CAVE: CarverConfig = CarverConfig {
         min_inclusive: YOffset::AboveBottom(AboveBottom { above_bottom: 8i8 }),
         max_inclusive: YOffset::Absolute(Absolute { absolute: 180i16 }),
     }),
+    replaceable: crate::tag::Block::MINECRAFT_OVERWORLD_CARVER_REPLACEABLES,
     additional: CarverAdditionalConfig::Cave(CaveCarverConfig {
         count: IntProvider::Object(NormalIntProvider::VeryBiasedToBottom(
             VeryBiasedToBottomIntProvider::new(0i32, 14i32, 1i32),
@@ -137,6 +141,7 @@ pub const CAVE_EXTRA_UNDERGROUND: CarverConfig = CarverConfig {
         min_inclusive: YOffset::AboveBottom(AboveBottom { above_bottom: 8i8 }),
         max_inclusive: YOffset::Absolute(Absolute { absolute: 47i16 }),
     }),
+    replaceable: crate::tag::Block::MINECRAFT_OVERWORLD_CARVER_REPLACEABLES,
     additional: CarverAdditionalConfig::Cave(CaveCarverConfig {
         count: IntProvider::Object(NormalIntProvider::VeryBiasedToBottom(
             VeryBiasedToBottomIntProvider::new(0i32, 14i32, 1i32),
@@ -166,6 +171,7 @@ pub const NETHER_CAVE: CarverConfig = CarverConfig {
         min_inclusive: YOffset::Absolute(Absolute { absolute: 0i16 }),
         max_inclusive: YOffset::BelowTop(BelowTop { below_top: 1i8 }),
     }),
+    replaceable: crate::tag::Block::MINECRAFT_NETHER_CARVER_REPLACEABLES,
     additional: CarverAdditionalConfig::Cave(CaveCarverConfig {
         count: IntProvider::Object(NormalIntProvider::VeryBiasedToBottom(
             VeryBiasedToBottomIntProvider::new(0i32, 9i32, 1i32),

--- a/crates/pumpkin-world/src/generation/carver/canyon.rs
+++ b/crates/pumpkin-world/src/generation/carver/canyon.rs
@@ -308,7 +308,8 @@ impl CanyonCarver {
             return false;
         }
 
-        let Some((state, should_schedule_fluid_update)) = overworld_carve_state(run, x, y, z)
+        let Some((state, should_schedule_fluid_update)) =
+            overworld_carve_state(run, config, x, y, z)
         else {
             return false;
         };

--- a/crates/pumpkin-world/src/generation/carver/canyon.rs
+++ b/crates/pumpkin-world/src/generation/carver/canyon.rs
@@ -288,7 +288,7 @@ impl CanyonCarver {
 
     fn carve_block(
         run: &mut CarveRun,
-        _config: &CarverConfig,
+        config: &CarverConfig,
         x: i32,
         y: i32,
         z: i32,
@@ -302,6 +302,10 @@ impl CanyonCarver {
             || block.id == pumpkin_data::Block::MYCELIUM.id
         {
             *has_grass = true;
+        }
+
+        if !block.id.has_tag(config.replaceable) {
+            return false;
         }
 
         let Some((state, should_schedule_fluid_update)) = overworld_carve_state(run, x, y, z)
@@ -319,5 +323,34 @@ impl CanyonCarver {
         );
 
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pumpkin_data::{Block, carver::CANYON, dimension::Dimension};
+    use pumpkin_util::math::vector3::Vector3;
+
+    /// `CanyonWorldCarver` inherits Vanilla 26.2's replaceable-block gate, so a
+    /// ravine that reaches the floor must not replace bedrock with lava.
+    #[test]
+    fn leaves_non_replaceable_bedrock_untouched() {
+        assert!(!Block::BEDROCK.id.has_tag(CANYON.replaceable));
+
+        super::super::with_carve_run(Dimension::OVERWORLD, |run| {
+            let (x, y, z) = (9, -61, 12);
+            run.chunk
+                .set_block_state(x, y, z, Block::BEDROCK.default_state);
+
+            let mut has_grass = false;
+            let carved = CanyonCarver::carve_block(run, &CANYON, x, y, z, &mut has_grass);
+
+            assert!(!carved);
+            assert_eq!(
+                run.chunk.get_block_state(&Vector3::new(x, y, z)),
+                Block::BEDROCK.default_state.id
+            );
+        });
     }
 }

--- a/crates/pumpkin-world/src/generation/carver/cave.rs
+++ b/crates/pumpkin-world/src/generation/carver/cave.rs
@@ -333,7 +333,7 @@ impl CaveCarver {
 
     fn carve_block(
         run: &mut CarveRun,
-        _config: &CarverConfig,
+        config: &CarverConfig,
         x: i32,
         y: i32,
         z: i32,
@@ -346,6 +346,10 @@ impl CaveCarver {
             || block.id == pumpkin_data::Block::MYCELIUM.id
         {
             *has_grass = true;
+        }
+
+        if !block.id.has_tag(config.replaceable) {
+            return false;
         }
 
         let Some((state, should_schedule_fluid_update)) = overworld_carve_state(run, x, y, z)
@@ -462,6 +466,27 @@ mod tests {
             assert_eq!(run.chunk.fluid_ticks.len(), old_tick_count + 1);
             let pos = run.chunk.fluid_ticks.last().unwrap().position.0;
             assert_eq!((pos.x, pos.y, pos.z), (x, y, z));
+        });
+    }
+
+    /// Vanilla 26.2 `WorldCarver.carveBlock` rejects blocks outside the configured
+    /// `#minecraft:overworld_carver_replaceables` tag. The seed-13579 reference keeps
+    /// bedrock intact where caves reach y=-62 (286 exact baseline mismatches).
+    #[test]
+    fn leaves_non_replaceable_bedrock_untouched() {
+        assert!(!Block::BEDROCK.id.has_tag(CAVE.replaceable));
+        assert!(Block::STONE.id.has_tag(CAVE.replaceable));
+
+        super::super::with_carve_run(Dimension::OVERWORLD, |run| {
+            let (x, y, z) = (3, -61, 4);
+            run.chunk
+                .set_block_state(x, y, z, Block::BEDROCK.default_state);
+
+            let mut has_grass = false;
+            let carved = CaveCarver::carve_block(run, &CAVE, x, y, z, &mut has_grass);
+
+            assert!(!carved);
+            assert_eq!(block_id(run, x, y, z), Block::BEDROCK.default_state.id);
         });
     }
 

--- a/crates/pumpkin-world/src/generation/carver/cave.rs
+++ b/crates/pumpkin-world/src/generation/carver/cave.rs
@@ -352,7 +352,8 @@ impl CaveCarver {
             return false;
         }
 
-        let Some((state, should_schedule_fluid_update)) = overworld_carve_state(run, x, y, z)
+        let Some((state, should_schedule_fluid_update)) =
+            overworld_carve_state(run, config, x, y, z)
         else {
             return false;
         };
@@ -439,7 +440,7 @@ mod tests {
     #[test]
     fn carves_at_world_y() {
         super::super::with_carve_run(Dimension::OVERWORLD, |run| {
-            let expected = super::super::overworld_carve_state(run, 5, 20, 6)
+            let expected = super::super::overworld_carve_state(run, &CAVE, 5, 20, 6)
                 .expect("test position should carve")
                 .0
                 .id;
@@ -528,7 +529,7 @@ mod tests {
             for x in 0..16 {
                 for z in 0..16 {
                     let Some((state, should_schedule)) =
-                        super::super::overworld_carve_state(run, x, y, z)
+                        super::super::overworld_carve_state(run, &CAVE, x, y, z)
                     else {
                         continue;
                     };

--- a/crates/pumpkin-world/src/generation/carver/mod.rs
+++ b/crates/pumpkin-world/src/generation/carver/mod.rs
@@ -284,10 +284,19 @@ fn carve_top_material(
 
 fn overworld_carve_state(
     run: &mut CarveRun,
+    config: &CarverConfig,
     x: i32,
     y: i32,
     z: i32,
 ) -> Option<(&'static BlockState, bool)> {
+    // Vanilla `WorldCarver.getCarveState`: below the config's `lavaLevel` anchor the
+    // carver always emits lava, before consulting the aquifer.
+    let lava_level = config
+        .lava_level
+        .get_y(run.ctx.min_y as i16, run.ctx.height);
+    if y <= lava_level {
+        return Some((run.ids.lava, false));
+    }
     if let Some(aquifer) = run.ctx.carver_aquifer.as_mut() {
         let result = aquifer.compute(&Vector3::new(x, y, z), 0.0);
         result

--- a/tools/pumpkin-codegen/src/carver.rs
+++ b/tools/pumpkin-codegen/src/carver.rs
@@ -30,6 +30,7 @@ pub fn build() -> TokenStream {
 
         let prob = data["probability"].as_f64().unwrap_or(0.0) as f32;
         let y = value_to_height_provider(&data["y"]);
+        let replaceable = value_to_block_tag(&data["replaceable"]);
 
         let additional = match carver_type {
             "minecraft:cave" => {
@@ -101,6 +102,7 @@ pub fn build() -> TokenStream {
             pub const #variant_name: CarverConfig = CarverConfig {
                 probability: #prob,
                 y: #y,
+                replaceable: #replaceable,
                 additional: #additional,
             };
         });
@@ -190,12 +192,23 @@ pub fn build() -> TokenStream {
         pub struct CarverConfig {
             pub probability: f32,
             pub y: HeightProvider,
+            /// Vanilla `CarverConfiguration.replaceable`: blocks this carver may replace.
+            pub replaceable: crate::tag::Tag,
             pub additional: CarverAdditionalConfig,
         }
 
         use super::*;
         #(#carver_instances)*
     }
+}
+
+fn value_to_block_tag(v: &Value) -> TokenStream {
+    let name = v
+        .as_str()
+        .and_then(|value| value.strip_prefix('#'))
+        .expect("carver `replaceable` must be a block tag reference");
+    let ident = format_ident!("{}", name.to_uppercase().replace([':', '/', '.'], "_"));
+    quote! { crate::tag::Block::#ident }
 }
 
 fn value_to_int_provider(v: &Value) -> TokenStream {

--- a/tools/pumpkin-codegen/src/carver.rs
+++ b/tools/pumpkin-codegen/src/carver.rs
@@ -31,6 +31,7 @@ pub fn build() -> TokenStream {
         let prob = data["probability"].as_f64().unwrap_or(0.0) as f32;
         let y = value_to_height_provider(&data["y"]);
         let replaceable = value_to_block_tag(&data["replaceable"]);
+        let lava_level = value_to_y_offset(&data["lava_level"]);
 
         let additional = match carver_type {
             "minecraft:cave" => {
@@ -103,6 +104,7 @@ pub fn build() -> TokenStream {
                 probability: #prob,
                 y: #y,
                 replaceable: #replaceable,
+                lava_level: #lava_level,
                 additional: #additional,
             };
         });
@@ -194,6 +196,8 @@ pub fn build() -> TokenStream {
             pub y: HeightProvider,
             /// Vanilla `CarverConfiguration.replaceable`: blocks this carver may replace.
             pub replaceable: crate::tag::Tag,
+            /// Vanilla `CarverConfiguration.lavaLevel`: below this anchor the carver emits lava.
+            pub lava_level: YOffset,
             pub additional: CarverAdditionalConfig,
         }
 


### PR DESCRIPTION
## Description

Two carver fixes that are independent of #3229 / #3233 / #3234 in code, but belong to the same series.

**1. Respect the carver's `replaceable` tag.** Vanilla 26.2 `WorldCarver.carveBlock` rejects any block outside the configured `#minecraft:overworld_carver_replaceables` (`#nether_carver_replaceables` for `nether_cave`). Pumpkin carved everything, including bedrock, so caves that reach y −62 punched holes in the bedrock floor (286 exact-baseline mismatches in the reference box). The `replaceable` field is added to the carver codegen and the four datapack JSONs, `carver.rs` is regenerated, and both `CaveCarver::carve_block` and `CanyonCarver` check the tag before writing.

**2. Emit lava below the carver's `lava_level`.** Vanilla `WorldCarver.getCarveState` returns lava whenever `pos.getY() <= config.lavaLevel.resolveY(context)`, *before* it consults the aquifer. Pumpkin had no `lava_level` on `CarverConfig` and let the aquifer's fluid picker decide, so the thin band just above the aquifer's lava floor (vanilla `lava_level = above_bottom: 8`, i.e. y ≤ −56) was carved to air or water instead of lava. `lava_level` is added to the codegen and JSONs (cave / cave_extra_underground / canyon `above_bottom: 8`, `nether_cave` `above_bottom: 10`), `carver.rs` regenerated, and `overworld_carve_state` does the lava check first.

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

Both are part of the carver series. The bedrock half was 286 exact mismatches in the box on the baseline (bedrock carved to air at y −62..−60); the lava band was not measured on its own. At the end of the series the carvers are bit-identical to vanilla in the box except for two float-rounding edge blocks.

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. New unit test `leaves_non_replaceable_bedrock_untouched` in `cave.rs` puts bedrock at (3, −61, 4) inside a `CarveRun` and asserts `carve_block` returns `false` and leaves it in place.

**Note for #3234:** `overworld_carve_state` now takes the carver config (`&CAVE`) to read `lava_level`; the `carves_below_y_one` test in #3234 needs that extra argument once both are in. Whichever lands second gets a one-line rebase.

**Known impact:** changes worldgen output below y −55 and at the bedrock floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **World Generation**
  * Cave and canyon carving now preserves non-replaceable blocks, including bedrock.
  * Lava generates up to 8 blocks above the bottom in Overworld caves and canyons.
  * Nether caves now generate lava up to 10 blocks above the bottom.
  * Carving behavior now consistently respects the blocks designated as replaceable for each dimension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->