### PR TITLE
fix: avoid tool break effects when placing the last block

### DIFF
--- a/crates/pumpkin/src/net/java/play/use_item_on.rs
+++ b/crates/pumpkin/src/net/java/play/use_item_on.rs
@@ -169,15 +169,13 @@ impl JavaClient {
 
         // Broadcast the break entity status before the slot sync; the client
         // needs the old item texture in the slot for break particles.
-        if !before.is_empty() && after.is_empty() {
+        if before.is_damageable() && after.is_empty() {
             let slot = if slot_index == player.inventory.get_selected_slot() as usize {
                 &EquipmentSlot::MAIN_HAND
             } else {
                 &EquipmentSlot::OFF_HAND
             };
-            if before.is_damageable() {
-                player.increment_stat(StatisticCategory::Broken, before.item.id as i32, 1);
-            }
+            player.increment_stat(StatisticCategory::Broken, before.item.id as i32, 1);
             player.world().send_entity_status(
                 player.get_entity(),
                 equipment_break_status(slot),


### PR DESCRIPTION
## Description

When playing through Bedrock/Geyser, placing the last cobblestone, crafting table or leaf litter in a survival stack produces an erroneous tool-breaking sound. A manual Java-client test against the pre-fix server did not produce that sound. The Java use-item-on handler sends an equipment-break status whenever the held stack becomes empty, including ordinary block consumption.

Only send the break status for damageable items. This matches the existing entity-interaction and native Bedrock placement handlers, preserves the pre-slot-sync ordering for real break particles, and retains broken-item statistics.

## Testing

A real-server protocol observer reproduces entity event 47 for final cobblestone, leaf litter and crafting-table stacks, but not a two-item cobblestone stack. Block-update packets confirm the blocks were placed. A flint and steel at damage 63 provides the genuine tool-break control. The user confirmed the erroneous sound occurs only on the last block through a real Bedrock/Geyser session, then tested with a Java client on the pre-fix server and heard no tool-breaking sound. The packet regression establishes that Pumpkin sends an incorrect equipment-break event; the audible symptom is confirmed only through Bedrock/Geyser. The difference in client handling has not been traced in code. The user subsequently retested the fixed build with Bedrock through Geyser and confirmed that placing the last block no longer plays the tool-breaking sound.

All five candidate packet checks pass: each block is placed, no ordinary consumption emits event 47, and the worn-out flint and steel still emits exactly one break event. The observer reports no errors and both servers shut down cleanly.

All 203 Pumpkin library tests pass, plus release all-target/all-feature Clippy, formatting and whitespace checks. The functional validation binary also contains an independent generic-status-protocol fix; it uses unoptimized server/data/world packages and is not a performance build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated item-use tracking so the “Broken” statistic and break status are recorded only when a damageable item actually breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->