### PR TITLE
perf(world): avoid repeated scans when packing dense palettes

### DIFF
--- a/crates/pumpkin-world/Cargo.toml
+++ b/crates/pumpkin-world/Cargo.toml
@@ -65,6 +65,10 @@ name = "chunk"
 harness = false
 
 [[bench]]
+name = "palette_packing"
+harness = false
+
+[[bench]]
 name = "chunk_io"
 harness = false
 

--- a/crates/pumpkin-world/benches/palette_packing.rs
+++ b/crates/pumpkin-world/benches/palette_packing.rs
@@ -1,0 +1,28 @@
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use pumpkin_world::chunk::palette::BlockPalette;
+
+fn palette_packing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("palette_packing");
+    for size in [16usize, 256, 257, 1024, 4096] {
+        let palette: Vec<_> = (0..size as u16)
+            .map(pumpkin_data::BlockStateId::new_or_air)
+            .collect();
+        let bits = pumpkin_util::encompassing_bits(size).max(4);
+        let per_word = 64 / bits as usize;
+        let mut packed = vec![0i64; 4096usize.div_ceil(per_word)];
+        for index in 0..4096 {
+            packed[index / per_word] |=
+                ((index % size) as i64) << ((index % per_word) * bits as usize);
+        }
+        let container = BlockPalette::from_palette_and_packed_data(&palette, &packed, 4);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &container, |b, data| {
+            b.iter(|| black_box(data).to_palette_and_packed_data(black_box(bits)));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, palette_packing);
+criterion_main!(benches);

--- a/crates/pumpkin-world/src/chunk/palette.rs
+++ b/crates/pumpkin-world/src/chunk/palette.rs
@@ -266,26 +266,46 @@ impl<V: Hash + Eq + Copy + Default, const DIM: usize> PalettedContainer<V, DIM> 
                 debug_assert!(bits_per_entry >= encompassing_bits(data.counts.len()));
                 debug_assert!(bits_per_entry <= 15);
 
-                // Don't use HashMap's here, because its slow
                 let blocks_per_i64 = 64 / bits_per_entry;
 
                 let packed_indices: Box<[i64]> = match &data.storage {
-                    PaletteStorage::Dense(cube) => cube
-                        .as_flattened()
-                        .as_flattened()
-                        .chunks(blocks_per_i64 as usize)
-                        .map(|chunk| {
-                            chunk.iter().enumerate().fold(0, |acc, (index, key)| {
-                                let key_index =
-                                    data.palette.iter().position(|&x| x == *key).unwrap_or(0);
-                                debug_assert!((1 << bits_per_entry) > key_index);
+                    PaletteStorage::Dense(cube) => {
+                        // Large dense palettes otherwise scan up to thousands of
+                        // entries for every block. Small palettes avoid map setup.
+                        let palette_indices = (data.palette.len() > 256).then(|| {
+                            let mut indices = rustc_hash::FxHashMap::with_capacity_and_hasher(
+                                data.palette.len(),
+                                rustc_hash::FxBuildHasher,
+                            );
+                            for (index, value) in data.palette.iter().enumerate() {
+                                // Preserve the first match for duplicate disk entries.
+                                indices.entry(*value).or_insert(index);
+                            }
+                            indices
+                        });
+                        cube.as_flattened()
+                            .as_flattened()
+                            .chunks(blocks_per_i64 as usize)
+                            .map(|chunk| {
+                                chunk.iter().enumerate().fold(0, |acc, (index, key)| {
+                                    let key_index = palette_indices.as_ref().map_or_else(
+                                        || {
+                                            data.palette
+                                                .iter()
+                                                .position(|&x| x == *key)
+                                                .unwrap_or(0)
+                                        },
+                                        |indices| indices.get(key).copied().unwrap_or(0),
+                                    );
+                                    debug_assert!((1 << bits_per_entry) > key_index);
 
-                                let packed_offset_index =
-                                    (key_index as u64) << (bits_per_entry as u64 * index as u64);
-                                acc | packed_offset_index as i64
+                                    let packed_offset_index = (key_index as u64)
+                                        << (bits_per_entry as u64 * index as u64);
+                                    acc | packed_offset_index as i64
+                                })
                             })
-                        })
-                        .collect(),
+                            .collect()
+                    }
                     PaletteStorage::Indexed(indices) => indices
                         .as_flattened()
                         .as_flattened()
@@ -1006,6 +1026,40 @@ pub(crate) const BIOME_NETWORK_MAX_BITS: u8 = 7;
 mod tests {
     use super::{BlockPalette, NetworkPalette};
     use pumpkin_data::{Block, BlockStateId};
+
+    #[test]
+    fn packing_preserves_palette_order_and_partial_words() {
+        for size in [16usize, 256, 257, 1024, 4096] {
+            let palette: Vec<_> = (0..size as u16)
+                .rev()
+                .map(BlockStateId::new_or_air)
+                .collect();
+            let bits = pumpkin_util::encompassing_bits(size).max(4);
+            let per_word = 64 / bits as usize;
+            let mut packed = vec![0i64; 4096usize.div_ceil(per_word)];
+            for index in 0..4096 {
+                packed[index / per_word] |=
+                    ((index % size) as i64) << ((index % per_word) * bits as usize);
+            }
+            let container = BlockPalette::from_palette_and_packed_data(&palette, &packed, 4);
+            let (actual_palette, actual_packed) = container.to_palette_and_packed_data(bits);
+            assert_eq!(&*actual_palette, palette);
+            assert_eq!(&*actual_packed, packed);
+        }
+    }
+
+    #[test]
+    fn dense_packing_uses_first_index_for_duplicate_palette_values() {
+        let mut palette: Vec<_> = (0..257).map(BlockStateId::new_or_air).collect();
+        palette[256] = palette[0];
+        // Decode index 256 at the start of each word; packing canonicalizes
+        // duplicate values to their first palette entry, without reordering it.
+        let packed = vec![256i64; 4096usize.div_ceil(7)];
+        let container = BlockPalette::from_palette_and_packed_data(&palette, &packed, 4);
+        let (actual_palette, actual_packed) = container.to_palette_and_packed_data(9);
+        assert_eq!(&*actual_palette, palette);
+        assert!(actual_packed.iter().all(|&word| word == 0));
+    }
 
     fn network_palette_values(palette: NetworkPalette<u16>) -> Option<Box<[u16]>> {
         match palette {


### PR DESCRIPTION
## Problem and change

Saving a chunk section with more than 256 distinct block states uses dense storage. `to_palette_and_packed_data` previously scanned the entire palette to find the index of each of the 4096 blocks. At 4096 states this performs about 8.4 million comparisons per section.

Build a temporary `FxHashMap` for dense palettes larger than 256 entries and reuse it while packing. Keep the indexed path and small dense scans. Preserve palette order and the first-index behavior for duplicate palette entries. This trades O(palette size) temporary memory for expected O(block count + palette size) lookup work.

## Validation

- All 175 world-crate unit tests passed, including new exact-output tests at 16/256/257/1024/4096 states, partial packed words, reversed palette order and duplicate values.
- `cargo clippy -p pumpkin-world --all-targets --all-features --release --locked -- -D warnings`, formatting and `git diff --check` passed.
- Added the Criterion `palette_packing` benchmark. It invokes the production method with fixture construction outside timing and lookup allocation inside timing. Whole-server TPS and full chunk-save latency are not measured.

Criterion point estimates, per section:

| Distinct states | Before | After (repeat) | Speedup |
| --- | --- | --- | --- |
| 16, indexed control | 1.304 us | 1.331 us | Within noise threshold |
| 256, indexed control | 1.620 us | 1.595 us | No significant change |
| 257, dense | 136.13 us | 7.167 us | 19x |
| 1024, dense | 475.26 us | 9.307 us | 51x |
| 4096, dense | 1781.8 us | 21.973 us | 81x |

The initial 16-state comparison flagged a roughly 5% slowdown; the longer repeat classified it within the noise threshold. These synthetic cases establish the dense-packing improvement, not a universal performance gain.

Base: `786e2fbf782f92113543fcb46eaf95ba53835d41`. Intel i9-13900HX, Windows, Rust 1.98.1; both versions use the bench profile with `CARGO_PROFILE_RELEASE_LTO=false` and `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16`, without lowering world-crate optimization. Baseline: 20 samples, 1-second warmup, 2-second measurement; final repeat: 40 samples, 2-second warmup, 4-second measurement.

Reproduce from repository root:

```text
cargo bench -p pumpkin-world --bench palette_packing -- --save-baseline before
# Apply the source fix, keeping the same benchmark/profile.
cargo bench -p pumpkin-world --bench palette_packing -- --baseline before
```

Searched existing PRs for overlap. Merged #2492 addresses bulk palette construction and #2786 direct-network output preallocation; this change targets dense palette index packing during saving. Prepared with Codex assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved serialization efficiency for large block palettes, reducing lookup overhead as palette sizes grow.
  - Preserved efficient handling for smaller palettes.

- **Bug Fixes**
  - Ensured duplicate palette values consistently resolve to their first matching index.
  - Improved correctness when packing palette data, including partial word boundaries and large palettes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->