### PR TITLE
fix(worldgen): underwater magma parity and chunk post-processing 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-world/src/chunk_system/generation_cache.rs
+++ b/crates/pumpkin-world/src/chunk_system/generation_cache.rs
@@ -4,6 +4,7 @@ use crate::chunk::ChunkHeightmapType;
 use crate::generation::biome_coords;
 use crate::generation::generator;
 use crate::generation::height_limit::HeightLimitView;
+use crate::generation::post_processing::post_process_pos;
 use crate::generation::proto_chunk::GenerationCache;
 use crate::world::{BlockAccessor, WorldPortalExt};
 use pumpkin_config::lighting::LightingEngineConfig;
@@ -296,6 +297,15 @@ impl GenerationCache for Cache {
             Chunk::Proto(data) => {
                 data.set_block_state(pos.x, pos.y, pos.z, block_state);
             }
+        }
+
+        // `WorldGenRegion.setBlock`: `if ((updateFlags & 16) == 0) { BlockPos p =
+        // blockState.getPostProcessPos(this, pos); if (p != null) markPosForPostProcessing(p); }`
+        // `markPosForPostProcessing` targets the chunk that holds the marked position.
+        if let Some(mark) = post_process_pos(block_state.id, *pos)
+            && let Some(chunk) = self.get_chunk_mut(mark.x >> 4, mark.z >> 4)
+        {
+            chunk.mark_pos_for_post_processing(mark);
         }
     }
 

