### PR TITLE
fix(block): harden concrete powder placed directly into water

### DIFF
--- a/crates/pumpkin/src/block/blocks/falling.rs
+++ b/crates/pumpkin/src/block/blocks/falling.rs
@@ -83,8 +83,10 @@ impl BlockMetadata for FallingBlock {
 
 impl BlockBehaviour for FallingBlock {
     fn on_place(&self, args: OnPlaceArgs<'_>) -> BlockStateId {
+        // Vanilla getPlacementState uses shouldSolidify (own position OR neighbors),
+        // so powder placed directly into water hardens even without a water neighbor.
         if args.block.has_tag(&tag::Block::MINECRAFT_CONCRETE_POWDERS)
-            && Self::touches_liquid(args.world, args.position)
+            && Self::should_solidify(args.world, args.position)
             && let Some(name) = args.block.name.strip_suffix("_powder")
             && let Some(concrete) = Block::from_name(name)
         {


### PR DESCRIPTION
## What
`on_place` gates concrete-powder hardening on `touches_liquid` (neighbors only), so powder placed **directly into a water source** with no water neighbor stays loose. Vanilla `ConcretePowderBlock.getPlacementState` uses `shouldSolidify` (`canSolidify(own position) || touchesLiquid`), so it hardens. This swaps `on_place` to the `should_solidify` helper.

`get_state_for_neighbor_update` is intentionally left on `touches_liquid`, matching vanilla `getStateForNeighborUpdate` (neighbors only).

## Why
#3256 added the `should_solidify` helper and fixed the neighbor-update and landing paths, but was merged with `on_place` still on `touches_liquid` — so the placement path was left short of vanilla parity. This completes it: a one-line change reusing the helper already in the tree, no new logic.

## Testing
`cargo check` could not complete in my environment due to an unrelated host SDK/linker failure (`MacOSX27.0.sdk` malformed `.tbd`, `arm64e.x1` unknown arch) in a `wasmtime` proc-macro dependency. The change is a swap between two same-signature `pub fn(&dyn BlockAccessor, &BlockPos) -> bool` associated functions called with identical arguments, so it type-checks by construction; verified by inspection against vanilla, consistent with how #3256 was validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Concrete powder now hardens into concrete when placed directly in water, matching expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->