### PR TITLE
fix(worldgen): place fossils and ruined portals the way vanilla does 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-util/src/math/block_box.rs
+++ b/crates/pumpkin-util/src/math/block_box.rs
@@ -232,6 +232,25 @@ impl BlockBox {
         self.max.y - self.min.y + 1
     }
 
+    /// Vanilla `BoundingBox.getCenter()`:
+    ///
+    /// ```java
+    /// return new BlockPos(this.minX() + this.getXSpan() / 2,
+    ///                     this.minY() + this.getYSpan() / 2,
+    ///                     this.minZ() + this.getZSpan() / 2);
+    /// ```
+    ///
+    /// The span is inclusive (`max - min + 1`), so on an even span this sits one block
+    /// past the arithmetic midpoint of the corners.
+    #[must_use]
+    pub const fn center(&self) -> Vector3<i32> {
+        Vector3::new(
+            self.min.x + (self.max.x - self.min.x + 1) / 2,
+            self.min.y + (self.max.y - self.min.y + 1) / 2,
+            self.min.z + (self.max.z - self.min.z + 1) / 2,
+        )
+    }
+
     /// Expands this box to encompass another box.
     ///
     /// # Arguments

--- a/crates/pumpkin-util/src/random/mod.rs
+++ b/crates/pumpkin-util/src/random/mod.rs
@@ -149,7 +149,19 @@ pub const fn seed_slime_chunk(x: i32, z: i32, seed: u64, salt: u64) -> u64 {
 
 /// Generates a carver seed for cave and ravine generation.
 ///
-/// Carver seeds are used for terrain carving features like caves and ravines.
+/// This is vanilla's `WorldgenRandom.setLargeFeatureSeed(seed, chunkX, chunkZ)`, which is
+/// shared by the carvers, the structure `GenerationContext` random and the `legacy_type_3`
+/// structure frequency reduction:
+///
+/// ```text
+/// this.setSeed(seed);
+/// long xScale = this.nextLong();
+/// long zScale = this.nextLong();
+/// this.setSeed(chunkX * xScale ^ chunkZ * zScale ^ seed);
+/// ```
+///
+/// Not to be confused with `setDecorationSeed`, which ORs the scales with 1 and *adds* the
+/// two products (see `get_population_seed`).
 ///
 /// # Arguments
 /// - `world_seed` – The base world seed (plus carver index).
@@ -162,11 +174,9 @@ pub const fn seed_slime_chunk(x: i32, z: i32, seed: u64, salt: u64) -> u64 {
 #[must_use]
 pub fn get_carver_seed(world_seed: u64, chunk_x: i32, chunk_z: i32) -> u64 {
     let mut random = LegacyRand::from_seed(world_seed);
-    let l = random.next_i64() | 1;
-    let m = random.next_i64() | 1;
-    ((chunk_x as i64)
-        .wrapping_mul(l)
-        .wrapping_add((chunk_z as i64).wrapping_mul(m)) as u64)
+    let x_scale = random.next_i64();
+    let z_scale = random.next_i64();
+    ((i64::from(chunk_x).wrapping_mul(x_scale)) ^ (i64::from(chunk_z).wrapping_mul(z_scale))) as u64
         ^ world_seed
 }
 
@@ -373,7 +383,7 @@ pub const fn hash_block_pos(x: i32, y: i32, z: i32) -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::random::get_region_seed;
+    use crate::random::{RandomImpl, get_carver_seed, get_region_seed, legacy_rand::LegacyRand};
 
     use super::hash_block_pos;
 
@@ -381,6 +391,24 @@ mod tests {
     fn region_seed() {
         let seed = get_region_seed(12345612, 1, 1, 14357620);
         assert_eq!(seed, 474797819485);
+    }
+
+    /// `WorldgenRandom.setLargeFeatureSeed(13579, -11, 11)`. In the vanilla 26.2 world for
+    /// seed 13579, chunk (-11, 11) is the only chunk in x -16..-1, z 0..15 whose
+    /// `legacy_type_3` mineshaft roll (`new LegacyRandomSource(thisSeed).nextDouble() < 0.004`)
+    /// passes; with the `setDecorationSeed` formula (`| 1`, `+`) no chunk in that area passes.
+    #[test]
+    fn carver_seed_is_large_feature_seed() {
+        assert_eq!(
+            get_carver_seed(13579, -11, 11),
+            (-4_375_068_746_237_355_838i64) as u64
+        );
+        assert_eq!(get_carver_seed(13579, 0, 0), 13579);
+
+        let mut random = LegacyRand::from_seed(get_carver_seed(13579, -11, 11));
+        assert!(random.next_f64() < 0.004);
+        let mut random = LegacyRand::from_seed(get_carver_seed(13579, -10, 11));
+        assert!(random.next_f64() >= 0.004);
     }
 
     #[test]

--- a/crates/pumpkin-world/src/chunk_system/chunk_state.rs
+++ b/crates/pumpkin-world/src/chunk_system/chunk_state.rs
@@ -245,7 +245,7 @@ impl Chunk {
                 for (heightmap_type, height) in [
                     (
                         ChunkHeightmapType::WorldSurface,
-                        proto_chunk.flat_surface_height_map[source_index],
+                        proto_chunk.flat_final_surface_height_map[source_index],
                     ),
                     (
                         ChunkHeightmapType::MotionBlocking,

--- a/crates/pumpkin-world/src/chunk_system/generation_cache.rs
+++ b/crates/pumpkin-world/src/chunk_system/generation_cache.rs
@@ -322,12 +322,10 @@ impl GenerationCache for Cache {
 
     fn get_top_y(&self, heightmap: &HeightMap, x: i32, z: i32) -> i32 {
         match heightmap {
-            HeightMap::WorldSurfaceWg | HeightMap::WorldSurface => {
-                self.top_block_height_exclusive(x, z)
-            }
-            HeightMap::OceanFloorWg | HeightMap::OceanFloor => {
-                self.ocean_floor_height_exclusive(x, z)
-            }
+            HeightMap::WorldSurfaceWg => self.top_block_height_wg_exclusive(x, z),
+            HeightMap::WorldSurface => self.top_block_height_exclusive(x, z),
+            HeightMap::OceanFloorWg => self.ocean_floor_height_wg_exclusive(x, z),
+            HeightMap::OceanFloor => self.ocean_floor_height_exclusive(x, z),
             HeightMap::MotionBlocking => self.top_motion_blocking_block_height_exclusive(x, z),
             HeightMap::MotionBlockingNoLeaves => {
                 self.top_motion_blocking_block_no_leaves_height_exclusive(x, z)
@@ -461,6 +459,44 @@ impl GenerationCache for Cache {
 }
 
 impl Cache {
+    /// Vanilla `OCEAN_FLOOR_WG` on a `WorldGenRegion`: the worldgen heightmap the proto chunk
+    /// kept while noise and the carvers ran. It is live for every chunk in the region, whereas
+    /// the four `FINAL_HEIGHTMAPS` maps are only primed for the chunk being decorated, so
+    /// reading the final map here returns `minY - 1` for every neighbour column.
+    fn ocean_floor_height_wg_exclusive(&self, x: i32, z: i32) -> i32 {
+        let dx = (x >> 4) - self.x;
+        let dy = (z >> 4) - self.z;
+        if dx < 0 || dy < 0 || dx >= self.size || dy >= self.size {
+            return 0;
+        }
+        match &self.chunks[(dx * self.size + dy) as usize] {
+            Chunk::Level(_data) => {
+                0 // todo missing
+            }
+            Chunk::Proto(data) => data.ocean_floor_height_wg_exclusive(x, z),
+        }
+    }
+
+    /// Vanilla `WORLD_SURFACE_WG`; see [`Self::ocean_floor_height_wg_exclusive`].
+    fn top_block_height_wg_exclusive(&self, x: i32, z: i32) -> i32 {
+        let dx = (x >> 4) - self.x;
+        let dy = (z >> 4) - self.z;
+        if dx < 0 || dy < 0 || dx >= self.size || dy >= self.size {
+            return 0;
+        }
+        match &self.chunks[(dx * self.size + dy) as usize] {
+            Chunk::Level(data) => {
+                let heightmap = data
+                    .heightmap
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let min_y = data.section.min_y;
+                heightmap.get(ChunkHeightmapType::WorldSurface, x, z, min_y)
+            }
+            Chunk::Proto(data) => data.top_block_height_wg_exclusive(x, z),
+        }
+    }
+
     pub fn advance_all(
         &mut self,
         stage: StagedChunkEnum,

--- a/crates/pumpkin-world/src/generation/feature/features/fossil.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/fossil.rs
@@ -169,6 +169,21 @@ fn place_fossil_template<T: GenerationCache>(
     random: &mut RandomGenerator,
     placement_box: &BlockBox,
 ) {
+    // `StructureTemplate.placeInWorld` opens with
+    // `settings.getRandomPalette(this.palettes, position).blocks()`, and
+    // `StructurePlaceSettings.getRandomPalette` is unconditional:
+    //
+    //     return palettes.get(this.getRandom(pos).nextInt(paletteSize));
+    //
+    // so a single-palette template still burns one `nextInt(1)` off the feature random
+    // before the first block-rot draw. `placeInWorld` bails out first when there is no
+    // palette at all (`if (this.palettes.isEmpty()) return false;`).
+    let palette_count = template.palettes.len();
+    if palette_count == 0 {
+        return;
+    }
+    let _ = random.next_bounded_i32(palette_count as i32);
+
     for block in &template.blocks {
         let local_pos = rotation.transform_pos(block.pos, template.size);
         let world_pos = origin + local_pos;
@@ -194,5 +209,72 @@ fn place_fossil_template<T: GenerationCache>(
         {
             chunk.set_block_state(&world_pos, processor.process(state));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FossilProcessor, place_fossil_template};
+    use crate::ProtoChunk;
+    use crate::generation::get_world_gen;
+    use crate::generation::structure::template::get_template;
+    use pumpkin_data::{Rotation, dimension::Dimension};
+    use pumpkin_util::math::{block_box::BlockBox, vector3::Vector3};
+    use pumpkin_util::random::{RandomGenerator, RandomImpl, xoroshiro128::Xoroshiro};
+    use pumpkin_util::world_seed::Seed;
+
+    /// `StructureTemplate.placeInWorld` reads its block list through
+    ///
+    /// ```java
+    /// List<StructureBlockInfo> blockInfoList = settings.getRandomPalette(this.palettes, position).blocks();
+    /// ```
+    ///
+    /// and `StructurePlaceSettings.getRandomPalette` is unconditional:
+    ///
+    /// ```java
+    /// return palettes.get(this.getRandom(pos).nextInt(paletteSize));
+    /// ```
+    ///
+    /// Every fossil template ships a single palette, and `nextInt(1)` still consumes one
+    /// `nextInt()` off the shared feature random before the first `BlockRotProcessor` draw.
+    /// Pumpkin skipped it, so both the fossil and its ore overlay read the rot stream one
+    /// draw early.
+    #[test]
+    fn placing_a_template_burns_the_palette_draw_before_the_rot_draws() {
+        let world_gen = get_world_gen(
+            Seed(13579),
+            Dimension::OVERWORLD,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+        let mut chunk = ProtoChunk::new(0, 0, &world_gen);
+        let template = get_template("fossil/spine_3").expect("fossil/spine_3 template");
+        assert_eq!(template.palettes.len(), 1, "spine_3 ships a single palette");
+        assert_eq!(template.size, Vector3::new(7, 4, 13));
+
+        // A box that holds the whole unrotated template, so every block draws.
+        let placement_box = BlockBox::new(-16, -64, -16, 31, 319, 31);
+        let mut random = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(13579));
+        place_fossil_template(
+            &mut chunk,
+            &template,
+            Vector3::new(0, 0, 0),
+            Rotation::None,
+            FossilProcessor::FossilRot,
+            &mut random,
+            &placement_box,
+        );
+
+        let mut expected = RandomGenerator::Xoroshiro(Xoroshiro::from_seed(13579));
+        expected.next_bounded_i32(template.palettes.len() as i32);
+        for _ in 0..template.blocks.len() {
+            let _ = expected.next_f32();
+        }
+        assert_eq!(
+            random.next_i64(),
+            expected.next_i64(),
+            "placing a fossil template must consume nextInt(paletteSize) + one nextFloat() per block"
+        );
     }
 }

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1422,11 +1422,11 @@ impl ProtoChunk {
                 }
 
                 match instance {
-                    StructureInstance::Start(pos) => tasks.push(pos.collector.clone()),
+                    StructureInstance::Start(pos) => tasks.push((*id, pos.collector.clone())),
                     StructureInstance::Reference(collector) => {
                         let collector_arc = collector.clone();
-                        if !tasks.iter().any(|t| Arc::ptr_eq(t, &collector_arc)) {
-                            tasks.push(collector_arc);
+                        if !tasks.iter().any(|(_, t)| Arc::ptr_eq(t, &collector_arc)) {
+                            tasks.push((*id, collector_arc));
                         }
                     }
                 }
@@ -1461,15 +1461,18 @@ impl ProtoChunk {
                                         .intersects_raw_xz(start_x, start_z, end_x, end_z)
                                     {
                                         let collector_arc = pos.collector.clone();
-                                        if !tasks.iter().any(|t| Arc::ptr_eq(t, &collector_arc)) {
-                                            tasks.push(collector_arc);
+                                        if !tasks
+                                            .iter()
+                                            .any(|(_, t)| Arc::ptr_eq(t, &collector_arc))
+                                        {
+                                            tasks.push((*id, collector_arc));
                                         }
                                     }
                                 }
                                 StructureInstance::Reference(collector) => {
                                     let collector_arc = collector.clone();
-                                    if !tasks.iter().any(|t| Arc::ptr_eq(t, &collector_arc)) {
-                                        tasks.push(collector_arc);
+                                    if !tasks.iter().any(|(_, t)| Arc::ptr_eq(t, &collector_arc)) {
+                                        tasks.push((*id, collector_arc));
                                     }
                                 }
                             }
@@ -1479,15 +1482,27 @@ impl ProtoChunk {
             }
         }
 
-        let decorator_seed = get_decorator_seed(population_seed, 0, step as u64);
-        let mut random = RandomGenerator::Worldgen(WorldgenRandom::from_seed(decorator_seed));
-
+        // Vanilla `ChunkGenerator.applyBiomeDecoration` walks the structure registry
+        // once per decoration step and reseeds before each structure:
+        //     for (Structure s : structuresByStep.getOrDefault(stepIndex, List.of())) {
+        //         random.setFeatureSeed(decorationSeed, index, stepIndex);
+        //         startsForStructure(sectionPos, s).forEach(start -> start.placeInChunk(..., random, ...));
+        //         index++;
+        //     }
+        // `index` is the structure's position inside its step's list in registry
+        // order, i.e. resource-location order, and it is counted for every
+        // structure of the step whether or not the chunk holds a start of it.
         let chunk = cache.get_center_chunk_mut();
-        for collector_arc in tasks {
-            let mut collector = collector_arc
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            collector.generate_in_chunk(chunk, block_registry, &mut random, world_seed);
+        for (structure_index, id) in structures_in_step(step) {
+            let decorator_seed = get_decorator_seed(population_seed, structure_index, step as u64);
+            let mut random = RandomGenerator::Worldgen(WorldgenRandom::from_seed(decorator_seed));
+
+            for (_, collector_arc) in tasks.iter().filter(|(task_id, _)| *task_id == id) {
+                let mut collector = collector_arc
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                collector.generate_in_chunk(chunk, block_registry, &mut random, world_seed);
+            }
         }
     }
 
@@ -1914,5 +1929,58 @@ impl GenerationCache for ProtoChunk {
     }
     fn get_sea_level(&self) -> i32 {
         Self::get_sea_level(self)
+    }
+}
+
+/// The structures of one decoration step, paired with the index vanilla uses to
+/// derive their feature seed.
+///
+/// `ChunkGenerator.applyBiomeDecoration` groups the whole structure registry by
+/// `structure.step().ordinal()` and walks each step's list in registry order,
+/// counting one index per structure whether or not the chunk holds a start of it:
+///
+///     int index = 0;
+///     for (Structure s : structuresByStep.getOrDefault(stepIndex, List.of())) {
+///         random.setFeatureSeed(decorationSeed, index, stepIndex);
+///         ...
+///         index++;
+///     }
+///
+/// The structure registry is data-driven, so its iteration order is the
+/// resource-location order that `StructureKeys::all_names` is generated in.
+fn structures_in_step(step: usize) -> impl Iterator<Item = (u64, StructureKeys)> {
+    StructureKeys::all_names()
+        .iter()
+        .filter_map(|name| StructureKeys::from_name(name))
+        .filter(move |id| Structure::get(id).step.ordinal() == step)
+        .enumerate()
+        .map(|(index, id)| (index as u64, id))
+}
+
+#[cfg(test)]
+mod structure_step_tests {
+    use super::structures_in_step;
+    use pumpkin_data::structures::{GenerationStep, StructureKeys};
+
+    #[test]
+    fn underground_structures_are_indexed_in_registry_order() {
+        // Vanilla 26.2 `assets/datapacks/26_2/data/minecraft/worldgen/structure`:
+        // buried_treasure, mineshaft, mineshaft_mesa, trail_ruins and trial_chambers
+        // all declare "step": "underground_structures", and the data-driven registry
+        // iterates them in resource-location order, so
+        // `ChunkGenerator.applyBiomeDecoration`'s per-step `index` runs 0..4 in that
+        // order. `mineshaft_mesa` is 2, not 0.
+        let step = GenerationStep::UndergroundStructures.ordinal();
+        let listed: Vec<_> = structures_in_step(step).collect();
+        assert_eq!(
+            listed,
+            vec![
+                (0, StructureKeys::BuriedTreasure),
+                (1, StructureKeys::Mineshaft),
+                (2, StructureKeys::MineshaftMesa),
+                (3, StructureKeys::TrailRuins),
+                (4, StructureKeys::TrialChambers),
+            ]
+        );
     }
 }

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1939,12 +1939,14 @@ impl GenerationCache for ProtoChunk {
 /// `structure.step().ordinal()` and walks each step's list in registry order,
 /// counting one index per structure whether or not the chunk holds a start of it:
 ///
-///     int index = 0;
-///     for (Structure s : structuresByStep.getOrDefault(stepIndex, List.of())) {
-///         random.setFeatureSeed(decorationSeed, index, stepIndex);
-///         ...
-///         index++;
-///     }
+/// ```text
+/// int index = 0;
+/// for (Structure s : structuresByStep.getOrDefault(stepIndex, List.of())) {
+///     random.setFeatureSeed(decorationSeed, index, stepIndex);
+///     ...
+///     index++;
+/// }
+/// ```
 ///
 /// The structure registry is data-driven, so its iteration order is the
 /// resource-location order that `StructureKeys::all_names` is generated in.

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1681,11 +1681,17 @@ impl ProtoChunk {
 
             match &set.placement.placement_type {
                 StructurePlacementType::RandomSpread(spread) => {
-                    let region_x = pumpkin_util::math::floor_div(self.x, spread.spacing);
-                    let region_z = pumpkin_util::math::floor_div(self.z, spread.spacing);
+                    // Vanilla `ChunkGenerator.createReferences` looks at the starts of every
+                    // chunk within 8 chunks of this one, so cover every placement region
+                    // that overlaps that 17x17 window (for `spacing: 1` sets such as
+                    // mineshafts that is 289 regions, not the 9 around this chunk).
+                    let region_min_x = pumpkin_util::math::floor_div(self.x - 8, spread.spacing);
+                    let region_max_x = pumpkin_util::math::floor_div(self.x + 8, spread.spacing);
+                    let region_min_z = pumpkin_util::math::floor_div(self.z - 8, spread.spacing);
+                    let region_max_z = pumpkin_util::math::floor_div(self.z + 8, spread.spacing);
 
-                    for rx in (region_x - 1)..=(region_x + 1) {
-                        for rz in (region_z - 1)..=(region_z + 1) {
+                    for rx in region_min_x..=region_max_x {
+                        for rz in region_min_z..=region_max_z {
                             candidate_chunks.push(
                                 crate::generation::structure::placement::get_structure_chunk_in_region(
                                     spread,

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -140,10 +140,24 @@ pub struct ProtoChunk {
     biome_mixer_seed: i64,
     pub(crate) flat_block_map: Box<[BlockStateId]>,
     pub flat_biome_map: Box<[u8]>,
+    /// Vanilla `WORLD_SURFACE_WG`. `ChunkStatus.WORLDGEN_HEIGHTMAPS` is only maintained up
+    /// to and including the surface step, so carving still lowers it but features never
+    /// touch it again.
     pub flat_surface_height_map: [i16; CHUNK_AREA],
+    /// Vanilla `OCEAN_FLOOR_WG`, same lifetime as `flat_surface_height_map`.
     pub flat_ocean_floor_height_map: [i16; CHUNK_AREA],
+    /// Vanilla `WORLD_SURFACE`, one of `ChunkStatus.FINAL_HEIGHTMAPS`: primed from the blocks
+    /// when the chunk's feature step starts and kept current by every later write.
+    pub flat_final_surface_height_map: [i16; CHUNK_AREA],
+    /// Vanilla `OCEAN_FLOOR`, same lifetime as `flat_final_surface_height_map`.
+    pub flat_final_ocean_floor_height_map: [i16; CHUNK_AREA],
+    /// Vanilla `MOTION_BLOCKING`, same lifetime as `flat_final_surface_height_map`.
     pub flat_motion_blocking_height_map: [i16; CHUNK_AREA],
+    /// Vanilla `MOTION_BLOCKING_NO_LEAVES`, same lifetime as `flat_final_surface_height_map`.
     pub flat_motion_blocking_no_leaves_height_map: [i16; CHUNK_AREA],
+    /// Whether the four `FINAL_HEIGHTMAPS` have been primed for this chunk yet; vanilla
+    /// creates them lazily, so the first write after the carver step primes them.
+    final_heightmaps_primed: bool,
     structure_starts: FxHashMap<StructureKeys, StructureInstance>,
 
     height: u16,
@@ -229,7 +243,8 @@ impl ProtoChunk {
             super::generator::WorldGenerator::Custom(custom_gen) => custom_gen.biome_mixer_seed(),
         };
 
-        let default_heightmap = [i16::MIN; CHUNK_AREA];
+        // A column with nothing in it reads as "first available = bottom", i.e. top = bottom - 1.
+        let default_heightmap = [i16::from(bottom_y) - 1; CHUNK_AREA];
         Self {
             x,
             z,
@@ -246,8 +261,11 @@ impl ProtoChunk {
             .into_boxed_slice(),
             flat_surface_height_map: default_heightmap,
             flat_ocean_floor_height_map: default_heightmap,
+            flat_final_surface_height_map: default_heightmap,
+            flat_final_ocean_floor_height_map: default_heightmap,
             flat_motion_blocking_height_map: default_heightmap,
             flat_motion_blocking_no_leaves_height_map: default_heightmap,
+            final_heightmaps_primed: false,
             structure_starts: FxHashMap::default(),
             height,
             bottom_y,
@@ -362,11 +380,17 @@ impl ProtoChunk {
                 )
                     as i16;
 
-                proto_chunk.flat_surface_height_map[index] =
+                proto_chunk.flat_final_surface_height_map[index] =
                     heightmap_data.get(ChunkHeightmapType::WorldSurface, x, z, section_data.min_y)
                         as i16;
             }
         }
+
+        // Only the three level heightmaps are saved; the remaining maps are a pure function
+        // of the blocks, so rebuild them the way vanilla primes a missing one.
+        proto_chunk.final_heightmaps_primed = true;
+        proto_chunk.prime_ocean_floor_from_blocks();
+        proto_chunk.prime_worldgen_heightmaps();
 
         let saved_stage = StagedChunkEnum::from(chunk_data.status);
         proto_chunk.stage = saved_stage;
@@ -437,35 +461,176 @@ impl ProtoChunk {
         });
     }
 
-    fn maybe_update_surface_height_map(&mut self, index: usize, y: i16) {
-        let current_height = self.flat_surface_height_map[index];
-        self.flat_surface_height_map[index] = current_height.max(y);
+    /// Vanilla `Heightmap.update` after the block at `y` in this column was written:
+    ///
+    /// ```java
+    /// int i = this.getFirstAvailable(x, z);
+    /// if (y <= i - 2) return false;
+    /// if (this.isOpaque.test(state)) {
+    ///     if (y >= i) { this.setHeight(x, z, y + 1); return true; }
+    /// } else if (i - 1 == y) {
+    ///     for (int j = y - 1; j >= this.chunk.getMinY(); j--) {
+    ///         if (this.isOpaque.test(this.chunk.getBlockState(mutable.set(x, j, z)))) {
+    ///             this.setHeight(x, z, j + 1);
+    ///             return true;
+    ///         }
+    ///     }
+    ///     this.setHeight(x, z, this.chunk.getMinY());
+    ///     return true;
+    /// }
+    /// ```
+    ///
+    /// Pumpkin stores the top matching block itself rather than the first free slot above it,
+    /// so `first_available == current + 1`. Overwriting the top of a column with something the
+    /// map does not match scans down for the next match: that is how carving *lowers* a map,
+    /// which the old `max`-only updaters never did.
+    fn heightmap_after_write(
+        &self,
+        current: i16,
+        local_x: i32,
+        local_z: i32,
+        y: i32,
+        matches: bool,
+        predicate: fn(BlockStateId) -> bool,
+    ) -> i16 {
+        let first_available = i32::from(current) + 1;
+        if y <= first_available - 2 {
+            return current;
+        }
+        if matches {
+            return if y >= first_available {
+                y as i16
+            } else {
+                current
+            };
+        }
+        if first_available - 1 != y {
+            return current;
+        }
+        let bottom = i32::from(self.bottom_y());
+        for below in (bottom..y).rev() {
+            if predicate(self.get_block_state_raw(local_x, below - bottom, local_z)) {
+                return below as i16;
+            }
+        }
+        (bottom - 1) as i16
     }
 
-    fn maybe_update_ocean_floor_height_map(&mut self, index: usize, y: i16) {
-        let current_height = self.flat_ocean_floor_height_map[index];
-        self.flat_ocean_floor_height_map[index] = current_height.max(y);
+    /// Vanilla `Heightmap.Types.WORLD_SURFACE(_WG)`: `!state.isAir()`.
+    const fn heightmap_not_air(id: BlockStateId) -> bool {
+        !BlockState::from_id(id).is_air()
     }
 
-    fn maybe_update_motion_blocking_height_map(&mut self, index: usize, y: i16) {
-        let current_height = self.flat_motion_blocking_height_map[index];
-        self.flat_motion_blocking_height_map[index] = current_height.max(y);
+    /// Vanilla `Heightmap.Types.OCEAN_FLOOR(_WG)`: `state.blocksMotion()`.
+    const fn heightmap_blocks_motion(id: BlockStateId) -> bool {
+        let state = BlockState::from_id(id);
+        !state.is_air() && blocks_movement(state, BlockId::from_state_id(id))
     }
 
-    fn maybe_update_motion_blocking_no_leaves_height_map(&mut self, index: usize, y: i16) {
-        let current_height = self.flat_motion_blocking_no_leaves_height_map[index];
-        self.flat_motion_blocking_no_leaves_height_map[index] = current_height.max(y);
+    /// Vanilla `Heightmap.Types.MOTION_BLOCKING`:
+    /// `state.blocksMotion() || !state.getFluidState().isEmpty()`.
+    const fn heightmap_motion_blocking(id: BlockStateId) -> bool {
+        let state = BlockState::from_id(id);
+        !state.is_air() && (blocks_movement(state, BlockId::from_state_id(id)) || state.is_liquid())
+    }
+
+    /// Vanilla `Heightmap.Types.MOTION_BLOCKING_NO_LEAVES`: the above minus `LeavesBlock`.
+    fn heightmap_motion_blocking_no_leaves(id: BlockStateId) -> bool {
+        Self::heightmap_motion_blocking(id)
+            && !BlockId::from_state_id(id).has_tag(tag::Block::MINECRAFT_LEAVES)
+    }
+
+    fn prime_column<const N: usize>(
+        &self,
+        local_x: i32,
+        local_z: i32,
+        predicates: [fn(BlockStateId) -> bool; N],
+    ) -> [i16; N] {
+        let bottom = i32::from(self.bottom_y());
+        let empty = (bottom - 1) as i16;
+        let mut tops = [empty; N];
+        let mut remaining = N;
+        for local_y in (0..i32::from(self.height())).rev() {
+            let id = self.get_block_state_raw(local_x, local_y, local_z);
+            if BlockState::from_id(id).is_air() {
+                continue;
+            }
+            for (top, predicate) in tops.iter_mut().zip(predicates) {
+                if *top == empty && predicate(id) {
+                    *top = (bottom + local_y) as i16;
+                    remaining -= 1;
+                }
+            }
+            if remaining == 0 {
+                break;
+            }
+        }
+        tops
+    }
+
+    /// Vanilla `Heightmap.primeHeightmaps` for `ChunkStatus.FINAL_HEIGHTMAPS`, which
+    /// `ChunkStatusTasks.generateFeatures` runs before any feature is placed:
+    ///
+    /// ```java
+    /// Heightmap.primeHeightmaps(chunk, EnumSet.of(MOTION_BLOCKING, MOTION_BLOCKING_NO_LEAVES,
+    ///                                             OCEAN_FLOOR, WORLD_SURFACE));
+    /// ```
+    pub fn prime_final_heightmaps(&mut self) {
+        for local_x in 0..CHUNK_DIM as i32 {
+            for local_z in 0..CHUNK_DIM as i32 {
+                let [surface, ocean_floor, motion_blocking, no_leaves] = self.prime_column(
+                    local_x,
+                    local_z,
+                    [
+                        Self::heightmap_not_air,
+                        Self::heightmap_blocks_motion,
+                        Self::heightmap_motion_blocking,
+                        Self::heightmap_motion_blocking_no_leaves,
+                    ],
+                );
+                let index = Self::local_position_to_height_map_index(local_x, local_z);
+                self.flat_final_surface_height_map[index] = surface;
+                self.flat_final_ocean_floor_height_map[index] = ocean_floor;
+                self.flat_motion_blocking_height_map[index] = motion_blocking;
+                self.flat_motion_blocking_no_leaves_height_map[index] = no_leaves;
+            }
+        }
+        self.final_heightmaps_primed = true;
+    }
+
+    fn prime_worldgen_heightmaps(&mut self) {
+        for local_x in 0..CHUNK_DIM as i32 {
+            for local_z in 0..CHUNK_DIM as i32 {
+                let [surface, ocean_floor] = self.prime_column(
+                    local_x,
+                    local_z,
+                    [Self::heightmap_not_air, Self::heightmap_blocks_motion],
+                );
+                let index = Self::local_position_to_height_map_index(local_x, local_z);
+                self.flat_surface_height_map[index] = surface;
+                self.flat_ocean_floor_height_map[index] = ocean_floor;
+            }
+        }
+    }
+
+    fn prime_ocean_floor_from_blocks(&mut self) {
+        for local_x in 0..CHUNK_DIM as i32 {
+            for local_z in 0..CHUNK_DIM as i32 {
+                let [ocean_floor] =
+                    self.prime_column(local_x, local_z, [Self::heightmap_blocks_motion]);
+                let index = Self::local_position_to_height_map_index(local_x, local_z);
+                self.flat_final_ocean_floor_height_map[index] = ocean_floor;
+            }
+        }
     }
 
     #[must_use]
     pub const fn get_top_y(&self, heightmap: &HeightMap, x: i32, z: i32) -> i32 {
         match heightmap {
-            HeightMap::WorldSurfaceWg | HeightMap::WorldSurface => {
-                self.top_block_height_exclusive(x, z)
-            }
-            HeightMap::OceanFloorWg | HeightMap::OceanFloor => {
-                self.ocean_floor_height_exclusive(x, z)
-            }
+            HeightMap::WorldSurfaceWg => self.top_block_height_wg_exclusive(x, z),
+            HeightMap::WorldSurface => self.top_block_height_exclusive(x, z),
+            HeightMap::OceanFloorWg => self.ocean_floor_height_wg_exclusive(x, z),
+            HeightMap::OceanFloor => self.ocean_floor_height_exclusive(x, z),
             HeightMap::MotionBlocking => self.top_motion_blocking_block_height_exclusive(x, z),
             HeightMap::MotionBlockingNoLeaves => {
                 self.top_motion_blocking_block_no_leaves_height_exclusive(x, z)
@@ -473,16 +638,33 @@ impl ProtoChunk {
         }
     }
 
+    /// Vanilla `WORLD_SURFACE_WG`: the surface as the carvers left it, frozen for the whole
+    /// feature step. Surface rules read this one (`SurfaceRules.Steep`).
     #[must_use]
-    pub const fn top_block_height_exclusive(&self, x: i32, z: i32) -> i32 {
+    pub const fn top_block_height_wg_exclusive(&self, x: i32, z: i32) -> i32 {
         let index = Self::local_position_to_height_map_index(x & 15, z & 15);
         self.flat_surface_height_map[index] as i32 + 1
     }
 
+    /// Vanilla `OCEAN_FLOOR_WG`, frozen the same way.
+    #[must_use]
+    pub const fn ocean_floor_height_wg_exclusive(&self, x: i32, z: i32) -> i32 {
+        let index = Self::local_position_to_height_map_index(x & 15, z & 15);
+        self.flat_ocean_floor_height_map[index] as i32 + 1
+    }
+
+    /// Vanilla `WORLD_SURFACE`: live during feature placement.
+    #[must_use]
+    pub const fn top_block_height_exclusive(&self, x: i32, z: i32) -> i32 {
+        let index = Self::local_position_to_height_map_index(x & 15, z & 15);
+        self.flat_final_surface_height_map[index] as i32 + 1
+    }
+
+    /// Vanilla `OCEAN_FLOOR`: live during feature placement.
     #[must_use]
     pub const fn ocean_floor_height_exclusive(&self, x: i32, z: i32) -> i32 {
         let index = Self::local_position_to_height_map_index(x & 15, z & 15);
-        self.flat_ocean_floor_height_map[index] as i32 + 1
+        self.flat_final_ocean_floor_height_map[index] as i32 + 1
     }
 
     #[must_use]
@@ -553,28 +735,74 @@ impl ProtoChunk {
         if local_y < 0 || local_y >= self.height() as i32 {
             return;
         }
-        if !block_state.is_air() {
-            let index = Self::local_position_to_height_map_index(local_x, local_z);
-            let y = y as i16;
-            self.maybe_update_surface_height_map(index, y);
-            let block = BlockId::from_state_id(block_state.id);
-
-            let blocks_movement = blocks_movement(block_state, block);
-            if blocks_movement {
-                self.maybe_update_ocean_floor_height_map(index, y);
-            }
-            if blocks_movement || block_state.is_liquid() {
-                self.maybe_update_motion_blocking_height_map(index, y);
-                if !block.has_tag(tag::Block::MINECRAFT_LEAVES) {
-                    {
-                        self.maybe_update_motion_blocking_no_leaves_height_map(index, y);
-                    }
-                }
-            }
-        }
-
         let index = self.local_pos_to_block_index(local_x, local_y, local_z);
         self.flat_block_map[index] = block_state.id;
+
+        // Vanilla `ProtoChunk.setBlockState` writes the block first and then updates exactly
+        // the maps in `getPersistedStatus().heightmapsAfter()`: `WORLDGEN_HEIGHTMAPS`
+        // (`WORLD_SURFACE_WG`, `OCEAN_FLOOR_WG`) up to and including the surface step, and
+        // `FINAL_HEIGHTMAPS` from the carver step on. A chunk's persisted status is still
+        // `SURFACE` while its carvers run and `CARVERS` while its features run, so carving
+        // lowers the worldgen maps and features only ever move the final ones.
+        let column = Self::local_position_to_height_map_index(local_x, local_z);
+        let id = block_state.id;
+        if self.stage < StagedChunkEnum::Carvers {
+            self.flat_surface_height_map[column] = self.heightmap_after_write(
+                self.flat_surface_height_map[column],
+                local_x,
+                local_z,
+                y,
+                Self::heightmap_not_air(id),
+                Self::heightmap_not_air,
+            );
+            self.flat_ocean_floor_height_map[column] = self.heightmap_after_write(
+                self.flat_ocean_floor_height_map[column],
+                local_x,
+                local_z,
+                y,
+                Self::heightmap_blocks_motion(id),
+                Self::heightmap_blocks_motion,
+            );
+            return;
+        }
+
+        if !self.final_heightmaps_primed {
+            self.prime_final_heightmaps();
+            return;
+        }
+
+        self.flat_final_surface_height_map[column] = self.heightmap_after_write(
+            self.flat_final_surface_height_map[column],
+            local_x,
+            local_z,
+            y,
+            Self::heightmap_not_air(id),
+            Self::heightmap_not_air,
+        );
+        self.flat_final_ocean_floor_height_map[column] = self.heightmap_after_write(
+            self.flat_final_ocean_floor_height_map[column],
+            local_x,
+            local_z,
+            y,
+            Self::heightmap_blocks_motion(id),
+            Self::heightmap_blocks_motion,
+        );
+        self.flat_motion_blocking_height_map[column] = self.heightmap_after_write(
+            self.flat_motion_blocking_height_map[column],
+            local_x,
+            local_z,
+            y,
+            Self::heightmap_motion_blocking(id),
+            Self::heightmap_motion_blocking,
+        );
+        self.flat_motion_blocking_no_leaves_height_map[column] = self.heightmap_after_write(
+            self.flat_motion_blocking_no_leaves_height_map[column],
+            local_x,
+            local_z,
+            y,
+            Self::heightmap_motion_blocking_no_leaves(id),
+            Self::heightmap_motion_blocking_no_leaves,
+        );
     }
 
     #[inline]
@@ -990,7 +1218,8 @@ impl ProtoChunk {
                 let x = start_x + local_x;
                 let z = start_z + local_z;
 
-                let mut top_block = self.top_block_height_exclusive(local_x, local_z);
+                // Vanilla `SurfaceSystem.buildSurface` reads `Heightmap.Types.WORLD_SURFACE_WG`.
+                let mut top_block = self.top_block_height_wg_exclusive(local_x, local_z);
 
                 let biome_y = if settings.legacy_random_source {
                     0
@@ -1008,7 +1237,7 @@ impl ProtoChunk {
                         .terrain_builder
                         .place_badlands_pillar(self, x, z, top_block);
 
-                    top_block = self.top_block_height_exclusive(local_x, local_z);
+                    top_block = self.top_block_height_wg_exclusive(local_x, local_z);
                 }
 
                 context.init_horizontal(x, z);
@@ -1104,6 +1333,10 @@ impl ProtoChunk {
         block_registry: &dyn WorldPortalExt,
         random_config: &GlobalRandomConfig,
     ) {
+        // `ChunkStatusTasks.generateFeatures` primes the four final heightmaps from the
+        // carved blocks before the first feature runs.
+        cache.get_center_chunk_mut().prime_final_heightmaps();
+
         let (center_x, center_z, min_y, generation_min_y, generation_height) = {
             let chunk = cache.get_center_chunk();
             (

--- a/crates/pumpkin-world/src/generation/proto_chunk.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk.rs
@@ -1492,7 +1492,6 @@ impl ProtoChunk {
         // `index` is the structure's position inside its step's list in registry
         // order, i.e. resource-location order, and it is counted for every
         // structure of the step whether or not the chunk holds a start of it.
-        let chunk = cache.get_center_chunk_mut();
         for (structure_index, id) in structures_in_step(step) {
             let decorator_seed = get_decorator_seed(population_seed, structure_index, step as u64);
             let mut random = RandomGenerator::Worldgen(WorldgenRandom::from_seed(decorator_seed));
@@ -1501,7 +1500,10 @@ impl ProtoChunk {
                 let mut collector = collector_arc
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
-                collector.generate_in_chunk(chunk, block_registry, &mut random, world_seed);
+                // The whole write window, not just the centre chunk: vanilla hands
+                // `StructureStart.placeInChunk` the `WorldGenLevel`, and a piece may write
+                // outside the chunk it is being placed for.
+                collector.generate_in_chunk(cache, block_registry, &mut random, world_seed);
             }
         }
     }

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -132,6 +132,46 @@ mod test {
         assert!(resumed.has_structure(StructureKeys::Monument));
     }
 
+    /// Real vanilla 26.2 for seed 13579 stores exactly one structure start in the 16x16
+    /// chunks x -16..-1, z 0..15: `minecraft:mineshaft_mesa` in chunk (-11, 11)
+    /// (`structures.starts` of the saved region files, pumpkin-parity/vanilla/world-13579).
+    /// Mineshafts use `legacy_type_3` frequency reduction, i.e. the large-feature seed.
+    #[test]
+    fn mineshaft_mesa_start_matches_vanilla_seed_13579() {
+        use pumpkin_data::structures::StructureKeys;
+
+        let world_gen = get_world_gen(
+            Seed(13579),
+            Dimension::OVERWORLD,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+
+        let mut proto = ProtoChunk::new(-11, 11, &world_gen);
+        proto.step_to_biomes(generator);
+        proto.set_structure_starts(generator);
+        assert!(proto.has_structure(StructureKeys::MineshaftMesa));
+        assert!(!proto.has_structure(StructureKeys::Mineshaft));
+
+        for (cx, cz) in [(-10, 11), (-11, 10), (-12, 12)] {
+            let mut proto = ProtoChunk::new(cx, cz, &world_gen);
+            proto.step_to_biomes(generator);
+            proto.set_structure_starts(generator);
+            assert!(
+                !proto.has_structure(StructureKeys::MineshaftMesa),
+                "({cx}, {cz})"
+            );
+            assert!(
+                !proto.has_structure(StructureKeys::Mineshaft),
+                "({cx}, {cz})"
+            );
+        }
+    }
+
     // Regression test for transposed heightmaps during Noise-stage chunk resume.
     // Flat terrain cannot expose this bug, so use a sloped chunk.
     #[test]

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -307,6 +307,63 @@ mod test {
         }
     }
 
+    /// Vanilla `FossilFeature.place` reads a neighbouring column through the region:
+    ///
+    /// ```java
+    /// lowestSurfaceY = Math.min(lowestSurfaceY,
+    ///     level.getHeight(Heightmap.Types.OCEAN_FLOOR_WG, lowCorner.getX() + xscan, lowCorner.getZ() + zscan));
+    /// ```
+    ///
+    /// `WorldGenRegion.getHeight` forwards to the chunk holding that column, and
+    /// `OCEAN_FLOOR_WG` / `WORLD_SURFACE_WG` are live on every proto chunk of the region:
+    /// noise and the carvers maintained them. Only the chunk being decorated has the four
+    /// `FINAL_HEIGHTMAPS` primed (`ChunkStatusTasks.generateFeatures`). Pumpkin's multi-chunk
+    /// cache used to answer both `*_WG` maps out of the final maps, so any column outside the
+    /// centre chunk reported `minY - 1`.
+    #[test]
+    fn the_worldgen_heightmaps_are_live_on_every_chunk_of_the_cache() {
+        use crate::chunk_system::{Chunk, generation_cache::Cache};
+        use crate::generation::proto_chunk::GenerationCache;
+        use pumpkin_util::HeightMap;
+
+        let seed = Seed(13579);
+        let world_gen = get_world_gen(seed, Dimension::OVERWORLD, false, Vec::new(), String::new());
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+
+        let mut cache = Cache::new(-1, -1, 3);
+        for chunk_x in -1..=1 {
+            for chunk_z in -1..=1 {
+                let mut chunk = ProtoChunk::new(chunk_x, chunk_z, &world_gen);
+                chunk.step_to_biomes(generator);
+                chunk.stage = StagedChunkEnum::StructureReferences;
+                chunk.step_to_noise(generator);
+                let surface_biomes = surface_biomes(&world_gen, chunk_x, chunk_z);
+                chunk.step_to_surface(generator, &surface_biomes);
+                chunk.stage = StagedChunkEnum::Carvers;
+                cache.chunks.push(Chunk::Proto(Box::new(chunk)));
+            }
+        }
+        // Exactly what `generate_features_and_structure` does before the first feature runs.
+        cache.get_center_chunk_mut().prime_final_heightmaps();
+
+        let bottom = cache.get_center_chunk().bottom_y() as i32;
+        for (x, z) in [(0, 0), (-16, 0), (0, -16), (24, 24), (-3, 20)] {
+            let wg = cache.get_top_y(&HeightMap::OceanFloorWg, x, z);
+            assert!(
+                wg > bottom,
+                "OCEAN_FLOOR_WG at ({x}, {z}) is {wg}; the worldgen heightmap must be live \
+                 outside the decorated chunk, not the unprimed final map ({bottom})"
+            );
+            let surface = cache.get_top_y(&HeightMap::WorldSurfaceWg, x, z);
+            assert!(
+                surface >= wg,
+                "WORLD_SURFACE_WG ({surface}) at ({x}, {z}) must sit at or above OCEAN_FLOOR_WG ({wg})"
+            );
+        }
+    }
+
     /// Vanilla `Heightmap.update` lowers a map when the block it was pointing at is replaced
     /// by one the map does not match:
     ///

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -156,7 +156,8 @@ mod test {
         let mut expected_heights = [[0i32; 16]; 16];
         for z in 0..16i32 {
             for x in 0..16i32 {
-                expected_heights[z as usize][x as usize] = proto.top_block_height_exclusive(x, z);
+                expected_heights[z as usize][x as usize] =
+                    proto.top_block_height_wg_exclusive(x, z);
             }
         }
 
@@ -174,7 +175,7 @@ mod test {
         for z in 0..16i32 {
             for x in 0..16i32 {
                 let expected = expected_heights[z as usize][x as usize];
-                let got = resumed.top_block_height_exclusive(x, z);
+                let got = resumed.top_block_height_wg_exclusive(x, z);
                 if got != expected {
                     height_mismatches += 1;
                 }
@@ -304,6 +305,102 @@ mod test {
                 }
             }
         }
+    }
+
+    /// Vanilla `Heightmap.update` lowers a map when the block it was pointing at is replaced
+    /// by one the map does not match:
+    ///
+    /// ```java
+    /// } else if (i - 1 == y) {
+    ///     for (int j = y - 1; j >= this.chunk.getMinY(); j--) {
+    ///         if (this.isOpaque.test(this.chunk.getBlockState(mutableBlockPos.set(x, j, z)))) {
+    ///             this.setHeight(x, z, j + 1);
+    ///             return true;
+    ///         }
+    ///     }
+    ///     this.setHeight(x, z, this.chunk.getMinY());
+    ///     return true;
+    /// }
+    /// ```
+    ///
+    /// which is how carving pulls `WORLD_SURFACE_WG` / `OCEAN_FLOOR_WG` back down. Pumpkin
+    /// used to keep a running `max`, so a carved-open column still reported its pre-carver
+    /// surface for the whole feature step.
+    #[test]
+    fn a_write_over_the_top_block_lowers_the_worldgen_heightmap() {
+        use pumpkin_data::Block;
+
+        let seed = Seed(13579);
+        let world_gen = get_world_gen(seed, Dimension::OVERWORLD, false, Vec::new(), String::new());
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+        let (chunk_x, chunk_z) = (0, 0);
+        let mut chunk = ProtoChunk::new(chunk_x, chunk_z, &world_gen);
+        chunk.step_to_biomes(generator);
+        chunk.stage = StagedChunkEnum::StructureReferences;
+        chunk.step_to_noise(generator);
+        let surface_biomes = surface_biomes(&world_gen, chunk_x, chunk_z);
+        chunk.step_to_surface(generator, &surface_biomes);
+        assert_eq!(chunk.stage, StagedChunkEnum::Surface);
+
+        // A carver-shaped write: replace the top block of every column with air.
+        let bottom = chunk.bottom_y() as i32;
+        for x in 0..16i32 {
+            for z in 0..16i32 {
+                let top = chunk.top_block_height_wg_exclusive(x, z) - 1;
+                assert!(
+                    top >= bottom,
+                    "column ({x}, {z}) has no surface after the surface step"
+                );
+                chunk.set_block_state(x, top, z, Block::AIR.default_state);
+
+                let expected = (bottom..top)
+                    .rev()
+                    .find(|&y| {
+                        !pumpkin_data::BlockState::from_id(chunk.get_block_state_raw(
+                            x,
+                            y - bottom,
+                            z,
+                        ))
+                        .is_air()
+                    })
+                    .unwrap_or(bottom - 1);
+                assert_eq!(
+                    chunk.top_block_height_wg_exclusive(x, z) - 1,
+                    expected,
+                    "WORLD_SURFACE_WG at ({x}, {z}) was not lowered onto the next non-air block"
+                );
+            }
+        }
+
+        // From the carver step on, vanilla maintains `FINAL_HEIGHTMAPS` instead: feature
+        // writes move `WORLD_SURFACE` and leave `WORLD_SURFACE_WG` frozen where carving
+        // left it.
+        chunk.stage = StagedChunkEnum::Carvers;
+        chunk.prime_final_heightmaps();
+        let frozen = chunk.flat_surface_height_map;
+        for x in 0..16i32 {
+            for z in 0..16i32 {
+                assert_eq!(
+                    chunk.top_block_height_exclusive(x, z),
+                    chunk.top_block_height_wg_exclusive(x, z),
+                    "priming WORLD_SURFACE must reproduce the carved surface at ({x}, {z})"
+                );
+            }
+        }
+
+        let grown = chunk.top_block_height_exclusive(0, 0);
+        chunk.set_block_state(0, grown, 0, Block::SHORT_GRASS.default_state);
+        assert_eq!(
+            chunk.flat_surface_height_map, frozen,
+            "a feature write must not touch WORLD_SURFACE_WG"
+        );
+        assert_eq!(
+            chunk.top_block_height_exclusive(0, 0),
+            grown + 1,
+            "a feature write must raise WORLD_SURFACE"
+        );
     }
 
     fn verify_chunk_surface(

--- a/crates/pumpkin-world/src/generation/proto_chunk_test.rs
+++ b/crates/pumpkin-world/src/generation/proto_chunk_test.rs
@@ -172,6 +172,35 @@ mod test {
         }
     }
 
+    /// Vanilla `ChunkGenerator.createReferences` scans the starts of every chunk within 8
+    /// chunks. In the saved vanilla world for seed 13579, chunk (-6, 8) carries a
+    /// `minecraft:mineshaft_mesa` reference to the start in (-11, 11) (five chunks away).
+    #[test]
+    fn structure_references_reach_eight_chunks_seed_13579() {
+        use pumpkin_data::structures::StructureKeys;
+
+        let world_gen = get_world_gen(
+            Seed(13579),
+            Dimension::OVERWORLD,
+            false,
+            Vec::new(),
+            String::new(),
+        );
+        let WorldGenerator::Noise(generator) = &*world_gen else {
+            unreachable!()
+        };
+
+        // Only the positive case is asserted here: the exact extent of the start (vanilla
+        // references it from x -15..-6, z 8..15 and *not* from (-5, 8) or (-6, 7)) also
+        // depends on the pieces being generated depth-first, which is fixed in the mineshaft
+        // series; the negative cases are asserted there.
+        let mut proto = ProtoChunk::new(-6, 8, &world_gen);
+        proto.step_to_biomes(generator);
+        proto.set_structure_starts(generator);
+        proto.set_structure_references(generator);
+        assert!(proto.has_structure(StructureKeys::MineshaftMesa), "(-6, 8)");
+    }
+
     // Regression test for transposed heightmaps during Noise-stage chunk resume.
     // Flat terrain cannot expose this bug, so use a sloped chunk.
     #[test]

--- a/crates/pumpkin-world/src/generation/structure/height_sampler.rs
+++ b/crates/pumpkin-world/src/generation/structure/height_sampler.rs
@@ -19,11 +19,47 @@ use crate::generation::{
 
 use super::structures::HeightSampler;
 
+/// One noise column, vanilla `NoiseBasedChunkGenerator.getBaseColumn`, reduced to the two
+/// heightmap predicates that structure placement asks it about.
+struct NoiseColumn {
+    min_y: i32,
+    not_air: Box<[bool]>,
+    blocks_motion: Box<[bool]>,
+}
+
+impl NoiseColumn {
+    fn top(&self, blocks_motion: bool) -> i32 {
+        let flags = if blocks_motion {
+            &self.blocks_motion
+        } else {
+            &self.not_air
+        };
+        for (index, solid) in flags.iter().enumerate().rev() {
+            if *solid {
+                return self.min_y + index as i32 + 1;
+            }
+        }
+        self.min_y
+    }
+
+    fn is_opaque(&self, y: i32, blocks_motion: bool) -> bool {
+        let index = y - self.min_y;
+        if index < 0 || index >= self.not_air.len() as i32 {
+            return false;
+        }
+        let flags = if blocks_motion {
+            &self.blocks_motion
+        } else {
+            &self.not_air
+        };
+        flags[index as usize]
+    }
+}
+
 pub struct NoiseHeightSampler<'a> {
     generator: &'a VanillaGenerator,
     preliminary: SurfaceHeightEstimateSampler<'a>,
-    heights: FxHashMap<(i32, i32), i32>,
-    ocean_floor_heights: FxHashMap<(i32, i32), i32>,
+    columns: FxHashMap<(i32, i32), NoiseColumn>,
 }
 
 impl<'a> NoiseHeightSampler<'a> {
@@ -40,12 +76,11 @@ impl<'a> NoiseHeightSampler<'a> {
         Self {
             generator,
             preliminary,
-            heights: FxHashMap::default(),
-            ocean_floor_heights: FxHashMap::default(),
+            columns: FxHashMap::default(),
         }
     }
 
-    fn sample_column(&mut self, x: i32, z: i32, ocean_floor: bool) -> i32 {
+    fn sample_column(&mut self, x: i32, z: i32) -> NoiseColumn {
         let settings = self.generator.settings;
         let shape = &settings.shape;
         let fluid_sampler = StandardChunkFluidLevelSampler::new(
@@ -77,7 +112,9 @@ impl<'a> NoiseHeightSampler<'a> {
         );
 
         let densities = noise.sample_density();
-        for y in (0..volume.size_y).rev() {
+        let mut not_air = vec![false; volume.size_y].into_boxed_slice();
+        let mut blocks_motion = vec![false; volume.size_y].into_boxed_slice();
+        for y in 0..volume.size_y {
             let block_y = volume.block_y(y);
             let index = volume.index_unchecked(0, y, 0);
             let state = noise
@@ -89,39 +126,38 @@ impl<'a> NoiseHeightSampler<'a> {
                     &mut self.preliminary,
                 )
                 .unwrap_or(self.generator.default_block);
-            if if ocean_floor {
-                blocks_movement(state, BlockId::from_state_id(state.id))
-            } else {
-                !state.is_air()
-            } {
-                return block_y + 1;
-            }
+            not_air[y] = !state.is_air();
+            blocks_motion[y] = blocks_movement(state, BlockId::from_state_id(state.id));
         }
 
-        i32::from(shape.min_y)
+        NoiseColumn {
+            min_y: i32::from(shape.min_y),
+            not_air,
+            blocks_motion,
+        }
+    }
+
+    fn column(&mut self, x: i32, z: i32) -> &NoiseColumn {
+        if !self.columns.contains_key(&(x, z)) {
+            let column = self.sample_column(x, z);
+            self.columns.insert((x, z), column);
+        }
+        &self.columns[&(x, z)]
     }
 }
 
 impl HeightSampler for NoiseHeightSampler<'_> {
     fn estimate_height(&mut self, block_x: i32, block_z: i32) -> i32 {
-        let key = (block_x, block_z);
-        if let Some(height) = self.heights.get(&key) {
-            return *height;
-        }
-        let height = self.sample_column(block_x, block_z, false);
-        self.heights.insert(key, height);
-        height
+        self.column(block_x, block_z).top(false)
     }
 
     fn estimate_ocean_floor_height(&mut self, block_x: i32, block_z: i32) -> i32 {
-        let key = (block_x, block_z);
-        if let Some(height) = self.ocean_floor_heights.get(&key) {
-            return *height;
-        }
         // Vanilla's structure helper asks for the highest occupied block, while
         // heightmaps store the first free block above it.
-        let height = self.sample_column(block_x, block_z, true) - 1;
-        self.ocean_floor_heights.insert(key, height);
-        height
+        self.column(block_x, block_z).top(true) - 1
+    }
+
+    fn column_is_opaque(&mut self, block_x: i32, block_z: i32, y: i32, ocean_floor: bool) -> bool {
+        self.column(block_x, block_z).is_opaque(y, ocean_floor)
     }
 }

--- a/crates/pumpkin-world/src/generation/structure/structures/mod.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     ProtoChunk,
     generation::{
         positions::chunk_pos::{start_block_x, start_block_z},
+        proto_chunk::GenerationCache,
         structure::piece::StructurePieceType,
     },
 };
@@ -67,6 +68,20 @@ pub trait StructurePieceBase: Send + Sync {
         seed: i64,
         _chunk_box: &BlockBox,
     );
+
+    /// Extra placement that reaches outside the chunk being decorated.
+    ///
+    /// Vanilla pieces write through the `WorldGenLevel`, so a `postProcess` may touch any
+    /// column of the region, not just the chunk it was called for
+    /// (`RuinedPortalPiece.spreadNetherrack` walks 14 blocks out from the piece centre).
+    /// Runs right after [`Self::place`] for the same chunk; the default does nothing.
+    fn place_across_chunks(
+        &mut self,
+        _cache: &mut dyn GenerationCache,
+        _random: &mut RandomGenerator,
+        _chunk_box: &BlockBox,
+    ) {
+    }
 
     #[expect(clippy::too_many_arguments)]
     fn fill_openings(
@@ -709,27 +724,37 @@ impl StructurePiecesCollector {
     }
 
     /// Iterates over all pieces and generates them if they intersect the current chunk.
-    pub fn generate_in_chunk(
+    pub fn generate_in_chunk<T: GenerationCache>(
         &mut self,
-        chunk: &mut ProtoChunk,
+        cache: &mut T,
         block_registry: &dyn WorldPortalExt,
         random: &mut RandomGenerator,
         seed: i64,
     ) {
-        let chunk_x = start_block_x(chunk.x);
-        let chunk_z = start_block_z(chunk.z);
-        let chunk_box = BlockBox::new(
-            chunk_x,
-            chunk.bottom_y() as i32,
-            chunk_z,
-            chunk_x + 15,
-            i32::MAX,
-            chunk_z + 15,
-        );
+        let chunk_box = {
+            let chunk = cache.get_center_chunk();
+            let chunk_x = start_block_x(chunk.x);
+            let chunk_z = start_block_z(chunk.z);
+            BlockBox::new(
+                chunk_x,
+                chunk.bottom_y() as i32,
+                chunk_z,
+                chunk_x + 15,
+                i32::MAX,
+                chunk_z + 15,
+            )
+        };
 
         for piece in &mut self.pieces {
             if piece.bounding_box().intersects(&chunk_box) {
-                piece.place(chunk, block_registry, random, seed, &chunk_box);
+                piece.place(
+                    cache.get_center_chunk_mut(),
+                    block_registry,
+                    random,
+                    seed,
+                    &chunk_box,
+                );
+                piece.place_across_chunks(cache, random, &chunk_box);
             }
         }
     }
@@ -834,6 +859,19 @@ pub trait HeightSampler {
 
     fn estimate_ocean_floor_height(&mut self, block_x: i32, block_z: i32) -> i32 {
         self.estimate_height(block_x, block_z)
+    }
+
+    /// Vanilla `ChunkGenerator.getBaseColumn(x, z).getBlock(y)` tested against a heightmap's
+    /// `isOpaque` predicate (`RuinedPortalStructure.findSuitableY` walks the four bottom
+    /// corners of a piece down the noise columns). Samplers that only know a surface level
+    /// answer from it.
+    fn column_is_opaque(&mut self, block_x: i32, block_z: i32, y: i32, ocean_floor: bool) -> bool {
+        let top = if ocean_floor {
+            self.estimate_ocean_floor_height(block_x, block_z) + 1
+        } else {
+            self.estimate_height(block_x, block_z)
+        };
+        y < top
     }
 }
 

--- a/crates/pumpkin-world/src/generation/structure/structures/ruined_portal.rs
+++ b/crates/pumpkin-world/src/generation/structure/structures/ruined_portal.rs
@@ -10,12 +10,12 @@ use pumpkin_util::{
 use crate::{
     ProtoChunk,
     generation::{
-        positions::chunk_pos::{get_center_x, get_center_z},
+        proto_chunk::GenerationCache,
         structure::{
             piece::StructurePieceType,
             structures::{
-                StructureGenerator, StructureGeneratorContext, StructurePiece, StructurePieceBase,
-                StructurePiecesCollector, StructurePosition, WorldPortalExt,
+                HeightSampler, StructureGenerator, StructureGeneratorContext, StructurePiece,
+                StructurePieceBase, StructurePiecesCollector, StructurePosition, WorldPortalExt,
             },
             template::{
                 BlockStateResolver, PaletteEntry, StructurePlaceSettings, StructureTemplate,
@@ -40,6 +40,9 @@ const PORTALS: &[&str] = &[
     "ruined_portal/portal_8",
     "ruined_portal/portal_9",
     "ruined_portal/portal_10",
+];
+
+const GIANT_PORTALS: &[&str] = &[
     "ruined_portal/giant_portal_1",
     "ruined_portal/giant_portal_2",
     "ruined_portal/giant_portal_3",
@@ -79,89 +82,216 @@ pub struct RuinedPortalProperties {
     pub replace_with_blackstone: bool,
 }
 
-impl RuinedPortalProperties {
-    #[must_use]
-    pub const fn for_variant(variant: StructureKeys) -> (VerticalPlacement, Self) {
-        match variant {
-            StructureKeys::RuinedPortalDesert => (
-                VerticalPlacement::PartlyBuried,
-                Self {
-                    cold: false,
-                    mossiness: 0.0,
-                    air_pocket: false,
-                    overgrown: false,
-                    vines: false,
-                    replace_with_blackstone: false,
-                },
-            ),
-            StructureKeys::RuinedPortalJungle => (
-                VerticalPlacement::OnLandSurface,
-                Self {
-                    cold: false,
-                    mossiness: 0.8,
-                    air_pocket: false,
-                    overgrown: true,
-                    vines: true,
-                    replace_with_blackstone: false,
-                },
-            ),
-            StructureKeys::RuinedPortalSwamp => (
-                VerticalPlacement::OnLandSurface,
-                Self {
-                    cold: false,
-                    mossiness: 0.5,
-                    air_pocket: false,
-                    overgrown: false,
-                    vines: true,
-                    replace_with_blackstone: false,
-                },
-            ),
-            StructureKeys::RuinedPortalMountain => (
-                VerticalPlacement::InMountain,
-                Self {
-                    cold: true,
-                    mossiness: 0.2,
-                    air_pocket: true,
-                    overgrown: false,
-                    vines: false,
-                    replace_with_blackstone: false,
-                },
-            ),
-            StructureKeys::RuinedPortalOcean => (
-                VerticalPlacement::OnOceanFloor,
-                Self {
-                    cold: false,
-                    mossiness: 0.8,
-                    air_pocket: false,
-                    overgrown: false,
-                    vines: false,
-                    replace_with_blackstone: false,
-                },
-            ),
-            StructureKeys::RuinedPortalNether => (
-                VerticalPlacement::InNether,
-                Self {
-                    cold: false,
-                    mossiness: 0.0,
-                    air_pocket: false,
-                    overgrown: false,
-                    vines: false,
-                    replace_with_blackstone: true,
-                },
-            ),
-            _ => (
-                VerticalPlacement::OnLandSurface,
-                Self {
-                    cold: false,
-                    mossiness: 0.2,
-                    air_pocket: false,
-                    overgrown: false,
-                    vines: false,
-                    replace_with_blackstone: false,
-                },
-            ),
-        }
+/// One entry of a `minecraft:ruined_portal` structure's `setups` list.
+#[derive(Clone, Copy)]
+pub struct RuinedPortalSetup {
+    pub placement: VerticalPlacement,
+    pub air_pocket_probability: f32,
+    pub mossiness: f32,
+    pub overgrown: bool,
+    pub vines: bool,
+    pub can_be_cold: bool,
+    pub replace_with_blackstone: bool,
+    pub weight: f32,
+}
+
+const DESERT_SETUPS: &[RuinedPortalSetup] = &[RuinedPortalSetup {
+    placement: VerticalPlacement::PartlyBuried,
+    air_pocket_probability: 0.0,
+    mossiness: 0.0,
+    overgrown: false,
+    vines: false,
+    can_be_cold: false,
+    replace_with_blackstone: false,
+    weight: 1.0,
+}];
+const JUNGLE_SETUPS: &[RuinedPortalSetup] = &[RuinedPortalSetup {
+    placement: VerticalPlacement::OnLandSurface,
+    air_pocket_probability: 0.5,
+    mossiness: 0.8,
+    overgrown: true,
+    vines: true,
+    can_be_cold: false,
+    replace_with_blackstone: false,
+    weight: 1.0,
+}];
+const SWAMP_SETUPS: &[RuinedPortalSetup] = &[RuinedPortalSetup {
+    placement: VerticalPlacement::OnOceanFloor,
+    air_pocket_probability: 0.0,
+    mossiness: 0.5,
+    overgrown: false,
+    vines: true,
+    can_be_cold: false,
+    replace_with_blackstone: false,
+    weight: 1.0,
+}];
+const MOUNTAIN_SETUPS: &[RuinedPortalSetup] = &[
+    RuinedPortalSetup {
+        placement: VerticalPlacement::InMountain,
+        air_pocket_probability: 1.0,
+        mossiness: 0.2,
+        overgrown: false,
+        vines: false,
+        can_be_cold: true,
+        replace_with_blackstone: false,
+        weight: 0.5,
+    },
+    RuinedPortalSetup {
+        placement: VerticalPlacement::OnLandSurface,
+        air_pocket_probability: 0.5,
+        mossiness: 0.2,
+        overgrown: false,
+        vines: false,
+        can_be_cold: true,
+        replace_with_blackstone: false,
+        weight: 0.5,
+    },
+];
+const OCEAN_SETUPS: &[RuinedPortalSetup] = &[RuinedPortalSetup {
+    placement: VerticalPlacement::OnOceanFloor,
+    air_pocket_probability: 0.0,
+    mossiness: 0.8,
+    overgrown: false,
+    vines: false,
+    can_be_cold: true,
+    replace_with_blackstone: false,
+    weight: 1.0,
+}];
+const NETHER_SETUPS: &[RuinedPortalSetup] = &[RuinedPortalSetup {
+    placement: VerticalPlacement::InNether,
+    air_pocket_probability: 0.5,
+    mossiness: 0.0,
+    overgrown: false,
+    vines: false,
+    can_be_cold: false,
+    replace_with_blackstone: true,
+    weight: 1.0,
+}];
+const STANDARD_SETUPS: &[RuinedPortalSetup] = &[
+    RuinedPortalSetup {
+        placement: VerticalPlacement::Underground,
+        air_pocket_probability: 1.0,
+        mossiness: 0.2,
+        overgrown: false,
+        vines: false,
+        can_be_cold: true,
+        replace_with_blackstone: false,
+        weight: 0.5,
+    },
+    RuinedPortalSetup {
+        placement: VerticalPlacement::OnLandSurface,
+        air_pocket_probability: 0.5,
+        mossiness: 0.2,
+        overgrown: false,
+        vines: false,
+        can_be_cold: true,
+        replace_with_blackstone: false,
+        weight: 0.5,
+    },
+];
+
+/// `data/minecraft/worldgen/structure/ruined_portal*.json`, in file order: the weighted
+/// draw in `RuinedPortalStructure.findGenerationPoint` walks the list as written.
+const fn setups_for(variant: StructureKeys) -> &'static [RuinedPortalSetup] {
+    match variant {
+        StructureKeys::RuinedPortalDesert => DESERT_SETUPS,
+        StructureKeys::RuinedPortalJungle => JUNGLE_SETUPS,
+        StructureKeys::RuinedPortalSwamp => SWAMP_SETUPS,
+        StructureKeys::RuinedPortalMountain => MOUNTAIN_SETUPS,
+        StructureKeys::RuinedPortalOcean => OCEAN_SETUPS,
+        StructureKeys::RuinedPortalNether => NETHER_SETUPS,
+        // `minecraft:ruined_portal`
+        _ => STANDARD_SETUPS,
     }
+}
+
+/// Vanilla `RuinedPortalStructure.sample`: a probability of exactly 0 or 1 is decided
+/// without touching the random.
+fn sample(random: &mut RandomGenerator, limit: f32) -> bool {
+    if limit == 0.0 {
+        false
+    } else if limit == 1.0 {
+        true
+    } else {
+        random.next_f32() < limit
+    }
+}
+
+/// `Mth.randomBetweenInclusive`.
+fn random_between_inclusive(random: &mut RandomGenerator, min: i32, max: i32) -> i32 {
+    random.next_bounded_i32(max - min + 1) + min
+}
+
+/// `RuinedPortalStructure.getRandomWithinInterval`.
+fn random_within_interval(random: &mut RandomGenerator, min_preferred: i32, max: i32) -> i32 {
+    if min_preferred < max {
+        random_between_inclusive(random, min_preferred, max)
+    } else {
+        max
+    }
+}
+
+/// `RuinedPortalStructure.findSuitableY`.
+#[expect(clippy::too_many_arguments)]
+fn find_suitable_y(
+    random: &mut RandomGenerator,
+    sampler: Option<&mut (dyn HeightSampler + '_)>,
+    placement: VerticalPlacement,
+    air_pocket: bool,
+    surface_y_at_center: i32,
+    y_span: i32,
+    bounding_box: &BlockBox,
+    world_min_y: i32,
+) -> i32 {
+    let min_y = world_min_y + 15;
+    let new_y = match placement {
+        VerticalPlacement::InNether => {
+            if air_pocket {
+                random_between_inclusive(random, 32, 100)
+            } else if random.next_f32() < 0.5 {
+                random_between_inclusive(random, 27, 29)
+            } else {
+                random_between_inclusive(random, 29, 100)
+            }
+        }
+        VerticalPlacement::InMountain => {
+            random_within_interval(random, 70, surface_y_at_center - y_span)
+        }
+        VerticalPlacement::Underground => {
+            random_within_interval(random, min_y, surface_y_at_center - y_span)
+        }
+        VerticalPlacement::PartlyBuried => {
+            surface_y_at_center - y_span + random_between_inclusive(random, 2, 8)
+        }
+        VerticalPlacement::OnLandSurface | VerticalPlacement::OnOceanFloor => surface_y_at_center,
+    };
+
+    let Some(sampler) = sampler else {
+        return new_y;
+    };
+
+    let corners = [
+        (bounding_box.min.x, bounding_box.min.z),
+        (bounding_box.max.x, bounding_box.min.z),
+        (bounding_box.min.x, bounding_box.max.z),
+        (bounding_box.max.x, bounding_box.max.z),
+    ];
+    let ocean_floor = placement == VerticalPlacement::OnOceanFloor;
+
+    let mut projected_y = new_y;
+    while projected_y > min_y {
+        let mut corners_on_solid_ground = 0;
+        for (x, z) in corners {
+            if sampler.column_is_opaque(x, z, projected_y, ocean_floor) {
+                corners_on_solid_ground += 1;
+                if corners_on_solid_ground == 3 {
+                    return projected_y;
+                }
+            }
+        }
+        projected_y -= 1;
+    }
+    projected_y
 }
 
 pub struct RuinedPortalGenerator {
@@ -169,54 +299,116 @@ pub struct RuinedPortalGenerator {
 }
 
 impl StructureGenerator for RuinedPortalGenerator {
+    /// Vanilla `RuinedPortalStructure.findGenerationPoint`:
+    ///
+    /// ```java
+    /// // (weighted setup draw only when setups.size() > 1)
+    /// boolean airPocket = sample(random, setup.airPocketProbability());
+    /// if (random.nextFloat() < 0.05F) templateLocation = GIANT_PORTALS[random.nextInt(3)];
+    /// else                            templateLocation = PORTALS[random.nextInt(10)];
+    /// Rotation rotation = Util.getRandom(Rotation.values(), random);
+    /// Mirror mirror = random.nextFloat() < 0.5F ? Mirror.NONE : Mirror.FRONT_BACK;
+    /// BlockPos pivot = new BlockPos(template.getSize().getX() / 2, 0, template.getSize().getZ() / 2);
+    /// BlockPos basePosition = context.chunkPos().getWorldPosition();
+    /// BoundingBox boundingBox = template.getBoundingBox(basePosition, rotation, pivot, mirror);
+    /// BlockPos center = boundingBox.getCenter();
+    /// int surfaceY = chunkGenerator.getBaseHeight(center.getX(), center.getZ(), ...) - 1;
+    /// int projectedY = findSuitableY(random, ..., boundingBox.getYSpan(), boundingBox, ...);
+    /// BlockPos origin = new BlockPos(basePosition.getX(), projectedY, basePosition.getZ());
+    /// ```
+    ///
+    /// The piece sits at the chunk's *corner*, the pivot is only the rotation pivot, and the
+    /// surface is sampled at the centre of the rotated bounding box, not at the chunk centre.
     fn get_structure_position(
         &self,
-        mut context: StructureGeneratorContext<'_>,
+        context: StructureGeneratorContext<'_>,
     ) -> Option<StructurePosition> {
-        let chunk_center_x = get_center_x(context.chunk_x);
-        let chunk_center_z = get_center_z(context.chunk_z);
+        let StructureGeneratorContext {
+            chunk_x,
+            chunk_z,
+            mut random,
+            sea_level,
+            min_y,
+            mut height_sampler,
+            ..
+        } = context;
 
-        let rotation_idx = context.random.next_bounded_i32(4) as u8;
-        let rotation = Rotation::from_index(rotation_idx);
-        let mirror = if context.random.next_f32() < 0.5 {
+        let setups = setups_for(self.variant);
+        let setup = if setups.len() > 1 {
+            let total: f32 = setups.iter().map(|s| s.weight).sum();
+            let mut pick = random.next_f32();
+            let mut chosen = None;
+            for candidate in setups {
+                pick -= candidate.weight / total;
+                if pick < 0.0 {
+                    chosen = Some(candidate);
+                    break;
+                }
+            }
+            *chosen?
+        } else {
+            *setups.first()?
+        };
+
+        let air_pocket = sample(&mut random, setup.air_pocket_probability);
+        let template_name = if random.next_f32() < 0.05 {
+            GIANT_PORTALS[random.next_bounded_i32(GIANT_PORTALS.len() as i32) as usize]
+        } else {
+            PORTALS[random.next_bounded_i32(PORTALS.len() as i32) as usize]
+        };
+        let template = get_template(template_name)?;
+
+        let rotation = Rotation::from_index(random.next_bounded_i32(4) as u8);
+        let mirror = if random.next_f32() < 0.5 {
             Mirror::None
         } else {
             Mirror::FrontBack
         };
 
-        let (vertical_placement, properties) = RuinedPortalProperties::for_variant(self.variant);
-
-        let template_idx = context.random.next_bounded_i32(PORTALS.len() as i32) as usize;
-        let template_name = PORTALS[template_idx];
-        let template = get_template(template_name)?;
-
-        let pivot = Vector3::new(template.size.x / 2, 0, template.size.z / 2);
-
-        let y = match vertical_placement {
-            VerticalPlacement::OnOceanFloor => context
-                .height_sampler
-                .as_deref_mut()
-                .map_or(context.sea_level, |s| {
-                    s.estimate_ocean_floor_height(chunk_center_x, chunk_center_z)
-                }),
-            VerticalPlacement::InNether => context.random.next_bounded_i32(45) + 45,
-            VerticalPlacement::PartlyBuried => {
-                let surface_y = context
-                    .height_sampler
-                    .as_deref_mut()
-                    .map_or(64, |s| s.estimate_height(chunk_center_x, chunk_center_z));
-                surface_y - 2 - context.random.next_bounded_i32(3)
-            }
-            _ => {
-                let surface_y = context
-                    .height_sampler
-                    .as_deref_mut()
-                    .map_or(64, |s| s.estimate_height(chunk_center_x, chunk_center_z));
-                surface_y - 1
-            }
+        let vertical_placement = setup.placement;
+        let properties = RuinedPortalProperties {
+            // `setup.canBeCold() && isCold(origin, biome, seaLevel)`; the biome test draws
+            // nothing, so getting it wrong cannot shift the random stream.
+            cold: setup.can_be_cold,
+            mossiness: setup.mossiness,
+            air_pocket,
+            overgrown: setup.overgrown,
+            vines: setup.vines,
+            replace_with_blackstone: setup.replace_with_blackstone,
         };
 
-        let template_position = Vector3::new(chunk_center_x - pivot.x, y, chunk_center_z - pivot.z);
+        let pivot = Vector3::new(template.size.x / 2, 0, template.size.z / 2);
+        let base_x = chunk_x * 16;
+        let base_z = chunk_z * 16;
+        let base_settings = make_settings(mirror, rotation, vertical_placement, pivot, &properties);
+        let bounding_box =
+            template.get_bounding_box(&base_settings, Vector3::new(base_x, 0, base_z));
+        let bb_center = bounding_box.center();
+        let center_x = bb_center.x;
+        let center_z = bb_center.z;
+        let y_span = bounding_box.max.y - bounding_box.min.y + 1;
+
+        let ocean_floor = vertical_placement == VerticalPlacement::OnOceanFloor;
+        let surface_y = height_sampler.as_deref_mut().map_or(sea_level, |sampler| {
+            if ocean_floor {
+                sampler.estimate_ocean_floor_height(center_x, center_z)
+            } else {
+                sampler.estimate_height(center_x, center_z)
+            }
+        }) - 1;
+
+        let projected_y = find_suitable_y(
+            &mut random,
+            height_sampler,
+            vertical_placement,
+            air_pocket,
+            surface_y,
+            y_span,
+            &bounding_box,
+            min_y,
+        );
+
+        let template_position = Vector3::new(base_x, projected_y, base_z);
 
         let piece = RuinedPortalPiece::new(
             template,
@@ -233,7 +425,7 @@ impl StructureGenerator for RuinedPortalGenerator {
         collector.add_piece(Box::new(piece));
 
         Some(StructurePosition {
-            start_pos: BlockPos::new(chunk_center_x, y, chunk_center_z),
+            start_pos: BlockPos::new(base_x, projected_y, base_z),
             collector: Arc::new(collector.into()),
         })
     }
@@ -277,7 +469,12 @@ impl RuinedPortalPiece {
         }
     }
 
-    fn place_blocks(&self, chunk: &mut ProtoChunk, chunk_box: &BlockBox) {
+    fn place_blocks(
+        &self,
+        chunk: &mut ProtoChunk,
+        random: &mut RandomGenerator,
+        chunk_box: &BlockBox,
+    ) {
         let rotation = self.place_settings.get_rotation();
         let mirror = self.place_settings.get_mirror();
         let pivot = self.place_settings.get_rotation_pivot();
@@ -377,14 +574,19 @@ impl RuinedPortalPiece {
                     }
                 }
 
-                if placed_nbt.get_string("LootTable").is_some()
-                    && placed_nbt.get_long("LootTableSeed").is_none()
-                {
-                    let mut rng =
-                        LegacyRand::from_seed(
-                            hash_block_pos(world_pos.x, world_pos.y, world_pos.z) as u64,
-                        );
-                    placed_nbt.put_long("LootTableSeed", rng.next_i64());
+                // `StructureTemplate.placeInWorld`, inside the placement loop:
+                //
+                //     if (blockInfo.nbt != null) {
+                //         BlockEntity blockEntity = level.getBlockEntity(blockPos);
+                //         if (blockEntity != null && blockEntity instanceof RandomizableContainer) {
+                //             blockInfo.nbt.putLong("LootTableSeed", random.nextLong());
+                //         }
+                //     }
+                //
+                // The seed comes off the *feature* random, so the chest every ruined portal
+                // ships costs the piece one `nextLong()` before `spreadNetherrack` runs.
+                if block_entity_nbt.is_some() && placed_nbt.get_string("LootTable").is_some() {
+                    placed_nbt.put_long("LootTableSeed", random.next_i64());
                 }
 
                 chunk.add_block_entity(placed_nbt);
@@ -392,21 +594,19 @@ impl RuinedPortalPiece {
         }
     }
 
-    fn spread_netherrack(
-        &self,
-        random: &mut RandomGenerator,
-        chunk: &mut ProtoChunk,
-        chunk_box: &BlockBox,
-    ) {
+    fn spread_netherrack(&self, random: &mut RandomGenerator, cache: &mut dyn GenerationCache) {
         let follow_ground_surface = self.vertical_placement == VerticalPlacement::OnLandSurface
             || self.vertical_placement == VerticalPlacement::OnOceanFloor;
         let bb = self.piece.bounding_box;
-        let center_x = i32::midpoint(bb.min.x, bb.max.x);
-        let center_z = i32::midpoint(bb.min.z, bb.max.z);
+        let center = bb.center();
+        let center_x = center.x;
+        let center_z = center.z;
 
         let max_distance = NETHERRACK_PROBABILITY_BY_DISTANCE.len() as i32;
         let x_span = bb.max.x - bb.min.x + 1;
         let z_span = bb.max.z - bb.min.z + 1;
+        // Vanilla `(this.boundingBox.getXSpan() + this.boundingBox.getZSpan()) / 2`;
+        // both spans are positive, so the midpoint is the same value.
         let average_width = i32::midpoint(x_span, z_span);
         let max_adj = (8 - average_width / 2).max(1);
         let distance_adjustment = random.next_bounded_i32(max_adj);
@@ -420,7 +620,7 @@ impl RuinedPortalPiece {
                 if adjusted_distance < max_distance {
                     let prob = NETHERRACK_PROBABILITY_BY_DISTANCE[adjusted_distance as usize];
                     if random.next_f64() < prob as f64 {
-                        let surface_y = chunk.get_top_y(&heightmap, x, z) - 1;
+                        let surface_y = cache.get_top_y(&heightmap, x, z) - 1;
                         let y = if follow_ground_surface {
                             surface_y
                         } else {
@@ -428,18 +628,16 @@ impl RuinedPortalPiece {
                         };
                         let pos = Vector3::new(x, y, z);
                         if (y - bb.min.y).abs() <= 3
-                            && chunk_box.contains_pos(&pos)
-                            && self.can_block_be_replaced_by_netherrack_or_magma(chunk, pos)
+                            && self.can_block_be_replaced_by_netherrack_or_magma(cache, pos)
                         {
-                            self.place_netherrack_or_magma(random, chunk, pos);
+                            self.place_netherrack_or_magma(random, cache, pos);
                             if self.properties.overgrown {
-                                Self::maybe_add_leaves_above(random, chunk, pos);
+                                Self::maybe_add_leaves_above(random, cache, pos);
                             }
                             self.add_netherrack_drip_column(
                                 random,
-                                chunk,
+                                cache,
                                 pos + Vector3::new(0, -1, 0),
-                                chunk_box,
                             );
                         }
                     }
@@ -450,10 +648,10 @@ impl RuinedPortalPiece {
 
     fn can_block_be_replaced_by_netherrack_or_magma(
         &self,
-        chunk: &ProtoChunk,
+        cache: &dyn GenerationCache,
         pos: Vector3<i32>,
     ) -> bool {
-        let state = chunk.get_block_state(&pos);
+        let state = GenerationCache::get_block_state(cache, &pos);
         let block_id = state.to_block_id();
         block_id != Block::AIR.id
             && block_id != Block::OBSIDIAN.id
@@ -465,32 +663,32 @@ impl RuinedPortalPiece {
     fn place_netherrack_or_magma(
         &self,
         random: &mut RandomGenerator,
-        chunk: &mut ProtoChunk,
+        cache: &mut dyn GenerationCache,
         pos: Vector3<i32>,
     ) {
         if !self.properties.cold && random.next_f32() < 0.07 {
-            chunk.set_block_state(pos.x, pos.y, pos.z, Block::MAGMA_BLOCK.default_state);
+            cache.set_block_state(&pos, Block::MAGMA_BLOCK.default_state);
         } else {
-            chunk.set_block_state(pos.x, pos.y, pos.z, Block::NETHERRACK.default_state);
+            cache.set_block_state(&pos, Block::NETHERRACK.default_state);
         }
     }
 
     fn add_netherrack_drip_columns_below_portal(
         &self,
         random: &mut RandomGenerator,
-        chunk: &mut ProtoChunk,
-        chunk_box: &BlockBox,
+        cache: &mut dyn GenerationCache,
     ) {
         let bb = self.piece.bounding_box;
         for x in (bb.min.x + 1)..bb.max.x {
             for z in (bb.min.z + 1)..bb.max.z {
                 let pos = Vector3::new(x, bb.min.y, z);
-                if chunk.get_block_state(&pos).to_block_id() == Block::NETHERRACK.id {
+                if GenerationCache::get_block_state(cache, &pos).to_block_id()
+                    == Block::NETHERRACK.id
+                {
                     self.add_netherrack_drip_column(
                         random,
-                        chunk,
+                        cache,
                         Vector3::new(x, bb.min.y - 1, z),
-                        chunk_box,
                     );
                 }
             }
@@ -500,26 +698,25 @@ impl RuinedPortalPiece {
     fn add_netherrack_drip_column(
         &self,
         random: &mut RandomGenerator,
-        chunk: &mut ProtoChunk,
+        cache: &mut dyn GenerationCache,
         start_pos: Vector3<i32>,
-        chunk_box: &BlockBox,
     ) {
         let mut cur = start_pos;
-        if chunk_box.contains_pos(&cur) {
-            self.place_netherrack_or_magma(random, chunk, cur);
-        }
+        self.place_netherrack_or_magma(random, cache, cur);
         let mut remaining = 8;
         while remaining > 0 && random.next_f32() < 0.5 {
             cur.y -= 1;
             remaining -= 1;
-            if chunk_box.contains_pos(&cur) {
-                self.place_netherrack_or_magma(random, chunk, cur);
-            }
+            self.place_netherrack_or_magma(random, cache, cur);
         }
     }
 
-    fn maybe_add_vines(random: &mut RandomGenerator, chunk: &mut ProtoChunk, pos: Vector3<i32>) {
-        let state = chunk.get_block_state(&pos);
+    fn maybe_add_vines(
+        random: &mut RandomGenerator,
+        cache: &mut dyn GenerationCache,
+        pos: Vector3<i32>,
+    ) {
+        let state = GenerationCache::get_block_state(cache, &pos);
         let block_id = state.to_block_id();
         if block_id != Block::AIR.id && block_id != Block::VINE.id {
             let dir_idx = random.next_bounded_i32(4);
@@ -530,7 +727,8 @@ impl RuinedPortalPiece {
                 _ => (Vector3::new(1, 0, 0), "west"),
             };
             let neighbor_pos = pos + dir_offset;
-            if chunk.get_block_state(&neighbor_pos).to_block_id() == Block::AIR.id {
+            if GenerationCache::get_block_state(cache, &neighbor_pos).to_block_id() == Block::AIR.id
+            {
                 let entry = PaletteEntry::with_properties(
                     "minecraft:vine".to_string(),
                     vec![(vine_face.to_string(), "true".to_string())],
@@ -538,12 +736,7 @@ impl RuinedPortalPiece {
                 if let Some(vine_state) =
                     BlockStateResolver::resolve(&entry, Rotation::None, Mirror::None)
                 {
-                    chunk.set_block_state(
-                        neighbor_pos.x,
-                        neighbor_pos.y,
-                        neighbor_pos.z,
-                        vine_state,
-                    );
+                    cache.set_block_state(&neighbor_pos, vine_state);
                 }
             }
         }
@@ -551,14 +744,14 @@ impl RuinedPortalPiece {
 
     fn maybe_add_leaves_above(
         random: &mut RandomGenerator,
-        chunk: &mut ProtoChunk,
+        cache: &mut dyn GenerationCache,
         pos: Vector3<i32>,
     ) {
         if random.next_f32() < 0.5
-            && chunk.get_block_state(&pos).to_block_id() == Block::NETHERRACK.id
+            && GenerationCache::get_block_state(cache, &pos).to_block_id() == Block::NETHERRACK.id
         {
             let above = pos + Vector3::new(0, 1, 0);
-            if chunk.get_block_state(&above).to_block_id() == Block::AIR.id {
+            if GenerationCache::get_block_state(cache, &above).to_block_id() == Block::AIR.id {
                 let entry = PaletteEntry::with_properties(
                     "minecraft:jungle_leaves".to_string(),
                     vec![("persistent".to_string(), "true".to_string())],
@@ -566,7 +759,7 @@ impl RuinedPortalPiece {
                 if let Some(leaves_state) =
                     BlockStateResolver::resolve(&entry, Rotation::None, Mirror::None)
                 {
-                    chunk.set_block_state(above.x, above.y, above.z, leaves_state);
+                    cache.set_block_state(&above, leaves_state);
                 }
             }
         }
@@ -594,32 +787,54 @@ impl StructurePieceBase for RuinedPortalPiece {
         let bounding_box = self
             .template
             .get_bounding_box(&self.place_settings, self.template_position);
-        let center = Vector3::new(
-            i32::midpoint(bounding_box.min.x, bounding_box.max.x),
-            i32::midpoint(bounding_box.min.y, bounding_box.max.y),
-            i32::midpoint(bounding_box.min.z, bounding_box.max.z),
-        );
+        let center = bounding_box.center();
 
         if chunk_box.contains_pos(&center) {
             let mut enlarged_box = *chunk_box;
             enlarged_box.encompass(&bounding_box);
 
-            self.place_blocks(chunk, &enlarged_box);
-            self.spread_netherrack(random, chunk, &enlarged_box);
-            self.add_netherrack_drip_columns_below_portal(random, chunk, &enlarged_box);
+            self.place_blocks(chunk, random, &enlarged_box);
+        }
+    }
+
+    /// The tail of vanilla `RuinedPortalPiece.postProcess`. Everything after
+    /// `super.postProcess` writes straight through the `WorldGenLevel`, with no chunk
+    /// bounding box in the way:
+    ///
+    /// ```java
+    /// chunkBB.encapsulate(boundingBox);
+    /// super.postProcess(level, structureManager, generator, random, chunkBB, chunkPos, referencePos);
+    /// this.spreadNetherrack(random, level);
+    /// this.addNetherrackDripColumnsBelowPortal(random, level);
+    /// ```
+    ///
+    /// so the netherrack mound reaches up to 14 blocks past the piece, into chunks the
+    /// piece itself never touches.
+    fn place_across_chunks(
+        &mut self,
+        cache: &mut dyn GenerationCache,
+        random: &mut RandomGenerator,
+        chunk_box: &BlockBox,
+    ) {
+        let bounding_box = self
+            .template
+            .get_bounding_box(&self.place_settings, self.template_position);
+        let center = bounding_box.center();
+
+        if chunk_box.contains_pos(&center) {
+            self.spread_netherrack(random, cache);
+            self.add_netherrack_drip_columns_below_portal(random, cache);
 
             if self.properties.vines || self.properties.overgrown {
                 for x in self.piece.bounding_box.min.x..=self.piece.bounding_box.max.x {
                     for y in self.piece.bounding_box.min.y..=self.piece.bounding_box.max.y {
                         for z in self.piece.bounding_box.min.z..=self.piece.bounding_box.max.z {
                             let pos = Vector3::new(x, y, z);
-                            if enlarged_box.contains_pos(&pos) {
-                                if self.properties.vines {
-                                    Self::maybe_add_vines(random, chunk, pos);
-                                }
-                                if self.properties.overgrown {
-                                    Self::maybe_add_leaves_above(random, chunk, pos);
-                                }
+                            if self.properties.vines {
+                                Self::maybe_add_vines(random, cache, pos);
+                            }
+                            if self.properties.overgrown {
+                                Self::maybe_add_leaves_above(random, cache, pos);
                             }
                         }
                     }
@@ -731,4 +946,82 @@ fn make_settings(
     }
 
     settings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RuinedPortalGenerator, VerticalPlacement, setups_for};
+    use crate::generation::structure::structures::{
+        StructureGenerator, StructureGeneratorContext, create_chunk_random,
+    };
+    use pumpkin_data::structures::StructureKeys;
+    use pumpkin_util::math::block_box::BlockBox;
+
+    /// `RuinedPortalStructure.findGenerationPoint` anchors the piece at the chunk's corner:
+    ///
+    /// ```java
+    /// BlockPos basePosition = context.chunkPos().getWorldPosition();
+    /// ...
+    /// BlockPos origin = new BlockPos(basePosition.getX(), projectedY, basePosition.getZ());
+    /// ```
+    ///
+    /// `ChunkPos.getWorldPosition()` is `new BlockPos(getMinBlockX(), 0, getMinBlockZ())`, and
+    /// the pivot only turns the template — it never shifts the origin. Pumpkin used to place
+    /// the template at `chunkCentre - pivot`, which moved every ruined portal (and the
+    /// netherrack mound around it) by up to a chunk.
+    #[test]
+    fn a_ruined_portal_is_anchored_at_the_chunk_corner() {
+        for (chunk_x, chunk_z) in [(0, 15), (-3, 7), (12, -5)] {
+            let generator = RuinedPortalGenerator {
+                variant: StructureKeys::RuinedPortalDesert,
+            };
+            let context = StructureGeneratorContext {
+                seed: 13579,
+                chunk_x,
+                chunk_z,
+                random: create_chunk_random(13579, chunk_x, chunk_z),
+                sea_level: 63,
+                min_y: -64,
+                height_sampler: None,
+                structure_key: Some(StructureKeys::RuinedPortalDesert),
+            };
+            let position = generator
+                .get_structure_position(context)
+                .expect("the desert ruined portal always produces a stub");
+            assert_eq!(position.start_pos.0.x, chunk_x * 16);
+            assert_eq!(position.start_pos.0.z, chunk_z * 16);
+        }
+    }
+
+    /// The desert variant ships a single `partly_buried` setup with `air_pocket_probability`
+    /// 0, so `RuinedPortalStructure.sample` short-circuits and no weighted setup draw
+    /// happens: the first value the structure random is asked for is the giant-portal float.
+    #[test]
+    fn the_desert_setup_matches_the_datapack() {
+        let setups = setups_for(StructureKeys::RuinedPortalDesert);
+        assert_eq!(setups.len(), 1);
+        assert_eq!(setups[0].placement, VerticalPlacement::PartlyBuried);
+        assert!((setups[0].air_pocket_probability - 0.0).abs() < f32::EPSILON);
+        assert!((setups[0].mossiness - 0.0).abs() < f32::EPSILON);
+        assert!(!setups[0].can_be_cold);
+        // `minecraft:ruined_portal` and `..._mountain` are the two with a weighted choice.
+        assert_eq!(setups_for(StructureKeys::RuinedPortal).len(), 2);
+        assert_eq!(setups_for(StructureKeys::RuinedPortalMountain).len(), 2);
+    }
+
+    /// Vanilla `BoundingBox.getCenter()` uses the inclusive spans, so an even span lands one
+    /// block past the midpoint of the corners:
+    ///
+    /// ```java
+    /// new BlockPos(this.minX() + this.getXSpan() / 2, ..., this.minZ() + this.getZSpan() / 2)
+    /// ```
+    #[test]
+    fn a_bounding_box_centre_uses_the_inclusive_span() {
+        // The desert portal of chunk (0, 15): x 0..9 (span 10), z 240..246 (span 7).
+        let box_ = BlockBox::new(0, 63, 240, 9, 72, 246);
+        let center = box_.center();
+        assert_eq!(center.x, 5, "0 + 10 / 2");
+        assert_eq!(center.y, 68, "63 + 10 / 2");
+        assert_eq!(center.z, 243, "240 + 7 / 2");
+    }
 }

--- a/crates/pumpkin-world/src/generation/surface/mod.rs
+++ b/crates/pumpkin-world/src/generation/surface/mod.rs
@@ -188,8 +188,9 @@ pub fn steep_material_condition(chunk: &ProtoChunk, block_x: i32, block_z: i32) 
     let local_z_sub = 0.max(local_z - 1);
     let local_z_add = 15.min(local_z + 1);
 
-    let sub_height = chunk.top_block_height_exclusive(local_x, local_z_sub);
-    let add_height = chunk.top_block_height_exclusive(local_x, local_z_add);
+    // Vanilla `SurfaceRules.Steep` reads `Heightmap.Types.WORLD_SURFACE_WG`.
+    let sub_height = chunk.top_block_height_wg_exclusive(local_x, local_z_sub);
+    let add_height = chunk.top_block_height_wg_exclusive(local_x, local_z_add);
 
     if add_height >= sub_height + 4 {
         return true;
@@ -198,8 +199,8 @@ pub fn steep_material_condition(chunk: &ProtoChunk, block_x: i32, block_z: i32) 
     let local_x_sub = 0.max(local_x - 1);
     let local_x_add = 15.min(local_x + 1);
 
-    let sub_height = chunk.top_block_height_exclusive(local_x_sub, local_z);
-    let add_height = chunk.top_block_height_exclusive(local_x_add, local_z);
+    let sub_height = chunk.top_block_height_wg_exclusive(local_x_sub, local_z);
+    let add_height = chunk.top_block_height_wg_exclusive(local_x_add, local_z);
 
     sub_height >= add_height + 4
 }

--- a/crates/pumpkin/src/command/commands/place.rs
+++ b/crates/pumpkin/src/command/commands/place.rs
@@ -426,6 +426,8 @@ impl CommandExecutor for PlaceStructureExecutor {
                             let ground = surface_y as i16;
                             chunk.flat_surface_height_map = [ground; 256];
                             chunk.flat_ocean_floor_height_map = [ground; 256];
+                            chunk.flat_final_surface_height_map = [ground; 256];
+                            chunk.flat_final_ocean_floor_height_map = [ground; 256];
                             chunk.flat_motion_blocking_height_map = [ground; 256];
                             chunk.flat_motion_blocking_no_leaves_height_map = [ground; 256];
 
@@ -554,6 +556,8 @@ impl CommandExecutor for PlaceFeatureExecutor {
         let ground = surface_y as i16;
         chunk.flat_surface_height_map = [ground; 256];
         chunk.flat_ocean_floor_height_map = [ground; 256];
+        chunk.flat_final_surface_height_map = [ground; 256];
+        chunk.flat_final_ocean_floor_height_map = [ground; 256];
         chunk.flat_motion_blocking_height_map = [ground; 256];
         chunk.flat_motion_blocking_no_leaves_height_map = [ground; 256];
 


### PR DESCRIPTION
## Description

**Builds on the heightmaps PR (#3314) and the structure-seeding PR (#3311); their commits are included here and drop out once those merge.** The ruined portal writes its mound through the whole generation window (which needs the live `_WG` heightmaps on neighbour chunks) and is placed from the per-structure random stream.

**1. Fossils burn the palette draw.** `StructureTemplate.placeInWorld` opens with `settings.getRandomPalette(palettes, position)`, which is `palettes.get(random.nextInt(paletteSize))` unconditionally. Every fossil template ships one palette, but `nextInt(1)` still consumes one `nextInt()` off the feature random before the first `BlockRotProcessor` draw. Pumpkin's `place_fossil_template` went straight into the block loop, so both the fossil pass and the ore-overlay pass read the rot stream one draw early.

**2. Ruined portal.** Four things kept it (and its netherrack mound) off vanilla's position; all four are needed before any of them shows in a dump:
* `RuinedPortalStructure.findGenerationPoint` was not ported: origin is the chunk's world position (not centre − pivot), the surface is sampled at the centre of the rotated box, the weighted `setups` list, `sample(airPocketProbability)`, the 5 % giant-portal branch and `findSuitableY` (whose corner scan needs real noise columns; `NoiseHeightSampler` now caches the whole `getBaseColumn` per column and answers `column_is_opaque`).
* `BoundingBox.getCenter()` is `min + span / 2` with an inclusive span, not the midpoint of the corners (x = 5, not 4, on the 10-wide box). Added `BlockBox::center`.
* `placeInWorld` takes the chest's `LootTableSeed` off the *feature* random (`random.nextLong()`), before `spreadNetherrack`. Pumpkin derived it from `hashBlockPos` and ran the whole mound one draw early.
* `RuinedPortalPiece.postProcess` writes the mound through the `WorldGenLevel`, up to 14 blocks into neighbouring chunks. Pumpkin handed pieces the centre `ProtoChunk` and clipped (and, through `x & 15`, silently *wrapped*) every write. Structure placement now gets the whole `GenerationCache` window, and pieces that write outside their chunk do it in a new `StructurePieceBase::place_across_chunks` hook.

## Measurement

All numbers below are against an **unmodified Mojang 26.2 server**: seed 13579, chunks x −16..−1 / z 0..15 (256 chunks), exact block states, y −64..319. Pumpkin is driven through its Features stage by a standalone dumper; the reference world was saved with `tick freeze` on its first tick, and the blocks that differ between six independent vanilla runs (thread-order-dependent overlap of neighbouring ore blobs) are masked out. The commits were measured one on top of the other on a long parity branch, so the absolute counts in different PRs of this batch are not comparable with each other; the deltas are. The whole batch ends at 3 mismatching blocks / 253 of 256 chunks bit-identical (the last 3 are an f32-vs-double density-function difference and are not addressed here).

| | mismatching blocks | chunks identical |
|---|---|---|
| fossil palette draw | 874 → 784 | 156 → 160/256 |
| ruined portal (all four) | 784 → **669** | 160 → **161/256** |

Every fossil in the box is bit-identical after (1) (`bone_block` / `deepslate` / `deepslate_diamond_ore` confusions 38 → 0). For (2): chunk (−1, 15) goes 107 → 1 and (−1, 14) 9 → 0; no other chunk moves. Intermediate steps: 784 → 784 (points 1–2 invisible while writes are clipped) → 800 (region writes, old centre) → 787 (`getCenter`) → 669 (loot-seed draw).

## Testing

`cargo test -p pumpkin-world -p pumpkin-util --lib` green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean. Unit tests: `placing_a_template_burns_the_palette_draw_before_the_rot_draws`, `a_ruined_portal_is_anchored_at_the_chunk_corner`, `the_desert_setup_matches_the_datapack` and `a_bounding_box_centre_uses_the_inclusive_span`.

**Known impact:** ruined portals and fossils move to vanilla's positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
