### PR TITLE
fix: preserve goat horn instrument components

### DIFF
--- a/crates/pumpkin-data/src/data_component_impl/basic.rs
+++ b/crates/pumpkin-data/src/data_component_impl/basic.rs
@@ -444,14 +444,91 @@ impl DataComponentImpl for BaseColorImpl {
     default_impl!(BaseColor);
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct InstrumentImpl;
+#[derive(Clone, Debug, PartialEq)]
+pub enum InstrumentImpl {
+    Reference(Cow<'static, str>),
+    Inline {
+        sound_event: super::IdOr<SoundEvent>,
+        use_duration: f32,
+        range: f32,
+        description: NbtTag,
+    },
+}
 impl InstrumentImpl {
-    pub const fn read_data(_data: &NbtTag) -> Option<Self> {
-        Some(Self)
+    pub fn read_data(data: &NbtTag) -> Option<Self> {
+        if let NbtTag::String(name) = data {
+            return Some(Self::Reference(Cow::Owned(if name.contains(':') {
+                name.to_string()
+            } else {
+                format!("minecraft:{name}")
+            })));
+        }
+        let compound = data.extract_compound()?;
+        let sound_event = match compound.get("sound_event")? {
+            NbtTag::String(name) => super::IdOr::Id(crate::sound::Sound::from_name(
+                name.strip_prefix("minecraft:").unwrap_or(name),
+            )?),
+            NbtTag::Compound(sound) => super::IdOr::Value(SoundEvent {
+                sound_name: sound.get_string("sound_id")?.to_string(),
+                range: match sound.get("range") {
+                    Some(tag) => Some(Self::number(tag)?),
+                    None => None,
+                },
+            }),
+            _ => return None,
+        };
+        let use_duration = Self::number(compound.get("use_duration")?)?;
+        let range = Self::number(compound.get("range")?)?;
+        if !use_duration.is_finite() || use_duration <= 0.0 || !range.is_finite() || range <= 0.0 {
+            return None;
+        }
+        let description = compound.get("description")?.clone();
+        if !matches!(
+            description,
+            NbtTag::String(_) | NbtTag::Compound(_) | NbtTag::List(_)
+        ) {
+            return None;
+        }
+        Some(Self::Inline {
+            sound_event,
+            use_duration,
+            range,
+            description,
+        })
+    }
+
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+    fn number(tag: &NbtTag) -> Option<f32> {
+        Some(match tag {
+            NbtTag::Byte(value) => f32::from(*value),
+            NbtTag::Short(value) => f32::from(*value),
+            NbtTag::Int(value) => *value as f32,
+            NbtTag::Long(value) => *value as f32,
+            NbtTag::Float(value) => *value,
+            NbtTag::Double(value) => *value as f32,
+            _ => return None,
+        })
     }
 }
 impl DataComponentImpl for InstrumentImpl {
+    fn write_data(&self) -> NbtTag {
+        match self {
+            Self::Reference(name) => NbtTag::String(name.to_string().into()),
+            Self::Inline {
+                sound_event,
+                use_duration,
+                range,
+                description,
+            } => {
+                let mut compound = NbtCompound::new();
+                super::put_idor(&mut compound, "sound_event", sound_event);
+                compound.put_float("use_duration", *use_duration);
+                compound.put_float("range", *range);
+                compound.put("description", description.clone());
+                NbtTag::Compound(compound)
+            }
+        }
+    }
     default_impl!(Instrument);
 }
 

--- a/crates/pumpkin-data/src/generated/item.rs
+++ b/crates/pumpkin-data/src/generated/item.rs
@@ -29746,7 +29746,10 @@ impl Item {
                     enchantment: Cow::Borrowed(&[]),
                 },
             ),
-            (Instrument, &InstrumentImpl),
+            (
+                Instrument,
+                &InstrumentImpl::Reference(Cow::Borrowed("minecraft:ponder_goat_horn")),
+            ),
             (
                 ItemModel,
                 &ItemModelImpl {

--- a/crates/pumpkin-protocol/src/codec/data_component.rs
+++ b/crates/pumpkin-protocol/src/codec/data_component.rs
@@ -2384,13 +2384,83 @@ impl DataComponentCodec<Self> for BlockEntityDataImpl {
 
 impl DataComponentCodec<Self> for InstrumentImpl {
     fn serialize(&self, seq: &mut impl NetworkWriteExt) -> Result<(), WritingError> {
-        seq.write_var_int(&VarInt(0))
+        match self {
+            Self::Reference(name) => {
+                let name = name.strip_prefix("minecraft:").unwrap_or(name);
+                let id = instrument_entries()
+                    .iter()
+                    .position(|entry| entry.name == name)
+                    .ok_or_else(|| WritingError::Message(format!("Unknown instrument: {name}")))?;
+                seq.write_var_int(&VarInt(i32::try_from(id + 1).map_err(|_| {
+                    WritingError::Message("Instrument registry is too large".into())
+                })?))
+            }
+            Self::Inline {
+                sound_event,
+                use_duration,
+                range,
+                description,
+            } => {
+                seq.write_var_int(&VarInt(0))?;
+                crate::IdOr::write(&data_to_proto_sound(sound_event), seq, |writer, sound| {
+                    writer.write_string(&sound.sound_name)?;
+                    writer.write_option(&sound.range, |writer, range| writer.write_f32(*range))
+                })?;
+                seq.write_f32(*use_duration)?;
+                seq.write_f32(*range)?;
+                seq.write_nbt(description.clone())
+            }
+        }
     }
 
     fn deserialize(seq: &mut impl NetworkReadExt) -> Result<Self, ReadingError> {
-        let _ = seq.get_var_int()?;
-        Ok(Self)
+        let id = seq.get_var_int()?.0;
+        if id != 0 {
+            let index = usize::try_from(id).ok().and_then(|id| id.checked_sub(1));
+            let entry = index
+                .and_then(|index| instrument_entries().get(index))
+                .ok_or_else(|| {
+                    ReadingError::Message(format!("Invalid instrument registry id: {id}"))
+                })?;
+            return Ok(Self::Reference(Cow::Owned(format!(
+                "minecraft:{}",
+                entry.name
+            ))));
+        }
+        let sound_id = seq.get_var_int()?.0;
+        let sound = if sound_id == 0 {
+            crate::IdOr::Value(crate::SoundEvent {
+                sound_name: seq.get_str()?.into(),
+                range: seq.get_option(NetworkReadExt::get_f32)?,
+            })
+        } else {
+            let id = sound_id
+                .checked_sub(1)
+                .and_then(|id| u16::try_from(id).ok())
+                .ok_or_else(|| ReadingError::Message("Invalid instrument sound event id".into()))?;
+            crate::IdOr::Id(id)
+        };
+        let sound_event = proto_to_data_sound(&sound)
+            .ok_or_else(|| ReadingError::Message("Invalid instrument sound event".into()))?;
+        let use_duration = seq.get_f32()?;
+        let range = seq.get_f32()?;
+        let description = seq
+            .get_nbt_with_version(&JavaMinecraftVersion::V_26_2)?
+            .ok_or_else(|| ReadingError::Message("Missing instrument description".into()))?;
+        Ok(Self::Inline {
+            sound_event,
+            use_duration,
+            range,
+            description,
+        })
     }
+}
+
+fn instrument_entries() -> &'static [pumpkin_data::registry::StaticRegistryEntry] {
+    pumpkin_data::registry::REGISTRY_V_26_2
+        .iter()
+        .find(|registry| registry.registry_id == "instrument")
+        .map_or(&[], |registry| registry.entries)
 }
 
 impl DataComponentCodec<Self> for ProvidesTrimMaterialImpl {
@@ -2801,5 +2871,123 @@ impl DataComponentCodec<Self> for BreakSoundImpl {
     fn deserialize(seq: &mut impl NetworkReadExt) -> Result<Self, ReadingError> {
         let _ = seq.get_var_int()?;
         Ok(Self)
+    }
+}
+
+#[cfg(test)]
+mod instrument_tests {
+    use super::*;
+
+    #[test]
+    fn default_horn_is_ponder() {
+        let stack =
+            pumpkin_data::item_stack::ItemStack::new(1, &pumpkin_data::item::Item::GOAT_HORN);
+        let default = stack
+            .get_data_component::<InstrumentImpl>()
+            .expect("default instrument");
+        assert_eq!(
+            default,
+            &InstrumentImpl::Reference(Cow::Borrowed("minecraft:ponder_goat_horn"))
+        );
+        let other = InstrumentImpl::Reference(Cow::Borrowed("minecraft:seek_goat_horn"));
+        assert!(!default.equal(&other));
+    }
+
+    #[test]
+    fn every_horn_preserves_its_registry_reference() {
+        let names = [
+            "admire", "call", "dream", "feel", "ponder", "seek", "sing", "yearn",
+        ];
+        for (index, name) in names.iter().enumerate() {
+            let tag = NbtTag::String(format!("minecraft:{name}_goat_horn").into());
+            let instrument = InstrumentImpl::read_data(&tag).expect("instrument NBT");
+            assert_eq!(instrument.write_data(), tag);
+            let mut bytes = Vec::new();
+            instrument.serialize(&mut bytes).expect("encode horn");
+            assert_eq!(bytes, [u8::try_from(index + 1).expect("small registry id")]);
+            bytes.push(0x7f);
+            let mut reader = bytes.as_slice();
+            let decoded = InstrumentImpl::deserialize(&mut reader).expect("decode horn");
+            assert_eq!(decoded, instrument);
+            assert_eq!(reader, [0x7f]);
+        }
+    }
+
+    #[test]
+    fn inline_instrument_preserves_sound_floats_and_description() {
+        let instrument = InstrumentImpl::Inline {
+            sound_event: IdOr::Value(SoundEvent::new("custom:horn".into(), Some(20.0))),
+            use_duration: 7.0,
+            range: 256.0,
+            description: NbtTag::String("Custom horn".into()),
+        };
+        assert_eq!(
+            InstrumentImpl::read_data(&instrument.write_data()),
+            Some(instrument.clone())
+        );
+        let mut bytes = Vec::new();
+        instrument
+            .serialize(&mut bytes)
+            .expect("encode inline instrument");
+        // Produced by vanilla 26.2's Instrument.STREAM_CODEC for this instrument.
+        assert_eq!(
+            bytes,
+            b"\x00\x00\x0bcustom:horn\x01\x41\xa0\x00\x00\x40\xe0\x00\x00\x43\x80\x00\x00\x08\x00\x0bCustom horn"
+        );
+        for end in 0..bytes.len() {
+            assert!(InstrumentImpl::deserialize(&mut &bytes[..end]).is_err());
+        }
+        bytes.push(0x7f);
+        let mut reader = bytes.as_slice();
+        assert_eq!(
+            InstrumentImpl::deserialize(&mut reader).expect("decode inline"),
+            instrument
+        );
+        assert_eq!(reader, [0x7f]);
+    }
+
+    #[test]
+    fn invalid_instrument_registry_ids_are_rejected() {
+        for id in [-1, i32::MIN, 9, i32::MAX] {
+            let mut bytes = Vec::new();
+            bytes.write_var_int(&VarInt(id)).expect("registry id");
+            assert!(InstrumentImpl::deserialize(&mut bytes.as_slice()).is_err());
+        }
+        let unknown = InstrumentImpl::Reference(Cow::Borrowed("custom:unknown"));
+        assert!(unknown.serialize(&mut Vec::new()).is_err());
+    }
+
+    #[test]
+    fn inline_instrument_preserves_registered_sound_and_rejects_invalid_ids() {
+        let sound = Sound::from_name("item.goat_horn.sound.0").expect("goat horn sound");
+        let instrument = InstrumentImpl::Inline {
+            sound_event: IdOr::Id(sound),
+            use_duration: 7.0,
+            range: 256.0,
+            description: NbtTag::String("Ponder".into()),
+        };
+        assert_eq!(
+            InstrumentImpl::read_data(&instrument.write_data()),
+            Some(instrument.clone())
+        );
+        let mut bytes = Vec::new();
+        instrument
+            .serialize(&mut bytes)
+            .expect("encode registered sound");
+        assert_eq!(
+            InstrumentImpl::deserialize(&mut bytes.as_slice()).expect("decode registered sound"),
+            instrument
+        );
+
+        for id in [-1, i32::MIN, 65_537, i32::MAX] {
+            let mut bytes = vec![0];
+            bytes.write_var_int(&VarInt(id)).expect("sound id");
+            bytes.write_f32(7.0).expect("duration");
+            bytes.write_f32(256.0).expect("range");
+            bytes
+                .write_nbt(NbtTag::String("Ponder".into()))
+                .expect("description");
+            assert!(InstrumentImpl::deserialize(&mut bytes.as_slice()).is_err());
+        }
     }
 }

--- a/crates/pumpkin-protocol/src/codec/data_component.rs
+++ b/crates/pumpkin-protocol/src/codec/data_component.rs
@@ -2447,6 +2447,20 @@ impl DataComponentCodec<Self> for InstrumentImpl {
         let description = seq
             .get_nbt_with_version(&JavaMinecraftVersion::V_26_2)?
             .ok_or_else(|| ReadingError::Message("Missing instrument description".into()))?;
+        // Keep network input within the same bounds as the persistent NBT codec.
+        if !use_duration.is_finite() || use_duration <= 0.0 || !range.is_finite() || range <= 0.0 {
+            return Err(ReadingError::Message(
+                "Instrument duration and range must be finite and positive".into(),
+            ));
+        }
+        if !matches!(
+            description,
+            NbtTag::String(_) | NbtTag::Compound(_) | NbtTag::List(_)
+        ) {
+            return Err(ReadingError::Message(
+                "Invalid instrument description".into(),
+            ));
+        }
         Ok(Self::Inline {
             sound_event,
             use_duration,
@@ -2987,6 +3001,31 @@ mod instrument_tests {
             bytes
                 .write_nbt(NbtTag::String("Ponder".into()))
                 .expect("description");
+            assert!(InstrumentImpl::deserialize(&mut bytes.as_slice()).is_err());
+        }
+    }
+
+    #[test]
+    fn inline_instrument_rejects_fields_that_cannot_be_saved() {
+        let mut invalid_fields = Vec::new();
+        for value in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY, 0.0, -1.0] {
+            invalid_fields.push((value, 256.0, NbtTag::String("Horn".into())));
+            invalid_fields.push((7.0, value, NbtTag::String("Horn".into())));
+        }
+        invalid_fields.push((7.0, 256.0, NbtTag::Int(42)));
+        invalid_fields.push((7.0, 256.0, NbtTag::End));
+        for (use_duration, range, description) in invalid_fields {
+            let instrument = InstrumentImpl::Inline {
+                sound_event: IdOr::Value(SoundEvent::new("custom:horn".into(), None)),
+                use_duration,
+                range,
+                description,
+            };
+            assert!(InstrumentImpl::read_data(&instrument.write_data()).is_none());
+            let mut bytes = Vec::new();
+            instrument
+                .serialize(&mut bytes)
+                .expect("encode invalid fields");
             assert!(InstrumentImpl::deserialize(&mut bytes.as_slice()).is_err());
         }
     }

--- a/tools/pumpkin-codegen/src/item.rs
+++ b/tools/pumpkin-codegen/src/item.rs
@@ -832,8 +832,13 @@ impl ToTokens for ItemComponents {
         if self.glider.is_some() {
             tokens.extend(quote! { (Glider, &GliderImpl), });
         }
-        if self.instrument.is_some() {
-            tokens.extend(quote! { (Instrument, &InstrumentImpl), });
+        if let Some(instrument) = &self.instrument {
+            let name = instrument
+                .as_str()
+                .expect("default instrument registry reference");
+            let name = LitStr::new(name, Span::call_site());
+            tokens
+                .extend(quote! { (Instrument, &InstrumentImpl::Reference(Cow::Borrowed(#name))), });
         }
         if let Some(model) = &self.item_model {
             let model_lit = LitStr::new(model, Span::call_site());


### PR DESCRIPTION
## Description

Fixes #3113.

Moving a non-Ponder goat horn into the inventory loses its instrument reference: the component decoder discards the registry ID, and the encoder sends only zero. Vanilla interprets zero as an inline instrument and tries to read a missing sound event, duration, range and description.

Preserve named instrument references and complete inline instruments in network and NBT data. Encode built-in instruments using the synchronized registry order, reject invalid instrument/sound IDs, and generate Ponder as the default goat horn component so other variants remain distinguishable.

## Testing

- All 106 protocol library tests pass. Regressions cover all eight built-in horns, Ponder's default component, NBT preservation, inline sounds and instruments, truncated payloads, invalid registry IDs, and consumption of exactly one component.
- The custom instrument byte fixture was generated independently with the official vanilla 26.2 `Instrument.STREAM_CODEC`. Vanilla also rejects the previous zero-only payload with `IndexOutOfBoundsException`.
- Release Clippy for protocol and codegen, all targets/features; workspace formatting and whitespace checks.

Functional builds disable LTO and use unoptimized generated data/world dependencies. Validation is at the codec/NBT level; no graphical Minecraft client session was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for instrument references using namespaced sound identifiers.
  - Added inline instrument data, including sound events, duration, range, and descriptions.
  - Instrument descriptions can preserve text, compound, and list content.
  - Instrument data is serialized and restored through the protocol format.

- **Bug Fixes**
  - Invalid instrument values, identifiers, and numeric settings are now rejected.
  - Unqualified instrument names are automatically interpreted with the default namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->