### PR TITLE
fix(worldgen): place and spread multiface growth like vanilla 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-world/src/generation/feature/features/multiface_growth.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/multiface_growth.rs
@@ -61,15 +61,8 @@ impl MultifaceGrowthFeature {
     /// The position vanilla probes on iteration `i` of the search loop.
     ///
     /// `MultifaceGrowthFeature.place` keeps the cursor as a `MutableBlockPos` but re-seeds it
-    /// from the *origin* on every iteration:
-    ///
-    /// ```java
-    /// for (int i = 0; i < config.searchRange; i++) {
-    ///     mutableBlockPos.setWithOffset(blockPos, direction);   // blockPos, not mutableBlockPos
-    ///     ...
-    /// }
-    /// ```
-    ///
+    /// from the *origin* on every iteration — the offset is taken from the origin position, not
+    /// from the cursor it just wrote —
     /// so the search never walks away from `origin + direction`, whatever `search_range` says,
     /// and the loop just re-tests the same block. Advancing the cursor instead (what Pumpkin
     /// used to do) let glow lichen attach up to 20 blocks from where vanilla put it.
@@ -77,25 +70,11 @@ impl MultifaceGrowthFeature {
         origin.offset(direction.to_offset())
     }
 
-    /// Vanilla `MultifaceGrowthFeature.placeGrowthIfPossible`:
-    ///
-    /// ```java
-    /// for (Direction direction : list) {
-    ///     BlockState blockState = level.getBlockState(mutable.setWithOffset(pos, direction));
-    ///     if (config.canBePlacedOn.contains(blockState)) {
-    ///         BlockState blockState2 = block.getStateForPlacement(state, level, pos, direction);
-    ///         if (blockState2 == null) return false;
-    ///         level.setBlock(pos, blockState2, 3);
-    ///         level.getChunk(pos).markPosForPostProcessing(pos);
-    ///         if (random.nextFloat() < config.chanceOfSpreading) {
-    ///             block.getSpreader()
-    ///                 .spreadFromFaceTowardRandomDirection(blockState2, level, pos, direction, random, true);
-    ///         }
-    ///         return true;
-    ///     }
-    /// }
-    /// return false;
-    /// ```
+    /// Vanilla `MultifaceGrowthFeature.placeGrowthIfPossible` walks the direction list and stops
+    /// at the first neighbour whose state is in `can_be_placed_on`. It asks the block for a
+    /// placement state against that face, bails out if there is none, writes the growth, marks
+    /// the position for post-processing, and then draws a `nextFloat` against
+    /// `chance_of_spreading` — on success spreading from that face towards a random direction.
     ///
     /// The `nextFloat` is drawn on *every* successful placement (`chance_of_spreading` is 0.5
     /// for `glow_lichen`, 1.0 for `sculk_vein`), so leaving it out desynchronises the rest of
@@ -210,9 +189,9 @@ impl MultifaceGrowthFeature {
     }
 
     /// Vanilla `Direction.allShuffled` = `Util.shuffledCopy(Direction.values(), random)`, i.e.
-    /// `[DOWN, UP, NORTH, SOUTH, WEST, EAST]` run through
-    /// `for (int j = size; j > 1; j--) { int k = random.nextInt(j); swap(j - 1, k); }`,
-    /// which always spends exactly five `nextInt` draws.
+    /// `[DOWN, UP, NORTH, SOUTH, WEST, EAST]` run through a downward Fisher-Yates pass that
+    /// swaps each tail element with `nextInt(remaining)`, which always spends exactly five
+    /// `nextInt` draws.
     fn shuffled_all_directions(random: &mut RandomGenerator) -> [BlockDirection; 6] {
         let mut directions = BlockDirection::all();
         for i in (1..directions.len()).rev() {
@@ -244,14 +223,9 @@ impl MultifaceGrowthFeature {
             .find(|&(spread_pos, spread_face)| self.can_spread_into(chunk, spread_pos, spread_face))
     }
 
-    /// `MultifaceSpreader.DEFAULT_SPREAD_ORDER`, in order:
-    ///
-    /// ```java
-    /// SAME_POSITION -> new SpreadPos(pos, spreadDirection)
-    /// SAME_PLANE    -> new SpreadPos(pos.relative(spreadDirection), face)
-    /// WRAP_AROUND   -> new SpreadPos(pos.relative(spreadDirection).relative(face),
-    ///                                spreadDirection.getOpposite())
-    /// ```
+    /// `MultifaceSpreader.DEFAULT_SPREAD_ORDER`, in order: the same position facing the spread
+    /// direction; the neighbour along the spread direction keeping the original face; then that
+    /// neighbour offset again along the face, facing back against the spread direction.
     fn spread_candidates(
         pos: BlockPos,
         face: BlockDirection,
@@ -413,11 +387,9 @@ mod tests {
         }
     }
 
-    /// Reference values from the real 26.2 server jar:
-    /// `Direction.allShuffled(new XoroshiroRandomSource(13579))`, four calls in a row, and the
-    /// raw `nextInt()` after a single call (`-1266923548`, the *sixth* value of that stream
-    /// `1544854625, -1649625109, 454558489, -1024776688, -2036914607, -1266923548, ...`, so a
-    /// shuffle costs exactly five draws).
+    /// Reference values from the real 26.2 server jar: four `Direction.allShuffled` calls in a
+    /// row on a Xoroshiro stream seeded with 13579, plus the raw `nextInt()` after a single call
+    /// — the sixth value of that stream, so a shuffle costs exactly five draws.
     #[test]
     fn shuffled_all_directions_matches_vanilla() {
         use pumpkin_util::random::{RandomGenerator, RandomImpl, xoroshiro128::Xoroshiro};

--- a/crates/pumpkin-world/src/generation/feature/features/multiface_growth.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/multiface_growth.rs
@@ -39,10 +39,9 @@ impl MultifaceGrowthFeature {
         for search_direction in shuffled_dirs {
             let placement_directions =
                 self.get_shuffled_directions_except(random, search_direction.opposite());
-            let mut cur_pos = pos;
 
             for _ in 0..self.search_range {
-                cur_pos = cur_pos.offset(search_direction.to_offset());
+                let cur_pos = Self::search_position(pos, search_direction);
                 let block_id = GenerationCache::get_block_state(chunk, &cur_pos.0).to_block_id();
                 if !Self::is_air_or_water(chunk, cur_pos) && block_id != self.place_block {
                     break;
@@ -55,6 +54,25 @@ impl MultifaceGrowthFeature {
         }
 
         false
+    }
+
+    /// The position vanilla probes on iteration `i` of the search loop.
+    ///
+    /// `MultifaceGrowthFeature.place` keeps the cursor as a `MutableBlockPos` but re-seeds it
+    /// from the *origin* on every iteration:
+    ///
+    /// ```java
+    /// for (int i = 0; i < config.searchRange; i++) {
+    ///     mutableBlockPos.setWithOffset(blockPos, direction);   // blockPos, not mutableBlockPos
+    ///     ...
+    /// }
+    /// ```
+    ///
+    /// so the search never walks away from `origin + direction`, whatever `search_range` says,
+    /// and the loop just re-tests the same block. Advancing the cursor instead (what Pumpkin
+    /// used to do) let glow lichen attach up to 20 blocks from where vanilla put it.
+    fn search_position(origin: BlockPos, direction: BlockDirection) -> BlockPos {
+        origin.offset(direction.to_offset())
     }
 
     fn place_growth_if_possible<T: GenerationCache>(
@@ -152,5 +170,42 @@ impl MultifaceGrowthFeature {
     fn is_air_or_water<T: GenerationCache>(chunk: &T, pos: BlockPos) -> bool {
         let id = GenerationCache::get_block_state(chunk, &pos.0).to_block_id();
         id == Block::AIR.id || id == Block::WATER.id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pumpkin_data::BlockDirection;
+    use pumpkin_util::math::{position::BlockPos, vector3::Vector3};
+
+    use super::MultifaceGrowthFeature;
+
+    /// `glow_lichen` has `search_range: 20`, but vanilla's loop re-offsets from the origin
+    /// every iteration, so all 20 probes land on the same block, one step from the origin.
+    #[test]
+    fn search_never_walks_away_from_the_origin() {
+        let origin = BlockPos(Vector3::new(7, 42, -3));
+        for direction in [
+            BlockDirection::Up,
+            BlockDirection::Down,
+            BlockDirection::North,
+            BlockDirection::South,
+            BlockDirection::East,
+            BlockDirection::West,
+        ] {
+            let offset = direction.to_offset();
+            let expected = BlockPos(Vector3::new(
+                origin.0.x + offset.x,
+                origin.0.y + offset.y,
+                origin.0.z + offset.z,
+            ));
+            for _ in 0..20 {
+                assert_eq!(
+                    MultifaceGrowthFeature::search_position(origin, direction),
+                    expected,
+                    "probe for {direction:?} moved away from origin + direction"
+                );
+            }
+        }
     }
 }

--- a/crates/pumpkin-world/src/generation/feature/features/multiface_growth.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/multiface_growth.rs
@@ -1,4 +1,6 @@
-use pumpkin_data::{Block, BlockDirection, BlockState, block_properties::GlowLichenLikeProperties};
+use pumpkin_data::{
+    Block, BlockDirection, BlockState, BlockStateId, block_properties::GlowLichenLikeProperties,
+};
 use pumpkin_util::{
     math::position::BlockPos,
     random::{RandomGenerator, RandomImpl},
@@ -75,11 +77,34 @@ impl MultifaceGrowthFeature {
         origin.offset(direction.to_offset())
     }
 
+    /// Vanilla `MultifaceGrowthFeature.placeGrowthIfPossible`:
+    ///
+    /// ```java
+    /// for (Direction direction : list) {
+    ///     BlockState blockState = level.getBlockState(mutable.setWithOffset(pos, direction));
+    ///     if (config.canBePlacedOn.contains(blockState)) {
+    ///         BlockState blockState2 = block.getStateForPlacement(state, level, pos, direction);
+    ///         if (blockState2 == null) return false;
+    ///         level.setBlock(pos, blockState2, 3);
+    ///         level.getChunk(pos).markPosForPostProcessing(pos);
+    ///         if (random.nextFloat() < config.chanceOfSpreading) {
+    ///             block.getSpreader()
+    ///                 .spreadFromFaceTowardRandomDirection(blockState2, level, pos, direction, random, true);
+    ///         }
+    ///         return true;
+    ///     }
+    /// }
+    /// return false;
+    /// ```
+    ///
+    /// The `nextFloat` is drawn on *every* successful placement (`chance_of_spreading` is 0.5
+    /// for `glow_lichen`, 1.0 for `sculk_vein`), so leaving it out desynchronises the rest of
+    /// the feature's stream, and the spread it gates places a second growth block.
     fn place_growth_if_possible<T: GenerationCache>(
         &self,
         chunk: &mut T,
         pos: BlockPos,
-        _random: &mut RandomGenerator,
+        random: &mut RandomGenerator,
         placement_directions: &[BlockDirection],
     ) -> bool {
         for &direction in placement_directions {
@@ -87,42 +112,221 @@ impl MultifaceGrowthFeature {
             let neighbor_id =
                 GenerationCache::get_block_state(chunk, &neighbor_pos.0).to_block_id();
 
-            if self.can_be_placed_on.contains(&neighbor_id) {
-                let is_water = GenerationCache::get_block_state(chunk, &pos.0).to_block_id()
-                    == Block::WATER.id;
-                let block = Block::from_id(self.place_block);
-
-                let mut props = GlowLichenLikeProperties {
-                    down: direction == BlockDirection::Down,
-                    up: direction == BlockDirection::Up,
-                    north: direction == BlockDirection::North,
-                    south: direction == BlockDirection::South,
-                    west: direction == BlockDirection::West,
-                    east: direction == BlockDirection::East,
-                    waterlogged: is_water,
-                };
-
-                let cur_state = GenerationCache::get_block_state(chunk, &pos.0);
-                if cur_state.to_block_id() == self.place_block
-                    && (self.place_block == Block::GLOW_LICHEN.id
-                        || self.place_block == Block::SCULK_VEIN.id)
-                {
-                    let cur_props = GlowLichenLikeProperties::from_state_id(cur_state);
-                    props.down |= cur_props.down;
-                    props.up |= cur_props.up;
-                    props.north |= cur_props.north;
-                    props.south |= cur_props.south;
-                    props.west |= cur_props.west;
-                    props.east |= cur_props.east;
-                }
-
-                let state_id = props.to_state_id(block);
-                chunk.set_block_state(&pos.0, BlockState::from_id(state_id));
-                return true;
+            if !self.can_be_placed_on.contains(&neighbor_id) {
+                continue;
             }
+
+            // `getStateForPlacement` returning null aborts the whole call in vanilla; it does
+            // not fall through to the next direction.
+            let Some(state_id) = self.state_for_placement(chunk, pos, direction) else {
+                return false;
+            };
+            chunk.set_block_state(&pos.0, BlockState::from_id(state_id));
+
+            if random.next_f32() < self.chance_of_spreading {
+                self.spread_from_face_toward_random_direction(
+                    chunk, state_id, pos, direction, random,
+                );
+            }
+            return true;
         }
 
         false
+    }
+
+    /// Vanilla `MultifaceBlock.getStateForPlacement`: `null` when the face cannot take the
+    /// growth, otherwise the current growth state (or a fresh, possibly waterlogged one) with
+    /// this face turned on.
+    fn state_for_placement<T: GenerationCache>(
+        &self,
+        chunk: &T,
+        pos: BlockPos,
+        direction: BlockDirection,
+    ) -> Option<BlockStateId> {
+        if !self.is_valid_state_for_placement(chunk, pos, direction) {
+            return None;
+        }
+
+        let current = GenerationCache::get_block_state(chunk, &pos.0);
+        let mut props = if current.to_block_id() == self.place_block {
+            GlowLichenLikeProperties::from_state_id(current)
+        } else {
+            GlowLichenLikeProperties {
+                down: false,
+                up: false,
+                north: false,
+                south: false,
+                west: false,
+                east: false,
+                waterlogged: current.to_block_id() == Block::WATER.id,
+            }
+        };
+        Self::set_face(&mut props, direction, true);
+        Some(props.to_state_id(Block::from_id(self.place_block)))
+    }
+
+    /// Vanilla `MultifaceBlock.isValidStateForPlacement`: every face is supported, a face the
+    /// growth already has cannot be placed again, and the neighbour must offer a sturdy face
+    /// towards this block (`MultifaceBlock.canAttachTo`).
+    fn is_valid_state_for_placement<T: GenerationCache>(
+        &self,
+        chunk: &T,
+        pos: BlockPos,
+        direction: BlockDirection,
+    ) -> bool {
+        let current = GenerationCache::get_block_state(chunk, &pos.0);
+        if current.to_block_id() == self.place_block && self.has_face(current, direction) {
+            return false;
+        }
+        let neighbor_pos = pos.offset(direction.to_offset());
+        GenerationCache::get_block_state(chunk, &neighbor_pos.0)
+            .to_state()
+            .is_side_solid(direction.opposite())
+    }
+
+    /// Vanilla `MultifaceSpreader.spreadFromFaceTowardRandomDirection`: shuffle all six
+    /// directions (five `nextInt` draws) and take the first that yields a spread position the
+    /// growth can actually be placed into.
+    fn spread_from_face_toward_random_direction<T: GenerationCache>(
+        &self,
+        chunk: &mut T,
+        state: BlockStateId,
+        pos: BlockPos,
+        face: BlockDirection,
+        random: &mut RandomGenerator,
+    ) {
+        for spread_direction in Self::shuffled_all_directions(random) {
+            if let Some((spread_pos, spread_face)) = self.spread_pos_from_face_toward_direction(
+                chunk,
+                state,
+                pos,
+                face,
+                spread_direction,
+            ) && self.spread_to_face(chunk, spread_pos, spread_face)
+            {
+                return;
+            }
+        }
+    }
+
+    /// Vanilla `Direction.allShuffled` = `Util.shuffledCopy(Direction.values(), random)`, i.e.
+    /// `[DOWN, UP, NORTH, SOUTH, WEST, EAST]` run through
+    /// `for (int j = size; j > 1; j--) { int k = random.nextInt(j); swap(j - 1, k); }`,
+    /// which always spends exactly five `nextInt` draws.
+    fn shuffled_all_directions(random: &mut RandomGenerator) -> [BlockDirection; 6] {
+        let mut directions = BlockDirection::all();
+        for i in (1..directions.len()).rev() {
+            let j = random.next_bounded_i32((i + 1) as i32) as usize;
+            directions.swap(i, j);
+        }
+        directions
+    }
+
+    /// Vanilla `MultifaceSpreader.getSpreadFromFaceTowardDirection` with the default
+    /// `SAME_POSITION, SAME_PLANE, WRAP_AROUND` order.
+    fn spread_pos_from_face_toward_direction<T: GenerationCache>(
+        &self,
+        chunk: &T,
+        state: BlockStateId,
+        pos: BlockPos,
+        face: BlockDirection,
+        spread_direction: BlockDirection,
+    ) -> Option<(BlockPos, BlockDirection)> {
+        if spread_direction.to_axis() == face.to_axis() {
+            return None;
+        }
+        if !self.has_face(state, face) || self.has_face(state, spread_direction) {
+            return None;
+        }
+
+        Self::spread_candidates(pos, face, spread_direction)
+            .into_iter()
+            .find(|&(spread_pos, spread_face)| self.can_spread_into(chunk, spread_pos, spread_face))
+    }
+
+    /// `MultifaceSpreader.DEFAULT_SPREAD_ORDER`, in order:
+    ///
+    /// ```java
+    /// SAME_POSITION -> new SpreadPos(pos, spreadDirection)
+    /// SAME_PLANE    -> new SpreadPos(pos.relative(spreadDirection), face)
+    /// WRAP_AROUND   -> new SpreadPos(pos.relative(spreadDirection).relative(face),
+    ///                                spreadDirection.getOpposite())
+    /// ```
+    fn spread_candidates(
+        pos: BlockPos,
+        face: BlockDirection,
+        spread_direction: BlockDirection,
+    ) -> [(BlockPos, BlockDirection); 3] {
+        [
+            (pos, spread_direction),
+            (pos.offset(spread_direction.to_offset()), face),
+            (
+                pos.offset(spread_direction.to_offset())
+                    .offset(face.to_offset()),
+                spread_direction.opposite(),
+            ),
+        ]
+    }
+
+    /// Vanilla `MultifaceSpreader.DefaultSpreaderConfig.canSpreadInto`: the target must be
+    /// air, the growth itself or a water source, and the face must be placeable there.
+    fn can_spread_into<T: GenerationCache>(
+        &self,
+        chunk: &T,
+        pos: BlockPos,
+        face: BlockDirection,
+    ) -> bool {
+        let target = GenerationCache::get_block_state(chunk, &pos.0);
+        let target_block = target.to_block_id();
+        let replaceable = target.to_state().is_air()
+            || target_block == self.place_block
+            || target_block == Block::WATER.id;
+        replaceable && self.is_valid_state_for_placement(chunk, pos, face)
+    }
+
+    /// Vanilla `MultifaceSpreader.spreadToFace`.
+    fn spread_to_face<T: GenerationCache>(
+        &self,
+        chunk: &mut T,
+        pos: BlockPos,
+        face: BlockDirection,
+    ) -> bool {
+        let Some(state_id) = self.state_for_placement(chunk, pos, face) else {
+            return false;
+        };
+        chunk.set_block_state(&pos.0, BlockState::from_id(state_id));
+        true
+    }
+
+    /// Vanilla `MultifaceBlock.hasFace` (`getValueOrElse(faceProperty, false)`).
+    fn has_face(&self, state: BlockStateId, direction: BlockDirection) -> bool {
+        if state.to_block_id() != self.place_block {
+            return false;
+        }
+        let props = GlowLichenLikeProperties::from_state_id(state);
+        match direction {
+            BlockDirection::Down => props.down,
+            BlockDirection::Up => props.up,
+            BlockDirection::North => props.north,
+            BlockDirection::South => props.south,
+            BlockDirection::West => props.west,
+            BlockDirection::East => props.east,
+        }
+    }
+
+    const fn set_face(
+        props: &mut GlowLichenLikeProperties,
+        direction: BlockDirection,
+        value: bool,
+    ) {
+        match direction {
+            BlockDirection::Down => props.down = value,
+            BlockDirection::Up => props.up = value,
+            BlockDirection::North => props.north = value,
+            BlockDirection::South => props.south = value,
+            BlockDirection::West => props.west = value,
+            BlockDirection::East => props.east = value,
+        }
     }
 
     fn get_valid_directions(&self) -> Vec<BlockDirection> {
@@ -207,5 +411,60 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Reference values from the real 26.2 server jar:
+    /// `Direction.allShuffled(new XoroshiroRandomSource(13579))`, four calls in a row, and the
+    /// raw `nextInt()` after a single call (`-1266923548`, the *sixth* value of that stream
+    /// `1544854625, -1649625109, 454558489, -1024776688, -2036914607, -1266923548, ...`, so a
+    /// shuffle costs exactly five draws).
+    #[test]
+    fn shuffled_all_directions_matches_vanilla() {
+        use pumpkin_util::random::{RandomGenerator, RandomImpl, xoroshiro128::Xoroshiro};
+
+        use BlockDirection::{Down, East, North, South, Up, West};
+        let expected = [
+            [West, Up, East, Down, South, North],
+            [North, East, Up, South, Down, West],
+            [Down, Up, North, East, South, West],
+            [Up, Down, West, North, South, East],
+        ];
+
+        let mut random = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(13579));
+        for (call, expected) in expected.iter().enumerate() {
+            assert_eq!(
+                &MultifaceGrowthFeature::shuffled_all_directions(&mut random),
+                expected,
+                "allShuffled call #{call}"
+            );
+        }
+
+        let mut random = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(13579));
+        MultifaceGrowthFeature::shuffled_all_directions(&mut random);
+        assert_eq!(random.next_i32(), -1_266_923_548);
+    }
+
+    /// `MultifaceSpreader.DEFAULT_SPREAD_ORDER` for a growth on the `Up` face spreading north.
+    #[test]
+    fn spread_candidates_match_the_vanilla_spread_types() {
+        let pos = BlockPos(Vector3::new(4, 70, 9));
+        let candidates = MultifaceGrowthFeature::spread_candidates(
+            pos,
+            BlockDirection::Up,
+            BlockDirection::North,
+        );
+
+        // SAME_POSITION: the same block, now carrying the spread direction as its face.
+        assert_eq!(candidates[0], (pos, BlockDirection::North));
+        // SAME_PLANE: one step along the spread direction, keeping the original face.
+        assert_eq!(
+            candidates[1],
+            (BlockPos(Vector3::new(4, 70, 8)), BlockDirection::Up)
+        );
+        // WRAP_AROUND: around the corner, facing back the way it came.
+        assert_eq!(
+            candidates[2],
+            (BlockPos(Vector3::new(4, 71, 8)), BlockDirection::South)
+        );
     }
 }


### PR DESCRIPTION
## Description

Two fixes to `MultifaceGrowthFeature` (glow lichen, sculk vein), both read off the 26.2 server jar with `javap -c -p`.

**1. The search never leaves `origin + direction`.** Vanilla's search loop re-seeds its cursor from the *origin* on every iteration (`mutableBlockPos.setWithOffset(blockPos, direction)` — `blockPos`, not the cursor), so `search_range` only makes vanilla re-test the same block and `glow_lichen`'s `search_range: 20` reaches exactly one block. Pumpkin walked the cursor outward, which let a single origin seed lichen up to 20 blocks away, in caves vanilla leaves bare.

**2. Placement goes through `getStateForPlacement` and spreads.** Vanilla `placeGrowthIfPossible` computes `MultifaceBlock.getStateForPlacement` (a face the growth already carries cannot be re-placed, the neighbour must offer a sturdy face back, an existing growth keeps its faces), returns `false` if that is null, sets the block, and then `if (random.nextFloat() < chanceOfSpreading) spreader.spreadFromFaceTowardRandomDirection(...)`. Pumpkin took `_random` and never touched it: no `nextFloat`, no spread, and a face that could not be placed fell through to the next direction instead of aborting. `chance_of_spreading` is 0.5 for `glow_lichen` and 1.0 for `sculk_vein`, so roughly every other placement was short one `nextFloat` plus the five `nextInt` draws of `Direction.allShuffled`; with `glow_lichen`'s `count` of 104..157 per chunk the stream drifted with every patch. This adds `MultifaceBlock.getStateForPlacement` / `isValidStateForPlacement` / `canAttachTo`, and `MultifaceSpreader.spreadFromFaceTowardRandomDirection` over `Direction.allShuffled(random)` with the default `SAME_POSITION, SAME_PLANE, WRAP_AROUND` order and `DefaultSpreaderConfig.canSpreadInto`.

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

| | before | after (1) | after (2) |
|---|---|---|---|
| mismatching blocks | 18,839 (0.075 %) | 18,111 | **17,776 (0.071 %)** |
| chunks bit-identical | 16/256 | 24/256 | **55/256** |
| glow_lichen confusions | 1,043 | 345 | **8** |

`air→glow_lichen` 565 → 78 → 0; the 36 property-only lichen mismatches go to zero. No category got worse.

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. Tests pin `Direction.allShuffled(new XoroshiroRandomSource(13579))` to the four permutations the real jar returns and its five-draw cost, and the spread order to the three `SpreadType` expressions.

**Known impact:** changes glow lichen and sculk vein placement in caves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiface growth placement by validating available surfaces and preserving existing block properties.
  * Added correct handling for waterlogged locations during growth.
  * Updated spreading behavior to better match vanilla mechanics, including direction selection and spread order.
  * Fixed positioning checks so growth consistently evaluates the correct locations.
* **Tests**
  * Added coverage for growth positioning, direction selection, and spread ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->