### PR TITLE
fix(worldgen): bring amethyst geodes to vanilla parity 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-data/src/generated/configured_features_generated.rs
+++ b/crates/pumpkin-data/src/generated/configured_features_generated.rs
@@ -178,8 +178,16 @@ fn build_configured_features()
                     max_inclusive: 6i32,
                 },
             )),
-            distribution_points: IntProvider::Constant(0),
-            point_offset: IntProvider::Constant(0),
+            distribution_points: IntProvider::Object(NormalIntProvider::Uniform(
+                UniformIntProvider {
+                    min_inclusive: 3i32,
+                    max_inclusive: 4i32,
+                },
+            )),
+            point_offset: IntProvider::Object(NormalIntProvider::Uniform(UniformIntProvider {
+                min_inclusive: 1i32,
+                max_inclusive: 2i32,
+            })),
             min_gen_offset: -16i32,
             max_gen_offset: 16i32,
             noise_multiplier: 0.05f64,

--- a/crates/pumpkin-world/src/generation/feature/features/geode.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/geode.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use pumpkin_data::{Block, BlockDirection, BlockId, BlockState, BlockStateId};
 use pumpkin_util::{
     math::{int_provider::IntProvider, position::BlockPos},
-    random::RandomGenerator,
+    random::{RandomGenerator, legacy_rand::LegacyRand},
 };
 
 use crate::generation::feature::features::spring_feature::BlockWrapper;
