### PR TITLE
fix: correct red mushroom generation

### DIFF
--- a/crates/pumpkin-world/src/generation/feature/features/huge_red_mushroom.rs
+++ b/crates/pumpkin-world/src/generation/feature/features/huge_red_mushroom.rs
@@ -53,7 +53,6 @@ impl HugeRedMushroomFeature {
         let radius = Self::FOLIAGE_RADIUS;
         for i in (tree_height - 3)..=tree_height {
             let j = if i < tree_height { radius } else { radius - 1 };
-            let k = radius - 2;
 
             for l in -j..=j {
                 for m in -j..=j {
@@ -67,10 +66,10 @@ impl HugeRedMushroomFeature {
                     let props = BrownMushroomBlockLikeProperties {
                         up: i >= tree_height - 1,
                         down: false,
-                        west: l < -k,
-                        east: l > k,
-                        north: m < -k,
-                        south: m > k,
+                        west: l < 0,
+                        east: l > 0,
+                        north: m < 0,
+                        south: m > 0,
                     };
                     let state_id = props.to_state_id(&Block::RED_MUSHROOM_BLOCK);
                     let cap_pos = BlockPos::new(pos.0.x + l, pos.0.y + i, pos.0.z + m);

--- a/crates/pumpkin/src/block/blocks/plant/mushroom_plant.rs
+++ b/crates/pumpkin/src/block/blocks/plant/mushroom_plant.rs
@@ -176,7 +176,6 @@ fn place_huge_red_mushroom(world: &Arc<World>, pos: &BlockPos, tree_height: i32)
     let radius = 2;
     for i in (tree_height - 3)..=tree_height {
         let j = if i < tree_height { radius } else { radius - 1 };
-        let k = radius - 2;
 
         for l in -j..=j {
             for m in -j..=j {
@@ -190,10 +189,10 @@ fn place_huge_red_mushroom(world: &Arc<World>, pos: &BlockPos, tree_height: i32)
                 let props = BrownMushroomBlockLikeProperties {
                     up: i >= tree_height - 1,
                     down: false,
-                    west: l < -k,
-                    east: l > k,
-                    north: m < -k,
-                    south: m > k,
+                    west: l < 0,
+                    east: l > 0,
+                    north: m < 0,
+                    south: m > 0,
                 };
                 let state_id = props.to_state_id(&Block::RED_MUSHROOM_BLOCK);
                 let cap_pos = BlockPos::new(pos.0.x + l, pos.0.y + i, pos.0.z + m);


### PR DESCRIPTION
<!-- Follow the Conventional Commits spec: <https://www.conventionalcommits.org/en/v1.0.0/> -->
<!-- Empty or bad descriptions are not welcome. Don't waste my time -->

## Description
Fixes the block state face properties for Huge Red Mushroom caps in both procedural world generation.

### Problem

1. Mushrooms were not looking different from vanilla ones. Mushrooms Lowest red layer was spawning offset by one on every side to outside. (See issue #2429 for printscreen).

### Solution

- Updated BrownMushroomBlockLikeProperties in "huge_red_mushroom.rs" and "mushroom_plant.rs" to use directional quadrant checks.
- Ensures all faces display the correct texture on everyside.
- Remove unused k calculation
- Fixes #2429 

## Testing
- [x] Ran cargo check -p pumpkin-world (passed with 0 warnings, 0 errors).
- [x] Started local server and tested with a new world
- [x] Verified procedurally generated Huge Red Mushrooms in forest/mushroom biomes to confirm outer cap side textures display correctly.
- [ ]  Could not verify when applying bonemeal on a mushroom because of #2531, however prepared the file for when the feature is ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified huge red mushroom cap generation logic.
  - Mushroom placement, appearance, and directional block behavior remain unchanged for players.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->