### PR TITLE
fix: actually load forced chunks via chunk loading tickets 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/world/active_chunks.rs
+++ b/crates/pumpkin/src/world/active_chunks.rs
@@ -111,7 +111,7 @@ impl ActiveChunkTracker {
         forced_chunks: &FxHashSet<Vector2<i32>>,
         active_chunks: &mut FxHashSet<Vector2<i32>>,
         newly_active: &mut Vec<Vector2<i32>>,
-    ) {
+    ) -> (Vec<Vector2<i32>>, Vec<Vector2<i32>>) {
         let removed: Vec<_> = self
             .forced_chunks
             .difference(forced_chunks)
@@ -121,13 +121,14 @@ impl ActiveChunkTracker {
             .difference(&self.forced_chunks)
             .copied()
             .collect();
-        for pos in removed {
-            self.remove_chunk(pos, active_chunks);
+        for pos in &removed {
+            self.remove_chunk(*pos, active_chunks);
         }
-        for pos in added {
-            self.add_chunk(pos, active_chunks, newly_active);
+        for pos in &added {
+            self.add_chunk(*pos, active_chunks, newly_active);
         }
         self.forced_chunks.clone_from(forced_chunks);
+        (added, removed)
     }
 }
 

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -473,7 +473,23 @@ impl World {
         for id in removed_players {
             tracker.remove_player(id, &mut active_chunks);
         }
-        tracker.sync_forced_chunks(&forced_chunks, &mut active_chunks, &mut newly_active);
+        let (added_forced, removed_forced) =
+            tracker.sync_forced_chunks(&forced_chunks, &mut active_chunks, &mut newly_active);
+
+        if !added_forced.is_empty() || !removed_forced.is_empty() {
+            let mut chunk_loading = self
+                .level
+                .chunk_loading
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for pos in &added_forced {
+                chunk_loading.add_force_ticket(*pos);
+            }
+            for pos in &removed_forced {
+                chunk_loading.remove_force_ticket(*pos);
+            }
+            chunk_loading.send_change();
+        }
 
         for pos in newly_active {
             if self.level.is_chunk_loaded(&pos) && tracker.loaded_active_chunks.insert(pos) {


### PR DESCRIPTION
## Description

`/forceload` currently does nothing in a playerless area: the command only inserts the chunk position into `world.forced_chunks` and calls `update_active_chunks()`, which syncs the forced-chunk tracker into the active-chunk tracker but never touches the chunk loading system. `ChunkLoading::add_force_ticket` / `remove_force_ticket` were effectively dead code — the only ticket producers were players (via the chunker), so forced chunks without a nearby player were never generated or published, and any command touching them (e.g. `setblock`) reports "That position is not loaded".

This PR makes `update_active_chunks` diff-sync force tickets into the chunk loading system:

- `ActiveChunksManager::sync_forced_chunks` now returns the `(added, removed)` diff between the forced-chunk set and the tracker's previous state instead of mutating silently.
- `World::update_active_chunks` applies `add_force_ticket` / `remove_force_ticket` for each position in the diff and calls `send_change()` on the chunk loading queue when the diff is non-empty.

Lock ordering is documented (active chunk tracker → `chunk_loading`); no reverse path exists.

Verified end-to-end on a headless server: `/forceload add 0 0` with no players online → full-chunk force ticket sent → chunk generated and published (~9s) → subsequent `setblock` at that position succeeds. Pre-fix, the same flow failed with "That position is not loaded".

Known pre-existing limitation (unchanged by this PR): forced chunks are not persisted across server restarts.

## Testing

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets --all-features` with `RUSTFLAGS=-Dwarnings` clean
- `cargo test` — all tests pass
- Runtime verification on a headless console server (force-load, wait for ticket → chunk publish, place blocks at the forced position)

🤖 Generated with AI assistance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of forced world chunks.
  * Updated chunk loading to correctly apply both newly forced and released chunks.
  * Improved notifications when chunk-loading requirements change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->