### PR TITLE
fix: advertise current protocol to generic status probes

### DIFF
--- a/crates/pumpkin/src/server/connection_cache.rs
+++ b/crates/pumpkin/src/server/connection_cache.rs
@@ -204,7 +204,8 @@ impl CachedStatus {
         StatusResponse {
             version: Some(Version {
                 name: format!("{LOWEST_SUPPORTED_MC_VERSION}-{CURRENT_MC_VERSION}"),
-                protocol: LOWEST_SUPPORTED_MC_VERSION.protocol_version() as u32,
+                // Generic proxy probes must detect our native protocol, not the oldest client.
+                protocol: CURRENT_MC_VERSION.protocol_version() as u32,
             }),
             players: Some(Players {
                 max: max_players,
@@ -227,5 +228,48 @@ impl Default for CachedStatus {
             "A blazingly fast Pumpkin server!",
             1000,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generic_status_probes_advertise_the_current_protocol() {
+        let status = CachedStatus::default();
+        for protocol in [-1, 0, i32::MAX] {
+            let response = status.get_status_response(protocol);
+            assert_eq!(
+                response.version.expect("server version").protocol,
+                CURRENT_MC_VERSION.protocol_version() as u32,
+                "probe protocol {protocol}"
+            );
+        }
+    }
+
+    #[test]
+    fn supported_clients_keep_their_protocol_without_changing_the_default() {
+        let status = CachedStatus::default();
+        for version in [
+            LOWEST_SUPPORTED_MC_VERSION,
+            pumpkin_util::version::JavaMinecraftVersion::V_1_16,
+            CURRENT_MC_VERSION,
+        ] {
+            let protocol = version.protocol_version();
+            let response = status.get_status_response(protocol);
+            assert_eq!(
+                response.version.expect("client version").protocol,
+                protocol as u32
+            );
+        }
+        assert_eq!(
+            status
+                .status_response
+                .version
+                .expect("cached version")
+                .protocol,
+            CURRENT_MC_VERSION.protocol_version() as u32
+        );
     }
 }


### PR DESCRIPTION
## Description

Fixes #3340.

Generic status probes currently identify Pumpkin as its oldest supported version (1.7.2/protocol 4). Velocity/ViaVersion then select the legacy login UUID decoder for a modern backend connection, disconnecting players; a leading-zero UUID produces the reported empty UUID error.

Advertise the current native protocol when a probe does not name a supported client version. Supported clients still receive their own protocol, and the advertised version-range name remains intact.

## Testing

- Both new status regressions fail before the fix (protocol 4 versus 776); all 203 Pumpkin library tests pass afterward.
- Real Velocity 4.1.0-SNAPSHOT build 20 + ViaVersion 5.11.0: the original server fails in the legacy UUID decoder; the candidate automatically detects and saves `ana: 776`, then completes login and sends teleport/world chunks. The explicitly pinned control also passes.
- Release all-target/all-feature Clippy, formatting and whitespace checks.

The functional validation binary also contains an independent last-block placement-effect fix; it uses unoptimized generated data/world and server code, with release LTO disabled. No performance claim is made. The user previously verified real Bedrock 26.45 login through Geyser/Floodgate with the configuration workaround; this code fix was verified with the protocol observer, not a new graphical Bedrock run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Generic server status probes now receive the current Minecraft protocol version.
  - Supported clients continue to receive their requested protocol version.
  - Cached status responses remain consistent across repeated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->