### PR TITLE
fix(worldgen): sample float and symmetric trapezoid int providers like vanilla 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-util/src/math/float_provider.rs
+++ b/crates/pumpkin-util/src/math/float_provider.rs
@@ -337,8 +337,8 @@ impl ClampedNormalFloatProvider {
     /// A random float from a normal distribution, clamped to [min, max].
     #[allow(clippy::suboptimal_flops)]
     pub fn get(&self, random: &mut impl RandomImpl) -> f32 {
-        // NOTE: Vanilla's `Mth.normal` is `mean + (float) nextGaussian() * deviation`: the
-        // product is rounded to f32 before the add, so no fused multiply-add here either.
+        // NOTE: Vanilla's `Mth.normal` narrows the gaussian to a float, scales it by the
+        // deviation and adds the mean, so no fused multiply-add here either.
         let gaussian = random.next_gaussian() as f32;
         let value = self.mean + gaussian * self.deviation;
 
@@ -469,12 +469,9 @@ mod tests {
         assert_eq!(provider.get(&mut random), 5.5); // Should always return the same value
     }
 
-    /// Vanilla's `UniformFloat.sample` is `Mth.randomBetween`:
-    /// `random.nextFloat() * (maxExclusive - min) + min`, i.e. the product is rounded to f32
-    /// before the add. On the legacy stream seeded with 4 the first float is
-    /// `0.730_609_4`; for the cave carver's `0.7..1.4` horizontal radius multiplier the
-    /// vanilla expression gives `1.211_426_5`, while a fused multiply-add gives
-    /// `1.211_426_6`.
+    /// `Mth.randomBetween` rounds the product to f32 before adding the minimum. On the legacy
+    /// stream seeded with 4, the carver's `0.7..1.4` multiplier gives `1.211_426_5` that way and
+    /// `1.211_426_6` under a fused multiply-add.
     #[test]
     fn uniform_float_provider_matches_vanilla_rounding() {
         let provider = UniformFloatProvider::new(0.7, 1.4);
@@ -499,10 +496,8 @@ mod tests {
         );
     }
 
-    /// Vanilla's `ClampedNormalFloat.sample` is `Mth.normal`:
-    /// `mean + (float) random.nextGaussian() * deviation`, again two roundings. Search the
-    /// legacy stream for the first seed where a fused multiply-add would differ and check
-    /// the provider follows the vanilla expression there.
+    /// `Mth.normal` narrows the gaussian to a float before scaling and adding — two roundings,
+    /// so a fused multiply-add gives a different float on some seeds.
     #[test]
     fn clamped_normal_float_provider_matches_vanilla_rounding() {
         let (mean, deviation) = (0.5f32, 0.3f32);

--- a/crates/pumpkin-util/src/math/float_provider.rs
+++ b/crates/pumpkin-util/src/math/float_provider.rs
@@ -247,10 +247,14 @@ impl UniformFloatProvider {
     ///
     /// # Returns
     /// A random float in the range [`min_inclusive`, `max_exclusive`].
+    #[allow(clippy::suboptimal_flops)]
     pub fn get(&self, random: &mut impl RandomImpl) -> f32 {
-        // NOTE: Use the random range in [min_inclusive, max_exclusive)
+        // NOTE: Vanilla's `Mth.randomBetween` is `nextFloat() * (max - min) + min` with the
+        // product rounded to f32 before the add. A fused multiply-add rounds only once and
+        // lands one ulp off for about one draw in seven, which is enough to move a carver
+        // radius across a block boundary. Keep the two roundings.
         let range = self.max_exclusive - self.min_inclusive;
-        random.next_f32().mul_add(range, self.min_inclusive)
+        random.next_f32() * range + self.min_inclusive
     }
 
     /// Returns the maximum exclusive value.
@@ -331,10 +335,12 @@ impl ClampedNormalFloatProvider {
     ///
     /// # Returns
     /// A random float from a normal distribution, clamped to [min, max].
+    #[allow(clippy::suboptimal_flops)]
     pub fn get(&self, random: &mut impl RandomImpl) -> f32 {
-        // NOTE: Generate normal distribution value
+        // NOTE: Vanilla's `Mth.normal` is `mean + (float) nextGaussian() * deviation`: the
+        // product is rounded to f32 before the add, so no fused multiply-add here either.
         let gaussian = random.next_gaussian() as f32;
-        let value = gaussian.mul_add(self.deviation, self.mean);
+        let value = self.mean + gaussian * self.deviation;
 
         // NOTE: Clamp to min/max range
         value.clamp(self.min, self.max)
@@ -461,6 +467,63 @@ mod tests {
         assert_eq!(provider.get_max(), 5.5);
         assert_eq!(provider.get(&mut random), 5.5);
         assert_eq!(provider.get(&mut random), 5.5); // Should always return the same value
+    }
+
+    /// Vanilla's `UniformFloat.sample` is `Mth.randomBetween`:
+    /// `random.nextFloat() * (maxExclusive - min) + min`, i.e. the product is rounded to f32
+    /// before the add. On the legacy stream seeded with 4 the first float is
+    /// `0.730_609_4`; for the cave carver's `0.7..1.4` horizontal radius multiplier the
+    /// vanilla expression gives `1.211_426_5`, while a fused multiply-add gives
+    /// `1.211_426_6`.
+    #[test]
+    fn uniform_float_provider_matches_vanilla_rounding() {
+        let provider = UniformFloatProvider::new(0.7, 1.4);
+
+        let mut random =
+            RandomGenerator::Legacy(crate::random::legacy_rand::LegacyRand::from_seed(4));
+        let sampled = provider.get(&mut random);
+
+        let mut reference =
+            RandomGenerator::Legacy(crate::random::legacy_rand::LegacyRand::from_seed(4));
+        let next_float = reference.next_f32();
+        assert_eq!(next_float, 0.730_609_4);
+        #[allow(clippy::suboptimal_flops)]
+        let vanilla = next_float * (1.4f32 - 0.7f32) + 0.7f32;
+        let fused = next_float.mul_add(1.4f32 - 0.7f32, 0.7f32);
+
+        assert_eq!(sampled, 1.211_426_5);
+        assert_eq!(sampled, vanilla);
+        assert_ne!(
+            sampled, fused,
+            "the seed must discriminate the two roundings"
+        );
+    }
+
+    /// Vanilla's `ClampedNormalFloat.sample` is `Mth.normal`:
+    /// `mean + (float) random.nextGaussian() * deviation`, again two roundings. Search the
+    /// legacy stream for the first seed where a fused multiply-add would differ and check
+    /// the provider follows the vanilla expression there.
+    #[test]
+    fn clamped_normal_float_provider_matches_vanilla_rounding() {
+        let (mean, deviation) = (0.5f32, 0.3f32);
+        let provider = ClampedNormalFloatProvider::new(mean, deviation, -10.0, 10.0);
+
+        for seed in 0..10_000u64 {
+            let mut reference =
+                RandomGenerator::Legacy(crate::random::legacy_rand::LegacyRand::from_seed(seed));
+            let gaussian = reference.next_gaussian() as f32;
+            #[allow(clippy::suboptimal_flops)]
+            let vanilla = mean + gaussian * deviation;
+            if gaussian.mul_add(deviation, mean) == vanilla {
+                continue;
+            }
+
+            let mut random =
+                RandomGenerator::Legacy(crate::random::legacy_rand::LegacyRand::from_seed(seed));
+            assert_eq!(provider.get(&mut random), vanilla, "seed {seed}");
+            return;
+        }
+        panic!("no seed in 0..10000 discriminates fused from plain rounding");
     }
 
     #[test]

--- a/crates/pumpkin-util/src/math/int_provider.rs
+++ b/crates/pumpkin-util/src/math/int_provider.rs
@@ -516,22 +516,12 @@ impl TrapezoidIntProvider {
     /// # Returns
     /// A random integer from the source provider, clamped to [`min_inclusive`, `max_inclusive`].
     ///
-    /// Mirrors vanilla `TrapezoidInt.sample` draw for draw:
+    /// Mirrors vanilla `TrapezoidInt.sample` draw for draw, in three branches:
     ///
-    /// ```java
-    /// if (this.plateau == 0 && this.maxInclusive == -this.minInclusive) {
-    ///     return random.nextInt(this.maxInclusive + 1) - random.nextInt(this.maxInclusive + 1);
-    /// }
-    /// int range = this.maxInclusive - this.minInclusive;
-    /// if (this.plateau == range) {
-    ///     return Mth.randomBetweenInclusive(random, this.minInclusive, this.maxInclusive);
-    /// }
-    /// int half = (range - this.plateau) / 2;
-    /// int rest = range - half;
-    /// return this.minInclusive
-    ///     + Mth.randomBetweenInclusive(random, 0, rest)
-    ///     + Mth.randomBetweenInclusive(random, 0, half);
-    /// ```
+    /// - a symmetric range with no plateau is the *difference* of two `nextInt(max + 1)` draws;
+    /// - a plateau covering the whole range is a single uniform draw over `[min, max]`;
+    /// - otherwise it is `min` plus two uniform draws, over `[0, range - half]` and `[0, half]`,
+    ///   where `half = (range - plateau) / 2`.
     ///
     /// The symmetric branch is the one every `random_offset` placement modifier in the 26.2
     /// data takes, and it is a *difference* of two draws, not a sum offset by `min`.
@@ -1066,10 +1056,8 @@ mod tests {
         }
     }
 
-    /// A `[0, 0]` trapezoid consumes two draws in vanilla, not zero: after one
-    /// `sample(new LegacyRandomSource(13579))` the next `nextInt()` is 392090517, the *third*
-    /// value of that stream (`1265370827, 1234256338, 392090517, ...`). Skipping those draws
-    /// desynchronises every later draw of the feature.
+    /// A `[0, 0]` trapezoid consumes two draws in vanilla, not zero: after one sample on the
+    /// legacy stream seeded with 13579 the next `nextInt()` is its *third* value, 392090517.
     #[test]
     fn trapezoid_int_empty_range_still_consumes_two_draws() {
         let mut random = crate::random::legacy_rand::LegacyRand::from_seed(13579);

--- a/crates/pumpkin-util/src/math/int_provider.rs
+++ b/crates/pumpkin-util/src/math/int_provider.rs
@@ -515,19 +515,38 @@ impl TrapezoidIntProvider {
     ///
     /// # Returns
     /// A random integer from the source provider, clamped to [`min_inclusive`, `max_inclusive`].
+    ///
+    /// Mirrors vanilla `TrapezoidInt.sample` draw for draw:
+    ///
+    /// ```java
+    /// if (this.plateau == 0 && this.maxInclusive == -this.minInclusive) {
+    ///     return random.nextInt(this.maxInclusive + 1) - random.nextInt(this.maxInclusive + 1);
+    /// }
+    /// int range = this.maxInclusive - this.minInclusive;
+    /// if (this.plateau == range) {
+    ///     return Mth.randomBetweenInclusive(random, this.minInclusive, this.maxInclusive);
+    /// }
+    /// int half = (range - this.plateau) / 2;
+    /// int rest = range - half;
+    /// return this.minInclusive
+    ///     + Mth.randomBetweenInclusive(random, 0, rest)
+    ///     + Mth.randomBetweenInclusive(random, 0, half);
+    /// ```
+    ///
+    /// The symmetric branch is the one every `random_offset` placement modifier in the 26.2
+    /// data takes, and it is a *difference* of two draws, not a sum offset by `min`.
     pub fn get(&self, random: &mut impl RandomImpl) -> i32 {
-        if self.min_inclusive >= self.max_inclusive {
-            return self.min_inclusive;
+        if self.plateau == 0 && self.max_inclusive == -self.min_inclusive {
+            return random.next_bounded_i32(self.max_inclusive + 1)
+                - random.next_bounded_i32(self.max_inclusive + 1);
         }
         let range = self.max_inclusive - self.min_inclusive;
-        if self.plateau >= range {
+        if self.plateau == range {
             return self.min_inclusive + random.next_bounded_i32(range + 1);
         }
-        let plateau_start = (range - self.plateau) / 2;
-        let plateau_end = range - plateau_start;
-        self.min_inclusive
-            + random.next_bounded_i32(plateau_end + 1)
-            + random.next_bounded_i32(plateau_start + 1)
+        let half = (range - self.plateau) / 2;
+        let rest = range - half;
+        self.min_inclusive + random.next_bounded_i32(rest + 1) + random.next_bounded_i32(half + 1)
     }
 
     /// Returns the maximum value after clamping.
@@ -972,5 +991,94 @@ mod tests {
             (5..=15).contains(&value),
             "Value {value} is outside range [5, 15]"
         );
+    }
+
+    /// Reference values taken from the real 26.2 server jar:
+    /// `TrapezoidInt.of(min, max, plateau).sample(new LegacyRandomSource(13579))`, eight
+    /// samples per provider, and the same with a `XoroshiroRandomSource(13579)`.
+    #[test]
+    fn trapezoid_int_matches_vanilla_samples() {
+        /// `(min, max, plateau)` plus the eight `LegacyRandomSource(13579)` samples and the
+        /// eight `XoroshiroRandomSource(13579)` samples vanilla returns for it.
+        type TrapezoidCase = (i32, i32, i32, [i32; 8], [i32; 8]);
+
+        let cases: &[TrapezoidCase] = &[
+            // Every `random_offset` placement modifier in the 26.2 data is symmetric with
+            // plateau 0, i.e. `nextInt(max + 1) - nextInt(max + 1)`.
+            (
+                -7,
+                7,
+                0,
+                [0, -5, 1, -4, 0, -7, -4, 3],
+                [-2, -6, -1, -7, 2, 0, 0, -3],
+            ),
+            (
+                -6,
+                6,
+                0,
+                [3, 2, 3, -4, 1, -2, 6, 1],
+                [-2, -5, -1, -6, 2, 0, 1, -2],
+            ),
+            (
+                -3,
+                3,
+                0,
+                [0, -2, 1, -2, 0, -3, -2, 1],
+                [-1, -3, 0, -3, 1, 0, 0, -1],
+            ),
+            (
+                -2,
+                2,
+                0,
+                [0, -1, 0, -1, 0, -1, 1, -1],
+                [0, -2, -1, -2, 1, 0, 0, -1],
+            ),
+            // `patch_sugar_cane*` uses a `[0, 0]` y_spread: still two draws, always zero.
+            (0, 0, 0, [0; 8], [0; 8]),
+            // The general branch: `min + nextInt(rest + 1) + nextInt(half + 1)`.
+            (
+                -3,
+                5,
+                2,
+                [3, 3, -2, 0, 4, 0, 1, 0],
+                [1, 0, 2, 0, -1, 3, 5, 3],
+            ),
+            // `plateau == range`: a single uniform draw.
+            (2, 5, 3, [3, 3, 2, 4, 4, 3, 2, 4], [3, 4, 2, 5, 4, 4, 2, 5]),
+        ];
+
+        for (min, max, plateau, legacy_expected, xoroshiro_expected) in cases {
+            let provider = TrapezoidIntProvider::new(*min, *max, *plateau);
+
+            let mut legacy = crate::random::legacy_rand::LegacyRand::from_seed(13579);
+            let legacy_actual: [i32; 8] = std::array::from_fn(|_| provider.get(&mut legacy));
+            assert_eq!(
+                &legacy_actual, legacy_expected,
+                "legacy samples for trapezoid({min}, {max}, {plateau})"
+            );
+
+            let mut xoroshiro = crate::random::xoroshiro128::Xoroshiro::from_seed(13579);
+            let xoroshiro_actual: [i32; 8] = std::array::from_fn(|_| provider.get(&mut xoroshiro));
+            assert_eq!(
+                &xoroshiro_actual, xoroshiro_expected,
+                "xoroshiro samples for trapezoid({min}, {max}, {plateau})"
+            );
+        }
+    }
+
+    /// A `[0, 0]` trapezoid consumes two draws in vanilla, not zero: after one
+    /// `sample(new LegacyRandomSource(13579))` the next `nextInt()` is 392090517, the *third*
+    /// value of that stream (`1265370827, 1234256338, 392090517, ...`). Skipping those draws
+    /// desynchronises every later draw of the feature.
+    #[test]
+    fn trapezoid_int_empty_range_still_consumes_two_draws() {
+        let mut random = crate::random::legacy_rand::LegacyRand::from_seed(13579);
+        assert_eq!(TrapezoidIntProvider::new(0, 0, 0).get(&mut random), 0);
+        assert_eq!(random.next_i32(), 392090517);
+
+        // `plateau == range` consumes exactly one draw.
+        let mut random = crate::random::legacy_rand::LegacyRand::from_seed(13579);
+        TrapezoidIntProvider::new(2, 5, 3).get(&mut random);
+        assert_eq!(random.next_i32(), 1234256338);
     }
 }


### PR DESCRIPTION
## Description

Two provider fixes; the first is a follow-up to #3229 / #3233, the second touches every vegetation patch.

**1. No fused multiply-add in float providers.** Vanilla `UniformFloat.sample` is `Mth.randomBetween`: `random.nextFloat() * (maxExclusive − min) + min`, and `ClampedNormalFloat.sample` is `Mth.normal`, which narrows the gaussian to a float, scales it by the deviation and adds the mean. In both the product is rounded to f32 before the add. Pumpkin used `f32::mul_add`, which rounds once and lands one ulp away for roughly one draw in seven (for the cave carver's 0.7..1.4 radius multiplier, 2,827 of the first 20,000 legacy seeds differ). The carvers draw every radius multiplier, floor level and room scale through it. Measured effect on the 256-chunk box: 0 blocks (the ulp never crossed an ellipsoid boundary here); correctness fix.

**2. Symmetric trapezoid int is a difference of two draws.** Vanilla `TrapezoidInt.sample` (26.2 jar) starts with

For a symmetric range with no plateau it returns the *difference* of two `nextInt(max + 1)` draws.

Every `minecraft:random_offset` placement modifier in the 26.2 data is exactly that shape (`{−7,7,0}`, `{−6,6,0}`, `{−4,4,0}`, `{−3,3,0}`, `{−2,2,0}`, `{0,0,0}`, `{−5,5,0}`), so every vegetation, flower, mushroom and cactus patch goes through it. Pumpkin had no symmetric branch and bailed out early on an empty range: for `{−6,6,0}` it returned `−6 + a + b` where vanilla returns `a − b` from the same two draws (same distribution, different column), and `patch_sugar_cane*`'s `{0,0,0}` y_spread returned 0 *without drawing* while vanilla still spends two `nextInt(1)`, so every later draw of the feature was off by two.

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

| | before | after |
|---|---|---|
| mismatching blocks | 22,508 (0.089 %) | **18,839 (0.075 %)** |
| chunks bit-identical | 3/256 | **16/256** |
| median chunk | 43 | 24 |

Vegetation-involved mismatches 5,277 → 1,782; `dead_bush` (2,229), `tall_dry_grass` (618) and `short_dry_grass` (569) confusions to zero; y ≥ 101 clean. No category got worse.

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. The trapezoid test compares eight samples per provider against the values the real 26.2 `TrapezoidInt` produces from `LegacyRandomSource(13579)` and `XoroshiroRandomSource(13579)` and pins the draw count via the raw `nextInt()` that follows a sample.

**Known impact:** changes vegetation placement everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

