### PR TITLE
fix(entity): panic goals only trigger on vanilla panic damage causes 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/entity/ai/goal/escape_danger.rs
+++ b/crates/pumpkin/src/entity/ai/goal/escape_danger.rs
@@ -53,10 +53,27 @@ impl EscapeDangerGoal {
         // Vanilla `PanicGoal#shouldPanic`: only the last damage source's type decides
         // whether the mob panics, so being punched does not scare tamed animals.
         let last_damage_type_id = living.last_damage_type_id.load(Relaxed);
-        u8::try_from(last_damage_type_id)
+        let Some(damage_type) = u8::try_from(last_damage_type_id)
             .ok()
             .and_then(DamageType::from_id)
-            .is_some_and(|damage_type| damage_type.has_tag(self.panic_tag))
+        else {
+            return false;
+        };
+
+        // Vanilla `LivingEntity#getLastDamageSource`: the marker expires after 40 ticks,
+        // so stale damage cannot re-trigger panic episodes.
+        let last_damage_time = living.last_damage_time.load(Relaxed);
+        if living
+            .entity
+            .age
+            .load(Relaxed)
+            .saturating_sub(last_damage_time)
+            > 40
+        {
+            return false;
+        }
+
+        damage_type.has_tag(self.panic_tag)
     }
 
     fn find_escape_target(mob: &dyn Mob) -> Option<Vector3<f64>> {

--- a/crates/pumpkin/src/entity/ai/goal/escape_danger.rs
+++ b/crates/pumpkin/src/entity/ai/goal/escape_danger.rs
@@ -2,42 +2,61 @@ use std::sync::atomic::Ordering::Relaxed;
 
 use super::{Controls, Goal};
 use crate::entity::{ai::pathfinder::NavigatorGoal, mob::Mob};
+use pumpkin_data::damage::DamageType;
+use pumpkin_data::tag::{self, Taggable};
 use pumpkin_util::math::vector3::Vector3;
 use rand::RngExt;
 
 const RANGE: i32 = 5;
-const RECENT_DAMAGE_TICKS: i32 = 100;
 const TARGET_ATTEMPTS: usize = 10;
 
 pub struct EscapeDangerGoal {
     speed: f64,
     goal_control: Controls,
     target: Option<Vector3<f64>>,
+    /// Only damage types in this tag cause panic (vanilla `PanicGoal#shouldPanic`).
+    panic_tag: &'static tag::Tag,
 }
 
 impl EscapeDangerGoal {
     #[must_use]
     pub fn new(speed: f64) -> Box<Self> {
-        Box::new(Self {
+        Box::new(Self::with_panic_tag(
+            speed,
+            &tag::DamageType::MINECRAFT_PANIC_CAUSES,
+        ))
+    }
+
+    /// Creates a panic goal that only reacts to environmental damage
+    /// (vanilla `TamableAnimalPanicGoal`, used by tamed animals like wolves and cats).
+    #[must_use]
+    pub fn with_environmental_panic(speed: f64) -> Box<Self> {
+        Box::new(Self::with_panic_tag(
+            speed,
+            &tag::DamageType::MINECRAFT_PANIC_ENVIRONMENTAL_CAUSES,
+        ))
+    }
+
+    #[must_use]
+    const fn with_panic_tag(speed: f64, panic_tag: &'static tag::Tag) -> Self {
+        Self {
             speed,
             goal_control: Controls::MOVE,
             target: None,
-        })
+            panic_tag,
+        }
     }
 
-    fn is_in_danger(mob: &dyn Mob) -> bool {
+    fn is_in_danger(&self, mob: &dyn Mob) -> bool {
         let living = &mob.get_mob_entity().living_entity;
 
-        if living.entity.fire_ticks.load(Relaxed) > 0 {
-            return true;
-        }
-
-        let last_attacked = living.last_attacked_time.load(Relaxed);
-        if last_attacked == 0 {
-            return false;
-        }
-        let age = living.entity.age.load(Relaxed);
-        age - last_attacked < RECENT_DAMAGE_TICKS
+        // Vanilla `PanicGoal#shouldPanic`: only the last damage source's type decides
+        // whether the mob panics, so being punched does not scare tamed animals.
+        let last_damage_type_id = living.last_damage_type_id.load(Relaxed);
+        u8::try_from(last_damage_type_id)
+            .ok()
+            .and_then(DamageType::from_id)
+            .is_some_and(|damage_type| damage_type.has_tag(self.panic_tag))
     }
 
     fn find_escape_target(mob: &dyn Mob) -> Option<Vector3<f64>> {
@@ -59,7 +78,7 @@ impl EscapeDangerGoal {
 
 impl Goal for EscapeDangerGoal {
     fn can_start(&mut self, mob: &dyn Mob) -> bool {
-        if !Self::is_in_danger(mob) {
+        if !self.is_in_danger(mob) {
             return false;
         }
         self.target = Self::find_escape_target(mob);

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -109,6 +109,9 @@ pub struct LivingEntity {
     pub last_attacker_id: AtomicI32,
     /// The tick at which this entity was last attacked (entity age).
     pub last_attacked_time: AtomicI32,
+    /// The [`pumpkin_data::DamageType`] id of the last damage taken, or `-1` if none.
+    /// Used by panic goals (`PanicGoal#shouldPanic` in vanilla).
+    pub last_damage_type_id: AtomicI32,
 
     /// The entity ID of the entity this living entity last attacked.
     pub last_attacking_id: AtomicI32,
@@ -236,6 +239,7 @@ impl LivingEntity {
             climbing_pos: AtomicCell::new(None),
             last_attacker_id: AtomicI32::new(0),
             last_attacked_time: AtomicI32::new(0),
+            last_damage_type_id: AtomicI32::new(-1),
             last_attacking_id: AtomicI32::new(0),
             last_attack_time: AtomicI32::new(0),
             combat_tracker: std::sync::Mutex::new(CombatTracker::new()),
@@ -2881,6 +2885,11 @@ impl LivingEntity {
         let new_health = (self.health.load() - dmg_to_health).clamp(0.0, max_h);
 
         if dmg_to_health > 0.0 {
+            // Vanilla `Entity#setLastHurtByMob`/`LivingEntity#hurt`: the last damage source is
+            // recorded regardless of whether an attacker entity exists (fire, lava, etc.).
+            self.last_damage_type_id
+                .store(i32::from(damage_type.id), Relaxed);
+
             if let Some(player) = caller.get_player() {
                 if damage_type.exhaustion > 0.0 {
                     player.add_exhaustion(damage_type.exhaustion);

--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -112,6 +112,9 @@ pub struct LivingEntity {
     /// The [`pumpkin_data::DamageType`] id of the last damage taken, or `-1` if none.
     /// Used by panic goals (`PanicGoal#shouldPanic` in vanilla).
     pub last_damage_type_id: AtomicI32,
+    /// The tick (entity age) at which the last damage was taken, or `i32::MIN` if none.
+    /// Expires the marker above after 40 ticks (vanilla `LivingEntity#getLastDamageSource`).
+    pub last_damage_time: AtomicI32,
 
     /// The entity ID of the entity this living entity last attacked.
     pub last_attacking_id: AtomicI32,
@@ -240,6 +243,7 @@ impl LivingEntity {
             last_attacker_id: AtomicI32::new(0),
             last_attacked_time: AtomicI32::new(0),
             last_damage_type_id: AtomicI32::new(-1),
+            last_damage_time: AtomicI32::new(i32::MIN),
             last_attacking_id: AtomicI32::new(0),
             last_attack_time: AtomicI32::new(0),
             combat_tracker: std::sync::Mutex::new(CombatTracker::new()),
@@ -2274,6 +2278,9 @@ impl LivingEntity {
         // Give a short grace period of invulnerability after respawn
         self.hurt_cooldown.store(20, Relaxed);
         self.last_damage_taken.store(0f32);
+        // Clear the panic-goal damage marker from before the respawn
+        self.last_damage_type_id.store(-1, Relaxed);
+        self.last_damage_time.store(i32::MIN, Relaxed);
 
         self.entity.portal_cooldown.store(0, Relaxed);
         *self
@@ -2889,6 +2896,8 @@ impl LivingEntity {
             // recorded regardless of whether an attacker entity exists (fire, lava, etc.).
             self.last_damage_type_id
                 .store(i32::from(damage_type.id), Relaxed);
+            self.last_damage_time
+                .store(self.entity.age.load(Relaxed), Relaxed);
 
             if let Some(player) = caller.get_player() {
                 if damage_type.exhaustion > 0.0 {

--- a/crates/pumpkin/src/entity/passive/cat.rs
+++ b/crates/pumpkin/src/entity/passive/cat.rs
@@ -108,8 +108,8 @@ impl CatEntity {
 
             // Goal 1: SwimGoal (FloatGoal)
             goal_selector.add_goal(1, Box::new(SwimGoal::default()));
-            // Goal 1: TamableAnimalPanicGoal (EscapeDangerGoal)
-            goal_selector.add_goal(1, EscapeDangerGoal::new(1.5));
+            // Goal 1: TamableAnimalPanicGoal (EscapeDangerGoal) — only environmental damage causes panic
+            goal_selector.add_goal(1, EscapeDangerGoal::with_environmental_panic(1.5));
             // Goal 4: CatTemptGoal
             goal_selector.add_goal(4, Box::new(TemptGoal::new(0.6, TEMPT_ITEMS)));
             // Goal 4: CatAvoidEntityGoal (when untamed)

--- a/crates/pumpkin/src/entity/passive/wolf.rs
+++ b/crates/pumpkin/src/entity/passive/wolf.rs
@@ -64,8 +64,8 @@ impl WolfEntity {
             // Goal selector (matching Vanilla registerGoals):
             // 1: SwimGoal (FloatGoal)
             goal_selector.add_goal(1, Box::new(SwimGoal::default()));
-            // 1: EscapeDangerGoal (TamableAnimalPanicGoal)
-            goal_selector.add_goal(1, EscapeDangerGoal::new(1.5));
+            // 1: EscapeDangerGoal (TamableAnimalPanicGoal) — only environmental damage causes panic
+            goal_selector.add_goal(1, EscapeDangerGoal::with_environmental_panic(1.5));
             // 3: Avoid Llama
             goal_selector.add_goal(
                 3,


### PR DESCRIPTION
## Description

Attacking a wolf that is attacking you makes it stop attacking (#3328). The root cause is in the shared panic goal, not the wolf specifically:

- Vanilla `PanicGoal#shouldPanic` only panics when the **last damage source's type is in the goal's panic damage-type tag**. Wolves and cats use `TamableAnimalPanicGoal` with `minecraft:panic_environmental_causes` (fire, lava, lightning, freeze, cactus, ...), which deliberately excludes melee attacks.
- Pumpkin's `EscapeDangerGoal` panicked on **any** damage within 100 ticks. Hitting an attacking wolf flipped it into panic mode at goal priority 1, overriding `MeleeAttackGoal` (5), so the wolf ran/froze instead of fighting back.

Changes:

- `LivingEntity` now records the id of the last damage type taken (vanilla `getLastDamageSource` is set even for attacker-less damage such as fire or lava).
- `EscapeDangerGoal` gates `is_in_danger` on the panic tag via that recorded type: `EscapeDangerGoal::new` uses the vanilla default `minecraft:panic_causes` (which does include `player_attack`, so cows and other animals still flee when punched — vanilla behavior), and the new `EscapeDangerGoal::with_environmental_panic` uses `minecraft:panic_environmental_causes` for tamable animals (wolf, cat).
- A side effect of the tag gating: mobs with panic goals now also correctly ignore non-tag damage types (fall, drown, thorns, starvation, ...) where previously *any* damage caused panic.

## Testing

- `cargo check`, `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features` (with `-Dwarnings`), and `cargo test` all pass locally.
- Behavior reasoning checked against the vanilla 1.21.10 decompiles (`PanicGoal`, `TamableAnimal.TamableAnimalPanicGoal`, `Wolf#registerGoals`) and the vanilla `panic_causes` / `panic_environmental_causes` damage-type tags.

Fixes #3328

🤖 Generated with AI assistance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cats and wolves now flee from environmental hazards while avoiding panic caused by unrelated damage.
  - Danger detection now considers the most recent damage type and timing, improving reactions to supported hazards.
  - Damage information is retained even when no attacking entity is involved, enabling more consistent defensive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->