### PR TITLE
fix(worldgen): split worldgen and final heightmaps and update them like vanilla 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-world/src/chunk_system/chunk_state.rs
+++ b/crates/pumpkin-world/src/chunk_system/chunk_state.rs
@@ -245,7 +245,7 @@ impl Chunk {
                 for (heightmap_type, height) in [
                     (
                         ChunkHeightmapType::WorldSurface,
-                        proto_chunk.flat_surface_height_map[source_index],
+                        proto_chunk.flat_final_surface_height_map[source_index],
                     ),
                     (
                         ChunkHeightmapType::MotionBlocking,

--- a/crates/pumpkin-world/src/chunk_system/generation_cache.rs
+++ b/crates/pumpkin-world/src/chunk_system/generation_cache.rs
@@ -322,12 +322,10 @@ impl GenerationCache for Cache {
 
     fn get_top_y(&self, heightmap: &HeightMap, x: i32, z: i32) -> i32 {
         match heightmap {
-            HeightMap::WorldSurfaceWg | HeightMap::WorldSurface => {
-                self.top_block_height_exclusive(x, z)
-            }
-            HeightMap::OceanFloorWg | HeightMap::OceanFloor => {
-                self.ocean_floor_height_exclusive(x, z)
-            }
+            HeightMap::WorldSurfaceWg => self.top_block_height_wg_exclusive(x, z),
+            HeightMap::WorldSurface => self.top_block_height_exclusive(x, z),
+            HeightMap::OceanFloorWg => self.ocean_floor_height_wg_exclusive(x, z),
+            HeightMap::OceanFloor => self.ocean_floor_height_exclusive(x, z),
             HeightMap::MotionBlocking => self.top_motion_blocking_block_height_exclusive(x, z),
             HeightMap::MotionBlockingNoLeaves => {
                 self.top_motion_blocking_block_no_leaves_height_exclusive(x, z)
@@ -461,6 +459,44 @@ impl GenerationCache for Cache {
 }
 
 impl Cache {
+    /// Vanilla `OCEAN_FLOOR_WG` on a `WorldGenRegion`: the worldgen heightmap the proto chunk
+    /// kept while noise and the carvers ran. It is live for every chunk in the region, whereas
+    /// the four `FINAL_HEIGHTMAPS` maps are only primed for the chunk being decorated, so
+    /// reading the final map here returns `minY - 1` for every neighbour column.
+    fn ocean_floor_height_wg_exclusive(&self, x: i32, z: i32) -> i32 {
+        let dx = (x >> 4) - self.x;
+        let dy = (z >> 4) - self.z;
+        if dx < 0 || dy < 0 || dx >= self.size || dy >= self.size {
+            return 0;
+        }
+        match &self.chunks[(dx * self.size + dy) as usize] {
+            Chunk::Level(_data) => {
+                0 // todo missing
+            }
+            Chunk::Proto(data) => data.ocean_floor_height_wg_exclusive(x, z),
+        }
+    }
+
+    /// Vanilla `WORLD_SURFACE_WG`; see [`Self::ocean_floor_height_wg_exclusive`].
+    fn top_block_height_wg_exclusive(&self, x: i32, z: i32) -> i32 {
+        let dx = (x >> 4) - self.x;
+        let dy = (z >> 4) - self.z;
+        if dx < 0 || dy < 0 || dx >= self.size || dy >= self.size {
+            return 0;
+        }
+        match &self.chunks[(dx * self.size + dy) as usize] {
+            Chunk::Level(data) => {
+                let heightmap = data
+                    .heightmap
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let min_y = data.section.min_y;
+                heightmap.get(ChunkHeightmapType::WorldSurface, x, z, min_y)
+            }
+            Chunk::Proto(data) => data.top_block_height_wg_exclusive(x, z),
+        }
+    }
+
     pub fn advance_all(
         &mut self,
         stage: StagedChunkEnum,

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -461,24 +461,11 @@ impl ProtoChunk {
         });
     }
 
-    /// Vanilla `Heightmap.update` after the block at `y` in this column was written:
-    ///
-    /// ```java
-    /// int i = this.getFirstAvailable(x, z);
-    /// if (y <= i - 2) return false;
-    /// if (this.isOpaque.test(state)) {
-    ///     if (y >= i) { this.setHeight(x, z, y + 1); return true; }
-    /// } else if (i - 1 == y) {
-    ///     for (int j = y - 1; j >= this.chunk.getMinY(); j--) {
-    ///         if (this.isOpaque.test(this.chunk.getBlockState(mutable.set(x, j, z)))) {
-    ///             this.setHeight(x, z, j + 1);
-    ///             return true;
-    ///         }
-    ///     }
-    ///     this.setHeight(x, z, this.chunk.getMinY());
-    ///     return true;
-    /// }
-    /// ```
+    /// Vanilla `Heightmap.update` after the block at `y` in this column was written, against the
+    /// column's first available slot: a write more than one block below it changes nothing; a
+    /// matching block at or above it lifts the map to `y + 1`; and a non-matching write to the
+    /// top block itself scans down from `y - 1` for the next matching block, setting the map
+    /// just above it, or to the chunk's minimum Y if the column holds none.
     ///
     /// Pumpkin stores the top matching block itself rather than the first free slot above it,
     /// so `first_available == current + 1`. Overwriting the top of a column with something the
@@ -569,12 +556,9 @@ impl ProtoChunk {
     }
 
     /// Vanilla `Heightmap.primeHeightmaps` for `ChunkStatus.FINAL_HEIGHTMAPS`, which
-    /// `ChunkStatusTasks.generateFeatures` runs before any feature is placed:
-    ///
-    /// ```java
-    /// Heightmap.primeHeightmaps(chunk, EnumSet.of(MOTION_BLOCKING, MOTION_BLOCKING_NO_LEAVES,
-    ///                                             OCEAN_FLOOR, WORLD_SURFACE));
-    /// ```
+    /// `ChunkStatusTasks.generateFeatures` runs before any feature is placed. It primes exactly
+    /// four maps: `MOTION_BLOCKING`, `MOTION_BLOCKING_NO_LEAVES`, `OCEAN_FLOOR` and
+    /// `WORLD_SURFACE`.
     pub fn prime_final_heightmaps(&mut self) {
         for local_x in 0..CHUNK_DIM as i32 {
             for local_z in 0..CHUNK_DIM as i32 {

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -140,10 +140,24 @@ pub struct ProtoChunk {
     biome_mixer_seed: i64,
     pub(crate) flat_block_map: Box<[BlockStateId]>,
     pub flat_biome_map: Box<[u8]>,
+    /// Vanilla `WORLD_SURFACE_WG`. `ChunkStatus.WORLDGEN_HEIGHTMAPS` is only maintained up
+    /// to and including the surface step, so carving still lowers it but features never
+    /// touch it again.
     pub flat_surface_height_map: [i16; CHUNK_AREA],
+    /// Vanilla `OCEAN_FLOOR_WG`, same lifetime as `flat_surface_height_map`.
     pub flat_ocean_floor_height_map: [i16; CHUNK_AREA],
+    /// Vanilla `WORLD_SURFACE`, one of `ChunkStatus.FINAL_HEIGHTMAPS`: primed from the blocks
+    /// when the chunk's feature step starts and kept current by every later write.
+    pub flat_final_surface_height_map: [i16; CHUNK_AREA],
+    /// Vanilla `OCEAN_FLOOR`, same lifetime as `flat_final_surface_height_map`.
+    pub flat_final_ocean_floor_height_map: [i16; CHUNK_AREA],
+    /// Vanilla `MOTION_BLOCKING`, same lifetime as `flat_final_surface_height_map`.
     pub flat_motion_blocking_height_map: [i16; CHUNK_AREA],
+    /// Vanilla `MOTION_BLOCKING_NO_LEAVES`, same lifetime as `flat_final_surface_height_map`.
     pub flat_motion_blocking_no_leaves_height_map: [i16; CHUNK_AREA],
+    /// Whether the four `FINAL_HEIGHTMAPS` have been primed for this chunk yet; vanilla
+    /// creates them lazily, so the first write after the carver step primes them.
+    final_heightmaps_primed: bool,
     structure_starts: FxHashMap<StructureKeys, StructureInstance>,
 
     height: u16,
@@ -229,7 +243,8 @@ impl ProtoChunk {
             super::generator::WorldGenerator::Custom(custom_gen) => custom_gen.biome_mixer_seed(),
         };
 
-        let default_heightmap = [i16::MIN; CHUNK_AREA];
+        // A column with nothing in it reads as "first available = bottom", i.e. top = bottom - 1.
+        let default_heightmap = [i16::from(bottom_y) - 1; CHUNK_AREA];
         Self {
             x,
             z,
@@ -246,8 +261,11 @@ impl ProtoChunk {
             .into_boxed_slice(),
             flat_surface_height_map: default_heightmap,
             flat_ocean_floor_height_map: default_heightmap,
+            flat_final_surface_height_map: default_heightmap,
+            flat_final_ocean_floor_height_map: default_heightmap,
             flat_motion_blocking_height_map: default_heightmap,
             flat_motion_blocking_no_leaves_height_map: default_heightmap,
+            final_heightmaps_primed: false,
             structure_starts: FxHashMap::default(),
             height,
             bottom_y,
@@ -362,11 +380,17 @@ impl ProtoChunk {
                 )
                     as i16;
 
-                proto_chunk.flat_surface_height_map[index] =
+                proto_chunk.flat_final_surface_height_map[index] =
                     heightmap_data.get(ChunkHeightmapType::WorldSurface, x, z, section_data.min_y)
                         as i16;
             }
         }
+
+        // Only the three level heightmaps are saved; the remaining maps are a pure function
+        // of the blocks, so rebuild them the way vanilla primes a missing one.
+        proto_chunk.final_heightmaps_primed = true;
+        proto_chunk.prime_ocean_floor_from_blocks();
+        proto_chunk.prime_worldgen_heightmaps();
 
         let saved_stage = StagedChunkEnum::from(chunk_data.status);
         proto_chunk.stage = saved_stage;
@@ -437,35 +461,176 @@ impl ProtoChunk {
         });
     }
 
-    fn maybe_update_surface_height_map(&mut self, index: usize, y: i16) {
-        let current_height = self.flat_surface_height_map[index];
-        self.flat_surface_height_map[index] = current_height.max(y);
+    /// Vanilla `Heightmap.update` after the block at `y` in this column was written:
+    ///
+    /// ```java
+    /// int i = this.getFirstAvailable(x, z);
+    /// if (y <= i - 2) return false;
+    /// if (this.isOpaque.test(state)) {
+    ///     if (y >= i) { this.setHeight(x, z, y + 1); return true; }
+    /// } else if (i - 1 == y) {
+    ///     for (int j = y - 1; j >= this.chunk.getMinY(); j--) {
+    ///         if (this.isOpaque.test(this.chunk.getBlockState(mutable.set(x, j, z)))) {
+    ///             this.setHeight(x, z, j + 1);
+    ///             return true;
+    ///         }
+    ///     }
+    ///     this.setHeight(x, z, this.chunk.getMinY());
+    ///     return true;
+    /// }
+    /// ```
+    ///
+    /// Pumpkin stores the top matching block itself rather than the first free slot above it,
+    /// so `first_available == current + 1`. Overwriting the top of a column with something the
+    /// map does not match scans down for the next match: that is how carving *lowers* a map,
+    /// which the old `max`-only updaters never did.
+    fn heightmap_after_write(
+        &self,
+        current: i16,
+        local_x: i32,
+        local_z: i32,
+        y: i32,
+        matches: bool,
+        predicate: fn(BlockStateId) -> bool,
+    ) -> i16 {
+        let first_available = i32::from(current) + 1;
+        if y <= first_available - 2 {
+            return current;
+        }
+        if matches {
+            return if y >= first_available {
+                y as i16
+            } else {
+                current
+            };
+        }
+        if first_available - 1 != y {
+            return current;
+        }
+        let bottom = i32::from(self.bottom_y());
+        for below in (bottom..y).rev() {
+            if predicate(self.get_block_state_raw(local_x, below - bottom, local_z)) {
+                return below as i16;
+            }
+        }
+        (bottom - 1) as i16
     }
 
-    fn maybe_update_ocean_floor_height_map(&mut self, index: usize, y: i16) {
-        let current_height = self.flat_ocean_floor_height_map[index];
-        self.flat_ocean_floor_height_map[index] = current_height.max(y);
+    /// Vanilla `Heightmap.Types.WORLD_SURFACE(_WG)`: `!state.isAir()`.
+    const fn heightmap_not_air(id: BlockStateId) -> bool {
+        !BlockState::from_id(id).is_air()
     }
 
-    fn maybe_update_motion_blocking_height_map(&mut self, index: usize, y: i16) {
-        let current_height = self.flat_motion_blocking_height_map[index];
-        self.flat_motion_blocking_height_map[index] = current_height.max(y);
+    /// Vanilla `Heightmap.Types.OCEAN_FLOOR(_WG)`: `state.blocksMotion()`.
+    const fn heightmap_blocks_motion(id: BlockStateId) -> bool {
+        let state = BlockState::from_id(id);
+        !state.is_air() && blocks_movement(state, BlockId::from_state_id(id))
     }
 
-    fn maybe_update_motion_blocking_no_leaves_height_map(&mut self, index: usize, y: i16) {
-        let current_height = self.flat_motion_blocking_no_leaves_height_map[index];
-        self.flat_motion_blocking_no_leaves_height_map[index] = current_height.max(y);
+    /// Vanilla `Heightmap.Types.MOTION_BLOCKING`:
+    /// `state.blocksMotion() || !state.getFluidState().isEmpty()`.
+    const fn heightmap_motion_blocking(id: BlockStateId) -> bool {
+        let state = BlockState::from_id(id);
+        !state.is_air() && (blocks_movement(state, BlockId::from_state_id(id)) || state.is_liquid())
+    }
+
+    /// Vanilla `Heightmap.Types.MOTION_BLOCKING_NO_LEAVES`: the above minus `LeavesBlock`.
+    fn heightmap_motion_blocking_no_leaves(id: BlockStateId) -> bool {
+        Self::heightmap_motion_blocking(id)
+            && !BlockId::from_state_id(id).has_tag(tag::Block::MINECRAFT_LEAVES)
+    }
+
+    fn prime_column<const N: usize>(
+        &self,
+        local_x: i32,
+        local_z: i32,
+        predicates: [fn(BlockStateId) -> bool; N],
+    ) -> [i16; N] {
+        let bottom = i32::from(self.bottom_y());
+        let empty = (bottom - 1) as i16;
+        let mut tops = [empty; N];
+        let mut remaining = N;
+        for local_y in (0..i32::from(self.height())).rev() {
+            let id = self.get_block_state_raw(local_x, local_y, local_z);
+            if BlockState::from_id(id).is_air() {
+                continue;
+            }
+            for (top, predicate) in tops.iter_mut().zip(predicates) {
+                if *top == empty && predicate(id) {
+                    *top = (bottom + local_y) as i16;
+                    remaining -= 1;
+                }
+            }
+            if remaining == 0 {
+                break;
+            }
+        }
+        tops
+    }
+
+    /// Vanilla `Heightmap.primeHeightmaps` for `ChunkStatus.FINAL_HEIGHTMAPS`, which
+    /// `ChunkStatusTasks.generateFeatures` runs before any feature is placed:
+    ///
+    /// ```java
+    /// Heightmap.primeHeightmaps(chunk, EnumSet.of(MOTION_BLOCKING, MOTION_BLOCKING_NO_LEAVES,
+    ///                                             OCEAN_FLOOR, WORLD_SURFACE));
+    /// ```
+    pub fn prime_final_heightmaps(&mut self) {
+        for local_x in 0..CHUNK_DIM as i32 {
+            for local_z in 0..CHUNK_DIM as i32 {
+                let [surface, ocean_floor, motion_blocking, no_leaves] = self.prime_column(
+                    local_x,
+                    local_z,
+                    [
+                        Self::heightmap_not_air,
+                        Self::heightmap_blocks_motion,
+                        Self::heightmap_motion_blocking,
+                        Self::heightmap_motion_blocking_no_leaves,
+                    ],
+                );
+                let index = Self::local_position_to_height_map_index(local_x, local_z);
+                self.flat_final_surface_height_map[index] = surface;
+                self.flat_final_ocean_floor_height_map[index] = ocean_floor;
+                self.flat_motion_blocking_height_map[index] = motion_blocking;
+                self.flat_motion_blocking_no_leaves_height_map[index] = no_leaves;
+            }
+        }
+        self.final_heightmaps_primed = true;
+    }
+
+    fn prime_worldgen_heightmaps(&mut self) {
+        for local_x in 0..CHUNK_DIM as i32 {
+            for local_z in 0..CHUNK_DIM as i32 {
+                let [surface, ocean_floor] = self.prime_column(
+                    local_x,
+                    local_z,
+                    [Self::heightmap_not_air, Self::heightmap_blocks_motion],
+                );
+                let index = Self::local_position_to_height_map_index(local_x, local_z);
+                self.flat_surface_height_map[index] = surface;
+                self.flat_ocean_floor_height_map[index] = ocean_floor;
+            }
+        }
+    }
+
+    fn prime_ocean_floor_from_blocks(&mut self) {
+        for local_x in 0..CHUNK_DIM as i32 {
+            for local_z in 0..CHUNK_DIM as i32 {
+                let [ocean_floor] =
+                    self.prime_column(local_x, local_z, [Self::heightmap_blocks_motion]);
+                let index = Self::local_position_to_height_map_index(local_x, local_z);
+                self.flat_final_ocean_floor_height_map[index] = ocean_floor;
+            }
+        }
     }
 
     #[must_use]
     pub const fn get_top_y(&self, heightmap: &HeightMap, x: i32, z: i32) -> i32 {
         match heightmap {
-            HeightMap::WorldSurfaceWg | HeightMap::WorldSurface => {
-                self.top_block_height_exclusive(x, z)
-            }
-            HeightMap::OceanFloorWg | HeightMap::OceanFloor => {
-                self.ocean_floor_height_exclusive(x, z)
-            }
+            HeightMap::WorldSurfaceWg => self.top_block_height_wg_exclusive(x, z),
+            HeightMap::WorldSurface => self.top_block_height_exclusive(x, z),
+            HeightMap::OceanFloorWg => self.ocean_floor_height_wg_exclusive(x, z),
+            HeightMap::OceanFloor => self.ocean_floor_height_exclusive(x, z),
             HeightMap::MotionBlocking => self.top_motion_blocking_block_height_exclusive(x, z),
             HeightMap::MotionBlockingNoLeaves => {
                 self.top_motion_blocking_block_no_leaves_height_exclusive(x, z)
@@ -473,16 +638,33 @@ impl ProtoChunk {
         }
     }
 
+    /// Vanilla `WORLD_SURFACE_WG`: the surface as the carvers left it, frozen for the whole
+    /// feature step. Surface rules read this one (`SurfaceRules.Steep`).
     #[must_use]
-    pub const fn top_block_height_exclusive(&self, x: i32, z: i32) -> i32 {
+    pub const fn top_block_height_wg_exclusive(&self, x: i32, z: i32) -> i32 {
         let index = Self::local_position_to_height_map_index(x & 15, z & 15);
         self.flat_surface_height_map[index] as i32 + 1
     }
 
+    /// Vanilla `OCEAN_FLOOR_WG`, frozen the same way.
+    #[must_use]
+    pub const fn ocean_floor_height_wg_exclusive(&self, x: i32, z: i32) -> i32 {
+        let index = Self::local_position_to_height_map_index(x & 15, z & 15);
+        self.flat_ocean_floor_height_map[index] as i32 + 1
+    }
+
+    /// Vanilla `WORLD_SURFACE`: live during feature placement.
+    #[must_use]
+    pub const fn top_block_height_exclusive(&self, x: i32, z: i32) -> i32 {
+        let index = Self::local_position_to_height_map_index(x & 15, z & 15);
+        self.flat_final_surface_height_map[index] as i32 + 1
+    }
+
+    /// Vanilla `OCEAN_FLOOR`: live during feature placement.
     #[must_use]
     pub const fn ocean_floor_height_exclusive(&self, x: i32, z: i32) -> i32 {
         let index = Self::local_position_to_height_map_index(x & 15, z & 15);
-        self.flat_ocean_floor_height_map[index] as i32 + 1
+        self.flat_final_ocean_floor_height_map[index] as i32 + 1
     }
 
     #[must_use]
@@ -553,28 +735,74 @@ impl ProtoChunk {
         if local_y < 0 || local_y >= self.height() as i32 {
             return;
         }
-        if !block_state.is_air() {
-            let index = Self::local_position_to_height_map_index(local_x, local_z);
-            let y = y as i16;
-            self.maybe_update_surface_height_map(index, y);
-            let block = BlockId::from_state_id(block_state.id);
-
-            let blocks_movement = blocks_movement(block_state, block);
-            if blocks_movement {
-                self.maybe_update_ocean_floor_height_map(index, y);
-            }
-            if blocks_movement || block_state.is_liquid() {
-                self.maybe_update_motion_blocking_height_map(index, y);
-                if !block.has_tag(tag::Block::MINECRAFT_LEAVES) {
-                    {
-                        self.maybe_update_motion_blocking_no_leaves_height_map(index, y);
-                    }
-                }
-            }
-        }
-
         let index = self.local_pos_to_block_index(local_x, local_y, local_z);
         self.flat_block_map[index] = block_state.id;
+
+        // Vanilla `ProtoChunk.setBlockState` writes the block first and then updates exactly
+        // the maps in `getPersistedStatus().heightmapsAfter()`: `WORLDGEN_HEIGHTMAPS`
+        // (`WORLD_SURFACE_WG`, `OCEAN_FLOOR_WG`) up to and including the surface step, and
+        // `FINAL_HEIGHTMAPS` from the carver step on. A chunk's persisted status is still
+        // `SURFACE` while its carvers run and `CARVERS` while its features run, so carving
+        // lowers the worldgen maps and features only ever move the final ones.
+        let column = Self::local_position_to_height_map_index(local_x, local_z);
+        let id = block_state.id;
+        if self.stage < StagedChunkEnum::Carvers {
+            self.flat_surface_height_map[column] = self.heightmap_after_write(
+                self.flat_surface_height_map[column],
+                local_x,
+                local_z,
+                y,
+                Self::heightmap_not_air(id),
+                Self::heightmap_not_air,
+            );
+            self.flat_ocean_floor_height_map[column] = self.heightmap_after_write(
+                self.flat_ocean_floor_height_map[column],
+                local_x,
+                local_z,
+                y,
+                Self::heightmap_blocks_motion(id),
+                Self::heightmap_blocks_motion,
+            );
+            return;
+        }
+
+        if !self.final_heightmaps_primed {
+            self.prime_final_heightmaps();
+            return;
+        }
+
+        self.flat_final_surface_height_map[column] = self.heightmap_after_write(
+            self.flat_final_surface_height_map[column],
+            local_x,
+            local_z,
+            y,
+            Self::heightmap_not_air(id),
+            Self::heightmap_not_air,
+        );
+        self.flat_final_ocean_floor_height_map[column] = self.heightmap_after_write(
+            self.flat_final_ocean_floor_height_map[column],
+            local_x,
+            local_z,
+            y,
+            Self::heightmap_blocks_motion(id),
+            Self::heightmap_blocks_motion,
+        );
+        self.flat_motion_blocking_height_map[column] = self.heightmap_after_write(
+            self.flat_motion_blocking_height_map[column],
+            local_x,
+            local_z,
+            y,
+            Self::heightmap_motion_blocking(id),
+            Self::heightmap_motion_blocking,
+        );
+        self.flat_motion_blocking_no_leaves_height_map[column] = self.heightmap_after_write(
+            self.flat_motion_blocking_no_leaves_height_map[column],
+            local_x,
+            local_z,
+            y,
+            Self::heightmap_motion_blocking_no_leaves(id),
+            Self::heightmap_motion_blocking_no_leaves,
+        );
     }
 
     #[inline]
@@ -990,7 +1218,8 @@ impl ProtoChunk {
                 let x = start_x + local_x;
                 let z = start_z + local_z;
 
-                let mut top_block = self.top_block_height_exclusive(local_x, local_z);
+                // Vanilla `SurfaceSystem.buildSurface` reads `Heightmap.Types.WORLD_SURFACE_WG`.
+                let mut top_block = self.top_block_height_wg_exclusive(local_x, local_z);
 
                 let biome_y = if settings.legacy_random_source {
                     0
@@ -1008,7 +1237,7 @@ impl ProtoChunk {
                         .terrain_builder
                         .place_badlands_pillar(self, x, z, top_block);
 
-                    top_block = self.top_block_height_exclusive(local_x, local_z);
+                    top_block = self.top_block_height_wg_exclusive(local_x, local_z);
                 }
 
                 context.init_horizontal(x, z);
@@ -1104,6 +1333,10 @@ impl ProtoChunk {
         block_registry: &dyn WorldPortalExt,
         random_config: &GlobalRandomConfig,
     ) {
+        // `ChunkStatusTasks.generateFeatures` primes the four final heightmaps from the
+        // carved blocks before the first feature runs.
+        cache.get_center_chunk_mut().prime_final_heightmaps();
+
         let (center_x, center_z, min_y, generation_min_y, generation_height) = {
             let chunk = cache.get_center_chunk();
             (

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -307,6 +307,63 @@ mod test {
         }
     }
 
+    /// Vanilla `FossilFeature.place` reads a neighbouring column through the region:
+    ///
+    /// ```java
+    /// lowestSurfaceY = Math.min(lowestSurfaceY,
+    ///     level.getHeight(Heightmap.Types.OCEAN_FLOOR_WG, lowCorner.getX() + xscan, lowCorner.getZ() + zscan));
+    /// ```
+    ///
+    /// `WorldGenRegion.getHeight` forwards to the chunk holding that column, and
+    /// `OCEAN_FLOOR_WG` / `WORLD_SURFACE_WG` are live on every proto chunk of the region:
+    /// noise and the carvers maintained them. Only the chunk being decorated has the four
+    /// `FINAL_HEIGHTMAPS` primed (`ChunkStatusTasks.generateFeatures`). Pumpkin's multi-chunk
+    /// cache used to answer both `*_WG` maps out of the final maps, so any column outside the
+    /// centre chunk reported `minY - 1`.
+    #[test]
+    fn the_worldgen_heightmaps_are_live_on_every_chunk_of_the_cache() {
+        use crate::chunk_system::{Chunk, generation_cache::Cache};
+        use crate::generation::proto_chunk::GenerationCache;
+        use pumpkin_util::HeightMap;
+
+        let seed = Seed(13579);
+        let world_gen = get_world_gen(seed, Dimension::OVERWORLD, false, Vec::new(), String::new());
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+
+        let mut cache = Cache::new(-1, -1, 3);
+        for chunk_x in -1..=1 {
+            for chunk_z in -1..=1 {
+                let mut chunk = ProtoChunk::new(chunk_x, chunk_z, &world_gen);
+                chunk.step_to_biomes(generator);
+                chunk.stage = StagedChunkEnum::StructureReferences;
+                chunk.step_to_noise(generator);
+                let surface_biomes = surface_biomes(&world_gen, chunk_x, chunk_z);
+                chunk.step_to_surface(generator, &surface_biomes);
+                chunk.stage = StagedChunkEnum::Carvers;
+                cache.chunks.push(Chunk::Proto(Box::new(chunk)));
+            }
+        }
+        // Exactly what `generate_features_and_structure` does before the first feature runs.
+        cache.get_center_chunk_mut().prime_final_heightmaps();
+
+        let bottom = cache.get_center_chunk().bottom_y() as i32;
+        for (x, z) in [(0, 0), (-16, 0), (0, -16), (24, 24), (-3, 20)] {
+            let wg = cache.get_top_y(&HeightMap::OceanFloorWg, x, z);
+            assert!(
+                wg > bottom,
+                "OCEAN_FLOOR_WG at ({x}, {z}) is {wg}; the worldgen heightmap must be live \
+                 outside the decorated chunk, not the unprimed final map ({bottom})"
+            );
+            let surface = cache.get_top_y(&HeightMap::WorldSurfaceWg, x, z);
+            assert!(
+                surface >= wg,
+                "WORLD_SURFACE_WG ({surface}) at ({x}, {z}) must sit at or above OCEAN_FLOOR_WG ({wg})"
+            );
+        }
+    }
+
     /// Vanilla `Heightmap.update` lowers a map when the block it was pointing at is replaced
     /// by one the map does not match:
     ///

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -156,7 +156,8 @@ mod test {
         let mut expected_heights = [[0i32; 16]; 16];
         for z in 0..16i32 {
             for x in 0..16i32 {
-                expected_heights[z as usize][x as usize] = proto.top_block_height_exclusive(x, z);
+                expected_heights[z as usize][x as usize] =
+                    proto.top_block_height_wg_exclusive(x, z);
             }
         }
 
@@ -174,7 +175,7 @@ mod test {
         for z in 0..16i32 {
             for x in 0..16i32 {
                 let expected = expected_heights[z as usize][x as usize];
-                let got = resumed.top_block_height_exclusive(x, z);
+                let got = resumed.top_block_height_wg_exclusive(x, z);
                 if got != expected {
                     height_mismatches += 1;
                 }
@@ -304,6 +305,102 @@ mod test {
                 }
             }
         }
+    }
+
+    /// Vanilla `Heightmap.update` lowers a map when the block it was pointing at is replaced
+    /// by one the map does not match:
+    ///
+    /// ```java
+    /// } else if (i - 1 == y) {
+    ///     for (int j = y - 1; j >= this.chunk.getMinY(); j--) {
+    ///         if (this.isOpaque.test(this.chunk.getBlockState(mutableBlockPos.set(x, j, z)))) {
+    ///             this.setHeight(x, z, j + 1);
+    ///             return true;
+    ///         }
+    ///     }
+    ///     this.setHeight(x, z, this.chunk.getMinY());
+    ///     return true;
+    /// }
+    /// ```
+    ///
+    /// which is how carving pulls `WORLD_SURFACE_WG` / `OCEAN_FLOOR_WG` back down. Pumpkin
+    /// used to keep a running `max`, so a carved-open column still reported its pre-carver
+    /// surface for the whole feature step.
+    #[test]
+    fn a_write_over_the_top_block_lowers_the_worldgen_heightmap() {
+        use pumpkin_data::Block;
+
+        let seed = Seed(13579);
+        let world_gen = get_world_gen(seed, Dimension::OVERWORLD, false, Vec::new(), String::new());
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+        let (chunk_x, chunk_z) = (0, 0);
+        let mut chunk = ProtoChunk::new(chunk_x, chunk_z, &world_gen);
+        chunk.step_to_biomes(generator);
+        chunk.stage = StagedChunkEnum::StructureReferences;
+        chunk.step_to_noise(generator);
+        let surface_biomes = surface_biomes(&world_gen, chunk_x, chunk_z);
+        chunk.step_to_surface(generator, &surface_biomes);
+        assert_eq!(chunk.stage, StagedChunkEnum::Surface);
+
+        // A carver-shaped write: replace the top block of every column with air.
+        let bottom = chunk.bottom_y() as i32;
+        for x in 0..16i32 {
+            for z in 0..16i32 {
+                let top = chunk.top_block_height_wg_exclusive(x, z) - 1;
+                assert!(
+                    top >= bottom,
+                    "column ({x}, {z}) has no surface after the surface step"
+                );
+                chunk.set_block_state(x, top, z, Block::AIR.default_state);
+
+                let expected = (bottom..top)
+                    .rev()
+                    .find(|&y| {
+                        !pumpkin_data::BlockState::from_id(chunk.get_block_state_raw(
+                            x,
+                            y - bottom,
+                            z,
+                        ))
+                        .is_air()
+                    })
+                    .unwrap_or(bottom - 1);
+                assert_eq!(
+                    chunk.top_block_height_wg_exclusive(x, z) - 1,
+                    expected,
+                    "WORLD_SURFACE_WG at ({x}, {z}) was not lowered onto the next non-air block"
+                );
+            }
+        }
+
+        // From the carver step on, vanilla maintains `FINAL_HEIGHTMAPS` instead: feature
+        // writes move `WORLD_SURFACE` and leave `WORLD_SURFACE_WG` frozen where carving
+        // left it.
+        chunk.stage = StagedChunkEnum::Carvers;
+        chunk.prime_final_heightmaps();
+        let frozen = chunk.flat_surface_height_map;
+        for x in 0..16i32 {
+            for z in 0..16i32 {
+                assert_eq!(
+                    chunk.top_block_height_exclusive(x, z),
+                    chunk.top_block_height_wg_exclusive(x, z),
+                    "priming WORLD_SURFACE must reproduce the carved surface at ({x}, {z})"
+                );
+            }
+        }
+
+        let grown = chunk.top_block_height_exclusive(0, 0);
+        chunk.set_block_state(0, grown, 0, Block::SHORT_GRASS.default_state);
+        assert_eq!(
+            chunk.flat_surface_height_map, frozen,
+            "a feature write must not touch WORLD_SURFACE_WG"
+        );
+        assert_eq!(
+            chunk.top_block_height_exclusive(0, 0),
+            grown + 1,
+            "a feature write must raise WORLD_SURFACE"
+        );
     }
 
     fn verify_chunk_surface(

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -307,19 +307,9 @@ mod test {
         }
     }
 
-    /// Vanilla `FossilFeature.place` reads a neighbouring column through the region:
-    ///
-    /// ```java
-    /// lowestSurfaceY = Math.min(lowestSurfaceY,
-    ///     level.getHeight(Heightmap.Types.OCEAN_FLOOR_WG, lowCorner.getX() + xscan, lowCorner.getZ() + zscan));
-    /// ```
-    ///
-    /// `WorldGenRegion.getHeight` forwards to the chunk holding that column, and
-    /// `OCEAN_FLOOR_WG` / `WORLD_SURFACE_WG` are live on every proto chunk of the region:
-    /// noise and the carvers maintained them. Only the chunk being decorated has the four
-    /// `FINAL_HEIGHTMAPS` primed (`ChunkStatusTasks.generateFeatures`). Pumpkin's multi-chunk
-    /// cache used to answer both `*_WG` maps out of the final maps, so any column outside the
-    /// centre chunk reported `minY - 1`.
+    /// `OCEAN_FLOOR_WG` / `WORLD_SURFACE_WG` are live on every proto chunk of the region, since
+    /// noise and the carvers maintain them; only the chunk being decorated has the four
+    /// `FINAL_HEIGHTMAPS` primed.
     #[test]
     fn the_worldgen_heightmaps_are_live_on_every_chunk_of_the_cache() {
         use crate::chunk_system::{Chunk, generation_cache::Cache};
@@ -364,25 +354,9 @@ mod test {
         }
     }
 
-    /// Vanilla `Heightmap.update` lowers a map when the block it was pointing at is replaced
-    /// by one the map does not match:
-    ///
-    /// ```java
-    /// } else if (i - 1 == y) {
-    ///     for (int j = y - 1; j >= this.chunk.getMinY(); j--) {
-    ///         if (this.isOpaque.test(this.chunk.getBlockState(mutableBlockPos.set(x, j, z)))) {
-    ///             this.setHeight(x, z, j + 1);
-    ///             return true;
-    ///         }
-    ///     }
-    ///     this.setHeight(x, z, this.chunk.getMinY());
-    ///     return true;
-    /// }
-    /// ```
-    ///
-    /// which is how carving pulls `WORLD_SURFACE_WG` / `OCEAN_FLOOR_WG` back down. Pumpkin
-    /// used to keep a running `max`, so a carved-open column still reported its pre-carver
-    /// surface for the whole feature step.
+    /// `Heightmap.update` scans down for the next matching block when the top one is replaced by
+    /// something the map does not match, which is how carving pulls `WORLD_SURFACE_WG` /
+    /// `OCEAN_FLOOR_WG` back down rather than only ever raising them.
     #[test]
     fn a_write_over_the_top_block_lowers_the_worldgen_heightmap() {
         use pumpkin_data::Block;

--- a/crates/pumpkin-world/src/generation/surface/mod.rs
+++ b/crates/pumpkin-world/src/generation/surface/mod.rs
@@ -188,8 +188,9 @@ pub fn steep_material_condition(chunk: &ProtoChunk, block_x: i32, block_z: i32) 
     let local_z_sub = 0.max(local_z - 1);
     let local_z_add = 15.min(local_z + 1);
 
-    let sub_height = chunk.top_block_height_exclusive(local_x, local_z_sub);
-    let add_height = chunk.top_block_height_exclusive(local_x, local_z_add);
+    // Vanilla `SurfaceRules.Steep` reads `Heightmap.Types.WORLD_SURFACE_WG`.
+    let sub_height = chunk.top_block_height_wg_exclusive(local_x, local_z_sub);
+    let add_height = chunk.top_block_height_wg_exclusive(local_x, local_z_add);
 
     if add_height >= sub_height + 4 {
         return true;
@@ -198,8 +199,8 @@ pub fn steep_material_condition(chunk: &ProtoChunk, block_x: i32, block_z: i32) 
     let local_x_sub = 0.max(local_x - 1);
     let local_x_add = 15.min(local_x + 1);
 
-    let sub_height = chunk.top_block_height_exclusive(local_x_sub, local_z);
-    let add_height = chunk.top_block_height_exclusive(local_x_add, local_z);
+    let sub_height = chunk.top_block_height_wg_exclusive(local_x_sub, local_z);
+    let add_height = chunk.top_block_height_wg_exclusive(local_x_add, local_z);
 
     sub_height >= add_height + 4
 }

--- a/crates/pumpkin/src/command/commands/place.rs
+++ b/crates/pumpkin/src/command/commands/place.rs
@@ -426,6 +426,8 @@ impl CommandExecutor for PlaceStructureExecutor {
                             let ground = surface_y as i16;
                             chunk.flat_surface_height_map = [ground; 256];
                             chunk.flat_ocean_floor_height_map = [ground; 256];
+                            chunk.flat_final_surface_height_map = [ground; 256];
+                            chunk.flat_final_ocean_floor_height_map = [ground; 256];
                             chunk.flat_motion_blocking_height_map = [ground; 256];
                             chunk.flat_motion_blocking_no_leaves_height_map = [ground; 256];
 
@@ -554,6 +556,8 @@ impl CommandExecutor for PlaceFeatureExecutor {
         let ground = surface_y as i16;
         chunk.flat_surface_height_map = [ground; 256];
         chunk.flat_ocean_floor_height_map = [ground; 256];
+        chunk.flat_final_surface_height_map = [ground; 256];
+        chunk.flat_final_ocean_floor_height_map = [ground; 256];
         chunk.flat_motion_blocking_height_map = [ground; 256];
         chunk.flat_motion_blocking_no_leaves_height_map = [ground; 256];
 


### PR DESCRIPTION
## Description

Pumpkin kept one surface map and one ocean-floor map serving both the `_WG` and the final heightmap variants, and updated them with a running maximum. Vanilla keeps six maps in two groups (`ChunkStatus`, 26.2 jar):

The worldgen group holds `OCEAN_FLOOR_WG` and `WORLD_SURFACE_WG`; the final group holds `OCEAN_FLOOR`, `WORLD_SURFACE`, `MOTION_BLOCKING` and `MOTION_BLOCKING_NO_LEAVES`.

`ProtoChunk.setBlockState` updates `WORLDGEN_HEIGHTMAPS` while the chunk's status is `empty`..`surface` (i.e. through the carvers) and `FINAL_HEIGHTMAPS` from `carvers` on (i.e. during features); `ChunkStatusTasks.generateFeatures` primes the final four from the carved blocks before the first feature. And `Heightmap.update` is not a running maximum: replacing the block a map points at with one it does not match scans *down* for the next match.

**Commit 1** splits the maps, gives them vanilla's update rule, primes the final four when the feature step starts, and routes each reader at the map vanilla names (`SurfaceRules.Steep` and `buildSurface` at `WORLD_SURFACE_WG`, features at the final maps). Before this, a column carved open still reported its pre-carver surface, and any block a feature placed raised the map that `OCEAN_FLOOR_WG` readers see, which vanilla freezes for the whole feature step. Everything placed off a heightmap was affected: `heightmap` and `surface_relative_threshold_filter` placement, seagrass, kelp, sea pickles, ore, fossils, bamboo. `/place` is updated for the new accessor.

**Commit 2** fixes the multi-chunk cache: `Cache::get_top_y` answered `WorldSurfaceWg` / `OceanFloorWg` out of the *final* maps, which are primed only for the chunk being decorated, so any column outside the centre chunk reported `minY − 1` (−64). `FossilFeature.place` takes `min(origin.y, OCEAN_FLOOR_WG over the footprint)`, so every fossil whose footprint crossed a chunk border collapsed onto the `minY + 10` clamp (the fossil at (−2, −25, 84) went to y −54 instead of −44). `RuinedPortalPiece`, `ShiftablePiece` and the shipwreck / ocean-ruin placements read the same maps.

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

| | before | after |
|---|---|---|
| (1) split maps: mismatching blocks | 17,639 | **17,529**; median chunk 19 → 16 |
| (2) `_WG` from the cache, late in the series: mismatching blocks | 1,067 | **874**; chunks identical 131 → **156/256** |

(1): seagrass 328 → 238, `sand→dirt` 309 → 267, `dirt↔stone` 433 → 270, several ore confusions down; fossils move (+85 `deepslate↔bone_block`) because they now genuinely read the frozen `OCEAN_FLOOR_WG`, which (2) then fixes. (2): fossil pairs 165 → 38, `dead_bush↔air` 91 → 0.

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. New tests: `a_write_over_the_top_block_lowers_the_worldgen_heightmap` (the update rule) and `the_worldgen_heightmaps_are_live_on_every_chunk_of_the_cache` (the cache fix, with a fossil-style footprint that crosses a chunk border).

**Known impact:** changes placement of every heightmap-relative feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terrain height calculations during world generation, including ocean floors and water-gradient surfaces.
  - Fixed terrain heights updating correctly when blocks are raised, lowered, or replaced.
  - Improved consistency between generated terrain and terrain modified by later features.
  - Corrected height calculations when placing structures and other content.
  - Improved terrain restoration when resuming chunk loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
