### PR TITLE
fix(loot): support block_state_property conditions and pool-level functions in loot tables 🤖🤖🤖

### DIFF
--- a/crates/pumpkin-data/src/generated/loot_table.rs
+++ b/crates/pumpkin-data/src/generated/loot_table.rs
@@ -711,7 +711,10 @@ static BLOCKS_ACACIA_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:acacia_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_ACACIA_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -1397,7 +1400,10 @@ static BLOCKS_BAMBOO_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:bamboo_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BAMBOO_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -1768,7 +1774,10 @@ static BLOCKS_BEETROOTS_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:beetroots",
+            properties: &[("age", "3")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -1804,7 +1813,10 @@ static BLOCKS_BEETROOTS_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:beetroots",
+            properties: &[("age", "3")],
+        },
     },
 ];
 pub static BLOCKS_BEETROOTS: LootTable = LootTable {
@@ -1887,7 +1899,10 @@ static BLOCKS_BIRCH_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:birch_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BIRCH_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -2212,7 +2227,10 @@ static BLOCKS_BLACK_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:black_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BLACK_BED_POOLS: &[LootPool] = &[LootPool {
@@ -2536,7 +2554,10 @@ static BLOCKS_BLUE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:blue_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BLUE_BED_POOLS: &[LootPool] = &[LootPool {
@@ -3009,7 +3030,10 @@ static BLOCKS_BROWN_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:brown_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_BROWN_BED_POOLS: &[LootPool] = &[LootPool {
@@ -3530,7 +3554,10 @@ static BLOCKS_CARROTS_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:carrots",
+            properties: &[("age", "7")],
+        },
     },
 ];
 pub static BLOCKS_CARROTS: LootTable = LootTable {
@@ -3603,7 +3630,10 @@ static BLOCKS_CAVE_VINES_POOLS: &[LootPool] = &[LootPool {
     min_rolls: 1i32,
     max_rolls: 1i32,
     empty_weight: 0i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:cave_vines",
+        properties: &[("berries", "true")],
+    },
 }];
 pub static BLOCKS_CAVE_VINES: LootTable = LootTable {
     pools: BLOCKS_CAVE_VINES_POOLS,
@@ -3621,7 +3651,10 @@ static BLOCKS_CAVE_VINES_PLANT_POOLS: &[LootPool] = &[LootPool {
     min_rolls: 1i32,
     max_rolls: 1i32,
     empty_weight: 0i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:cave_vines_plant",
+        properties: &[("berries", "true")],
+    },
 }];
 pub static BLOCKS_CAVE_VINES_PLANT: LootTable = LootTable {
     pools: BLOCKS_CAVE_VINES_PLANT_POOLS,
@@ -3649,7 +3682,10 @@ static BLOCKS_CHERRY_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:cherry_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_CHERRY_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -4769,7 +4805,10 @@ static BLOCKS_COMPOSTER_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:composter",
+            properties: &[("level", "8")],
+        },
     },
 ];
 pub static BLOCKS_COMPOSTER: LootTable = LootTable {
@@ -4888,7 +4927,10 @@ static BLOCKS_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:copper_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -5232,7 +5274,10 @@ static BLOCKS_CRIMSON_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:crimson_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_CRIMSON_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -5695,7 +5740,10 @@ static BLOCKS_CYAN_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:cyan_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_CYAN_BED_POOLS: &[LootPool] = &[LootPool {
@@ -5965,7 +6013,10 @@ static BLOCKS_DARK_OAK_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:dark_oak_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_DARK_OAK_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -7691,7 +7742,10 @@ static BLOCKS_EXPOSED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:exposed_copper_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_EXPOSED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -8481,7 +8535,10 @@ static BLOCKS_GRAY_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:gray_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_GRAY_BED_POOLS: &[LootPool] = &[LootPool {
@@ -8715,7 +8772,10 @@ static BLOCKS_GREEN_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:green_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_GREEN_BED_POOLS: &[LootPool] = &[LootPool {
@@ -9340,7 +9400,10 @@ static BLOCKS_IRON_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:iron_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_IRON_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -9458,7 +9521,10 @@ static BLOCKS_JUNGLE_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:jungle_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_JUNGLE_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -9950,14 +10016,20 @@ static BLOCKS_LARGE_FERN_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:large_fern",
+            properties: &[("half", "lower")],
+        },
     },
     LootPool {
         entries: BLOCKS_LARGE_FERN_POOL1_ENTRIES,
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:large_fern",
+            properties: &[("half", "upper")],
+        },
     },
 ];
 pub static BLOCKS_LARGE_FERN: LootTable = LootTable {
@@ -10058,7 +10130,10 @@ static BLOCKS_LIGHT_BLUE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:light_blue_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_LIGHT_BLUE_BED_POOLS: &[LootPool] = &[LootPool {
@@ -10292,7 +10367,10 @@ static BLOCKS_LIGHT_GRAY_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:light_gray_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_LIGHT_GRAY_BED_POOLS: &[LootPool] = &[LootPool {
@@ -10544,7 +10622,10 @@ static BLOCKS_LILAC_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:lilac",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_LILAC_POOLS: &[LootPool] = &[LootPool {
@@ -10616,7 +10697,10 @@ static BLOCKS_LIME_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:lime_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_LIME_BED_POOLS: &[LootPool] = &[LootPool {
@@ -10886,7 +10970,10 @@ static BLOCKS_MAGENTA_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:magenta_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_MAGENTA_BED_POOLS: &[LootPool] = &[LootPool {
@@ -11138,7 +11225,10 @@ static BLOCKS_MANGROVE_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:mangrove_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_MANGROVE_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -11305,7 +11395,10 @@ static BLOCKS_MANGROVE_PROPAGULE_POOLS: &[LootPool] = &[LootPool {
     min_rolls: 1i32,
     max_rolls: 1i32,
     empty_weight: 0i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:mangrove_propagule",
+        properties: &[("age", "4")],
+    },
 }];
 pub static BLOCKS_MANGROVE_PROPAGULE: LootTable = LootTable {
     pools: BLOCKS_MANGROVE_PROPAGULE_POOLS,
@@ -12118,7 +12211,10 @@ static BLOCKS_OAK_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:oak_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_OAK_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -12541,7 +12637,10 @@ static BLOCKS_ORANGE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:orange_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_ORANGE_BED_POOLS: &[LootPool] = &[LootPool {
@@ -12901,7 +13000,10 @@ static BLOCKS_OXIDIZED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:oxidized_copper_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_OXIDIZED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -13135,7 +13237,10 @@ static BLOCKS_PALE_MOSS_CARPET_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:pale_moss_carpet",
+        properties: &[("bottom", "true")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PALE_MOSS_CARPET_POOLS: &[LootPool] = &[LootPool {
@@ -13171,7 +13276,10 @@ static BLOCKS_PALE_OAK_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:pale_oak_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PALE_OAK_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -13496,7 +13604,10 @@ static BLOCKS_PEONY_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:peony",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PEONY_POOLS: &[LootPool] = &[LootPool {
@@ -13568,7 +13679,10 @@ static BLOCKS_PINK_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:pink_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PINK_BED_POOLS: &[LootPool] = &[LootPool {
@@ -13839,7 +13953,16 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                block: "minecraft:pitcher_crop",
+                properties: &[("age", "0")],
+            },
+            LootCondition::BlockStateProperty {
+                block: "minecraft:pitcher_crop",
+                properties: &[("half", "lower")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -13847,7 +13970,16 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                block: "minecraft:pitcher_crop",
+                properties: &[("age", "1")],
+            },
+            LootCondition::BlockStateProperty {
+                block: "minecraft:pitcher_crop",
+                properties: &[("half", "lower")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -13855,7 +13987,16 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                block: "minecraft:pitcher_crop",
+                properties: &[("age", "2")],
+            },
+            LootCondition::BlockStateProperty {
+                block: "minecraft:pitcher_crop",
+                properties: &[("half", "lower")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -13863,7 +14004,16 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                block: "minecraft:pitcher_crop",
+                properties: &[("age", "3")],
+            },
+            LootCondition::BlockStateProperty {
+                block: "minecraft:pitcher_crop",
+                properties: &[("half", "lower")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -13871,7 +14021,16 @@ static BLOCKS_PITCHER_CROP_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::AllOf(&[
+            LootCondition::BlockStateProperty {
+                block: "minecraft:pitcher_crop",
+                properties: &[("age", "4")],
+            },
+            LootCondition::BlockStateProperty {
+                block: "minecraft:pitcher_crop",
+                properties: &[("half", "lower")],
+            },
+        ]),
         bonus_formula: None,
     },
 ];
@@ -13890,7 +14049,10 @@ static BLOCKS_PITCHER_PLANT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:pitcher_plant",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PITCHER_PLANT_POOLS: &[LootPool] = &[LootPool {
@@ -14676,14 +14838,20 @@ static BLOCKS_POTATOES_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:potatoes",
+            properties: &[("age", "7")],
+        },
     },
     LootPool {
         entries: BLOCKS_POTATOES_POOL2_ENTRIES,
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:potatoes",
+            properties: &[("age", "7")],
+        },
     },
 ];
 pub static BLOCKS_POTATOES: LootTable = LootTable {
@@ -16262,7 +16430,10 @@ static BLOCKS_PURPLE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:purple_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_PURPLE_BED_POOLS: &[LootPool] = &[LootPool {
@@ -16730,7 +16901,10 @@ static BLOCKS_RED_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:red_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_RED_BED_POOLS: &[LootPool] = &[LootPool {
@@ -17438,7 +17612,10 @@ static BLOCKS_ROSE_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:rose_bush",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_ROSE_BUSH_POOLS: &[LootPool] = &[LootPool {
@@ -18146,7 +18323,13 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::BlockStateProperty {
+                block: "minecraft:snow",
+                properties: &[("layers", "1")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18154,7 +18337,13 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 2i32,
         max_count: 2i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::BlockStateProperty {
+                block: "minecraft:snow",
+                properties: &[("layers", "2")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18162,7 +18351,13 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 3i32,
         max_count: 3i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::BlockStateProperty {
+                block: "minecraft:snow",
+                properties: &[("layers", "3")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18170,7 +18365,13 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 4i32,
         max_count: 4i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::BlockStateProperty {
+                block: "minecraft:snow",
+                properties: &[("layers", "4")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18178,7 +18379,13 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 5i32,
         max_count: 5i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::BlockStateProperty {
+                block: "minecraft:snow",
+                properties: &[("layers", "5")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18186,7 +18393,13 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 6i32,
         max_count: 6i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::BlockStateProperty {
+                block: "minecraft:snow",
+                properties: &[("layers", "6")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18194,7 +18407,13 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 7i32,
         max_count: 7i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::BlockStateProperty {
+                block: "minecraft:snow",
+                properties: &[("layers", "7")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18202,7 +18421,13 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 8i32,
         max_count: 8i32,
-        condition: LootCondition::NoSilkTouch,
+        condition: LootCondition::AllOf(&[
+            LootCondition::NoSilkTouch,
+            LootCondition::BlockStateProperty {
+                block: "minecraft:snow",
+                properties: &[("layers", "8")],
+            },
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18210,7 +18435,10 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:snow",
+            properties: &[("layers", "1")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -18218,7 +18446,10 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 2i32,
         max_count: 2i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:snow",
+            properties: &[("layers", "2")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -18226,7 +18457,10 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 3i32,
         max_count: 3i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:snow",
+            properties: &[("layers", "3")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -18234,7 +18468,10 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 4i32,
         max_count: 4i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:snow",
+            properties: &[("layers", "4")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -18242,7 +18479,10 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 5i32,
         max_count: 5i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:snow",
+            properties: &[("layers", "5")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -18250,7 +18490,10 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 6i32,
         max_count: 6i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:snow",
+            properties: &[("layers", "6")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -18258,7 +18501,10 @@ static BLOCKS_SNOW_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 7i32,
         max_count: 7i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:snow",
+            properties: &[("layers", "7")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -18478,7 +18724,10 @@ static BLOCKS_SPRUCE_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:spruce_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_SPRUCE_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -19590,7 +19839,10 @@ static BLOCKS_SUNFLOWER_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:sunflower",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_SUNFLOWER_POOLS: &[LootPool] = &[LootPool {
@@ -19614,18 +19866,18 @@ pub static BLOCKS_SUSPICIOUS_SAND: LootTable = LootTable {
 static BLOCKS_SWEET_BERRY_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:sweet_berries",
     weight: 1i32,
-    min_count: 1i32,
-    max_count: 1i32,
+    min_count: 2i32,
+    max_count: 3i32,
     condition: LootCondition::None,
-    bonus_formula: None,
+    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
 }];
 static BLOCKS_SWEET_BERRY_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {
     item: "minecraft:sweet_berries",
     weight: 1i32,
     min_count: 1i32,
-    max_count: 1i32,
+    max_count: 2i32,
     condition: LootCondition::None,
-    bonus_formula: None,
+    bonus_formula: Some(LootBonusFormula::UniformBonusCount(1i32)),
 }];
 static BLOCKS_SWEET_BERRY_BUSH_POOLS: &[LootPool] = &[
     LootPool {
@@ -19633,14 +19885,20 @@ static BLOCKS_SWEET_BERRY_BUSH_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:sweet_berry_bush",
+            properties: &[("age", "3")],
+        },
     },
     LootPool {
         entries: BLOCKS_SWEET_BERRY_BUSH_POOL1_ENTRIES,
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:sweet_berry_bush",
+            properties: &[("age", "2")],
+        },
     },
 ];
 pub static BLOCKS_SWEET_BERRY_BUSH: LootTable = LootTable {
@@ -19718,14 +19976,20 @@ static BLOCKS_TALL_GRASS_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:tall_grass",
+            properties: &[("half", "lower")],
+        },
     },
     LootPool {
         entries: BLOCKS_TALL_GRASS_POOL1_ENTRIES,
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:tall_grass",
+            properties: &[("half", "upper")],
+        },
     },
 ];
 pub static BLOCKS_TALL_GRASS: LootTable = LootTable {
@@ -19808,7 +20072,10 @@ static BLOCKS_TNT_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:tnt",
+        properties: &[("unstable", "false")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_TNT_POOLS: &[LootPool] = &[LootPool {
@@ -20291,7 +20558,10 @@ static BLOCKS_WARPED_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:warped_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WARPED_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -20736,7 +21006,10 @@ static BLOCKS_WAXED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:waxed_copper_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WAXED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -20988,7 +21261,10 @@ static BLOCKS_WAXED_EXPOSED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntr
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:waxed_exposed_copper_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WAXED_EXPOSED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -21276,7 +21552,10 @@ static BLOCKS_WAXED_OXIDIZED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEnt
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:waxed_oxidized_copper_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WAXED_OXIDIZED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -21546,7 +21825,10 @@ static BLOCKS_WAXED_WEATHERED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEn
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:waxed_weathered_copper_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WAXED_WEATHERED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -21816,7 +22098,10 @@ static BLOCKS_WEATHERED_COPPER_DOOR_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:weathered_copper_door",
+        properties: &[("half", "lower")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WEATHERED_COPPER_DOOR_POOLS: &[LootPool] = &[LootPool {
@@ -22063,7 +22348,10 @@ static BLOCKS_WHEAT_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:wheat",
+            properties: &[("age", "7")],
+        },
         bonus_formula: None,
     },
     LootEntry {
@@ -22099,7 +22387,10 @@ static BLOCKS_WHEAT_POOLS: &[LootPool] = &[
         min_rolls: 1i32,
         max_rolls: 1i32,
         empty_weight: 0i32,
-        condition: LootCondition::None,
+        condition: LootCondition::BlockStateProperty {
+            block: "minecraft:wheat",
+            properties: &[("age", "7")],
+        },
     },
 ];
 pub static BLOCKS_WHEAT: LootTable = LootTable {
@@ -22128,7 +22419,10 @@ static BLOCKS_WHITE_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:white_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_WHITE_BED_POOLS: &[LootPool] = &[LootPool {
@@ -22434,7 +22728,10 @@ static BLOCKS_YELLOW_BED_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:yellow_bed",
+        properties: &[("part", "head")],
+    },
     bonus_formula: None,
 }];
 static BLOCKS_YELLOW_BED_POOLS: &[LootPool] = &[LootPool {
@@ -34997,7 +35294,10 @@ static HARVEST_SWEET_BERRY_BUSH_POOL0_ENTRIES: &[LootEntry] = &[LootEntry {
     weight: 1i32,
     min_count: 1i32,
     max_count: 1i32,
-    condition: LootCondition::None,
+    condition: LootCondition::BlockStateProperty {
+        block: "minecraft:sweet_berry_bush",
+        properties: &[("age", "3")],
+    },
     bonus_formula: None,
 }];
 static HARVEST_SWEET_BERRY_BUSH_POOL1_ENTRIES: &[LootEntry] = &[LootEntry {

--- a/crates/pumpkin-data/src/generated/loot_table.rs
+++ b/crates/pumpkin-data/src/generated/loot_table.rs
@@ -787,7 +787,10 @@ static BLOCKS_ACACIA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -1076,7 +1079,7 @@ static BLOCKS_AMETHYST_CLUSTER_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -1274,7 +1277,10 @@ static BLOCKS_AZALEA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -1746,7 +1752,7 @@ static BLOCKS_BEEHIVE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -1975,7 +1981,10 @@ static BLOCKS_BIRCH_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -2828,7 +2837,7 @@ static BLOCKS_BOOKSHELF_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -2874,7 +2883,7 @@ static BLOCKS_BRAIN_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -3178,7 +3187,7 @@ static BLOCKS_BROWN_MUSHROOM_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -3314,7 +3323,7 @@ static BLOCKS_BUBBLE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -3461,7 +3470,7 @@ static BLOCKS_CAMPFIRE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -3758,7 +3767,10 @@ static BLOCKS_CHERRY_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -4461,7 +4473,7 @@ static BLOCKS_CLAY_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -4525,7 +4537,7 @@ static BLOCKS_COAL_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -4715,7 +4727,10 @@ static BLOCKS_COBWEB_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -5003,7 +5018,7 @@ static BLOCKS_COPPER_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -5211,7 +5226,7 @@ static BLOCKS_CREAKING_HEART_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -5386,7 +5401,7 @@ static BLOCKS_CRIMSON_NYLIUM_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -6089,7 +6104,10 @@ static BLOCKS_DARK_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -6530,7 +6548,7 @@ static BLOCKS_DEAD_BUSH_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::Shears,
+        condition: LootCondition::AllOf(&[LootCondition::Shears, LootCondition::Shears]),
         bonus_formula: None,
     },
     LootEntry {
@@ -6738,7 +6756,7 @@ static BLOCKS_DEEPSLATE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -6841,7 +6859,7 @@ static BLOCKS_DEEPSLATE_COAL_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -6869,7 +6887,7 @@ static BLOCKS_DEEPSLATE_COPPER_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -6897,7 +6915,7 @@ static BLOCKS_DEEPSLATE_DIAMOND_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -6925,7 +6943,7 @@ static BLOCKS_DEEPSLATE_EMERALD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -6953,7 +6971,7 @@ static BLOCKS_DEEPSLATE_GOLD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -6981,7 +6999,7 @@ static BLOCKS_DEEPSLATE_IRON_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -7009,7 +7027,7 @@ static BLOCKS_DEEPSLATE_LAPIS_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -7037,7 +7055,7 @@ static BLOCKS_DEEPSLATE_REDSTONE_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -7173,7 +7191,7 @@ static BLOCKS_DIAMOND_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -7453,7 +7471,7 @@ static BLOCKS_EMERALD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -7607,7 +7625,7 @@ static BLOCKS_ENDER_CHEST_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -7926,7 +7944,7 @@ static BLOCKS_FERN_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::Shears,
+        condition: LootCondition::AllOf(&[LootCondition::Shears, LootCondition::Shears]),
         bonus_formula: None,
     },
     LootEntry {
@@ -7979,7 +7997,7 @@ static BLOCKS_FIRE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -8100,7 +8118,10 @@ static BLOCKS_FLOWERING_AZALEA_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -8181,7 +8202,7 @@ static BLOCKS_GILDED_BLACKSTONE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -8279,7 +8300,7 @@ static BLOCKS_GLOWSTONE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -8325,7 +8346,7 @@ static BLOCKS_GOLD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -8443,7 +8464,7 @@ static BLOCKS_GRASS_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -8474,7 +8495,7 @@ static BLOCKS_GRAVEL_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -9154,7 +9175,7 @@ static BLOCKS_HORN_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -9422,7 +9443,7 @@ static BLOCKS_IRON_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -9597,7 +9618,10 @@ static BLOCKS_JUNGLE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -9922,7 +9946,7 @@ static BLOCKS_LAPIS_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -9968,7 +9992,7 @@ static BLOCKS_LARGE_FERN_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 2i32,
         max_count: 2i32,
-        condition: LootCondition::Shears,
+        condition: LootCondition::AllOf(&[LootCondition::Shears, LootCondition::Shears]),
         bonus_formula: None,
     },
     LootEntry {
@@ -9992,7 +10016,7 @@ static BLOCKS_LARGE_FERN_POOL1_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 2i32,
         max_count: 2i32,
-        condition: LootCondition::Shears,
+        condition: LootCondition::AllOf(&[LootCondition::Shears, LootCondition::Shears]),
         bonus_formula: None,
     },
     LootEntry {
@@ -11301,7 +11325,10 @@ static BLOCKS_MANGROVE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -11553,7 +11580,7 @@ static BLOCKS_MELON_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -11905,7 +11932,7 @@ static BLOCKS_MYCELIUM_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -12026,7 +12053,7 @@ static BLOCKS_NETHER_GOLD_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -12058,7 +12085,7 @@ static BLOCKS_NETHER_QUARTZ_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -12287,7 +12314,10 @@ static BLOCKS_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -13352,7 +13382,10 @@ static BLOCKS_PALE_OAK_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -14089,7 +14122,7 @@ static BLOCKS_PODZOL_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -17049,7 +17082,7 @@ static BLOCKS_RED_MUSHROOM_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -17383,7 +17416,7 @@ static BLOCKS_REDSTONE_ORE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -17832,7 +17865,7 @@ static BLOCKS_SEA_LANTERN_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -17914,7 +17947,7 @@ static BLOCKS_SHORT_GRASS_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::Shears,
+        condition: LootCondition::AllOf(&[LootCondition::Shears, LootCondition::Shears]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18532,7 +18565,7 @@ static BLOCKS_SNOW_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18560,7 +18593,7 @@ static BLOCKS_SOUL_CAMPFIRE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -18800,7 +18833,10 @@ static BLOCKS_SPRUCE_LEAVES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -19053,7 +19089,7 @@ static BLOCKS_STONE_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -19928,7 +19964,7 @@ static BLOCKS_TALL_GRASS_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 2i32,
         max_count: 2i32,
-        condition: LootCondition::Shears,
+        condition: LootCondition::AllOf(&[LootCondition::Shears, LootCondition::Shears]),
         bonus_formula: None,
     },
     LootEntry {
@@ -19952,7 +19988,7 @@ static BLOCKS_TALL_GRASS_POOL1_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 2i32,
         max_count: 2i32,
-        condition: LootCondition::Shears,
+        condition: LootCondition::AllOf(&[LootCondition::Shears, LootCondition::Shears]),
         bonus_formula: None,
     },
     LootEntry {
@@ -20224,7 +20260,7 @@ static BLOCKS_TUBE_CORAL_BLOCK_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -20435,7 +20471,10 @@ static BLOCKS_TWISTING_VINES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -20468,7 +20507,10 @@ static BLOCKS_TWISTING_VINES_PLANT_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -20670,7 +20712,7 @@ static BLOCKS_WARPED_NYLIUM_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouch,
+        condition: LootCondition::AllOf(&[LootCondition::SilkTouch, LootCondition::SilkTouch]),
         bonus_formula: None,
     },
     LootEntry {
@@ -22264,7 +22306,10 @@ static BLOCKS_WEEPING_VINES_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {
@@ -22297,7 +22342,10 @@ static BLOCKS_WEEPING_VINES_PLANT_POOL0_ENTRIES: &[LootEntry] = &[
         weight: 1i32,
         min_count: 1i32,
         max_count: 1i32,
-        condition: LootCondition::SilkTouchOrShears,
+        condition: LootCondition::AllOf(&[
+            LootCondition::SilkTouchOrShears,
+            LootCondition::SilkTouchOrShears,
+        ]),
         bonus_formula: None,
     },
     LootEntry {

--- a/crates/pumpkin-util/src/loot_table.rs
+++ b/crates/pumpkin-util/src/loot_table.rs
@@ -21,6 +21,10 @@ pub enum LootCondition {
     TableBonus {
         chances: &'static [f32],
     },
+    BlockStateProperty {
+        block: &'static str,
+        properties: &'static [(&'static str, &'static str)],
+    },
     AllOf(&'static [Self]),
 }
 

--- a/crates/pumpkin/src/world/loot.rs
+++ b/crates/pumpkin/src/world/loot.rs
@@ -65,6 +65,23 @@ fn check_condition(
                 .get(index)
                 .is_some_and(|chance| rng.next_f32() < *chance)
         }
+        LootCondition::BlockStateProperty { block, properties } => {
+            params.block_state.is_some_and(|state| {
+                let block_def = pumpkin_data::Block::from_state_id(state.id);
+                if block_def.name != block.strip_prefix("minecraft:").unwrap_or(block) {
+                    return false;
+                }
+                if properties.is_empty() {
+                    return true;
+                }
+                let props = block_def.properties(state.id).map(|p| p.to_props());
+                properties.iter().all(|(key, value)| {
+                    props
+                        .as_deref()
+                        .is_some_and(|props| props.iter().any(|(k, v)| k == key && v == value))
+                })
+            })
+        }
         LootCondition::AllOf(conditions) => conditions
             .iter()
             .all(|c| check_condition(*c, has_silk_touch, has_shears, fortune_level, params, rng)),

--- a/tools/pumpkin-codegen/src/loot_table.rs
+++ b/tools/pumpkin-codegen/src/loot_table.rs
@@ -244,20 +244,22 @@ fn combine_conditions(conditions: &[ConditionStruct]) -> LootCondition {
     merge_conditions(conditions.iter().map(parse_condition).collect())
 }
 
-/// Combines parsed conditions, dropping `None`s and duplicates.
+/// Combines parsed conditions, dropping `None`s.
 /// Returns a single condition when possible, otherwise `AllOf`.
+///
+/// Repeated stochastic conditions (e.g. two identical `random_chance` terms in an
+/// `all_of`) must each roll, so equal conditions are intentionally kept.
 fn merge_conditions(conditions: Vec<LootCondition>) -> LootCondition {
-    let mut unique: Vec<LootCondition> = Vec::with_capacity(conditions.len());
+    let mut kept: Vec<LootCondition> = Vec::with_capacity(conditions.len());
     for cond in conditions {
-        if cond == LootCondition::None || unique.contains(&cond) {
-            continue;
+        if cond != LootCondition::None {
+            kept.push(cond);
         }
-        unique.push(cond);
     }
-    match unique.len() {
+    match kept.len() {
         0 => LootCondition::None,
-        1 => unique[0],
-        _ => LootCondition::AllOf(Box::leak(unique.into_boxed_slice())),
+        1 => kept[0],
+        _ => LootCondition::AllOf(Box::leak(kept.into_boxed_slice())),
     }
 }
 
@@ -384,7 +386,8 @@ fn extract_entries_with_depth(
 
     let entry_cond = match (inherited_condition, combine_conditions(&entry.conditions)) {
         (LootCondition::None, cond) | (cond, LootCondition::None) => cond,
-        (first, second) if first == second => first,
+        // Equal conditions are combined, not collapsed: a repeated stochastic
+        // condition (e.g. two `random_chance` terms) must roll independently.
         (first, second) => LootCondition::AllOf(Box::leak(vec![first, second].into_boxed_slice())),
     };
 

--- a/tools/pumpkin-codegen/src/loot_table.rs
+++ b/tools/pumpkin-codegen/src/loot_table.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path};
+use std::{collections::BTreeMap, fs, path::Path};
 
 use heck::ToShoutySnakeCase;
 use proc_macro2::{Span, TokenStream};
@@ -112,6 +112,10 @@ struct ConditionStruct {
     term: Option<Box<ConditionStruct>>,
     #[serde(default)]
     terms: Option<Vec<ConditionStruct>>,
+    #[serde(default)]
+    block: Option<String>,
+    #[serde(default)]
+    properties: Option<BTreeMap<String, String>>,
 }
 
 fn parse_condition(cond: &ConditionStruct) -> LootCondition {
@@ -213,6 +217,25 @@ fn parse_condition(cond: &ConditionStruct) -> LootCondition {
                 LootCondition::None
             }
         }
+        "minecraft:block_state_property" => match &cond.block {
+            Some(block) if !block.is_empty() => {
+                let block: &'static str = Box::leak(block.clone().into_boxed_str());
+                let mut properties: Vec<(&'static str, &'static str)> = Vec::new();
+                if let Some(props) = &cond.properties {
+                    for (key, value) in props {
+                        properties.push((
+                            Box::leak(key.clone().into_boxed_str()),
+                            Box::leak(value.clone().into_boxed_str()),
+                        ));
+                    }
+                }
+                LootCondition::BlockStateProperty {
+                    block,
+                    properties: Box::leak(properties.into_boxed_slice()),
+                }
+            }
+            _ => LootCondition::None,
+        },
         _ => LootCondition::None,
     }
 }
@@ -287,6 +310,8 @@ struct PoolStruct {
     #[serde(default = "default_rolls")]
     rolls: RollsStruct,
     #[serde(default)]
+    functions: Vec<EntryFunctionStruct>,
+    #[serde(default)]
     conditions: Vec<ConditionStruct>,
 }
 
@@ -296,6 +321,8 @@ fn default_rolls() -> RollsStruct {
 
 #[derive(Deserialize, Clone, Debug)]
 struct ChestLootTableJson {
+    #[serde(default)]
+    functions: Vec<EntryFunctionStruct>,
     #[serde(default)]
     pools: Vec<PoolStruct>,
 }
@@ -320,15 +347,27 @@ struct ParsedEntry {
 fn extract_entries(
     entry: &PoolEntryStruct,
     inherited_condition: LootCondition,
+    pool_functions: &[EntryFunctionStruct],
+    table_functions: &[EntryFunctionStruct],
     out: &mut Vec<ParsedEntry>,
     empty_weight: &mut i32,
 ) {
-    extract_entries_with_depth(entry, inherited_condition, out, empty_weight, 0);
+    extract_entries_with_depth(
+        entry,
+        inherited_condition,
+        pool_functions,
+        table_functions,
+        out,
+        empty_weight,
+        0,
+    );
 }
 
 fn extract_entries_with_depth(
     entry: &PoolEntryStruct,
     inherited_condition: LootCondition,
+    pool_functions: &[EntryFunctionStruct],
+    table_functions: &[EntryFunctionStruct],
     out: &mut Vec<ParsedEntry>,
     empty_weight: &mut i32,
     depth: usize,
@@ -349,47 +388,49 @@ fn extract_entries_with_depth(
         }
         "minecraft:item" => {
             if let Some(name) = &entry.name {
-                let (min_count, max_count) = entry
-                    .functions
+                let function_layers = [entry.functions.as_slice(), pool_functions, table_functions];
+                let (min_count, max_count) = function_layers
                     .iter()
-                    .find(|f| f.function == "minecraft:set_count")
+                    .find_map(|fns| fns.iter().find(|f| f.function == "minecraft:set_count"))
                     .and_then(|f| f.count.as_ref())
                     .map(|c| (c.min(), c.max()))
                     .unwrap_or((1, 1));
 
-                let bonus_formula = entry.functions.iter().find_map(|f| {
-                    if f.function == "minecraft:apply_bonus" {
-                        match f.formula.as_deref() {
-                            Some("minecraft:ore_drops") => Some(LootBonusFormula::OreDrops),
-                            Some("minecraft:uniform_bonus_count") => {
-                                let mult = f
-                                    .parameters
-                                    .as_ref()
-                                    .and_then(|p| p.bonus_multiplier)
-                                    .unwrap_or(1);
-                                Some(LootBonusFormula::UniformBonusCount(mult))
+                let bonus_formula = function_layers.iter().find_map(|fns| {
+                    fns.iter().find_map(|f| {
+                        if f.function == "minecraft:apply_bonus" {
+                            match f.formula.as_deref() {
+                                Some("minecraft:ore_drops") => Some(LootBonusFormula::OreDrops),
+                                Some("minecraft:uniform_bonus_count") => {
+                                    let mult = f
+                                        .parameters
+                                        .as_ref()
+                                        .and_then(|p| p.bonus_multiplier)
+                                        .unwrap_or(1);
+                                    Some(LootBonusFormula::UniformBonusCount(mult))
+                                }
+                                Some("minecraft:binomial_with_bonus_count") => {
+                                    let extra =
+                                        f.parameters.as_ref().and_then(|p| p.extra).unwrap_or(0);
+                                    let prob = f
+                                        .parameters
+                                        .as_ref()
+                                        .and_then(|p| p.probability)
+                                        .unwrap_or(0.0);
+                                    Some(LootBonusFormula::BinomialWithBonusCount {
+                                        extra,
+                                        probability: prob,
+                                    })
+                                }
+                                _ => None,
                             }
-                            Some("minecraft:binomial_with_bonus_count") => {
-                                let extra =
-                                    f.parameters.as_ref().and_then(|p| p.extra).unwrap_or(0);
-                                let prob = f
-                                    .parameters
-                                    .as_ref()
-                                    .and_then(|p| p.probability)
-                                    .unwrap_or(0.0);
-                                Some(LootBonusFormula::BinomialWithBonusCount {
-                                    extra,
-                                    probability: prob,
-                                })
-                            }
-                            _ => None,
+                        } else if f.function == "minecraft:enchanted_count_increase" {
+                            let mult = f.count.as_ref().map_or(1, |c| c.max());
+                            Some(LootBonusFormula::UniformBonusCount(mult))
+                        } else {
+                            None
                         }
-                    } else if f.function == "minecraft:enchanted_count_increase" {
-                        let mult = f.count.as_ref().map_or(1, |c| c.max());
-                        Some(LootBonusFormula::UniformBonusCount(mult))
-                    } else {
-                        None
-                    }
+                    })
                 });
 
                 out.push(ParsedEntry {
@@ -450,6 +491,8 @@ fn extract_entries_with_depth(
                                 extract_entries_with_depth(
                                     child_entry,
                                     pool_cond,
+                                    &pool.functions,
+                                    &nested_table.functions,
                                     out,
                                     empty_weight,
                                     depth + 1,
@@ -472,6 +515,8 @@ fn extract_entries_with_depth(
                         extract_entries_with_depth(
                             child_entry,
                             pool_cond,
+                            &pool.functions,
+                            &nested_table.functions,
                             out,
                             empty_weight,
                             depth + 1,
@@ -501,6 +546,8 @@ fn extract_entries_with_depth(
                                     extract_entries_with_depth(
                                         child_entry,
                                         pool_cond,
+                                        &pool.functions,
+                                        &nested_table.functions,
                                         out,
                                         empty_weight,
                                         depth + 1,
@@ -539,12 +586,28 @@ fn extract_entries_with_depth(
                     entry_cond
                 };
 
-                extract_entries_with_depth(child, effective_cond, out, empty_weight, depth + 1);
+                extract_entries_with_depth(
+                    child,
+                    effective_cond,
+                    pool_functions,
+                    table_functions,
+                    out,
+                    empty_weight,
+                    depth + 1,
+                );
             }
         }
         "minecraft:sequence" | "minecraft:group" => {
             for child in &entry.children {
-                extract_entries_with_depth(child, entry_cond, out, empty_weight, depth + 1);
+                extract_entries_with_depth(
+                    child,
+                    entry_cond,
+                    pool_functions,
+                    table_functions,
+                    out,
+                    empty_weight,
+                    depth + 1,
+                );
             }
         }
         _ => {}
@@ -580,6 +643,23 @@ fn condition_to_tokens(cond: LootCondition) -> TokenStream {
         LootCondition::TableBonus { chances } => {
             let values = chances.iter();
             quote! { LootCondition::TableBonus { chances: &[#(#values),*] } }
+        }
+        LootCondition::BlockStateProperty { block, properties } => {
+            let block_lit = syn::LitStr::new(block, proc_macro2::Span::call_site());
+            let props: Vec<TokenStream> = properties
+                .iter()
+                .map(|(key, value)| {
+                    let key = syn::LitStr::new(key, proc_macro2::Span::call_site());
+                    let value = syn::LitStr::new(value, proc_macro2::Span::call_site());
+                    quote! { (#key, #value) }
+                })
+                .collect();
+            quote! {
+                LootCondition::BlockStateProperty {
+                    block: #block_lit,
+                    properties: &[#(#props),*],
+                }
+            }
         }
         LootCondition::AllOf(list) => {
             let tokens: Vec<TokenStream> = list.iter().copied().map(condition_to_tokens).collect();
@@ -625,6 +705,8 @@ fn emit_table(
             extract_entries(
                 entry,
                 LootCondition::None,
+                &pool.functions,
+                &table.functions,
                 &mut parsed_entries,
                 &mut empty_weight,
             );
@@ -694,7 +776,7 @@ fn collect_json_files(base: &Path, dir: &Path) -> Vec<(String, ChestLootTableJso
                 .unwrap()
                 .with_extension("")
                 .to_string_lossy()
-                .to_string();
+                .replace('\\', "/");
 
             let content = match fs::read_to_string(&path) {
                 Ok(c) => c,

--- a/tools/pumpkin-codegen/src/loot_table.rs
+++ b/tools/pumpkin-codegen/src/loot_table.rs
@@ -352,6 +352,57 @@ struct ParsedEntry {
     bonus_formula: Option<LootBonusFormula>,
 }
 
+/// Resolves count and bonus functions across the entry, pool, and table
+/// function layers. The first layer providing a value wins.
+fn resolve_functions(
+    function_layers: &[&[EntryFunctionStruct]],
+) -> (i32, i32, Option<LootBonusFormula>) {
+    let (min_count, max_count) = function_layers
+        .iter()
+        .find_map(|fns| fns.iter().find(|f| f.function == "minecraft:set_count"))
+        .and_then(|f| f.count.as_ref())
+        .map(|c| (c.min(), c.max()))
+        .unwrap_or((1, 1));
+
+    let bonus_formula = function_layers.iter().find_map(|fns| {
+        fns.iter().find_map(|f| {
+            if f.function == "minecraft:apply_bonus" {
+                match f.formula.as_deref() {
+                    Some("minecraft:ore_drops") => Some(LootBonusFormula::OreDrops),
+                    Some("minecraft:uniform_bonus_count") => {
+                        let mult = f
+                            .parameters
+                            .as_ref()
+                            .and_then(|p| p.bonus_multiplier)
+                            .unwrap_or(1);
+                        Some(LootBonusFormula::UniformBonusCount(mult))
+                    }
+                    Some("minecraft:binomial_with_bonus_count") => {
+                        let extra = f.parameters.as_ref().and_then(|p| p.extra).unwrap_or(0);
+                        let prob = f
+                            .parameters
+                            .as_ref()
+                            .and_then(|p| p.probability)
+                            .unwrap_or(0.0);
+                        Some(LootBonusFormula::BinomialWithBonusCount {
+                            extra,
+                            probability: prob,
+                        })
+                    }
+                    _ => None,
+                }
+            } else if f.function == "minecraft:enchanted_count_increase" {
+                let mult = f.count.as_ref().map_or(1, |c| c.max());
+                Some(LootBonusFormula::UniformBonusCount(mult))
+            } else {
+                None
+            }
+        })
+    });
+
+    (min_count, max_count, bonus_formula)
+}
+
 fn extract_entries(
     entry: &PoolEntryStruct,
     inherited_condition: LootCondition,
@@ -397,50 +448,11 @@ fn extract_entries_with_depth(
         }
         "minecraft:item" => {
             if let Some(name) = &entry.name {
-                let function_layers = [entry.functions.as_slice(), pool_functions, table_functions];
-                let (min_count, max_count) = function_layers
-                    .iter()
-                    .find_map(|fns| fns.iter().find(|f| f.function == "minecraft:set_count"))
-                    .and_then(|f| f.count.as_ref())
-                    .map(|c| (c.min(), c.max()))
-                    .unwrap_or((1, 1));
-
-                let bonus_formula = function_layers.iter().find_map(|fns| {
-                    fns.iter().find_map(|f| {
-                        if f.function == "minecraft:apply_bonus" {
-                            match f.formula.as_deref() {
-                                Some("minecraft:ore_drops") => Some(LootBonusFormula::OreDrops),
-                                Some("minecraft:uniform_bonus_count") => {
-                                    let mult = f
-                                        .parameters
-                                        .as_ref()
-                                        .and_then(|p| p.bonus_multiplier)
-                                        .unwrap_or(1);
-                                    Some(LootBonusFormula::UniformBonusCount(mult))
-                                }
-                                Some("minecraft:binomial_with_bonus_count") => {
-                                    let extra =
-                                        f.parameters.as_ref().and_then(|p| p.extra).unwrap_or(0);
-                                    let prob = f
-                                        .parameters
-                                        .as_ref()
-                                        .and_then(|p| p.probability)
-                                        .unwrap_or(0.0);
-                                    Some(LootBonusFormula::BinomialWithBonusCount {
-                                        extra,
-                                        probability: prob,
-                                    })
-                                }
-                                _ => None,
-                            }
-                        } else if f.function == "minecraft:enchanted_count_increase" {
-                            let mult = f.count.as_ref().map_or(1, |c| c.max());
-                            Some(LootBonusFormula::UniformBonusCount(mult))
-                        } else {
-                            None
-                        }
-                    })
-                });
+                let (min_count, max_count, bonus_formula) = resolve_functions(&[
+                    entry.functions.as_slice(),
+                    pool_functions,
+                    table_functions,
+                ]);
 
                 out.push(ParsedEntry {
                     item: name.clone(),
@@ -467,14 +479,19 @@ fn extract_entries_with_depth(
                         values: Vec<String>,
                     }
                     if let Ok(tag_data) = serde_json::from_str::<TagJson>(&content) {
+                        let (min_count, max_count, bonus_formula) = resolve_functions(&[
+                            entry.functions.as_slice(),
+                            pool_functions,
+                            table_functions,
+                        ]);
                         for item_name in tag_data.values {
                             out.push(ParsedEntry {
                                 item: item_name,
                                 weight: entry.weight,
-                                min_count: 1,
-                                max_count: 1,
+                                min_count,
+                                max_count,
                                 condition: entry_cond,
-                                bonus_formula: None,
+                                bonus_formula,
                             });
                         }
                     }
@@ -489,13 +506,13 @@ fn extract_entries_with_depth(
                 if let Ok(content) = fs::read_to_string(&table_path) {
                     if let Ok(nested_table) = serde_json::from_str::<ChestLootTableJson>(&content) {
                         for pool in &nested_table.pools {
-                            let mut pool_cond = entry_cond;
-                            for c in &pool.conditions {
-                                let parsed = parse_condition(c);
-                                if parsed != LootCondition::None {
-                                    pool_cond = parsed;
+                            let pool_cond = {
+                                let mut conds = vec![entry_cond];
+                                for c in &pool.conditions {
+                                    conds.push(parse_condition(c));
                                 }
-                            }
+                                merge_conditions(conds)
+                            };
                             for child_entry in &pool.entries {
                                 extract_entries_with_depth(
                                     child_entry,
@@ -513,13 +530,13 @@ fn extract_entries_with_depth(
             }
             Some(LootTableValue::Inline(nested_table)) => {
                 for pool in &nested_table.pools {
-                    let mut pool_cond = entry_cond;
-                    for c in &pool.conditions {
-                        let parsed = parse_condition(c);
-                        if parsed != LootCondition::None {
-                            pool_cond = parsed;
+                    let pool_cond = {
+                        let mut conds = vec![entry_cond];
+                        for c in &pool.conditions {
+                            conds.push(parse_condition(c));
                         }
-                    }
+                        merge_conditions(conds)
+                    };
                     for child_entry in &pool.entries {
                         extract_entries_with_depth(
                             child_entry,

--- a/tools/pumpkin-codegen/src/loot_table.rs
+++ b/tools/pumpkin-codegen/src/loot_table.rs
@@ -241,17 +241,23 @@ fn parse_condition(cond: &ConditionStruct) -> LootCondition {
 }
 
 fn combine_conditions(conditions: &[ConditionStruct]) -> LootCondition {
-    let mut parsed_list: Vec<LootCondition> = Vec::new();
-    for c in conditions {
-        let parsed = parse_condition(c);
-        if parsed != LootCondition::None {
-            parsed_list.push(parsed);
+    merge_conditions(conditions.iter().map(parse_condition).collect())
+}
+
+/// Combines parsed conditions, dropping `None`s and duplicates.
+/// Returns a single condition when possible, otherwise `AllOf`.
+fn merge_conditions(conditions: Vec<LootCondition>) -> LootCondition {
+    let mut unique: Vec<LootCondition> = Vec::with_capacity(conditions.len());
+    for cond in conditions {
+        if cond == LootCondition::None || unique.contains(&cond) {
+            continue;
         }
+        unique.push(cond);
     }
-    match parsed_list.len() {
+    match unique.len() {
         0 => LootCondition::None,
-        1 => parsed_list[0],
-        _ => LootCondition::AllOf(Box::leak(parsed_list.into_boxed_slice())),
+        1 => unique[0],
+        _ => LootCondition::AllOf(Box::leak(unique.into_boxed_slice())),
     }
 }
 
@@ -535,13 +541,13 @@ fn extract_entries_with_depth(
                             serde_json::from_str::<ChestLootTableJson>(&content)
                         {
                             for pool in &nested_table.pools {
-                                let mut pool_cond = entry_cond;
-                                for c in &pool.conditions {
-                                    let parsed = parse_condition(c);
-                                    if parsed != LootCondition::None {
-                                        pool_cond = parsed;
+                                let pool_cond = {
+                                    let mut conds = vec![entry_cond];
+                                    for c in &pool.conditions {
+                                        conds.push(parse_condition(c));
                                     }
-                                }
+                                    merge_conditions(conds)
+                                };
                                 for child_entry in &pool.entries {
                                     extract_entries_with_depth(
                                         child_entry,


### PR DESCRIPTION
## Description

The loot table codegen silently mapped every condition type it didn't know to `LootCondition::None` (i.e. unconditional). This broke every loot table gated on `minecraft:block_state_property`:

- Breaking a **composter** at any fill level dropped a bone meal — the drop is gated on `level=8` (#3293).
- Breaking a **sweet berry bush** always dropped 2 berries at every age instead of following the vanilla age gates (#3292).

The codegen also only read `set_count` / `apply_bonus` functions from the entries themselves, ignoring the pool-level and table-level function layers that vanilla data uses. Vanilla `sweet_berry_bush.json` puts its functions on the pools, so berry counts collapsed to a constant 1 and the fortune bonus was dropped entirely.

### Changes

**Codegen (`tools/pumpkin-codegen`):**
- Parse `minecraft:block_state_property` conditions into a new `LootCondition::BlockStateProperty` variant.
- Thread pool-level and table-level functions through entry extraction so `set_count` / bonus formulas from any layer apply (entry → pool → table, first match wins, matching vanilla resolution).
- Normalize path separators when collecting JSON files so the generated keys/identifiers are identical on Windows and Unix hosts (previously a Windows regen produced `minecraft:blocks\foo` keys).

**Runtime (`pumpkin` / `pumpkin-util`):**
- Evaluate `BlockStateProperty` against the loot context's block state: the block must match and every specified property must match (unspecified properties ignored), matching vanilla semantics.

**Regenerated `pumpkin-data` loot tables** now honor block state conditions everywhere — composter (`level=8`), sweet berry bush (`age=2`/`age=3` with counts 1-2/2-3 + fortune), snow (`layers=1`), and ~30 other previously-unconditional pools.

## Testing

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets --all-features` with `RUSTFLAGS=-Dwarnings` clean
- `cargo test` — all tests pass
- Verified regenerated tables: `BLOCKS_COMPOSTER` bone meal pool now carries `level=8`; `BLOCKS_SWEET_BERRY_BUSH` pools carry `age=3` (2-3 berries) / `age=2` (1-2 berries) + `UniformBonusCount` fortune; age 0-1 bushes drop nothing (no pool condition passes)

Fixes #3293
Fixes #3292

🤖 Generated with AI assistance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Loot tables can apply conditions based on a block’s type and state properties.
  - Block-state conditions support optional namespace prefixes and multiple property checks.
  - Conditions without additional properties succeed when the specified block type matches.
  - Loot-table functions, including count and bonus formulas, are preserved through nested and combined entries.
  - Repeated random conditions now resolve independently, preserving separate rolls.
  - Loot-table files are processed consistently across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->