@@ -67,6 +67,20 @@ pub struct GeodeFeature {
 }
 
 impl GeodeFeature {
+    /// The geode's shape noise: vanilla creates it from a `LegacyRandomSource(level.getSeed())`,
+    /// i.e. it is a function of the world seed only and consumes nothing from the feature random
+    /// (`NormalNoise.create(new WorldgenRandom(new LegacyRandomSource(level.getSeed())), -4, 1.0)`).
+    fn shape_noise(world_seed: u64) -> NormalNoise {
+        let mut random = RandomGenerator::Legacy(LegacyRand::from_seed(world_seed));
+        NormalNoise::create(&mut random, -4, &[1.0])
+    }
+
+    /// Vanilla geode noise value for testing: `GeodeFeature.place`'s `normalNoise.getValue(x, y, z)`.
+    #[cfg(test)]
+    pub(crate) fn shape_noise_value(world_seed: u64, x: f64, y: f64, z: f64) -> f64 {
+        Self::shape_noise(world_seed).get_value(x, y, z)
+    }
+
     fn safe_set_block<T: GenerationCache>(
         chunk: &mut T,
         pos: BlockPos,
@@ -102,7 +116,7 @@ impl GeodeFeature {
     ) -> bool {
         let origin = pos;
         let num_points = self.distribution_points.get(random);
-        let noise = NormalNoise::create(random, -4, &[1.0]);
+        let noise = Self::shape_noise(chunk.get_world_seed());
 
         // Precompute sets of raw block ids for fast lookups
         let mut invalid_raw_ids: HashSet<BlockId> = HashSet::new();
@@ -398,5 +412,25 @@ mod tests {
         assert_eq!(uniform_bounds(&geode.point_offset), (1, 2));
         assert_eq!(uniform_bounds(&geode.outer_wall_distance), (4, 6));
         assert_eq!(geode.invalid_blocks_threshold, 1);
+    }
+
+    /// Values printed by the real 26.2 server classes for seed 13579:
+    /// `NormalNoise.create(new WorldgenRandom(new LegacyRandomSource(13579L)), -4, 1.0)
+    ///     .getValue(x, y, z)` (see `GeodeFeature.place`).
+    #[test]
+    fn shape_noise_is_seeded_from_the_world_seed() {
+        let cases = [
+            ((0.0, 0.0, 0.0), 0.293_497_274_324_212_6f64),
+            ((-24.0, -17.0, 135.0), -0.141_043_541_033_730_46f64),
+            ((-121.0, -28.0, 36.0), -0.041_936_309_071_201_51f64),
+            ((100.5, -40.0, -7.0), 0.092_317_015_824_239_66f64),
+        ];
+        for ((x, y, z), expected) in cases {
+            let actual = GeodeFeature::shape_noise_value(13579, x, y, z);
+            assert!(
+                (actual - expected).abs() < 1e-6,
+                "noise at ({x}, {y}, {z}) = {actual}, vanilla {expected}"
+            );
+        }
     }
 }

--- a/crates/pumpkin-world/src/generation/feature/features/geode.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/geode.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use pumpkin_data::{Block, BlockDirection, BlockId, BlockState, BlockStateId};
+use pumpkin_data::{Block, BlockDirection, BlockId, BlockState, BlockStateId, tag::Taggable};
 use pumpkin_util::{
     math::{int_provider::IntProvider, position::BlockPos},
     random::{RandomGenerator, legacy_rand::LegacyRand},
@@ -81,6 +81,28 @@ impl GeodeFeature {
         Self::shape_noise(world_seed).get_value(x, y, z)
     }
 
+    /// Resolves a `BlockWrapper` (block names and/or `#tags`, as vanilla `HolderSet`s) to the
+    /// set of block ids it matches.
+    fn resolve_block_set(wrapper: &BlockWrapper) -> HashSet<BlockId> {
+        let mut ids = HashSet::new();
+        let entries: Vec<&str> = match wrapper {
+            BlockWrapper::Single(s) => vec![s.as_str()],
+            BlockWrapper::Multi(v) => v.iter().map(String::as_str).collect(),
+        };
+        for entry in entries {
+            if let Some(tag) = entry.strip_prefix('#') {
+                for name in Block::get_tag_values(tag).into_iter().flatten() {
+                    if let Some(block) = Block::from_name(name) {
+                        ids.insert(block.id);
+                    }
+                }
+            } else if let Some(block) = Block::from_name(entry) {
+                ids.insert(block.id);
+            }
+        }
+        ids
+    }
+
     fn safe_set_block<T: GenerationCache>(
         chunk: &mut T,
         pos: BlockPos,
@@ -118,38 +140,9 @@ impl GeodeFeature {
         let num_points = self.distribution_points.get(random);
         let noise = Self::shape_noise(chunk.get_world_seed());
 
-        // Precompute sets of raw block ids for fast lookups
-        let mut invalid_raw_ids: HashSet<BlockId> = HashSet::new();
-        match &self.invalid_blocks {
-            BlockWrapper::Single(s) => {
-                if let Some(b) = Block::from_name(s.as_str()) {
-                    invalid_raw_ids.insert(b.id);
-                }
-            }
-            BlockWrapper::Multi(v) => {
-                for s in v {
-                    if let Some(b) = Block::from_name(s.as_str()) {
-                        invalid_raw_ids.insert(b.id);
-                    }
-                }
-            }
-        }
-
-        let mut cannot_replace_raw_ids: HashSet<BlockId> = HashSet::new();
-        match &self.cannot_replace {
-            BlockWrapper::Single(s) => {
-                if let Some(b) = Block::from_name(s.as_str()) {
-                    cannot_replace_raw_ids.insert(b.id);
-                }
-            }
-            BlockWrapper::Multi(v) => {
-                for s in v {
-                    if let Some(b) = Block::from_name(s.as_str()) {
-                        cannot_replace_raw_ids.insert(b.id);
-                    }
-                }
-            }
-        }
+        // Precompute sets of raw block ids for fast lookups (tags included).
+        let invalid_raw_ids = Self::resolve_block_set(&self.invalid_blocks);
+        let cannot_replace_raw_ids = Self::resolve_block_set(&self.cannot_replace);
 
         let mut points: Vec<(BlockPos, i32)> = Vec::with_capacity(num_points as usize);
         let mut crack_points: Vec<BlockPos> = Vec::new();
@@ -432,5 +425,21 @@ mod tests {
                 "noise at ({x}, {y}, {z}) = {actual}, vanilla {expected}"
             );
         }
+    }
+
+    /// Vanilla resolves `#minecraft:geode_invalid_blocks` / `#minecraft:features_cannot_replace`
+    /// as `HolderSet`s (`BlockState.is(HolderSet)`); a tag string must not silently resolve to
+    /// an empty set.
+    #[test]
+    fn amethyst_geode_resolves_block_tags() {
+        let geode = amethyst_geode();
+        let invalid = GeodeFeature::resolve_block_set(&geode.invalid_blocks);
+        assert!(invalid.contains(&Block::WATER.id));
+        assert!(invalid.contains(&Block::LAVA.id));
+        assert!(invalid.contains(&Block::BEDROCK.id));
+        assert!(!invalid.contains(&Block::STONE.id));
+        let cannot_replace = GeodeFeature::resolve_block_set(&geode.cannot_replace);
+        assert!(cannot_replace.contains(&Block::BEDROCK.id));
+        assert!(!cannot_replace.contains(&Block::DEEPSLATE.id));
     }
 }

--- a/crates/pumpkin-world/src/generation/feature/features/geode.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/geode.rs
@@ -362,3 +362,41 @@ impl GeodeFeature {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generation::feature::configured_features::CONFIGURED_FEATURES;
+    use crate::generation::feature::configured_features::ConfiguredFeature;
+    use pumpkin_util::math::int_provider::NormalIntProvider;
+
+    fn amethyst_geode() -> &'static GeodeFeature {
+        match CONFIGURED_FEATURES
+            .get(&pumpkin_data::configured_feature::ConfiguredFeature::AmethystGeode)
+        {
+            Some(ConfiguredFeature::Geode(feature)) => feature,
+            _ => panic!("amethyst_geode is not a geode feature"),
+        }
+    }
+
+    fn uniform_bounds(provider: &IntProvider) -> (i32, i32) {
+        match provider {
+            IntProvider::Object(NormalIntProvider::Uniform(uniform)) => {
+                (uniform.min_inclusive, uniform.max_inclusive)
+            }
+            _ => panic!("expected a uniform int provider"),
+        }
+    }
+
+    /// Vanilla `GeodeConfiguration.CODEC` fills the fields the `amethyst_geode` datapack entry
+    /// omits with `UniformInt.of(3, 4)` (`distribution_points`) and `UniformInt.of(1, 2)`
+    /// (`point_offset`); `outer_wall_distance` is given explicitly as uniform 4..6.
+    #[test]
+    fn amethyst_geode_uses_vanilla_codec_defaults() {
+        let geode = amethyst_geode();
+        assert_eq!(uniform_bounds(&geode.distribution_points), (3, 4));
+        assert_eq!(uniform_bounds(&geode.point_offset), (1, 2));
+        assert_eq!(uniform_bounds(&geode.outer_wall_distance), (4, 6));
+        assert_eq!(geode.invalid_blocks_threshold, 1);
+    }
+}

--- a/crates/pumpkin-world/src/generation/feature/features/geode.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/geode.rs
@@ -67,9 +67,9 @@ pub struct GeodeFeature {
 }
 
 impl GeodeFeature {
-    /// The geode's shape noise: vanilla creates it from a `LegacyRandomSource(level.getSeed())`,
-    /// i.e. it is a function of the world seed only and consumes nothing from the feature random
-    /// (`NormalNoise.create(new WorldgenRandom(new LegacyRandomSource(level.getSeed())), -4, 1.0)`).
+    /// The geode's shape noise is a normal noise of octave -4 seeded from the world seed through
+    /// a legacy random source, so it is a function of the world seed only and consumes nothing
+    /// from the feature random.
     fn shape_noise(world_seed: u64) -> NormalNoise {
         let mut random = RandomGenerator::Legacy(LegacyRand::from_seed(world_seed));
         NormalNoise::create(&mut random, -4, &[1.0])
@@ -115,8 +115,8 @@ impl GeodeFeature {
         }
     }
 
-    /// Vanilla compares `(double)random.nextFloat() < chance` (the float draw is widened to a
-    /// double, the double chance is never narrowed to a float).
+    /// Vanilla widens the `nextFloat` draw to a double and compares it against the double
+    /// chance; the chance is never narrowed to a float.
     fn chance_hit(draw: f32, chance: f64) -> bool {
         f64::from(draw) < chance
     }
@@ -432,9 +432,8 @@ mod tests {
         assert_eq!(geode.invalid_blocks_threshold, 1);
     }
 
-    /// Values printed by the real 26.2 server classes for seed 13579:
-    /// `NormalNoise.create(new WorldgenRandom(new LegacyRandomSource(13579L)), -4, 1.0)
-    ///     .getValue(x, y, z)` (see `GeodeFeature.place`).
+    /// Values printed by the real 26.2 server classes for seed 13579: the shape noise
+    /// `GeodeFeature.place` builds, sampled at each position.
     #[test]
     fn shape_noise_is_seeded_from_the_world_seed() {
         let cases = [
@@ -468,10 +467,9 @@ mod tests {
         assert!(!cannot_replace.contains(&Block::DEEPSLATE.id));
     }
 
-    /// Vanilla: `(double)random.nextFloat() < config.generateCrackChance` (`f2d; dcmpg`).
-    /// The largest float below 0.95 is 0.94999998807907104, which is below the double 0.95
-    /// but *not* below `0.95 as f32` (they are the same float), so narrowing the chance to a
-    /// float flips that draw.
+    /// The draw is widened to a double, never the chance narrowed to a float: the largest float
+    /// below 0.95 is 0.94999998807907104, which is under the double 0.95 but not under
+    /// `0.95 as f32`, so narrowing flips that draw.
     #[test]
     fn chance_draws_are_compared_as_doubles() {
         let draw = 0.95f32; // == 0.949_999_988_079_071_04

--- a/crates/pumpkin-world/src/generation/feature/features/geode.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/geode.rs
@@ -115,6 +115,27 @@ impl GeodeFeature {
         }
     }
 
+    /// Vanilla compares `(double)random.nextFloat() < chance` (the float draw is widened to a
+    /// double, the double chance is never narrowed to a float).
+    fn chance_hit(draw: f32, chance: f64) -> bool {
+        f64::from(draw) < chance
+    }
+
+    /// The `level` property of a water block state, if `state` is water.
+    fn water_level(state: BlockStateId) -> Option<&'static str> {
+        let block = Block::from_state_id(state);
+        if block.id != Block::WATER.id {
+            return None;
+        }
+        block.properties(state).and_then(|props| {
+            props
+                .to_props()
+                .iter()
+                .find(|(k, _)| *k == "level")
+                .map(|(_, v)| *v)
+        })
+    }
+
     fn has_property(codec: &BlockStateCodec, property: &str) -> bool {
         let state = codec.get_state();
         // Obtain the block corresponding to this state id
@@ -160,7 +181,7 @@ impl GeodeFeature {
                     0.0
                 })
             .sqrt();
-        let should_generate_crack = random.next_f32() < self.generate_crack_chance as f32;
+        let should_generate_crack = Self::chance_hit(random.next_f32(), self.generate_crack_chance);
         let mut num_invalid_points = 0;
 
         // Sample distribution points; bail out early if too many fall into invalid blocks
@@ -274,7 +295,8 @@ impl GeodeFeature {
                             .get(random, point_inside, chunk, block_registry);
                     Self::safe_set_block(chunk, point_inside, state, &can_replace_pred);
                 } else if dist_sum_shell >= innermost_block_layer {
-                    let use_alternate = random.next_f32() < self.use_alternate_layer0_chance as f32;
+                    let use_alternate =
+                        Self::chance_hit(random.next_f32(), self.use_alternate_layer0_chance);
                     if use_alternate {
                         let state = self.alternate_inner_layer_provider.get(
                             random,
@@ -293,7 +315,7 @@ impl GeodeFeature {
                         Self::safe_set_block(chunk, point_inside, state, &can_replace_pred);
                     }
                     if (!self.placements_require_layer0_alternate || use_alternate)
-                        && random.next_f32() < self.use_potential_placements_chance as f32
+                        && Self::chance_hit(random.next_f32(), self.use_potential_placements_chance)
                     {
                         potential_crystal_placements.push(point_inside);
                     }
@@ -324,11 +346,13 @@ impl GeodeFeature {
                     let place_raw = GenerationCache::get_block_state(chunk, &place_pos.0);
                     let place_state = place_raw.to_state();
 
-                    // Only place if the target block is replaceable (air/water)
+                    // `BuddingAmethystBlock.canClusterGrowAtState`: air, or water whose fluid
+                    // amount is 8 (`FluidState.isFull()`: a source, or a falling column).
                     let is_air = place_state.is_air();
-                    let is_water = place_raw.to_block_id() == BlockId::WATER;
+                    let water_level = Self::water_level(place_raw);
+                    let is_full_water = matches!(water_level, Some("0" | "8"));
 
-                    if is_air || is_water {
+                    if is_air || is_full_water {
                         let mut final_codec = base_codec.clone();
 
                         // Set facing based on direction
@@ -348,12 +372,13 @@ impl GeodeFeature {
                                 .insert("facing".to_string(), dir_name.to_string());
                         }
 
-                        // Handle waterlogging dynamically based on the block we are replacing
+                        // Waterlogged iff the replaced fluid is a source (`FluidState.isSource`).
                         if Self::has_property(&final_codec, "waterlogged") {
+                            let is_source = water_level == Some("0");
                             final_codec
                                 .properties
                                 .get_or_insert_with(HashMap::new)
-                                .insert("waterlogged".to_string(), is_water.to_string());
+                                .insert("waterlogged".to_string(), is_source.to_string());
                         }
 
                         let final_state = final_codec.get_state();
@@ -441,5 +466,45 @@ mod tests {
         let cannot_replace = GeodeFeature::resolve_block_set(&geode.cannot_replace);
         assert!(cannot_replace.contains(&Block::BEDROCK.id));
         assert!(!cannot_replace.contains(&Block::DEEPSLATE.id));
+    }
+
+    /// Vanilla: `(double)random.nextFloat() < config.generateCrackChance` (`f2d; dcmpg`).
+    /// The largest float below 0.95 is 0.94999998807907104, which is below the double 0.95
+    /// but *not* below `0.95 as f32` (they are the same float), so narrowing the chance to a
+    /// float flips that draw.
+    #[test]
+    fn chance_draws_are_compared_as_doubles() {
+        let draw = 0.95f32; // == 0.949_999_988_079_071_04
+        assert!(f64::from(draw) < 0.95);
+        assert!(GeodeFeature::chance_hit(draw, 0.95));
+        // Narrowing the chance instead makes the draw equal to it, i.e. not below it.
+        assert_eq!(draw.partial_cmp(&(0.95f64 as f32)), Some(Ordering::Equal));
+        let just_above = f32::from_bits(0.083f32.to_bits() + 1);
+        assert!(!GeodeFeature::chance_hit(just_above, 0.083));
+    }
+
+    /// `BuddingAmethystBlock.canClusterGrowAtState`: air, or water with `FluidState.isFull()`
+    /// (amount 8: `level=0` source or `level=8` falling); `waterlogged` follows `isSource()`.
+    #[test]
+    fn cluster_placement_water_levels_follow_vanilla() {
+        assert_eq!(
+            GeodeFeature::water_level(Block::WATER.default_state.id),
+            Some("0")
+        );
+        assert_eq!(
+            GeodeFeature::water_level(Block::STONE.default_state.id),
+            None
+        );
+        let flowing = BlockStateCodec {
+            name: &Block::WATER,
+            properties: Some(HashMap::from([("level".to_string(), "3".to_string())])),
+        }
+        .get_state()
+        .id;
+        assert_eq!(GeodeFeature::water_level(flowing), Some("3"));
+        assert!(!matches!(
+            GeodeFeature::water_level(flowing),
+            Some("0" | "8")
+        ));
     }
 }

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -99,6 +99,12 @@ pub trait GenerationCache: HeightLimitView + BlockAccessor {
     fn get_sea_level(&self) -> i32 {
         63
     }
+
+    /// The world seed, vanilla's `WorldGenLevel.getSeed()`; some features seed their own
+    /// noise from it directly instead of from the decoration random.
+    fn get_world_seed(&self) -> u64 {
+        self.get_center_chunk().world_seed
+    }
 }
 
 const AIR_BLOCK: Block = Block::AIR;
@@ -138,6 +144,8 @@ pub struct ProtoChunk {
     pub z: i32,
     pub default_block: &'static BlockState,
     biome_mixer_seed: i64,
+    /// The raw world seed (vanilla `WorldGenLevel.getSeed()`).
+    pub world_seed: u64,
     pub(crate) flat_block_map: Box<[BlockStateId]>,
     pub flat_biome_map: Box<[u8]>,
     pub flat_surface_height_map: [i16; CHUNK_AREA],
@@ -228,6 +236,11 @@ impl ProtoChunk {
             }
             super::generator::WorldGenerator::Custom(custom_gen) => custom_gen.biome_mixer_seed(),
         };
+        let world_seed = match generator {
+            super::generator::WorldGenerator::Noise(noise_gen) => noise_gen.random_config.seed,
+            super::generator::WorldGenerator::Flat(flat_gen) => flat_gen.seed,
+            super::generator::WorldGenerator::Custom(custom_gen) => custom_gen.seed(),
+        };
 
         let default_heightmap = [i16::MIN; CHUNK_AREA];
         Self {
@@ -235,6 +248,7 @@ impl ProtoChunk {
             z,
             default_block,
             biome_mixer_seed,
+            world_seed,
             flat_block_map: vec![BlockStateId::AIR; CHUNK_AREA * height as usize]
                 .into_boxed_slice(),
             flat_biome_map: vec![

--- a/tools/pumpkin-codegen/src/configured_feature.rs
+++ b/tools/pumpkin-codegen/src/configured_feature.rs
@@ -533,9 +533,14 @@ pub fn value_to_configured_feature(v: &Value) -> TokenStream {
             let placements_require_layer0_alternate = config["placements_require_layer0_alternate"]
                 .as_bool()
                 .unwrap_or(true);
-            let outer_wall_distance = value_to_int_provider(&config["outer_wall_distance"]);
-            let distribution_points = value_to_int_provider(&config["distribution_points"]);
-            let point_offset = value_to_int_provider(&config["point_offset"]);
+            // Vanilla `GeodeConfiguration.CODEC` defaults (`optionalFieldOf`):
+            // outer_wall_distance UniformInt.of(4, 5), distribution_points UniformInt.of(3, 4),
+            // point_offset UniformInt.of(1, 2). The datapack `amethyst_geode` omits the last two.
+            let outer_wall_distance =
+                geode_int_provider_or_uniform(&config["outer_wall_distance"], 4, 5);
+            let distribution_points =
+                geode_int_provider_or_uniform(&config["distribution_points"], 3, 4);
+            let point_offset = geode_int_provider_or_uniform(&config["point_offset"], 1, 2);
             let min_gen_offset = config["min_gen_offset"].as_i64().unwrap_or(-16) as i32;
             let max_gen_offset = config["max_gen_offset"].as_i64().unwrap_or(16) as i32;
             let noise_multiplier = config["noise_multiplier"].as_f64().unwrap_or(0.05);
@@ -1258,6 +1263,17 @@ fn value_to_block_wrapper(v: &Value) -> TokenStream {
             quote! { BlockWrapper::Multi(vec![#(#items),*]) }
         }
         _ => quote! { BlockWrapper::Single(String::new()) },
+    }
+}
+
+/// Geode int-provider fields are `optionalFieldOf` in vanilla's `GeodeConfiguration.CODEC`
+/// with a `UniformInt.of(min, max)` default; an absent field must not collapse to `Constant(0)`
+/// (zero distribution points means the geode never places a single block).
+fn geode_int_provider_or_uniform(v: &Value, min: i32, max: i32) -> TokenStream {
+    if v.is_null() {
+        quote! { IntProvider::Object(NormalIntProvider::Uniform(UniformIntProvider { min_inclusive: #min, max_inclusive: #max })) }
+    } else {
+        value_to_int_provider(v)
     }
 }
 


### PR DESCRIPTION
## Description

Four commits that take amethyst geodes from "never generated" to bit-identical with vanilla.

**1. Default distribution points and point offset.** `GeodeConfiguration.CODEC` declares `distribution_points`, `point_offset` and `outer_wall_distance` as `optionalFieldOf` with `UniformInt.of(3, 4)`, `UniformInt.of(1, 2)` and `UniformInt.of(4, 5)` defaults. `amethyst_geode` omits the first two and the codegen turned every absent int provider into `Constant(0)`: with zero distribution points every shell sum is 0 and `GeodeFeature.generate` never placed a block. **No amethyst geode existed anywhere in the world.**

**2. Shape noise seeded from the world seed.** Vanilla builds it as a normal noise of octave −4 on a legacy random seeded from the raw world seed: a fresh legacy random on the raw world seed, the same for every geode, consuming nothing from the feature random. Pumpkin created the noise from the decoration random, which produced a different noise per geode *and* consumed two `nextLong`s before the crack / distribution / offset draws. `GenerationCache::get_world_seed` is added so the feature can reach the raw seed.

**3. Resolve the block tags.** `invalidBlocks` / `cannotReplace` are `HolderSet`s given as `#minecraft:geode_invalid_blocks` and `#minecraft:features_cannot_replace`; Pumpkin fed the tag strings to `Block::from_name`, which returned `None`, so both sets were silently empty: a geode whose distribution point landed in water or lava was still generated, and a geode could overwrite bedrock or a spawner.

**4. Compare chance draws as doubles; grow clusters only into full water.** Vanilla widens the `nextFloat` draw to a double before comparing it against the chance for the 0.95 / 0.083 / 0.35 chances; Pumpkin narrowed the chance to f32 (the largest float below 0.95 is `0.95f32`, one draw in 2^24 flips). Buds are placed next to budding amethyst only where `BuddingAmethystBlock.canClusterGrowAtState` holds: air, or water whose `FluidState.isFull()`; `waterlogged` comes from `isSource()`. Pumpkin accepted any water state.

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

| | before | after (1) | after (2) |
|---|---|---|---|
| mismatching blocks | 69,248 (0.275 %) | 66,885 (0.266 %) | **36,199 (0.144 %)** |
| y < 0 band | — | 25,708 | **3,726** |
| geode-block category | 24,956 (vanilla) vs 0 | 29,132 | **150** |

All 150 remaining geode blocks are amethyst buds that grew by random ticks while the reference server was running (each sits on a `budding_amethyst`, facing away from it), not generation differences; the inner air of the geodes also stops reading as `air→deepslate` (5,408 blocks). Commits 3 and 4 change 0 blocks in this box (no geode here has a point in water/lava/ice/bedrock; the 2^24 case does not occur) and are committed for parity elsewhere.

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. The shape-noise unit test compares Pumpkin's values against numbers printed by the real 26.2 server classes for seed 13579.

**Known impact:** amethyst geodes now generate; changes worldgen output around y −64..30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved geode generation consistency across worlds by aligning results with the world seed.
  - Corrected geode block replacement handling, including configured block tags.
  - Improved crystal placement in air and full water, with more accurate waterlogging behavior.
  - Fixed random chance comparisons for more reliable generation outcomes.

- **Generation Improvements**
  - Geode configuration now applies standard defaults when optional distribution settings are omitted.
  - Improved deterministic behavior for geode noise and water-level handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
