### PR TITLE
fix(worldgen): generate mineshafts bit-identical to vanilla 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-util/src/random/mod.rs
+++ b/crates/pumpkin-util/src/random/mod.rs
@@ -151,14 +151,8 @@ pub const fn seed_slime_chunk(x: i32, z: i32, seed: u64, salt: u64) -> u64 {
 ///
 /// This is vanilla's `WorldgenRandom.setLargeFeatureSeed(seed, chunkX, chunkZ)`, which is
 /// shared by the carvers, the structure `GenerationContext` random and the `legacy_type_3`
-/// structure frequency reduction:
-///
-/// ```text
-/// this.setSeed(seed);
-/// long xScale = this.nextLong();
-/// long zScale = this.nextLong();
-/// this.setSeed(chunkX * xScale ^ chunkZ * zScale ^ seed);
-/// ```
+/// structure frequency reduction. It seeds with the world seed, draws two longs as the X and Z
+/// scales, and re-seeds with `chunk_x * x_scale ^ chunk_z * z_scale ^ seed`.
 ///
 /// Not to be confused with `setDecorationSeed`, which ORs the scales with 1 and *adds* the
 /// two products (see `get_population_seed`).

--- a/crates/pumpkin-util/src/random/mod.rs
+++ b/crates/pumpkin-util/src/random/mod.rs
@@ -149,7 +149,19 @@ pub const fn seed_slime_chunk(x: i32, z: i32, seed: u64, salt: u64) -> u64 {
 
 /// Generates a carver seed for cave and ravine generation.
 ///
-/// Carver seeds are used for terrain carving features like caves and ravines.
+/// This is vanilla's `WorldgenRandom.setLargeFeatureSeed(seed, chunkX, chunkZ)`, which is
+/// shared by the carvers, the structure `GenerationContext` random and the `legacy_type_3`
+/// structure frequency reduction:
+///
+/// ```text
+/// this.setSeed(seed);
+/// long xScale = this.nextLong();
+/// long zScale = this.nextLong();
+/// this.setSeed(chunkX * xScale ^ chunkZ * zScale ^ seed);
+/// ```
+///
+/// Not to be confused with `setDecorationSeed`, which ORs the scales with 1 and *adds* the
+/// two products (see `get_population_seed`).
 ///
 /// # Arguments
 /// - `world_seed` – The base world seed (plus carver index).
@@ -162,11 +174,9 @@ pub const fn seed_slime_chunk(x: i32, z: i32, seed: u64, salt: u64) -> u64 {
 #[must_use]
 pub fn get_carver_seed(world_seed: u64, chunk_x: i32, chunk_z: i32) -> u64 {
     let mut random = LegacyRand::from_seed(world_seed);
-    let l = random.next_i64() | 1;
-    let m = random.next_i64() | 1;
-    ((chunk_x as i64)
-        .wrapping_mul(l)
-        .wrapping_add((chunk_z as i64).wrapping_mul(m)) as u64)
+    let x_scale = random.next_i64();
+    let z_scale = random.next_i64();
+    ((i64::from(chunk_x).wrapping_mul(x_scale)) ^ (i64::from(chunk_z).wrapping_mul(z_scale))) as u64
         ^ world_seed
 }
 
@@ -373,7 +383,7 @@ pub const fn hash_block_pos(x: i32, y: i32, z: i32) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::random::get_region_seed;
+    use crate::random::{RandomImpl, get_carver_seed, get_region_seed, legacy_rand::LegacyRand};
 
     use super::hash_block_pos;
 
@@ -381,6 +391,24 @@ mod tests {
     fn region_seed() {
         let seed = get_region_seed(12345612, 1, 1, 14357620);
         assert_eq!(seed, 474797819485);
+    }
+
+    /// `WorldgenRandom.setLargeFeatureSeed(13579, -11, 11)`. In the vanilla 26.2 world for
+    /// seed 13579, chunk (-11, 11) is the only chunk in x -16..-1, z 0..15 whose
+    /// `legacy_type_3` mineshaft roll (`new LegacyRandomSource(thisSeed).nextDouble() < 0.004`)
+    /// passes; with the `setDecorationSeed` formula (`| 1`, `+`) no chunk in that area passes.
+    #[test]
+    fn carver_seed_is_large_feature_seed() {
+        assert_eq!(
+            get_carver_seed(13579, -11, 11),
+            (-4_375_068_746_237_355_838i64) as u64
+        );
+        assert_eq!(get_carver_seed(13579, 0, 0), 13579);
+
+        let mut random = LegacyRand::from_seed(get_carver_seed(13579, -11, 11));
+        assert!(random.next_f64() < 0.004);
+        let mut random = LegacyRand::from_seed(get_carver_seed(13579, -10, 11));
+        assert!(random.next_f64() >= 0.004);
     }
 
     #[test]

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1448,11 +1448,17 @@ impl ProtoChunk {
 
             match &set.placement.placement_type {
                 StructurePlacementType::RandomSpread(spread) => {
-                    let region_x = pumpkin_util::math::floor_div(self.x, spread.spacing);
-                    let region_z = pumpkin_util::math::floor_div(self.z, spread.spacing);
+                    // Vanilla `ChunkGenerator.createReferences` looks at the starts of every
+                    // chunk within 8 chunks of this one, so cover every placement region
+                    // that overlaps that 17x17 window (for `spacing: 1` sets such as
+                    // mineshafts that is 289 regions, not the 9 around this chunk).
+                    let region_min_x = pumpkin_util::math::floor_div(self.x - 8, spread.spacing);
+                    let region_max_x = pumpkin_util::math::floor_div(self.x + 8, spread.spacing);
+                    let region_min_z = pumpkin_util::math::floor_div(self.z - 8, spread.spacing);
+                    let region_max_z = pumpkin_util::math::floor_div(self.z + 8, spread.spacing);
 
-                    for rx in (region_x - 1)..=(region_x + 1) {
-                        for rz in (region_z - 1)..=(region_z + 1) {
+                    for rx in region_min_x..=region_max_x {
+                        for rz in region_min_z..=region_max_z {
                             candidate_chunks.push(
                                 crate::generation::structure::placement::get_structure_chunk_in_region(
                                     spread,

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -197,6 +197,36 @@ impl ProtoChunk {
         self.structure_starts.contains_key(&key)
     }
 
+    /// The pieces (type, bounding box) of the structure start owned by this chunk, in
+    /// generation order.
+    #[cfg(test)]
+    pub(crate) fn structure_start_pieces(
+        &self,
+        key: StructureKeys,
+    ) -> Option<
+        Vec<(
+            crate::generation::structure::piece::StructurePieceType,
+            BlockBox,
+        )>,
+    > {
+        match self.structure_starts.get(&key)? {
+            StructureInstance::Start(position) => Some(
+                position
+                    .collector
+                    .lock()
+                    .unwrap()
+                    .pieces
+                    .iter()
+                    .map(|piece| {
+                        let piece = piece.get_structure_piece();
+                        (piece.r#type, piece.bounding_box)
+                    })
+                    .collect(),
+            ),
+            StructureInstance::Reference(_) => None,
+        }
+    }
+
     #[must_use]
     pub fn new(x: i32, z: i32, generator: &super::generator::WorldGenerator) -> Self {
         let dimension = generator.dimension();

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1706,12 +1706,14 @@ impl GenerationCache for ProtoChunk {
 /// `structure.step().ordinal()` and walks each step's list in registry order,
 /// counting one index per structure whether or not the chunk holds a start of it:
 ///
-///     int index = 0;
-///     for (Structure s : structuresByStep.getOrDefault(stepIndex, List.of())) {
-///         random.setFeatureSeed(decorationSeed, index, stepIndex);
-///         ...
-///         index++;
-///     }
+/// ```text
+/// int index = 0;
+/// for (Structure s : structuresByStep.getOrDefault(stepIndex, List.of())) {
+///     random.setFeatureSeed(decorationSeed, index, stepIndex);
+///     ...
+///     index++;
+/// }
+/// ```
 ///
 /// The structure registry is data-driven, so its iteration order is the
 /// resource-location order that `StructureKeys::all_names` is generated in.

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1280,12 +1280,8 @@ impl ProtoChunk {
         }
 
         // Vanilla `ChunkGenerator.applyBiomeDecoration` walks the structure registry
-        // once per decoration step and reseeds before each structure:
-        //     for (Structure s : structuresByStep.getOrDefault(stepIndex, List.of())) {
-        //         random.setFeatureSeed(decorationSeed, index, stepIndex);
-        //         startsForStructure(sectionPos, s).forEach(start -> start.placeInChunk(..., random, ...));
-        //         index++;
-        //     }
+        // once per decoration step, reseeding the feature random from the decoration seed, the
+        // running index and the step index before placing that structure's starts in the chunk.
         // `index` is the structure's position inside its step's list in registry
         // order, i.e. resource-location order, and it is counted for every
         // structure of the step whether or not the chunk holds a start of it.
@@ -1734,16 +1730,8 @@ impl GenerationCache for ProtoChunk {
 ///
 /// `ChunkGenerator.applyBiomeDecoration` groups the whole structure registry by
 /// `structure.step().ordinal()` and walks each step's list in registry order,
-/// counting one index per structure whether or not the chunk holds a start of it:
-///
-/// ```text
-/// int index = 0;
-/// for (Structure s : structuresByStep.getOrDefault(stepIndex, List.of())) {
-///     random.setFeatureSeed(decorationSeed, index, stepIndex);
-///     ...
-///     index++;
-/// }
-/// ```
+/// seeding the feature random from the decoration seed, the running index and the step index,
+/// and counting one index per structure whether or not the chunk holds a start of it.
 ///
 /// The structure registry is data-driven, so its iteration order is the
 /// resource-location order that `StructureKeys::all_names` is generated in.

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1189,11 +1189,11 @@ impl ProtoChunk {
                 }
 
                 match instance {
-                    StructureInstance::Start(pos) => tasks.push(pos.collector.clone()),
+                    StructureInstance::Start(pos) => tasks.push((*id, pos.collector.clone())),
                     StructureInstance::Reference(collector) => {
                         let collector_arc = collector.clone();
-                        if !tasks.iter().any(|t| Arc::ptr_eq(t, &collector_arc)) {
-                            tasks.push(collector_arc);
+                        if !tasks.iter().any(|(_, t)| Arc::ptr_eq(t, &collector_arc)) {
+                            tasks.push((*id, collector_arc));
                         }
                     }
                 }
@@ -1228,15 +1228,18 @@ impl ProtoChunk {
                                         .intersects_raw_xz(start_x, start_z, end_x, end_z)
                                     {
                                         let collector_arc = pos.collector.clone();
-                                        if !tasks.iter().any(|t| Arc::ptr_eq(t, &collector_arc)) {
-                                            tasks.push(collector_arc);
+                                        if !tasks
+                                            .iter()
+                                            .any(|(_, t)| Arc::ptr_eq(t, &collector_arc))
+                                        {
+                                            tasks.push((*id, collector_arc));
                                         }
                                     }
                                 }
                                 StructureInstance::Reference(collector) => {
                                     let collector_arc = collector.clone();
-                                    if !tasks.iter().any(|t| Arc::ptr_eq(t, &collector_arc)) {
-                                        tasks.push(collector_arc);
+                                    if !tasks.iter().any(|(_, t)| Arc::ptr_eq(t, &collector_arc)) {
+                                        tasks.push((*id, collector_arc));
                                     }
                                 }
                             }
@@ -1246,15 +1249,27 @@ impl ProtoChunk {
             }
         }
 
-        let decorator_seed = get_decorator_seed(population_seed, 0, step as u64);
-        let mut random = RandomGenerator::Worldgen(WorldgenRandom::from_seed(decorator_seed));
-
+        // Vanilla `ChunkGenerator.applyBiomeDecoration` walks the structure registry
+        // once per decoration step and reseeds before each structure:
+        //     for (Structure s : structuresByStep.getOrDefault(stepIndex, List.of())) {
+        //         random.setFeatureSeed(decorationSeed, index, stepIndex);
+        //         startsForStructure(sectionPos, s).forEach(start -> start.placeInChunk(..., random, ...));
+        //         index++;
+        //     }
+        // `index` is the structure's position inside its step's list in registry
+        // order, i.e. resource-location order, and it is counted for every
+        // structure of the step whether or not the chunk holds a start of it.
         let chunk = cache.get_center_chunk_mut();
-        for collector_arc in tasks {
-            let mut collector = collector_arc
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            collector.generate_in_chunk(chunk, block_registry, &mut random, world_seed);
+        for (structure_index, id) in structures_in_step(step) {
+            let decorator_seed = get_decorator_seed(population_seed, structure_index, step as u64);
+            let mut random = RandomGenerator::Worldgen(WorldgenRandom::from_seed(decorator_seed));
+
+            for (_, collector_arc) in tasks.iter().filter(|(task_id, _)| *task_id == id) {
+                let mut collector = collector_arc
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                collector.generate_in_chunk(chunk, block_registry, &mut random, world_seed);
+            }
         }
     }
 
@@ -1681,5 +1696,58 @@ impl GenerationCache for ProtoChunk {
     }
     fn get_sea_level(&self) -> i32 {
         Self::get_sea_level(self)
+    }
+}
+
+/// The structures of one decoration step, paired with the index vanilla uses to
+/// derive their feature seed.
+///
+/// `ChunkGenerator.applyBiomeDecoration` groups the whole structure registry by
+/// `structure.step().ordinal()` and walks each step's list in registry order,
+/// counting one index per structure whether or not the chunk holds a start of it:
+///
+///     int index = 0;
+///     for (Structure s : structuresByStep.getOrDefault(stepIndex, List.of())) {
+///         random.setFeatureSeed(decorationSeed, index, stepIndex);
+///         ...
+///         index++;
+///     }
+///
+/// The structure registry is data-driven, so its iteration order is the
+/// resource-location order that `StructureKeys::all_names` is generated in.
+fn structures_in_step(step: usize) -> impl Iterator<Item = (u64, StructureKeys)> {
+    StructureKeys::all_names()
+        .iter()
+        .filter_map(|name| StructureKeys::from_name(name))
+        .filter(move |id| Structure::get(id).step.ordinal() == step)
+        .enumerate()
+        .map(|(index, id)| (index as u64, id))
+}
+
+#[cfg(test)]
+mod structure_step_tests {
+    use super::structures_in_step;
+    use pumpkin_data::structures::{GenerationStep, StructureKeys};
+
+    #[test]
+    fn underground_structures_are_indexed_in_registry_order() {
+        // Vanilla 26.2 `assets/datapacks/26_2/data/minecraft/worldgen/structure`:
+        // buried_treasure, mineshaft, mineshaft_mesa, trail_ruins and trial_chambers
+        // all declare "step": "underground_structures", and the data-driven registry
+        // iterates them in resource-location order, so
+        // `ChunkGenerator.applyBiomeDecoration`'s per-step `index` runs 0..4 in that
+        // order. `mineshaft_mesa` is 2, not 0.
+        let step = GenerationStep::UndergroundStructures.ordinal();
+        let listed: Vec<_> = structures_in_step(step).collect();
+        assert_eq!(
+            listed,
+            vec![
+                (0, StructureKeys::BuriedTreasure),
+                (1, StructureKeys::Mineshaft),
+                (2, StructureKeys::MineshaftMesa),
+                (3, StructureKeys::TrailRuins),
+                (4, StructureKeys::TrialChambers),
+            ]
+        );
     }
 }

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -132,6 +132,46 @@ mod test {
         assert!(resumed.has_structure(StructureKeys::Monument));
     }
 
+    /// Real vanilla 26.2 for seed 13579 stores exactly one structure start in the 16x16
+    /// chunks x -16..-1, z 0..15: `minecraft:mineshaft_mesa` in chunk (-11, 11)
+    /// (`structures.starts` of the saved region files, pumpkin-parity/vanilla/world-13579).
+    /// Mineshafts use `legacy_type_3` frequency reduction, i.e. the large-feature seed.
+    #[test]
+    fn mineshaft_mesa_start_matches_vanilla_seed_13579() {
+        use pumpkin_data::structures::StructureKeys;
+
+        let world_gen = get_world_gen(
+            Seed(13579),
+            Dimension::OVERWORLD,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+
+        let mut proto = ProtoChunk::new(-11, 11, &world_gen);
+        proto.step_to_biomes(generator);
+        proto.set_structure_starts(generator);
+        assert!(proto.has_structure(StructureKeys::MineshaftMesa));
+        assert!(!proto.has_structure(StructureKeys::Mineshaft));
+
+        for (cx, cz) in [(-10, 11), (-11, 10), (-12, 12)] {
+            let mut proto = ProtoChunk::new(cx, cz, &world_gen);
+            proto.step_to_biomes(generator);
+            proto.set_structure_starts(generator);
+            assert!(
+                !proto.has_structure(StructureKeys::MineshaftMesa),
+                "({cx}, {cz})"
+            );
+            assert!(
+                !proto.has_structure(StructureKeys::Mineshaft),
+                "({cx}, {cz})"
+            );
+        }
+    }
+
     // Regression test for transposed heightmaps during Noise-stage chunk resume.
     // Flat terrain cannot expose this bug, so use a sloped chunk.
     #[test]

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -172,6 +172,35 @@ mod test {
         }
     }
 
+    /// Vanilla `ChunkGenerator.createReferences` scans the starts of every chunk within 8
+    /// chunks. In the saved vanilla world for seed 13579, chunk (-6, 8) carries a
+    /// `minecraft:mineshaft_mesa` reference to the start in (-11, 11) (five chunks away).
+    #[test]
+    fn structure_references_reach_eight_chunks_seed_13579() {
+        use pumpkin_data::structures::StructureKeys;
+
+        let world_gen = get_world_gen(
+            Seed(13579),
+            Dimension::OVERWORLD,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+
+        // Only the positive case is asserted here: the exact extent of the start (vanilla
+        // references it from x -15..-6, z 8..15 and *not* from (-5, 8) or (-6, 7)) also
+        // depends on the pieces being generated depth-first, which is fixed in the mineshaft
+        // series; the negative cases are asserted there.
+        let mut proto = ProtoChunk::new(-6, 8, &world_gen);
+        proto.step_to_biomes(generator);
+        proto.set_structure_starts(generator);
+        proto.set_structure_references(generator);
+        assert!(proto.has_structure(StructureKeys::MineshaftMesa), "(-6, 8)");
+    }
+
     // Regression test for transposed heightmaps during Noise-stage chunk resume.
     // Flat terrain cannot expose this bug, so use a sloped chunk.
     #[test]

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -172,9 +172,61 @@ mod test {
         }
     }
 
+    /// The same vanilla start has 180 pieces; vanilla `generateAndAddPiece` adds each piece
+    /// and generates its children immediately (depth-first), which fixes both the piece
+    /// order and every random draw / collision check after it. Bounding boxes are the
+    /// `BB` tags of the first pieces in vanilla's `structures.starts` for chunk (-11, 11).
+    #[test]
+    fn mineshaft_mesa_pieces_match_vanilla_seed_13579() {
+        use crate::generation::structure::piece::StructurePieceType as T;
+        use pumpkin_data::structures::StructureKeys;
+        use pumpkin_util::math::block_box::BlockBox;
+
+        let world_gen = get_world_gen(
+            Seed(13579),
+            Dimension::OVERWORLD,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+        let mut proto = ProtoChunk::new(-11, 11, &world_gen);
+        proto.step_to_biomes(generator);
+        proto.set_structure_starts(generator);
+        let pieces = proto
+            .structure_start_pieces(StructureKeys::MineshaftMesa)
+            .expect("mineshaft_mesa start in chunk (-11, 11)");
+
+        assert_eq!(pieces.len(), 180);
+        let expected = [
+            (T::MineshaftRoom, [-174, 59, 178, -165, 66, 189]),
+            (T::MineshaftCorridor, [-171, 63, 168, -169, 65, 177]),
+            (T::MineshaftCorridor, [-168, 64, 168, -149, 66, 170]),
+            (T::MineshaftCorridor, [-152, 65, 148, -150, 67, 167]),
+            (T::MineshaftCorridor, [-162, 64, 148, -153, 66, 150]),
+            (T::MineshaftStairs, [-171, 58, 148, -163, 65, 150]),
+            (T::MineshaftCorridor, [-186, 58, 148, -172, 60, 150]),
+            (T::MineshaftCorridor, [-196, 58, 148, -187, 60, 150]),
+            (T::MineshaftCorridor, [-211, 58, 148, -197, 60, 150]),
+            (T::MineshaftCorridor, [-211, 58, 138, -209, 60, 147]),
+            (T::MineshaftCorridor, [-193, 58, 128, -191, 60, 147]),
+        ];
+        for (i, (piece_type, [x0, y0, z0, x1, y1, z1])) in expected.into_iter().enumerate() {
+            assert_eq!(pieces[i].0, piece_type, "piece {i}");
+            assert_eq!(
+                pieces[i].1,
+                BlockBox::new(x0, y0, z0, x1, y1, z1),
+                "piece {i}"
+            );
+        }
+    }
+
     /// Vanilla `ChunkGenerator.createReferences` scans the starts of every chunk within 8
     /// chunks. In the saved vanilla world for seed 13579, chunk (-6, 8) carries a
-    /// `minecraft:mineshaft_mesa` reference to the start in (-11, 11) (five chunks away).
+    /// `minecraft:mineshaft_mesa` reference to the start in (-11, 11) (five chunks away),
+    /// while (-5, 8) and (-6, 7) carry none.
     #[test]
     fn structure_references_reach_eight_chunks_seed_13579() {
         use pumpkin_data::structures::StructureKeys;
@@ -190,15 +242,17 @@ mod test {
             unreachable!()
         };
 
-        // Only the positive case is asserted here: the exact extent of the start (vanilla
-        // references it from x -15..-6, z 8..15 and *not* from (-5, 8) or (-6, 7)) also
-        // depends on the pieces being generated depth-first, which is fixed in the mineshaft
-        // series; the negative cases are asserted there.
-        let mut proto = ProtoChunk::new(-6, 8, &world_gen);
-        proto.step_to_biomes(generator);
-        proto.set_structure_starts(generator);
-        proto.set_structure_references(generator);
-        assert!(proto.has_structure(StructureKeys::MineshaftMesa), "(-6, 8)");
+        for ((cx, cz), expected) in [((-6, 8), true), ((-5, 8), false), ((-6, 7), false)] {
+            let mut proto = ProtoChunk::new(cx, cz, &world_gen);
+            proto.step_to_biomes(generator);
+            proto.set_structure_starts(generator);
+            proto.set_structure_references(generator);
+            assert_eq!(
+                proto.has_structure(StructureKeys::MineshaftMesa),
+                expected,
+                "({cx}, {cz})"
+            );
+        }
     }
 
     // Regression test for transposed heightmaps during Noise-stage chunk resume.

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use pumpkin_data::{
-    Block, BlockState,
+    Block, BlockDirection as DataBlockDirection, BlockState,
     block_properties::{HorizontalFacing, WallTorchLikeProperties},
 };
 use pumpkin_nbt::compound::NbtCompound;
@@ -128,6 +128,10 @@ fn for_each_maybe_box_position(
 
 fn is_supporting_box(min_x: i32, max_x: i32, mut is_air: impl FnMut(i32) -> bool) -> bool {
     (min_x..=max_x).all(|x| !is_air(x))
+}
+
+fn passes_cobweb_random_gate(random: &mut RandomGenerator, chance: f32, is_interior: bool) -> bool {
+    is_interior && random.next_f32() < chance
 }
 
 pub struct MineshaftGenerator {
@@ -1083,6 +1087,67 @@ impl MineShaftCorridor {
             dist += 1;
         }
     }
+
+    fn maybe_place_cobweb(
+        &self,
+        chunk: &mut ProtoChunk,
+        chunk_box: &BlockBox,
+        random: &mut RandomGenerator,
+        chance: f32,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) {
+        let is_interior = self.piece.is_under_sea_level(chunk, x, y, z, chunk_box);
+        if !passes_cobweb_random_gate(random, chance, is_interior) {
+            return;
+        }
+
+        let world_pos = self.piece.offset_pos(x, y, z);
+        let mut sturdy_neighbours = 0;
+        for direction in [
+            BlockDirection::Down,
+            BlockDirection::Up,
+            BlockDirection::North,
+            BlockDirection::South,
+            BlockDirection::West,
+            BlockDirection::East,
+        ] {
+            let offset = direction.to_vector();
+            let neighbour = Vector3::new(
+                world_pos.x + offset.x,
+                world_pos.y + offset.y,
+                world_pos.z + offset.z,
+            );
+            if chunk_box.contains_pos(&neighbour)
+                && chunk.get_block_state(&neighbour).to_state().is_side_solid(
+                    match direction.opposite() {
+                        BlockDirection::Down => DataBlockDirection::Down,
+                        BlockDirection::Up => DataBlockDirection::Up,
+                        BlockDirection::North => DataBlockDirection::North,
+                        BlockDirection::South => DataBlockDirection::South,
+                        BlockDirection::West => DataBlockDirection::West,
+                        BlockDirection::East => DataBlockDirection::East,
+                    },
+                )
+            {
+                sturdy_neighbours += 1;
+                if sturdy_neighbours >= 2 {
+                    add_mineshaft_block(
+                        &self.piece,
+                        self.shaft_type,
+                        chunk,
+                        Block::COBWEB.default_state,
+                        x,
+                        y,
+                        z,
+                        chunk_box,
+                    );
+                    return;
+                }
+            }
+        }
+    }
 }
 
 impl StructurePieceBase for MineShaftCorridor {
@@ -1150,7 +1215,7 @@ impl StructurePieceBase for MineShaftCorridor {
             let z = 2 + section * 5;
             self.place_support(chunk, chunk_box, 0, 0, z, 2, 2, random);
 
-            for (cx, cy, cz, prob) in [
+            for (cx, cy, cz, chance) in [
                 (0, 2, z - 1, 0.1f32),
                 (2, 2, z - 1, 0.1),
                 (0, 2, z + 1, 0.1),
@@ -1160,18 +1225,7 @@ impl StructurePieceBase for MineShaftCorridor {
                 (0, 2, z + 2, 0.05),
                 (2, 2, z + 2, 0.05),
             ] {
-                if random.next_f32() < prob {
-                    add_mineshaft_block(
-                        &self.piece,
-                        self.shaft_type,
-                        chunk,
-                        Block::COBWEB.default_state,
-                        cx,
-                        cy,
-                        cz,
-                        chunk_box,
-                    );
-                }
+                self.maybe_place_cobweb(chunk, chunk_box, random, chance, cx, cy, cz);
             }
 
             if random.next_bounded_i32(100) == 0 {
@@ -1801,7 +1855,9 @@ impl StructurePieceBase for MineShaftStairs {
 
 #[cfg(test)]
 mod tests {
-    use super::{MineshaftType, for_each_maybe_box_position, is_supporting_box};
+    use super::{
+        MineshaftType, for_each_maybe_box_position, is_supporting_box, passes_cobweb_random_gate,
+    };
     use pumpkin_data::Block;
     use pumpkin_util::random::{RandomGenerator, RandomImpl, legacy_rand::LegacyRand};
 
@@ -1851,5 +1907,15 @@ mod tests {
         // for (x = minX; x <= maxX; x++) if (getBlock(x, y + 1, z).isAir()) return false.
         assert!(is_supporting_box(0, 2, |_| false));
         assert!(!is_supporting_box(0, 2, |x| x == 1));
+    }
+
+    #[test]
+    fn cobweb_interior_gate_precedes_the_random_draw() {
+        // Vanilla 26.2 MineShaftCorridor.maybePlaceCobWeb:
+        // isInterior(...) && random.nextFloat() < chance && hasSturdyNeighbours(..., 2).
+        let mut random = RandomGenerator::Legacy(LegacyRand::from_seed(0));
+        assert!(!passes_cobweb_random_gate(&mut random, 0.8, false));
+        assert!(passes_cobweb_random_gate(&mut random, 0.8, true));
+        assert_eq!(random.next_f32(), 0.831_441);
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -77,31 +77,20 @@ impl StructureGenerator for MineshaftGenerator {
 
         let mut start_room = MineShaftRoom::new(0, &mut context.random, room_x, room_z, shaft_type);
 
+        // Vanilla `MineshaftStructure.generatePiecesAndAdjust`: `builder.addPiece(room);
+        // room.addChildren(room, builder, random);` — the room is in the collector while its
+        // children (and, depth-first, their children) are generated, and it collects the
+        // entrance boxes along the way, so write the finished room back over the placeholder.
         let mut collector = StructurePiecesCollector::default();
         let start_piece_box = start_room.piece.bounding_box;
-
-        let mut children = Vec::new();
+        collector.add_piece(Box::new(start_room.clone()));
         start_room.add_children_to_list(
             &start_piece_box,
             shaft_type,
-            &collector,
+            &mut collector,
             &mut context.random,
-            &mut children,
         );
-
-        collector.add_piece(Box::new(start_room));
-
-        while !children.is_empty() {
-            let next_piece = children.remove(0);
-            next_piece.build_children(
-                &start_piece_box,
-                shaft_type,
-                &collector,
-                &mut context.random,
-                &mut children,
-            );
-            collector.add_piece(next_piece.into_piece_base());
-        }
+        collector.pieces[0] = Box::new(start_room);
 
         if self.is_mesa {
             let bbox = collector.get_bounding_box();
@@ -145,28 +134,35 @@ impl GeneratedPiece {
         &self,
         start_piece_box: &BlockBox,
         shaft_type: MineshaftType,
-        collector: &StructurePiecesCollector,
+        collector: &mut StructurePiecesCollector,
         random: &mut RandomGenerator,
-        children: &mut Vec<Self>,
     ) {
         match self {
             Self::Corridor(c) => {
-                c.add_children_to_list(start_piece_box, shaft_type, collector, random, children);
+                c.add_children_to_list(start_piece_box, shaft_type, collector, random);
             }
             Self::Crossing(cr) => {
-                cr.add_children_to_list(start_piece_box, shaft_type, collector, random, children);
+                cr.add_children_to_list(start_piece_box, shaft_type, collector, random);
             }
             Self::Stairs(s) => {
-                s.add_children_to_list(start_piece_box, shaft_type, collector, random, children);
+                s.add_children_to_list(start_piece_box, shaft_type, collector, random);
             }
         }
     }
 
-    fn into_piece_base(self) -> Box<dyn StructurePieceBase> {
+    const fn bounding_box(&self) -> BlockBox {
         match self {
-            Self::Corridor(c) => Box::new(c),
-            Self::Crossing(cr) => Box::new(cr),
-            Self::Stairs(s) => Box::new(s),
+            Self::Corridor(c) => c.piece.bounding_box,
+            Self::Crossing(cr) => cr.piece.bounding_box,
+            Self::Stairs(s) => s.piece.bounding_box,
+        }
+    }
+
+    fn clone_piece_base(&self) -> Box<dyn StructurePieceBase> {
+        match self {
+            Self::Corridor(c) => Box::new(c.clone()),
+            Self::Crossing(cr) => Box::new(cr.clone()),
+            Self::Stairs(s) => Box::new(s.clone()),
         }
     }
 }
@@ -216,10 +212,14 @@ fn create_random_shaft_piece(
     None
 }
 
+/// Vanilla `MineshaftPieces.generateAndAddPiece`: the new piece is added to the collector
+/// and its own children are generated *immediately* (depth-first), so every later
+/// collision check and random draw sees the pieces in vanilla's order. Returns the new
+/// piece's bounding box.
 #[expect(clippy::too_many_arguments)]
 fn generate_and_add_piece(
     start_piece_box: &BlockBox,
-    collector: &StructurePiecesCollector,
+    collector: &mut StructurePiecesCollector,
     random: &mut RandomGenerator,
     foot_x: i32,
     foot_y: i32,
@@ -227,26 +227,30 @@ fn generate_and_add_piece(
     direction: BlockDirection,
     depth: u32,
     shaft_type: MineshaftType,
-    children: &mut Vec<GeneratedPiece>,
-) {
-    if depth <= 8
-        && (foot_x - start_piece_box.min.x).abs() <= 80
-        && (foot_z - start_piece_box.min.z).abs() <= 80
-        && let Some(new_piece) = create_random_shaft_piece(
-            collector,
-            random,
-            foot_x,
-            foot_y,
-            foot_z,
-            direction,
-            depth + 1,
-            shaft_type,
-        )
+) -> Option<BlockBox> {
+    if depth > 8
+        || (foot_x - start_piece_box.min.x).abs() > 80
+        || (foot_z - start_piece_box.min.z).abs() > 80
     {
-        children.push(new_piece);
+        return None;
     }
+    let new_piece = create_random_shaft_piece(
+        collector,
+        random,
+        foot_x,
+        foot_y,
+        foot_z,
+        direction,
+        depth + 1,
+        shaft_type,
+    )?;
+    let bounding_box = new_piece.bounding_box();
+    collector.add_piece(new_piece.clone_piece_base());
+    new_piece.build_children(start_piece_box, shaft_type, collector, random);
+    Some(bounding_box)
 }
 
+#[derive(Clone)]
 pub struct MineShaftRoom {
     pub piece: StructurePiece,
     pub shaft_type: MineshaftType,
@@ -278,9 +282,8 @@ impl MineShaftRoom {
         &mut self,
         start_piece_box: &BlockBox,
         shaft_type: MineshaftType,
-        collector: &StructurePiecesCollector,
+        collector: &mut StructurePiecesCollector,
         random: &mut RandomGenerator,
-        children: &mut Vec<GeneratedPiece>,
     ) {
         let depth = self.piece.chain_length;
         let y_span = self.piece.bounding_box.max.y - self.piece.bounding_box.min.y + 1;
@@ -302,8 +305,7 @@ impl MineShaftRoom {
             let child_y = self.piece.bounding_box.min.y + random.next_bounded_i32(height_space) + 1;
             let child_z = self.piece.bounding_box.min.z - 1;
 
-            let prev_len = children.len();
-            generate_and_add_piece(
+            if let Some(bb) = generate_and_add_piece(
                 start_piece_box,
                 collector,
                 random,
@@ -313,14 +315,7 @@ impl MineShaftRoom {
                 BlockDirection::North,
                 depth,
                 shaft_type,
-                children,
-            );
-            if children.len() > prev_len {
-                let bb = match &children[prev_len] {
-                    GeneratedPiece::Corridor(c) => c.piece.bounding_box,
-                    GeneratedPiece::Crossing(c) => c.piece.bounding_box,
-                    GeneratedPiece::Stairs(s) => s.piece.bounding_box,
-                };
+            ) {
                 self.child_entrance_boxes.push(BlockBox::new(
                     bb.min.x,
                     bb.min.y,
@@ -343,8 +338,7 @@ impl MineShaftRoom {
             let child_y = self.piece.bounding_box.min.y + random.next_bounded_i32(height_space) + 1;
             let child_z = self.piece.bounding_box.max.z + 1;
 
-            let prev_len = children.len();
-            generate_and_add_piece(
+            if let Some(bb) = generate_and_add_piece(
                 start_piece_box,
                 collector,
                 random,
@@ -354,14 +348,7 @@ impl MineShaftRoom {
                 BlockDirection::South,
                 depth,
                 shaft_type,
-                children,
-            );
-            if children.len() > prev_len {
-                let bb = match &children[prev_len] {
-                    GeneratedPiece::Corridor(c) => c.piece.bounding_box,
-                    GeneratedPiece::Crossing(c) => c.piece.bounding_box,
-                    GeneratedPiece::Stairs(s) => s.piece.bounding_box,
-                };
+            ) {
                 self.child_entrance_boxes.push(BlockBox::new(
                     bb.min.x,
                     bb.min.y,
@@ -384,8 +371,7 @@ impl MineShaftRoom {
             let child_y = self.piece.bounding_box.min.y + random.next_bounded_i32(height_space) + 1;
             let child_z = self.piece.bounding_box.min.z + pos;
 
-            let prev_len = children.len();
-            generate_and_add_piece(
+            if let Some(bb) = generate_and_add_piece(
                 start_piece_box,
                 collector,
                 random,
@@ -395,14 +381,7 @@ impl MineShaftRoom {
                 BlockDirection::West,
                 depth,
                 shaft_type,
-                children,
-            );
-            if children.len() > prev_len {
-                let bb = match &children[prev_len] {
-                    GeneratedPiece::Corridor(c) => c.piece.bounding_box,
-                    GeneratedPiece::Crossing(c) => c.piece.bounding_box,
-                    GeneratedPiece::Stairs(s) => s.piece.bounding_box,
-                };
+            ) {
                 self.child_entrance_boxes.push(BlockBox::new(
                     self.piece.bounding_box.min.x,
                     bb.min.y,
@@ -425,8 +404,7 @@ impl MineShaftRoom {
             let child_y = self.piece.bounding_box.min.y + random.next_bounded_i32(height_space) + 1;
             let child_z = self.piece.bounding_box.min.z + pos;
 
-            let prev_len = children.len();
-            generate_and_add_piece(
+            if let Some(bb) = generate_and_add_piece(
                 start_piece_box,
                 collector,
                 random,
@@ -436,14 +414,7 @@ impl MineShaftRoom {
                 BlockDirection::East,
                 depth,
                 shaft_type,
-                children,
-            );
-            if children.len() > prev_len {
-                let bb = match &children[prev_len] {
-                    GeneratedPiece::Corridor(c) => c.piece.bounding_box,
-                    GeneratedPiece::Crossing(c) => c.piece.bounding_box,
-                    GeneratedPiece::Stairs(s) => s.piece.bounding_box,
-                };
+            ) {
                 self.child_entrance_boxes.push(BlockBox::new(
                     self.piece.bounding_box.max.x - 1,
                     bb.min.y,
@@ -536,6 +507,7 @@ impl StructurePieceBase for MineShaftRoom {
     }
 }
 
+#[derive(Clone)]
 pub struct MineShaftCorridor {
     pub piece: StructurePiece,
     pub shaft_type: MineshaftType,
@@ -611,9 +583,8 @@ impl MineShaftCorridor {
         &self,
         start_piece_box: &BlockBox,
         shaft_type: MineshaftType,
-        collector: &StructurePiecesCollector,
+        collector: &mut StructurePiecesCollector,
         random: &mut RandomGenerator,
-        children: &mut Vec<GeneratedPiece>,
     ) {
         let depth = self.piece.chain_length;
         let end_selection = random.next_bounded_i32(4);
@@ -633,7 +604,6 @@ impl MineShaftCorridor {
                         orientation,
                         depth,
                         shaft_type,
-                        children,
                     );
                 } else if end_selection == 2 {
                     generate_and_add_piece(
@@ -646,7 +616,6 @@ impl MineShaftCorridor {
                         BlockDirection::West,
                         depth,
                         shaft_type,
-                        children,
                     );
                 } else {
                     generate_and_add_piece(
@@ -659,7 +628,6 @@ impl MineShaftCorridor {
                         BlockDirection::East,
                         depth,
                         shaft_type,
-                        children,
                     );
                 }
             }
@@ -675,7 +643,6 @@ impl MineShaftCorridor {
                         orientation,
                         depth,
                         shaft_type,
-                        children,
                     );
                 } else if end_selection == 2 {
                     generate_and_add_piece(
@@ -688,7 +655,6 @@ impl MineShaftCorridor {
                         BlockDirection::West,
                         depth,
                         shaft_type,
-                        children,
                     );
                 } else {
                     generate_and_add_piece(
@@ -701,7 +667,6 @@ impl MineShaftCorridor {
                         BlockDirection::East,
                         depth,
                         shaft_type,
-                        children,
                     );
                 }
             }
@@ -717,7 +682,6 @@ impl MineShaftCorridor {
                         orientation,
                         depth,
                         shaft_type,
-                        children,
                     );
                 } else if end_selection == 2 {
                     generate_and_add_piece(
@@ -730,7 +694,6 @@ impl MineShaftCorridor {
                         BlockDirection::North,
                         depth,
                         shaft_type,
-                        children,
                     );
                 } else {
                     generate_and_add_piece(
@@ -743,7 +706,6 @@ impl MineShaftCorridor {
                         BlockDirection::South,
                         depth,
                         shaft_type,
-                        children,
                     );
                 }
             }
@@ -759,7 +721,6 @@ impl MineShaftCorridor {
                         orientation,
                         depth,
                         shaft_type,
-                        children,
                     );
                 } else if end_selection == 2 {
                     generate_and_add_piece(
@@ -772,7 +733,6 @@ impl MineShaftCorridor {
                         BlockDirection::North,
                         depth,
                         shaft_type,
-                        children,
                     );
                 } else {
                     generate_and_add_piece(
@@ -785,7 +745,6 @@ impl MineShaftCorridor {
                         BlockDirection::South,
                         depth,
                         shaft_type,
-                        children,
                     );
                 }
             }
@@ -808,7 +767,6 @@ impl MineShaftCorridor {
                             BlockDirection::North,
                             depth + 1,
                             shaft_type,
-                            children,
                         );
                     } else if sel == 1 {
                         generate_and_add_piece(
@@ -821,7 +779,6 @@ impl MineShaftCorridor {
                             BlockDirection::South,
                             depth + 1,
                             shaft_type,
-                            children,
                         );
                     }
                     x += 5;
@@ -841,7 +798,6 @@ impl MineShaftCorridor {
                             BlockDirection::West,
                             depth + 1,
                             shaft_type,
-                            children,
                         );
                     } else if sel == 1 {
                         generate_and_add_piece(
@@ -854,7 +810,6 @@ impl MineShaftCorridor {
                             BlockDirection::East,
                             depth + 1,
                             shaft_type,
-                            children,
                         );
                     }
                     z += 5;
@@ -1121,6 +1076,7 @@ impl StructurePieceBase for MineShaftCorridor {
     }
 }
 
+#[derive(Clone)]
 pub struct MineShaftCrossing {
     pub piece: StructurePiece,
     pub shaft_type: MineshaftType,
@@ -1183,9 +1139,8 @@ impl MineShaftCrossing {
         &self,
         start_piece_box: &BlockBox,
         shaft_type: MineshaftType,
-        collector: &StructurePiecesCollector,
+        collector: &mut StructurePiecesCollector,
         random: &mut RandomGenerator,
-        children: &mut Vec<GeneratedPiece>,
     ) {
         let depth = self.piece.chain_length;
         let dir = self.direction.unwrap_or(BlockDirection::North);
@@ -1202,7 +1157,6 @@ impl MineShaftCrossing {
                     BlockDirection::North,
                     depth,
                     shaft_type,
-                    children,
                 );
                 generate_and_add_piece(
                     start_piece_box,
@@ -1214,7 +1168,6 @@ impl MineShaftCrossing {
                     BlockDirection::West,
                     depth,
                     shaft_type,
-                    children,
                 );
                 generate_and_add_piece(
                     start_piece_box,
@@ -1226,7 +1179,6 @@ impl MineShaftCrossing {
                     BlockDirection::East,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             BlockDirection::South => {
@@ -1240,7 +1192,6 @@ impl MineShaftCrossing {
                     BlockDirection::South,
                     depth,
                     shaft_type,
-                    children,
                 );
                 generate_and_add_piece(
                     start_piece_box,
@@ -1252,7 +1203,6 @@ impl MineShaftCrossing {
                     BlockDirection::West,
                     depth,
                     shaft_type,
-                    children,
                 );
                 generate_and_add_piece(
                     start_piece_box,
@@ -1264,7 +1214,6 @@ impl MineShaftCrossing {
                     BlockDirection::East,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             BlockDirection::West => {
@@ -1278,7 +1227,6 @@ impl MineShaftCrossing {
                     BlockDirection::North,
                     depth,
                     shaft_type,
-                    children,
                 );
                 generate_and_add_piece(
                     start_piece_box,
@@ -1290,7 +1238,6 @@ impl MineShaftCrossing {
                     BlockDirection::South,
                     depth,
                     shaft_type,
-                    children,
                 );
                 generate_and_add_piece(
                     start_piece_box,
@@ -1302,7 +1249,6 @@ impl MineShaftCrossing {
                     BlockDirection::West,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             BlockDirection::East => {
@@ -1316,7 +1262,6 @@ impl MineShaftCrossing {
                     BlockDirection::North,
                     depth,
                     shaft_type,
-                    children,
                 );
                 generate_and_add_piece(
                     start_piece_box,
@@ -1328,7 +1273,6 @@ impl MineShaftCrossing {
                     BlockDirection::South,
                     depth,
                     shaft_type,
-                    children,
                 );
                 generate_and_add_piece(
                     start_piece_box,
@@ -1340,7 +1284,6 @@ impl MineShaftCrossing {
                     BlockDirection::East,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             _ => {}
@@ -1358,7 +1301,6 @@ impl MineShaftCrossing {
                     BlockDirection::North,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             if random.next_bool() {
@@ -1372,7 +1314,6 @@ impl MineShaftCrossing {
                     BlockDirection::West,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             if random.next_bool() {
@@ -1386,7 +1327,6 @@ impl MineShaftCrossing {
                     BlockDirection::East,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             if random.next_bool() {
@@ -1400,7 +1340,6 @@ impl MineShaftCrossing {
                     BlockDirection::South,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
         }
@@ -1523,6 +1462,7 @@ impl StructurePieceBase for MineShaftCrossing {
     }
 }
 
+#[derive(Clone)]
 pub struct MineShaftStairs {
     pub piece: StructurePiece,
     pub shaft_type: MineshaftType,
@@ -1568,9 +1508,8 @@ impl MineShaftStairs {
         &self,
         start_piece_box: &BlockBox,
         shaft_type: MineshaftType,
-        collector: &StructurePiecesCollector,
+        collector: &mut StructurePiecesCollector,
         random: &mut RandomGenerator,
-        children: &mut Vec<GeneratedPiece>,
     ) {
         let depth = self.piece.chain_length;
         let dir = self.piece.facing.unwrap_or(BlockDirection::North);
@@ -1587,7 +1526,6 @@ impl MineShaftStairs {
                     BlockDirection::North,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             BlockDirection::South => {
@@ -1601,7 +1539,6 @@ impl MineShaftStairs {
                     BlockDirection::South,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             BlockDirection::West => {
@@ -1615,7 +1552,6 @@ impl MineShaftStairs {
                     BlockDirection::West,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             BlockDirection::East => {
@@ -1629,7 +1565,6 @@ impl MineShaftStairs {
                     BlockDirection::East,
                     depth,
                     shaft_type,
-                    children,
                 );
             }
             _ => {}

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -101,6 +101,31 @@ fn fill_mineshaft_box(
     }
 }
 
+#[expect(clippy::too_many_arguments)]
+fn for_each_maybe_box_position(
+    random: &mut RandomGenerator,
+    chance: f32,
+    min_x: i32,
+    min_y: i32,
+    min_z: i32,
+    max_x: i32,
+    max_y: i32,
+    max_z: i32,
+    mut place: impl FnMut(i32, i32, i32),
+) {
+    // StructurePiece.generateMaybeBox iterates Y, then X, then Z and consumes a
+    // float before any of its placement gates.
+    for y in min_y..=max_y {
+        for x in min_x..=max_x {
+            for z in min_z..=max_z {
+                if random.next_f32() <= chance {
+                    place(x, y, z);
+                }
+            }
+        }
+    }
+}
+
 pub struct MineshaftGenerator {
     pub is_mesa: bool,
 }
@@ -1088,33 +1113,25 @@ impl StructurePieceBase for MineShaftCorridor {
             air,
         );
 
-        for z in 0..=length {
-            for x in 0..=2 {
-                if random.next_f32() < 0.8 {
-                    add_mineshaft_block(
-                        &self.piece,
-                        self.shaft_type,
-                        chunk,
-                        air,
-                        x,
-                        2,
-                        z,
-                        chunk_box,
-                    );
-                }
-                if self.spider_corridor && random.next_f32() < 0.6 {
+        for_each_maybe_box_position(random, 0.8, 0, 2, 0, 2, 2, length, |x, y, z| {
+            add_mineshaft_block(&self.piece, self.shaft_type, chunk, air, x, y, z, chunk_box);
+        });
+
+        if self.spider_corridor {
+            for_each_maybe_box_position(random, 0.6, 0, 0, 0, 2, 1, length, |x, y, z| {
+                if self.piece.is_under_sea_level(chunk, x, y, z, chunk_box) {
                     add_mineshaft_block(
                         &self.piece,
                         self.shaft_type,
                         chunk,
                         Block::COBWEB.default_state,
                         x,
-                        0,
+                        y,
                         z,
                         chunk_box,
                     );
                 }
-            }
+            });
         }
 
         for section in 0..self.num_sections {
@@ -1772,8 +1789,9 @@ impl StructurePieceBase for MineShaftStairs {
 
 #[cfg(test)]
 mod tests {
-    use super::MineshaftType;
+    use super::{MineshaftType, for_each_maybe_box_position};
     use pumpkin_data::Block;
+    use pumpkin_util::random::{RandomGenerator, RandomImpl, legacy_rand::LegacyRand};
 
     #[test]
     fn mineshaft_can_be_replaced_excludes_its_own_building_blocks() {
@@ -1787,5 +1805,31 @@ mod tests {
             assert!(shaft_type.can_replace(Block::STONE.default_state));
             assert!(shaft_type.can_replace(Block::CAVE_AIR.default_state));
         }
+    }
+
+    #[test]
+    fn generate_maybe_box_draws_in_y_x_z_order_before_placement_gates() {
+        // Vanilla 26.2 StructurePiece.generateMaybeBox:
+        // for (y) for (x) for (z) if (random.nextFloat() > chance) continue.
+        let mut random = RandomGenerator::Legacy(LegacyRand::from_seed(0));
+        let mut accepted = Vec::new();
+        for_each_maybe_box_position(&mut random, 0.8, 0, 2, 0, 2, 2, 2, |x, y, z| {
+            accepted.push((x, y, z));
+        });
+
+        assert_eq!(
+            accepted,
+            [
+                (0, 2, 0),
+                (0, 2, 2),
+                (1, 2, 0),
+                (1, 2, 1),
+                (1, 2, 2),
+                (2, 2, 0),
+                (2, 2, 1),
+                (2, 2, 2),
+            ]
+        );
+        assert_eq!(random.next_f32(), 0.781_534_6);
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -126,6 +126,10 @@ fn for_each_maybe_box_position(
     }
 }
 
+fn is_supporting_box(min_x: i32, max_x: i32, mut is_air: impl FnMut(i32) -> bool) -> bool {
+    (min_x..=max_x).all(|x| !is_air(x))
+}
+
 pub struct MineshaftGenerator {
     pub is_mesa: bool,
 }
@@ -902,6 +906,14 @@ impl MineShaftCorridor {
         x1: i32,
         random: &mut RandomGenerator,
     ) {
+        if !is_supporting_box(x0, x1, |x| {
+            self.piece
+                .get_block_at(chunk, x, y1 + 1, z, chunk_box)
+                .is_air()
+        }) {
+            return;
+        }
+
         let planks = self.shaft_type.planks();
         let fence = self.shaft_type.fence();
 
@@ -1789,7 +1801,7 @@ impl StructurePieceBase for MineShaftStairs {
 
 #[cfg(test)]
 mod tests {
-    use super::{MineshaftType, for_each_maybe_box_position};
+    use super::{MineshaftType, for_each_maybe_box_position, is_supporting_box};
     use pumpkin_data::Block;
     use pumpkin_util::random::{RandomGenerator, RandomImpl, legacy_rand::LegacyRand};
 
@@ -1831,5 +1843,13 @@ mod tests {
             ]
         );
         assert_eq!(random.next_f32(), 0.781_534_6);
+    }
+
+    #[test]
+    fn corridor_support_requires_a_complete_non_air_ceiling() {
+        // Vanilla 26.2 MineShaftPiece.isSupportingBox:
+        // for (x = minX; x <= maxX; x++) if (getBlock(x, y + 1, z).isAir()) return false.
+        assert!(is_supporting_box(0, 2, |_| false));
+        assert!(!is_supporting_box(0, 2, |x| x == 1));
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -1432,7 +1432,11 @@ impl StructurePieceBase for MineShaftCorridor {
             if self.spider_corridor && !self.has_placed_spider {
                 let spawner_z = z - 1 + random.next_bounded_i32(3);
                 let spawner_pos = self.piece.offset_pos(1, 0, spawner_z);
-                if chunk_box.contains_pos(&spawner_pos) {
+                if chunk_box.contains_pos(&spawner_pos)
+                    && self
+                        .piece
+                        .is_under_sea_level(chunk, 1, 0, spawner_z, chunk_box)
+                {
                     self.has_placed_spider = true;
                     chunk.set_block_state(
                         spawner_pos.x,

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -52,6 +52,53 @@ impl MineshaftType {
             Self::Mesa => Block::DARK_OAK_FENCE.default_state,
         }
     }
+
+    fn can_replace(self, state: &BlockState) -> bool {
+        let block_id = state.id.to_block_id();
+        block_id != self.planks().id.to_block_id()
+            && block_id != self.wood().id.to_block_id()
+            && block_id != self.fence().id.to_block_id()
+            && block_id != Block::IRON_CHAIN.id
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn add_mineshaft_block(
+    piece: &StructurePiece,
+    shaft_type: MineshaftType,
+    chunk: &mut ProtoChunk,
+    state: &BlockState,
+    x: i32,
+    y: i32,
+    z: i32,
+    chunk_box: &BlockBox,
+) {
+    if shaft_type.can_replace(piece.get_block_at(chunk, x, y, z, chunk_box)) {
+        piece.add_block(chunk, state, x, y, z, chunk_box);
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn fill_mineshaft_box(
+    piece: &StructurePiece,
+    shaft_type: MineshaftType,
+    chunk: &mut ProtoChunk,
+    chunk_box: &BlockBox,
+    min_x: i32,
+    min_y: i32,
+    min_z: i32,
+    max_x: i32,
+    max_y: i32,
+    max_z: i32,
+    state: &BlockState,
+) {
+    for y in min_y..=max_y {
+        for x in min_x..=max_x {
+            for z in min_z..=max_z {
+                add_mineshaft_block(piece, shaft_type, chunk, state, x, y, z, chunk_box);
+            }
+        }
+    }
 }
 
 pub struct MineshaftGenerator {
@@ -833,19 +880,74 @@ impl MineShaftCorridor {
         let planks = self.shaft_type.planks();
         let fence = self.shaft_type.fence();
 
-        self.piece
-            .fill(chunk, chunk_box, x0, y0, z, x0, y1 - 1, z, fence);
-        self.piece
-            .fill(chunk, chunk_box, x1, y0, z, x1, y1 - 1, z, fence);
+        fill_mineshaft_box(
+            &self.piece,
+            self.shaft_type,
+            chunk,
+            chunk_box,
+            x0,
+            y0,
+            z,
+            x0,
+            y1 - 1,
+            z,
+            fence,
+        );
+        fill_mineshaft_box(
+            &self.piece,
+            self.shaft_type,
+            chunk,
+            chunk_box,
+            x1,
+            y0,
+            z,
+            x1,
+            y1 - 1,
+            z,
+            fence,
+        );
 
         if random.next_bounded_i32(4) == 0 {
-            self.piece
-                .fill(chunk, chunk_box, x0, y1, z, x0, y1, z, planks);
-            self.piece
-                .fill(chunk, chunk_box, x1, y1, z, x1, y1, z, planks);
+            fill_mineshaft_box(
+                &self.piece,
+                self.shaft_type,
+                chunk,
+                chunk_box,
+                x0,
+                y1,
+                z,
+                x0,
+                y1,
+                z,
+                planks,
+            );
+            fill_mineshaft_box(
+                &self.piece,
+                self.shaft_type,
+                chunk,
+                chunk_box,
+                x1,
+                y1,
+                z,
+                x1,
+                y1,
+                z,
+                planks,
+            );
         } else {
-            self.piece
-                .fill(chunk, chunk_box, x0, y1, z, x1, y1, z, planks);
+            fill_mineshaft_box(
+                &self.piece,
+                self.shaft_type,
+                chunk,
+                chunk_box,
+                x0,
+                y1,
+                z,
+                x1,
+                y1,
+                z,
+                planks,
+            );
 
             let mut props_s = WallTorchLikeProperties::default(&Block::WALL_TORCH);
             props_s.facing = HorizontalFacing::South;
@@ -856,12 +958,28 @@ impl MineShaftCorridor {
             let torch_n = BlockState::from_id(props_n.to_state_id(&Block::WALL_TORCH));
 
             if random.next_f32() < 0.05 {
-                self.piece
-                    .add_block(chunk, torch_s, x0 + 1, y1, z - 1, chunk_box);
+                add_mineshaft_block(
+                    &self.piece,
+                    self.shaft_type,
+                    chunk,
+                    torch_s,
+                    x0 + 1,
+                    y1,
+                    z - 1,
+                    chunk_box,
+                );
             }
             if random.next_f32() < 0.05 {
-                self.piece
-                    .add_block(chunk, torch_n, x0 + 1, y1, z + 1, chunk_box);
+                add_mineshaft_block(
+                    &self.piece,
+                    self.shaft_type,
+                    chunk,
+                    torch_n,
+                    x0 + 1,
+                    y1,
+                    z + 1,
+                    chunk_box,
+                );
             }
         }
     }
@@ -956,17 +1074,45 @@ impl StructurePieceBase for MineShaftCorridor {
         let length = self.num_sections * 5 - 1;
         let planks = self.shaft_type.planks();
 
-        self.piece
-            .fill(chunk, chunk_box, 0, 0, 0, 2, 1, length, air);
+        fill_mineshaft_box(
+            &self.piece,
+            self.shaft_type,
+            chunk,
+            chunk_box,
+            0,
+            0,
+            0,
+            2,
+            1,
+            length,
+            air,
+        );
 
         for z in 0..=length {
             for x in 0..=2 {
                 if random.next_f32() < 0.8 {
-                    self.piece.add_block(chunk, air, x, 2, z, chunk_box);
+                    add_mineshaft_block(
+                        &self.piece,
+                        self.shaft_type,
+                        chunk,
+                        air,
+                        x,
+                        2,
+                        z,
+                        chunk_box,
+                    );
                 }
                 if self.spider_corridor && random.next_f32() < 0.6 {
-                    self.piece
-                        .add_block(chunk, Block::COBWEB.default_state, x, 0, z, chunk_box);
+                    add_mineshaft_block(
+                        &self.piece,
+                        self.shaft_type,
+                        chunk,
+                        Block::COBWEB.default_state,
+                        x,
+                        0,
+                        z,
+                        chunk_box,
+                    );
                 }
             }
         }
@@ -986,8 +1132,16 @@ impl StructurePieceBase for MineShaftCorridor {
                 (2, 2, z + 2, 0.05),
             ] {
                 if random.next_f32() < prob {
-                    self.piece
-                        .add_block(chunk, Block::COBWEB.default_state, cx, cy, cz, chunk_box);
+                    add_mineshaft_block(
+                        &self.piece,
+                        self.shaft_type,
+                        chunk,
+                        Block::COBWEB.default_state,
+                        cx,
+                        cy,
+                        cz,
+                        chunk_box,
+                    );
                 }
             }
 
@@ -1068,7 +1222,16 @@ impl StructurePieceBase for MineShaftCorridor {
                 if chunk_box.contains_pos(&floor_pos) {
                     let floor_state = chunk.get_block_state(&floor_pos);
                     if !floor_state.to_state().is_air() && random.next_f32() < 0.7 {
-                        self.piece.add_block(chunk, rail, 1, 0, z, chunk_box);
+                        add_mineshaft_block(
+                            &self.piece,
+                            self.shaft_type,
+                            chunk,
+                            rail,
+                            1,
+                            0,
+                            z,
+                            chunk_box,
+                        );
                     }
                 }
             }
@@ -1603,6 +1766,26 @@ impl StructurePieceBase for MineShaftStairs {
             let z = 2 + i;
             self.piece
                 .fill(chunk, chunk_box, 0, y_min, z, 2, y_max, z, air);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MineshaftType;
+    use pumpkin_data::Block;
+
+    #[test]
+    fn mineshaft_can_be_replaced_excludes_its_own_building_blocks() {
+        // Vanilla 26.2 MineShaftPiece.canBeReplaced:
+        // state is neither type.planks nor type.wood nor type.fence nor IRON_CHAIN.
+        for shaft_type in [MineshaftType::Normal, MineshaftType::Mesa] {
+            assert!(!shaft_type.can_replace(shaft_type.planks()));
+            assert!(!shaft_type.can_replace(shaft_type.wood()));
+            assert!(!shaft_type.can_replace(shaft_type.fence()));
+            assert!(!shaft_type.can_replace(Block::IRON_CHAIN.default_state));
+            assert!(shaft_type.can_replace(Block::STONE.default_state));
+            assert!(shaft_type.can_replace(Block::CAVE_AIR.default_state));
         }
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use pumpkin_data::{
     Block, BlockDirection as DataBlockDirection, BlockState,
-    block_properties::{HorizontalFacing, WallTorchLikeProperties},
+    block_properties::{HorizontalFacing, OakFenceLikeProperties, WallTorchLikeProperties},
 };
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::{
@@ -51,6 +51,17 @@ impl MineshaftType {
             Self::Normal => Block::OAK_FENCE.default_state,
             Self::Mesa => Block::DARK_OAK_FENCE.default_state,
         }
+    }
+
+    fn connected_fence(self, west: bool, east: bool) -> &'static BlockState {
+        let block = match self {
+            Self::Normal => &Block::OAK_FENCE,
+            Self::Mesa => &Block::DARK_OAK_FENCE,
+        };
+        let mut properties = OakFenceLikeProperties::default(block);
+        properties.west = west;
+        properties.east = east;
+        BlockState::from_id(properties.to_state_id(block))
     }
 
     fn can_replace(self, state: &BlockState) -> bool {
@@ -923,7 +934,8 @@ impl MineShaftCorridor {
         }
 
         let planks = self.shaft_type.planks();
-        let fence = self.shaft_type.fence();
+        let west_fence = self.shaft_type.connected_fence(true, false);
+        let east_fence = self.shaft_type.connected_fence(false, true);
 
         fill_mineshaft_box(
             &self.piece,
@@ -936,7 +948,7 @@ impl MineShaftCorridor {
             x0,
             y1 - 1,
             z,
-            fence,
+            west_fence,
         );
         fill_mineshaft_box(
             &self.piece,
@@ -949,7 +961,7 @@ impl MineShaftCorridor {
             x1,
             y1 - 1,
             z,
-            fence,
+            east_fence,
         );
 
         if random.next_bounded_i32(4) == 0 {
@@ -1934,5 +1946,19 @@ mod tests {
         // float chance = isInterior(world, 1, 0, z, box) ? 0.7F : 0.9F.
         assert_eq!(rail_chance(true), 0.7);
         assert_eq!(rail_chance(false), 0.9);
+    }
+
+    #[test]
+    fn corridor_support_fences_connect_toward_the_beam() {
+        // Vanilla 26.2 MineShaftCorridor.placeSupport uses
+        // fence.setValue(WEST, true) at x0 and fence.setValue(EAST, true) at x1.
+        let west = MineshaftType::Mesa.connected_fence(true, false);
+        let east = MineshaftType::Mesa.connected_fence(false, true);
+        let west_props =
+            pumpkin_data::block_properties::OakFenceLikeProperties::from_state_id(west.id);
+        let east_props =
+            pumpkin_data::block_properties::OakFenceLikeProperties::from_state_id(east.id);
+        assert!(west_props.west && !west_props.east);
+        assert!(!east_props.west && east_props.east);
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -149,6 +149,55 @@ const fn rail_chance(is_interior: bool) -> f32 {
     if is_interior { 0.7 } else { 0.9 }
 }
 
+fn boundary_matches(
+    piece_box: &BlockBox,
+    chunk_box: &BlockBox,
+    mut predicate: impl FnMut(i32, i32, i32) -> bool,
+) -> bool {
+    let min_x = (piece_box.min.x - 1).max(chunk_box.min.x);
+    let min_y = (piece_box.min.y - 1).max(chunk_box.min.y);
+    let min_z = (piece_box.min.z - 1).max(chunk_box.min.z);
+    let max_x = (piece_box.max.x + 1).min(chunk_box.max.x);
+    let max_y = (piece_box.max.y + 1).min(chunk_box.max.y);
+    let max_z = (piece_box.max.z + 1).min(chunk_box.max.z);
+
+    for x in min_x..=max_x {
+        for z in min_z..=max_z {
+            if predicate(x, min_y, z) || predicate(x, max_y, z) {
+                return true;
+            }
+        }
+    }
+    for x in min_x..=max_x {
+        for y in min_y..=max_y {
+            if predicate(x, y, min_z) || predicate(x, y, max_z) {
+                return true;
+            }
+        }
+    }
+    for z in min_z..=max_z {
+        for y in min_y..=max_y {
+            if predicate(min_x, y, z) || predicate(max_x, y, z) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn is_in_invalid_liquid_location(
+    chunk: &ProtoChunk,
+    piece_box: &BlockBox,
+    chunk_box: &BlockBox,
+) -> bool {
+    boundary_matches(piece_box, chunk_box, |x, y, z| {
+        chunk
+            .get_block_state(&Vector3::new(x, y, z))
+            .to_state()
+            .is_liquid()
+    })
+}
+
 pub struct MineshaftGenerator {
     pub is_mesa: bool,
 }
@@ -552,6 +601,10 @@ impl StructurePieceBase for MineShaftRoom {
         _seed: i64,
         chunk_box: &BlockBox,
     ) {
+        if is_in_invalid_liquid_location(chunk, &self.piece.bounding_box, chunk_box) {
+            return;
+        }
+
         let air = Block::CAVE_AIR.default_state;
         let bb = self.piece.bounding_box;
 
@@ -1188,6 +1241,10 @@ impl StructurePieceBase for MineShaftCorridor {
         _seed: i64,
         chunk_box: &BlockBox,
     ) {
+        if is_in_invalid_liquid_location(chunk, &self.piece.bounding_box, chunk_box) {
+            return;
+        }
+
         let air = Block::CAVE_AIR.default_state;
         let length = self.num_sections * 5 - 1;
         let planks = self.shaft_type.planks();
@@ -1634,6 +1691,10 @@ impl StructurePieceBase for MineShaftCrossing {
         _seed: i64,
         chunk_box: &BlockBox,
     ) {
+        if is_in_invalid_liquid_location(chunk, &self.piece.bounding_box, chunk_box) {
+            return;
+        }
+
         let air = Block::CAVE_AIR.default_state;
         let planks = self.shaft_type.planks();
         let bb = self.piece.bounding_box;
@@ -1859,6 +1920,10 @@ impl StructurePieceBase for MineShaftStairs {
         _seed: i64,
         chunk_box: &BlockBox,
     ) {
+        if is_in_invalid_liquid_location(chunk, &self.piece.bounding_box, chunk_box) {
+            return;
+        }
+
         let air = Block::CAVE_AIR.default_state;
         self.piece.fill(chunk, chunk_box, 0, 5, 0, 2, 7, 1, air);
         self.piece.fill(chunk, chunk_box, 0, 0, 7, 2, 2, 8, air);
@@ -1877,7 +1942,7 @@ impl StructurePieceBase for MineShaftStairs {
 mod tests {
     use super::{
         MineshaftType, for_each_maybe_box_position, is_supporting_box, passes_cobweb_random_gate,
-        rail_chance,
+        boundary_matches, rail_chance,
     };
     use pumpkin_data::Block;
     use pumpkin_util::random::{RandomGenerator, RandomImpl, legacy_rand::LegacyRand};
@@ -1967,5 +2032,19 @@ mod tests {
         // Vanilla 26.2 fillColumnBetween: for (int y = start; y < end; ++y).
         assert_eq!((6..10).collect::<Vec<_>>(), [6, 7, 8, 9]);
         assert_eq!((12..12).count(), 0);
+    }
+
+    #[test]
+    fn invalid_location_scans_only_the_expanded_piece_boundary() {
+        // Vanilla 26.2 MineShaftPiece.isInInvalidLocation scans the six faces of
+        // piece.boundingBox inflated by one and intersected with the chunk box.
+        let piece = pumpkin_util::math::block_box::BlockBox::new(10, 20, 30, 12, 22, 32);
+        let chunk = pumpkin_util::math::block_box::BlockBox::new(0, 0, 0, 40, 40, 40);
+        assert!(boundary_matches(&piece, &chunk, |x, y, z| {
+            x == 9 && y == 20 && z == 31
+        }));
+        assert!(!boundary_matches(&piece, &chunk, |x, y, z| {
+            x == 11 && y == 21 && z == 31
+        }));
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -184,25 +184,12 @@ fn set_planks_block(
     }
 }
 
-/// Vanilla `MineshaftPieces$MineShaftCorridor.createChest`
-/// (`MineshaftPieces.java:355-378`) overrides the generic
-/// `StructurePiece.createChest`: it does *not* place a chest block. It places a
-/// rail whose shape comes from `random.nextBoolean()` and spawns a
-/// `chest_minecart` entity whose loot seed is `random.nextLong()`:
-///
-/// ```java
-/// BlockPos pos = this.getWorldPos(x, y, z);
-/// if (chunkBB.isInside(pos) && level.getBlockState(pos).isAir() && !level.getBlockState(pos.below()).isAir()) {
-///    BlockState state = Blocks.RAIL.defaultBlockState()
-///        .setValue(RailBlock.SHAPE, random.nextBoolean() ? RailShape.NORTH_SOUTH : RailShape.EAST_WEST);
-///    this.placeBlock(level, state, x, y, z, chunkBB);
-///    MinecartChest chest = EntityTypes.CHEST_MINECART.create(...);
-///    chest.setLootTable(lootTable, random.nextLong());
-///    ...
-///    return true;
-/// }
-/// return false;
-/// ```
+/// Vanilla `MineshaftPieces$MineShaftCorridor.createChest` overrides the generic
+/// `StructurePiece.createChest`: it does *not* place a chest block. The gate is that the world
+/// position lies inside the chunk bounding box, holds air, and has a non-air block beneath it.
+/// When it passes, the piece places a rail whose shape comes from `random.nextBoolean()` —
+/// north-south or east-west — and spawns a `chest_minecart` entity whose loot seed is
+/// `random.nextLong()`.
 ///
 /// So the gate consumes **no** random at all when it fails, and exactly **two**
 /// draws (a boolean then a long) when it succeeds.
@@ -328,8 +315,8 @@ impl StructureGenerator for MineshaftGenerator {
 
         let mut start_room = MineShaftRoom::new(0, &mut context.random, room_x, room_z, shaft_type);
 
-        // Vanilla `MineshaftStructure.generatePiecesAndAdjust`: `builder.addPiece(room);
-        // room.addChildren(room, builder, random);` — the room is in the collector while its
+        // Vanilla `MineshaftStructure.generatePiecesAndAdjust` adds the room to the collector and
+        // only then generates its children — the room is in the collector while its
         // children (and, depth-first, their children) are generated, and it collects the
         // entrance boxes along the way, so write the finished room back over the placeholder.
         let mut collector = StructurePiecesCollector::default();
@@ -2123,10 +2110,9 @@ mod tests {
 
     #[test]
     fn minecart_chest_places_a_rail_not_a_chest() {
-        // Vanilla 26.2 MineshaftPieces$MineShaftCorridor.createChest:
-        //   BlockState state = Blocks.RAIL.defaultBlockState()
-        //       .setValue(RailBlock.SHAPE, random.nextBoolean() ? RailShape.NORTH_SOUTH
-        //                                                       : RailShape.EAST_WEST);
+        // Vanilla 26.2 `MineshaftPieces$MineShaftCorridor.createChest` places the default rail
+        // state with its shape property set from a `nextBoolean` — north-south on true,
+        // east-west on false.
         // The corridor never writes a chest block; the loot lives in a
         // `chest_minecart` entity spawned on top of the rail.
         let north_south = minecart_chest_rail(true);
@@ -2135,8 +2121,8 @@ mod tests {
         assert_eq!(BlockId::from_state_id(north_south.id), Block::RAIL.id);
         assert_eq!(BlockId::from_state_id(east_west.id), Block::RAIL.id);
         assert_ne!(north_south.id, east_west.id);
-        // `Blocks.RAIL.defaultBlockState()` already carries SHAPE=north_south, so
-        // the `nextBoolean() == true` branch must be exactly the default state.
+        // The rail's default state already carries SHAPE=north_south, so the
+        // `nextBoolean() == true` branch must be exactly the default state.
         assert_eq!(north_south.id, Block::RAIL.default_state.id);
         assert_eq!(
             RailLikeProperties::from_state_id(east_west.id).shape,
@@ -2164,8 +2150,8 @@ mod tests {
 
     #[test]
     fn generate_maybe_box_draws_in_y_x_z_order_before_placement_gates() {
-        // Vanilla 26.2 StructurePiece.generateMaybeBox:
-        // for (y) for (x) for (z) if (random.nextFloat() > chance) continue.
+        // Vanilla 26.2 `StructurePiece.generateMaybeBox` walks Y, then X, then Z, and draws one
+        // `nextFloat` per position, skipping the position when the draw exceeds the chance.
         let mut random = RandomGenerator::Legacy(LegacyRand::from_seed(0));
         let mut accepted = Vec::new();
         for_each_maybe_box_position(&mut random, 0.8, 0, 2, 0, 2, 2, 2, |x, y, z| {
@@ -2190,16 +2176,17 @@ mod tests {
 
     #[test]
     fn corridor_support_requires_a_complete_non_air_ceiling() {
-        // Vanilla 26.2 MineShaftPiece.isSupportingBox:
-        // for (x = minX; x <= maxX; x++) if (getBlock(x, y + 1, z).isAir()) return false.
+        // Vanilla 26.2 `MineShaftPiece.isSupportingBox` walks the span and fails as soon as one
+        // block above the row is air.
         assert!(is_supporting_box(0, 2, |_| false));
         assert!(!is_supporting_box(0, 2, |x| x == 1));
     }
 
     #[test]
     fn cobweb_interior_gate_precedes_the_random_draw() {
-        // Vanilla 26.2 MineShaftCorridor.maybePlaceCobWeb:
-        // isInterior(...) && random.nextFloat() < chance && hasSturdyNeighbours(..., 2).
+        // Vanilla 26.2 `MineShaftCorridor.maybePlaceCobWeb` gates on the interior test first, then
+        // the `nextFloat` against the chance, and only then on having two sturdy neighbours — so a
+        // non-interior position spends no draw at all.
         let mut random = RandomGenerator::Legacy(LegacyRand::from_seed(0));
         assert!(!passes_cobweb_random_gate(&mut random, 0.8, false));
         assert!(passes_cobweb_random_gate(&mut random, 0.8, true));
@@ -2208,16 +2195,16 @@ mod tests {
 
     #[test]
     fn corridor_rail_chance_depends_on_interior_status() {
-        // Vanilla 26.2 MineShaftCorridor.postProcess:
-        // float chance = isInterior(world, 1, 0, z, box) ? 0.7F : 0.9F.
+        // Vanilla 26.2 `MineShaftCorridor.postProcess` uses 0.7 for an interior column and 0.9
+        // otherwise.
         assert_eq!(rail_chance(true), 0.7);
         assert_eq!(rail_chance(false), 0.9);
     }
 
     #[test]
     fn corridor_support_fences_connect_toward_the_beam() {
-        // Vanilla 26.2 MineShaftCorridor.placeSupport uses
-        // fence.setValue(WEST, true) at x0 and fence.setValue(EAST, true) at x1.
+        // Vanilla 26.2 `MineShaftCorridor.placeSupport` sets the west connection on the low-x
+        // fence and the east connection on the high-x one.
         let west = MineshaftType::Mesa.connected_fence(true, false);
         let east = MineshaftType::Mesa.connected_fence(false, true);
         let west_props =
@@ -2230,7 +2217,7 @@ mod tests {
 
     #[test]
     fn pillar_fill_column_excludes_its_anchor_endpoint() {
-        // Vanilla 26.2 fillColumnBetween: for (int y = start; y < end; ++y).
+        // Vanilla 26.2 `fillColumnBetween` runs from the start Y up to, but not including, the end.
         assert_eq!((6..10).collect::<Vec<_>>(), [6, 7, 8, 9]);
         assert_eq!((12..12).count(), 0);
     }
@@ -2251,12 +2238,9 @@ mod tests {
 
     #[test]
     fn floor_planks_need_interior_and_a_non_sturdy_top_face() {
-        // Vanilla 26.2 MineShaftPiece.setPlanksBlock:
-        //   if (this.isInterior(level, x, y, z, chunkBB)) {
-        //       BlockState existingState = level.getBlockState(pos);
-        //       if (!existingState.isFaceSturdy(level, pos, Direction.UP)) { setBlock(planks) }
-        //   }
-        // so both a non-interior position and a sturdy upward face suppress the plank.
+        // Vanilla 26.2 `MineShaftPiece.setPlanksBlock` places the plank only for an interior
+        // position whose existing state has a non-sturdy upward face, so both a non-interior
+        // position and a sturdy upward face suppress the plank.
         assert!(places_floor_planks(true, false));
         assert!(!places_floor_planks(true, true));
         assert!(!places_floor_planks(false, false));

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use pumpkin_data::{
     Block, BlockDirection as DataBlockDirection, BlockState,
-    block_properties::{HorizontalFacing, OakFenceLikeProperties, WallTorchLikeProperties},
+    block_properties::{
+        HorizontalFacing, OakFenceLikeProperties, RailLikeProperties, RailShape,
+        WallTorchLikeProperties,
+    },
 };
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_util::{
@@ -179,6 +182,40 @@ fn set_planks_block(
     if places_floor_planks(is_interior, sturdy) {
         chunk.set_block_state(pos.x, pos.y, pos.z, planks);
     }
+}
+
+/// Vanilla `MineshaftPieces$MineShaftCorridor.createChest`
+/// (`MineshaftPieces.java:355-378`) overrides the generic
+/// `StructurePiece.createChest`: it does *not* place a chest block. It places a
+/// rail whose shape comes from `random.nextBoolean()` and spawns a
+/// `chest_minecart` entity whose loot seed is `random.nextLong()`:
+///
+/// ```java
+/// BlockPos pos = this.getWorldPos(x, y, z);
+/// if (chunkBB.isInside(pos) && level.getBlockState(pos).isAir() && !level.getBlockState(pos.below()).isAir()) {
+///    BlockState state = Blocks.RAIL.defaultBlockState()
+///        .setValue(RailBlock.SHAPE, random.nextBoolean() ? RailShape.NORTH_SOUTH : RailShape.EAST_WEST);
+///    this.placeBlock(level, state, x, y, z, chunkBB);
+///    MinecartChest chest = EntityTypes.CHEST_MINECART.create(...);
+///    chest.setLootTable(lootTable, random.nextLong());
+///    ...
+///    return true;
+/// }
+/// return false;
+/// ```
+///
+/// So the gate consumes **no** random at all when it fails, and exactly **two**
+/// draws (a boolean then a long) when it succeeds.
+fn minecart_chest_rail(north_south: bool) -> &'static BlockState {
+    let props = RailLikeProperties {
+        shape: if north_south {
+            RailShape::NorthSouth
+        } else {
+            RailShape::EastWest
+        },
+        waterlogged: false,
+    };
+    BlockState::from_id(props.to_state_id(&Block::RAIL))
 }
 
 fn boundary_matches(
@@ -1260,6 +1297,62 @@ impl MineShaftCorridor {
         }
     }
 
+    /// Vanilla `MineShaftCorridor.createChest`: a rail plus a `chest_minecart`
+    /// entity, gated on the target being air with a non-air block below it. See
+    /// [`minecart_chest_rail`] for the vanilla source.
+    fn create_minecart_chest(
+        &self,
+        chunk: &mut ProtoChunk,
+        chunk_box: &BlockBox,
+        random: &mut RandomGenerator,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) -> bool {
+        let pos = self.piece.offset_pos(x, y, z);
+        if !chunk_box.contains_pos(&pos) {
+            return false;
+        }
+        if !chunk.get_block_state(&pos).to_state().is_air() {
+            return false;
+        }
+        let below = Vector3::new(pos.x, pos.y - 1, pos.z);
+        if chunk.get_block_state(&below).to_state().is_air() {
+            return false;
+        }
+
+        let rail = minecart_chest_rail(random.next_bool());
+        add_mineshaft_block(
+            &self.piece,
+            self.shaft_type,
+            chunk,
+            rail,
+            x,
+            y,
+            z,
+            chunk_box,
+        );
+
+        let loot_seed = random.next_i64();
+        let mut nbt = NbtCompound::new();
+        nbt.put_string("id", "minecraft:chest_minecart".to_string());
+        nbt.put_list(
+            "Pos",
+            vec![
+                (f64::from(pos.x) + 0.5).into(),
+                (f64::from(pos.y) + 0.5).into(),
+                (f64::from(pos.z) + 0.5).into(),
+            ],
+        );
+        nbt.put_string(
+            "LootTable",
+            "minecraft:chests/abandoned_mineshaft".to_string(),
+        );
+        nbt.put_long("LootTableSeed", loot_seed);
+        chunk.add_structure_entity(nbt);
+        true
+    }
+
     #[expect(clippy::too_many_arguments)]
     fn maybe_place_cobweb(
         &self,
@@ -1406,26 +1499,10 @@ impl StructurePieceBase for MineShaftCorridor {
             }
 
             if random.next_bounded_i32(100) == 0 {
-                self.piece.add_chest(
-                    chunk,
-                    chunk_box,
-                    random,
-                    2,
-                    0,
-                    z - 1,
-                    "minecraft:chests/abandoned_mineshaft",
-                );
+                self.create_minecart_chest(chunk, chunk_box, random, 2, 0, z - 1);
             }
             if random.next_bounded_i32(100) == 0 {
-                self.piece.add_chest(
-                    chunk,
-                    chunk_box,
-                    random,
-                    0,
-                    0,
-                    z + 1,
-                    "minecraft:chests/abandoned_mineshaft",
-                );
+                self.create_minecart_chest(chunk, chunk_box, random, 0, 0, z + 1);
             }
 
             if self.spider_corridor && !self.has_placed_spider {
@@ -2037,10 +2114,39 @@ impl StructurePieceBase for MineShaftStairs {
 mod tests {
     use super::{
         MineshaftType, boundary_matches, for_each_maybe_box_position, is_falling_block,
-        is_supporting_box, passes_cobweb_random_gate, places_floor_planks, rail_chance,
+        is_supporting_box, minecart_chest_rail, passes_cobweb_random_gate, places_floor_planks,
+        rail_chance,
     };
-    use pumpkin_data::Block;
+    use pumpkin_data::block_properties::{RailLikeProperties, RailShape};
+    use pumpkin_data::{Block, BlockId};
     use pumpkin_util::random::{RandomGenerator, RandomImpl, legacy_rand::LegacyRand};
+
+    #[test]
+    fn minecart_chest_places_a_rail_not_a_chest() {
+        // Vanilla 26.2 MineshaftPieces$MineShaftCorridor.createChest:
+        //   BlockState state = Blocks.RAIL.defaultBlockState()
+        //       .setValue(RailBlock.SHAPE, random.nextBoolean() ? RailShape.NORTH_SOUTH
+        //                                                       : RailShape.EAST_WEST);
+        // The corridor never writes a chest block; the loot lives in a
+        // `chest_minecart` entity spawned on top of the rail.
+        let north_south = minecart_chest_rail(true);
+        let east_west = minecart_chest_rail(false);
+
+        assert_eq!(BlockId::from_state_id(north_south.id), Block::RAIL.id);
+        assert_eq!(BlockId::from_state_id(east_west.id), Block::RAIL.id);
+        assert_ne!(north_south.id, east_west.id);
+        // `Blocks.RAIL.defaultBlockState()` already carries SHAPE=north_south, so
+        // the `nextBoolean() == true` branch must be exactly the default state.
+        assert_eq!(north_south.id, Block::RAIL.default_state.id);
+        assert_eq!(
+            RailLikeProperties::from_state_id(east_west.id).shape,
+            RailShape::EastWest
+        );
+        assert_eq!(
+            RailLikeProperties::from_state_id(north_south.id).shape,
+            RailShape::NorthSouth
+        );
+    }
 
     #[test]
     fn mineshaft_can_be_replaced_excludes_its_own_building_blocks() {

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -1036,7 +1036,7 @@ impl MineShaftCorridor {
         }
     }
 
-    #[expect(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments, clippy::too_many_lines)]
     fn place_support(
         &self,
         chunk: &mut ProtoChunk,
@@ -1217,11 +1217,7 @@ impl MineShaftCorridor {
                     state_below.to_state(),
                     state_below.to_block(),
                 ) && state_below.to_block_id() != Block::LAVA.id;
-                if !empty_below
-                    && state_below
-                        .to_state()
-                        .is_side_solid(DataBlockDirection::Up)
-                {
+                if !empty_below && state_below.to_state().is_side_solid(DataBlockDirection::Up) {
                     for py in (below_y + 1)..world_y {
                         chunk.set_block_state(world_pos.x, py, world_pos.z, self.shaft_type.wood());
                     }
@@ -1238,7 +1234,9 @@ impl MineShaftCorridor {
                     state_above.to_state(),
                     state_above.to_block(),
                 );
-                if !empty_above && can_hang_chain_below(state_above.to_state(), state_above.to_block()) {
+                if !empty_above
+                    && can_hang_chain_below(state_above.to_state(), state_above.to_block())
+                {
                     chunk.set_block_state(
                         world_pos.x,
                         world_y + 1,
@@ -1262,6 +1260,7 @@ impl MineShaftCorridor {
         }
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn maybe_place_cobweb(
         &self,
         chunk: &mut ProtoChunk,

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -230,6 +230,44 @@ fn is_in_invalid_liquid_location(
     })
 }
 
+/// Vanilla `Block.canSupportCenter(level, pos, Direction.DOWN)` combined with the
+/// `!(stateAbove.getBlock() instanceof FallingBlock)` test of
+/// `MineShaftCorridor.canHangChainBelow`. The 26.2 `FallingBlock` subclasses are
+/// `AnvilBlock`, `ColoredFallingBlock`, `ConcretePowderBlock`, `DragonEggBlock`
+/// and `SandBlock`.
+fn is_falling_block(block: &Block) -> bool {
+    matches!(
+        block.id,
+        id if id == Block::ANVIL.id
+            || id == Block::CHIPPED_ANVIL.id
+            || id == Block::DAMAGED_ANVIL.id
+            || id == Block::DRAGON_EGG.id
+            || id == Block::SAND.id
+            || id == Block::RED_SAND.id
+            || id == Block::GRAVEL.id
+            || id == Block::WHITE_CONCRETE_POWDER.id
+            || id == Block::ORANGE_CONCRETE_POWDER.id
+            || id == Block::MAGENTA_CONCRETE_POWDER.id
+            || id == Block::LIGHT_BLUE_CONCRETE_POWDER.id
+            || id == Block::YELLOW_CONCRETE_POWDER.id
+            || id == Block::LIME_CONCRETE_POWDER.id
+            || id == Block::PINK_CONCRETE_POWDER.id
+            || id == Block::GRAY_CONCRETE_POWDER.id
+            || id == Block::LIGHT_GRAY_CONCRETE_POWDER.id
+            || id == Block::CYAN_CONCRETE_POWDER.id
+            || id == Block::PURPLE_CONCRETE_POWDER.id
+            || id == Block::BLUE_CONCRETE_POWDER.id
+            || id == Block::BROWN_CONCRETE_POWDER.id
+            || id == Block::GREEN_CONCRETE_POWDER.id
+            || id == Block::RED_CONCRETE_POWDER.id
+            || id == Block::BLACK_CONCRETE_POWDER.id
+    )
+}
+
+fn can_hang_chain_below(state: &BlockState, block: &Block) -> bool {
+    state.is_center_solid(DataBlockDirection::Down) && !is_falling_block(block)
+}
+
 pub struct MineshaftGenerator {
     pub is_mesa: bool,
 }
@@ -1175,9 +1213,15 @@ impl MineShaftCorridor {
                 let below_y = world_y - dist;
                 let state_below =
                     chunk.get_block_state(&Vector3::new(world_pos.x, below_y, world_pos.z));
-                let empty_below =
-                    state_below.to_state().is_air() || state_below.to_block_id() == Block::WATER.id;
-                if !empty_below && state_below.to_block_id() != Block::LAVA.id {
+                let empty_below = StructurePiece::is_replaceable_by_structures(
+                    state_below.to_state(),
+                    state_below.to_block(),
+                ) && state_below.to_block_id() != Block::LAVA.id;
+                if !empty_below
+                    && state_below
+                        .to_state()
+                        .is_side_solid(DataBlockDirection::Up)
+                {
                     for py in (below_y + 1)..world_y {
                         chunk.set_block_state(world_pos.x, py, world_pos.z, self.shaft_type.wood());
                     }
@@ -1190,8 +1234,11 @@ impl MineShaftCorridor {
                 let above_y = world_y + dist;
                 let state_above =
                     chunk.get_block_state(&Vector3::new(world_pos.x, above_y, world_pos.z));
-                let empty_above = state_above.to_state().is_air();
-                if !empty_above {
+                let empty_above = StructurePiece::is_replaceable_by_structures(
+                    state_above.to_state(),
+                    state_above.to_block(),
+                );
+                if !empty_above && can_hang_chain_below(state_above.to_state(), state_above.to_block()) {
                     chunk.set_block_state(
                         world_pos.x,
                         world_y + 1,
@@ -1986,8 +2033,8 @@ impl StructurePieceBase for MineShaftStairs {
 #[cfg(test)]
 mod tests {
     use super::{
-        MineshaftType, boundary_matches, for_each_maybe_box_position, is_supporting_box,
-        passes_cobweb_random_gate, places_floor_planks, rail_chance,
+        MineshaftType, boundary_matches, for_each_maybe_box_position, is_falling_block,
+        is_supporting_box, passes_cobweb_random_gate, places_floor_planks, rail_chance,
     };
     use pumpkin_data::Block;
     use pumpkin_util::random::{RandomGenerator, RandomImpl, legacy_rand::LegacyRand};
@@ -2114,5 +2161,26 @@ mod tests {
         // i.e. the two wall columns of the 3-wide corridor, in that order.
         let x = 0;
         assert_eq!([x, x + 2], [0, 2]);
+    }
+
+    #[test]
+    fn chains_do_not_hang_from_falling_blocks() {
+        // Vanilla 26.2 MineShaftCorridor.canHangChainBelow rejects any
+        // `stateAbove.getBlock() instanceof FallingBlock`; the FallingBlock
+        // subclasses in 26.2 are AnvilBlock, ColoredFallingBlock,
+        // ConcretePowderBlock, DragonEggBlock and SandBlock.
+        for block in [
+            &Block::SAND,
+            &Block::RED_SAND,
+            &Block::GRAVEL,
+            &Block::ANVIL,
+            &Block::DRAGON_EGG,
+            &Block::BLACK_CONCRETE_POWDER,
+        ] {
+            assert!(is_falling_block(block), "{} should fall", block.name);
+        }
+        for block in [&Block::STONE, &Block::DEEPSLATE, &Block::DARK_OAK_PLANKS] {
+            assert!(!is_falling_block(block), "{} should not fall", block.name);
+        }
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -149,6 +149,38 @@ const fn rail_chance(is_interior: bool) -> f32 {
     if is_interior { 0.7 } else { 0.9 }
 }
 
+/// Vanilla `MineshaftPieces$MineShaftPiece.setPlanksBlock`: the floor block is
+/// only planked when the position is *interior* (the block above it still sits
+/// under the `OCEAN_FLOOR_WG` heightmap) and the existing block's upward face is
+/// not sturdy. It writes with `level.setBlock`, so `canBeReplaced` does not apply.
+const fn places_floor_planks(is_interior: bool, existing_up_face_sturdy: bool) -> bool {
+    is_interior && !existing_up_face_sturdy
+}
+
+fn set_planks_block(
+    piece: &StructurePiece,
+    chunk: &mut ProtoChunk,
+    chunk_box: &BlockBox,
+    planks: &'static BlockState,
+    x: i32,
+    y: i32,
+    z: i32,
+) {
+    let is_interior = piece.is_under_sea_level(chunk, x, y, z, chunk_box);
+    if !is_interior {
+        return;
+    }
+
+    let pos = piece.offset_pos(x, y, z);
+    let sturdy = chunk
+        .get_block_state(&pos)
+        .to_state()
+        .is_side_solid(DataBlockDirection::Up);
+    if places_floor_planks(is_interior, sturdy) {
+        chunk.set_block_state(pos.x, pos.y, pos.z, planks);
+    }
+}
+
 fn boundary_matches(
     piece_box: &BlockBox,
     chunk_box: &BlockBox,
@@ -1353,13 +1385,7 @@ impl StructurePieceBase for MineShaftCorridor {
 
         for x in 0..=2 {
             for z in 0..=length {
-                let world_pos = self.piece.offset_pos(x, -1, z);
-                if chunk_box.contains_pos(&world_pos) {
-                    let below = chunk.get_block_state(&world_pos);
-                    if below.to_state().is_air() {
-                        chunk.set_block_state(world_pos.x, world_pos.y, world_pos.z, planks);
-                    }
-                }
+                set_planks_block(&self.piece, chunk, chunk_box, planks, x, -1, z);
             }
         }
 
@@ -1778,12 +1804,7 @@ impl StructurePieceBase for MineShaftCrossing {
         let floor_y = bb.min.y - 1;
         for x in bb.min.x..=bb.max.x {
             for z in bb.min.z..=bb.max.z {
-                if chunk_box.contains(x, floor_y, z) {
-                    let state = chunk.get_block_state(&Vector3::new(x, floor_y, z));
-                    if state.to_state().is_air() {
-                        chunk.set_block_state(x, floor_y, z, planks);
-                    }
-                }
+                set_planks_block(&self.piece, chunk, chunk_box, planks, x, floor_y, z);
             }
         }
     }
@@ -1941,8 +1962,8 @@ impl StructurePieceBase for MineShaftStairs {
 #[cfg(test)]
 mod tests {
     use super::{
-        MineshaftType, for_each_maybe_box_position, is_supporting_box, passes_cobweb_random_gate,
-        boundary_matches, rail_chance,
+        MineshaftType, boundary_matches, for_each_maybe_box_position, is_supporting_box,
+        passes_cobweb_random_gate, places_floor_planks, rail_chance,
     };
     use pumpkin_data::Block;
     use pumpkin_util::random::{RandomGenerator, RandomImpl, legacy_rand::LegacyRand};
@@ -2046,5 +2067,19 @@ mod tests {
         assert!(!boundary_matches(&piece, &chunk, |x, y, z| {
             x == 11 && y == 21 && z == 31
         }));
+    }
+
+    #[test]
+    fn floor_planks_need_interior_and_a_non_sturdy_top_face() {
+        // Vanilla 26.2 MineShaftPiece.setPlanksBlock:
+        //   if (this.isInterior(level, x, y, z, chunkBB)) {
+        //       BlockState existingState = level.getBlockState(pos);
+        //       if (!existingState.isFaceSturdy(level, pos, Direction.UP)) { setBlock(planks) }
+        //   }
+        // so both a non-interior position and a sturdy upward face suppress the plank.
+        assert!(places_floor_planks(true, false));
+        assert!(!places_floor_planks(true, true));
+        assert!(!places_floor_planks(false, false));
+        assert!(!places_floor_planks(false, true));
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -1126,6 +1126,32 @@ impl MineShaftCorridor {
         }
     }
 
+    /// Vanilla `MineShaftCorridor.placeDoubleLowerOrUpperSupport`: each of the two
+    /// pillar anchors is only followed down (or chained up) when the block already
+    /// standing there is the shaft's planks block, i.e. when `setPlanksBlock`
+    /// actually floored that column.
+    fn place_double_lower_or_upper_support(
+        &self,
+        chunk: &mut ProtoChunk,
+        chunk_box: &BlockBox,
+        x: i32,
+        y: i32,
+        z: i32,
+    ) {
+        let planks_id = self.shaft_type.planks().id.to_block_id();
+        for anchor_x in [x, x + 2] {
+            if self
+                .piece
+                .get_block_at(chunk, anchor_x, y, z, chunk_box)
+                .id
+                .to_block_id()
+                == planks_id
+            {
+                self.fill_pillar_down_or_chain_up(chunk, anchor_x, y, z, chunk_box);
+            }
+        }
+    }
+
     fn fill_pillar_down_or_chain_up(
         &self,
         chunk: &mut ProtoChunk,
@@ -1389,12 +1415,10 @@ impl StructurePieceBase for MineShaftCorridor {
             }
         }
 
-        self.fill_pillar_down_or_chain_up(chunk, 0, -1, 2, chunk_box);
-        self.fill_pillar_down_or_chain_up(chunk, 2, -1, 2, chunk_box);
+        self.place_double_lower_or_upper_support(chunk, chunk_box, 0, -1, 2);
         if self.num_sections > 1 {
             let last_support = length - 2;
-            self.fill_pillar_down_or_chain_up(chunk, 0, -1, last_support, chunk_box);
-            self.fill_pillar_down_or_chain_up(chunk, 2, -1, last_support, chunk_box);
+            self.place_double_lower_or_upper_support(chunk, chunk_box, 0, -1, last_support);
         }
 
         if self.has_rails {
@@ -2081,5 +2105,14 @@ mod tests {
         assert!(!places_floor_planks(true, true));
         assert!(!places_floor_planks(false, false));
         assert!(!places_floor_planks(false, true));
+    }
+
+    #[test]
+    fn double_support_anchors_are_the_two_corridor_walls() {
+        // Vanilla 26.2 MineShaftCorridor.placeDoubleLowerOrUpperSupport tests
+        // getBlock(x, y, z) and getBlock(x + 2, y, z) against type.getPlanksState(),
+        // i.e. the two wall columns of the 3-wide corridor, in that order.
+        let x = 0;
+        assert_eq!([x, x + 2], [0, 2]);
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -1067,7 +1067,7 @@ impl MineShaftCorridor {
                 let empty_below =
                     state_below.to_state().is_air() || state_below.to_block_id() == Block::WATER.id;
                 if !empty_below && state_below.to_block_id() != Block::LAVA.id {
-                    for py in (below_y + 1)..=world_y {
+                    for py in (below_y + 1)..world_y {
                         chunk.set_block_state(world_pos.x, py, world_pos.z, self.shaft_type.wood());
                     }
                     return;
@@ -1087,7 +1087,7 @@ impl MineShaftCorridor {
                         world_pos.z,
                         self.shaft_type.fence(),
                     );
-                    for py in (world_y + 2)..=above_y {
+                    for py in (world_y + 2)..above_y {
                         chunk.set_block_state(
                             world_pos.x,
                             py,
@@ -1960,5 +1960,12 @@ mod tests {
             pumpkin_data::block_properties::OakFenceLikeProperties::from_state_id(east.id);
         assert!(west_props.west && !west_props.east);
         assert!(!east_props.west && east_props.east);
+    }
+
+    #[test]
+    fn pillar_fill_column_excludes_its_anchor_endpoint() {
+        // Vanilla 26.2 fillColumnBetween: for (int y = start; y < end; ++y).
+        assert_eq!((6..10).collect::<Vec<_>>(), [6, 7, 8, 9]);
+        assert_eq!((12..12).count(), 0);
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mineshaft.rs
@@ -134,6 +134,10 @@ fn passes_cobweb_random_gate(random: &mut RandomGenerator, chance: f32, is_inter
     is_interior && random.next_f32() < chance
 }
 
+const fn rail_chance(is_interior: bool) -> f32 {
+    if is_interior { 0.7 } else { 0.9 }
+}
+
 pub struct MineshaftGenerator {
     pub is_mesa: bool,
 }
@@ -1304,7 +1308,11 @@ impl StructurePieceBase for MineShaftCorridor {
                 let floor_pos = self.piece.offset_pos(1, -1, z);
                 if chunk_box.contains_pos(&floor_pos) {
                     let floor_state = chunk.get_block_state(&floor_pos);
-                    if !floor_state.to_state().is_air() && random.next_f32() < 0.7 {
+                    if !floor_state.to_state().is_air()
+                        && floor_state.to_state().is_solid_render()
+                        && random.next_f32()
+                            < rail_chance(self.piece.is_under_sea_level(chunk, 1, 0, z, chunk_box))
+                    {
                         add_mineshaft_block(
                             &self.piece,
                             self.shaft_type,
@@ -1857,6 +1865,7 @@ impl StructurePieceBase for MineShaftStairs {
 mod tests {
     use super::{
         MineshaftType, for_each_maybe_box_position, is_supporting_box, passes_cobweb_random_gate,
+        rail_chance,
     };
     use pumpkin_data::Block;
     use pumpkin_util::random::{RandomGenerator, RandomImpl, legacy_rand::LegacyRand};
@@ -1917,5 +1926,13 @@ mod tests {
         assert!(!passes_cobweb_random_gate(&mut random, 0.8, false));
         assert!(passes_cobweb_random_gate(&mut random, 0.8, true));
         assert_eq!(random.next_f32(), 0.831_441);
+    }
+
+    #[test]
+    fn corridor_rail_chance_depends_on_interior_status() {
+        // Vanilla 26.2 MineShaftCorridor.postProcess:
+        // float chance = isInterior(world, 1, 0, z, box) ? 0.7F : 0.9F.
+        assert_eq!(rail_chance(true), 0.7);
+        assert_eq!(rail_chance(false), 0.9);
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mod.rs
@@ -345,7 +345,7 @@ impl StructurePiece {
         }
     }
 
-    fn is_replaceable_by_structures(state: &BlockState, block: &Block) -> bool {
+    pub(crate) fn is_replaceable_by_structures(state: &BlockState, block: &Block) -> bool {
         state.is_air()
             || state.is_liquid()
             || block == &Block::GLOW_LICHEN


### PR DESCRIPTION
## Description

Takes the mineshaft from "a different structure in the same chunk" to bit-identical with vanilla 26.2 for every mineshaft in the reference box. **Builds on the structure-seeding PR (#3311); its four commits are included here and will drop out once that one merges.** Without the large-feature seed fix there is no mineshaft in the box to compare against, and the 180-piece test below needs it.

The 15 commits on top, each read off `MineshaftPieces` / `MineShaftCorridor` / `StructurePiece` in the 26.2 jar and measured individually:

| commit | vanilla behaviour that was missing |
|---|---|
| depth-first pieces | `generateAndAddPiece` adds the piece and generates its children immediately; Pumpkin queued pieces FIFO and added a piece only after expanding it, so from the second piece on every draw and collision check diverged (694 pieces instead of 180 for the start in (−11, 11)) |
| protect corridor building blocks | `MineShaftPiece.canBeReplaced` refuses the type's planks, wood, fence and chains |
| maybe-box draw order | `generateMaybeBox` iterates Y, X, Z and draws `nextFloat() > chance` before the placement gates; the cobweb volume is a second call with `requireInterior` |
| supports gated on ceiling | `isSupportingBox` scans `x0..x1` at `y1 + 1` and `placeSupport` returns on any air |
| cobweb gates | `maybePlaceCobWeb` short-circuits `isInterior` *before* `nextFloat`, then needs two sturdy neighbouring faces |
| rail gates | rails only over a non-air `isSolidRender` floor, chance 0.7 interior / 0.9 otherwise |
| fence connections | `placeSupport` sets `WEST` on the x0 post and `EAST` on the x1 post |
| pillar endpoints | `fillColumnBetween` is `y < end`, not inclusive |
| pieces touching liquid | `isInInvalidLocation`: a piece whose inflated box touches any liquid is not placed at all |
| floor planks | `setPlanksBlock` is `isInterior && !isFaceSturdy(UP)`, so a shaft that breaks out above the terrain gets no plank floor |
| pillars only under planks | `placeDoubleLowerOrUpperSupport` follows a wall column down only where a plank was actually left |
| pillar / chain anchor tests | `isReplaceableByStructures && !LAVA`, `isFaceSturdy(UP)`, `canSupportCenter && !FallingBlock` |
| spawner interior check | `chunkBB.isInside && isInterior` before `hasPlacedSpider = true`; the early latch skipped the `nextInt(3)` of every later section |
| clippy pedantic allows | no behaviour change |
| minecart chest | `MineShaftCorridor.createChest` never writes a chest block: it places a rail (`nextBoolean` shape) and spawns a `MinecartChest` with `nextLong` loot seed, and consumes **nothing** when its gate fails; Pumpkin wrote a `chest` block and always burned one long |

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

| point in the series | mismatching blocks | chunks identical | chunk (−11, 11) |
|---|---|---|---|
| depth-first (early, whole box) | 395,592 → 373,566 | — | — |
| corridor gates (7 commits) | 36,725 → 34,994 | 0 | 1,187 → 1,166 |
| pieces touching liquid | 16,253 → 11,105 | — | 1,098 → 279 |
| floor planks | 7,110 → 4,810 | — | 278 → 155 |
| pillars under planks | 4,810 → 3,408 | 88 → 93 | 155 → 54 |
| spawner gate | 3,408 → 3,350 | — | — |
| (step-index seed, from the seeding PR) | 3,350 → 1,781 | 93 → 105 | 54 → 2 |
| minecart chest (with tick mask) | 148 → **32** | 245 → **248/256** | mesa shafts (−9,12) 68 → 0, (−12,13) 29 → 0, (−10,10) 19 → 0 |

The whole mineshaft bucket is zero at the end; the mineshaft-mesa fence property mismatches that remain are fixed by the post-processing PR.

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. `mineshaft_mesa_pieces_match_vanilla_seed_13579` asserts the 180 pieces, their order and the bounding boxes of the first eleven against the `structures.starts` NBT of the real vanilla chunk; the chain anchor has a unit test for the `FallingBlock` set (`chains_do_not_hang_from_falling_blocks`).

**Known impact:** every mineshaft changes shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved structure generation to more closely match vanilla behavior and seeding.
  - Corrected mineshaft layouts, piece placement, supports, rails, cobwebs, pillars, and minecart chests.
  - Fixed structure references across all overlapping placement regions.
  - Prevented structure pieces from generating in invalid liquid locations.

- **Compatibility**
  - Mineshaft generation now produces more consistent locations, layouts, and contents across matching world seeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->