### PR TITLE
fix(worldgen): use selected nether complex structure

### DIFF
--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1250,6 +1250,38 @@ impl ProtoChunk {
         allowed_biomes
     }
 
+    fn weighted_structure_order(
+        entries: &[WeightedEntry],
+        seed: u64,
+        chunk_x: i32,
+        chunk_z: i32,
+    ) -> Vec<WeightedEntry> {
+        let mut candidates = entries.to_vec();
+        let large_feature_seed = get_large_feature_seed(seed, chunk_x, chunk_z);
+        let mut random = LegacyRand::from_seed(large_feature_seed);
+        let mut total_weight: u32 = candidates.iter().map(|entry| entry.weight).sum();
+        let mut ordered = Vec::with_capacity(candidates.len());
+
+        while !candidates.is_empty() {
+            let mut roll = random.next_bounded_i32(total_weight as i32);
+            let mut selected_idx = 0;
+
+            for (index, entry) in candidates.iter().enumerate() {
+                roll -= entry.weight as i32;
+                if roll < 0 {
+                    selected_idx = index;
+                    break;
+                }
+            }
+
+            let selected = candidates.remove(selected_idx);
+            total_weight -= selected.weight;
+            ordered.push(selected);
+        }
+
+        ordered
+    }
+
     pub fn set_structure_starts(&mut self, generator: &super::generator::VanillaGenerator) {
         debug_assert_eq!(self.stage, StagedChunkEnum::Biomes);
         let random_config = &generator.random_config;
@@ -1287,38 +1319,16 @@ impl ProtoChunk {
                 continue;
             }
 
-            let mut candidates = set.structures.to_vec();
-            let large_feature_seed = get_large_feature_seed(seed, self.x, self.z);
-            let mut random = LegacyRand::from_seed(large_feature_seed);
-
-            let mut total_weight: u32 = candidates.iter().map(|e| e.weight).sum();
-
-            while !candidates.is_empty() {
-                let mut roll = random.next_bounded_i32(total_weight as i32);
-                let mut selected_idx = 0;
-
-                for (i, entry) in candidates.iter().enumerate() {
-                    roll -= entry.weight as i32;
-                    if roll < 0 {
-                        selected_idx = i;
-                        break;
-                    }
-                }
-
-                let selected_entry = &candidates[selected_idx];
-
+            for entry in Self::weighted_structure_order(set.structures, seed, self.x, self.z) {
                 if self.try_set_structure_start(
                     global_cache,
                     settings.sea_level,
-                    selected_entry,
+                    &entry,
                     generator,
                     &mut height_sampler,
                 ) {
                     break;
                 }
-
-                let failed_entry = candidates.remove(selected_idx);
-                total_weight -= failed_entry.weight;
             }
         }
         self.stage = StagedChunkEnum::StructureStart;
@@ -1456,7 +1466,18 @@ impl ProtoChunk {
                 if (candidate_chunk_x - self.x).abs() <= 8
                     && (candidate_chunk_z - self.z).abs() <= 8
                 {
-                    for entry in set.structures {
+                    let entries = if set.structures.len() == 1 {
+                        set.structures.to_vec()
+                    } else {
+                        Self::weighted_structure_order(
+                            set.structures,
+                            random_config.seed,
+                            candidate_chunk_x,
+                            candidate_chunk_z,
+                        )
+                    };
+
+                    for entry in entries {
                         let structure = Structure::get(&entry.structure);
 
                         // A structure's placement depends only on its start chunk and the
@@ -1493,12 +1514,13 @@ impl ProtoChunk {
                             },
                         );
 
-                        if let Some(start_data) = start_data
-                            && start_data
+                        if let Some(start_data) = start_data {
+                            if start_data
                                 .get_bounding_box()
                                 .intersects_raw_xz(start_x, start_z, end_x, end_z)
-                        {
-                            references.push((entry.structure, start_data.collector.clone()));
+                            {
+                                references.push((entry.structure, start_data.collector.clone()));
+                            }
                             break;
                         }
                     }

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1232,6 +1232,7 @@ impl ProtoChunk {
         }
     }
 
+    /// Returns every biome allowed by at least one structure in the set.
     #[must_use]
     pub fn get_allowed_biomes(set: &StructureSet) -> Vec<u16> {
         let mut allowed_biomes = Vec::new();
@@ -1250,6 +1251,7 @@ impl ProtoChunk {
         allowed_biomes
     }
 
+    /// Returns the deterministic weighted fallback order for structures in a set.
     fn weighted_structure_order(
         entries: &[WeightedEntry],
         seed: u64,
@@ -1282,6 +1284,7 @@ impl ProtoChunk {
         ordered
     }
 
+    /// Creates the structure starts owned by this chunk.
     pub fn set_structure_starts(&mut self, generator: &super::generator::VanillaGenerator) {
         debug_assert_eq!(self.stage, StagedChunkEnum::Biomes);
         let random_config = &generator.random_config;
@@ -1334,6 +1337,7 @@ impl ProtoChunk {
         self.stage = StagedChunkEnum::StructureStart;
     }
 
+    /// Attempts to create and store the selected structure start in this chunk.
     fn try_set_structure_start(
         &mut self,
         global_cache: &GlobalStructureCache,
@@ -1382,6 +1386,7 @@ impl ProtoChunk {
         false
     }
 
+    /// Adds references to nearby structure starts that intersect this chunk.
     #[expect(clippy::too_many_lines)]
     pub fn set_structure_references(&mut self, generator: &super::generator::VanillaGenerator) {
         debug_assert_eq!(self.stage, StagedChunkEnum::StructureStart);

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -103,6 +103,54 @@ mod test {
     }
 
     #[test]
+    fn nether_complex_references_use_selected_structure() {
+        use crate::generation::structure::placement::get_structure_chunk_in_region;
+        use pumpkin_data::structures::{StructureKeys, StructurePlacementType, StructureSet};
+
+        let seed = Seed(0);
+        let world_gen = get_world_gen(
+            seed,
+            Dimension::THE_NETHER,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+        let set = &StructureSet::NETHER_COMPLEXES;
+        let StructurePlacementType::RandomSpread(spread) = &set.placement.placement_type else {
+            unreachable!()
+        };
+
+        for region_x in 0..8 {
+            for region_z in 0..8 {
+                let (chunk_x, chunk_z) = get_structure_chunk_in_region(
+                    spread,
+                    seed.0 as i64,
+                    region_x,
+                    region_z,
+                    set.placement.salt,
+                );
+                let mut proto = ProtoChunk::new(chunk_x, chunk_z, &world_gen);
+                proto.step_to_biomes(generator);
+                proto.set_structure_starts(generator);
+
+                if !proto.has_structure(StructureKeys::BastionRemnant) {
+                    continue;
+                }
+
+                proto.set_structure_references(generator);
+                assert!(proto.has_structure(StructureKeys::BastionRemnant));
+                assert!(!proto.has_structure(StructureKeys::Fortress));
+                return;
+            }
+        }
+
+        panic!("no bastion remnant start found in sampled nether complex regions");
+    }
+
+    #[test]
     fn structure_references_are_rebuilt_when_resuming_generation() {
         use crate::chunk_system::chunk_state::Chunk;
         use pumpkin_config::lighting::LightingEngineConfig;

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -102,6 +102,7 @@ mod test {
         );
     }
 
+    /// Verifies that references use the structure selected for the shared Nether start.
     #[test]
     fn nether_complex_references_use_selected_structure() {
         use crate::generation::structure::placement::get_structure_chunk_in_region;
@@ -150,6 +151,7 @@ mod test {
         panic!("no bastion remnant start found in sampled nether complex regions");
     }
 
+    /// Verifies that structure references survive a partial-generation round trip.
     #[test]
     fn structure_references_are_rebuilt_when_resuming_generation() {
         use crate::chunk_system::chunk_state::Chunk;


### PR DESCRIPTION
Fixes #3298.

## Summary

- Share the vanilla weighted selection order between structure starts and structure references.
- Make the reference pass stop after the selected successful structure instead of materializing losing entries from the same structure set.
- Add a Nether regression test covering a bastion winner so no phantom fortress reference is created.

## Tests

- `cargo test -p pumpkin-world`
- `cargo clippy -p pumpkin-world --tests -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected structure start and reference selection to consistently follow weighted ordering.
  - Fixed Nether structure reference handling so valid bastion references are preserved without incorrectly reporting fortress references.

- **Documentation**
  - Added explanatory documentation for biome collection, structure ordering, structure-start generation, and structure-reference generation.

- **Tests**
  - Added Nether regression coverage for bastion and fortress references.
  - Expanded documentation for structure-reference tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->