### PR TITLE
perf(worldgen): compute concurrent structure cache misses once

### DIFF
--- a/crates/pumpkin-world/benches/chunk_gen_concurrent.rs
+++ b/crates/pumpkin-world/benches/chunk_gen_concurrent.rs
@@ -4,9 +4,12 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use pumpkin_data::BlockStateId;
 use pumpkin_data::dimension::Dimension;
 use pumpkin_util::world_seed::Seed;
+use pumpkin_world::ProtoChunk;
 use pumpkin_world::chunk_system::{StagedChunkEnum, generate_single_chunk};
+use pumpkin_world::generation::generator::WorldGenerator;
 use pumpkin_world::generation::get_world_gen;
 use pumpkin_world::world::WorldPortalExt;
+use rayon::prelude::*;
 use std::hint::black_box;
 use std::sync::Arc;
 use std::time::Instant;
@@ -114,5 +117,58 @@ fn bench_concurrent_chunk_generation(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_concurrent_chunk_generation);
+// A fresh generator per iteration prevents the global structure cache from
+// turning a concurrent cold-miss workload into a warm lookup benchmark.
+fn bench_cold_structure_references(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cold_structure_references_16_chunks");
+    group.sample_size(10);
+    for threads in [1, 16] {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .expect("benchmark thread pool");
+        group.bench_function(format!("{threads}_threads"), |b| {
+            b.iter_custom(|iterations| {
+                let mut total = std::time::Duration::ZERO;
+                for _ in 0..iterations {
+                    let world_gen = get_world_gen(
+                        Seed(1),
+                        Dimension::OVERWORLD,
+                        false,
+                        Vec::new(),
+                        String::new(),
+                    );
+                    let WorldGenerator::Noise(generator) = &*world_gen else {
+                        panic!("expected noise generator");
+                    };
+                    // These neighbors share the ancient-city candidate at (58, 5).
+                    let mut chunks: Vec<_> = (50..66)
+                        .map(|x| {
+                            let mut chunk = ProtoChunk::new(x, 0, &world_gen);
+                            chunk.step_to_biomes(generator);
+                            chunk.set_structure_starts(generator);
+                            chunk
+                        })
+                        .collect();
+                    let start = Instant::now();
+                    pool.install(|| {
+                        chunks.par_iter_mut().for_each(|chunk| {
+                            chunk.set_structure_references(generator);
+                        });
+                    });
+                    total += start.elapsed();
+                    black_box(chunks);
+                }
+                total
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_concurrent_chunk_generation,
+    bench_cold_structure_references
+);
 criterion_main!(benches);

--- a/crates/pumpkin-world/src/generation/structure/placement.rs
+++ b/crates/pumpkin-world/src/generation/structure/placement.rs
@@ -10,13 +10,14 @@ use pumpkin_util::{
     },
 };
 use std::f64::consts::PI;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use crate::ProtoChunk;
 use dashmap::DashMap;
 use pumpkin_data::structures::StructureKeys;
 
 use super::structures::StructurePosition;
+type CachedStructureStart = Arc<OnceLock<Option<StructurePosition>>>;
 /// A thread-safe global cache for structures that require world-wide placement calculations
 /// rather than localized chunk-based math (e.g., Strongholds using Concentric Rings).
 ///
@@ -30,7 +31,7 @@ pub struct GlobalStructureCache {
     /// A jigsaw structure's placement is fully determined by its start chunk and the
     /// world seed, so it is computed once here instead of being recomputed for every
     /// surrounding chunk whose structure references overlap it.
-    structure_starts: OnceLock<DashMap<(StructureKeys, i32, i32), Option<StructurePosition>>>,
+    structure_starts: OnceLock<DashMap<(StructureKeys, i32, i32), CachedStructureStart>>,
 }
 impl GlobalStructureCache {
     /// Creates a new, empty global structure cache.
@@ -62,12 +63,21 @@ impl GlobalStructureCache {
         compute: impl FnOnce() -> Option<StructurePosition>,
     ) -> Option<StructurePosition> {
         let cache = self.structure_starts.get_or_init(DashMap::new);
-        if let Some(cached) = cache.get(&(key, chunk_x, chunk_z)) {
-            return cached.value().clone();
-        }
-        let computed = compute();
-        cache.insert((key, chunk_x, chunk_z), computed.clone());
-        computed
+        let cache_key = (key, chunk_x, chunk_z);
+        let entry = cache.get(&cache_key).map_or_else(
+            || {
+                Arc::clone(
+                    cache
+                        .entry(cache_key)
+                        .or_insert_with(|| Arc::new(OnceLock::new()))
+                        .value(),
+                )
+            },
+            |cached| Arc::clone(cached.value()),
+        );
+        // Release the map guard before generating or waiting: unrelated starts may
+        // share its shard. Only callers for this exact start wait for its result.
+        entry.get_or_init(compute).clone()
     }
 
     /// Retrieves the list of chunk coordinates for Concentric Ring structures.
@@ -351,14 +361,23 @@ fn is_start_chunk_random_spread(
 }
 #[cfg(test)]
 mod tests {
+    use super::StructurePosition;
+    use crate::generation::structure::structures::StructurePiecesCollector;
+    use pumpkin_data::structures::StructureKeys;
     use pumpkin_data::{
         dimension::Dimension,
         structures::{RandomSpreadStructurePlacement, StructurePlacementCalculator, StructureSet},
     };
+    use pumpkin_util::math::position::BlockPos;
     use pumpkin_util::random::{
         RandomGenerator, RandomImpl, get_region_seed, legacy_rand::LegacyRand,
     };
     use pumpkin_util::world_seed::Seed;
+    use std::sync::{
+        Arc, Barrier, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
 
     use crate::{
         ProtoChunk,
@@ -370,6 +389,59 @@ mod tests {
             },
         },
     };
+
+    #[test]
+    fn concurrent_structure_requests_compute_once() {
+        let cache = GlobalStructureCache::new();
+        let requests = Barrier::new(16);
+        let computations = AtomicUsize::new(0);
+        let collector = Arc::new(Mutex::new(StructurePiecesCollector::new()));
+        std::thread::scope(|scope| {
+            for _ in 0..16 {
+                scope.spawn(|| {
+                    requests.wait();
+                    let result = cache
+                        .get_or_compute_structure_start(StructureKeys::AncientCity, 58, 5, || {
+                            computations.fetch_add(1, Ordering::SeqCst);
+                            // Keep the miss in progress while neighboring requests arrive.
+                            std::thread::sleep(Duration::from_millis(20));
+                            Some(StructurePosition {
+                                start_pos: BlockPos::new(928, -27, 80),
+                                collector: Arc::clone(&collector),
+                            })
+                        })
+                        .expect("structure start");
+                    assert!(Arc::ptr_eq(&result.collector, &collector));
+                    assert_eq!(result.start_pos, BlockPos::new(928, -27, 80));
+                });
+            }
+        });
+        assert_eq!(computations.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn absent_structure_starts_are_cached_separately() {
+        let cache = GlobalStructureCache::new();
+        let computations = AtomicUsize::new(0);
+        for _ in 0..2 {
+            for (key, x, z) in [
+                (StructureKeys::AncientCity, 58, 5),
+                (StructureKeys::EndCity, 58, 5),
+                (StructureKeys::AncientCity, 59, 5),
+                (StructureKeys::AncientCity, 58, 6),
+            ] {
+                assert!(
+                    cache
+                        .get_or_compute_structure_start(key, x, z, || {
+                            computations.fetch_add(1, Ordering::SeqCst);
+                            None
+                        })
+                        .is_none()
+                );
+            }
+        }
+        assert_eq!(computations.load(Ordering::SeqCst), 4);
+    }
 
     #[test]
     fn get_start_chunk_random() {


### PR DESCRIPTION
When neighboring chunks request the same uncached structure start concurrently,
`GlobalStructureCache` currently runs the expensive expansion once per requester
before any result is inserted. A seed-1 reproduction with 16 workers expanded
the ancient-city candidate at (58, 5) sixteen times.

Store a per-key `Arc<OnceLock<Option<StructurePosition>>>` so one requester
initializes the entry and the others reuse its result. Drop the DashMap guard
before computing or waiting, and keep the read-lock path for existing entries.
Absent starts remain cached. This extends the memoization introduced by #2335
to concurrent misses; it does not change structure placement algorithms.

The new cold-cache benchmark uses 16 adjacent chunks and a fresh generator on
each iteration, with setup excluded. On an i9-13900HX, stable Rust 1.98.1,
optimized builds with LTO disabled and 16 codegen units:

| Workers | Original | Changed |
| --- | --- | --- |
| 1 | 16.160 ms | 16.564 ms |
| 16 | 25.563 ms | 13.557 ms |

That is 47% less elapsed time in the parallel case; the single-worker confidence
intervals overlap. These are structure-reference timings, not whole-server TPS.

The concurrent regression fails on the original implementation (16 computations
versus one) and passes with the change. All 761 workspace tests pass, including
existing fixed-seed structure parity tests. Release all-target/all-feature
Clippy and formatting pass. Functional tests use `pumpkin` opt-level 0; the
performance builds use opt-level 3.

Related to #3116, investigated at 786e2fbf782f92113543fcb46eaf95ba53835d41.
Two alternating-order fresh-world flight pairs (Windows, seed 1, view distance
10, 16 generation workers, 6144 blocks at 8 blocks/30 ms, prompt batch acks):

| Metric | Original (two runs) | Changed (two runs) |
| --- | --- | --- |
| Unique chunks during flight | 420, 354 | 1060, 1152 |
| New chunks in second half | 15, 0 | 334, 379 |
| CPU (% of one core) | 1651, 1651 | 510, 516 |
| Maximum delivery gap | 9.69 s, 19.41 s | 7.02 s, 7.06 s |

All four runs completed without observer errors, teleport corrections or forced
shutdown. Average delivered chunks increased 2.86x and CPU fell about 69% in
this workload. Seven-second delivery gaps remain, so this does **not** claim to
resolve all of #3116. Current-code traces showed generation workers occupied
and no ready chunks at the sender, and saved region statuses were mostly
unfinished; disk growth alone did not establish a sender bottleneck.

Optimized binary SHA-256: original
`26ecbcf3a9781c806f4121e9a59614a31ebeebe6e59d351ef0e779a9ea6eee75`,
changed `28844bde7708f6e80a590da528e3850d878c32e13da18a499d98d172a526fa23`.
Both use release opt-level 3, LTO=false, codegen-units=16.

A separate 1536-block prebuilt-air control delivered all 2208 expected unique
chunks with zero duplicates, a maximum packet gap of 63 ms, and a clean shutdown.
All 14 local protocol-harness tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved concurrent world generation by coordinating shared structure calculations more efficiently.
  - Reduced redundant structure-placement work when multiple generation tasks request the same result simultaneously.
  - Improved handling and caching of absent structure results across different locations.
  - Added performance coverage for concurrent chunk generation and structure placement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->