### PR TITLE
fix(worldgen): seagrass draw order and source-water fluid state for plants 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-world/src/chunk_system/generation_cache.rs
+++ b/crates/pumpkin-world/src/chunk_system/generation_cache.rs
@@ -17,6 +17,34 @@ use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 use tracing::debug;
 
+/// Vanilla `BlockBehaviour.getFluidState`. A block that is not itself a fluid
+/// can still report a fluid state, and every such overworld block reports
+/// `Fluids.WATER.getSource(false)` — the water **source**, never
+/// `flowing_water`:
+///
+/// * `state.getValue(WATERLOGGED) ? Fluids.WATER.getSource(false) : ...` in
+///   `BaseRailBlock`, `SlabBlock`, `LeavesBlock`, `SignBlock`, … (26.2);
+/// * unconditionally in `SeagrassBlock:87`, `TallSeagrassBlock:80`,
+///   `KelpBlock:73`, `KelpPlantBlock:36` and `BubbleColumnBlock:74`, which have
+///   no `waterlogged` property at all.
+///
+/// This matters during worldgen because `MatchingFluidsPredicate` tests
+/// `state.getFluidState().getType()` against `minecraft:water`: the
+/// `disk_gravel` / `disk_sand` / `disk_clay` placements sit on the ocean floor,
+/// where an earlier feature has usually already replaced the water with
+/// seagrass or kelp.
+fn holds_source_water(id: BlockStateId) -> bool {
+    if id.is_waterlogged() {
+        return true;
+    }
+    let block = id.to_block_id();
+    block == Block::SEAGRASS.id
+        || block == Block::TALL_SEAGRASS.id
+        || block == Block::KELP.id
+        || block == Block::KELP_PLANT.id
+        || block == Block::BUBBLE_COLUMN.id
+}
+
 pub struct Cache {
     pub x: i32,
     pub z: i32,
@@ -233,8 +261,8 @@ impl GenerationCache for Cache {
         let id = GenerationCache::get_block_state(self, pos);
 
         let Some(fluid) = Fluid::from_state_id(id) else {
-            let fluid = if id.is_waterlogged() {
-                Fluid::FLOWING_WATER
+            let fluid = if holds_source_water(id) {
+                Fluid::WATER
             } else {
                 Fluid::EMPTY
             };
@@ -710,9 +738,46 @@ impl Cache {
 
 #[cfg(test)]
 mod tests {
-    use super::{Chunk, SurfaceBiomeNeighborhood};
+    use super::{Chunk, SurfaceBiomeNeighborhood, holds_source_water};
     use crate::chunk::ChunkData;
     use pumpkin_data::biome::Biome;
+    use pumpkin_data::{Block, BlockStateId};
+
+    #[test]
+    fn seagrass_kelp_and_waterlogged_blocks_report_source_water() {
+        // Vanilla 26.2 `getFluidState` overrides that return
+        // `Fluids.WATER.getSource(false)`:
+        //   SeagrassBlock:87, TallSeagrassBlock:80, KelpBlock:73,
+        //   KelpPlantBlock:36, BubbleColumnBlock:74 (unconditional, these blocks
+        //   have no `waterlogged` property), plus every
+        //   `state.getValue(WATERLOGGED) ? Fluids.WATER.getSource(false) : ...`
+        //   override (BaseRailBlock:298, SlabBlock:102, LeavesBlock:140, ...).
+        for block in [
+            &Block::SEAGRASS,
+            &Block::TALL_SEAGRASS,
+            &Block::KELP,
+            &Block::KELP_PLANT,
+            &Block::BUBBLE_COLUMN,
+        ] {
+            assert!(
+                holds_source_water(block.default_state.id),
+                "{} must report a water fluid state",
+                block.name
+            );
+        }
+
+        let waterlogged = Block::OAK_SLAB
+            .default_state
+            .set_waterlogged(true)
+            .expect("oak_slab is waterloggable");
+        assert!(holds_source_water(waterlogged.id));
+        assert!(!holds_source_water(Block::OAK_SLAB.default_state.id));
+
+        // Blocks with no fluid state of their own stay dry.
+        assert!(!holds_source_water(Block::DIRT.default_state.id));
+        assert!(!holds_source_water(Block::GRAVEL.default_state.id));
+        assert!(!holds_source_water(BlockStateId::AIR));
+    }
 
     #[test]
     fn surface_biome_snapshot_copies_level_chunk_palettes() {

--- a/crates/pumpkin-world/src/generation/feature/features/seagrass.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/seagrass.rs
@@ -31,30 +31,10 @@ impl SeagrassFeature {
         let grass_pos = BlockPos::new(pos.0.x + x, y, pos.0.z + z);
 
         // Vanilla draws the tall/short coin as soon as the target is water, *before* the
-        // survivability check, and reports success for any surviving spot even when the tall
-        // variant found no water above it:
-        //
-        // ```java
-        // if (level.getBlockState(blockPos).is(Blocks.WATER)) {
-        //     boolean bl2 = random.nextDouble() < config.probability;
-        //     BlockState blockState = bl2
-        //         ? Blocks.TALL_SEAGRASS.defaultBlockState()
-        //         : Blocks.SEAGRASS.defaultBlockState();
-        //     if (blockState.canSurvive(level, blockPos)) {
-        //         if (bl2) {
-        //             BlockState blockState2 = blockState.setValue(TallSeagrassBlock.HALF, DoubleBlockHalf.UPPER);
-        //             BlockPos blockPos2 = blockPos.above();
-        //             if (level.getBlockState(blockPos2).is(Blocks.WATER)) {
-        //                 level.setBlock(blockPos, blockState, 2);
-        //                 level.setBlock(blockPos2, blockState2, 2);
-        //             }
-        //         } else {
-        //             level.setBlock(blockPos, blockState, 2);
-        //         }
-        //         bl = true;
-        //     }
-        // }
-        // ```
+        // survivability check: `nextDouble() < probability` picks tall over short seagrass, and
+        // only then is the chosen state tested for survival. The tall variant additionally needs
+        // water in the block above before either half is written, but the feature reports
+        // success for any surviving spot even when that second water check fails.
         //
         // Skipping the `nextDouble` on the ocean floor blocks that cannot hold seagrass left
         // every later draw of the feature one behind.
@@ -124,15 +104,8 @@ mod tests {
     use super::SeagrassFeature;
 
     /// Vanilla spends the `nextDouble` on every water target, even one the seagrass cannot
-    /// survive on, and spends none when the target is not water:
-    ///
-    /// ```java
-    /// if (level.getBlockState(blockPos).is(Blocks.WATER)) {
-    ///     boolean bl2 = random.nextDouble() < config.probability;
-    ///     ...
-    ///     if (blockState.canSurvive(level, blockPos)) { ... }
-    /// }
-    /// ```
+    /// survive on, and spends none when the target is not water: the coin sits inside the
+    /// "target is water" branch and ahead of the survivability test.
     #[test]
     fn the_tall_coin_is_drawn_before_the_survivability_check() {
         // Not water: no draw at all.

--- a/crates/pumpkin-world/src/generation/feature/features/seagrass.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/seagrass.rs
@@ -30,10 +30,40 @@ impl SeagrassFeature {
         let y = chunk.ocean_floor_height_exclusive(pos.0.x + x, pos.0.z + z);
         let grass_pos = BlockPos::new(pos.0.x + x, y, pos.0.z + z);
 
-        if GenerationCache::get_block_state(chunk, &grass_pos.0).to_block_id() == Block::WATER
-            && Self::can_survive(chunk, grass_pos)
+        // Vanilla draws the tall/short coin as soon as the target is water, *before* the
+        // survivability check, and reports success for any surviving spot even when the tall
+        // variant found no water above it:
+        //
+        // ```java
+        // if (level.getBlockState(blockPos).is(Blocks.WATER)) {
+        //     boolean bl2 = random.nextDouble() < config.probability;
+        //     BlockState blockState = bl2
+        //         ? Blocks.TALL_SEAGRASS.defaultBlockState()
+        //         : Blocks.SEAGRASS.defaultBlockState();
+        //     if (blockState.canSurvive(level, blockPos)) {
+        //         if (bl2) {
+        //             BlockState blockState2 = blockState.setValue(TallSeagrassBlock.HALF, DoubleBlockHalf.UPPER);
+        //             BlockPos blockPos2 = blockPos.above();
+        //             if (level.getBlockState(blockPos2).is(Blocks.WATER)) {
+        //                 level.setBlock(blockPos, blockState, 2);
+        //                 level.setBlock(blockPos2, blockState2, 2);
+        //             }
+        //         } else {
+        //             level.setBlock(blockPos, blockState, 2);
+        //         }
+        //         bl = true;
+        //     }
+        // }
+        // ```
+        //
+        // Skipping the `nextDouble` on the ocean floor blocks that cannot hold seagrass left
+        // every later draw of the feature one behind.
+        let target_is_water =
+            GenerationCache::get_block_state(chunk, &grass_pos.0).to_block_id() == Block::WATER;
+        let can_survive = target_is_water && Self::can_survive(chunk, grass_pos);
+        if let Some(is_tall) =
+            Self::choose_variant(random, self.probability, target_is_water, can_survive)
         {
-            let is_tall = random.next_f64() < self.probability as f64;
             if is_tall {
                 let above = grass_pos.up();
                 if GenerationCache::get_block_state(chunk, &above.0).to_block_id() == Block::WATER {
@@ -45,15 +75,33 @@ impl SeagrassFeature {
 
                     chunk.set_block_state(&grass_pos.0, Block::TALL_SEAGRASS.default_state);
                     chunk.set_block_state(&above.0, upper_state);
-                    placed_any = true;
                 }
             } else {
                 chunk.set_block_state(&grass_pos.0, Block::SEAGRASS.default_state);
-                placed_any = true;
             }
+            placed_any = true;
         }
 
         placed_any
+    }
+
+    /// The RNG-consuming half of vanilla's `SeagrassFeature.place`, split out so its draw
+    /// order can be pinned by a test.
+    ///
+    /// `nextDouble` is spent whenever the target block is water, *before* `canSurvive` is
+    /// consulted, and not at all when the target is not water. Returns `None` when nothing is
+    /// placed, `Some(is_tall)` otherwise.
+    fn choose_variant(
+        random: &mut RandomGenerator,
+        probability: f32,
+        target_is_water: bool,
+        can_survive: bool,
+    ) -> Option<bool> {
+        if !target_is_water {
+            return None;
+        }
+        let is_tall = random.next_f64() < f64::from(probability);
+        can_survive.then_some(is_tall)
     }
 
     fn can_survive<T: GenerationCache>(chunk: &T, pos: BlockPos) -> bool {
@@ -66,5 +114,54 @@ impl SeagrassFeature {
         }
 
         below_state.to_state().is_side_solid(BlockDirection::Up)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pumpkin_util::random::{RandomGenerator, RandomImpl, xoroshiro128::Xoroshiro};
+
+    use super::SeagrassFeature;
+
+    /// Vanilla spends the `nextDouble` on every water target, even one the seagrass cannot
+    /// survive on, and spends none when the target is not water:
+    ///
+    /// ```java
+    /// if (level.getBlockState(blockPos).is(Blocks.WATER)) {
+    ///     boolean bl2 = random.nextDouble() < config.probability;
+    ///     ...
+    ///     if (blockState.canSurvive(level, blockPos)) { ... }
+    /// }
+    /// ```
+    #[test]
+    fn the_tall_coin_is_drawn_before_the_survivability_check() {
+        // Not water: no draw at all.
+        let mut random = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(13579));
+        let mut reference = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(13579));
+        assert_eq!(
+            SeagrassFeature::choose_variant(&mut random, 0.3, false, false),
+            None
+        );
+        assert_eq!(random.next_i64(), reference.next_i64());
+
+        // Water but nothing to stand on: the coin is still drawn, only the placement is lost.
+        let mut random = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(13579));
+        let mut reference = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(13579));
+        reference.next_f64();
+        assert_eq!(
+            SeagrassFeature::choose_variant(&mut random, 0.3, true, false),
+            None
+        );
+        assert_eq!(random.next_i64(), reference.next_i64());
+
+        // Water with support: the same single draw, and the coin decides tall vs short.
+        let mut random = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(13579));
+        let mut reference = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(13579));
+        let expected = reference.next_f64() < 0.3;
+        assert_eq!(
+            SeagrassFeature::choose_variant(&mut random, 0.3, true, true),
+            Some(expected)
+        );
+        assert_eq!(random.next_i64(), reference.next_i64());
     }
 }


### PR DESCRIPTION
## Description

Two fixes for underwater vegetation.

**1. Seagrass draws its tall/short coin before the survivability check.** Vanilla `SeagrassFeature.place` spends its `nextDouble` as soon as the target block is water and only then asks whether the plant can stand there; Pumpkin gated the draw on both checks at once, so every water column whose floor cannot hold seagrass skipped a draw. `seagrass_short` / `seagrass_slightly_less_short` place 48 and 64 attempts per chunk, so the stream drifted with each miss. The `placed` result now also follows vanilla (success for any surviving spot even when the tall variant found no water above it).

**2. Plants and waterlogged blocks report the water *source*.** Vanilla `BlockBehaviour.getFluidState` lets a non-fluid block carry a fluid state, and every such overworld block reports `Fluids.WATER.getSource(false)`: waterlogged states (`BaseRailBlock`, `SlabBlock`, `LeavesBlock`, `SignBlock`, …) and, unconditionally, `SeagrassBlock`, `TallSeagrassBlock`, `KelpBlock`, `KelpPlantBlock`, `BubbleColumnBlock`. `Cache::get_fluid_and_fluid_state` answered `Fluid::EMPTY` for the five unconditional ones and `FLOWING_WATER` for waterlogged states, so `MatchingFluidsPredicate` (`fluids = minecraft:water`) matched neither. That is the `block_predicate_filter matching_fluids water` step of `disk_gravel` / `disk_sand` / `disk_clay`, which sit at `heightmap OCEAN_FLOOR_WG`, i.e. exactly where an earlier feature has usually already put seagrass or kelp, so Pumpkin silently dropped the disks. Example: chunk (−16, 11), `in_square → (−249, 181)`, `heightmap → y 58`, rejected because Pumpkin had seagrass there; vanilla ran the disk and turned the dirt at y 56–57 into gravel.

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

| | before | after |
|---|---|---|
| (1) seagrass coin: mismatching blocks | 17,776 | **17,639**; seagrass confusions 465 → 328 |
| (2) source water, late in the series: mismatching blocks | 32 | **13**; chunks identical 248 → **249/256** |

The `gravel→dirt` bucket ((−16, 11), 19 blocks) goes to zero; nothing else moved in either direction.

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

**Known impact:** changes seagrass placement and restores ocean-floor gravel/sand/clay disks under vegetation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected fluid-state reporting for aquatic and waterlogged blocks, improving water behavior in generated worlds.
  - Updated seagrass generation to better match vanilla behavior, including variant selection and placement consistency.
  - Unsupported water locations no longer place seagrass, while valid water targets retain expected generation behavior.
- **Tests**
  - Added coverage for aquatic, waterlogged, dry, and air blocks, along with seagrass generation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->