### PR TITLE
fix(entity): sync item push velocity and force position updates when pushed 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/entity/item.rs
+++ b/crates/pumpkin/src/entity/item.rs
@@ -510,16 +510,22 @@ impl ItemEntity {
 
         entity.update_fluid_state(caller);
 
+        // Vanilla `ItemEntity#tick`: a velocity change larger than 0.01 sets
+        // `needsSync`, which makes the tracker send the update immediately.
         let velocity_dirty = entity.velocity_dirty.swap(false, Ordering::SeqCst)
             || entity.touching_water.load(Ordering::SeqCst)
             || entity.touching_lava.load(Ordering::SeqCst)
-            || entity.velocity.load().sub(&original_velo).length_squared() > 0.1;
+            || entity.velocity.load().sub(&original_velo).length_squared() > 0.01;
         let moved = entity.pos.load() != entity.last_sent_pos.load();
+        // A velocity change (for example being pushed out of blocks) also forces
+        // an immediate position update: vanilla `Entity#needsSync` bypasses the
+        // regular update interval in `ServerEntity#sendChanges`.
         let position_dirty = moved
-            && self
-                .item_age
-                .load(Ordering::Relaxed)
-                .is_multiple_of(ITEM_UPDATE_INTERVAL);
+            && (velocity_dirty
+                || self
+                    .item_age
+                    .load(Ordering::Relaxed)
+                    .is_multiple_of(ITEM_UPDATE_INTERVAL));
 
         if position_dirty || velocity_dirty {
             entity.send_pos_rot();


### PR DESCRIPTION
## Description

When blocks are placed around an item entity (issue #3325's repro), the item is pushed out of the block, then appears to jump violently and disappears client-side while remaining alive on the server.

Two sync rules in `ItemEntity` hid the escape motion from clients:

1. **Velocity threshold too high.** The escape velocity from `push_out_of_blocks` is `0.1 + rand*0.2` on one axis (length squared 0.01-0.09), but `sync_motion_if_dirty` only sent a velocity packet when the change's length squared exceeded `0.1` — so the push velocity was **never** sent.
2. **Position updates batched to every 20 ticks** (`ITEM_UPDATE_INTERVAL`), so the accumulated motion surfaced as one large delta jump, or was extrapolated by the client into the newly placed blocks (making the item invisible).

Vanilla behavior (26.2, `ItemEntity#tick` + `ServerEntity#sendChanges`):
- `ItemEntity#tick` sets `Entity#needsSync` when `getDeltaMovement().subtract(oldMovement).lengthSqr() > 0.01`;
- `ServerEntity#sendChanges` treats `needsSync` as a **bypass of the regular update interval** for both position (`tickCount % updateInterval == 0 || needsSync || data dirty`) and velocity (`needsSync || trackDelta`) packets.

This PR lowers the velocity-change threshold to the vanilla value (`0.01`) and forces a position update whenever the velocity changed since the start of the tick and the entity moved — the pumpkin equivalent of the vanilla `needsSync` interval bypass.

### Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features` and `cargo test` all pass locally with `RUSTFLAGS=-Dwarnings`.
- Verified against a fake-protocol 26.2 client: dropped items encased in a stone wall now receive their escape velocity via `CEntityVelocity` and smooth per-tick position deltas via `CUpdateEntityPos` instead of a single large delta, and the entity is no longer culled client-side. Before the change, packet traces showed the item's motion only as 0.2-2.7-block position deltas every 20 ticks with no velocity packet, matching the "jumps then disappears" report.

Fixes #3325

🤖 Generated with AI assistance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Movement updates are now synchronized more promptly when an item’s velocity changes.
  - Smaller velocity changes are detected, improving the accuracy and responsiveness of position updates.
  - Position updates are sent alongside qualifying velocity changes instead of waiting for the regular update interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->