### PR TITLE
fix(world): support 26.x world generation settings layouts

### DIFF
--- a/crates/pumpkin-world/src/world_info/anvil.rs
+++ b/crates/pumpkin-world/src/world_info/anvil.rs
@@ -657,6 +657,41 @@ mod test {
     }
 
     #[test]
+    fn read_26_x_world_gen_settings_layout() {
+        let temp_dir = TempDir::new().unwrap();
+        write_level_dat(temp_dir.path(), converted_level_dat(None));
+
+        let data_dir = temp_dir
+            .path()
+            .join("dimensions")
+            .join("minecraft")
+            .join("overworld")
+            .join("data")
+            .join("minecraft");
+        fs::create_dir_all(&data_dir).unwrap();
+
+        let mut settings = NbtCompound::new();
+        settings.put_long("seed", -2_016_744_919_588_476_706);
+        let mut data = NbtCompound::new();
+        data.put_compound("data", settings);
+        let mut root = NbtCompound::new();
+        root.put_compound("Data", data);
+
+        write_gzip_compound_tag(
+            root,
+            File::create(data_dir.join("world_gen_settings.dat")).unwrap(),
+        )
+        .unwrap();
+
+        let level_data = AnvilLevelInfo.read_world_info(temp_dir.path()).unwrap();
+
+        assert_eq!(
+            level_data.world_gen_settings.seed,
+            -2_016_744_919_588_476_706
+        );
+    }
+
+    #[test]
     fn rewrite_level_dat_keeps_unmanaged_tags() {
         let temp_dir = TempDir::new().unwrap();
         write_level_dat(temp_dir.path(), converted_level_dat(Some(42)));

--- a/crates/pumpkin-world/src/world_info/data_files.rs
+++ b/crates/pumpkin-world/src/world_info/data_files.rs
@@ -232,21 +232,38 @@ pub fn nbt_tag_to_json(tag: &NbtTag) -> serde_json::Value {
     }
 }
 
+#[must_use]
 pub fn read_world_gen_settings(level_folder: &Path) -> Option<WorldGenSettings> {
-    let path = minecraft_data_dir(level_folder).join("world_gen_settings.dat");
-    if !path.exists() {
-        return None;
+    // Support world generation settings locations used by vanilla and Paper-derived 26.x worlds.
+    let paths = [
+        minecraft_data_dir(level_folder).join("world_gen_settings.dat"),
+        level_folder
+            .join("dimensions")
+            .join("minecraft")
+            .join("overworld")
+            .join("data")
+            .join("minecraft")
+            .join("world_gen_settings.dat"),
+    ];
+
+    for path in paths.iter().filter(|path| path.exists()) {
+        if let Some(settings) = read_world_gen_settings_file(path) {
+            return Some(settings);
+        }
     }
-    match File::open(&path) {
+
+    None
+}
+
+fn read_world_gen_settings_file(path: &Path) -> Option<WorldGenSettings> {
+    match File::open(path) {
         Ok(f) => match read_gzip_compound_tag(f) {
             Ok(compound) => {
-                let data_compound = compound.get_compound("data");
-                let c = data_compound.as_ref().map_or(&compound, |v| v);
-                let seed = c.get_long("seed");
-                if seed.is_none() {
-                    warn!("world_gen_settings.dat has no seed");
-                }
-                let seed = seed?;
+                let Some(c) = world_gen_settings_payload(&compound) else {
+                    warn!("{} has no seed", path.display());
+                    return None;
+                };
+                let seed = c.get_long("seed")?;
                 let mut dimensions = std::collections::HashMap::new();
                 if let Some(dims_comp) = c.get_compound("dimensions") {
                     for (dim_name, dim_tag) in &dims_comp.child_tags {
@@ -309,14 +326,26 @@ pub fn read_world_gen_settings(level_folder: &Path) -> Option<WorldGenSettings> 
                 Some(WorldGenSettings { seed, dimensions })
             }
             Err(e) => {
-                warn!("Failed to deserialize world_gen_settings.dat: {e}");
+                warn!("Failed to deserialize {}: {e}", path.display());
                 None
             }
         },
         Err(e) => {
-            warn!("Failed to open world_gen_settings.dat: {e}");
+            warn!("Failed to open {}: {e}", path.display());
             None
         }
+    }
+}
+
+fn world_gen_settings_payload(mut compound: &NbtCompound) -> Option<&NbtCompound> {
+    loop {
+        if compound.get_long("seed").is_some() {
+            return Some(compound);
+        }
+
+        compound = compound
+            .get_compound("data")
+            .or_else(|| compound.get_compound("Data"))?;
     }
 }
 


### PR DESCRIPTION
## Description

Support world generation settings layouts used by vanilla and Paper-derived 26.x servers, as per an issue brought up by `@Stigstille`in `#general`. The loader now checks both the global and canonical overworld locations for `world_gen_settings.dat` and unwraps nested `data` or `Data` compounds when locating the world seed.

Fixes an existing issue with 26.x worlds failing to start with `No world seed found` even though their world generation settings contain a valid seed. Also added a regression test reproduces the affected nested file layout.

Tested with the following:

- `cargo test -p pumpkin-world`: 183 passed
- `cargo clippy -p pumpkin-world --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved world information loading for newer 26.x world layouts.
  - World seeds are now detected from both standard and nested world-generation data locations.
  - Added support for seed values nested within `data` or `Data` sections.
  - Improved warnings to identify the file that could not be parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->