### PR TITLE
feat(config): validate listener ports and addresses before startup

### DIFF
--- a/crates/pumpkin-config/src/lib.rs
+++ b/crates/pumpkin-config/src/lib.rs
@@ -91,6 +91,25 @@ impl LoadConfiguration for PumpkinConfig {
         Path::new("pumpkin.toml")
     }
 
+    #[expect(clippy::print_stdout, clippy::print_stderr)]
+    fn prepare(raw: &mut toml::Value) -> bool {
+        let report = networking::address::check(raw);
+        for warning in &report.warnings {
+            println!("Warning: {warning}");
+        }
+        if !report.errors.is_empty() {
+            for error in &report.errors {
+                eprintln!("Error: {error}");
+            }
+            eprintln!(
+                "Invalid network settings in {}, not starting",
+                Self::get_path().display()
+            );
+            std::process::exit(1);
+        }
+        report.patched
+    }
+
     fn validate(&self) {
         self.basic.validate();
         self.advanced.validate();
@@ -216,6 +235,8 @@ pub struct BasicConfiguration {
     pub white_list: bool,
     /// Whether to enforce the whitelist.
     pub enforce_whitelist: bool,
+    /// Whether to skip port and loopback address warnings.
+    pub ignore_port_warning: bool,
 }
 
 impl Default for BasicConfiguration {
@@ -237,6 +258,7 @@ impl Default for BasicConfiguration {
             allow_chat_reports: false,
             white_list: false,
             enforce_whitelist: false,
+            ignore_port_warning: false,
         }
     }
 }
@@ -293,7 +315,7 @@ pub trait LoadConfiguration {
                 }
             };
 
