### PR TITLE
fix(bedrock): restore hunger synchronization and eating feedback

### DIFF
--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -3091,6 +3091,11 @@ impl EntityBase for LivingEntity {
                     player
                         .hunger_manager
                         .eat(player, food.nutrition as u8, food.saturation);
+                    self.entity.world.load().play_bedrock_level_sound(
+                        "burp",
+                        &self.entity.pos.load(),
+                        -1,
+                    );
                 }
 
                 self.apply_consumable_effects(caller, item);

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -4122,7 +4122,9 @@ impl Player {
                         5.0,
                     ),
                 ],
-                tick: VarULong(self.tick_counter.load(Ordering::Relaxed).max(0) as u64),
+                // This is a client input tick, not our independent server tick counter.
+                // Zero applies the authoritative values without prediction-history matching.
+                tick: VarULong(0),
             },
         );
     }

--- a/crates/pumpkin/src/net/bedrock/mod.rs
+++ b/crates/pumpkin/src/net/bedrock/mod.rs
@@ -122,6 +122,8 @@ pub struct BedrockClient {
     /// The next form ID to use for custom forms.
     pub next_form_id: AtomicU32,
     pub inventory_opened: AtomicBool,
+    /// Separate from normal vitals caching so the first rejected use always gets corrected.
+    last_food_rejection_tick: AtomicCell<Option<i32>>,
     pub client_cache_supported: AtomicBool,
     pub blob_cache: std::sync::Mutex<HashMap<u64, Vec<u8>>>,
     /// An notifier that is triggered when this client is closed.
@@ -163,6 +165,7 @@ impl BedrockClient {
             pending_bytes: Arc::new(AtomicUsize::new(0)),
             next_form_id: AtomicU32::new(0),
             inventory_opened: AtomicBool::new(false),
+            last_food_rejection_tick: AtomicCell::new(None),
             client_cache_supported: AtomicBool::new(false),
             blob_cache: std::sync::Mutex::new(HashMap::new()),
             close_token: CancellationToken::new(),

--- a/crates/pumpkin/src/net/bedrock/play/inventory_action.rs
+++ b/crates/pumpkin/src/net/bedrock/play/inventory_action.rs
@@ -2,6 +2,30 @@
 use super::*;
 
 impl BedrockClient {
+    fn correct_rejected_food_use(&self, player: &Player) {
+        // Holding use can repeat rejected transactions. Limit prediction corrections
+        // to every 20 ticks, without indefinitely trusting a previously sent snapshot.
+        const CORRECTION_INTERVAL_TICKS: i32 = 20;
+        let tick = player.tick_counter.load(Ordering::Relaxed);
+        let recently_corrected = self.last_food_rejection_tick.load().is_some_and(|last| {
+            tick >= last && tick.saturating_sub(last) < CORRECTION_INTERVAL_TICKS
+        });
+        let has_active_use = player
+            .living_entity
+            .item_in_use
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some();
+        if recently_corrected && !has_active_use {
+            return;
+        }
+        if player.has_client_loaded() {
+            self.last_food_rejection_tick.store(Some(tick));
+        }
+        player.living_entity.clear_active_hand();
+        player.send_health();
+    }
+
     #[allow(clippy::too_many_lines, clippy::collapsible_if, clippy::unreachable)]
     pub fn handle_inventory_action(&self, player: &Arc<Player>, packet: SInventoryTransaction) {
         tracing::debug!("handle_inventory_action: packet={:?}", packet);
@@ -314,30 +338,41 @@ impl BedrockClient {
                         }
 
                         if !cooldown_active {
-                            if held.get_data_component::<ConsumableImpl>().is_some()
-                                || held.get_data_component::<BlocksAttacksImpl>().is_some()
+                            // Bedrock can repeat click-air while using an item. Do not
+                            // restart its server-side use timer on these timed inputs.
+                            let already_using =
+                                player.living_entity.item_use_time.load(Ordering::Relaxed) > 0
+                                    && player
+                                        .living_entity
+                                        .item_in_use
+                                        .lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                        .as_ref()
+                                        .is_some_and(|item| {
+                                            item.are_items_and_components_equal(&held)
+                                        });
+                            if !already_using
+                                && (held.get_data_component::<ConsumableImpl>().is_some()
+                                    || held.get_data_component::<BlocksAttacksImpl>().is_some())
                             {
-                                if let Some(food) = held.get_data_component::<FoodImpl>() {
-                                    if player
+                                if held.get_data_component::<FoodImpl>().is_none_or(|food| {
+                                    player
                                         .abilities
                                         .lock()
                                         .unwrap_or_else(std::sync::PoisonError::into_inner)
                                         .invulnerable
                                         || food.can_always_eat
                                         || player.hunger_manager.level.load() < 20
-                                    {
-                                        player.living_entity.set_active_hand(
-                                            Hand::Left,
-                                            held.clone(),
-                                            held.get_max_use_time(),
-                                        );
-                                    }
-                                } else {
+                                }) {
                                     player.living_entity.set_active_hand(
-                                        Hand::Left,
+                                        Hand::Right,
                                         held.clone(),
                                         held.get_max_use_time(),
                                     );
+                                } else {
+                                    // Correct predicted eating when the server's food
+                                    // level is already full, even if it has not changed.
+                                    self.correct_rejected_food_use(player);
                                 }
                             }
                             if let Some(equippable) = held.get_data_component::<EquippableImpl>() {

--- a/crates/pumpkin/src/net/bedrock/play/set_local_player_as_initialized.rs
+++ b/crates/pumpkin/src/net/bedrock/play/set_local_player_as_initialized.rs
@@ -13,5 +13,8 @@ impl BedrockClient {
         );
         // This is sent when the client has finished loading and rendering the world.
         player.set_client_loaded(true);
+        // Resend persisted vitals after the client is ready, even if an earlier
+        // pre-spawn update already populated the server's change-tracking cache.
+        player.send_health();
     }
 }


### PR DESCRIPTION
## Description
Fixes Bedrock hunger synchronization and eating feedback, including an incorrect hunger bar and interrupted food consumption.

## What
- Keeps the hunger bar synchronized when joining and eating.
- Restores reliable eating completion and burp sounds.
- Corrects rejected eating at full hunger while preserving always-edible foods.

## How
- Resends health and hunger after the Bedrock client finishes initialization.
- Uses zero for the attribute-update input tick instead of the server tick counter.
- Prevents repeated item-use packets from restarting the eating timer.
- Uses the correct main hand and resynchronizes hunger when eating is rejected.
- Restores the completion burp and adds regression tests through the actual packet handlers.

## Testing
- `cargo test`
- `cargo clippy`
- `cargo fmt --all -- --check`
- Verified in game that Bedrock hunger and eating now work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Eating food now plays a burp sound after hunger is restored.
  - Player health and hunger values are synchronized when joining or becoming ready.
  - Food-use actions now correctly use the active hand and provide health updates when hunger is full.

- **Bug Fixes**
  - Repeated use inputs no longer restart an ongoing food-use action.
  - Foods that are not edible at full hunger are prevented from being consumed, while always-edible foods remain usable.
  - Rejected food-use corrections are rate-limited to reduce redundant updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->