--- a/crates/pumpkin-world/src/chunk_system/generation_cache.rs
+++ b/crates/pumpkin-world/src/chunk_system/generation_cache.rs
@@ -178,6 +178,12 @@ impl BlockAccessor for Cache {
 }
 
 impl GenerationCache for Cache {
+    fn contains_chunk(&self, chunk_x: i32, chunk_z: i32) -> bool {
+        let dx = chunk_x - self.x;
+        let dz = chunk_z - self.z;
+        dx >= 0 && dx < self.size && dz >= 0 && dz < self.size
+    }
+
     fn get_chunk_mut(&mut self, chunk_x: i32, chunk_z: i32) -> Option<&mut ProtoChunk> {
         let dx = chunk_x - self.x;
         let dz = chunk_z - self.z;

--- a/crates/pumpkin-world/src/chunk_system/generation_cache.rs
+++ b/crates/pumpkin-world/src/chunk_system/generation_cache.rs
@@ -305,8 +305,8 @@ impl GenerationCache for Cache {
             }
         }
 
-        // `WorldGenRegion.setBlock`: `if ((updateFlags & 16) == 0) { BlockPos p =
-        // blockState.getPostProcessPos(this, pos); if (p != null) markPosForPostProcessing(p); }`
+        // `WorldGenRegion.setBlock` asks the written state for a post-process position unless
+        // the caller passed the "no post-processing" update flag, and marks it when there is one.
         // `markPosForPostProcessing` targets the chunk that holds the marked position.
         if let Some(mark) = post_process_pos(block_state.id, *pos)
             && let Some(chunk) = self.get_chunk_mut(mark.x >> 4, mark.z >> 4)

--- a/crates/pumpkin-world/src/generation/feature/features/underwater_magma.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/underwater_magma.rs
@@ -17,12 +17,12 @@ pub struct UnderwaterMagmaFeature {
 impl UnderwaterMagmaFeature {
     /// Y of the floor of the water column the origin sits in, or `None`.
     ///
-    /// Vanilla `UnderwaterMagmaFeature.getFloorY` runs `Column.scan(level, origin,
-    /// floorSearchRange, state -> state.is(WATER), state -> !state.is(WATER))` and takes
-    /// `Column::getFloor`. `Column.scan` bails out immediately when the origin itself is not
-    /// water, then `scanDirection(..., Direction.DOWN)` walks down with
-    /// `for (int i = 1; i < searchRange && isStateAtPosition(inside); i++) move(DOWN)` and
-    /// returns the reached Y only when the block there matches the edge predicate.
+    /// Vanilla `UnderwaterMagmaFeature.getFloorY` scans the column around the origin with water
+    /// as the "inside" predicate and non-water as the "edge" one, and takes the floor of the
+    /// result. That scan bails out immediately when the origin itself is not water; the downward
+    /// walk then steps one block at a time while the block stays inside and the search range is
+    /// not exhausted, and returns the reached Y only when the block there matches the edge
+    /// predicate.
     fn get_floor_y<T: GenerationCache>(&self, chunk: &T, origin: BlockPos) -> Option<i32> {
         let x = origin.0.x;
         let z = origin.0.z;
@@ -94,9 +94,9 @@ impl UnderwaterMagmaFeature {
         let floor_pos = BlockPos::new(pos.0.x, floor_y, pos.0.z);
 
         // Sample a cube around the floor, placing magma with probability and validity checks.
-        // `BlockPos.betweenClosedStream` walks X fastest, then Y, then Z (`x = index % width;
-        // y = index / width % height; z = index / width / height`), and the random draw happens
-        // per visited position, so the loop nesting decides which position gets which float.
+        // `BlockPos.betweenClosedStream` unpacks a running index, so X varies fastest, then Y,
+        // then Z, and the draw happens per visited position — the loop nesting decides which
+        // position gets which float.
         let mut placed = 0i32;
         let r = self.placement_radius;
 
@@ -129,12 +129,8 @@ impl UnderwaterMagmaFeature {
 mod tests {
     use pumpkin_data::{Block, BlockState};
 
-    /// `UnderwaterMagmaFeature.place` walks its cube with
-    /// `BlockPos.betweenClosedStream(BoundingBox.fromCorners(floor - r, floor + r))`, and
-    /// `BlockPos.betweenClosed` computes
-    /// `x = index % width; y = index / width % height; z = index / width / height`.
-    /// Every visited position consumes one `random.nextFloat()`, so the loop nesting has to
-    /// reproduce that exact order: X fastest, then Y, then Z.
+    /// `UnderwaterMagmaFeature.place` walks its cube with X varying fastest, then Y, then Z, and
+    /// spends one `nextFloat` per visited position — so the loop nesting has to match.
     #[test]
     fn cube_walk_matches_between_closed() {
         let r = 1i32;
@@ -165,11 +161,8 @@ mod tests {
         assert_eq!(ours[9], (-1, -1, 0));
     }
 
-    /// `isVisibleFromOutside` returns `faceOcclusionShape == Shapes.empty() ||
-    /// !Block.isShapeFullBlock(faceOcclusionShape)`. `BlockStateBase.initCache` stores
-    /// `FULL_BLOCK_OCCLUSION_SHAPES` for solid-render states and slices for everything else, so
-    /// the predicate is exactly `!state.isSolidRender()` — and `cave_air`, not just `air`, is on
-    /// the visible side of it.
+    /// `isVisibleFromOutside` reduces to `!state.isSolidRender()`, so `cave_air` is on the
+    /// visible side of it, not just `air`.
     #[test]
     fn cave_air_is_visible_from_outside() {
         assert!(!BlockState::from_id(Block::CAVE_AIR.default_state.id).is_solid_render());

--- a/crates/pumpkin-world/src/generation/feature/features/underwater_magma.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/underwater_magma.rs
@@ -15,57 +15,60 @@ pub struct UnderwaterMagmaFeature {
 }
 
 impl UnderwaterMagmaFeature {
-    /// Find the Y coordinate of a solid floor beneath a water column at the origin's XZ.
+    /// Y of the floor of the water column the origin sits in, or `None`.
+    ///
+    /// Vanilla `UnderwaterMagmaFeature.getFloorY` runs `Column.scan(level, origin,
+    /// floorSearchRange, state -> state.is(WATER), state -> !state.is(WATER))` and takes
+    /// `Column::getFloor`. `Column.scan` bails out immediately when the origin itself is not
+    /// water, then `scanDirection(..., Direction.DOWN)` walks down with
+    /// `for (int i = 1; i < searchRange && isStateAtPosition(inside); i++) move(DOWN)` and
+    /// returns the reached Y only when the block there matches the edge predicate.
     fn get_floor_y<T: GenerationCache>(&self, chunk: &T, origin: BlockPos) -> Option<i32> {
         let x = origin.0.x;
         let z = origin.0.z;
+        let is_water = |chunk: &T, y: i32| {
+            GenerationCache::get_block_state(chunk, &BlockPos::new(x, y, z).0).to_block_id()
+                == Block::WATER
+        };
 
-        // Drop down until water found
-        for dy in 0..=self.floor_search_range {
-            let check_y = origin.0.y - dy;
-            let pos = BlockPos::new(x, check_y, z);
-            let state_id = GenerationCache::get_block_state(chunk, &pos.0).to_block_id();
-
-            if state_id == Block::WATER {
-                // Sink to first non-water block below the column
-                let mut floor_y = check_y - 1;
-                loop {
-                    let floor_pos = BlockPos::new(x, floor_y, z);
-                    let floor_id =
-                        GenerationCache::get_block_state(chunk, &floor_pos.0).to_block_id();
-                    if floor_id != Block::WATER {
-                        return Some(floor_y);
-                    }
-                    if (check_y - floor_y) > self.floor_search_range {
-                        break;
-                    }
-                    floor_y -= 1;
-                }
-            }
+        // `Column.scan` returns empty unless the origin is inside the column.
+        if !is_water(chunk, origin.0.y) {
+            return None;
         }
-        None
+
+        let mut y = origin.0.y;
+        let mut i = 1;
+        while i < self.floor_search_range && is_water(chunk, y) {
+            y -= 1;
+            i += 1;
+        }
+
+        // The edge predicate is `!state.is(WATER)`.
+        if is_water(chunk, y) { None } else { Some(y) }
     }
 
-    /// Check if a block can host magma
+    /// Vanilla `UnderwaterMagmaFeature.isValidPlacement`.
+    ///
+    /// `!isWaterOrAir(state(pos)) && !isVisibleFromOutside(below, UP)` and then no horizontal
+    /// neighbour may be visible from outside. `isVisibleFromOutside` asks for
+    /// `getFaceOcclusionShape(dir)`, which `BlockBehaviour.BlockStateBase` fills with
+    /// `FULL_BLOCK_OCCLUSION_SHAPES` exactly when the state is solid-render (`canOcclude()` and
+    /// a full-block occlusion shape) and with slices otherwise, so the test collapses to
+    /// `!state.isSolidRender()`.
     fn is_valid_placement<T: GenerationCache>(chunk: &T, target: &BlockPos) -> bool {
-        // Reject water/air or unsupported blocks
-        let target_id = GenerationCache::get_block_state(chunk, &target.0).to_block_id();
-        if target_id == Block::WATER || target_id == Block::AIR {
+        let target_state = GenerationCache::get_block_state(chunk, &target.0);
+        if target_state.to_block_id() == Block::WATER || target_state.to_state().is_air() {
             return false;
         }
 
-        // Below must be solid
         let below = target.offset(BlockDirection::Down.to_offset());
-        let below_id = GenerationCache::get_block_state(chunk, &below.0).to_block_id();
-        if below_id == Block::WATER || below_id == Block::AIR {
+        if !GenerationCache::get_block_state(chunk, &below.0).is_solid_render() {
             return false;
         }
 
-        // No open horizontal faces
         for dir in &BlockDirection::horizontal() {
             let neighbour = target.offset(dir.to_offset());
-            let n_id = GenerationCache::get_block_state(chunk, &neighbour.0).to_block_id();
-            if n_id == Block::WATER || n_id == Block::AIR {
+            if !GenerationCache::get_block_state(chunk, &neighbour.0).is_solid_render() {
                 return false;
             }
         }
@@ -90,13 +93,16 @@ impl UnderwaterMagmaFeature {
 
         let floor_pos = BlockPos::new(pos.0.x, floor_y, pos.0.z);
 
-        // Sample a cube around the floor, placing magma with probability and validity checks
+        // Sample a cube around the floor, placing magma with probability and validity checks.
+        // `BlockPos.betweenClosedStream` walks X fastest, then Y, then Z (`x = index % width;
+        // y = index / width % height; z = index / width / height`), and the random draw happens
+        // per visited position, so the loop nesting decides which position gets which float.
         let mut placed = 0i32;
         let r = self.placement_radius;
 
-        for dx in -r..=r {
+        for dz in -r..=r {
             for dy in -r..=r {
-                for dz in -r..=r {
+                for dx in -r..=r {
                     if random.next_f32() >= self.placement_probability {
                         continue;
                     }
@@ -116,5 +122,61 @@ impl UnderwaterMagmaFeature {
         }
 
         placed > 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pumpkin_data::{Block, BlockState};
+
+    /// `UnderwaterMagmaFeature.place` walks its cube with
+    /// `BlockPos.betweenClosedStream(BoundingBox.fromCorners(floor - r, floor + r))`, and
+    /// `BlockPos.betweenClosed` computes
+    /// `x = index % width; y = index / width % height; z = index / width / height`.
+    /// Every visited position consumes one `random.nextFloat()`, so the loop nesting has to
+    /// reproduce that exact order: X fastest, then Y, then Z.
+    #[test]
+    fn cube_walk_matches_between_closed() {
+        let r = 1i32;
+        let width = 2 * r + 1;
+        let height = width;
+
+        let mut ours = Vec::new();
+        for dz in -r..=r {
+            for dy in -r..=r {
+                for dx in -r..=r {
+                    ours.push((dx, dy, dz));
+                }
+            }
+        }
+
+        let mut vanilla = Vec::new();
+        for index in 0..(width * height * width) {
+            let x = index % width;
+            let y = index / width % height;
+            let z = index / width / height;
+            vanilla.push((-r + x, -r + y, -r + z));
+        }
+
+        assert_eq!(ours, vanilla);
+        assert_eq!(ours[0], (-1, -1, -1));
+        assert_eq!(ours[1], (0, -1, -1));
+        assert_eq!(ours[3], (-1, 0, -1));
+        assert_eq!(ours[9], (-1, -1, 0));
+    }
+
+    /// `isVisibleFromOutside` returns `faceOcclusionShape == Shapes.empty() ||
+    /// !Block.isShapeFullBlock(faceOcclusionShape)`. `BlockStateBase.initCache` stores
+    /// `FULL_BLOCK_OCCLUSION_SHAPES` for solid-render states and slices for everything else, so
+    /// the predicate is exactly `!state.isSolidRender()` — and `cave_air`, not just `air`, is on
+    /// the visible side of it.
+    #[test]
+    fn cave_air_is_visible_from_outside() {
+        assert!(!BlockState::from_id(Block::CAVE_AIR.default_state.id).is_solid_render());
+        assert!(!BlockState::from_id(Block::AIR.default_state.id).is_solid_render());
+        assert!(!BlockState::from_id(Block::WATER.default_state.id).is_solid_render());
+        assert!(BlockState::from_id(Block::STONE.default_state.id).is_solid_render());
+        assert!(BlockState::from_id(Block::DEEPSLATE.default_state.id).is_solid_render());
+        assert!(BlockState::from_id(Block::MAGMA_BLOCK.default_state.id).is_solid_render());
     }
 }

--- a/crates/pumpkin-world/src/generation/mod.rs
+++ b/crates/pumpkin-world/src/generation/mod.rs
@@ -12,6 +12,7 @@ pub mod height_limit;
 pub mod height_provider;
 pub mod noise;
 pub mod positions;
+pub mod post_processing;
 pub mod proto_chunk;
 pub mod proto_chunk_test;
 pub mod rule;

--- a/crates/pumpkin-world/src/generation/post_processing.rs
+++ b/crates/pumpkin-world/src/generation/post_processing.rs
@@ -29,7 +29,7 @@ use pumpkin_util::math::vector3::Vector3;
 
 use super::proto_chunk::GenerationCache;
 
-/// `StructurePiece.SHAPE_CHECK_BLOCKS` (`StructurePiece.java:43`): the blocks whose shape
+/// `StructurePiece.SHAPE_CHECK_BLOCKS`: the blocks whose shape
 /// `StructurePiece.placeBlock` re-derives once the chunk is complete.
 const SHAPE_CHECK_BLOCKS: [BlockId; 12] = [
     Block::NETHER_BRICK_FENCE.id,
@@ -52,7 +52,7 @@ pub fn needs_shape_check(state: BlockStateId) -> bool {
     SHAPE_CHECK_BLOCKS.contains(&state.to_block_id())
 }
 
-/// `BlockBehaviour.UPDATE_SHAPE_ORDER` (`BlockBehaviour.java:85`).
+/// `BlockBehaviour.UPDATE_SHAPE_ORDER`.
 const UPDATE_SHAPE_ORDER: [BlockDirection; 6] = [
     BlockDirection::West,
     BlockDirection::East,
@@ -62,7 +62,7 @@ const UPDATE_SHAPE_ORDER: [BlockDirection; 6] = [
     BlockDirection::Up,
 ];
 
-/// `Block.updateFromNeighbourShapes` (`Block.java:200`): fold `updateShape` over
+/// `Block.updateFromNeighbourShapes`: fold `updateShape` over
 /// `UPDATE_SHAPE_ORDER`, reading every neighbour from the unmodified world.
 #[must_use]
 fn update_from_neighbour_shapes<C: GenerationCache + ?Sized>(
@@ -82,8 +82,8 @@ fn update_from_neighbour_shapes<C: GenerationCache + ?Sized>(
 
 /// `BlockState.updateShape`, restricted to the overrides worldgen can reach.
 ///
-/// `FenceBlock.updateShape` (`FenceBlock.java:99`) and, for the two mushrooms,
-/// `VegetationBlock.updateShape` (`VegetationBlock.java:28`) are ported; the other
+/// `FenceBlock.updateShape` and, for the two mushrooms,
+/// `VegetationBlock.updateShape` are ported; the other
 /// `SHAPE_CHECK_BLOCKS` (torch, wall torch, ladder, iron bars) keep the placed state, which is
 /// what Pumpkin did before this pass existed.
 #[must_use]
@@ -96,7 +96,8 @@ fn update_shape<C: GenerationCache + ?Sized>(
 ) -> BlockStateId {
     let block = state.to_block_id();
     if block == Block::BROWN_MUSHROOM || block == Block::RED_MUSHROOM {
-        // `!state.canSurvive(level, pos) ? Blocks.AIR.defaultBlockState() : super.updateShape(..)`
+        // The mushrooms' `updateShape` turns the block to air when it can no longer survive, and
+        // otherwise defers to the default shape update.
         return if mushroom_can_survive(cache, pos) {
             state
         } else {
@@ -106,10 +107,10 @@ fn update_shape<C: GenerationCache + ?Sized>(
     fence_update_shape(state, direction, neighbour)
 }
 
-/// `MushroomBlock.canSurvive` (`MushroomBlock.java:83`):
-/// `below.is(OVERRIDES_MUSHROOM_LIGHT_REQUIREMENT) ? true
-///  : level.getRawBrightness(pos, 0) < 13 && this.mayPlaceOn(below, level, belowPos)`,
-/// with `MushroomBlock.mayPlaceOn` = `state.isSolidRender()`.
+/// `MushroomBlock.canSurvive`: a block below carrying the
+/// `overrides_mushroom_light_requirement` tag is enough on its own; otherwise the raw brightness
+/// at the position must be under 13 *and* the block below must be placeable on, which for
+/// mushrooms means a solid-render state.
 #[must_use]
 fn mushroom_can_survive<C: GenerationCache + ?Sized>(cache: &C, pos: Vector3<i32>) -> bool {
     let below_pos = Vector3::new(pos.x, pos.y - 1, pos.z);
@@ -146,7 +147,7 @@ fn raw_brightness<C: GenerationCache + ?Sized>(cache: &C, pos: Vector3<i32>) -> 
     15
 }
 
-/// `FenceBlock.updateShape` (`FenceBlock.java:99`).
+/// `FenceBlock.updateShape`.
 #[must_use]
 fn fence_update_shape(
     state: BlockStateId,
@@ -158,9 +159,9 @@ fn fence_update_shape(
         return state;
     }
 
-    // `state.setValue(PROPERTY_BY_DIRECTION.get(directionToNeighbour), this.connectsTo(
-    //     neighbourState, neighbourState.isFaceSturdy(level, neighbourPos, direction.getOpposite()),
-    //     direction.getOpposite()))`
+    // Vanilla writes the property that belongs to the direction of the neighbour, with the value
+    // `connectsTo` returns for that neighbour, its face sturdiness towards the fence, and the
+    // opposite direction.
     let facing = direction.opposite();
     let face_sturdy = BlockState::from_id(neighbour).is_side_solid(facing);
     let connected = connects_to(block, neighbour, face_sturdy, facing);
@@ -176,7 +177,7 @@ fn fence_update_shape(
     properties.to_state_id(block)
 }
 
-/// `FenceBlock.connectsTo` (`FenceBlock.java:59`):
+/// `FenceBlock.connectsTo`:
 /// `!isExceptionForConnection(state) && faceSolid || sameFence || gate`.
 #[must_use]
 fn connects_to(
@@ -187,14 +188,14 @@ fn connects_to(
 ) -> bool {
     let block = neighbour.to_block();
 
-    // `isSameFence`: `state.is(FENCES) && state.is(WOODEN_FENCES) == this.defaultBlockState()
-    // .is(WOODEN_FENCES)`.
+    // `isSameFence`: the neighbour must carry the `fences` tag, and its `wooden_fences`
+    // membership must match this fence's own.
     let same_fence = block.has_tag(&tag::Block::MINECRAFT_FENCES)
         && block.has_tag(&tag::Block::MINECRAFT_WOODEN_FENCES)
             == fence.has_tag(&tag::Block::MINECRAFT_WOODEN_FENCES);
 
-    // `block instanceof FenceGateBlock && FenceGateBlock.connectsToDirection(state, direction)`,
-    // which is `state.getValue(FACING).getAxis() == direction.getClockWise().getAxis()`.
+    // A fence gate connects when its facing axis matches the clockwise axis of the direction
+    // being tested — `FenceGateBlock.connectsToDirection`.
     let gate = block.has_tag(&tag::Block::MINECRAFT_FENCE_GATES) && {
         let facing = OakFenceGateLikeProperties::from_state_id(neighbour).facing;
         BlockDirection::from_cardinal_direction(facing).to_axis()
@@ -204,7 +205,7 @@ fn connects_to(
     !is_exception_for_connection(neighbour) && face_solid || same_fence || gate
 }
 
-/// `Block.isExceptionForConnection` (`Block.java:251`).
+/// `Block.isExceptionForConnection`.
 #[must_use]
 fn is_exception_for_connection(state: BlockStateId) -> bool {
     let block = state.to_block();
@@ -226,8 +227,8 @@ pub fn post_process_pos(state: BlockStateId, pos: Vector3<i32>) -> Option<Vector
     if block == Block::MAGMA_BLOCK || block == Block::SOUL_SAND {
         return Some(Vector3::new(pos.x, pos.y + 1, pos.z));
     }
-    // `Blocks::postProcessSelf`, registered on `BROWN_MUSHROOM` (`Blocks.java:1015`) and
-    // `RED_MUSHROOM` (`Blocks.java:1027`).
+    // `Blocks::postProcessSelf`, registered on `BROWN_MUSHROOM` and
+    // `RED_MUSHROOM`.
     if block == Block::BROWN_MUSHROOM || block == Block::RED_MUSHROOM {
         return Some(pos);
     }
@@ -268,7 +269,7 @@ fn bubble_column(drag: bool) -> BlockStateId {
     BubbleColumnLikeProperties { drag }.to_state_id(&Block::BUBBLE_COLUMN)
 }
 
-/// `BubbleColumnBlock.updateColumn(bubbleColumn, level, occupyAt, occupyState, belowState)`.
+/// `BubbleColumnBlock.updateColumn`.
 ///
 /// The walk is strictly vertical, so it never leaves the chunk that holds `pos`.
 fn update_column<C: GenerationCache + ?Sized>(cache: &mut C, pos: Vector3<i32>) {
@@ -290,7 +291,7 @@ fn update_column<C: GenerationCache + ?Sized>(cache: &mut C, pos: Vector3<i32>) 
             &Vector3::new(pos.x, y, pos.z),
         ))
     {
-        // `if (!level.setBlock(pos, columnState, 2)) return;` — the only way that fails here is
+        // Vanilla stops the column as soon as a write fails; the only way that happens here is
         // leaving the build height, which the loop bound already covers.
         cache.set_block_state(&Vector3::new(pos.x, y, pos.z), column_state);
         y += 1;
@@ -312,13 +313,10 @@ fn shape_check_readable<C: GenerationCache + ?Sized>(cache: &C, pos: Vector3<i32
         })
 }
 
-/// `LevelChunk.postProcessGeneration` (`LevelChunk.java:565`) for one chunk's marked positions.
+/// `LevelChunk.postProcessGeneration` for one chunk's marked positions.
 ///
-/// ```text
-/// if (blockState.getBlock() instanceof LiquidBlock) blockState.tick(level, pos, random);
-/// else { BlockState s = Block.updateFromNeighbourShapes(blockState, level, pos);
-///        if (s != blockState) level.setBlock(pos, s, 276); }
-/// ```
+/// A liquid block is ticked; anything else is folded through `Block.updateFromNeighbourShapes`
+/// and written back — with flags 276 — only when the shape update actually changed the state.
 ///
 /// Vanilla runs this once, when the chunk reaches `FULL` and therefore after every one of its
 /// eight neighbours finished `FEATURES`. Pumpkin decorates a chunk from a 3x3 window and has no
@@ -387,8 +385,8 @@ mod tests {
         assert_eq!(post_process_pos(Block::WATER.default_state.id, pos), None);
     }
 
-    /// `Blocks.BROWN_MUSHROOM` (`Blocks.java:1015`) and `Blocks.RED_MUSHROOM`
-    /// (`Blocks.java:1027`) are registered with `.postProcess(Blocks::postProcessSelf)`, which
+    /// `Blocks.BROWN_MUSHROOM` and `Blocks.RED_MUSHROOM`
+    /// are registered with `.postProcess(Blocks::postProcessSelf)`, which
     /// returns the position itself.
     #[test]
     fn the_mushrooms_mark_themselves() {
@@ -403,10 +401,8 @@ mod tests {
         );
     }
 
-    /// `MushroomBlock.canSurvive` (`MushroomBlock.java:83`) short-circuits to `true` only for
-    /// `BlockTags.OVERRIDES_MUSHROOM_LIGHT_REQUIREMENT` — mycelium, podzol and the two nyliums.
-    /// On anything else, `mayPlaceOn` (`state.isSolidRender()`) passes for the sand these seven
-    /// worldgen mushrooms stand on, so `getRawBrightness(pos, 0) < 13` is what decides, and
+    /// Sand is not in `overrides_mushroom_light_requirement` but is solid-render, so for the
+    /// seven worldgen mushrooms standing on it the raw-brightness test is what decides — and
     /// under open sky it does not hold.
     #[test]
     fn only_the_light_requirement_can_remove_a_mushroom_from_sand() {
@@ -418,10 +414,8 @@ mod tests {
         assert!(!BlockState::from_id(Block::AIR.default_state.id).is_solid_render());
     }
 
-    /// `BubbleColumnBlock` calls `registerDefaultState(stateDefinition.any().setValue(DRAG_DOWN,
-    /// true))`, and `getColumnState` picks `DRAG_DOWN=true` over magma
-    /// (`ENABLES_BUBBLE_COLUMN_DRAG_DOWN`) and `DRAG_DOWN=false` over soul sand
-    /// (`ENABLES_BUBBLE_COLUMN_PUSH_UP`).
+    /// The bubble column's default state carries `drag_down`, and `getColumnState` keeps it over
+    /// magma and clears it over soul sand.
     #[test]
     fn column_state_follows_the_block_below() {
         let water = Block::WATER.default_state.id;
@@ -442,7 +436,7 @@ mod tests {
         assert_eq!(column_state(Block::STONE.default_state.id, drag), water);
     }
 
-    /// `StructurePiece.SHAPE_CHECK_BLOCKS` (`StructurePiece.java:43`) holds the six wood
+    /// `StructurePiece.SHAPE_CHECK_BLOCKS` holds the six wood
     /// fences, the nether brick fence, both torches, the ladder and iron bars — and nothing else.
     #[test]
     fn shape_check_blocks_are_the_vanilla_set() {
@@ -476,7 +470,7 @@ mod tests {
     }
 
     /// `BlockBehaviour.UPDATE_SHAPE_ORDER = {WEST, EAST, NORTH, SOUTH, DOWN, UP}`
-    /// (`BlockBehaviour.java:85`).
+    ///.
     #[test]
     fn update_shape_order_is_west_east_north_south_down_up() {
         assert_eq!(
@@ -504,10 +498,8 @@ mod tests {
         .to_state_id(&Block::DARK_OAK_FENCE)
     }
 
-    /// `FenceBlock.updateShape` (`FenceBlock.java:99`) writes
-    /// `PROPERTY_BY_DIRECTION.get(directionToNeighbour)` from `connectsTo(neighbourState,
-    /// neighbourState.isFaceSturdy(level, neighbourPos, direction.getOpposite()),
-    /// direction.getOpposite())`, and leaves the state alone for a vertical neighbour.
+    /// `FenceBlock.updateShape` writes the property belonging to the neighbour's direction from
+    /// `connectsTo`, and leaves the state alone for a vertical neighbour.
     #[test]
     fn fence_update_shape_follows_the_neighbour() {
         // A sturdy face connects.

--- a/crates/pumpkin-world/src/generation/post_processing.rs
+++ b/crates/pumpkin-world/src/generation/post_processing.rs
@@ -49,8 +49,7 @@ const SHAPE_CHECK_BLOCKS: [BlockId; 12] = [
 /// `SHAPE_CHECK_BLOCKS.contains(blockState.getBlock())`.
 #[must_use]
 pub fn needs_shape_check(state: BlockStateId) -> bool {
-    let block = state.to_block_id();
-    SHAPE_CHECK_BLOCKS.iter().any(|&id| id == block)
+    SHAPE_CHECK_BLOCKS.contains(&state.to_block_id())
 }
 
 /// `BlockBehaviour.UPDATE_SHAPE_ORDER` (`BlockBehaviour.java:85`).
@@ -76,18 +75,80 @@ fn update_from_neighbour_shapes<C: GenerationCache + ?Sized>(
         let offset = direction.to_offset();
         let neighbour_pos = Vector3::new(pos.x + offset.x, pos.y + offset.y, pos.z + offset.z);
         let neighbour = GenerationCache::get_block_state(cache, &neighbour_pos);
-        new_state = update_shape(new_state, direction, neighbour);
+        new_state = update_shape(new_state, pos, direction, neighbour, cache);
     }
     new_state
 }
 
 /// `BlockState.updateShape`, restricted to the overrides worldgen can reach.
 ///
-/// Only `FenceBlock.updateShape` (`FenceBlock.java:99`) is ported: the other
+/// `FenceBlock.updateShape` (`FenceBlock.java:99`) and, for the two mushrooms,
+/// `VegetationBlock.updateShape` (`VegetationBlock.java:28`) are ported; the other
 /// `SHAPE_CHECK_BLOCKS` (torch, wall torch, ladder, iron bars) keep the placed state, which is
 /// what Pumpkin did before this pass existed.
 #[must_use]
-fn update_shape(
+fn update_shape<C: GenerationCache + ?Sized>(
+    state: BlockStateId,
+    pos: Vector3<i32>,
+    direction: BlockDirection,
+    neighbour: BlockStateId,
+    cache: &C,
+) -> BlockStateId {
+    let block = state.to_block_id();
+    if block == Block::BROWN_MUSHROOM || block == Block::RED_MUSHROOM {
+        // `!state.canSurvive(level, pos) ? Blocks.AIR.defaultBlockState() : super.updateShape(..)`
+        return if mushroom_can_survive(cache, pos) {
+            state
+        } else {
+            Block::AIR.default_state.id
+        };
+    }
+    fence_update_shape(state, direction, neighbour)
+}
+
+/// `MushroomBlock.canSurvive` (`MushroomBlock.java:83`):
+/// `below.is(OVERRIDES_MUSHROOM_LIGHT_REQUIREMENT) ? true
+///  : level.getRawBrightness(pos, 0) < 13 && this.mayPlaceOn(below, level, belowPos)`,
+/// with `MushroomBlock.mayPlaceOn` = `state.isSolidRender()`.
+#[must_use]
+fn mushroom_can_survive<C: GenerationCache + ?Sized>(cache: &C, pos: Vector3<i32>) -> bool {
+    let below_pos = Vector3::new(pos.x, pos.y - 1, pos.z);
+    let below = GenerationCache::get_block_state(cache, &below_pos);
+    if below
+        .to_block()
+        .has_tag(&tag::Block::MINECRAFT_OVERRIDES_MUSHROOM_LIGHT_REQUIREMENT)
+    {
+        return true;
+    }
+    raw_brightness(cache, pos) < 13 && BlockState::from_id(below).is_solid_render()
+}
+
+/// `LevelReader.getRawBrightness(pos, 0)` = `max(blockLight, skyLight)`.
+///
+/// Vanilla answers this from the light engine, which has run by the time a chunk reaches
+/// `FULL`. Pumpkin has no light at the feature stage, so only the one value the sky light
+/// engine reaches without propagating is modelled: a column of nothing but air above `pos`
+/// is sky light 15, exactly. Every other position answers 0, which keeps the block — the
+/// state Pumpkin had before this pass, never a removal vanilla did not make.
+#[must_use]
+fn raw_brightness<C: GenerationCache + ?Sized>(cache: &C, pos: Vector3<i32>) -> u8 {
+    let top = i32::from(cache.top_y());
+    for y in pos.y + 1..top {
+        if !BlockState::from_id(GenerationCache::get_block_state(
+            cache,
+            &Vector3::new(pos.x, y, pos.z),
+        ))
+        .is_air()
+        {
+            return 0;
+        }
+    }
+    15
+}
+
+/// `FenceBlock.updateShape` (`FenceBlock.java:99`).
+#[must_use]
+fn fence_update_shape(
     state: BlockStateId,
     direction: BlockDirection,
     neighbour: BlockStateId,
@@ -164,6 +225,11 @@ pub fn post_process_pos(state: BlockStateId, pos: Vector3<i32>) -> Option<Vector
     // `Blocks::postProcessAbove`, registered on `MAGMA_BLOCK` and `SOUL_SAND`.
     if block == Block::MAGMA_BLOCK || block == Block::SOUL_SAND {
         return Some(Vector3::new(pos.x, pos.y + 1, pos.z));
+    }
+    // `Blocks::postProcessSelf`, registered on `BROWN_MUSHROOM` (`Blocks.java:1015`) and
+    // `RED_MUSHROOM` (`Blocks.java:1027`).
+    if block == Block::BROWN_MUSHROOM || block == Block::RED_MUSHROOM {
+        return Some(pos);
     }
     None
 }
@@ -321,6 +387,37 @@ mod tests {
         assert_eq!(post_process_pos(Block::WATER.default_state.id, pos), None);
     }
 
+    /// `Blocks.BROWN_MUSHROOM` (`Blocks.java:1015`) and `Blocks.RED_MUSHROOM`
+    /// (`Blocks.java:1027`) are registered with `.postProcess(Blocks::postProcessSelf)`, which
+    /// returns the position itself.
+    #[test]
+    fn the_mushrooms_mark_themselves() {
+        let pos = Vector3::new(-127, 64, 33);
+        assert_eq!(
+            post_process_pos(Block::BROWN_MUSHROOM.default_state.id, pos),
+            Some(pos)
+        );
+        assert_eq!(
+            post_process_pos(Block::RED_MUSHROOM.default_state.id, pos),
+            Some(pos)
+        );
+    }
+
+    /// `MushroomBlock.canSurvive` (`MushroomBlock.java:83`) short-circuits to `true` only for
+    /// `BlockTags.OVERRIDES_MUSHROOM_LIGHT_REQUIREMENT` — mycelium, podzol and the two nyliums.
+    /// On anything else, `mayPlaceOn` (`state.isSolidRender()`) passes for the sand these seven
+    /// worldgen mushrooms stand on, so `getRawBrightness(pos, 0) < 13` is what decides, and
+    /// under open sky it does not hold.
+    #[test]
+    fn only_the_light_requirement_can_remove_a_mushroom_from_sand() {
+        for block in [Block::MYCELIUM, Block::PODZOL] {
+            assert!(block.has_tag(&tag::Block::MINECRAFT_OVERRIDES_MUSHROOM_LIGHT_REQUIREMENT));
+        }
+        assert!(!Block::SAND.has_tag(&tag::Block::MINECRAFT_OVERRIDES_MUSHROOM_LIGHT_REQUIREMENT));
+        assert!(BlockState::from_id(Block::SAND.default_state.id).is_solid_render());
+        assert!(!BlockState::from_id(Block::AIR.default_state.id).is_solid_render());
+    }
+
     /// `BubbleColumnBlock` calls `registerDefaultState(stateDefinition.any().setValue(DRAG_DOWN,
     /// true))`, and `getColumnState` picks `DRAG_DOWN=true` over magma
     /// (`ENABLES_BUBBLE_COLUMN_DRAG_DOWN`) and `DRAG_DOWN=false` over soul sand
@@ -395,6 +492,7 @@ mod tests {
         );
     }
 
+    #[expect(clippy::fn_params_excessive_bools)]
     fn fence(north: bool, east: bool, south: bool, west: bool) -> BlockStateId {
         OakFenceLikeProperties {
             north,
@@ -414,7 +512,7 @@ mod tests {
     fn fence_update_shape_follows_the_neighbour() {
         // A sturdy face connects.
         assert_eq!(
-            update_shape(
+            fence_update_shape(
                 fence(false, false, false, false),
                 BlockDirection::East,
                 Block::ORANGE_TERRACOTTA.default_state.id,
@@ -423,7 +521,7 @@ mod tests {
         );
         // Cave air does not, and it also clears a connection the piece placed.
         assert_eq!(
-            update_shape(
+            fence_update_shape(
                 fence(false, true, false, false),
                 BlockDirection::East,
                 Block::CAVE_AIR.default_state.id,
@@ -432,7 +530,7 @@ mod tests {
         );
         // `isSameFence`: another wooden fence connects even though its face is not sturdy...
         assert_eq!(
-            update_shape(
+            fence_update_shape(
                 fence(false, false, false, false),
                 BlockDirection::North,
                 Block::OAK_FENCE.default_state.id,
@@ -441,7 +539,7 @@ mod tests {
         );
         // ...but the nether brick fence is not in `WOODEN_FENCES`, so it does not.
         assert_eq!(
-            update_shape(
+            fence_update_shape(
                 fence(false, false, false, false),
                 BlockDirection::North,
                 Block::NETHER_BRICK_FENCE.default_state.id,
@@ -450,7 +548,7 @@ mod tests {
         );
         // `isExceptionForConnection`: a pumpkin has a sturdy face and still does not connect.
         assert_eq!(
-            update_shape(
+            fence_update_shape(
                 fence(false, false, false, false),
                 BlockDirection::South,
                 Block::PUMPKIN.default_state.id,
@@ -459,7 +557,7 @@ mod tests {
         );
         // `directionToNeighbour.getAxis().isHorizontal()` gates the whole thing.
         assert_eq!(
-            update_shape(
+            fence_update_shape(
                 fence(false, false, false, false),
                 BlockDirection::Up,
                 Block::ORANGE_TERRACOTTA.default_state.id,
@@ -468,7 +566,7 @@ mod tests {
         );
         // Non-fences take the `super.updateShape` identity branch here.
         assert_eq!(
-            update_shape(
+            fence_update_shape(
                 Block::DARK_OAK_PLANKS.default_state.id,
                 BlockDirection::East,
                 Block::ORANGE_TERRACOTTA.default_state.id,

--- a/crates/pumpkin-world/src/generation/post_processing.rs
+++ b/crates/pumpkin-world/src/generation/post_processing.rs
@@ -1,0 +1,167 @@
+//! Vanilla `LevelChunk.postProcessGeneration`, the pass that runs once a chunk reaches
+//! `FULL` and replays the block updates worldgen deferred.
+//!
+//! `WorldGenRegion.setBlock` asks every written state for
+//! `blockState.getPostProcessPos(this, pos)` (unless the write carries flag `16`) and, when it
+//! answers with a position, calls `chunk.markPosForPostProcessing(pos)`. Only four vanilla
+//! blocks register a `PostProcess`: `SOUL_SAND` and `MAGMA_BLOCK` use `Blocks::postProcessAbove`
+//! (`pos.above()`), the two mushrooms use `Blocks::postProcessSelf`.
+//!
+//! `LevelChunk.postProcessGeneration` then walks the marked positions and, for a
+//! `LiquidBlock`, runs `blockState.tick(level, pos, random)`. `LiquidBlock.tick` grows a bubble
+//! column when the fluid there is a full water source, which is how vanilla ends up with
+//! `bubble_column` above worldgen magma without a single game tick having run.
+//!
+//! Only the magma/soul-sand -> bubble-column half is implemented here; the mushrooms take the
+//! `Block.updateFromNeighbourShapes` branch instead and no worldgen mismatch is attributed to
+//! them yet.
+
+use pumpkin_data::{Block, BlockState, BlockStateId, block_properties::BubbleColumnLikeProperties};
+use pumpkin_util::math::vector3::Vector3;
+
+use super::proto_chunk::ProtoChunk;
+
+/// The position `WorldGenRegion.setBlock` marks for post-processing after writing `state`,
+/// mirroring `BlockBehaviour.Properties.postProcess`.
+#[must_use]
+pub fn post_process_pos(state: BlockStateId, pos: Vector3<i32>) -> Option<Vector3<i32>> {
+    let block = state.to_block_id();
+    // `Blocks::postProcessAbove`, registered on `MAGMA_BLOCK` and `SOUL_SAND`.
+    if block == Block::MAGMA_BLOCK || block == Block::SOUL_SAND {
+        return Some(Vector3::new(pos.x, pos.y + 1, pos.z));
+    }
+    None
+}
+
+/// `BubbleColumnBlock.canOccupy`: the state is already a bubble column, or it is a full water
+/// source (`fluid.is(BUBBLE_COLUMN_CAN_OCCUPY) && block instanceof LiquidBlock &&
+/// fluid.isSource() && fluid.getAmount() >= 8`).
+#[must_use]
+fn can_occupy(state: BlockStateId) -> bool {
+    state.to_block_id() == Block::BUBBLE_COLUMN || state == Block::WATER.default_state.id
+}
+
+/// `BubbleColumnBlock.getColumnState`. `below` is what decides drag: magma is in
+/// `ENABLES_BUBBLE_COLUMN_DRAG_DOWN`, soul sand in `ENABLES_BUBBLE_COLUMN_PUSH_UP`.
+#[must_use]
+fn column_state(below: BlockStateId, occupy: BlockStateId) -> BlockStateId {
+    let below_block = below.to_block_id();
+    if below_block == Block::BUBBLE_COLUMN {
+        return below;
+    }
+    if below_block == Block::SOUL_SAND {
+        return bubble_column(false);
+    }
+    if below_block == Block::MAGMA_BLOCK {
+        return bubble_column(true);
+    }
+    if occupy.to_block_id() == Block::BUBBLE_COLUMN {
+        Block::WATER.default_state.id
+    } else {
+        occupy
+    }
+}
+
+#[must_use]
+fn bubble_column(drag: bool) -> BlockStateId {
+    BubbleColumnLikeProperties { drag }.to_state_id(&Block::BUBBLE_COLUMN)
+}
+
+/// `BubbleColumnBlock.updateColumn(bubbleColumn, level, occupyAt, occupyState, belowState)`.
+///
+/// The walk is strictly vertical, so it never leaves the chunk that holds `pos`.
+fn update_column(chunk: &mut ProtoChunk, pos: Vector3<i32>) {
+    let occupy = chunk.get_block_state(&pos);
+    if !can_occupy(occupy) {
+        return;
+    }
+
+    let below = chunk.get_block_state(&Vector3::new(pos.x, pos.y - 1, pos.z));
+    let column = column_state(below, occupy);
+    let column_state = BlockState::from_id(column);
+    chunk.set_block_state(pos.x, pos.y, pos.z, column_state);
+
+    let top = chunk.bottom_y() as i32 + chunk.height() as i32;
+    let mut y = pos.y + 1;
+    while y < top && can_occupy(chunk.get_block_state(&Vector3::new(pos.x, y, pos.z))) {
+        // `if (!level.setBlock(pos, columnState, 2)) return;` — the only way that fails here is
+        // leaving the build height, which the loop bound already covers.
+        chunk.set_block_state(pos.x, y, pos.z, column_state);
+        y += 1;
+    }
+}
+
+/// `LevelChunk.postProcessGeneration`, restricted to the `blockState.getBlock() instanceof
+/// LiquidBlock -> blockState.tick(...)` branch (`LiquidBlock.tick` ->
+/// `BubbleColumnBlock.updateColumn`).
+pub fn post_process_generation(chunk: &mut ProtoChunk) {
+    if chunk.post_processing.is_empty() {
+        return;
+    }
+    let marked = std::mem::take(&mut chunk.post_processing);
+    for pos in marked {
+        let state = chunk.get_block_state(&pos);
+        // `LiquidBlock.tick` -> `shouldBubbleColumnOccupy(state)`, the same predicate as
+        // `canOccupy` minus the "already a bubble column" shortcut.
+        if state == Block::WATER.default_state.id {
+            update_column(chunk, pos);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Blocks.MAGMA_BLOCK` and `Blocks.SOUL_SAND` are registered with
+    /// `.postProcess(Blocks::postProcessAbove)`, which returns `blockPos.above()`.
+    #[test]
+    fn only_magma_and_soul_sand_mark_the_block_above() {
+        let pos = Vector3::new(3, 7, -5);
+        assert_eq!(
+            post_process_pos(Block::MAGMA_BLOCK.default_state.id, pos),
+            Some(Vector3::new(3, 8, -5))
+        );
+        assert_eq!(
+            post_process_pos(Block::SOUL_SAND.default_state.id, pos),
+            Some(Vector3::new(3, 8, -5))
+        );
+        assert_eq!(post_process_pos(Block::STONE.default_state.id, pos), None);
+        assert_eq!(post_process_pos(Block::WATER.default_state.id, pos), None);
+    }
+
+    /// `BubbleColumnBlock` calls `registerDefaultState(stateDefinition.any().setValue(DRAG_DOWN,
+    /// true))`, and `getColumnState` picks `DRAG_DOWN=true` over magma
+    /// (`ENABLES_BUBBLE_COLUMN_DRAG_DOWN`) and `DRAG_DOWN=false` over soul sand
+    /// (`ENABLES_BUBBLE_COLUMN_PUSH_UP`).
+    #[test]
+    fn column_state_follows_the_block_below() {
+        let water = Block::WATER.default_state.id;
+        let drag = bubble_column(true);
+        let push = bubble_column(false);
+
+        assert_eq!(drag, Block::BUBBLE_COLUMN.default_state.id);
+        assert_ne!(drag, push);
+        assert_eq!(
+            column_state(Block::MAGMA_BLOCK.default_state.id, water),
+            drag
+        );
+        assert_eq!(column_state(Block::SOUL_SAND.default_state.id, water), push);
+        // An existing column above just propagates.
+        assert_eq!(column_state(push, water), push);
+        // Nothing enabling below and no column to remove: the state stays put.
+        assert_eq!(column_state(Block::STONE.default_state.id, water), water);
+        assert_eq!(column_state(Block::STONE.default_state.id, drag), water);
+    }
+
+    /// `canOccupy` accepts an existing bubble column and a full water source only.
+    #[test]
+    fn can_occupy_accepts_source_water_and_columns() {
+        assert!(can_occupy(Block::WATER.default_state.id));
+        assert!(can_occupy(bubble_column(true)));
+        assert!(can_occupy(bubble_column(false)));
+        assert!(!can_occupy(Block::LAVA.default_state.id));
+        assert!(!can_occupy(Block::AIR.default_state.id));
+        assert!(!can_occupy(Block::STONE.default_state.id));
+    }
+}

--- a/crates/pumpkin-world/src/generation/post_processing.rs
+++ b/crates/pumpkin-world/src/generation/post_processing.rs
@@ -12,14 +12,149 @@
 //! column when the fluid there is a full water source, which is how vanilla ends up with
 //! `bubble_column` above worldgen magma without a single game tick having run.
 //!
-//! Only the magma/soul-sand -> bubble-column half is implemented here; the mushrooms take the
-//! `Block.updateFromNeighbourShapes` branch instead and no worldgen mismatch is attributed to
-//! them yet.
+//! `StructurePiece.placeBlock` marks a second family of positions: after `level.setBlock`, a
+//! block in `SHAPE_CHECK_BLOCKS` (the fences, torches, ladder and iron bars) marks *itself* on
+//! the chunk that holds it. Those take the other branch of `postProcessGeneration`,
+//! `Block.updateFromNeighbourShapes`, which is what gives worldgen fences their connections.
 
-use pumpkin_data::{Block, BlockState, BlockStateId, block_properties::BubbleColumnLikeProperties};
+use pumpkin_data::{
+    Block, BlockDirection, BlockId, BlockState, BlockStateId,
+    block_properties::{
+        Axis, BubbleColumnLikeProperties, OakFenceGateLikeProperties, OakFenceLikeProperties,
+    },
+    tag,
+    tag::Taggable,
+};
 use pumpkin_util::math::vector3::Vector3;
 
-use super::proto_chunk::ProtoChunk;
+use super::proto_chunk::GenerationCache;
+
+/// `StructurePiece.SHAPE_CHECK_BLOCKS` (`StructurePiece.java:43`): the blocks whose shape
+/// `StructurePiece.placeBlock` re-derives once the chunk is complete.
+const SHAPE_CHECK_BLOCKS: [BlockId; 12] = [
+    Block::NETHER_BRICK_FENCE.id,
+    Block::TORCH.id,
+    Block::WALL_TORCH.id,
+    Block::OAK_FENCE.id,
+    Block::SPRUCE_FENCE.id,
+    Block::DARK_OAK_FENCE.id,
+    Block::PALE_OAK_FENCE.id,
+    Block::ACACIA_FENCE.id,
+    Block::BIRCH_FENCE.id,
+    Block::JUNGLE_FENCE.id,
+    Block::LADDER.id,
+    Block::IRON_BARS.id,
+];
+
+/// `SHAPE_CHECK_BLOCKS.contains(blockState.getBlock())`.
+#[must_use]
+pub fn needs_shape_check(state: BlockStateId) -> bool {
+    let block = state.to_block_id();
+    SHAPE_CHECK_BLOCKS.iter().any(|&id| id == block)
+}
+
+/// `BlockBehaviour.UPDATE_SHAPE_ORDER` (`BlockBehaviour.java:85`).
+const UPDATE_SHAPE_ORDER: [BlockDirection; 6] = [
+    BlockDirection::West,
+    BlockDirection::East,
+    BlockDirection::North,
+    BlockDirection::South,
+    BlockDirection::Down,
+    BlockDirection::Up,
+];
+
+/// `Block.updateFromNeighbourShapes` (`Block.java:200`): fold `updateShape` over
+/// `UPDATE_SHAPE_ORDER`, reading every neighbour from the unmodified world.
+#[must_use]
+fn update_from_neighbour_shapes<C: GenerationCache + ?Sized>(
+    state: BlockStateId,
+    pos: Vector3<i32>,
+    cache: &C,
+) -> BlockStateId {
+    let mut new_state = state;
+    for direction in UPDATE_SHAPE_ORDER {
+        let offset = direction.to_offset();
+        let neighbour_pos = Vector3::new(pos.x + offset.x, pos.y + offset.y, pos.z + offset.z);
+        let neighbour = GenerationCache::get_block_state(cache, &neighbour_pos);
+        new_state = update_shape(new_state, direction, neighbour);
+    }
+    new_state
+}
+
+/// `BlockState.updateShape`, restricted to the overrides worldgen can reach.
+///
+/// Only `FenceBlock.updateShape` (`FenceBlock.java:99`) is ported: the other
+/// `SHAPE_CHECK_BLOCKS` (torch, wall torch, ladder, iron bars) keep the placed state, which is
+/// what Pumpkin did before this pass existed.
+#[must_use]
+fn update_shape(
+    state: BlockStateId,
+    direction: BlockDirection,
+    neighbour: BlockStateId,
+) -> BlockStateId {
+    let block = state.to_block();
+    if !block.has_tag(&tag::Block::MINECRAFT_FENCES) || direction.to_axis() == Axis::Y {
+        return state;
+    }
+
+    // `state.setValue(PROPERTY_BY_DIRECTION.get(directionToNeighbour), this.connectsTo(
+    //     neighbourState, neighbourState.isFaceSturdy(level, neighbourPos, direction.getOpposite()),
+    //     direction.getOpposite()))`
+    let facing = direction.opposite();
+    let face_sturdy = BlockState::from_id(neighbour).is_side_solid(facing);
+    let connected = connects_to(block, neighbour, face_sturdy, facing);
+
+    let mut properties = OakFenceLikeProperties::from_state_id(state);
+    match direction {
+        BlockDirection::North => properties.north = connected,
+        BlockDirection::South => properties.south = connected,
+        BlockDirection::West => properties.west = connected,
+        BlockDirection::East => properties.east = connected,
+        BlockDirection::Up | BlockDirection::Down => unreachable!("filtered by the axis check"),
+    }
+    properties.to_state_id(block)
+}
+
+/// `FenceBlock.connectsTo` (`FenceBlock.java:59`):
+/// `!isExceptionForConnection(state) && faceSolid || sameFence || gate`.
+#[must_use]
+fn connects_to(
+    fence: &'static Block,
+    neighbour: BlockStateId,
+    face_solid: bool,
+    direction: BlockDirection,
+) -> bool {
+    let block = neighbour.to_block();
+
+    // `isSameFence`: `state.is(FENCES) && state.is(WOODEN_FENCES) == this.defaultBlockState()
+    // .is(WOODEN_FENCES)`.
+    let same_fence = block.has_tag(&tag::Block::MINECRAFT_FENCES)
+        && block.has_tag(&tag::Block::MINECRAFT_WOODEN_FENCES)
+            == fence.has_tag(&tag::Block::MINECRAFT_WOODEN_FENCES);
+
+    // `block instanceof FenceGateBlock && FenceGateBlock.connectsToDirection(state, direction)`,
+    // which is `state.getValue(FACING).getAxis() == direction.getClockWise().getAxis()`.
+    let gate = block.has_tag(&tag::Block::MINECRAFT_FENCE_GATES) && {
+        let facing = OakFenceGateLikeProperties::from_state_id(neighbour).facing;
+        BlockDirection::from_cardinal_direction(facing).to_axis()
+            == direction.rotate_clockwise().to_axis()
+    };
+
+    !is_exception_for_connection(neighbour) && face_solid || same_fence || gate
+}
+
+/// `Block.isExceptionForConnection` (`Block.java:251`).
+#[must_use]
+fn is_exception_for_connection(state: BlockStateId) -> bool {
+    let block = state.to_block();
+    block.has_tag(&tag::Block::MINECRAFT_LEAVES)
+        || block.id == Block::BARRIER.id
+        || block.id == Block::CARVED_PUMPKIN.id
+        || block.id == Block::JACK_O_LANTERN.id
+        || block.id == Block::MELON.id
+        || block.id == Block::PUMPKIN.id
+        || block.has_tag(&tag::Block::MINECRAFT_SHULKER_BOXES)
+}
 
 /// The position `WorldGenRegion.setBlock` marks for post-processing after writing `state`,
 /// mirroring `BlockBehaviour.Properties.postProcess`.
@@ -70,42 +205,98 @@ fn bubble_column(drag: bool) -> BlockStateId {
 /// `BubbleColumnBlock.updateColumn(bubbleColumn, level, occupyAt, occupyState, belowState)`.
 ///
 /// The walk is strictly vertical, so it never leaves the chunk that holds `pos`.
-fn update_column(chunk: &mut ProtoChunk, pos: Vector3<i32>) {
-    let occupy = chunk.get_block_state(&pos);
+fn update_column<C: GenerationCache + ?Sized>(cache: &mut C, pos: Vector3<i32>) {
+    let occupy = GenerationCache::get_block_state(cache, &pos);
     if !can_occupy(occupy) {
         return;
     }
 
-    let below = chunk.get_block_state(&Vector3::new(pos.x, pos.y - 1, pos.z));
+    let below = GenerationCache::get_block_state(cache, &Vector3::new(pos.x, pos.y - 1, pos.z));
     let column = column_state(below, occupy);
     let column_state = BlockState::from_id(column);
-    chunk.set_block_state(pos.x, pos.y, pos.z, column_state);
+    cache.set_block_state(&pos, column_state);
 
-    let top = chunk.bottom_y() as i32 + chunk.height() as i32;
+    let top = cache.bottom_y() as i32 + cache.height() as i32;
     let mut y = pos.y + 1;
-    while y < top && can_occupy(chunk.get_block_state(&Vector3::new(pos.x, y, pos.z))) {
+    while y < top
+        && can_occupy(GenerationCache::get_block_state(
+            cache,
+            &Vector3::new(pos.x, y, pos.z),
+        ))
+    {
         // `if (!level.setBlock(pos, columnState, 2)) return;` — the only way that fails here is
         // leaving the build height, which the loop bound already covers.
-        chunk.set_block_state(pos.x, y, pos.z, column_state);
+        cache.set_block_state(&Vector3::new(pos.x, y, pos.z), column_state);
         y += 1;
     }
 }
 
-/// `LevelChunk.postProcessGeneration`, restricted to the `blockState.getBlock() instanceof
-/// LiquidBlock -> blockState.tick(...)` branch (`LiquidBlock.tick` ->
-/// `BubbleColumnBlock.updateColumn`).
-pub fn post_process_generation(chunk: &mut ProtoChunk) {
-    if chunk.post_processing.is_empty() {
-        return;
-    }
-    let marked = std::mem::take(&mut chunk.post_processing);
-    for pos in marked {
-        let state = chunk.get_block_state(&pos);
-        // `LiquidBlock.tick` -> `shouldBubbleColumnOccupy(state)`, the same predicate as
-        // `canOccupy` minus the "already a bubble column" shortcut.
-        if state == Block::WATER.default_state.id {
-            update_column(chunk, pos);
+/// Whether all four horizontal neighbours of `pos` sit in chunks this cache can read.
+///
+/// A `SHAPE_CHECK_BLOCKS` position is only re-derived from a window that actually holds its
+/// neighbours; from any other window the missing side would read as `AIR`.
+#[must_use]
+fn shape_check_readable<C: GenerationCache + ?Sized>(cache: &C, pos: Vector3<i32>) -> bool {
+    UPDATE_SHAPE_ORDER
+        .iter()
+        .filter(|direction| direction.to_axis() != Axis::Y)
+        .all(|direction| {
+            let offset = direction.to_offset();
+            cache.contains_chunk((pos.x + offset.x) >> 4, (pos.z + offset.z) >> 4)
+        })
+}
+
+/// `LevelChunk.postProcessGeneration` (`LevelChunk.java:565`) for one chunk's marked positions.
+///
+/// ```text
+/// if (blockState.getBlock() instanceof LiquidBlock) blockState.tick(level, pos, random);
+/// else { BlockState s = Block.updateFromNeighbourShapes(blockState, level, pos);
+///        if (s != blockState) level.setBlock(pos, s, 276); }
+/// ```
+///
+/// Vanilla runs this once, when the chunk reaches `FULL` and therefore after every one of its
+/// eight neighbours finished `FEATURES`. Pumpkin decorates a chunk from a 3x3 window and has no
+/// `FULL` transition, so the shape half is instead run again every time a chunk of the window
+/// finishes its features: `Block.updateFromNeighbourShapes` recomputes all four sides from the
+/// world, so the last run — the one after the neighbour on that side was decorated — is the one
+/// that decides, and it sees exactly what vanilla saw. The liquid half is not idempotent in
+/// principle and stays a one-shot.
+pub fn post_process_generation<C: GenerationCache + ?Sized>(
+    cache: &mut C,
+    chunk_x: i32,
+    chunk_z: i32,
+) {
+    let marked = match cache.get_chunk_mut(chunk_x, chunk_z) {
+        Some(chunk) if !chunk.post_processing.is_empty() => {
+            std::mem::take(&mut chunk.post_processing)
         }
+        _ => return,
+    };
+
+    let mut pending = Vec::new();
+    for pos in marked {
+        let state = GenerationCache::get_block_state(cache, &pos);
+        let block = state.to_block_id();
+        if block == Block::WATER.id || block == Block::LAVA.id {
+            // `LiquidBlock.tick` -> `shouldBubbleColumnOccupy(state)`, the same predicate as
+            // `canOccupy` minus the "already a bubble column" shortcut.
+            if state == Block::WATER.default_state.id {
+                update_column(cache, pos);
+            }
+            continue;
+        }
+        pending.push(pos);
+        if !shape_check_readable(cache, pos) {
+            continue;
+        }
+        let new_state = update_from_neighbour_shapes(state, pos, cache);
+        if new_state != state {
+            cache.set_block_state(&pos, BlockState::from_id(new_state));
+        }
+    }
+
+    if let Some(chunk) = cache.get_chunk_mut(chunk_x, chunk_z) {
+        chunk.post_processing = pending;
     }
 }
 
@@ -152,6 +343,138 @@ mod tests {
         // Nothing enabling below and no column to remove: the state stays put.
         assert_eq!(column_state(Block::STONE.default_state.id, water), water);
         assert_eq!(column_state(Block::STONE.default_state.id, drag), water);
+    }
+
+    /// `StructurePiece.SHAPE_CHECK_BLOCKS` (`StructurePiece.java:43`) holds the six wood
+    /// fences, the nether brick fence, both torches, the ladder and iron bars — and nothing else.
+    #[test]
+    fn shape_check_blocks_are_the_vanilla_set() {
+        for block in [
+            Block::NETHER_BRICK_FENCE,
+            Block::TORCH,
+            Block::WALL_TORCH,
+            Block::OAK_FENCE,
+            Block::SPRUCE_FENCE,
+            Block::DARK_OAK_FENCE,
+            Block::PALE_OAK_FENCE,
+            Block::ACACIA_FENCE,
+            Block::BIRCH_FENCE,
+            Block::JUNGLE_FENCE,
+            Block::LADDER,
+            Block::IRON_BARS,
+        ] {
+            assert!(needs_shape_check(block.default_state.id), "{}", block.name);
+        }
+        for block in [
+            Block::CRIMSON_FENCE,
+            Block::MANGROVE_FENCE,
+            Block::OAK_FENCE_GATE,
+            Block::DARK_OAK_PLANKS,
+            Block::RAIL,
+            Block::COBWEB,
+            Block::STONE,
+        ] {
+            assert!(!needs_shape_check(block.default_state.id), "{}", block.name);
+        }
+    }
+
+    /// `BlockBehaviour.UPDATE_SHAPE_ORDER = {WEST, EAST, NORTH, SOUTH, DOWN, UP}`
+    /// (`BlockBehaviour.java:85`).
+    #[test]
+    fn update_shape_order_is_west_east_north_south_down_up() {
+        assert_eq!(
+            UPDATE_SHAPE_ORDER,
+            [
+                BlockDirection::West,
+                BlockDirection::East,
+                BlockDirection::North,
+                BlockDirection::South,
+                BlockDirection::Down,
+                BlockDirection::Up,
+            ]
+        );
+    }
+
+    fn fence(north: bool, east: bool, south: bool, west: bool) -> BlockStateId {
+        OakFenceLikeProperties {
+            north,
+            east,
+            south,
+            west,
+            waterlogged: false,
+        }
+        .to_state_id(&Block::DARK_OAK_FENCE)
+    }
+
+    /// `FenceBlock.updateShape` (`FenceBlock.java:99`) writes
+    /// `PROPERTY_BY_DIRECTION.get(directionToNeighbour)` from `connectsTo(neighbourState,
+    /// neighbourState.isFaceSturdy(level, neighbourPos, direction.getOpposite()),
+    /// direction.getOpposite())`, and leaves the state alone for a vertical neighbour.
+    #[test]
+    fn fence_update_shape_follows_the_neighbour() {
+        // A sturdy face connects.
+        assert_eq!(
+            update_shape(
+                fence(false, false, false, false),
+                BlockDirection::East,
+                Block::ORANGE_TERRACOTTA.default_state.id,
+            ),
+            fence(false, true, false, false)
+        );
+        // Cave air does not, and it also clears a connection the piece placed.
+        assert_eq!(
+            update_shape(
+                fence(false, true, false, false),
+                BlockDirection::East,
+                Block::CAVE_AIR.default_state.id,
+            ),
+            fence(false, false, false, false)
+        );
+        // `isSameFence`: another wooden fence connects even though its face is not sturdy...
+        assert_eq!(
+            update_shape(
+                fence(false, false, false, false),
+                BlockDirection::North,
+                Block::OAK_FENCE.default_state.id,
+            ),
+            fence(true, false, false, false)
+        );
+        // ...but the nether brick fence is not in `WOODEN_FENCES`, so it does not.
+        assert_eq!(
+            update_shape(
+                fence(false, false, false, false),
+                BlockDirection::North,
+                Block::NETHER_BRICK_FENCE.default_state.id,
+            ),
+            fence(false, false, false, false)
+        );
+        // `isExceptionForConnection`: a pumpkin has a sturdy face and still does not connect.
+        assert_eq!(
+            update_shape(
+                fence(false, false, false, false),
+                BlockDirection::South,
+                Block::PUMPKIN.default_state.id,
+            ),
+            fence(false, false, false, false)
+        );
+        // `directionToNeighbour.getAxis().isHorizontal()` gates the whole thing.
+        assert_eq!(
+            update_shape(
+                fence(false, false, false, false),
+                BlockDirection::Up,
+                Block::ORANGE_TERRACOTTA.default_state.id,
+            ),
+            fence(false, false, false, false)
+        );
+        // Non-fences take the `super.updateShape` identity branch here.
+        assert_eq!(
+            update_shape(
+                Block::DARK_OAK_PLANKS.default_state.id,
+                BlockDirection::East,
+                Block::ORANGE_TERRACOTTA.default_state.id,
+            ),
+            Block::DARK_OAK_PLANKS.default_state.id
+        );
     }
 
     /// `canOccupy` accepts an existing bubble column and a full water source only.

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -80,6 +80,12 @@ pub trait GenerationCache: HeightLimitView + BlockAccessor {
 
     fn try_get_proto_chunk(&self, chunk_x: i32, chunk_z: i32) -> Option<&ProtoChunk>;
 
+    /// Whether reads and writes at that chunk position land in this cache's window.
+    ///
+    /// `WorldGenRegion.getBlockState` throws outside the region; Pumpkin's caches quietly
+    /// answer `AIR`, so anything replaying vanilla's post-`FEATURES` passes has to ask first.
+    fn contains_chunk(&self, chunk_x: i32, chunk_z: i32) -> bool;
+
     fn get_block_state(&self, pos: &Vector3<i32>) -> BlockStateId;
     fn get_fluid_and_fluid_state(&self, position: &Vector3<i32>) -> (Fluid, FluidState);
     fn set_block_state(&mut self, pos: &Vector3<i32>, block_state: &BlockState);
@@ -1178,15 +1184,17 @@ impl ProtoChunk {
         cache.get_center_chunk_mut().stage = StagedChunkEnum::Features;
 
         // Vanilla runs `LevelChunk.postProcessGeneration` when the chunk reaches `FULL`, which
-        // needs all nine neighbours past `FEATURES`. Pumpkin has no such step, so the marks are
-        // drained here: for the chunk that just finished, and for any neighbour that is already
-        // done and therefore would never look at its list again.
+        // needs all nine neighbours past `FEATURES`. Pumpkin has no such step, so every chunk of
+        // the window that is done gets its marks replayed here, not just the one that finished:
+        // a fence on a shared border only sees its neighbour's mineshaft once that neighbour has
+        // been decorated, and the replay is what lets it see it.
         for chunk_x in center_x - 1..=center_x + 1 {
             for chunk_z in center_z - 1..=center_z + 1 {
-                if let Some(chunk) = cache.get_chunk_mut(chunk_x, chunk_z)
-                    && chunk.stage >= StagedChunkEnum::Features
+                if cache
+                    .get_chunk(chunk_x, chunk_z)
+                    .is_some_and(|chunk| chunk.stage >= StagedChunkEnum::Features)
                 {
-                    super::post_processing::post_process_generation(chunk);
+                    super::post_processing::post_process_generation(cache, chunk_x, chunk_z);
                 }
             }
         }
@@ -1629,6 +1637,10 @@ impl BlockPlacer for ProtoChunk {
 }
 
 impl GenerationCache for ProtoChunk {
+    fn contains_chunk(&self, chunk_x: i32, chunk_z: i32) -> bool {
+        chunk_x == self.x && chunk_z == self.z
+    }
+
     fn get_center_chunk_mut(&mut self) -> &mut ProtoChunk {
         self
     }

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1676,8 +1676,8 @@ impl GenerationCache for ProtoChunk {
     }
     fn set_block_state(&mut self, pos: &Vector3<i32>, block_state: &BlockState) {
         Self::set_block_state(self, pos.x, pos.y, pos.z, block_state);
-        // `WorldGenRegion.setBlock`: `if ((updateFlags & 16) == 0) { BlockPos p =
-        // blockState.getPostProcessPos(this, pos); if (p != null) markPosForPostProcessing(p); }`
+        // `WorldGenRegion.setBlock` asks the written state for a post-process position unless
+        // the caller passed the "no post-processing" update flag, and marks it when there is one.
         if let Some(mark) = super::post_processing::post_process_pos(block_state.id, *pos) {
             self.mark_pos_for_post_processing(mark);
         }

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -157,6 +157,9 @@ pub struct ProtoChunk {
     pub pending_block_entities: Vec<NbtCompound>,
     pending_structure_entities: Vec<NbtCompound>,
     pub fluid_ticks: Vec<ScheduledTick<&'static Fluid>>,
+    /// Vanilla `ChunkAccess.postProcessing`: positions `WorldGenRegion.setBlock` handed to
+    /// `markPosForPostProcessing`, replayed by `LevelChunk.postProcessGeneration`.
+    pub(crate) post_processing: Vec<Vector3<i32>>,
 }
 
 pub struct TerrainCache {
@@ -270,7 +273,13 @@ impl ProtoChunk {
             pending_block_entities: Vec::new(),
             pending_structure_entities: Vec::new(),
             fluid_ticks: Vec::new(),
+            post_processing: Vec::new(),
         }
+    }
+
+    /// Vanilla `ChunkAccess.markPosForPostProcessing`.
+    pub(crate) fn mark_pos_for_post_processing(&mut self, pos: Vector3<i32>) {
+        self.post_processing.push(pos);
     }
 
     #[must_use]
@@ -1167,6 +1176,20 @@ impl ProtoChunk {
         }
 
         cache.get_center_chunk_mut().stage = StagedChunkEnum::Features;
+
+        // Vanilla runs `LevelChunk.postProcessGeneration` when the chunk reaches `FULL`, which
+        // needs all nine neighbours past `FEATURES`. Pumpkin has no such step, so the marks are
+        // drained here: for the chunk that just finished, and for any neighbour that is already
+        // done and therefore would never look at its list again.
+        for chunk_x in center_x - 1..=center_x + 1 {
+            for chunk_z in center_z - 1..=center_z + 1 {
+                if let Some(chunk) = cache.get_chunk_mut(chunk_x, chunk_z)
+                    && chunk.stage >= StagedChunkEnum::Features
+                {
+                    super::post_processing::post_process_generation(chunk);
+                }
+            }
+        }
     }
 
     fn generate_structure_step<T: GenerationCache>(
@@ -1641,6 +1664,11 @@ impl GenerationCache for ProtoChunk {
     }
     fn set_block_state(&mut self, pos: &Vector3<i32>, block_state: &BlockState) {
         Self::set_block_state(self, pos.x, pos.y, pos.z, block_state);
+        // `WorldGenRegion.setBlock`: `if ((updateFlags & 16) == 0) { BlockPos p =
+        // blockState.getPostProcessPos(this, pos); if (p != null) markPosForPostProcessing(p); }`
+        if let Some(mark) = super::post_processing::post_process_pos(block_state.id, *pos) {
+            self.mark_pos_for_post_processing(mark);
+        }
     }
     fn add_block_entity(&mut self, _pos: &Vector3<i32>, nbt: NbtCompound) {
         self.add_block_entity(nbt);

--- a/crates/pumpkin-world/src/generation/structure/structures/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mod.rs
@@ -458,9 +458,13 @@ impl StructurePiece {
         //     world.schedule_fluid_tick(&block_pos, fluid_state.fluid(), 0);
         // }
 
-        // if block.needs_post_processing() {
-        //     world.mark_block_for_post_processing(&block_pos);
-        // }
+        // `StructurePiece.placeBlock`: `if (SHAPE_CHECK_BLOCKS.contains(blockState.getBlock()))
+        // level.getChunk(pos).markPosForPostProcessing(pos);`. Pieces only ever write into the
+        // chunk currently being decorated (`generate_in_chunk` clips them to its column), so
+        // `getChunk(pos)` is this chunk.
+        if crate::generation::post_processing::needs_shape_check(block.id) {
+            world.mark_pos_for_post_processing(block_pos);
+        }
     }
 
     /// Reorients a chest block state based on solid render neighbors, matching vanilla `StructurePiece.reorient`.

--- a/crates/pumpkin-world/src/generation/structure/structures/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mod.rs
@@ -458,10 +458,10 @@ impl StructurePiece {
         //     world.schedule_fluid_tick(&block_pos, fluid_state.fluid(), 0);
         // }
 
-        // `StructurePiece.placeBlock`: `if (SHAPE_CHECK_BLOCKS.contains(blockState.getBlock()))
-        // level.getChunk(pos).markPosForPostProcessing(pos);`. Pieces only ever write into the
-        // chunk currently being decorated (`generate_in_chunk` clips them to its column), so
-        // `getChunk(pos)` is this chunk.
+        // `StructurePiece.placeBlock` marks the position for post-processing whenever the written
+        // block is one of `SHAPE_CHECK_BLOCKS`, on the chunk that holds it. Pieces only ever write
+        // into the chunk currently being decorated (`generate_in_chunk` clips them to its column),
+        // so that chunk is this one.
         if crate::generation::post_processing::needs_shape_check(block.id) {
             world.mark_pos_for_post_processing(block_pos);
         }

--- a/crates/pumpkin/src/world/generation_cache.rs
+++ b/crates/pumpkin/src/world/generation_cache.rs
@@ -131,6 +131,11 @@ impl GenerationCache for WorldGenerationCache {
         None
     }
 
+    fn contains_chunk(&self, _chunk_x: i32, _chunk_z: i32) -> bool {
+        // Reads and writes go through the live world, so every chunk position is answered.
+        true
+    }
+
     fn get_block_state(&self, pos: &Vector3<i32>) -> BlockStateId {
         self.read(&BlockPos(*pos))
     }


### PR DESCRIPTION
## Description

Vanilla ends up with bubble columns, connected structure fences and no mushrooms in daylight without a single game tick, because `LevelChunk.postProcessGeneration` runs over the positions that `WorldGenRegion.setBlock` / `StructurePiece.placeBlock` marked with `markPosForPostProcessing`. Pumpkin had no post-processing at all. This PR adds it (`generation/post_processing.rs`) and, first, fixes the underwater magma feature whose output the bubble columns sit on.

**1. Underwater magma.** Three mis-ports in `UnderwaterMagmaFeature`: `getFloorY` is `Column.scan` from the *origin* (empty unless the origin itself is water); `betweenClosed` walks X fastest and Z slowest (Pumpkin had it transposed, so the 27 `nextFloat` draws landed on the wrong cells); `isValidPlacement` rejects neighbours that are `isVisibleFromOutside`, i.e. `!isSolidRender()` (Pumpkin only rejected water and air, so it walled magma into `cave_air` cave faces).

**2. Bubble columns.** `MAGMA_BLOCK` and `SOUL_SAND` are registered with `.postProcess(Blocks::postProcessAbove)`; at `FULL`, `postProcessGeneration` calls `LiquidBlock.tick` on the mark, which runs `BubbleColumnBlock.updateColumn` upward. `ProtoChunk` now carries the `postProcessing` list, the worldgen `set_block_state` marks `pos.above()` for magma and soul sand, and the marks are drained at the end of the feature step (Pumpkin has no `FULL` transition).

**3. Structure fence shapes.** `StructurePiece.placeBlock` marks every `SHAPE_CHECK_BLOCKS` write and `postProcessGeneration` runs `Block.updateFromNeighbourShapes`, i.e. `FenceBlock.updateShape` from all four neighbours, so the `WEST` / `EAST` a mineshaft support sets is only a starting point. The marking was commented out in `StructurePiece::add_block`. Vanilla runs this at `FULL`, after all eight neighbours finished `FEATURES`; Pumpkin decorates from a 3×3 window, so the shape half is replayed for every window chunk that is done, and positions whose neighbours are not all in the window are skipped (`GenerationCache::contains_chunk`) instead of read as air.

**4. Mushrooms in daylight.** `BROWN_MUSHROOM` / `RED_MUSHROOM` are `.postProcess(Blocks::postProcessSelf)`; `VegetationBlock.updateShape` deletes them when `MushroomBlock.canSurvive` fails (`getRawBrightness < 13 && below.isSolidRender()`). Worldgen light is 0 at feature time, so vanilla places them and deletes them at `FULL`. Only the value the sky-light engine reaches without propagation is modelled: a column of nothing but air above is sky light 15 exactly, everything else answers 0 and keeps the block (what Pumpkin did before).

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

| | mismatching blocks | chunks identical |
|---|---|---|
| underwater magma | 1,781 → 1,392 | 105 → 121/256 |
| bubble columns | 1,392 → 1,067 | 121 → 131/256 |
| fence shapes (later in the series) | 290 → 252 | 182 → 193/256 |
| mushrooms | 252 → **245** | 193 → **195/256** |

Every `magma_block` confusion, the whole `bubble_column→water` bucket (325 blocks, 15 chunks), all 38 `dark_oak_fence` property mismatches and all 7 `air→brown_mushroom` are gone; nothing else moved in any of the four steps.

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. Unit tests: the `betweenClosed` cube order and the `cave_air` cover test; that only magma and soul sand mark the block above, the column state for the block below and `canOccupy`; the `SHAPE_CHECK_BLOCKS` set, the west/east/north/south/down/up update order and the fence re-derivation from a neighbour; that mushrooms mark themselves and that only the light requirement removes one from sand.

**Known impact:** magma vents, fences in structures and surface mushrooms change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added chunk post-processing for generated terrain, including bubble-column water updates, mushroom survival checks, and fence connection updates.
  - Generation now tracks and applies eligible block updates across neighboring chunks for more consistent results.
- **Tests**
  - Added comprehensive coverage for post-processing behavior, including update ordering, block visibility, feature placement, traversal, and fence connections.
- **Documentation**
  - Clarified generation and post-processing behavior in developer-facing comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->