### PR TITLE
Use client-side argparser to split Coordinates into correct arg

### DIFF
--- a/crates/pumpkin/src/plugin/loader/wasm/wasm_host/args.rs
+++ b/crates/pumpkin/src/plugin/loader/wasm/wasm_host/args.rs
@@ -4,9 +4,19 @@ use pumpkin_util::text::TextComponent;
 
 use crate::{
     command::{
-        argument_types::entity_anchor::EntityAnchor, context::command_context::CommandContext,
+        argument_types::{
+            argument_type::JavaClientArgumentType, coordinates::Coordinates,
+            entity_anchor::EntityAnchor,
+        },
+        context::command_context::CommandContext,
+        node::attached::AttachedNode,
     },
     entity::player::Player,
+};
+use pumpkin_util::math::{
+    position::BlockPos,
+    vector2::Vector2,
+    vector3::{Axis, Vector3},
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -88,6 +98,12 @@ pub fn build_consumed_args_from_context(context: &CommandContext) -> HashMap<Str
             map.insert(name.clone(), OwnedArg::TextComponent(t.clone()));
         } else if let Some(&anchor) = res.downcast_ref::<EntityAnchor>() {
             map.insert(name.clone(), OwnedArg::EntityAnchor(anchor));
+        } else if let Some(&coords) = res.downcast_ref::<Coordinates>() {
+            // `block_pos`, `column_pos`, `vec2`, `vec3` and `rotation` all parse
+            // to `Coordinates` and the original type cannot be detected here
+            if let Some(arg) = coordinates_to_owned_arg(context, name, coords) {
+                map.insert(name.clone(), arg);
+            }
         } else if let Some(selector) =
             res.downcast_ref::<crate::command::argument_types::entity_selector::EntitySelector>()
         {
@@ -99,6 +115,58 @@ pub fn build_consumed_args_from_context(context: &CommandContext) -> HashMap<Str
         }
     }
     map
+}
+
+/// The Java client-side parser declared for argument `name`
+fn declared_parser(context: &CommandContext, name: &str) -> Option<JavaClientArgumentType> {
+    context
+        .nodes
+        .iter()
+        .find_map(|parsed| match &context.tree[parsed.node] {
+            AttachedNode::Argument(argument) if argument.meta.name == name => {
+                Some(argument.meta.argument_type.client_side_parser())
+            }
+            _ => None,
+        })
+}
+
+/// Converts a parsed `Coordinates` into the `OwnedArg` shape matching the
+/// argument type it was declared as
+fn coordinates_to_owned_arg(
+    context: &CommandContext,
+    name: &str,
+    coords: Coordinates,
+) -> Option<OwnedArg> {
+    let source = context.source.as_ref();
+    match declared_parser(context, name)? {
+        JavaClientArgumentType::BlockPos => {
+            let resolved: Vector3<f64> = coords.resolve(source);
+            Some(OwnedArg::BlockPos(BlockPos::floored_v(resolved)))
+        }
+        JavaClientArgumentType::ColumnPos => {
+            let resolved: Vector3<f64> = coords.resolve(source);
+            let pos = BlockPos::floored_v(resolved);
+            Some(OwnedArg::Pos2D(Vector2::new(
+                f64::from(pos.0.x),
+                f64::from(pos.0.z),
+            )))
+        }
+        JavaClientArgumentType::Vec3 => Some(OwnedArg::Pos3D(coords.resolve(source))),
+        JavaClientArgumentType::Vec2 => {
+            let resolved: Vector3<f64> = coords.resolve(source);
+            Some(OwnedArg::Pos2D(Vector2::new(resolved.x, resolved.z)))
+        }
+        JavaClientArgumentType::Rotation => {
+            let rotation = coords.rotation(source);
+            Some(OwnedArg::Rotation(
+                rotation.x,
+                coords.is_relative(Axis::X),
+                rotation.y,
+                coords.is_relative(Axis::Y),
+            ))
+        }
+        _ => None,
+    }
 }
 
 pub struct ConsumedArgsResource {


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description
`BlockPos`, `ColumnPos`, `Vec2`, `Vec3` and `Rotation` arguments are all currently parsed as `Coordinates`, and `build_consumed_args_from_context()` doesn't contain a match arm to be able to pass this to plugins. This PR adds the match arm, but also adds helpre methods to determine which argument type was originally used (based on the client-side parser used) and maps the `Coordinates` to the correct `OwnedArg` based on that

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of coordinate-based command arguments.
  - Commands now correctly interpret block positions, column positions, 2D and 3D vectors, and rotations.
  - Unsupported coordinate argument types are safely ignored instead of causing incorrect conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->