### PR TITLE
fix(block): use the supporting block position when trampling turtle eggs 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/block/blocks/turtle_egg.rs
+++ b/crates/pumpkin/src/block/blocks/turtle_egg.rs
@@ -155,9 +155,11 @@ impl BlockBehaviour for TurtleEggBlock {
 
         if args.entity.get_entity().entity_type.id != EntityType::ZOMBIE.id {
             let entity_pos = args.entity.get_entity().pos.load();
+            // Vanilla uses the landed-on block position (`Entity#getOnPosLegacy`),
+            // which is `Mth.floor(y - 0.2)`, not the feet position.
             let pos = BlockPos(Vector3::new(
                 entity_pos.x.floor() as i32,
-                entity_pos.y.floor() as i32,
+                (entity_pos.y - 0.2).floor() as i32,
                 entity_pos.z.floor() as i32,
             ));
             let (block, state) = args.world.get_block_and_state(&pos);


### PR DESCRIPTION
## Description

`TurtleEggBlock::on_landed_upon` derived the landed-on block position by flooring the raw entity position. That is the block at **feet level** — the air block above the egg — so the `TURTLE_EGG` check could never match, and falling onto turtle eggs never cracked them.

Vanilla passes the landed-on (supporting) block position into `TurtleEggBlock#fallOn`, which is `Entity#getOnPosLegacy` = `Mth.floor(y - 0.2)` on the Y axis. This PR uses the same offset when re-deriving the position, mirroring the farmland trampling fix in #3301 (which had the identical bug; `OnLandedUponArgs` doesn't carry the position, so handlers must derive it from the entity).

The walk-over path (`on_entity_step`, 1/100 chance with the sneaking check) was already correct and is untouched.

## Testing

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets --all-features` with `RUSTFLAGS=-Dwarnings` clean
- `cargo test` — all suites pass
- Manual check of the position math: entity resting on an egg at y=64 → feet at y=65.0 → old code floor(65.0)=65 (air), new code floor(65.0−0.2)=64 (the egg)

🤖 Generated with AI assistance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected turtle egg landing detection so eggs hatch or respond based on the actual block position beneath an entity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->