-            let parsed_toml_value: toml::Value = match toml::from_str(&file_content) {
+            let mut parsed_toml_value: toml::Value = match toml::from_str(&file_content) {
                 Ok(val) => val,
                 Err(err) => {
                     error!(
@@ -304,9 +326,10 @@ pub trait LoadConfiguration {
                 }
             };
 
+            let patched = Self::prepare(&mut parsed_toml_value);
             let (merged_config, changed) = Self::merge_with_default_toml(parsed_toml_value);
 
-            if changed {
+            if changed && !patched {
                 let file_name = path.file_name().map_or_else(
                     || path.display().to_string(),
                     |f| f.to_string_lossy().into_owned(),
@@ -420,6 +443,11 @@ pub trait LoadConfiguration {
 
     /// Returns the path to the configuration file relative to the config directory.
     fn get_path() -> &'static Path;
+
+    /// Checks the raw TOML before it is deserialized. Returns true if it was changed in memory.
+    fn prepare(_raw: &mut toml::Value) -> bool {
+        false
+    }
 
     /// Validates the configuration after loading or merging.
     fn validate(&self);

--- a/crates/pumpkin-config/src/networking/address.rs
+++ b/crates/pumpkin-config/src/networking/address.rs
@@ -1,0 +1,183 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use toml::{Table, Value};
+
+use super::bedrock::NetherNetConfig;
+use super::java::JavaConfig;
+use super::query::QueryConfig;
+use super::rcon::RCONConfig;
+
+#[derive(Default)]
+pub struct AddressReport {
+    pub warnings: Vec<String>,
+    pub errors: Vec<String>,
+    pub patched: bool,
+}
+
+enum Address {
+    Valid(SocketAddr),
+    NoPort(IpAddr),
+    BadPort(String),
+    Invalid,
+}
+
+fn listeners() -> [(&'static str, &'static str, u16); 4] {
+    [
+        (
+            "networking.java",
+            "Java Edition",
+            JavaConfig::default().address.port(),
+        ),
+        (
+            "networking.bedrock.nethernet",
+            "Bedrock Edition",
+            NetherNetConfig::default().address.port(),
+        ),
+        (
+            "networking.rcon",
+            "RCON",
+            RCONConfig::default().address.port(),
+        ),
+        (
+            "networking.query",
+            "Query",
+            QueryConfig::default().address.port(),
+        ),
+    ]
+}
+
+pub fn check(raw: &mut Value) -> AddressReport {
+    let ignore = raw
+        .get("ignore_port_warning")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let mut report = AddressReport::default();
+
+    for (path, name, default_port) in listeners() {
+        let Some(table) = table_mut(raw, path) else {
+            continue;
+        };
+        let Some(value) = table.get("address") else {
+            continue;
+        };
+        let Some(text) = value.as_str().map(str::to_owned) else {
+            report.errors.push(format!(
+                "{name} address in [{path}] must be a string, e.g. \"0.0.0.0:{default_port}\""
+            ));
+            continue;
+        };
+        let subject = format!("{name} address \"{text}\" in [{path}]");
+
+        let addr = match classify(&text) {
+            Address::Valid(addr) => addr,
+            Address::NoPort(ip) => {
+                let addr = SocketAddr::new(ip, default_port);
+                if !ignore {
+                    report
+                        .warnings
+                        .push(format!("{subject} has no port, using {addr}"));
+                }
+                table.insert("address".to_owned(), Value::String(addr.to_string()));
+                report.patched = true;
+                addr
+            }
+            Address::BadPort(port) => {
+                let message = format!("{subject}: {}", port_problem(&port));
+                reject_port(table, "address", name, message, ignore, &mut report);
+                continue;
+            }
+            Address::Invalid => {
+                let reason = if text.matches(':').count() > 1 && !text.starts_with('[') {
+                    "IPv6 with a port needs brackets, e.g. \"[::1]:25565\""
+                } else {
+                    "hostnames are not resolved"
+                };
+                report
+                    .errors
+                    .push(format!("{subject} is not a valid IP address ({reason})"));
+                continue;
+            }
+        };
+
+        if addr.ip().is_loopback() && !ignore {
+            report.warnings.push(format!(
+                "{name} is bound to loopback {addr}, only local connections can reach it"
+            ));
+        }
+    }
+
+    let path = "networking.lan_broadcast";
+    if let Some(table) = table_mut(raw, path)
+        && let Some(port) = table.get("port")
+        && port.as_integer().is_none_or(|p| u16::try_from(p).is_err())
+    {
+        let text = port
+            .as_str()
+            .map_or_else(|| port.to_string(), str::to_owned);
+        let message = format!("LAN broadcast in [{path}]: {}", port_problem(&text));
+        reject_port(table, "port", "LAN broadcast", message, ignore, &mut report);
+    }
+
+    report
+}
+
+fn classify(text: &str) -> Address {
+    if let Ok(addr) = text.parse::<SocketAddr>() {
+        return Address::Valid(addr);
+    }
+    if let Ok(ip) = text.parse::<IpAddr>() {
+        return Address::NoPort(ip);
+    }
+    if let Some(ip) = bracketed_ipv6(text) {
+        return Address::NoPort(ip.into());
+    }
+    match text.rsplit_once(':') {
+        Some((host, port))
+            if host.parse::<Ipv4Addr>().is_ok() || bracketed_ipv6(host).is_some() =>
+        {
+            Address::BadPort(port.to_owned())
+        }
+        _ => Address::Invalid,
+    }
+}
+
+fn port_problem(port: &str) -> String {
+    let number = port.strip_prefix('-').unwrap_or(port);
+    if port.is_empty() {
+        "port is empty".to_owned()
+    } else if !number.is_empty() && number.bytes().all(|b| b.is_ascii_digit()) {
+        format!("port {port} is out of range (0-65535)")
+    } else {
+        format!("port \"{port}\" is not a number")
+    }
+}
+
+fn bracketed_ipv6(text: &str) -> Option<Ipv6Addr> {
+    text.strip_prefix('[')?.strip_suffix(']')?.parse().ok()
+}
+
+fn reject_port(
+    table: &mut Table,
+    key: &str,
+    name: &str,
+    message: String,
+    ignore: bool,
+    report: &mut AddressReport,
+) {
+    if ignore {
+        report
+            .warnings
+            .push(format!("{message}, {name} is disabled"));
+        table.remove(key);
+        table.insert("enabled".to_owned(), Value::Boolean(false));
+        report.patched = true;
+    } else {
+        report.errors.push(message);
+    }
+}
+
+fn table_mut<'a>(raw: &'a mut Value, path: &str) -> Option<&'a mut Table> {
+    path.split('.')
+        .try_fold(raw, |value, key| value.get_mut(key))?
+        .as_table_mut()
+}

--- a/crates/pumpkin-config/src/networking/mod.rs
+++ b/crates/pumpkin-config/src/networking/mod.rs
@@ -7,6 +7,7 @@ use crate::LANBroadcastConfig;
 use bedrock::BedrockConfig;
 use java::JavaConfig;
 
+pub(crate) mod address;
 /// Authentication configuration.
 pub mod auth;
 /// Bedrock protocol networking configuration.


### PR DESCRIPTION
## Description

An invalid port in `pumpkin.toml` never produced an error. Every listener address is a `SocketAddr`, so something like `"0.0.0.0:70000"` fails to deserialize, and `merge_with_default_toml` then falls back to `Self::default()` for the whole config. The server starts on 25565 with every other setting reset, and nothing is printed. A hostname or an address without a port ends up the same way.

This adds a check on the raw TOML before it is deserialized. It covers the `address` of `networking.java`, `networking.bedrock.nethernet`, `networking.rcon` and `networking.query`, plus `networking.lan_broadcast.port`.

- A port outside 0-65535, or one that isn't a number, is an error and the server doesn't start.
- Hostnames are rejected. Nothing gets resolved, the address has to be an IP.
- An IP without a port prints a warning and uses that listener's default port, read from its `Default` impl.
- A loopback address prints a warning since only local connections can reach it. It is still allowed because that is the normal setup behind a reverse proxy or for RCON.

There is a new `ignore_port_warning` option, `false` by default. With it enabled the loopback and missing port warnings are skipped, and a listener with an invalid port is disabled instead of stopping startup. Hostnames are still an error.

The messages go through `println!`/`eprintln!` because the logger isn't initialized yet when the config is loaded.

```
Error: Java Edition address "0.0.0.0:70000" in [networking.java]: port 70000 is out of range (0-65535)
Error: Java Edition address "mc.example.com:25565" in [networking.java] is not a valid IP address (hostnames are not resolved)
Invalid network settings in pumpkin.toml, not starting
```

## Testing
I booted a debug build with different addresses like `0.0.0.0:70000`, `0.0.0.0:-1`, `[::1]:70000`, `mc.example.com:25565`, `localhost` and a LAN broadcast port of 70000 all stop startup with an error.

With `ignore_port_warning = true`, port 70000 starts the server with Java disabled and only Bedrock listed in the startup line. `0.0.0.0` without a port starts on 25565, and `127.0.0.1:25565` prints the loopback warning, which goes away with the option enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation and normalization for Java, Bedrock, RCON, and Query network addresses.
  - Portless addresses now receive appropriate default ports automatically.
  - Added an option to ignore port warnings when configuring network listeners.

- **Bug Fixes**
  - Invalid network settings now display clear warnings or errors during startup.
  - Invalid listener ports can be disabled when port warnings are ignored.
  - Configuration files are updated automatically when address values are corrected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->