### PR TITLE
fix(worldgen): aquifer centre tie-breaking and overworld springs 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-world/src/generation/feature/features/spring_feature.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/spring_feature.rs
@@ -1,5 +1,8 @@
-use pumpkin_data::{BlockDirection, BlockState};
-use pumpkin_util::{math::position::BlockPos, random::RandomGenerator};
+use pumpkin_data::{Block, BlockDirection, BlockState, tag::Taggable};
+use pumpkin_util::{
+    math::{position::BlockPos, vector3::Vector3},
+    random::RandomGenerator,
+};
 
 use crate::generation::proto_chunk::GenerationCache;
 use crate::world::WorldPortalExt;
@@ -18,13 +21,46 @@ pub enum BlockWrapper {
 }
 
 impl BlockWrapper {
-    fn contains(&self, name: &str) -> bool {
+    /// The raw entries of the vanilla `HolderSet`: either plain block ids
+    /// (`"minecraft:deepslate"`) or tag references (`"#minecraft:geode_invalid_blocks"`).
+    pub fn entries(&self) -> impl Iterator<Item = &str> {
         match self {
-            Self::Single(s) => s == name,
-            Self::Multi(h) => h.iter().any(|s| s == name),
+            Self::Single(s) => std::slice::from_ref(s),
+            Self::Multi(v) => v.as_slice(),
         }
+        .iter()
+        .map(String::as_str)
+    }
+
+    /// Vanilla compares with `BlockState.is(HolderSet<Block>)`, i.e. against *resolved*
+    /// registry entries. The datapack JSON spells them with their namespace
+    /// (`"minecraft:deepslate"`) while `Block::name` is the bare path (`"deepslate"`), so the
+    /// entries have to go through `Block::from_name` (which strips the namespace) instead of
+    /// being compared as strings.
+    #[must_use]
+    pub fn contains_block(&self, block: &Block) -> bool {
+        self.entries().any(|entry| {
+            entry.strip_prefix('#').map_or_else(
+                || Block::from_name(entry).is_some_and(|b| b.id == block.id),
+                |tag| {
+                    Block::get_tag_values(tag)
+                        .into_iter()
+                        .flatten()
+                        .any(|name| Block::from_name(name).is_some_and(|b| b.id == block.id))
+                },
+            )
+        })
     }
 }
+
+/// `SpringFeature.place` inspects west, east, north, south and below (never above).
+const NEIGHBOURS: [BlockDirection; 5] = [
+    BlockDirection::West,
+    BlockDirection::East,
+    BlockDirection::North,
+    BlockDirection::South,
+    BlockDirection::Down,
+];
 
 impl SpringFeatureFeature {
     pub fn generate<T: GenerationCache>(
@@ -35,102 +71,86 @@ impl SpringFeatureFeature {
         pos: BlockPos,
     ) -> bool {
         let valid_blocks = &self.valid_blocks;
+        let block_at = |chunk: &mut T, offset: Vector3<i32>| {
+            GenerationCache::get_block_state(chunk, &(pos.0 + offset)).to_block()
+        };
 
-        if !valid_blocks.contains(
-            GenerationCache::get_block_state(chunk, &pos.up().0)
-                .to_block()
-                .name,
-        ) {
+        if !valid_blocks.contains_block(block_at(chunk, Vector3::new(0, 1, 0))) {
             return false;
         }
         if self.requires_block_below
-            && !valid_blocks.contains(
-                GenerationCache::get_block_state(
-                    chunk,
-                    &pos.offset(BlockDirection::Down.to_offset()).0,
-                )
-                .to_block()
-                .name,
-            )
+            && !valid_blocks.contains_block(block_at(chunk, BlockDirection::Down.to_offset()))
         {
             return false;
         }
         let state = GenerationCache::get_block_state(chunk, &pos.0);
-        if !state.to_state().is_air() && !valid_blocks.contains(state.to_block().name) {
+        if !state.to_state().is_air() && !valid_blocks.contains_block(state.to_block()) {
             return false;
         }
 
         let mut valid = 0;
-        if valid_blocks.contains(
-            GenerationCache::get_block_state(
-                chunk,
-                &pos.offset(BlockDirection::West.to_offset()).0,
-            )
-            .to_block()
-            .name,
-        ) {
-            valid += 1;
-        }
-        if valid_blocks.contains(
-            GenerationCache::get_block_state(
-                chunk,
-                &pos.offset(BlockDirection::East.to_offset()).0,
-            )
-            .to_block()
-            .name,
-        ) {
-            valid += 1;
-        }
-        if valid_blocks.contains(
-            GenerationCache::get_block_state(
-                chunk,
-                &pos.offset(BlockDirection::North.to_offset()).0,
-            )
-            .to_block()
-            .name,
-        ) {
-            valid += 1;
-        }
-        if valid_blocks.contains(
-            GenerationCache::get_block_state(
-                chunk,
-                &pos.offset(BlockDirection::South.to_offset()).0,
-            )
-            .to_block()
-            .name,
-        ) {
-            valid += 1;
-        }
-        if valid_blocks.contains(
-            GenerationCache::get_block_state(
-                chunk,
-                &pos.offset(BlockDirection::Down.to_offset()).0,
-            )
-            .to_block()
-            .name,
-        ) {
-            valid += 1;
+        for direction in NEIGHBOURS {
+            if valid_blocks.contains_block(block_at(chunk, direction.to_offset())) {
+                valid += 1;
+            }
         }
         let mut air = 0;
-        if chunk.is_air(&pos.offset(BlockDirection::West.to_offset()).0) {
-            air += 1;
+        for direction in NEIGHBOURS {
+            if chunk.is_air(&(pos.0 + direction.to_offset())) {
+                air += 1;
+            }
         }
-        if chunk.is_air(&pos.offset(BlockDirection::East.to_offset()).0) {
-            air += 1;
-        }
-        if chunk.is_air(&pos.offset(BlockDirection::North.to_offset()).0) {
-            air += 1;
-        }
-        if chunk.is_air(&pos.offset(BlockDirection::South.to_offset()).0) {
-            air += 1;
-        }
-        if chunk.is_air(&pos.offset(BlockDirection::Down.to_offset()).0) {
-            air += 1;
-        }
+
         if valid == self.rock_count && air == self.hole_count {
             chunk.set_block_state(&pos.0, self.state);
             return true;
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pumpkin_data::Block;
+
+    use super::BlockWrapper;
+
+    /// `spring_lava_overworld.json` lists its `valid_blocks` with the `minecraft:` namespace,
+    /// and vanilla resolves them into a `HolderSet<Block>` before
+    /// `SpringFeature.place` asks `level.getBlockState(origin.above()).is(config.validBlocks)`.
+    /// Comparing the namespaced id against the bare `Block::name` never matched, so no
+    /// overworld spring was ever placed.
+    #[test]
+    fn namespaced_ids_resolve_to_blocks() {
+        let valid = BlockWrapper::Multi(
+            [
+                "minecraft:stone",
+                "minecraft:granite",
+                "minecraft:diorite",
+                "minecraft:andesite",
+                "minecraft:deepslate",
+                "minecraft:tuff",
+                "minecraft:calcite",
+                "minecraft:dirt",
+            ]
+            .map(str::to_string)
+            .to_vec(),
+        );
+
+        assert!(valid.contains_block(&Block::DEEPSLATE));
+        assert!(valid.contains_block(&Block::TUFF));
+        assert!(valid.contains_block(&Block::DIRT));
+        assert!(!valid.contains_block(&Block::AIR));
+        assert!(!valid.contains_block(&Block::GRAVEL));
+
+        // A bare id keeps working, and so does a `#tag` reference.
+        assert!(
+            BlockWrapper::Single("minecraft:netherrack".to_string())
+                .contains_block(&Block::NETHERRACK)
+        );
+        assert!(
+            BlockWrapper::Single("#minecraft:base_stone_overworld".to_string())
+                .contains_block(&Block::DEEPSLATE)
+        );
     }
 }

--- a/crates/pumpkin-world/src/generation/feature/features/spring_feature.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/spring_feature.rs
@@ -115,11 +115,8 @@ mod tests {
 
     use super::BlockWrapper;
 
-    /// `spring_lava_overworld.json` lists its `valid_blocks` with the `minecraft:` namespace,
-    /// and vanilla resolves them into a `HolderSet<Block>` before
-    /// `SpringFeature.place` asks `level.getBlockState(origin.above()).is(config.validBlocks)`.
-    /// Comparing the namespaced id against the bare `Block::name` never matched, so no
-    /// overworld spring was ever placed.
+    /// `spring_lava_overworld.json` lists its `valid_blocks` namespaced, and vanilla resolves
+    /// them through the block registry before testing the block above the origin against them.
     #[test]
     fn namespaced_ids_resolve_to_blocks() {
         let valid = BlockWrapper::Multi(

--- a/crates/pumpkin-world/src/generation/noise/aquifer_sampler.rs
+++ b/crates/pumpkin-world/src/generation/noise/aquifer_sampler.rs
@@ -334,13 +334,9 @@ impl WorldAquiferSampler {
     }
 
     /// Vanilla's four-nearest insertion sort from `Aquifer.NoiseBasedAquifer.computeSubstance`:
-    ///
-    /// ```java
-    /// if (distanceSqr1 >= newDistance) { ...shift 1..3 down...; closestIndex1 = index; }
-    /// else if (distanceSqr2 >= newDistance) { ...shift 2..3 down...; closestIndex2 = index; }
-    /// else if (distanceSqr3 >= newDistance) { closestIndex4 = closestIndex3; closestIndex3 = index; }
-    /// else if (distanceSqr4 >= newDistance) { closestIndex4 = index; }
-    /// ```
+    /// the new distance is tested against the four stored ones in slot order, and the first slot
+    /// whose stored distance is not smaller takes the candidate, shifting every slot below it
+    /// one place back.
     ///
     /// The comparison is `>=`, so a candidate that ties an already stored distance takes the
     /// *earlier* slot and pushes the stored one back.
@@ -923,10 +919,9 @@ mod random_positions_and_hypot {
         CarverAquiferSampler::new(7, 4, &PROTO_ROUTER, &RANDOM_CONFIG, settings)
     }
 
-    /// `Aquifer.NoiseBasedAquifer.computeSubstance` keeps the four nearest aquifer centres with
-    /// `if (distanceSqr1 >= newDistance) {...} else if (distanceSqr2 >= newDistance) {...} ...`.
-    /// Because the comparison is `>=` and not `>`, a candidate whose squared distance ties an
-    /// already stored one takes the *earlier* slot and pushes the stored candidate back.
+    /// `Aquifer.NoiseBasedAquifer.computeSubstance` tests a candidate against its four stored
+    /// distances with `>=`, not `>`, so one that ties an already stored distance takes the
+    /// *earlier* slot and pushes the stored candidate back.
     #[test]
     fn insert_nearest_matches_vanilla_tie_breaking() {
         let mut nearest = [(0i64, i32::MAX); 4];
@@ -949,9 +944,9 @@ mod random_positions_and_hypot {
         assert_eq!(nearest, [(21, 5), (20, 5), (10, 5), (11, 7)]);
     }
 
-    /// The twelve candidate centres must be visited x-major, then y, then z, exactly as
-    /// `for (int x1 = 0; x1 <= 1; x1++) for (int y1 = -1; y1 <= 1; y1++) for (int z1 = 0; z1 <= 1; z1++)`
-    /// in `computeSubstance`; the order is observable through the `>=` tie-breaking above.
+    /// The twelve candidate centres must be visited x-major, then y, then z — `computeSubstance`
+    /// runs X over 0..=1 outermost, Y over -1..=1, and Z over 0..=1 innermost; the order is
+    /// observable through the `>=` tie-breaking above.
     #[test]
     fn random_positions_are_returned_in_vanilla_visit_order() {
         let sampler = create_aquifer(&PROTO_ROUTER).0;

--- a/crates/pumpkin-world/src/generation/noise/aquifer_sampler.rs
+++ b/crates/pumpkin-world/src/generation/noise/aquifer_sampler.rs
@@ -312,20 +312,55 @@ impl WorldAquiferSampler {
 
         let p = &self.packed_positions;
 
+        // Vanilla `Aquifer.NoiseBasedAquifer.computeSubstance` visits the twelve candidate
+        // aquifer centres as `for x1 in 0..=1 { for y1 in -1..=1 { for z1 in 0..=1 } } }`,
+        // i.e. x-major, then y, then z. The visiting order is only observable through the
+        // `>=` tie-breaking of the four-nearest insertion sort below, but it *is* observable,
+        // so keep it identical.
         Some([
-            p[i11 + 2],
-            p[i10 + 2],
-            p[i01 + 2],
-            p[i00 + 2],
-            p[i11 + 1],
-            p[i10 + 1],
-            p[i01 + 1],
-            p[i00 + 1],
-            p[i11],
-            p[i10],
-            p[i01],
-            p[i00],
+            p[i00],     // (x  , y-1, z  )
+            p[i01],     // (x  , y-1, z+1)
+            p[i00 + 1], // (x  , y  , z  )
+            p[i01 + 1], // (x  , y  , z+1)
+            p[i00 + 2], // (x  , y+1, z  )
+            p[i01 + 2], // (x  , y+1, z+1)
+            p[i10],     // (x+1, y-1, z  )
+            p[i11],     // (x+1, y-1, z+1)
+            p[i10 + 1], // (x+1, y  , z  )
+            p[i11 + 1], // (x+1, y  , z+1)
+            p[i10 + 2], // (x+1, y+1, z  )
+            p[i11 + 2], // (x+1, y+1, z+1)
         ])
+    }
+
+    /// Vanilla's four-nearest insertion sort from `Aquifer.NoiseBasedAquifer.computeSubstance`:
+    ///
+    /// ```java
+    /// if (distanceSqr1 >= newDistance) { ...shift 1..3 down...; closestIndex1 = index; }
+    /// else if (distanceSqr2 >= newDistance) { ...shift 2..3 down...; closestIndex2 = index; }
+    /// else if (distanceSqr3 >= newDistance) { closestIndex4 = closestIndex3; closestIndex3 = index; }
+    /// else if (distanceSqr4 >= newDistance) { closestIndex4 = index; }
+    /// ```
+    ///
+    /// The comparison is `>=`, so a candidate that ties an already stored distance takes the
+    /// *earlier* slot and pushes the stored one back.
+    const fn insert_nearest(nearest: &mut [(i64, i32); 4], packed: i64, distance_sqr: i32) {
+        let entry = (packed, distance_sqr);
+        if nearest[0].1 >= distance_sqr {
+            nearest[3] = nearest[2];
+            nearest[2] = nearest[1];
+            nearest[1] = nearest[0];
+            nearest[0] = entry;
+        } else if nearest[1].1 >= distance_sqr {
+            nearest[3] = nearest[2];
+            nearest[2] = nearest[1];
+            nearest[1] = entry;
+        } else if nearest[2].1 >= distance_sqr {
+            nearest[3] = nearest[2];
+            nearest[2] = entry;
+        } else if nearest[3].1 >= distance_sqr {
+            nearest[3] = entry;
+        }
     }
 
     #[inline]
@@ -605,35 +640,12 @@ impl WorldAquiferSampler {
 
         let mut nearest = [(0i64, i32::MAX); 4];
 
-        macro_rules! process {
-            ($packed:expr) => {{
-                let packed = $packed;
-                let dx = block_pos::unpack_x(packed) - sample_x;
-                let dy = block_pos::unpack_y(packed) - sample_y;
-                let dz = block_pos::unpack_z(packed) - sample_z;
-                let h = dx * dx + dy * dy + dz * dz;
-
-                if nearest[3].1 > h {
-                    nearest[3] = (packed, h);
-                    if nearest[2].1 > h {
-                        nearest[3] = nearest[2];
-                        nearest[2] = (packed, h);
-                    }
-                    if nearest[1].1 > h {
-                        nearest[2] = nearest[1];
-                        nearest[1] = (packed, h);
-                    }
-                    if nearest[0].1 > h {
-                        nearest[1] = nearest[0];
-                        nearest[0] = (packed, h);
-                    }
-                }
-            }};
-        }
-
-        // Same insertion order as the original array literal; sort behaviour is preserved.
         for packed in random_positions {
-            process!(packed);
+            let dx = block_pos::unpack_x(packed) - sample_x;
+            let dy = block_pos::unpack_y(packed) - sample_y;
+            let dz = block_pos::unpack_z(packed) - sample_z;
+            let h = dx * dx + dy * dy + dz * dz;
+            Self::insert_nearest(&mut nearest, packed, h);
         }
 
         let fluid_level2 = self.get_water_level(nearest[0].0, router, height_estimator);
@@ -909,6 +921,59 @@ mod random_positions_and_hypot {
     fn create_carver_aquifer() -> CarverAquiferSampler<'static> {
         let settings = NoiseSettings::from_dimension(&Dimension::OVERWORLD);
         CarverAquiferSampler::new(7, 4, &PROTO_ROUTER, &RANDOM_CONFIG, settings)
+    }
+
+    /// `Aquifer.NoiseBasedAquifer.computeSubstance` keeps the four nearest aquifer centres with
+    /// `if (distanceSqr1 >= newDistance) {...} else if (distanceSqr2 >= newDistance) {...} ...`.
+    /// Because the comparison is `>=` and not `>`, a candidate whose squared distance ties an
+    /// already stored one takes the *earlier* slot and pushes the stored candidate back.
+    #[test]
+    fn insert_nearest_matches_vanilla_tie_breaking() {
+        let mut nearest = [(0i64, i32::MAX); 4];
+        for (packed, distance) in [(10i64, 5i32), (11, 7), (12, 9), (13, 11)] {
+            WorldAquiferSampler::insert_nearest(&mut nearest, packed, distance);
+        }
+        assert_eq!(nearest, [(10, 5), (11, 7), (12, 9), (13, 11)]);
+
+        // Ties the closest entry: vanilla takes the first branch, so the newcomer becomes
+        // `closestIndex1` and everything else shifts one slot back.
+        WorldAquiferSampler::insert_nearest(&mut nearest, 20, 5);
+        assert_eq!(nearest, [(20, 5), (10, 5), (11, 7), (12, 9)]);
+
+        // Ties the second entry: vanilla falls into the second branch.
+        WorldAquiferSampler::insert_nearest(&mut nearest, 21, 5);
+        assert_eq!(nearest, [(21, 5), (20, 5), (10, 5), (11, 7)]);
+
+        // Larger than every stored distance: vanilla drops it.
+        WorldAquiferSampler::insert_nearest(&mut nearest, 22, 100);
+        assert_eq!(nearest, [(21, 5), (20, 5), (10, 5), (11, 7)]);
+    }
+
+    /// The twelve candidate centres must be visited x-major, then y, then z, exactly as
+    /// `for (int x1 = 0; x1 <= 1; x1++) for (int y1 = -1; y1 <= 1; y1++) for (int z1 = 0; z1 <= 1; z1++)`
+    /// in `computeSubstance`; the order is observable through the `>=` tie-breaking above.
+    #[test]
+    fn random_positions_are_returned_in_vanilla_visit_order() {
+        let sampler = create_aquifer(&PROTO_ROUTER).0;
+        let (x, y, z) = (
+            sampler.start_x + 1,
+            sampler.start_y + 1,
+            sampler.start_z + 1,
+        );
+        let got = sampler.random_positions_for_pos(x, y, z).unwrap();
+
+        let mut expected = Vec::new();
+        for dx in 0..=1 {
+            for dy in -1..=1 {
+                for dz in 0..=1 {
+                    let index = sampler
+                        .checked_packed_position_index(x + dx, y + dy, z + dz)
+                        .unwrap();
+                    expected.push(sampler.packed_positions[index]);
+                }
+            }
+        }
+        assert_eq!(got.to_vec(), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Description

**1. Aquifer centre tie-breaking.** `Aquifer.NoiseBasedAquifer.computeSubstance` walks the twelve candidate centres as `x 0..1, y −1..1, z 0..1` and keeps the four nearest with an insertion sort whose comparisons are `>=`, so a candidate that *ties* a stored squared distance takes the earlier slot. `WorldAquiferSampler::apply_internal` fed the candidates y-major descending and compared with strict `>`, so whenever two centres were exactly the same distance it kept a different `closestIndex1` / `closestIndex2`, which changes the fluid status and the `barrier13` / `barrier23` pressures that decide fluid vs. solid for the cell. The vanilla order is restored in `random_positions_for_pos` and the insertion sort is extracted into `insert_nearest`, transcribed from the Java branch chain.

**2. Overworld springs were never placed.** `SpringFeature.place` gates every check on `BlockState.is(config.validBlocks)`, a `HolderSet` the codec resolved from the datapack ids. `spring_lava_overworld.json` / `spring_water.json` spell those ids with the namespace (`"minecraft:deepslate"`), the codegen copies them verbatim, and `BlockWrapper::contains` compared them as strings against `Block::name`, which is the bare path, so it never matched: the very first check failed at every candidate and Pumpkin placed **no overworld water or lava spring at all**. `BlockWrapper::contains_block` now resolves each entry the way the registry does (`Block::from_name` for a plain id, `Block::get_tag_values` for a `#tag`) and compares ids.

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

| | mismatching blocks | chunks identical |
|---|---|---|
| aquifer tie-breaking | 245 → 237 | 195 → 199/256 |
| springs | 237 → **194** | 199 → **232/256** |

Gone: `lava→{deepslate 18, andesite, diorite, dirt, stone, tuff}`, `water→{deepslate 14 → 1, stone 4, andesite 2, tuff}`. No confusion pair got worse.

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. `insert_nearest_matches_vanilla_tie_breaking` and `random_positions_are_returned_in_vanilla_visit_order` cover the aquifer; `namespaced_ids_resolve_to_blocks` covers the spring ids.

Follow-up once the geode PR is in: `GeodeFeature::resolve_block_set` can share `BlockWrapper::entries` (a six-line refactor, left out here to keep the two PRs independent).

**Known impact:** springs now generate in the overworld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Spring growth features now correctly recognize namespaced block IDs, bare block IDs, and block tags.
  - Block matching is more accurate, preventing spring features from activating on unrelated blocks.
  - Aquifer generation now consistently selects nearby candidates, including predictable behavior when candidates are equally close.
- **Tests**
  - Added coverage for block matching, non-matching blocks, aquifer candidate ordering, and tie handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->