### PR TITLE
fix(chest): unpack loot tables for both halves of double chests

### DIFF
--- a/crates/pumpkin/src/block/blocks/chests.rs
+++ b/crates/pumpkin/src/block/blocks/chests.rs
@@ -166,6 +166,10 @@ fn get_chest_comparator_output(args: &GetComparatorOutputArgs<'_>) -> Option<u8>
     }
 }
 
+/// Returns a screen handler factory for opening a chest or double chest inventory.
+///
+/// Unpacks deferred loot tables on first open (for non-spectator players) and combines
+/// connected inventories for double chests if neither chest half is obstructed.
 fn get_chest_screen_handler_factory(
     args: GetScreenHandlerFactoryArgs<'_>,
 ) -> Option<Box<dyn ScreenHandlerFactory>> {
@@ -181,27 +185,19 @@ fn get_chest_screen_handler_factory(
         ChestType::Right => Some(chest_props.facing.rotate_counter_clockwise()),
     };
 
-    // Unpack deferred loot tables on first open (non-spectator only).
-    // Both halves of a double chest are unpacked at once, like vanilla's CompoundContainer.
-    if !player_is_spectator {
-        let unpack = |entity: &Arc<dyn BlockEntity>| {
-            if let Some((loot_key, seed)) = entity.take_loot_table()
-                && let Some(table) = get_loot_table(&loot_key)
-                && let Some(inv) = entity.clone().get_inventory()
-            {
-                fill_chest_inventory(&inv, table, seed);
-                inv.mark_dirty();
-            }
-        };
-        if let Some(ref entity) = first_chest {
-            unpack(entity);
-        }
-        if let Some(direction) = connected_towards
-            && let Some(second) =
-                args.world.get_block_entity(&args.position.offset(direction.to_offset()))
+    let unpack = |entity: &Arc<dyn BlockEntity>| {
+        if let Some((loot_key, seed)) = entity.take_loot_table()
+            && let Some(table) = get_loot_table(&loot_key)
+            && let Some(inv) = entity.clone().get_inventory()
         {
-            unpack(&second);
+            fill_chest_inventory(&inv, table, seed);
+            inv.mark_dirty();
         }
+    };
+
+    // Unpack deferred loot table on first open (non-spectator only).
+    if !player_is_spectator && let Some(ref entity) = first_chest {
+        unpack(entity);
     }
 
     let first_inventory = first_chest.and_then(BlockEntity::get_inventory)?;
@@ -215,6 +211,16 @@ fn get_chest_screen_handler_factory(
         if is_chest_blocked(args.world, &neighbor_pos) {
             return None;
         }
+    }
+
+    // Both halves of a double chest are unpacked at once, like vanilla's CompoundContainer.
+    if !player_is_spectator
+        && let Some(direction) = connected_towards
+        && let Some(second) = args
+            .world
+            .get_block_entity(&args.position.offset(direction.to_offset()))
+    {
+        unpack(&second);
     }
 
     let inventory = if let Some(direction) = connected_towards

--- a/crates/pumpkin/src/block/blocks/chests.rs
+++ b/crates/pumpkin/src/block/blocks/chests.rs
@@ -174,25 +174,37 @@ fn get_chest_screen_handler_factory(
 
     let player_is_spectator = args.player.gamemode.load() == GameMode::Spectator;
 
-    // Unpack deferred loot table on first open (non-spectator only).
-    if !player_is_spectator
-        && let Some(ref entity) = first_chest
-        && let Some((loot_key, seed)) = entity.take_loot_table()
-        && let Some(table) = get_loot_table(&loot_key)
-        && let Some(inv) = entity.clone().get_inventory()
-    {
-        fill_chest_inventory(&inv, table, seed);
-        inv.mark_dirty();
-    }
-
-    let first_inventory = first_chest.and_then(BlockEntity::get_inventory)?;
-
     let chest_props = ChestLikeProperties::from_state_id(state);
     let connected_towards = match chest_props.r#type {
         ChestType::Single => None,
         ChestType::Left => Some(chest_props.facing.rotate_clockwise()),
         ChestType::Right => Some(chest_props.facing.rotate_counter_clockwise()),
     };
+
+    // Unpack deferred loot tables on first open (non-spectator only).
+    // Both halves of a double chest are unpacked at once, like vanilla's CompoundContainer.
+    if !player_is_spectator {
+        let unpack = |entity: &Arc<dyn BlockEntity>| {
+            if let Some((loot_key, seed)) = entity.take_loot_table()
+                && let Some(table) = get_loot_table(&loot_key)
+                && let Some(inv) = entity.clone().get_inventory()
+            {
+                fill_chest_inventory(&inv, table, seed);
+                inv.mark_dirty();
+            }
+        };
+        if let Some(ref entity) = first_chest {
+            unpack(entity);
+        }
+        if let Some(direction) = connected_towards
+            && let Some(second) =
+                args.world.get_block_entity(&args.position.offset(direction.to_offset()))
+        {
+            unpack(&second);
+        }
+    }
+
+    let first_inventory = first_chest.and_then(BlockEntity::get_inventory)?;
 
     if is_chest_blocked(args.world, args.position) {
         return None;

--- a/crates/pumpkin/src/block/blocks/chests.rs
+++ b/crates/pumpkin/src/block/blocks/chests.rs
@@ -133,6 +133,7 @@ fn player_placed_chest_impl(args: &PlayerPlacedArgs<'_>) {
     );
 }
 
+/// Computes the comparator output for a chest, combining both halves for double chests.
 fn get_chest_comparator_output(args: &GetComparatorOutputArgs<'_>) -> Option<u8> {
     let state = args.world.get_block_state_id(args.position);
     let first_chest = args.world.get_block_entity(args.position);


### PR DESCRIPTION
## Problem

Structure loot chests (e.g. bastion remnants) that generate as double chests only had loot in one half. Worldgen stores a deferred `LootTable` tag on **each** chest block's block entity, but `get_chest_screen_handler_factory` only unpacked the loot table of the chest half that was clicked:

- the clicked half filled with loot
- the other half stayed empty and kept its pending loot table forever, since a double chest can never be opened one half at a time

## Fix

Compute the connected-half direction first, then unpack deferred loot tables for **both** halves on first open (still skipping spectators), matching vanilla's `CompoundContainer` behavior where both halves unpack lazily through the combined container.

## Testing

- `cargo check -p pumpkin` clean
- Manually verified on a bastion: both halves of double chests now contain loot on first open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed double-chest opening behavior so deferred loot is unpacked correctly across both halves.
  * Connected chest loot is now unpacked only when the opening area is unobstructed.
  * Preserved spectator behavior by preventing connected-half loot from being unpacked for spectators.
  * Ensured the first chest’s deferred loot is available before obstruction checks are performed.
  * Improved consistency when opening chests with connected halves and obstructed areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->