### PR TITLE
fix(comparator): correct comparator container dirt update and diffrent container implementation

### DIFF
--- a/crates/pumpkin-world/src/chunk/mod.rs
+++ b/crates/pumpkin-world/src/chunk/mod.rs
@@ -598,6 +598,12 @@ impl ChunkSections {
 }
 
 impl ChunkData {
+    /// Vanilla `LevelChunkTicks` rides on the chunk, so restored NBT ticks count too.
+    #[must_use]
+    pub fn has_scheduled_ticks(&self) -> bool {
+        self.block_ticks.has_ticks() || self.fluid_ticks.has_ticks()
+    }
+
     #[must_use]
     pub fn empty(x: i32, z: i32) -> Self {
         Self {

--- a/crates/pumpkin-world/src/chunk_system/schedule.rs
+++ b/crates/pumpkin-world/src/chunk_system/schedule.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::chunk::io::Dirtiable;
 use crate::level::{Level, LoadedChunkChange, SyncChunk};
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use pumpkin_config::lighting::LightingEngineConfig;
 use pumpkin_util::math::vector2::Vector2;
 use slotmap::Key;
@@ -56,6 +56,9 @@ pub struct GenerationSchedule {
     send_level: Arc<LevelChannel>,
 
     public_chunk_map: Arc<DashMap<Vector2<i32>, SyncChunk>>,
+    /// Ticks restored from NBT are only in the chunk, so publishing has to
+    /// index them or they never run again.
+    chunks_with_scheduled_ticks: Arc<DashSet<Vector2<i32>>>,
     loaded_chunk_changes: Arc<crossbeam::queue::SegQueue<LoadedChunkChange>>,
     chunk_map: HashMap<ChunkPos, ChunkHolder>,
     unload_chunks: HashSetType<ChunkPos>,
@@ -81,6 +84,11 @@ pub struct GenerationSchedule {
 
 impl GenerationSchedule {
     fn publish_chunk(&self, pos: ChunkPos, chunk: SyncChunk) -> Option<SyncChunk> {
+        // Index before publishing: once the chunk is readable, a concurrent
+        // `schedule_block_tick` may index too.
+        if chunk.has_scheduled_ticks() {
+            self.chunks_with_scheduled_ticks.insert(pos);
+        }
         let previous = self.public_chunk_map.insert(pos, chunk);
         if previous.is_none() {
             self.loaded_chunk_changes
@@ -92,6 +100,7 @@ impl GenerationSchedule {
     fn unpublish_chunk(&self, pos: ChunkPos) -> Option<SyncChunk> {
         let removed = self.public_chunk_map.remove(&pos).map(|(_, chunk)| chunk);
         if removed.is_some() {
+            self.chunks_with_scheduled_ticks.remove(&pos);
             self.loaded_chunk_changes
                 .push(LoadedChunkChange::Unloaded(pos));
         }
@@ -155,6 +164,7 @@ impl GenerationSchedule {
                     last_high_priority: Vec::new(),
                     send_level: level_channel,
                     public_chunk_map: level_sched.loaded_chunks.clone(),
+                    chunks_with_scheduled_ticks: level_sched.chunks_with_scheduled_ticks.clone(),
                     loaded_chunk_changes: level_sched.loaded_chunk_changes.clone(),
                     unload_chunks: HashSetType::default(),
                     waiting_for_chunks: HashSetType::default(),

--- a/crates/pumpkin-world/src/level.rs
+++ b/crates/pumpkin-world/src/level.rs
@@ -583,6 +583,11 @@ impl Level {
             .map(|p| *p)
             .collect();
         for pos in scheduled_chunk_pos {
+            // Vanilla `LevelTicks.tickCheck`: a loaded but unsimulated chunk keeps its
+            // ticks queued instead of running them, so its neighbours stay loaded.
+            if !active_chunks.contains(&pos) {
+                continue;
+            }
             if let Some(chunk) = self.loaded_chunks.get(&pos) {
                 let chunk = chunk.value();
                 ticks.block_ticks.append(&mut chunk.block_ticks.step_tick());
@@ -959,6 +964,9 @@ impl Level {
             .is_some()
         {
             self.chunks_with_scheduled_ticks.insert(chunk_pos);
+        } else {
+            // Vanilla `LevelTicks.schedule` drops this too, but says so.
+            debug!("Trying to schedule block tick in not loaded position {block_pos:?}");
         }
     }
 
@@ -986,6 +994,9 @@ impl Level {
             .is_some()
         {
             self.chunks_with_scheduled_ticks.insert(chunk_pos);
+        } else {
+            // Vanilla `LevelTicks.schedule` drops this too, but says so.
+            debug!("Trying to schedule fluid tick in not loaded position {block_pos:?}");
         }
     }
 

--- a/crates/pumpkin-world/src/tick/scheduler.rs
+++ b/crates/pumpkin-world/src/tick/scheduler.rs
@@ -183,3 +183,49 @@ impl<T> Default for ChunkTickScheduler<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tick::TickPriority;
+
+    static A: u32 = 1;
+    static B: u32 = 2;
+
+    fn tick<T>(x: i32, value: &'static T, delay: u8) -> ScheduledTick<&'static T> {
+        ScheduledTick {
+            delay,
+            priority: TickPriority::Normal,
+            position: BlockPos::new(x, 0, 0),
+            value,
+        }
+    }
+
+    /// A clock only survives a chunk reload if the saved ticks keep their remaining delay.
+    #[test]
+    fn save_reload_keeps_remaining_delays() {
+        let scheduler = ChunkTickScheduler::default();
+        scheduler.schedule_tick(&tick(0, &A, 3), 0);
+        scheduler.schedule_tick(&tick(1, &B, 0), 1);
+
+        // One tick runs before the chunk is saved, leaving 2 of the original 3.
+        assert_eq!(scheduler.step_tick().len(), 1);
+
+        let restored = ChunkTickScheduler::from_iter(scheduler.to_vec());
+        assert!(restored.has_ticks());
+
+        assert!(restored.step_tick().is_empty());
+        assert!(restored.step_tick().is_empty());
+        assert_eq!(restored.step_tick().len(), 1);
+        assert!(!restored.has_ticks());
+    }
+
+    #[test]
+    fn reloaded_scheduler_reports_ticks_for_indexing() {
+        let scheduler: ChunkTickScheduler<&u32> = ChunkTickScheduler::default();
+        assert!(!scheduler.has_ticks());
+
+        let restored = ChunkTickScheduler::from_iter(vec![tick(0, &A, 5)]);
+        assert!(restored.has_ticks());
+    }
+}

--- a/crates/pumpkin/src/block/blocks/barrel.rs
+++ b/crates/pumpkin/src/block/blocks/barrel.rs
@@ -89,14 +89,6 @@ impl BlockBehaviour for BarrelBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
-        if let Some(block_entity) = args.world.get_block_entity(args.position)
-            && let Some(inventory) = block_entity.get_inventory()
-        {
-            Some(crate::block::calculate_comparator_output(
-                inventory.as_ref(),
-            ))
-        } else {
-            None
-        }
+        crate::block::container_comparator_output(&args)
     }
 }

--- a/crates/pumpkin/src/block/blocks/blast_furnace.rs
+++ b/crates/pumpkin/src/block/blocks/blast_furnace.rs
@@ -144,14 +144,6 @@ impl BlockBehaviour for BlastFurnaceBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
-        if let Some(block_entity) = args.world.get_block_entity(args.position)
-            && let Some(inventory) = block_entity.get_inventory()
-        {
-            Some(crate::block::calculate_comparator_output(
-                inventory.as_ref(),
-            ))
-        } else {
-            None
-        }
+        crate::block::container_comparator_output(&args)
     }
 }

--- a/crates/pumpkin/src/block/blocks/brewing_stand.rs
+++ b/crates/pumpkin/src/block/blocks/brewing_stand.rs
@@ -85,21 +85,7 @@ impl BlockBehaviour for BrewingStandBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
-        if let Some(block_entity) = args.world.get_block_entity(args.position)
-            && let Some(inventory) = block_entity.get_inventory()
-        {
-            let mut bottles = 0u8;
-            // Bottle slots are 0, 1, 2 in brewing stands
-            for slot in 0..3 {
-                let stack = inventory.get_stack(slot);
-                if !stack.is_empty() {
-                    bottles += 1;
-                }
-            }
-            Some(bottles)
-        } else {
-            None
-        }
+        crate::block::container_comparator_output(&args)
     }
 
     fn is_pathfindable(&self, _state: &BlockState, _computation_type: PathComputationType) -> bool {

--- a/crates/pumpkin/src/block/blocks/cake.rs
+++ b/crates/pumpkin/src/block/blocks/cake.rs
@@ -21,6 +21,16 @@ use pumpkin_world::{
     tick::TickPriority,
     world::{BlockAccessor, BlockFlags},
 };
+
+/// Vanilla `CakeBlock.getOutputSignal`. Saturates -> an out-of-range bite count reads 0.
+#[must_use]
+pub const fn cake_output_signal(bites: u8) -> u8 {
+    7u8.saturating_sub(bites) * 2
+}
+
+/// Vanilla `CakeBlock.FULL_CAKE_SIGNAL`.
+pub const FULL_CAKE_SIGNAL: u8 = cake_output_signal(0);
+
 #[pumpkin_block("minecraft:cake")]
 pub struct CakeBlock;
 
@@ -159,15 +169,9 @@ impl BlockBehaviour for CakeBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
-        {
-            let state_id = args.world.get_block_state_id(args.position);
-            let properties = CakeLikeProperties::from_state_id(state_id);
-            if properties.bites <= 6 {
-                Some((7 - properties.bites) * 2)
-            } else {
-                Some(0)
-            }
-        }
+        let state_id = args.world.get_block_state_id(args.position);
+        let properties = CakeLikeProperties::from_state_id(state_id);
+        Some(cake_output_signal(properties.bites))
     }
 
     fn is_pathfindable(&self, _state: &BlockState, _computation_type: PathComputationType) -> bool {

--- a/crates/pumpkin/src/block/blocks/candle_cakes.rs
+++ b/crates/pumpkin/src/block/blocks/candle_cakes.rs
@@ -10,8 +10,10 @@ use pumpkin_world::{
 
 use crate::{
     block::{
-        BlockBehaviour, GetStateForNeighborUpdateArgs, NormalUseArgs, OnScheduledTickArgs,
-        PathComputationType, UseWithItemArgs, blocks::cake::CakeBlock, registry::BlockActionResult,
+        BlockBehaviour, GetComparatorOutputArgs, GetStateForNeighborUpdateArgs, NormalUseArgs,
+        OnScheduledTickArgs, PathComputationType, UseWithItemArgs,
+        blocks::cake::{CakeBlock, FULL_CAKE_SIGNAL},
+        registry::BlockActionResult,
     },
     entity::player::Player,
     world::World,
@@ -120,6 +122,11 @@ impl BlockBehaviour for CandleCakeBlock {
                 .schedule_block_tick(args.block, *args.position, 1, TickPriority::Normal);
         }
         args.state_id
+    }
+
+    /// A candle cake is always uneaten, so it reads a full cake.
+    fn get_comparator_output(&self, _args: GetComparatorOutputArgs<'_>) -> Option<u8> {
+        Some(FULL_CAKE_SIGNAL)
     }
 
     fn is_pathfindable(&self, _state: &BlockState, _computation_type: PathComputationType) -> bool {

--- a/crates/pumpkin/src/block/blocks/chests.rs
+++ b/crates/pumpkin/src/block/blocks/chests.rs
@@ -133,6 +133,17 @@ fn get_chest_comparator_output(args: &GetComparatorOutputArgs<'_>) -> Option<u8>
         ChestType::Right => Some(chest_props.facing.rotate_counter_clockwise()),
     };
 
+    // Vanilla passes `ignoreBeingBlocked = false`, so a blocked half reads zero.
+    if is_chest_blocked(args.world, args.position) {
+        return Some(0);
+    }
+
+    if let Some(direction) = connected_towards
+        && is_chest_blocked(args.world, &args.position.offset(direction.to_offset()))
+    {
+        return Some(0);
+    }
+
     if let Some(direction) = connected_towards
         && let Some(second_inventory) = args
             .world

--- a/crates/pumpkin/src/block/blocks/end_portal_frame.rs
+++ b/crates/pumpkin/src/block/blocks/end_portal_frame.rs
@@ -2,7 +2,7 @@ use pumpkin_data::{BlockState, BlockStateId};
 use pumpkin_macros::pumpkin_block;
 
 use crate::{
-    block::{BlockBehaviour, OnPlaceArgs, PathComputationType},
+    block::{BlockBehaviour, GetComparatorOutputArgs, OnPlaceArgs, PathComputationType},
     entity::EntityBase,
 };
 
@@ -17,6 +17,12 @@ impl BlockBehaviour for EndPortalFrameBlock {
         end_portal_frame_props.facing = args.player.get_entity().get_horizontal_facing().opposite();
 
         end_portal_frame_props.to_state_id(args.block)
+    }
+
+    /// A frame with an eye reads full strength.
+    fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
+        let props = EndPortalFrameProperties::from_state_id(args.state.id);
+        Some(if props.eye { 15 } else { 0 })
     }
 
     fn is_pathfindable(&self, _state: &BlockState, _computation_type: PathComputationType) -> bool {

--- a/crates/pumpkin/src/block/blocks/furnace.rs
+++ b/crates/pumpkin/src/block/blocks/furnace.rs
@@ -142,14 +142,6 @@ impl BlockBehaviour for FurnaceBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
-        if let Some(block_entity) = args.world.get_block_entity(args.position)
-            && let Some(inventory) = block_entity.get_inventory()
-        {
-            Some(crate::block::calculate_comparator_output(
-                inventory.as_ref(),
-            ))
-        } else {
-            None
-        }
+        crate::block::container_comparator_output(&args)
     }
 }

--- a/crates/pumpkin/src/block/blocks/hopper.rs
+++ b/crates/pumpkin/src/block/blocks/hopper.rs
@@ -121,15 +121,7 @@ impl BlockBehaviour for HopperBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
-        if let Some(block_entity) = args.world.get_block_entity(args.position)
-            && let Some(inventory) = block_entity.get_inventory()
-        {
-            Some(crate::block::calculate_comparator_output(
-                inventory.as_ref(),
-            ))
-        } else {
-            None
-        }
+        crate::block::container_comparator_output(&args)
     }
 
     fn is_pathfindable(&self, _state: &BlockState, _computation_type: PathComputationType) -> bool {

--- a/crates/pumpkin/src/block/blocks/jukebox.rs
+++ b/crates/pumpkin/src/block/blocks/jukebox.rs
@@ -202,7 +202,7 @@ impl BlockBehaviour for JukeboxBlock {
             let record = jukebox_entity.get_record();
             // Get the song from the record's jukebox_playable component
             if let Some(playable) = record.get_data_component::<JukeboxPlayableImpl>()
-                && let Some(song_name) = playable.song.split(':').nth(1)
+                && let Some(song_name) = playable.song.rsplit(':').next()
                 && let Some(song) = JukeboxSong::from_name(song_name)
             {
                 return Some(song.comparator_output());

--- a/crates/pumpkin/src/block/blocks/redstone/comparator.rs
+++ b/crates/pumpkin/src/block/blocks/redstone/comparator.rs
@@ -214,6 +214,8 @@ impl RedstoneGateBlock<ComparatorLikeProperties> for ComparatorBlock {
 
         let props = ComparatorLikeProperties::from_state_id(state.id);
         let facing = props.facing;
+        // Vanilla passes `direction.getOpposite()`: the target face read from.
+        let read_from = facing.to_block_direction().opposite();
         let mut target_pos = pos.offset(facing.to_offset());
         let (target_block, target_state) = world.get_block_and_state(&target_pos);
 
@@ -227,6 +229,7 @@ impl RedstoneGateBlock<ComparatorLikeProperties> for ComparatorBlock {
                         block: target_block,
                         state: target_state,
                         position: &target_pos,
+                        direction: read_from,
                     })
                 })
                 .unwrap_or(0);
@@ -247,6 +250,7 @@ impl RedstoneGateBlock<ComparatorLikeProperties> for ComparatorBlock {
                             block: target_block,
                             state: target_state,
                             position: &target_pos,
+                            direction: read_from,
                         })
                     })
                     .unwrap_or(0);

--- a/crates/pumpkin/src/block/blocks/redstone/dispenser.rs
+++ b/crates/pumpkin/src/block/blocks/redstone/dispenser.rs
@@ -214,15 +214,7 @@ impl BlockBehaviour for DispenserBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
-        if let Some(block_entity) = args.world.get_block_entity(args.position)
-            && let Some(inventory) = block_entity.get_inventory()
-        {
-            Some(crate::block::calculate_comparator_output(
-                inventory.as_ref(),
-            ))
-        } else {
-            None
-        }
+        crate::block::container_comparator_output(&args)
     }
 }
 

--- a/crates/pumpkin/src/block/blocks/redstone/dropper.rs
+++ b/crates/pumpkin/src/block/blocks/redstone/dropper.rs
@@ -220,14 +220,6 @@ impl BlockBehaviour for DropperBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
-        if let Some(block_entity) = args.world.get_block_entity(args.position)
-            && let Some(inventory) = block_entity.get_inventory()
-        {
-            Some(crate::block::calculate_comparator_output(
-                inventory.as_ref(),
-            ))
-        } else {
-            None
-        }
+        crate::block::container_comparator_output(&args)
     }
 }

--- a/crates/pumpkin/src/block/blocks/redstone/sculk_sensor.rs
+++ b/crates/pumpkin/src/block/blocks/redstone/sculk_sensor.rs
@@ -33,6 +33,15 @@ const fn horizontal_facing_to_dir(facing: HorizontalFacing) -> BlockDirection {
     }
 }
 
+/// Both sensor variants carry the same phase property under different types.
+fn sculk_sensor_phase(block: &Block, state_id: BlockStateId) -> SculkSensorPhase {
+    if block.id == BlockId::CALIBRATED_SCULK_SENSOR {
+        CalibratedSculkSensorLikeProperties::from_state_id(state_id).sculk_sensor_phase
+    } else {
+        SculkSensorLikeProperties::from_state_id(state_id).sculk_sensor_phase
+    }
+}
+
 impl SculkSensorBlock {
     pub fn trigger(world: &Arc<World>, pos: &BlockPos, block: &Block, power: u8) {
         if block.id == BlockId::SCULK_SENSOR {
@@ -139,6 +148,11 @@ impl BlockBehaviour for SculkSensorBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
+        // Vanilla reads the frequency only while the sensor is active.
+        if sculk_sensor_phase(args.block, args.state.id) != SculkSensorPhase::Active {
+            return Some(0);
+        }
+
         let be = args.world.get_block_entity(args.position)?;
         if let Some(sensor_be) = be.as_any().downcast_ref::<SculkSensorBlockEntity>() {
             return Some(

--- a/crates/pumpkin/src/block/blocks/respawn_anchor.rs
+++ b/crates/pumpkin/src/block/blocks/respawn_anchor.rs
@@ -6,8 +6,13 @@ use pumpkin_macros::pumpkin_block;
 use pumpkin_world::world::BlockFlags;
 
 use crate::block::registry::BlockActionResult;
-use crate::block::{BlockBehaviour, NormalUseArgs, PathComputationType, UseWithItemArgs};
+use crate::block::{
+    BlockBehaviour, GetComparatorOutputArgs, NormalUseArgs, PathComputationType, UseWithItemArgs,
+};
 use crate::entity::EntityBase;
+
+/// Vanilla `RespawnAnchorBlock.MAX_CHARGES`.
+const MAX_CHARGES: u8 = 4;
 
 #[pumpkin_block("minecraft:respawn_anchor")]
 pub struct RespawnAnchorBlock;
@@ -89,6 +94,12 @@ impl BlockBehaviour for RespawnAnchorBlock {
         }
 
         BlockActionResult::SuccessServer
+    }
+
+    /// Charges scale over the full signal range, so each charge is worth 15 / 4.
+    fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
+        let props = RespawnAnchorLikeProperties::from_state_id(args.state.id);
+        Some(props.charges * 15 / MAX_CHARGES)
     }
 
     fn is_pathfindable(&self, _state: &BlockState, _computation_type: PathComputationType) -> bool {

--- a/crates/pumpkin/src/block/blocks/shelf.rs
+++ b/crates/pumpkin/src/block/blocks/shelf.rs
@@ -1,3 +1,4 @@
+use pumpkin_data::HorizontalFacingExt;
 use pumpkin_data::block_properties::AcaciaShelfLikeProperties;
 use pumpkin_data::{BlockState, BlockStateId};
 use pumpkin_inventory::Inventory;
@@ -30,6 +31,12 @@ impl BlockBehaviour for ShelfBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
+        // Vanilla reads a shelf only through its back face.
+        let props = AcaciaShelfLikeProperties::from_state_id(args.state.id);
+        if args.direction != props.facing.to_block_direction().opposite() {
+            return Some(0);
+        }
+
         if let Some(block_entity) = args.world.get_block_entity(args.position)
             && let Some(shelf) = block_entity.as_any().downcast_ref::<ShelfBlockEntity>()
         {

--- a/crates/pumpkin/src/block/blocks/shulker_box.rs
+++ b/crates/pumpkin/src/block/blocks/shulker_box.rs
@@ -100,15 +100,7 @@ impl BlockBehaviour for ShulkerBoxBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
-        if let Some(block_entity) = args.world.get_block_entity(args.position)
-            && let Some(inventory) = block_entity.get_inventory()
-        {
-            Some(crate::block::calculate_comparator_output(
-                inventory.as_ref(),
-            ))
-        } else {
-            None
-        }
+        crate::block::container_comparator_output(&args)
     }
 }
 

--- a/crates/pumpkin/src/block/blocks/smoker.rs
+++ b/crates/pumpkin/src/block/blocks/smoker.rs
@@ -141,14 +141,6 @@ impl BlockBehaviour for SmokerBlock {
     }
 
     fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
-        if let Some(block_entity) = args.world.get_block_entity(args.position)
-            && let Some(inventory) = block_entity.get_inventory()
-        {
-            Some(crate::block::calculate_comparator_output(
-                inventory.as_ref(),
-            ))
-        } else {
-            None
-        }
+        crate::block::container_comparator_output(&args)
     }
 }

--- a/crates/pumpkin/src/block/blocks/weathering_copper.rs
+++ b/crates/pumpkin/src/block/blocks/weathering_copper.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use pumpkin_data::block_properties::{
     ChestLikeProperties, ChestType, CopperBulbLikeProperties, CopperGolemStatueLikeProperties,
-    DoubleBlockHalf, IronChainLikeProperties, LanternLikeProperties, MangroveRootsLikeProperties,
-    OakDoorLikeProperties, OakFenceLikeProperties, OakStairsLikeProperties,
-    OakTrapdoorLikeProperties, ResinBrickSlabLikeProperties,
+    DoubleBlockHalf, EnumVariants, IronChainLikeProperties, LanternLikeProperties,
+    MangroveRootsLikeProperties, OakDoorLikeProperties, OakFenceLikeProperties,
+    OakStairsLikeProperties, OakTrapdoorLikeProperties, ResinBrickSlabLikeProperties,
 };
 use pumpkin_data::tag::Taggable;
 use pumpkin_data::{Block, BlockId, BlockState, BlockStateId, Mirror, Rotation};
@@ -19,8 +19,8 @@ use crate::block::blocks::trapdoor::TrapDoorBlock;
 use crate::block::registry::BlockActionResult;
 use crate::block::{
     BlockBehaviour, BlockMetadata, BrokenArgs, CanPlaceAtArgs, CanUpdateAtArgs,
-    GetStateForNeighborUpdateArgs, NormalUseArgs, OnNeighborUpdateArgs, OnPlaceArgs,
-    OnStateReplacedArgs, PathComputationType, PlacedArgs, RandomTickArgs,
+    GetComparatorOutputArgs, GetStateForNeighborUpdateArgs, NormalUseArgs, OnNeighborUpdateArgs,
+    OnPlaceArgs, OnStateReplacedArgs, PathComputationType, PlacedArgs, RandomTickArgs,
 };
 use crate::world::World;
 
@@ -643,6 +643,26 @@ impl BlockBehaviour for WeatheringCopperBlock {
     fn random_tick(&self, args: RandomTickArgs<'_>) {
         change_over_time(args.world, args.position, args.block);
     }
+
+    /// Only statues carry a pose, every other copper block here reads nothing.
+    fn get_comparator_output(&self, args: GetComparatorOutputArgs<'_>) -> Option<u8> {
+        if !is_copper_golem_statue(args.block.id) {
+            return None;
+        }
+        let props = CopperGolemStatueLikeProperties::from_state_id(args.state.id);
+        // Vanilla reads the pose ordinal, one-based.
+        Some(props.copper_golem_pose.to_index() as u8 + 1)
+    }
+}
+
+const fn is_copper_golem_statue(id: BlockId) -> bool {
+    matches!(
+        id,
+        BlockId::COPPER_GOLEM_STATUE
+            | BlockId::EXPOSED_COPPER_GOLEM_STATUE
+            | BlockId::WEATHERED_COPPER_GOLEM_STATUE
+            | BlockId::OXIDIZED_COPPER_GOLEM_STATUE
+    )
 }
 
 /// Weathering copper stair blocks.

--- a/crates/pumpkin/src/block/entities/barrel.rs
+++ b/crates/pumpkin/src/block/entities/barrel.rs
@@ -26,6 +26,7 @@ pub struct BarrelBlockEntity {
     pub position: BlockPos,
     pub items: RwLock<[ItemStack; Self::INVENTORY_SIZE]>,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 
     // Viewer
     viewers: ViewerCountTracker,
@@ -48,6 +49,7 @@ impl BlockEntity for BarrelBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
             viewers: ViewerCountTracker::new(),
         };
 
@@ -73,6 +75,14 @@ impl BlockEntity for BarrelBlockEntity {
 
     fn get_inventory(self: Arc<Self>) -> Option<Arc<dyn Inventory>> {
         Some(self)
+    }
+
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
     }
 
     fn is_dirty(&self) -> bool {
@@ -118,6 +128,7 @@ impl BarrelBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
             viewers: ViewerCountTracker::new(),
         }
     }
@@ -220,6 +231,7 @@ impl Inventory for BarrelBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/pumpkin/src/block/entities/blasting_furnace.rs
+++ b/crates/pumpkin/src/block/entities/blasting_furnace.rs
@@ -23,6 +23,7 @@ use crate::{
 pub struct BlastingFurnaceBlockEntity {
     pub position: BlockPos,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 
     pub cooking_time_spent: AtomicU16,
     pub cooking_total_time: AtomicU16,
@@ -45,6 +46,7 @@ impl BlastingFurnaceBlockEntity {
         Self {
             position,
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             cooking_total_time: AtomicU16::new(0),
             cooking_time_spent: AtomicU16::new(0),

--- a/crates/pumpkin/src/block/entities/brewing_stand.rs
+++ b/crates/pumpkin/src/block/entities/brewing_stand.rs
@@ -22,6 +22,7 @@ pub struct BrewingStandBlockEntity {
     pub position: BlockPos,
     pub items: RwLock<[ItemStack; Self::INVENTORY_SIZE]>,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
     pub brew_time: AtomicI32,
     pub fuel: AtomicI32,
     pub last_potion_count: StdMutex<Option<[bool; 3]>>,
@@ -39,6 +40,7 @@ impl BrewingStandBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
             brew_time: AtomicI32::new(0),
             fuel: AtomicI32::new(0),
             last_potion_count: StdMutex::new(None),
@@ -406,6 +408,7 @@ impl pumpkin_inventory::Inventory for BrewingStandBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -536,6 +539,14 @@ impl crate::block::entities::BlockEntity for BrewingStandBlockEntity {
             sync_write_items_to_nbt(&*items, &mut nbt);
         }
         Some(nbt)
+    }
+
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
     }
 
     fn is_dirty(&self) -> bool {

--- a/crates/pumpkin/src/block/entities/chest.rs
+++ b/crates/pumpkin/src/block/entities/chest.rs
@@ -12,6 +12,7 @@ pub struct ChestBlockEntity {
     pub position: BlockPos,
     pub items: RwLock<[ItemStack; Self::INVENTORY_SIZE]>,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 
     // Viewer
     viewers: ViewerCountTracker,

--- a/crates/pumpkin/src/block/entities/chest_like_block_entity.rs
+++ b/crates/pumpkin/src/block/entities/chest_like_block_entity.rs
@@ -28,6 +28,7 @@ macro_rules! impl_block_entity_for_chest {
                         ItemStack::EMPTY.clone()
                     })),
                     dirty: std::sync::atomic::AtomicBool::new(false),
+                    comparator_dirty: std::sync::atomic::AtomicBool::new(false),
                     viewers: $crate::block::viewer::ViewerCountTracker::new(),
                     loot_table: StdMutex::new(loot_table_key),
                     loot_table_seed,
@@ -86,6 +87,16 @@ macro_rules! impl_block_entity_for_chest {
 
             fn get_inventory(self: Arc<Self>) -> Option<Arc<dyn pumpkin_inventory::Inventory>> {
                 Some(self)
+            }
+
+            fn is_comparator_dirty(&self) -> bool {
+                self.comparator_dirty
+                    .load(std::sync::atomic::Ordering::Relaxed)
+            }
+
+            fn clear_comparator_dirty(&self) {
+                self.comparator_dirty
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
             }
 
             fn is_dirty(&self) -> bool {
@@ -202,6 +213,8 @@ macro_rules! impl_inventory_for_chest {
 
             fn mark_dirty(&self) {
                 self.dirty.store(true, std::sync::atomic::Ordering::Relaxed);
+                self.comparator_dirty
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
             }
 
             fn as_any(&self) -> &dyn std::any::Any {
@@ -302,6 +315,7 @@ macro_rules! impl_chest_helper_methods {
                     position,
                     items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
                     dirty: AtomicBool::new(false),
+                    comparator_dirty: AtomicBool::new(false),
                     viewers: $crate::block::viewer::ViewerCountTracker::new(),
                     loot_table: StdMutex::new(None),
                     loot_table_seed: 0,

--- a/crates/pumpkin/src/block/entities/chiseled_bookshelf.rs
+++ b/crates/pumpkin/src/block/entities/chiseled_bookshelf.rs
@@ -25,6 +25,7 @@ pub struct ChiseledBookshelfBlockEntity {
     pub items: RwLock<[ItemStack; Self::INVENTORY_SIZE]>,
     pub last_interacted_slot: AtomicI8,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 }
 
 const LAST_INTERACTED_SLOT: &str = "last_interacted_slot";
@@ -47,6 +48,7 @@ impl BlockEntity for ChiseledBookshelfBlockEntity {
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             last_interacted_slot: AtomicI8::new(-1),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         };
         pumpkin_inventory::sync_read_items_from_nbt(
             nbt,
@@ -80,6 +82,14 @@ impl BlockEntity for ChiseledBookshelfBlockEntity {
         Some(self as Arc<dyn Inventory>)
     }
 
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
+    }
+
     fn is_dirty(&self) -> bool {
         self.dirty.load(Ordering::Relaxed)
     }
@@ -104,6 +114,7 @@ impl ChiseledBookshelfBlockEntity {
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             last_interacted_slot: AtomicI8::new(-1),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         }
     }
 
@@ -226,6 +237,7 @@ impl Inventory for ChiseledBookshelfBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/pumpkin/src/block/entities/crafter.rs
+++ b/crates/pumpkin/src/block/entities/crafter.rs
@@ -21,6 +21,7 @@ pub struct CrafterBlockEntity {
     pub crafting_ticks_remaining: AtomicI32,
     pub triggered: AtomicBool,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 }
 
 impl BlockEntity for CrafterBlockEntity {
@@ -67,6 +68,7 @@ impl BlockEntity for CrafterBlockEntity {
                     .map_or_else(|| nbt.get_bool("triggered").unwrap_or(false), |t| t != 0),
             ),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         };
 
         sync_read_items_from_nbt(
@@ -124,6 +126,14 @@ impl BlockEntity for CrafterBlockEntity {
         Some(self)
     }
 
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
+    }
+
     fn is_dirty(&self) -> bool {
         self.dirty.load(Ordering::Relaxed)
     }
@@ -174,6 +184,7 @@ impl CrafterBlockEntity {
             crafting_ticks_remaining: AtomicI32::new(0),
             triggered: AtomicBool::new(false),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         }
     }
 
@@ -316,6 +327,7 @@ impl Inventory for CrafterBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/pumpkin/src/block/entities/decorated_pot.rs
+++ b/crates/pumpkin/src/block/entities/decorated_pot.rs
@@ -132,7 +132,8 @@ impl DecoratedPotBlockEntity {
                 if item.item_count == 0 {
                     0
                 } else {
-                    let max_count = 64f32;
+                    // Vanilla scales by the item's own stack size, not a fixed 64.
+                    let max_count = f32::from(item.get_max_stack_size());
                     1 + ((item.item_count as f32 / max_count) * 14.0).floor() as u8
                 }
             })

--- a/crates/pumpkin/src/block/entities/dispenser.rs
+++ b/crates/pumpkin/src/block/entities/dispenser.rs
@@ -14,6 +14,7 @@ pub struct DispenserBlockEntity {
     pub position: BlockPos,
     pub items: RwLock<[ItemStack; Self::INVENTORY_SIZE]>,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 }
 
 impl BlockEntity for DispenserBlockEntity {
@@ -29,6 +30,7 @@ impl BlockEntity for DispenserBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         };
 
         pumpkin_inventory::sync_read_items_from_nbt(
@@ -52,6 +54,14 @@ impl BlockEntity for DispenserBlockEntity {
 
     fn get_inventory(self: Arc<Self>) -> Option<Arc<dyn Inventory>> {
         Some(self)
+    }
+
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
     }
 
     fn is_dirty(&self) -> bool {
@@ -85,6 +95,7 @@ impl DispenserBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         }
     }
 
@@ -164,6 +175,7 @@ impl Inventory for DispenserBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/pumpkin/src/block/entities/dropper.rs
+++ b/crates/pumpkin/src/block/entities/dropper.rs
@@ -14,6 +14,7 @@ pub struct DropperBlockEntity {
     pub position: BlockPos,
     pub items: RwLock<[ItemStack; Self::INVENTORY_SIZE]>,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 }
 
 impl BlockEntity for DropperBlockEntity {
@@ -29,6 +30,7 @@ impl BlockEntity for DropperBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         };
 
         pumpkin_inventory::sync_read_items_from_nbt(
@@ -52,6 +54,14 @@ impl BlockEntity for DropperBlockEntity {
 
     fn get_inventory(self: Arc<Self>) -> Option<Arc<dyn Inventory>> {
         Some(self)
+    }
+
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
     }
 
     fn is_dirty(&self) -> bool {
@@ -85,6 +95,7 @@ impl DropperBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         }
     }
 
@@ -164,6 +175,7 @@ impl Inventory for DropperBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/pumpkin/src/block/entities/furnace.rs
+++ b/crates/pumpkin/src/block/entities/furnace.rs
@@ -22,6 +22,7 @@ use crate::{
 pub struct FurnaceBlockEntity {
     pub position: BlockPos,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 
     pub cooking_time_spent: AtomicU16,
     pub cooking_total_time: AtomicU16,
@@ -44,6 +45,7 @@ impl FurnaceBlockEntity {
         Self {
             position,
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             cooking_total_time: AtomicU16::new(0),
             cooking_time_spent: AtomicU16::new(0),

--- a/crates/pumpkin/src/block/entities/furnace_like_block_entity.rs
+++ b/crates/pumpkin/src/block/entities/furnace_like_block_entity.rs
@@ -342,6 +342,7 @@ macro_rules! impl_inventory_for_cooking {
 
             fn mark_dirty(&self) {
                 self.dirty.store(true, Ordering::Relaxed);
+                self.comparator_dirty.store(true, Ordering::Relaxed);
             }
 
             fn as_any(&self) -> &dyn std::any::Any {
@@ -560,6 +561,7 @@ macro_rules! impl_block_entity_for_cooking {
                 let mut furnace = Self {
                     position,
                     dirty: AtomicBool::new(false),
+                    comparator_dirty: AtomicBool::new(false),
                     items: std::sync::RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
                     cooking_total_time,
                     cooking_time_spent,
@@ -607,6 +609,20 @@ macro_rules! impl_block_entity_for_cooking {
             ) -> Option<Arc<dyn pumpkin_inventory::Inventory>> {
                 Some(self)
             }
+
+            fn is_comparator_dirty(&self) -> bool {
+
+                self.comparator_dirty.load(Ordering::Relaxed)
+
+            }
+
+
+            fn clear_comparator_dirty(&self) {
+
+                self.comparator_dirty.store(false, Ordering::Relaxed);
+
+            }
+
 
             fn is_dirty(&self) -> bool {
                 self.dirty.load(Ordering::Relaxed)

--- a/crates/pumpkin/src/block/entities/hopper.rs
+++ b/crates/pumpkin/src/block/entities/hopper.rs
@@ -22,6 +22,7 @@ pub struct HopperBlockEntity {
     pub position: BlockPos,
     pub items: RwLock<[ItemStack; Self::INVENTORY_SIZE]>,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
     pub facing: FacingHopper,
     pub cooldown_time: AtomicI32,
     pub ticked_game_time: AtomicI64,
@@ -56,6 +57,7 @@ impl BlockEntity for HopperBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
             facing: FacingHopper::Down,
             cooldown_time: AtomicI32::from(nbt.get_int("TransferCooldown").unwrap_or(-1)),
             ticked_game_time: AtomicI64::new(0),
@@ -105,6 +107,14 @@ impl BlockEntity for HopperBlockEntity {
         self.facing = HopperLikeProperties::from_state_id(block_state).facing;
     }
 
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
+    }
+
     fn is_dirty(&self) -> bool {
         self.dirty.load(Ordering::Relaxed)
     }
@@ -140,6 +150,7 @@ impl HopperBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
             facing,
             cooldown_time: AtomicI32::new(-1),
             ticked_game_time: AtomicI64::new(0),
@@ -433,6 +444,7 @@ impl Inventory for HopperBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/pumpkin/src/block/entities/jukebox.rs
+++ b/crates/pumpkin/src/block/entities/jukebox.rs
@@ -21,6 +21,7 @@ pub struct JukeboxBlockEntity {
     /// Length of the current song in ticks (0 if not playing)
     song_length_ticks: AtomicU64,
     dirty: AtomicBool,
+    comparator_dirty: AtomicBool,
 }
 
 const RECORD_ITEM_NBT_KEY: &str = "RecordItem";
@@ -53,6 +54,7 @@ impl BlockEntity for JukeboxBlockEntity {
             ticks_since_song_started: AtomicU64::new(ticks_since_song_started),
             song_length_ticks: AtomicU64::new(0), // Will be set when playing starts
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         }
     }
 
@@ -87,6 +89,14 @@ impl BlockEntity for JukeboxBlockEntity {
                 // In vanilla, the disc stays but music stops and redstone turns off
             }
         }
+    }
+
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
     }
 
     fn is_dirty(&self) -> bool {
@@ -129,6 +139,7 @@ impl JukeboxBlockEntity {
             ticks_since_song_started: AtomicU64::new(0),
             song_length_ticks: AtomicU64::new(0),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         }
     }
 
@@ -190,6 +201,7 @@ impl JukeboxBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 }
 
@@ -240,6 +252,7 @@ impl Inventory for JukeboxBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/pumpkin/src/block/entities/lectern.rs
+++ b/crates/pumpkin/src/block/entities/lectern.rs
@@ -19,6 +19,7 @@ pub struct LecternBlockEntity {
     pub book: Arc<Mutex<ItemStack>>,
     pub page: AtomicUsize,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 }
 
 impl BlockEntity for LecternBlockEntity {
@@ -51,6 +52,7 @@ impl BlockEntity for LecternBlockEntity {
             book,
             page: AtomicUsize::new(page),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         }
     }
 
@@ -69,6 +71,14 @@ impl BlockEntity for LecternBlockEntity {
 
     fn get_inventory(self: Arc<Self>) -> Option<Arc<dyn Inventory>> {
         Some(self)
+    }
+
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
     }
 
     fn is_dirty(&self) -> bool {
@@ -107,6 +117,7 @@ impl LecternBlockEntity {
             book: Arc::new(Mutex::new(ItemStack::EMPTY.clone())),
             page: AtomicUsize::new(0),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         }
     }
 
@@ -133,9 +144,8 @@ impl LecternBlockEntity {
         )
     }
 
-    /// Vanilla comparator output: `floor(page / (page_count - 1) * 14) + 1`,
-    /// or `0` without a book. Single-page books emit `1` (`0 / 0` is `NaN`,
-    /// which vanilla's `MathHelper.floor` turns into `0`).
+    /// Vanilla `LecternBlockEntity.getRedstoneSignal`: `floor(progress * 14) + 1`,
+    /// or `0` without a book. A single-page book counts as fully read and emits 15.
     pub fn comparator_output(&self) -> u8 {
         let book = self
             .book
@@ -145,11 +155,13 @@ impl LecternBlockEntity {
             return 0;
         }
 
-        let page = self.page.load(Ordering::Relaxed) as f32;
-        let page_count = Self::page_count_of(&book) as f32;
-        let fraction = page / (page_count - 1.0) * 14.0;
-        // `NaN as u8` is 0, matching vanilla's cast of NaN to int.
-        fraction.floor() as u8 + 1
+        let page_count = Self::page_count_of(&book);
+        let progress = if page_count > 1 {
+            self.page.load(Ordering::Relaxed) as f32 / (page_count - 1) as f32
+        } else {
+            1.0
+        };
+        (progress * 14.0).floor() as u8 + 1
     }
 }
 
@@ -208,6 +220,7 @@ impl Inventory for LecternBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/pumpkin/src/block/entities/mod.rs
+++ b/crates/pumpkin/src/block/entities/mod.rs
@@ -139,6 +139,13 @@ pub trait BlockEntity: Any + Send + Sync {
         // Override in implementations that have a dirty flag
     }
 
+    /// Same idea as [`Self::is_dirty`]/[`Self::clear_dirty`], tracked separately.
+    fn is_comparator_dirty(&self) -> bool {
+        false
+    }
+
+    fn clear_comparator_dirty(&self) {}
+
     fn as_any(&self) -> &dyn Any;
     fn to_property_delegate(self: Arc<Self>) -> Option<Arc<dyn PropertyDelegate>> {
         None

--- a/crates/pumpkin/src/block/entities/shelf.rs
+++ b/crates/pumpkin/src/block/entities/shelf.rs
@@ -14,6 +14,7 @@ pub struct ShelfBlockEntity {
     pub items: RwLock<[ItemStack; Self::INVENTORY_SIZE]>,
     pub align_items_to_bottom: AtomicBool,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 }
 
 impl BlockEntity for ShelfBlockEntity {
@@ -34,6 +35,7 @@ impl BlockEntity for ShelfBlockEntity {
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             align_items_to_bottom: AtomicBool::new(align_items_to_bottom),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         };
 
         pumpkin_inventory::sync_read_items_from_nbt(
@@ -57,6 +59,14 @@ impl BlockEntity for ShelfBlockEntity {
 
     fn get_inventory(self: Arc<Self>) -> Option<Arc<dyn Inventory>> {
         Some(self)
+    }
+
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
     }
 
     fn is_dirty(&self) -> bool {
@@ -94,6 +104,7 @@ impl ShelfBlockEntity {
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             align_items_to_bottom: AtomicBool::new(false),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
         }
     }
 }
@@ -154,6 +165,7 @@ impl Inventory for ShelfBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/pumpkin/src/block/entities/shulker_box.rs
+++ b/crates/pumpkin/src/block/entities/shulker_box.rs
@@ -16,6 +16,7 @@ pub struct ShulkerBoxBlockEntity {
     pub position: BlockPos,
     pub items: RwLock<[ItemStack; Self::INVENTORY_SIZE]>,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 
     // Viewer
     pub viewers: ViewerCountTracker,
@@ -38,6 +39,7 @@ impl BlockEntity for ShulkerBoxBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
             viewers: ViewerCountTracker::new(),
         };
 
@@ -67,6 +69,14 @@ impl BlockEntity for ShulkerBoxBlockEntity {
 
     fn get_inventory(self: Arc<Self>) -> Option<Arc<dyn Inventory>> {
         Some(self)
+    }
+
+    fn is_comparator_dirty(&self) -> bool {
+        self.comparator_dirty.load(Ordering::Relaxed)
+    }
+
+    fn clear_comparator_dirty(&self) {
+        self.comparator_dirty.store(false, Ordering::Relaxed);
     }
 
     fn is_dirty(&self) -> bool {
@@ -117,6 +127,7 @@ impl ShulkerBoxBlockEntity {
             position,
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
             viewers: ViewerCountTracker::new(),
         }
     }
@@ -201,6 +212,7 @@ impl Inventory for ShulkerBoxBlockEntity {
 
     fn mark_dirty(&self) {
         self.dirty.store(true, Ordering::Relaxed);
+        self.comparator_dirty.store(true, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/pumpkin/src/block/entities/smoker.rs
+++ b/crates/pumpkin/src/block/entities/smoker.rs
@@ -23,6 +23,7 @@ use crate::{
 pub struct SmokerBlockEntity {
     pub position: BlockPos,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 
     pub cooking_time_spent: AtomicU16,
     pub cooking_total_time: AtomicU16,
@@ -45,6 +46,7 @@ impl SmokerBlockEntity {
         Self {
             position,
             dirty: AtomicBool::new(false),
+            comparator_dirty: AtomicBool::new(false),
             items: RwLock::new(from_fn(|_| ItemStack::EMPTY.clone())),
             cooking_total_time: AtomicU16::new(0),
             cooking_time_spent: AtomicU16::new(0),

--- a/crates/pumpkin/src/block/entities/trapped_chest.rs
+++ b/crates/pumpkin/src/block/entities/trapped_chest.rs
@@ -12,6 +12,7 @@ pub struct TrappedChestBlockEntity {
     pub position: BlockPos,
     pub items: RwLock<[ItemStack; Self::INVENTORY_SIZE]>,
     pub dirty: AtomicBool,
+    pub comparator_dirty: AtomicBool,
 
     // Viewer
     viewers: ViewerCountTracker,

--- a/crates/pumpkin/src/block/mod.rs
+++ b/crates/pumpkin/src/block/mod.rs
@@ -434,6 +434,8 @@ pub struct GetComparatorOutputArgs<'a> {
     pub block: &'a Block,
     pub state: &'a BlockState,
     pub position: &'a BlockPos,
+    /// Face of this block that the reading comparator sits against.
+    pub direction: BlockDirection,
 }
 
 pub struct GetInsideCollisionShapeArgs<'a> {
@@ -541,6 +543,17 @@ impl BlockIsReplacing {
             _ => false,
         }
     }
+}
+
+/// Vanilla `AbstractContainerMenu.getRedstoneSignalFromBlockEntity`: read a block
+/// entity's own inventory as a comparator would.
+#[must_use]
+pub fn container_comparator_output(args: &GetComparatorOutputArgs<'_>) -> Option<u8> {
+    let inventory = args
+        .world
+        .get_block_entity(args.position)?
+        .get_inventory()?;
+    Some(calculate_comparator_output(inventory.as_ref()))
 }
 
 pub fn calculate_comparator_output(inventory: &dyn pumpkin_inventory::Inventory) -> u8 {

--- a/crates/pumpkin/src/command/commands/forceload.rs
+++ b/crates/pumpkin/src/command/commands/forceload.rs
@@ -31,6 +31,16 @@ static ERROR_TOO_MANY: CommandErrorType<2> = CommandErrorType::new(
     "Too many chunks",
 );
 
+fn chunk_range(min_x: i32, min_z: i32, max_x: i32, max_z: i32) -> Vec<Vector2<i32>> {
+    let mut positions = Vec::new();
+    for x in min_x..=max_x {
+        for z in min_z..=max_z {
+            positions.push(Vector2::new(x, z));
+        }
+    }
+    positions
+}
+
 struct ForceloadAddExecutor;
 
 impl CommandExecutor for ForceloadAddExecutor {
@@ -71,19 +81,7 @@ impl CommandExecutor for ForceloadAddExecutor {
             ));
         }
 
-        {
-            let mut forced = world
-                .forced_chunks
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            for x in min_x..=max_x {
-                for z in min_z..=max_z {
-                    forced.insert(Vector2::new(x, z));
-                }
-            }
-        }
-
-        world.update_active_chunks();
+        world.set_chunks_forced(&chunk_range(min_x, min_z, max_x, max_z), true);
 
         let dimension_name = world.dimension.minecraft_name.to_string();
 
@@ -154,19 +152,7 @@ impl CommandExecutor for ForceloadRemoveExecutor {
             ));
         }
 
-        {
-            let mut forced = world
-                .forced_chunks
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            for x in min_x..=max_x {
-                for z in min_z..=max_z {
-                    forced.remove(&Vector2::new(x, z));
-                }
-            }
-        }
-
-        world.update_active_chunks();
+        world.set_chunks_forced(&chunk_range(min_x, min_z, max_x, max_z), false);
 
         let dimension_name = world.dimension.minecraft_name.to_string();
 
@@ -207,17 +193,14 @@ impl CommandExecutor for ForceloadRemoveAllExecutor {
             .as_ref()
             .ok_or_else(|| ERROR_FAILED_REMOVE.create_without_context())?;
 
-        let removed_count = {
-            let mut forced = world
-                .forced_chunks
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let count = forced.len();
-            forced.clear();
-            count
-        };
-
-        world.update_active_chunks();
+        let all: Vec<Vector2<i32>> = world
+            .forced_chunks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .copied()
+            .collect();
+        let removed_count = world.set_chunks_forced(&all, false);
 
         let dimension_name = world.dimension.minecraft_name.to_string();
 

--- a/crates/pumpkin/src/command/commands/plugin.rs
+++ b/crates/pumpkin/src/command/commands/plugin.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::path::Path;
 
 use pumpkin_util::PermissionLvl;
@@ -9,56 +10,112 @@ use pumpkin_util::text::hover::HoverEvent;
 use crate::command::argument_builder::{ArgumentBuilder, argument, command, literal};
 use crate::command::argument_types::core::string::StringArgumentType;
 use crate::command::context::command_context::CommandContext;
+use crate::command::context::command_source::CommandSource;
 use crate::command::node::dispatcher::CommandDispatcher;
 use crate::command::node::{CommandExecutor, CommandExecutorResult};
+use crate::plugin::{PluginEntry, PluginStatus};
 
 const DESCRIPTION: &str = "Manage server plugins.";
 const PERMISSION: &str = "pumpkin:command.plugin";
+
+/// Green while running, yellow while starting, red for everything that is not.
+pub(super) const fn status_color(status: &PluginStatus) -> NamedColor {
+    match status {
+        PluginStatus::Active => NamedColor::Green,
+        PluginStatus::Loading => NamedColor::Yellow,
+        _ => NamedColor::Red,
+    }
+}
+
+/// plugin Tooltip -> tells about itself, plus why it is not running.
+pub(super) fn hover_text(entry: &PluginEntry) -> String {
+    let mut text = entry.metadata.as_ref().map_or_else(
+        || format!("File: {}", entry.path.display()),
+        |metadata| {
+            format!(
+                "Version: {}\nAuthors: {}\nDescription: {}",
+                metadata.version,
+                metadata.authors.join(", "),
+                metadata.description
+            )
+        },
+    );
+
+    if !entry.status.is_active() {
+        let _ = write!(text, "\nStatus: {}", entry.status);
+    }
+
+    text
+}
+
+/// Sends the outcome of a plugin operation, green on success and red on failure.
+fn send_result(source: &CommandSource, result: Result<(), String>, success: String) {
+    match result {
+        Ok(()) => source.send_feedback(
+            TextComponent::text(success).color_named(NamedColor::Green),
+            true,
+        ),
+        Err(message) => source.send_feedback(
+            TextComponent::text(message).color_named(NamedColor::Red),
+            false,
+        ),
+    }
+}
 
 struct ListExecutor;
 
 impl CommandExecutor for ListExecutor {
     fn execute(&self, context: &CommandContext) -> CommandExecutorResult {
         let server_arc = context.server().clone();
-        let plugins = server_arc.plugin_manager.active_plugins();
-        let loaded_plugins = server_arc.plugin_manager.loaded_plugins();
+        let source_clone = context.source.clone();
+        let server_clone = server_arc.clone();
 
-        let mut message = TextComponent::text(format!("Plugins ({}):", loaded_plugins.len()))
-            .color_named(NamedColor::Gold)
-            .add_child(TextComponent::text("\n"));
+        server_arc.spawn_task(async move {
+            let entries = server_clone.plugin_manager.plugin_entries().await;
+            let active = entries.iter().filter(|e| e.status.is_active()).count();
 
-        for (i, plugin) in plugins.iter().enumerate() {
-            let metadata = plugin;
-            let version = metadata
-                .version
-                .strip_prefix('v')
-                .unwrap_or(&metadata.version);
-            let line = if i == plugins.len() - 1 {
-                format!("- {} (v{version})", metadata.name)
-            } else {
-                format!("- {} (v{version})\n", metadata.name)
-            };
-            let hover_text = format!(
-                "Version: {}\nAuthors: {}\nDescription: {}",
-                metadata.version,
-                metadata.authors.join(", "),
-                metadata.description
-            );
-            let mut plugin_component = TextComponent::text(line)
-                .color_named(NamedColor::Green)
-                .hover_event(HoverEvent::show_text(TextComponent::text(hover_text)));
+            let mut message = TextComponent::text(format!("Plugins ({active}/{}):", entries.len()))
+                .color_named(NamedColor::Gold)
+                .add_child(TextComponent::text("\n"));
 
-            if !metadata.permissions.is_empty() {
-                plugin_component = plugin_component.add_child(
-                    TextComponent::text(format!(" (Permissions: {:?})", metadata.permissions))
-                        .color_named(NamedColor::Gray),
+            for (i, entry) in entries.iter().enumerate() {
+                let name = entry.name();
+                let line = entry.metadata.as_ref().map_or_else(
+                    || format!("- {name}"),
+                    |metadata| {
+                        let version = metadata
+                            .version
+                            .strip_prefix('v')
+                            .unwrap_or(&metadata.version);
+                        format!("- {name} (v{version})")
+                    },
                 );
+                let line = if i == entries.len() - 1 {
+                    line
+                } else {
+                    format!("{line}\n")
+                };
+
+                let mut plugin_component = TextComponent::text(line)
+                    .color_named(status_color(&entry.status))
+                    .hover_event(HoverEvent::show_text(TextComponent::text(hover_text(
+                        entry,
+                    ))));
+
+                if let Some(metadata) = &entry.metadata
+                    && !metadata.permissions.is_empty()
+                {
+                    plugin_component = plugin_component.add_child(
+                        TextComponent::text(format!(" (Permissions: {:?})", metadata.permissions))
+                            .color_named(NamedColor::Gray),
+                    );
+                }
+
+                message = message.add_child(plugin_component);
             }
 
-            message = message.add_child(plugin_component);
-        }
-
-        context.source.send_feedback(message, false);
+            source_clone.send_feedback(message, false);
+        });
 
         Ok(1)
     }
@@ -86,27 +143,14 @@ impl CommandExecutor for LoadExecutor {
             let result = server_clone
                 .plugin_manager
                 .try_load_plugin(&server_clone, Path::new(&plugin_name_clone))
-                .await;
+                .await
+                .map_err(|e| format!("Failed to load plugin {plugin_name_clone}: {e}"));
 
-            match result {
-                Ok(()) => {
-                    source_clone.send_feedback(
-                        TextComponent::text(format!(
-                            "Plugin {plugin_name_clone} loaded successfully"
-                        ))
-                        .color_named(NamedColor::Green),
-                        true,
-                    );
-                }
-                Err(e) => {
-                    source_clone.send_feedback(
-                        TextComponent::text(format!(
-                            "Failed to load plugin {plugin_name_clone}: {e}"
-                        )),
-                        false,
-                    );
-                }
-            }
+            send_result(
+                &source_clone,
+                result,
+                format!("Plugin {plugin_name_clone} loaded successfully"),
+            );
         });
 
         Ok(1)
@@ -135,27 +179,145 @@ impl CommandExecutor for UnloadExecutor {
             let result = server_clone
                 .plugin_manager
                 .unload_plugin(&plugin_name_clone)
-                .await;
+                .await
+                .map_err(|e| format!("Failed to unload plugin {plugin_name_clone}: {e}"));
 
-            match result {
-                Ok(()) => {
-                    source_clone.send_feedback(
-                        TextComponent::text(format!(
-                            "Plugin {plugin_name_clone} unloaded successfully"
-                        ))
-                        .color_named(NamedColor::Green),
-                        true,
-                    );
-                }
-                Err(e) => {
-                    source_clone.send_feedback(
-                        TextComponent::text(format!(
-                            "Failed to unload plugin {plugin_name_clone}: {e}"
-                        )),
-                        false,
-                    );
-                }
+            send_result(
+                &source_clone,
+                result,
+                format!("Plugin {plugin_name_clone} unloaded successfully"),
+            );
+        });
+
+        Ok(1)
+    }
+}
+
+struct ReloadExecutor;
+
+impl CommandExecutor for ReloadExecutor {
+    fn execute(&self, context: &CommandContext) -> CommandExecutorResult {
+        let plugin_name = StringArgumentType::get(context, "plugin")?.to_string();
+        let server_arc = context.server().clone();
+
+        let source_clone = context.source.clone();
+        let server_clone = server_arc.clone();
+        server_arc.spawn_task(async move {
+            // The manager has no reload: unload takes a name, load takes the file it came from
+            let Some(entry) = server_clone.plugin_manager.plugin_entry(&plugin_name).await else {
+                source_clone.send_feedback(
+                    TextComponent::text(format!("Plugin {plugin_name} is not known"))
+                        .color_named(NamedColor::Red),
+                    false,
+                );
+                return;
+            };
+
+            // Loading it a second time would leave two copies registered
+            if !entry.can_unload {
+                source_clone.send_feedback(
+                    TextComponent::text(format!(
+                        "Plugin {plugin_name} cannot be unloaded at runtime, restart the server"
+                    ))
+                    .color_named(NamedColor::Red),
+                    false,
+                );
+                return;
             }
+
+            if server_clone.plugin_manager.is_plugin_loaded(&plugin_name)
+                && let Err(e) = server_clone
+                    .plugin_manager
+                    .unload_plugin(&plugin_name)
+                    .await
+            {
+                source_clone.send_feedback(
+                    TextComponent::text(format!("Failed to unload plugin {plugin_name}: {e}"))
+                        .color_named(NamedColor::Red),
+                    false,
+                );
+                return;
+            }
+
+            let result = server_clone
+                .plugin_manager
+                .try_load_plugin(&server_clone, &entry.path)
+                .await
+                // The plugin is unloaded at this point, so say so
+                .map_err(|e| {
+                    format!("Plugin {plugin_name} was unloaded but could not be loaded again: {e}")
+                });
+
+            send_result(
+                &source_clone,
+                result,
+                format!("Plugin {plugin_name} reloaded successfully"),
+            );
+        });
+
+        Ok(1)
+    }
+}
+
+/// One gray detail line appended to a `/plugin info` message.
+fn info_line(message: TextComponent, text: String) -> TextComponent {
+    message
+        .add_child(TextComponent::text("\n"))
+        .add_child(TextComponent::text(text).color_named(NamedColor::Gray))
+}
+
+/// Full `/plugin info` message for one entry: name, status, path, and metadata when there is any.
+fn info_message(entry: &PluginEntry) -> TextComponent {
+    let mut message = TextComponent::text(entry.name().into_owned())
+        .color_named(NamedColor::Gold)
+        .add_child(TextComponent::text("\n"))
+        .add_child(
+            TextComponent::text(format!("Status: {}", entry.status))
+                .color_named(status_color(&entry.status)),
+        );
+    message = info_line(message, format!("Path: {}", entry.path.display()));
+
+    let Some(metadata) = &entry.metadata else {
+        return message;
+    };
+
+    message = info_line(message, format!("Version: {}", metadata.version));
+    message = info_line(message, format!("Authors: {}", metadata.authors.join(", ")));
+    message = info_line(message, format!("Description: {}", metadata.description));
+
+    if !metadata.dependencies.is_empty() {
+        message = info_line(
+            message,
+            format!("Dependencies: {}", metadata.dependencies.join(", ")),
+        );
+    }
+    if !metadata.permissions.is_empty() {
+        message = info_line(message, format!("Permissions: {:?}", metadata.permissions));
+    }
+
+    message
+}
+
+struct InfoExecutor;
+
+impl CommandExecutor for InfoExecutor {
+    fn execute(&self, context: &CommandContext) -> CommandExecutorResult {
+        let plugin_name = StringArgumentType::get(context, "plugin")?.to_string();
+        let server_arc = context.server().clone();
+
+        let source_clone = context.source.clone();
+        let server_clone = server_arc.clone();
+        server_arc.spawn_task(async move {
+            let Some(entry) = server_clone.plugin_manager.plugin_entry(&plugin_name).await else {
+                source_clone.send_feedback(
+                    TextComponent::text(format!("Plugin {plugin_name} is not known"))
+                        .color_named(NamedColor::Red),
+                    false,
+                );
+                return;
+            };
+
+            source_clone.send_feedback(info_message(&entry), false);
         });
 
         Ok(1)
@@ -220,16 +382,19 @@ pub fn register(dispatcher: &mut CommandDispatcher, registry: &PermissionRegistr
         command("plugin", DESCRIPTION)
             .requires(PERMISSION)
             .then(literal("list").executes(ListExecutor))
-            .then(
-                literal("load").then(
-                    argument("plugin", StringArgumentType::SingleWord).executes(LoadExecutor),
-                ),
-            )
-            .then(
-                literal("unload").then(
-                    argument("plugin", StringArgumentType::SingleWord).executes(UnloadExecutor),
-                ),
-            )
+            // Quotable rather than a single word: `load` takes a path, and names can contain spaces
+            .then(literal("load").then(
+                argument("plugin", StringArgumentType::QuotablePhrase).executes(LoadExecutor),
+            ))
+            .then(literal("unload").then(
+                argument("plugin", StringArgumentType::QuotablePhrase).executes(UnloadExecutor),
+            ))
+            .then(literal("reload").then(
+                argument("plugin", StringArgumentType::QuotablePhrase).executes(ReloadExecutor),
+            ))
+            .then(literal("info").then(
+                argument("plugin", StringArgumentType::QuotablePhrase).executes(InfoExecutor),
+            ))
             .then(
                 literal("hotreload")
                     .then(literal("enable").executes(HotReloadExecutor(true)))

--- a/crates/pumpkin/src/command/commands/plugins.rs
+++ b/crates/pumpkin/src/command/commands/plugins.rs
@@ -5,54 +5,51 @@ use pumpkin_util::text::color::NamedColor;
 use pumpkin_util::text::hover::HoverEvent;
 
 use crate::command::argument_builder::{ArgumentBuilder, command};
+use crate::command::commands::plugin::{hover_text, status_color};
 use crate::command::context::command_context::CommandContext;
 use crate::command::node::dispatcher::CommandDispatcher;
 use crate::command::node::{CommandExecutor, CommandExecutorResult};
 
-const DESCRIPTION: &str = "Lists all plugins loaded on the server.";
+const DESCRIPTION: &str = "Lists all plugins on the server.";
 const PERMISSION: &str = "pumpkin:command.plugins";
 
 struct PluginsExecutor;
 
 impl CommandExecutor for PluginsExecutor {
     fn execute(&self, context: &CommandContext) -> CommandExecutorResult {
-        let server_arc = context.server();
-        let plugins = server_arc.plugin_manager.active_plugins();
+        let server_arc = context.server().clone();
+        let source_clone = context.source.clone();
+        let server_clone = server_arc.clone();
 
-        let message_text = if plugins.is_empty() {
-            TextComponent::text("No plugins are loaded on the server.").color_named(NamedColor::Red)
-        } else {
-            let mut base_message = TextComponent::text(format!("Plugins ({}): ", plugins.len()))
-                .color_named(NamedColor::White);
+        server_arc.spawn_task(async move {
+            let entries = server_clone.plugin_manager.plugin_entries().await;
 
-            for (i, plugin) in plugins.iter().enumerate() {
-                let name = &plugin.name;
-                let version = plugin.version.strip_prefix('v').unwrap_or(&plugin.version);
-                let author_text = plugin.authors.join(", ");
-                let description = &plugin.description;
+            let message_text = if entries.is_empty() {
+                TextComponent::text("No plugins are installed on the server.")
+                    .color_named(NamedColor::Red)
+            } else {
+                let mut base_message =
+                    TextComponent::text(format!("Plugins ({}): ", entries.len()))
+                        .color_named(NamedColor::White);
 
-                let hover_text = format!(
-                    "Version: {version}\nAuthors: {author_text}\nDescription: {description}"
-                );
+                for (i, entry) in entries.iter().enumerate() {
+                    let plugin_component = TextComponent::text(entry.name().into_owned())
+                        .color_named(status_color(&entry.status))
+                        .hover_event(HoverEvent::show_text(TextComponent::text(hover_text(
+                            entry,
+                        ))));
 
-                let plugin_component = TextComponent::text(name.clone())
-                    .color_named(NamedColor::Green)
-                    .hover_event(HoverEvent::show_text(TextComponent::text(hover_text)));
-
-                if i > 0 {
+                    let separator = if i > 0 { ", " } else { " " };
                     base_message = base_message
-                        .add_child(TextComponent::text(", ").color_named(NamedColor::White));
-                } else {
-                    base_message = base_message
-                        .add_child(TextComponent::text(" ").color_named(NamedColor::White));
+                        .add_child(TextComponent::text(separator).color_named(NamedColor::White))
+                        .add_child(plugin_component);
                 }
-                base_message = base_message.add_child(plugin_component);
-            }
 
-            base_message
-        };
+                base_message
+            };
 
-        context.source.send_feedback(message_text, false);
+            source_clone.send_feedback(message_text, false);
+        });
 
         Ok(1)
     }

--- a/crates/pumpkin/src/plugin/mod.rs
+++ b/crates/pumpkin/src/plugin/mod.rs
@@ -4,6 +4,7 @@ use loader::{LoaderError, PluginLoader, native::NativePluginLoader};
 use notify::{EventKind, RecursiveMode, Watcher, event::ModifyKind};
 use std::{
     any::Any,
+    borrow::Cow,
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     pin::Pin,
@@ -180,12 +181,94 @@ pub enum PluginState {
     Failed(String),
 }
 
+/// State of a plugin file the manager knows about, running or not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluginStatus {
+    Active,
+    Loading,
+    /// Unloaded on request
+    Unloaded,
+    /// Turned off in the configuration, or a `.deactivated` file
+    Disabled,
+    /// Unsigned while `allow_unsigned` is off
+    Unsigned,
+    PermissionDenied,
+    /// Loader or initialization error
+    Failed(String),
+    /// No loader accepts the file
+    NoLoader,
+}
+
+impl PluginStatus {
+    #[must_use]
+    pub const fn is_active(&self) -> bool {
+        matches!(self, Self::Active)
+    }
+}
+
+impl std::fmt::Display for PluginStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Active => f.write_str("Running"),
+            Self::Loading => f.write_str("Loading"),
+            Self::Unloaded => f.write_str("Unloaded"),
+            Self::Disabled => f.write_str("Disabled in the server configuration"),
+            Self::Unsigned => {
+                f.write_str("Unsigned or invalid signature, and allow_unsigned is off")
+            }
+            Self::PermissionDenied => f.write_str("Permission request denied"),
+            Self::Failed(error) => write!(f, "Failed: {error}"),
+            Self::NoLoader => f.write_str("No plugin loader accepts this file"),
+        }
+    }
+}
+
+/// A plugin file, running or not.
+#[derive(Debug, Clone)]
+pub struct PluginEntry {
+    /// `None` when the file never got far enough to name itself
+    pub metadata: Option<PluginMetadata>,
+    pub path: PathBuf,
+    pub status: PluginStatus,
+    /// False while the loader holds it and cannot release it at runtime
+    pub can_unload: bool,
+}
+
+impl PluginEntry {
+    /// The plugin name, or the file name when it never named itself.
+    #[must_use]
+    pub fn name(&self) -> Cow<'_, str> {
+        self.metadata.as_ref().map_or_else(
+            || self.path.file_name().unwrap_or_default().to_string_lossy(),
+            |metadata| Cow::Borrowed(metadata.name.as_str()),
+        )
+    }
+}
+
+/// Keeps the first, richer record when a later source names the same plugin again.
+fn push_unless_known(entries: &mut Vec<PluginEntry>, entry: PluginEntry) {
+    if !entries.iter().any(|known| known.name() == entry.name()) {
+        entries.push(entry);
+    }
+}
+
+/// Whether a file claims to be a plugin, by extension.
+fn is_plugin_file(path: &Path) -> bool {
+    path.extension().is_some_and(|ext| {
+        ["wasm", "so", "dll", "dylib", "deactivated"]
+            .iter()
+            .any(|known| ext.eq_ignore_ascii_case(known))
+    })
+}
+
 /// Core plugin management system
 pub struct PluginManager {
     plugins: SyncRwLock<Vec<LoadedPlugin>>,
     loaders: RwLock<Vec<Arc<dyn PluginLoader>>>,
     handlers: Arc<ArcSwap<HandlerMap>>,
     unloaded_files: RwLock<HashSet<PathBuf>>,
+    /// Plugin files that are known but not running, by path
+    inactive: RwLock<HashMap<PathBuf, PluginEntry>>,
     services: Arc<RwLock<HashMap<String, Arc<dyn Payload>>>>,
     // Plugin state tracking
     plugin_states: RwLock<HashMap<String, PluginState>>,
@@ -244,6 +327,7 @@ impl PluginManager {
             ]),
             handlers: Arc::new(ArcSwap::from_pointee(HashMap::new())),
             unloaded_files: RwLock::new(HashSet::new()),
+            inactive: RwLock::new(HashMap::new()),
             services: Arc::new(RwLock::new(HashMap::new())),
             plugin_states: RwLock::new(HashMap::new()),
             state_notify: Arc::new(Notify::new()),
@@ -566,6 +650,8 @@ impl PluginManager {
             Arc::clone(&LOGGER_IMPL),
         ));
 
+        let plugin_path = path.clone();
+
         // Create the plugin structure first
         let plugin = LoadedPlugin {
             metadata: metadata.clone(),
@@ -612,6 +698,7 @@ impl PluginManager {
                         .write()
                         .await
                         .insert(plugin_name.clone(), PluginState::Loaded);
+                    self_ref_clone.inactive.write().await.remove(&plugin_path);
                     state_notify.notify_waiters();
 
                     info!("Loaded {} ({})", metadata.name, metadata.version);
@@ -660,6 +747,14 @@ impl PluginManager {
                         .write()
                         .await
                         .insert(plugin_name.clone(), PluginState::Failed(error_msg.clone()));
+                    // Keep it listed with its error, so it can be tried again
+                    self_ref_clone
+                        .mark_inactive(
+                            &plugin_path,
+                            Some(&metadata),
+                            PluginStatus::Failed(error_msg.clone()),
+                        )
+                        .await;
                     state_notify.notify_waiters();
 
                     error!("Failed to initialize plugin {plugin_name}: {error_msg}",);
@@ -701,6 +796,8 @@ impl PluginManager {
                 .extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("deactivated"))
             {
+                self.mark_inactive(&path, None, PluginStatus::Disabled)
+                    .await;
                 continue;
             }
 
@@ -718,6 +815,8 @@ impl PluginManager {
                                     "Plugin \"{}\" is disabled in configuration, skipping.",
                                     metadata.name
                                 );
+                                self.mark_inactive(&path, Some(&metadata), PluginStatus::Disabled)
+                                    .await;
                                 loader_found = true;
                                 break;
                             }
@@ -737,6 +836,12 @@ impl PluginManager {
                                         "Plugin \"{}\" ({:?}) is unsigned or invalid and allow_unsigned is disabled in configuration, skipping.",
                                         metadata.name, path
                                     );
+                                    self.mark_inactive(
+                                        &path,
+                                        Some(&metadata),
+                                        PluginStatus::Unsigned,
+                                    )
+                                    .await;
                                     loader_found = true;
                                     break;
                                 }
@@ -751,7 +856,13 @@ impl PluginManager {
                             ));
                             loader_found = true;
                         }
-                        Err(err) => error!("Failed to load plugin from {:?}: {}", path, err),
+                        Err(err) => {
+                            error!("Failed to load plugin from {:?}: {}", path, err);
+                            // No metadata -> the file never named itself
+                            self.mark_inactive(&path, None, PluginStatus::Failed(err.to_string()))
+                                .await;
+                            loader_found = true;
+                        }
                     }
                     break;
                 }
@@ -804,6 +915,8 @@ impl PluginManager {
                         "Permission denied for plugin \"{}\", skipping loading.",
                         metadata.name
                     );
+                    self.mark_inactive(&path, Some(&metadata), PluginStatus::PermissionDenied)
+                        .await;
                     continue;
                 }
 
@@ -922,7 +1035,16 @@ impl PluginManager {
         let loaders = self.loaders.read().await.clone();
         for loader in &loaders {
             if loader.can_load(path) {
-                let (instance, metadata, loader_data) = loader.load(path).await?;
+                let (instance, metadata, loader_data) = match loader.load(path).await {
+                    Ok(loaded) => loaded,
+                    Err(err) => {
+                        error!("Failed to load plugin from {:?}: {}", path, err);
+                        // No metadata -> the file never named itself
+                        self.mark_inactive(path, None, PluginStatus::Failed(err.to_string()))
+                            .await;
+                        return Err(err.into());
+                    }
+                };
 
                 let plugin_override = server.advanced_config.plugins.overrides.get(&metadata.name);
 
@@ -966,10 +1088,15 @@ impl PluginManager {
                         "Permission denied for plugin \"{}\", skipping loading.",
                         metadata.name
                     );
+                    self.mark_inactive(path, Some(&metadata), PluginStatus::PermissionDenied)
+                        .await;
                     return Err(ManagerError::LoaderError(LoaderError::RuntimeError(
                         "Permission denied".to_string(),
                     )));
                 }
+
+                // A loader took it, so it is no longer waiting for one
+                self.unloaded_files.write().await.remove(path);
 
                 return self
                     .spawn_plugin_initialization(
@@ -1082,6 +1209,90 @@ impl PluginManager {
         plugins.iter().map(|p| p.metadata.clone()).collect()
     }
 
+    /// Every plugin file the manager knows about: running, unloaded, failed or without a loader.
+    ///
+    /// Sorted by name; the first, richer record wins when a plugin is named more than once.
+    pub async fn plugin_entries(&self) -> Vec<PluginEntry> {
+        let states = self.plugin_states.read().await;
+
+        let mut entries: Vec<PluginEntry> = {
+            let plugins = self
+                .plugins
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            plugins
+                .iter()
+                .map(|p| PluginEntry {
+                    status: if p.is_active && p.instance.is_some() {
+                        PluginStatus::Active
+                    } else {
+                        match states.get(&p.metadata.name) {
+                            Some(PluginState::Loading) => PluginStatus::Loading,
+                            Some(PluginState::Failed(error)) => PluginStatus::Failed(error.clone()),
+                            _ => PluginStatus::Unloaded,
+                        }
+                    },
+                    metadata: Some(p.metadata.clone()),
+                    path: p.path.clone(),
+                    can_unload: p.loader.can_unload(),
+                })
+                .collect()
+        };
+        drop(states);
+
+        for entry in self.inactive.read().await.values() {
+            push_unless_known(&mut entries, entry.clone());
+        }
+
+        for path in self.unloaded_files.read().await.iter() {
+            // Only files that claim to be a plugin, not a readme or a config next to them
+            if !is_plugin_file(path) {
+                continue;
+            }
+            push_unless_known(
+                &mut entries,
+                PluginEntry {
+                    metadata: None,
+                    path: path.clone(),
+                    status: PluginStatus::NoLoader,
+                    can_unload: true,
+                },
+            );
+        }
+
+        entries.sort_by(|a, b| a.name().cmp(&b.name()));
+        entries
+    }
+
+    /// The plugin with this name, running or not.
+    ///
+    /// Reloading needs it: `unload_plugin` takes a name but `try_load_plugin` takes a file.
+    pub async fn plugin_entry(&self, name: &str) -> Option<PluginEntry> {
+        self.plugin_entries()
+            .await
+            .into_iter()
+            .find(|entry| entry.name() == name)
+    }
+
+    /// Records why a plugin file is not running, so it can be reported and not only logged.
+    async fn mark_inactive(
+        &self,
+        path: &Path,
+        metadata: Option<&PluginMetadata>,
+        status: PluginStatus,
+    ) {
+        self.inactive.write().await.insert(
+            path.to_path_buf(),
+            PluginEntry {
+                metadata: metadata.cloned(),
+                path: path.to_path_buf(),
+                status,
+                // Nothing is resident, so there is nothing that could block a load
+                can_unload: true,
+            },
+        );
+    }
+
     /// Unload a plugin by name
     pub async fn unload_plugin(&self, name: &str) -> Result<(), ManagerError> {
         let mut plugin = {
@@ -1104,9 +1315,12 @@ impl PluginManager {
         }
 
         if plugin.loader.can_unload() {
-            if let Some(data) = plugin.loader_data {
+            if let Some(data) = plugin.loader_data.take() {
                 plugin.loader.unload(data).await?;
             }
+            // Dropped from `plugins`, so remember it here or it vanishes from every view
+            self.mark_inactive(&plugin.path, Some(&plugin.metadata), PluginStatus::Unloaded)
+                .await;
         } else {
             plugin.is_active = false;
             self.plugins

--- a/crates/pumpkin/src/server/server_test_manager.rs
+++ b/crates/pumpkin/src/server/server_test_manager.rs
@@ -299,15 +299,8 @@ fn acquire_forced_game_test_chunk(world: &World, chunk: Vector2<i32>) {
         return;
     }
 
-    let was_forced = {
-        let mut forced_chunks = world
-            .forced_chunks
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let was_forced = forced_chunks.contains(&chunk);
-        forced_chunks.insert(chunk);
-        was_forced
-    };
+    // Go through `set_chunks_forced` so the chunk gets its loading ticket too.
+    let was_forced = world.set_chunks_forced(&[chunk], true) == 0;
     leases.insert(
         key,
         ForcedGameTestChunk {
@@ -334,11 +327,7 @@ fn release_forced_game_test_chunk(world: &World, chunk: Vector2<i32>) {
     drop(leases);
 
     if release_world_chunk {
-        world
-            .forced_chunks
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .remove(&chunk);
+        world.set_chunks_forced(&[chunk], false);
     }
 }
 

--- a/crates/pumpkin/src/world/chunker.rs
+++ b/crates/pumpkin/src/world/chunker.rs
@@ -103,7 +103,11 @@ pub fn update_position(player: &Arc<Player>) {
         let sim_dist = world.server.upgrade().map_or(10, |s| {
             s.advanced_config.networking.java.simulation_distance.get()
         });
-        pumpkin_world::chunk_system::ChunkLoading::get_level_from_simulation_distance(sim_dist)
+        // `+ 1` so every simulated chunk keeps loaded neighbours, which block updates
+        // across a chunk border need. Same reason the view ticket adds a ring.
+        pumpkin_world::chunk_system::ChunkLoading::get_level_from_simulation_distance(
+            sim_dist.saturating_add(1),
+        )
     });
 
     {

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -237,6 +237,10 @@ impl PumpkinError for GetBlockError {
     }
 }
 
+/// One ring of loaded neighbours around a forced chunk, so cross-border block updates
+/// resolve. Vanilla's `FORCED_TICKET_LEVEL` keeps two.
+const FORCED_TICKET_LEVEL: i8 = pumpkin_world::chunk_system::ChunkLoading::FULL_CHUNK_LEVEL - 1;
+
 /// Represents a Minecraft world, containing entities, players, and the underlying level data.
 ///
 /// Each dimension (Overworld, Nether, End) typically has its own `World`.
@@ -424,6 +428,47 @@ impl World {
             custom_block_entity_data: DashMap::new(),
             entity_tracker: entity_tracker::EntityTracker::new(),
         }
+    }
+
+    /// Vanilla `ServerLevel.setChunkForced`. The set drives simulation, keeps
+    /// the chunk and a ring of neighbours loaded so block updates can cross the border.
+    pub fn set_chunks_forced(&self, positions: &[Vector2<i32>], forced: bool) -> usize {
+        let changed: Vec<Vector2<i32>> = {
+            let mut set = self
+                .forced_chunks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            positions
+                .iter()
+                .copied()
+                .filter(|pos| {
+                    if forced {
+                        set.insert(*pos)
+                    } else {
+                        set.remove(pos)
+                    }
+                })
+                .collect()
+        };
+
+        if !changed.is_empty() {
+            let mut lock = self
+                .level
+                .chunk_loading
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for pos in &changed {
+                if forced {
+                    lock.add_ticket(*pos, FORCED_TICKET_LEVEL);
+                } else {
+                    lock.remove_ticket(*pos, FORCED_TICKET_LEVEL);
+                }
+            }
+            lock.send_change();
+            self.update_active_chunks();
+        }
+
+        changed.len()
     }
 
     pub fn update_active_chunks(&self) {

--- a/crates/pumpkin/src/world/mod.rs
+++ b/crates/pumpkin/src/world/mod.rs
@@ -1592,6 +1592,15 @@ impl World {
             let _guard = be_handle.enter();
             for be in batch {
                 be.tick(self);
+                // Vanilla `BlockEntity.setChanged` -> `Level.updateNeighbourForOutputSignal`.
+                if be.is_comparator_dirty() {
+                    be.clear_comparator_dirty();
+                    let pos = be.get_position();
+                    // The batch is a snapshot, so the chunk may be gone by now.
+                    if let Some(state_id) = self.get_block_state_id_if_loaded(&pos) {
+                        self.update_neighbour_for_output_signal(&pos, state_id.to_block());
+                    }
+                }
             }
         });
         let block_entity_elapsed = t_be.elapsed();


### PR DESCRIPTION
## Description
Implement Comparator helper for consistency and add missing comparator signals from blocks.
Comparator dirty flag for cheap updating, no block update for the comparator anymore

- Add comparator helper function for container block entity inventory reading
- Implement `get_comparator_output` for all container blocks (barrels, furnaces, hoppers, chests, etc.)
- Complete comparator redstone gate logic with signal calculation, neighbor detection, and state tracking
- Update `GetComparatorOutputArgs` to include reading face direction

## Fllow-Up

Detector Rail: Requires minecart implementation. Will be addressed separately once minecart movement and entity tracking are complete.

## Testing

- cargo clippy --release
- Game testing: container signal output, mode switching, neighbor detection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin status information, improved plugin listings, and new plugin `reload` and `info` commands.
  * Forced chunks now maintain nearby loaded neighbors, improving world continuity.
  * Added comparator support for end portal frames, respawn anchors, candle cakes, and copper golem statues.

* **Bug Fixes**
  * Improved comparator signals for containers, cakes, chests, shelves, lecterns, decorated pots, sculk sensors, and jukeboxes.
  * Scheduled block and fluid ticks now run only in active chunks and persist correctly across reloads.
  * Improved forced-chunk command handling and simulation-distance loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->