### PR TITLE
fix(command): include command name in unknown-command errors

### DIFF
--- a/crates/pumpkin-command/src/errors/error_types.rs
+++ b/crates/pumpkin-command/src/errors/error_types.rs
@@ -96,7 +96,7 @@ pub const LONG_TOO_HIGH: CommandErrorType<2> = CommandErrorType::new(
     translation::java::ARGUMENT_LONG_BIG,
 );
 
-pub const DISPATCHER_UNKNOWN_COMMAND: CommandErrorType<0> = CommandErrorType::new(
+pub const DISPATCHER_UNKNOWN_COMMAND: CommandErrorType<1> = CommandErrorType::new(
     translation::java::COMMAND_UNKNOWN_COMMAND,
     translation::bedrock::COMMANDS_GENERIC_UNKNOWN,
 );

--- a/crates/pumpkin-command/src/node/dispatcher.rs
+++ b/crates/pumpkin-command/src/node/dispatcher.rs
@@ -240,6 +240,13 @@ impl<S: CommandSource> CommandDispatcher<S> {
         input.split_whitespace().next().unwrap_or("")
     }
 
+    fn unknown_command_error(reader: &StringReader<'_>) -> CommandSyntaxError {
+        DISPATCHER_UNKNOWN_COMMAND.create(
+            reader,
+            TextComponent::text(Self::command_name(reader.string()).to_owned()),
+        )
+    }
+
     /// Registers a command which can then be dispatched.
     /// Returns the local ID of the node attached to the tree.
     ///
@@ -358,7 +365,7 @@ impl<S: CommandSource> CommandDispatcher<S> {
         // programmatic callers such as `/execute run <command>`, which reach the
         // dispatcher here without going through `handle_command`.
         if self.is_disabled(Self::command_name(input)) {
-            return Err(DISPATCHER_UNKNOWN_COMMAND.create(&reader));
+            return Err(Self::unknown_command_error(&reader));
         }
 
         self.execute_reader(&mut reader, source)
@@ -383,7 +390,7 @@ impl<S: CommandSource> CommandDispatcher<S> {
             return if let Some(err) = parsed.errors.values().next() {
                 Err(err.clone())
             } else if parsed.context.range.is_empty() {
-                Err(DISPATCHER_UNKNOWN_COMMAND.create(&parsed.reader))
+                Err(Self::unknown_command_error(&parsed.reader))
             } else {
                 Err(DISPATCHER_UNKNOWN_ARGUMENT.create(&parsed.reader))
             };
@@ -396,7 +403,7 @@ impl<S: CommandSource> CommandDispatcher<S> {
             None => {
                 self.consumer
                     .on_command_completion(&original_context, ReturnValue::Failure);
-                Err(DISPATCHER_UNKNOWN_COMMAND.create(&parsed.reader))
+                Err(Self::unknown_command_error(&parsed.reader))
             }
             Some(flat_context) => {
                 flat_context.execute_all(&original_context.source, self.consumer.as_ref())
@@ -537,7 +544,7 @@ impl<S: CommandSource> CommandDispatcher<S> {
         // before either dispatcher gets a chance to run it.
         if self.is_disabled(Self::command_name(input)) {
             let reader = StringReader::new(input);
-            Self::send_error_to_source(source, DISPATCHER_UNKNOWN_COMMAND.create(&reader), input);
+            Self::send_error_to_source(source, Self::unknown_command_error(&reader), input);
             return;
         }
 
@@ -985,6 +992,36 @@ mod test {
         let source = DummySource::dummy();
         let result = dispatcher.execute_input("unknown", &source);
         assert!(result.is_err_and(|error| error.error_type == &DISPATCHER_UNKNOWN_COMMAND));
+    }
+
+    #[test]
+    fn unknown_command_message_includes_command_name() {
+        use pumpkin_util::translation::Locale;
+
+        for (input, registered, disabled) in [
+            ("x", false, false),
+            ("x extra arguments", false, false),
+            ("x", true, false),
+            ("x extra arguments", true, true),
+        ] {
+            let mut dispatcher = CommandDispatcher::new();
+            if registered {
+                dispatcher.register(CommandArgumentBuilder::new("x", "test command").build());
+            }
+            if disabled {
+                dispatcher.disable_command("x");
+            }
+            let error = dispatcher
+                .execute_input(input, &DummySource::dummy())
+                .expect_err("unknown or unavailable command");
+            let expected = "Unknown command: x. Please check that the command exists and that you have permission to use it.";
+            assert_eq!(error.message.clone().to_pretty_console(), expected);
+            assert_eq!(error.message.0.to_bedrock_legacy(Locale::EnUs), expected);
+            let java = serde_json::to_value(&error.message).expect("Java text component");
+            assert_eq!(java["translate"], "command.unknown.command");
+            assert_eq!(java["with"][0]["text"], "x");
+            assert_eq!(error.context.expect("error context").input, input);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Unknown commands currently render as `Unknown command: %s...` in the console
and Bedrock output because the Bedrock translation expects one argument but
`DISPATCHER_UNKNOWN_COMMAND` supplies none.

Give that error one argument and supply the first command token through a shared
dispatcher helper. Unknown input, commands without an executor, and disabled
commands now include the command name. Extra command arguments are excluded
from the substitution, and the original error context is preserved.

Fixes #3265. This differs from closed #2623: it supplies the missing translation
argument rather than changing translation-key selection for every console/RCON
message. No overlapping open fix was found.

The regression checks exact console and Bedrock text, the Java translation key
and argument, and original context across four unknown/unavailable input cases.

Validation: all 79 command library tests pass. The new regression fails on
original code with the exact literal `%s` output, then passes with the fix.
Functional tests use release mode with `pumpkin-data` and `pumpkin-world`
opt-level 0 to avoid unnecessary optimization of generated dependencies.
Command-crate all-target/all-feature Clippy, workspace formatting, and whitespace
checks pass. This is validated at the dispatcher/text-renderer layer; no new
full-server binary was needed for this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unknown-command errors now include the entered command token for clearer feedback.
  - Improved unknown-command messaging across execution, parsing, unregistered, unavailable, and disabled command scenarios.
  - Updated localized messages for Java and Bedrock representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->