### PR TITLE
fix(protocol): stop double-remapping item ids in entity metadata 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-protocol/src/java/client/play/entity_metadata.rs
+++ b/crates/pumpkin-protocol/src/java/client/play/entity_metadata.rs
@@ -2,7 +2,6 @@ use std::io::{Cursor, Write};
 
 use pumpkin_data::{
     block_state_remap::remap_block_state_for_version,
-    item_id_remap::remap_item_id_for_version,
     meta_data_type::MetaDataType,
     packet::clientbound::play::SET_ENTITY_DATA,
     tracked_data::{TrackedData, TrackedId},
@@ -158,31 +157,6 @@ impl<T> Metadata<T> {
                 writer.write_var_int(&remapped_state)?;
             } else {
                 writer.write_i32(remapped_state.0)?;
-            }
-            return Ok(());
-        }
-
-        if self.r#type == MetaDataType::ITEM_STACK {
-            let mut serialized_value = Vec::new();
-            self.value.write_metadata(&mut serialized_value, version)?;
-
-            let mut cursor = Cursor::new(serialized_value);
-            let item_count = VarInt::decode(&mut cursor).map_err(|e| {
-                WritingError::Message(format!("Failed to decodeitem stack count: {e}"))
-            })?;
-
-            if item_count.0 <= 0 {
-                writer.write_var_int(&item_count)?;
-            } else {
-                let item_id = VarInt::decode(&mut cursor)
-                    .map_err(|e| WritingError::Message(format!("Failed to decode item id: {e}")))?;
-                let remapped_id = u16::try_from(item_id.0)
-                    .map_or(0, |id| remap_item_id_for_version(id, *version));
-                writer.write_var_int(&item_count)?;
-                writer.write_var_int(&VarInt(i32::from(remapped_id)))?;
-                let remainder_start = cursor.position() as usize;
-                let inner = cursor.into_inner();
-                writer.write_slice(&inner[remainder_start..])?;
             }
             return Ok(());
         }
@@ -580,6 +554,49 @@ mod tests {
 
         assert_eq!(particle_id, VarInt(29));
         assert_eq!(data, [0x12, 0x34, 0x56, 0x78]);
+    }
+
+    #[test]
+    fn item_stack_metadata_id_remaps_exactly_once_for_1_21_11() {
+        use std::borrow::Cow;
+
+        use pumpkin_data::{
+            item::Item, item_id_remap::remap_item_id_for_version, item_stack::ItemStack,
+        };
+
+        use crate::codec::item_stack_seralizer::ItemStackSerializer;
+
+        let version = JavaMinecraftVersion::V_1_21_11;
+        // `Item::SULFUR` (id 26) does not exist in 1.21.11, so its id is remapped.
+        let item = &Item::SULFUR;
+        let expected_id = remap_item_id_for_version(item.id, version);
+        assert_ne!(
+            expected_id, item.id,
+            "test item must have a non-identity remap for 1.21.11"
+        );
+
+        let metadata = Metadata::new(
+            pumpkin_data::tracked_data::item::DATA_ITEM,
+            ItemStackSerializer(Cow::Owned(ItemStack::new(3, item))),
+        );
+        let mut bytes = Vec::new();
+        metadata.write(&mut bytes, &version).unwrap();
+
+        assert_eq!(
+            bytes[0],
+            pumpkin_data::tracked_data::item::DATA_ITEM.get(&version)
+        );
+        assert_eq!(bytes[1], MetaDataType::ITEM_STACK.id(version) as u8);
+
+        let mut cursor = Cursor::new(&bytes[2..]);
+        let count = VarInt::decode(&mut cursor).unwrap();
+        let id = VarInt::decode(&mut cursor).unwrap();
+        assert_eq!(count, VarInt(3));
+        assert_eq!(
+            id,
+            VarInt(i32::from(expected_id)),
+            "item id must be remapped exactly once"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Dropped item entities rendered as the wrong item for older protocol versions.

`Metadata::write` in `crates/pumpkin-protocol/src/java/client/play/entity_metadata.rs` special-cased `ITEM_STACK` values by re-serializing the value, re-decoding the item id from those bytes, and applying `remap_item_id_for_version` a second time. The `ItemStackSerializer` already remaps the id inside `write_with_version`, so the wire id was `remap(remap(id))` — non-idempotent on the older tables (e.g. `26 → 191 → 160` for a 26.2 item on the 1.21.11 table), so clients on older versions saw a completely different item in entity metadata. Inventory/container packets use `write_with_version` directly (single remap) and were already correct; only the entity metadata path was affected.

The fix removes the `ITEM_STACK` special case so the generic path is used, writing the already correctly-remapped stack. The `BLOCK_STATE` and `PARTICLE` special cases are kept: their serializers write raw ids without remapping, so those paths are the only remap points for those types.

Adds a regression test (`item_stack_metadata_id_remaps_exactly_once_for_1_21_11`) that encodes an `Item::SULFUR` (id 26, absent in 1.21.11) item stack through entity metadata for `V_1_21_11` and asserts the wire id is remapped exactly once (and that the test item actually has a non-identity remap, so the test can't silently rot).

## Testing

- `cargo test -p pumpkin-protocol` — 102 passed, 0 failed (including the new regression test; it fails against the old code)
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features` with `RUSTFLAGS=-Dwarnings` clean

🤖 Generated with AI assistance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected item ID handling in Java 1.21.11 entity metadata.
  - Prevented item IDs from being remapped more than once, improving item-stack compatibility and ensuring the correct items are displayed and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->