### PR TITLE
fix(entity): keep fish wander targets in water 🤖🤖🤖

### DIFF
--- a/crates/pumpkin/src/entity/ai/goal/mod.rs
+++ b/crates/pumpkin/src/entity/ai/goal/mod.rs
@@ -36,6 +36,7 @@ pub mod owner_hurt_target;
 pub mod pathfind_to_raid;
 pub mod pick_up_block;
 pub mod place_block;
+pub mod random_swimming;
 pub mod ranged_attack;
 pub mod ranged_crossbow_attack;
 pub mod restrict_sun;

--- a/crates/pumpkin/src/entity/ai/goal/random_swimming.rs
+++ b/crates/pumpkin/src/entity/ai/goal/random_swimming.rs
@@ -1,0 +1,97 @@
+use super::{Controls, Goal};
+use crate::entity::{ai::pathfinder::NavigatorGoal, mob::Mob};
+use pumpkin_data::tag::Taggable;
+use pumpkin_util::math::{position::BlockPos, vector3::Vector3};
+use rand::RngExt;
+
+/// Vanilla `RandomSwimmingGoal` (fish strolling).
+///
+/// Unlike the generic [`WanderAroundGoal`](super::wander_around::WanderAroundGoal), this goal only
+/// picks targets whose block is water (`BehaviorUtils#getRandomSwimmablePos` resamples until the
+/// candidate block is pathfindable as water), so fish never navigate onto land.
+pub struct RandomSwimmingGoal {
+    goal_control: Controls,
+    speed: f64,
+    interval: i32,
+    target: Option<Vector3<f64>>,
+}
+
+impl RandomSwimmingGoal {
+    #[must_use]
+    pub const fn new(speed: f64, interval: i32) -> Self {
+        Self {
+            goal_control: Controls::MOVE,
+            speed,
+            interval,
+            target: None,
+        }
+    }
+
+    /// Vanilla picks a random 3D offset (±10 horizontal, ±7 vertical) around the mob and resamples
+    /// up to 10 times until the candidate block is water-pathfindable. Since pumpkin's navigator
+    /// has no water-bound pathing constraint, we reject invalid candidates instead of returning
+    /// the last one, so fish are never driven out of the water.
+    fn find_swimmable_target(mob: &dyn Mob) -> Option<Vector3<f64>> {
+        let entity = &mob.get_mob_entity().living_entity.entity;
+        let pos = entity.pos.load();
+        let world = entity.world.load_full();
+        let mut rng = mob.get_random();
+
+        for _ in 0..10 {
+            let dx = rng.random_range(-10.0..=10.0);
+            let dy = rng.random_range(-7.0..=7.0);
+            let dz = rng.random_range(-10.0..=10.0);
+
+            let target = Vector3::new(pos.x + dx, pos.y + dy, pos.z + dz);
+            let block_pos = BlockPos::containing_vec(target);
+            if world
+                .get_fluid(&block_pos)
+                .has_tag(&pumpkin_data::tag::Fluid::MINECRAFT_WATER)
+            {
+                return Some(target);
+            }
+        }
+
+        None
+    }
+}
+
+impl Goal for RandomSwimmingGoal {
+    fn can_start(&mut self, mob: &dyn Mob) -> bool {
+        if mob.get_random().random_range(0..self.interval) != 0 {
+            return false;
+        }
+
+        self.target = Self::find_swimmable_target(mob);
+        self.target.is_some()
+    }
+
+    fn should_continue(&self, mob: &dyn Mob) -> bool {
+        let navigator = mob
+            .get_mob_entity()
+            .navigator
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        !navigator.is_idle()
+    }
+
+    fn start(&mut self, mob: &dyn Mob) {
+        if let Some(target) = self.target {
+            let pos = mob.get_mob_entity().living_entity.entity.pos.load();
+            let mut navigator = mob
+                .get_mob_entity()
+                .navigator
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            navigator.set_progress(NavigatorGoal::new(pos, target, self.speed));
+        }
+    }
+
+    fn stop(&mut self, _mob: &dyn Mob) {
+        self.target = None;
+    }
+
+    fn controls(&self) -> Controls {
+        self.goal_control
+    }
+}

--- a/crates/pumpkin/src/entity/passive/cod.rs
+++ b/crates/pumpkin/src/entity/passive/cod.rs
@@ -8,6 +8,7 @@ use crate::entity::{
         look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal,
         random_swimming::RandomSwimmingGoal, swim::SwimGoal,
     },
+    ai::pathfinder::Navigator,
     mob::{Mob, MobEntity},
 };
 
