### PR TITLE
fix(worldgen): compute ore vein node radius and axis the way vanilla does 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-world/src/generation/feature/features/ore.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/ore.rs
@@ -205,12 +205,9 @@ impl OreFeature {
         placed_blocks_count > 0
     }
 
-    /// The two ends of the vein axis, as vanilla `OreFeature.place` offsets them:
-    ///
-    /// ```text
-    /// double x0 = origin.getX() + Math.sin(dir) * spreadXY;
-    /// double z0 = origin.getZ() + Math.cos(dir) * spreadXY;
-    /// ```
+    /// The two ends of the vein axis, as vanilla `OreFeature.place` offsets them: the origin's X
+    /// moves by `sin(dir) * spread_xy` and its Z by `cos(dir) * spread_xy`, both through
+    /// `java.lang.Math`.
     ///
     /// `Math.sin`/`Math.cos` take a `double`, so the `float` angle is widened *before* the sine.
     /// That is a different function from the `Mth.sin` lookup table `doPlace` uses a few lines
@@ -222,11 +219,9 @@ impl OreFeature {
         (dir.sin() * spread_xy, dir.cos() * spread_xy)
     }
 
-    /// Radius of one node of the vein, exactly as vanilla `OreFeature.doPlace` computes it:
-    ///
-    /// ```text
-    /// double r = ((Mth.sin((float) Math.PI * step) + 1.0F) * ss + 1.0) / 2.0;
-    /// ```
+    /// Radius of one node of the vein, exactly as vanilla `OreFeature.doPlace` computes it: the
+    /// table sine of `PI * step` plus one, times the node size, plus one, and the whole thing
+    /// halved.
     ///
     /// Two details matter for bit-for-bit parity:
     /// * `Mth.sin` is the 65536-entry lookup table (`pumpkin_util::math::sin`), not an accurate
