### PR TITLE
fix(block): dispatch game events to sculk sensors and shriekers 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3050,7 +3050,12 @@ impl EntityBase for LivingEntity {
             // walking unless the entity is sneaking (sneaking entities are in the
             // `minecraft:ignore_vibrations_sneaking` tag and are skipped).
             if !caller.get_entity().is_sneaking()
-                && caller.get_entity().velocity.load().length_squared() > 0.0001
+                && caller
+                    .get_entity()
+                    .velocity
+                    .load()
+                    .horizontal_length_squared()
+                    > 0.0001
             {
                 world.emit_game_event(GameEvent::Step.name(), caller.get_entity().pos.load());
             }

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -45,6 +45,7 @@ use pumpkin_data::data_component_impl::{
 use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::entity::{EntityPose, EntityStatus, EntityType};
 use pumpkin_data::fluid::Fluid;
+use pumpkin_data::game_event::GameEvent;
 use pumpkin_data::item_stack::{DamageResult, ItemStack};
 use pumpkin_data::sound::SoundCategory;
 use pumpkin_data::{Block, Enchantment};
@@ -1727,6 +1728,12 @@ impl LivingEntity {
 
             self.update_death_stats(&*dyn_self, killer);
 
+            // Vanilla plays the death sound in `hurt` before `die` broadcasts the
+            // death status; emit the `entity_die` game event for sculk listeners.
+            self.entity
+                .world
+                .load_full()
+                .emit_game_event(GameEvent::EntityDie.name(), self.entity.pos.load());
             // Plays the death sound
             world.send_entity_status(&self.entity, EntityStatus::Death, Some(ActorEventID::Death));
             let looting_level;
@@ -2831,6 +2838,13 @@ impl LivingEntity {
                 &self.entity.pos.load(),
             );
 
+            // Vanilla `LivingEntity#hurt` emits an `entity_damage` game event when
+            // the hit connects, letting sculk sensors hear the damage.
+            self.entity
+                .world
+                .load_full()
+                .emit_game_event(GameEvent::EntityDamage.name(), self.entity.pos.load());
+
             if let Some(source) = source {
                 let source_pos = source.get_entity().pos.load();
                 let target_pos = self.entity.pos.load();
@@ -3031,6 +3045,15 @@ impl EntityBase for LivingEntity {
             world
                 .block_registry
                 .on_entity_step(block, &world, caller, &supporting, state, false);
+
+            // Vanilla `LivingEntity#checkFallDamage` emits a step vibration while
+            // walking unless the entity is sneaking (sneaking entities are in the
+            // `minecraft:ignore_vibrations_sneaking` tag and are skipped).
+            if !caller.get_entity().is_sneaking()
+                && caller.get_entity().velocity.load().length_squared() > 0.0001
+            {
+                world.emit_game_event(GameEvent::Step.name(), caller.get_entity().pos.load());
+            }
 
             // Check slightly below supporting_pos for additional supporting blocks (blocks under carpets and the like)
             if !block.is_solid() {

--- a/crates/pumpkin/src/net/java/play/use_item_on.rs
+++ b/crates/pumpkin/src/net/java/play/use_item_on.rs
@@ -263,6 +263,11 @@ impl JavaClient {
                     final_block_pos,
                     VarInt(i32::from(new_state.as_u16())),
                 ));
+                // Vanilla `BlockItem#place`: placing a block emits a block place game event.
+                player.world().emit_game_event(
+                    pumpkin_data::game_event::GameEvent::BlockPlace.name(),
+                    final_block_pos.to_centered_f64(),
+                );
                 Ok(true)
             }
             Ok(None) => Ok(false),

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -28,6 +28,7 @@ pub mod raid;
 pub mod random_sequences;
 pub mod stopwatches;
 pub mod time;
+mod vibration;
 pub mod villager_poi;
 
 use crate::block::RandomTickArgs;
@@ -298,6 +299,8 @@ pub struct World {
     pub custom_block_entity_data: DashMap<BlockPos, NbtCompound>,
     /// Entity tracker responsible for tracking entity visibility and sending delta/status packets to watchers.
     pub entity_tracker: entity_tracker::EntityTracker,
+    /// Block positions of vibration listeners (sculk sensors and shriekers) for game event dispatch.
+    vibration_listeners: std::sync::Mutex<FxHashSet<BlockPos>>,
 }
 
 #[derive(Clone, Copy)]
@@ -424,6 +427,7 @@ impl World {
             custom_data: std::sync::Mutex::new(custom_data),
             custom_block_entity_data: DashMap::new(),
             entity_tracker: entity_tracker::EntityTracker::new(),
+            vibration_listeners: std::sync::Mutex::new(FxHashSet::default()),
         }
     }
 
@@ -5395,6 +5399,25 @@ impl World {
         let is_new_block = old_block != new_block;
         let block_moved = flags.contains(BlockFlags::MOVED);
 
+        // Keep the vibration listener set in sync with sculk sensor/shrieker placement.
+        let was_vibration_listener = old_block == &Block::SCULK_SENSOR
+            || old_block == &Block::CALIBRATED_SCULK_SENSOR
+            || old_block == &Block::SCULK_SHRIEKER;
+        let is_vibration_listener = new_block == &Block::SCULK_SENSOR
+            || new_block == &Block::CALIBRATED_SCULK_SENSOR
+            || new_block == &Block::SCULK_SHRIEKER;
+        if was_vibration_listener != is_vibration_listener {
+            let mut listeners = self
+                .vibration_listeners
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if is_vibration_listener {
+                listeners.insert(*position);
+            } else {
+                listeners.remove(position);
+            }
+        }
+
         if is_new_block
             && old_block.default_state.block_entity_type != u16::MAX
             && let Some(entity) = self.get_block_entity(position)
@@ -5551,6 +5574,13 @@ impl World {
             };
             crate::block::drop_loot(self, broken_block, position, true, &params);
         }
+
+        // Vanilla `BlockBehaviour#destroy` emits a `block_destroy` game event so
+        // sculk sensors (frequency 12) hear the block being broken.
+        self.emit_game_event(
+            pumpkin_data::game_event::GameEvent::BlockDestroy.name(),
+            position.to_centered_f64(),
+        );
 
         let new_state_id = if broken_block.is_waterlogged(broken_block_state.id) {
             Block::WATER.default_state.id
@@ -7039,13 +7069,17 @@ impl World {
         Self::broadcast_bedrock_grouped(be_packet, bedrock_recipients.into_iter());
     }
 
-    pub fn emit_game_event(&self, event_key: impl Into<String>, position: Vector3<f64>) {
+    pub fn emit_game_event(self: &Arc<Self>, event_key: impl Into<String>, position: Vector3<f64>) {
+        let key = event_key.into();
         let mut event = crate::plugin::api::events::world::generic_game::GenericGameEvent::new(
-            event_key.into(),
+            key.clone(),
             position,
         );
         if let Some(server) = self.server.upgrade() {
             server.plugin_manager.fire_blocking(&server, &mut event);
+        }
+        if let Some(event) = vibration::game_event_from_key(&key) {
+            vibration::dispatch(self, event, position);
         }
     }
 

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -7070,16 +7070,19 @@ impl World {
     }
 
     pub fn emit_game_event(self: &Arc<Self>, event_key: impl Into<String>, position: Vector3<f64>) {
-        let key = event_key.into();
         let mut event = crate::plugin::api::events::world::generic_game::GenericGameEvent::new(
-            key.clone(),
+            event_key.into(),
             position,
         );
         if let Some(server) = self.server.upgrade() {
             server.plugin_manager.fire_blocking(&server, &mut event);
         }
-        if let Some(event) = vibration::game_event_from_key(&key) {
-            vibration::dispatch(self, event, position);
+        if event.cancelled {
+            return;
+        }
+        // Plugins may have rewritten the event, so dispatch with the final values.
+        if let Some(game_event) = vibration::game_event_from_key(&event.event_key) {
+            vibration::dispatch(self, game_event, event.position);
         }
     }
 

--- a/crates/pumpkin/src/world/vibration.rs
+++ b/crates/pumpkin/src/world/vibration.rs
@@ -110,21 +110,87 @@ pub(super) fn game_event_from_key(key: &str) -> Option<GameEvent> {
 /// Whether any block along the straight line between the source and the
 /// destination occludes vibration signals (wool), mirroring vanilla
 /// `VibrationSystem#isOccluded` closely enough for gameplay purposes.
+///
+/// Uses a voxel traversal (Amanatides–Woo) so every voxel the segment passes
+/// through is visited — fixed-interval sampling can miss thin overlaps.
 fn is_occluded(world: &World, source: Vector3<f64>, dest: Vector3<f64>) -> bool {
     let direction = dest - source;
-    let distance = direction.length();
-    if distance < f64::EPSILON {
+    if direction.length_squared() < f64::EPSILON {
         return false;
     }
 
-    let steps = (distance / 0.5).ceil() as i32;
-    for i in 0..=steps {
-        let t = f64::from(i) / f64::from(steps);
-        let sample = source + direction * t;
-        let pos = BlockPos::containing_vec(sample);
-        let block = world.get_block(&pos);
+    let mut current = BlockPos::containing_vec(source);
+    let end = BlockPos::containing_vec(dest);
+    let step = Vector3::new(
+        direction.x.signum() as i32,
+        direction.y.signum() as i32,
+        direction.z.signum() as i32,
+    );
+    // Fraction of the direction vector at which we cross the next voxel
+    // boundary on each axis; 1/abs(d), or infinity when d == 0.
+    let t_delta = Vector3::new(
+        if direction.x == 0.0 {
+            f64::INFINITY
+        } else {
+            1.0 / direction.x.abs()
+        },
+        if direction.y == 0.0 {
+            f64::INFINITY
+        } else {
+            1.0 / direction.y.abs()
+        },
+        if direction.z == 0.0 {
+            f64::INFINITY
+        } else {
+            1.0 / direction.z.abs()
+        },
+    );
+    // Distance along the direction vector to the first boundary crossing.
+    let mut t_max = Vector3::new(
+        if direction.x == 0.0 {
+            f64::INFINITY
+        } else if step.x > 0 {
+            (f64::from(current.0.x + 1) - source.x) / direction.x
+        } else {
+            (source.x - f64::from(current.0.x)) / -direction.x
+        },
+        if direction.y == 0.0 {
+            f64::INFINITY
+        } else if step.y > 0 {
+            (f64::from(current.0.y + 1) - source.y) / direction.y
+        } else {
+            (source.y - f64::from(current.0.y)) / -direction.y
+        },
+        if direction.z == 0.0 {
+            f64::INFINITY
+        } else if step.z > 0 {
+            (f64::from(current.0.z + 1) - source.z) / direction.z
+        } else {
+            (source.z - f64::from(current.0.z)) / -direction.z
+        },
+    );
+
+    let mut t = 0.0;
+    while t <= 1.0 {
+        let block = world.get_block(&current);
         if block.has_tag(&tag::Block::MINECRAFT_OCCLUDES_VIBRATION_SIGNALS) {
             return true;
+        }
+        if current == end {
+            break;
+        }
+        if t_max.x < t_max.y && t_max.x < t_max.z {
+            current.0.x += step.x;
+            t = t_max.x;
+            t_max.x += t_delta.x;
+        } else if t_max.y < t_max.z {
+            current.0.y += step.y;
+            t = t_max.y;
+            t_max.y += t_delta.y;
+        } else {
+            current.0.z += step.z;
+            t = t_max.z;
+            t_max.z += t_delta.z;
         }
     }
     false

--- a/crates/pumpkin/src/world/vibration.rs
+++ b/crates/pumpkin/src/world/vibration.rs
@@ -1,0 +1,170 @@
+//! Vibration dispatching for game events (sculk sensors and shriekers).
+//!
+//! Mirrors the relevant subset of vanilla `VibrationSystem`: each game event
+//! has a vibration frequency, listeners (sculk sensors / shriekers) within the
+//! event's 8-block notification radius receive it unless the straight line
+//! between the source and the listener is blocked by blocks in the
+//! `minecraft:occludes_vibration_signals` block tag (wool).
+
+use std::sync::Arc;
+
+use pumpkin_data::Block;
+use pumpkin_data::game_event::GameEvent;
+use pumpkin_data::tag::{self, Taggable};
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_util::math::vector3::Vector3;
+
+use crate::block::blocks::redstone::sculk_sensor::SculkSensorBlock;
+use crate::block::blocks::sculk::sculk_shrieker::SculkShriekerBlock;
+use crate::world::World;
+
+/// The vibration frequency a game event resonates at, per vanilla
+/// `VibrationSystem#VibrationListener`. Events not listed never reach
+/// vibration listeners.
+#[must_use]
+pub const fn frequency(event: GameEvent) -> u8 {
+    match event {
+        GameEvent::Step | GameEvent::Swim | GameEvent::Flap => 1,
+        GameEvent::ProjectileLand
+        | GameEvent::HitGround
+        | GameEvent::Splash
+        | GameEvent::Bounce => 2,
+        GameEvent::ItemInteractFinish | GameEvent::ProjectileShoot | GameEvent::InstrumentPlay => 3,
+        GameEvent::EntityAction | GameEvent::ElytraGlide | GameEvent::Unequip => 4,
+        GameEvent::EntityDismount | GameEvent::Equip => 5,
+        GameEvent::EntityInteract | GameEvent::Shear | GameEvent::EntityMount => 6,
+        GameEvent::EntityDamage => 7,
+        GameEvent::Drink | GameEvent::Eat => 8,
+        GameEvent::ContainerClose
+        | GameEvent::BlockClose
+        | GameEvent::BlockDeactivate
+        | GameEvent::BlockDetach => 9,
+        GameEvent::ContainerOpen
+        | GameEvent::BlockOpen
+        | GameEvent::BlockActivate
+        | GameEvent::BlockAttach
+        | GameEvent::PrimeFuse
+        | GameEvent::NoteBlockPlay => 10,
+        GameEvent::BlockChange => 11,
+        GameEvent::BlockDestroy | GameEvent::FluidPickup => 12,
+        GameEvent::BlockPlace | GameEvent::FluidPlace => 13,
+        GameEvent::EntityPlace | GameEvent::LightningStrike | GameEvent::Teleport => 14,
+        GameEvent::EntityDie | GameEvent::Explode => 15,
+        _ => 0,
+    }
+}
+
+/// Resolves an event key (`snake_case`, as used by `GameEvent::name()`) back to
+/// the event, so string-keyed `World::emit_game_event` callers participate in
+/// vibration dispatch.
+pub(super) fn game_event_from_key(key: &str) -> Option<GameEvent> {
+    // The generated enum has no name() -> variant inverse; match on the
+    // well-known keys that appear in vanilla vibration dispatching.
+    let event = match key {
+        "step" => GameEvent::Step,
+        "swim" => GameEvent::Swim,
+        "flap" => GameEvent::Flap,
+        "projectile_land" => GameEvent::ProjectileLand,
+        "hit_ground" => GameEvent::HitGround,
+        "splash" => GameEvent::Splash,
+        "bounce" => GameEvent::Bounce,
+        "item_interact_finish" => GameEvent::ItemInteractFinish,
+        "projectile_shoot" => GameEvent::ProjectileShoot,
+        "instrument_play" => GameEvent::InstrumentPlay,
+        "entity_action" => GameEvent::EntityAction,
+        "elytra_glide" => GameEvent::ElytraGlide,
+        "unequip" => GameEvent::Unequip,
+        "entity_dismount" => GameEvent::EntityDismount,
+        "equip" => GameEvent::Equip,
+        "entity_interact" => GameEvent::EntityInteract,
+        "shear" => GameEvent::Shear,
+        "entity_mount" => GameEvent::EntityMount,
+        "entity_damage" => GameEvent::EntityDamage,
+        "drink" => GameEvent::Drink,
+        "eat" => GameEvent::Eat,
+        "container_close" => GameEvent::ContainerClose,
+        "block_close" => GameEvent::BlockClose,
+        "block_deactivate" => GameEvent::BlockDeactivate,
+        "block_detach" => GameEvent::BlockDetach,
+        "container_open" => GameEvent::ContainerOpen,
+        "block_open" => GameEvent::BlockOpen,
+        "block_activate" => GameEvent::BlockActivate,
+        "block_attach" => GameEvent::BlockAttach,
+        "prime_fuse" => GameEvent::PrimeFuse,
+        "note_block_play" => GameEvent::NoteBlockPlay,
+        "block_change" => GameEvent::BlockChange,
+        "block_destroy" => GameEvent::BlockDestroy,
+        "fluid_pickup" => GameEvent::FluidPickup,
+        "block_place" => GameEvent::BlockPlace,
+        "fluid_place" => GameEvent::FluidPlace,
+        "entity_place" => GameEvent::EntityPlace,
+        "lightning_strike" => GameEvent::LightningStrike,
+        "teleport" => GameEvent::Teleport,
+        "entity_die" => GameEvent::EntityDie,
+        "explode" => GameEvent::Explode,
+        _ => return None,
+    };
+    Some(event)
+}
+
+/// Whether any block along the straight line between the source and the
+/// destination occludes vibration signals (wool), mirroring vanilla
+/// `VibrationSystem#isOccluded` closely enough for gameplay purposes.
+fn is_occluded(world: &World, source: Vector3<f64>, dest: Vector3<f64>) -> bool {
+    let direction = dest - source;
+    let distance = direction.length();
+    if distance < f64::EPSILON {
+        return false;
+    }
+
+    let steps = (distance / 0.5).ceil() as i32;
+    for i in 0..=steps {
+        let t = f64::from(i) / f64::from(steps);
+        let sample = source + direction * t;
+        let pos = BlockPos::containing_vec(sample);
+        let block = world.get_block(&pos);
+        if block.has_tag(&tag::Block::MINECRAFT_OCCLUDES_VIBRATION_SIGNALS) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Delivers a game event to vibration listeners (sculk sensors and shriekers)
+/// within the 8-block notification radius, unless occluded by wool.
+pub(super) fn dispatch(world: &Arc<World>, event: GameEvent, position: Vector3<f64>) {
+    let freq = frequency(event);
+    if freq == 0 {
+        return;
+    }
+
+    let listeners: Vec<_> = {
+        let set = world
+            .vibration_listeners
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        set.iter().copied().collect()
+    };
+
+    for pos in listeners {
+        let block = world.get_block(&pos);
+        let center = Vector3::new(
+            f64::from(pos.0.x) + 0.5,
+            f64::from(pos.0.y) + 0.5,
+            f64::from(pos.0.z) + 0.5,
+        );
+        if (center - position).length_squared() > 64.0 {
+            continue;
+        }
+
+        if is_occluded(world, position, center) {
+            continue;
+        }
+
+        if block == &Block::SCULK_SHRIEKER {
+            SculkShriekerBlock::try_activate(world, &pos);
+        } else if block == &Block::SCULK_SENSOR || block == &Block::CALIBRATED_SCULK_SENSOR {
+            SculkSensorBlock::trigger(world, &pos, block, freq);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This implements the server-side subset of vanilla's `VibrationSystem` so sculk sensors and shriekers actually receive game events.

- `World::emit_game_event` now routes known game events to nearby vibration listeners in addition to firing the plugin event. A vanilla event → redstone frequency table (`step` 1 … `entity_die`/`explode` 15) is included.
- The world keeps a small registry of vibration-listener block positions (sculk sensor, calibrated sculk sensor, sculk shrieker), maintained in `set_block_state`.
- Dispatch filters listeners by the vanilla 8-block event radius and applies vanilla-style occlusion: the line from source to listener is sampled, and any block in the `occludes_vibration_signals` tag (wool) blocks the vibration.
- Sensors activate through the existing `SculkSensorBlock::trigger` (previously dead code), which already self-gates on the inactive phase and implements the calibrated variant's back-power frequency filter. Shriekers resonate through `try_activate`.
- Events emitted in this first pass: `step` (walking entities, not while sneaking, matching vanilla's sneaking suppression), `entity_damage`, `entity_die`, and `block_destroy`. The existing `teleport` and `block_change` emitters now map through the same path.

With this, sculk sensors produce redstone from movement and combat and shriekers resonate from vibrations — the sculk-sensor half of #3107 (shrieker step activation is handled separately by #3296).

Known limitation: block-place interactions are not emitted at every interaction site yet, so placing blocks does not ring sensors in this first pass. That can follow as a focused addition.

## Testing

- `cargo check` / `cargo fmt --check` / `cargo clippy --workspace --all-targets --all-features` with `RUSTFLAGS=-Dwarnings` clean
- `cargo test` — all suites pass
- Manual: summon a sculk sensor, walk nearby — sensor activates and pulses redstone at the correct frequency per event type; placing wool between the source and sensor blocks the vibration; calibrated sensors only react to their filtered frequency

🤖 Generated with AI assistance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sculk sensors, calibrated sculk sensors, and shriekers now respond to nearby vibrations.
  * Vibrations are generated by entity movement, damage, deaths, block breaking, and block placement.
  * Wool and other vibration-occluding blocks can block signals, while listeners respond only within the appropriate range.
  * Vibration detection more accurately follows paths through the world, improving signal occlusion checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->