@@ -27,6 +28,13 @@ impl CodEntity {
             let mob_arc: Arc<dyn Mob> = mob_arc.clone();
             Arc::downgrade(&mob_arc)
         };
+
+        // Vanilla `AbstractFish#createNavigation`: fish navigate through water.
+        *mob_arc
+            .mob_entity
+            .navigator
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Navigator::water_bound(false);
 
         {
             let mut goal_selector = mob_arc

--- a/crates/pumpkin/src/entity/passive/cod.rs
+++ b/crates/pumpkin/src/entity/passive/cod.rs
@@ -5,8 +5,8 @@ use pumpkin_data::entity::EntityType;
 use crate::entity::{
     Entity,
     ai::goal::{
-        look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal, swim::SwimGoal,
-        wander_around::WanderAroundGoal,
+        look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal,
+        random_swimming::RandomSwimmingGoal, swim::SwimGoal,
     },
     mob::{Mob, MobEntity},
 };
@@ -36,7 +36,7 @@ impl CodEntity {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
 
             goal_selector.add_goal(0, Box::new(SwimGoal::default()));
-            goal_selector.add_goal(1, Box::new(WanderAroundGoal::new(1.0)));
+            goal_selector.add_goal(1, Box::new(RandomSwimmingGoal::new(1.0, 40)));
             goal_selector.add_goal(
                 2,
                 LookAtEntityGoal::with_default(mob_weak, &EntityType::PLAYER, 6.0),

--- a/crates/pumpkin/src/entity/passive/pufferfish.rs
+++ b/crates/pumpkin/src/entity/passive/pufferfish.rs
@@ -8,6 +8,7 @@ use crate::entity::{
         look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal,
         random_swimming::RandomSwimmingGoal, swim::SwimGoal,
     },
+    ai::pathfinder::Navigator,
     mob::{Mob, MobEntity},
 };
 
@@ -27,6 +28,13 @@ impl PufferfishEntity {
             let mob_arc: Arc<dyn Mob> = mob_arc.clone();
             Arc::downgrade(&mob_arc)
         };
+
+        // Vanilla `AbstractFish#createNavigation`: fish navigate through water.
+        *mob_arc
+            .mob_entity
+            .navigator
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Navigator::water_bound(false);
 
         {
             let mut goal_selector = mob_arc

--- a/crates/pumpkin/src/entity/passive/pufferfish.rs
+++ b/crates/pumpkin/src/entity/passive/pufferfish.rs
@@ -5,8 +5,8 @@ use pumpkin_data::entity::EntityType;
 use crate::entity::{
     Entity,
     ai::goal::{
-        look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal, swim::SwimGoal,
-        wander_around::WanderAroundGoal,
+        look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal,
+        random_swimming::RandomSwimmingGoal, swim::SwimGoal,
     },
     mob::{Mob, MobEntity},
 };
@@ -36,7 +36,7 @@ impl PufferfishEntity {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
 
             goal_selector.add_goal(0, Box::new(SwimGoal::default()));
-            goal_selector.add_goal(1, Box::new(WanderAroundGoal::new(1.0)));
+            goal_selector.add_goal(1, Box::new(RandomSwimmingGoal::new(1.0, 40)));
             goal_selector.add_goal(
                 2,
                 LookAtEntityGoal::with_default(mob_weak, &EntityType::PLAYER, 6.0),

--- a/crates/pumpkin/src/entity/passive/salmon.rs
+++ b/crates/pumpkin/src/entity/passive/salmon.rs
@@ -5,8 +5,8 @@ use pumpkin_data::entity::EntityType;
 use crate::entity::{
     Entity,
     ai::goal::{
-        look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal, swim::SwimGoal,
-        wander_around::WanderAroundGoal,
+        look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal,
+        random_swimming::RandomSwimmingGoal, swim::SwimGoal,
     },
     mob::{Mob, MobEntity},
 };
@@ -33,7 +33,7 @@ impl SalmonEntity {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
 
             goal_selector.add_goal(0, Box::new(SwimGoal::default()));
-            goal_selector.add_goal(1, Box::new(WanderAroundGoal::new(1.0)));
+            goal_selector.add_goal(1, Box::new(RandomSwimmingGoal::new(1.0, 40)));
             goal_selector.add_goal(
                 2,
                 LookAtEntityGoal::with_default(mob_weak, &EntityType::PLAYER, 6.0),

--- a/crates/pumpkin/src/entity/passive/salmon.rs
+++ b/crates/pumpkin/src/entity/passive/salmon.rs
@@ -8,6 +8,7 @@ use crate::entity::{
         look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal,
         random_swimming::RandomSwimmingGoal, swim::SwimGoal,
     },
+    ai::pathfinder::Navigator,
     mob::{Mob, MobEntity},
 };
 
@@ -24,6 +25,13 @@ impl SalmonEntity {
             let mob_arc: Arc<dyn Mob> = mob_arc.clone();
             Arc::downgrade(&mob_arc)
         };
+
+        // Vanilla `AbstractFish#createNavigation`: fish navigate through water.
+        *mob_arc
+            .mob_entity
+            .navigator
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Navigator::water_bound(false);
 
         {
             let mut goal_selector = mob_arc

--- a/crates/pumpkin/src/entity/passive/tropical_fish.rs
+++ b/crates/pumpkin/src/entity/passive/tropical_fish.rs
@@ -5,8 +5,8 @@ use pumpkin_data::entity::EntityType;
 use crate::entity::{
     Entity,
     ai::goal::{
-        look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal, swim::SwimGoal,
-        wander_around::WanderAroundGoal,
+        look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal,
+        random_swimming::RandomSwimmingGoal, swim::SwimGoal,
     },
     mob::{Mob, MobEntity},
 };
@@ -33,7 +33,7 @@ impl TropicalFishEntity {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
 
             goal_selector.add_goal(0, Box::new(SwimGoal::default()));
-            goal_selector.add_goal(1, Box::new(WanderAroundGoal::new(1.0)));
+            goal_selector.add_goal(1, Box::new(RandomSwimmingGoal::new(1.0, 40)));
             goal_selector.add_goal(
                 2,
                 LookAtEntityGoal::with_default(mob_weak, &EntityType::PLAYER, 6.0),

--- a/crates/pumpkin/src/entity/passive/tropical_fish.rs
+++ b/crates/pumpkin/src/entity/passive/tropical_fish.rs
@@ -8,6 +8,7 @@ use crate::entity::{
         look_around::RandomLookAroundGoal, look_at_entity::LookAtEntityGoal,
         random_swimming::RandomSwimmingGoal, swim::SwimGoal,
     },
+    ai::pathfinder::Navigator,
     mob::{Mob, MobEntity},
 };
 
@@ -24,6 +25,13 @@ impl TropicalFishEntity {
             let mob_arc: Arc<dyn Mob> = mob_arc.clone();
             Arc::downgrade(&mob_arc)
         };
+
+        // Vanilla `AbstractFish#createNavigation`: fish navigate through water.
+        *mob_arc
+            .mob_entity
+            .navigator
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Navigator::water_bound(false);
 
         {
             let mut goal_selector = mob_arc


### PR DESCRIPTION
## Description

Fish (cod, salmon, pufferfish, tropical fish) regularly end up on land, looking like they spawned there. The natural spawn path is not the problem — it is fully water-gated (`is_spawn_position_ok` requires water, and the surface-water spawn rules check the blocks below and above).

The real cause is their AI: fish used the generic `WanderAroundGoal`, which picks a raw random 3D offset (±10 horizontal, ±7 vertical) with no validation. Since pumpkin's navigator has no water-bound pathing constraint, fish would regularly target land or air, navigate out of the water, and beach themselves — where they stay forever (no suffocation mechanic yet).

Vanilla fish use `FishSwimGoal`, which extends `RandomSwimmingGoal` (speed 1.0, interval 40). Its `getPosition` (`BehaviorUtils#getRandomSwimmablePos`) resamples up to 10 times until the candidate block is pathfindable as water. This PR:

- adds a `RandomSwimmingGoal` that only accepts wander targets whose block is water (`minecraft:water` fluid tag). It deliberately returns `None` instead of vanilla's "last candidate after 10 tries", because the pumpkin navigator would otherwise path straight to a land target — the resampling loop only works in vanilla because `WaterBoundPathNavigation` refuses non-water paths.
- wires it into cod, salmon, pufferfish and tropical fish at the same priority (1) and interval (40) as vanilla.

Fish flop-out-of-water behavior and the missing suffocation mechanic (tracked separately in #1674) are out of scope.

## Testing

- `cargo check`, `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features` (with `RUSTFLAGS=-Dwarnings`) and `cargo test` all pass.
- Vanilla `RandomSwimmingGoal` / `BehaviorUtils#getRandomSwimmablePos` / `AbstractFish#registerGoals` verified against the 26.2 (1.21.10) decompiled sources.

Fixes #3323

🤖 Generated with AI assistance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added natural random swimming behavior for fish.
  * Cod, pufferfish, salmon, and tropical fish now select valid water destinations while swimming.
  * Fish avoid being directed onto land during random movement.
  * Fish navigate within water using periodic movement decisions, producing more natural roaming behavior.
  * Random swimming supports varied vertical and horizontal movement across nearby water areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->