@@ -287,9 +282,8 @@ impl OreFeature {
 mod tests {
     use super::OreFeature;
 
-    /// Reference values produced by running vanilla's own expression
-    /// `((Mth.sin((float) Math.PI * step) + 1.0F) * ss + 1.0) / 2.0` on a JVM
-    /// (`step = (float) i / size`), printed as raw `double` bits.
+    /// Reference values produced by running vanilla's own node-radius expression on a JVM,
+    /// printed as raw `double` bits.
     #[test]
     fn node_radius_matches_vanilla_do_place() {
         // (size, i, ss, expected raw f64 bits)
@@ -317,8 +311,8 @@ mod tests {
         }
     }
 
-    /// Reference values produced by running vanilla's `Math.sin(dir) * spreadXY` /
-    /// `Math.cos(dir) * spreadXY` on a JVM (`spreadXY = size / 8.0F`), as raw `double` bits.
+    /// Reference values produced by running vanilla's vein-spread expression on a JVM, as raw
+    /// `double` bits.
     #[test]
     fn vein_spread_matches_vanilla_place() {
         // (dir, size, sin*spread bits, cos*spread bits)

--- a/crates/pumpkin-world/src/generation/feature/features/ore.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/ore.rs
@@ -2,7 +2,7 @@ use core::f32;
 
 use pumpkin_data::{BlockDirection, BlockState, BlockStateId};
 use pumpkin_util::{
-    math::{lerp, position::BlockPos, vector3::Vector3},
+    math::{self, lerp, position::BlockPos, vector3::Vector3},
     random::{RandomGenerator, RandomImpl},
 };
 
@@ -90,12 +90,12 @@ impl OreFeature {
             let e = lerp(f as f64, start_y, end_y);
             let g = lerp(f as f64, start_z, end_z);
             let h = random.next_f64() * j as f64 / 16.0;
-            let l = f32::midpoint(((f32::consts::PI * f).sin() + 1.0) * h as f32, 1.0);
+            let l = Self::node_radius(f, h);
 
             ds[k as usize * 4] = d;
             ds[k as usize * 4 + 1] = e;
             ds[k as usize * 4 + 2] = g;
-            ds[k as usize * 4 + 3] = l as f64;
+            ds[k as usize * 4 + 3] = l;
         }
 
         for k in 0..(j - 1) {
@@ -203,6 +203,27 @@ impl OreFeature {
         placed_blocks_count > 0
     }
 
+    /// Radius of one node of the vein, exactly as vanilla `OreFeature.doPlace` computes it:
+    ///
+    /// ```text
+    /// double r = ((Mth.sin((float) Math.PI * step) + 1.0F) * ss + 1.0) / 2.0;
+    /// ```
+    ///
+    /// Two details matter for bit-for-bit parity:
+    /// * `Mth.sin` is the 65536-entry lookup table (`pumpkin_util::math::sin`), not an accurate
+    ///   sine — its error is around 1e-4, which is enough to gain or lose a shell of blocks.
+    /// * only `Mth.sin(..) + 1.0F` is `float`; `* ss` widens to `double`, and the `+ 1.0` and
+    ///   `/ 2.0` are `double` too. Java rounds the multiply and the add separately, so this must
+    ///   not be contracted into a `mul_add`.
+    #[must_use]
+    #[expect(
+        clippy::manual_midpoint,
+        reason = "kept in vanilla's grouping: only `sin(..) + 1.0F` is float, the rest is double"
+    )]
+    pub fn node_radius(step: f32, ss: f64) -> f64 {
+        (f64::from(math::sin(f32::consts::PI * step) + 1.0) * ss + 1.0) / 2.0
+    }
+
     pub fn should_place<T: GenerationCache>(
         discard_chance: f32,
         chunk: &T,
@@ -240,5 +261,54 @@ impl OreFeature {
             }
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OreFeature;
+
+    /// Reference values produced by running vanilla's own expression
+    /// `((Mth.sin((float) Math.PI * step) + 1.0F) * ss + 1.0) / 2.0` on a JVM
+    /// (`step = (float) i / size`), printed as raw `double` bits.
+    #[test]
+    fn node_radius_matches_vanilla_do_place() {
+        // (size, i, ss, expected raw f64 bits)
+        let cases: [(i32, i32, f64, u64); 9] = [
+            (33, 0, 1.9375, 0x3ff7_8000_0000_0000),
+            (33, 1, 0.5, 0x3fe8_c27c_4000_0000),
+            (33, 7, 1.9375, 0x4000_8a4f_4e00_0000),
+            (33, 16, 0.314_159_265_358_979_3, 0x3fea_0c21_d7c6_5b3e),
+            (33, 32, 1.0, 0x3ff0_c2ae_4000_0000),
+            (64, 7, 0.5, 0x3fea_b1f3_5000_0000),
+            (64, 16, 1.9375, 0x4001_3ae6_6300_0000),
+            (64, 32, 0.314_159_265_358_979_3, 0x3fea_0d97_bb4e_7870),
+            (9, 7, 1.9375, 0x4000_bb52_ad00_0000),
+        ];
+        for (size, i, ss, expected) in cases {
+            let step = i as f32 / size as f32;
+            let actual = OreFeature::node_radius(step, ss);
+            assert_eq!(
+                actual.to_bits(),
+                expected,
+                "size={size} i={i} ss={ss}: got {actual} ({:#018x}), want {:#018x}",
+                actual.to_bits(),
+                expected
+            );
+        }
+    }
+
+    /// The naive all-`f32` form with an accurate sine, which Pumpkin used before, disagrees with
+    /// vanilla by more than a ULP — enough to move the ellipsoid boundary by a whole block.
+    #[test]
+    fn node_radius_differs_from_naive_f32_form() {
+        let step = 7.0f32 / 33.0f32;
+        let ss = 1.9375f64;
+        let naive = f32::midpoint(
+            ((core::f32::consts::PI * step).sin() + 1.0) * ss as f32,
+            1.0,
+        );
+        let vanilla = OreFeature::node_radius(step, ss);
+        assert!((f64::from(naive) - vanilla).abs() > 1e-6);
     }
 }

--- a/crates/pumpkin-world/src/generation/feature/features/ore.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/ore.rs
@@ -36,10 +36,12 @@ impl OreFeature {
         let g = self.size as f32 / 8.0f32;
         let i = f32::midpoint(self.size as f32 / 16.0f32 * 2.0, 1.0).ceil() as i32;
 
-        let d = pos.0.x as f64 + f.sin() as f64 * g as f64;
-        let e = pos.0.x as f64 - f.sin() as f64 * g as f64;
-        let h = pos.0.z as f64 + f.cos() as f64 * g as f64; // Use f.cos() for Math.cos(f)
-        let j = pos.0.z as f64 - f.cos() as f64 * g as f64;
+        let (sin_spread, cos_spread) = Self::vein_spread(f, g);
+
+        let d = pos.0.x as f64 + sin_spread;
+        let e = pos.0.x as f64 - sin_spread;
+        let h = pos.0.z as f64 + cos_spread;
+        let j = pos.0.z as f64 - cos_spread;
 
         let l = pos.0.y as f64 + random.next_bounded_i32(3) as f64 - 2.0;
         let m = pos.0.y as f64 + random.next_bounded_i32(3) as f64 - 2.0;
@@ -203,6 +205,23 @@ impl OreFeature {
         placed_blocks_count > 0
     }
 
+    /// The two ends of the vein axis, as vanilla `OreFeature.place` offsets them:
+    ///
+    /// ```text
+    /// double x0 = origin.getX() + Math.sin(dir) * spreadXY;
+    /// double z0 = origin.getZ() + Math.cos(dir) * spreadXY;
+    /// ```
+    ///
+    /// `Math.sin`/`Math.cos` take a `double`, so the `float` angle is widened *before* the sine.
+    /// That is a different function from the `Mth.sin` lookup table `doPlace` uses a few lines
+    /// later — the same method really does call both.
+    #[must_use]
+    pub fn vein_spread(dir: f32, spread_xy: f32) -> (f64, f64) {
+        let dir = f64::from(dir);
+        let spread_xy = f64::from(spread_xy);
+        (dir.sin() * spread_xy, dir.cos() * spread_xy)
+    }
+
     /// Radius of one node of the vein, exactly as vanilla `OreFeature.doPlace` computes it:
     ///
     /// ```text
@@ -296,6 +315,56 @@ mod tests {
                 expected
             );
         }
+    }
+
+    /// Reference values produced by running vanilla's `Math.sin(dir) * spreadXY` /
+    /// `Math.cos(dir) * spreadXY` on a JVM (`spreadXY = size / 8.0F`), as raw `double` bits.
+    #[test]
+    fn vein_spread_matches_vanilla_place() {
+        // (dir, size, sin*spread bits, cos*spread bits)
+        let cases: [(f32, i32, u64, u64); 8] = [
+            (0.0, 33, 0x0000_0000_0000_0000, 0x4010_8000_0000_0000),
+            (0.5, 33, 0x3fff_a45f_b7ed_5e20, 0x400c_f5d1_468e_593a),
+            (0.5, 8, 0x3fde_aee8_744b_05f0, 0x3fec_1528_065b_7d50),
+            (1.2345, 33, 0x400f_26c5_7166_4dc2, 0x3ff5_c790_472b_94a0),
+            (1.2345, 64, 0x401e_351c_8cfe_5aeb, 0x4005_1e9b_6bcd_2b46),
+            (2.718_281_7, 9, 0x3fdd_9385_aa8f_3df0, 0xbff0_6945_0c92_7123),
+            (
+                2.718_281_7,
+                64,
+                0x400a_4a3d_ecf1_1a9c,
+                0xc01d_2cec_8820_c922,
+            ),
+            (
+                core::f32::consts::PI,
+                33,
+                0xbe98_3362_fdee_653c,
+                0xc010_7fff_ffff_ffee,
+            ),
+        ];
+        for (dir, size, want_sin, want_cos) in cases {
+            let spread_xy = size as f32 / 8.0f32;
+            let (sin_spread, cos_spread) = OreFeature::vein_spread(dir, spread_xy);
+            assert_eq!(
+                sin_spread.to_bits(),
+                want_sin,
+                "dir={dir} size={size}: sin got {sin_spread}"
+            );
+            assert_eq!(
+                cos_spread.to_bits(),
+                want_cos,
+                "dir={dir} size={size}: cos got {cos_spread}"
+            );
+        }
+    }
+
+    /// The old form took the sine in `f32` and widened afterwards, which is a different number:
+    /// vanilla `3.893_931_280_073_702_3` vs `3.893_931_180_238_723_8` for dir=1.2345, size=33.
+    #[test]
+    fn vein_spread_differs_from_f32_sine() {
+        let (sin_spread, _) = OreFeature::vein_spread(1.2345, 33.0 / 8.0);
+        let old = f64::from(1.2345f32.sin()) * f64::from(33.0f32 / 8.0f32);
+        assert!((sin_spread - old).abs() > 1e-9);
     }
 
     /// The naive all-`f32` form with an accurate sine, which Pumpkin used before, disagrees with


### PR DESCRIPTION
## Description

Two floating-point details of `OreFeature` that vanilla evaluates differently from the way Pumpkin did.

**1. Node radius** (`OreFeature.doPlace`): vanilla takes the table sine of `PI * step`, adds one, multiplies by the node size, adds one again and halves the result.

`Mth.sin` is Minecraft's 65536-entry lookup table (error ≈ 1e−4 against a real sine), and only `Mth.sin(..) + 1.0F` is `float`: `* ss` widens to `double`, and the `+ 1.0` / `/ 2.0` are `double`. Pumpkin used Rust's accurate `f32::sin` and evaluated the whole expression in f32 before widening. For size 33, step 7/33, ss 1.9375 that gives 2.0675914 where vanilla gives 2.0675340741872787; through the node-pruning loop (`dr*dr > dx*dx+dy*dy+dz*dz`) a radius that far off kills or spares whole nodes, which is why whole lobes of coal blobs were missing. The radius is now `OreFeature::node_radius`, using `pumpkin_util::math::sin` (the same table) and vanilla's exact widening, with the multiply and add kept as two separately rounded operations.

**2. Vein axis** (`OreFeature.place`): `Math.sin(dir)` / `Math.cos(dir)` take a `double`, so the float angle is widened *before* the sine; Pumpkin took `f32::sin` and widened afterwards (3.8939311802 vs vanilla 3.8939312800 for dir 1.2345, size 33). `f64::sin` / `f64::cos` reproduce `Math.sin` / `Math.cos` bit for bit on the sampled angles; the extracted `OreFeature::vein_spread` is now exact.

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

| | before | after |
|---|---|---|
| mismatching blocks | 669 | **523** |
| chunks bit-identical | 161/256 | **170/256** |

Gone entirely: `coal_ore→stone` 58, `stone→coal_ore` 28, `coal_ore→granite` 23, `andesite→coal_ore` 14, `coal_ore→andesite` 10. The axis fix on its own changes 0 blocks in this box (error ≈ 1e−7 of a block) but would surface on another seed. After these two, `doPlace` was replayed on the JVM with the same draws and is bit-identical.

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. Unit tests pin `node_radius` and `vein_spread` to the values the real 26.2 expressions produce.

**Known impact:** changes ore blob shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved underground ore vein generation for more consistent, vanilla-compatible shapes and node sizes.
  - Updated ore placement calculations to improve accuracy across different vein orientations and generation conditions.
  - Reduced differences in generated vein geometry caused by calculation precision.

- **Tests**
  - Added regression coverage to verify stable ore vein geometry and prevent calculation differences from returning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
