### PR TITLE
perf: batch chunk inhabited time updates

### DIFF
--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -2032,14 +2032,18 @@ impl World {
             });
         }
 
-        // Update chunk inhabited time for active chunks in parallel with Rayon
+        // Batch these cheap lookups and atomic increments to avoid waking Rayon
+        // workers for tiny tasks every tick, while retaining parallelism for large sets.
         let loaded_chunks = self.level.loaded_chunks.clone();
         let active_chunks_vec: Vec<_> = active_chunks.iter().copied().collect();
-        active_chunks_vec.par_iter().for_each(|pos| {
-            if let Some(chunk) = loaded_chunks.get(pos) {
-                chunk.inhabited_time.fetch_add(1, Relaxed);
-            }
-        });
+        active_chunks_vec
+            .par_iter()
+            .with_min_len(1024)
+            .for_each(|pos| {
+                if let Some(chunk) = loaded_chunks.get(pos) {
+                    chunk.inhabited_time.fetch_add(1, Relaxed);
+                }
+            });
     }
 
     pub fn check_fluid_collision(&self, bounding_box: BoundingBox) -> bool {

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1896,6 +1896,7 @@ impl World {
     #[expect(clippy::too_many_lines)]
     pub fn tick_chunks(self: &Arc<Self>, server: &Arc<Server>) {
         const BATCH_SIZE: usize = 32;
+        const INHABITED_TIME_BATCH_SIZE: usize = 1024;
         let random_tick_speed = self.level_info.load().game_rules.random_tick_speed;
 
         let active_chunks = self
@@ -2038,7 +2039,7 @@ impl World {
         let active_chunks_vec: Vec<_> = active_chunks.iter().copied().collect();
         active_chunks_vec
             .par_iter()
-            .with_min_len(1024)
+            .with_min_len(INHABITED_TIME_BATCH_SIZE)
             .for_each(|pos| {
                 if let Some(chunk) = loaded_chunks.get(pos) {
                     chunk.inhabited_time.fetch_add(1, Relaxed);


### PR DESCRIPTION
## Description

Inhabited-time updates perform a DashMap lookup and one atomic increment per active chunk every tick. Letting Rayon split this small workload freely creates avoidable scheduling overhead with a stationary player. This was found while investigating the sustained CPU reported in #3264.

Set a minimum parallel task length of 1024 for this iterator. Small active sets execute without subdivision; larger sets retain parallelism. Chunk selection, relaxed atomic increments, and tick frequency are unchanged.

## Testing

On Windows / i9-13900HX (32 logical processors), a local server test with one stationary Java client, view/simulation distance 10, prebuilt air chunks, and mob spawning/random ticks disabled before joining measured:

| 30-second stationary sample | Before, % of one core | After, % of one core |
| --- | --- | --- |
| First pair | 14.17 | 0.89 |
| Repeat pair | 11.09 | 1.25 |

The mean is 12.63% before and 1.07% after, about 91.5% lower CPU **in this controlled workload**. Runs were sequential, without concurrent compilation, with successful client connections and clean shutdowns. Both binaries were built from `786e2fbf782f92113543fcb46eaf95ba53835d41` using Rust 1.98.1, release opt-level 3, LTO disabled and 16 codegen units; the candidate differs only by this patch.

A separate 20 Hz model of the lookup/increment loop checked all counters after 200 ticks. Minimum task length 1024 reduced mean work time from 523 to 33 microseconds at 441 chunks, 611 to 210 at 4225, and 778 to 607 at 16641. This models the loop with atomic counters, not full ChunkData; short-run process CPU readings were variable, so these are elapsed-work measurements.

The normal generated-world control was mixed: its warming phase measured 48.65% before / 37.19% after, but its subsequent stationary phase measured 25.78% / 30.73%. This does **not** establish an overall normal-world CPU improvement. This PR addresses the isolated scheduling overhead and does not claim to resolve the first-join generation spike or all symptoms in #3264.

Validation: all 759 workspace nextest tests, release all-target/all-feature Clippy, formatting, whitespace checks, and eight local harness tests passed. Functional tests use pumpkin opt-level 0; performance measurements use the optimized binaries described above. No overlapping inhabited-time PR was found when checking open PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the efficiency of world update processing by batching background work more effectively.
  * Gameplay behavior and visible functionality remain unchanged in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->