### PR TITLE
fix: defer datapack load functions until the next game tick

### DIFF
--- a/crates/pumpkin/src/command/commands/datapack.rs
+++ b/crates/pumpkin/src/command/commands/datapack.rs
@@ -253,7 +253,7 @@ impl CommandExecutor for DatapackEnableExecutor {
             error!("Failed to save world info: {err}");
         }
 
-        server.reload_datapacks(server);
+        server.reload_datapacks();
 
         context.source.send_feedback(
             TextComponent::translate_cross(
@@ -337,7 +337,7 @@ impl CommandExecutor for DatapackEnableExistingExecutor {
             error!("Failed to save world info: {err}");
         }
 
-        server.reload_datapacks(server);
+        server.reload_datapacks();
 
         context.source.send_feedback(
             TextComponent::translate_cross(
@@ -389,7 +389,7 @@ impl CommandExecutor for DatapackDisableExecutor {
             error!("Failed to save world info: {err}");
         }
 
-        server.reload_datapacks(server);
+        server.reload_datapacks();
 
         context.source.send_feedback(
             TextComponent::translate_cross(

--- a/crates/pumpkin/src/command/commands/reload.rs
+++ b/crates/pumpkin/src/command/commands/reload.rs
@@ -27,7 +27,7 @@ impl CommandExecutor for ReloadExecutor {
         );
 
         let server = context.server().clone();
-        server.reload_datapacks(&server);
+        server.reload_datapacks();
 
         Ok(0)
     }

--- a/crates/pumpkin/src/data/datapack/mod.rs
+++ b/crates/pumpkin/src/data/datapack/mod.rs
@@ -782,7 +782,7 @@ impl DatapackManager {
             tracing::error!("Failed to save world info: {err}");
         }
 
-        server.reload_datapacks(server);
+        server.reload_datapacks();
         Ok(())
     }
 
@@ -816,12 +816,12 @@ impl DatapackManager {
             tracing::error!("Failed to save world info: {err}");
         }
 
-        server.reload_datapacks(server);
+        server.reload_datapacks();
         Ok(())
     }
 
     pub fn reload(server: &Arc<Server>) -> Result<(), String> {
-        server.reload_datapacks(server);
+        server.reload_datapacks();
         Ok(())
     }
 

--- a/crates/pumpkin/src/server/mod.rs
+++ b/crates/pumpkin/src/server/mod.rs
@@ -104,6 +104,8 @@ pub struct Server {
     container_id: AtomicU32,
     pub recipe_manager: Arc<recipe::RecipeManager>,
     pub datapack_manager: Arc<crate::data::datapack::DatapackManager>,
+    /// Runs the latest load tag on the next game tick, coalescing resource reloads.
+    datapack_load_pending: AtomicBool,
     pub enchantment_manager: Arc<enchantment::EnchantmentManager>,
     /// Assigns unique IDs to maps.
     map_id: AtomicI32,
@@ -287,6 +289,7 @@ impl Server {
             container_id: 0.into(),
             recipe_manager: Arc::new(recipe::RecipeManager::new()),
             datapack_manager: Arc::new(crate::data::datapack::DatapackManager::new()),
+            datapack_load_pending: AtomicBool::new(true),
             enchantment_manager: Arc::new(enchantment::EnchantmentManager::new()),
             map_id: level_info.load().map_id.into(),
             worlds: ArcSwap::from_pointee(vec![]),
@@ -433,11 +436,6 @@ impl Server {
             .datapack_manager
             .load_all(&world_path, &enabled_packs, &server.recipe_manager);
 
-        let source = crate::command::CommandSender::Console.into_source(&server);
-        let _ = server
-            .datapack_manager
-            .execute_function(&server, &source, "#minecraft:load");
-
         server
     }
 
@@ -539,16 +537,13 @@ impl Server {
             .write_world_info(&level_data, &self.basic_config.get_world_path())
     }
 
-    pub fn reload_datapacks(&self, server: &Arc<Self>) {
+    pub fn reload_datapacks(&self) {
         let enabled_packs = self.level_info.load().data_packs.enabled.clone();
         let world_path = self.basic_config.get_world_path();
         self.datapack_manager
             .load_all(&world_path, &enabled_packs, &self.recipe_manager);
 
-        let source = crate::command::CommandSender::Console.into_source(server);
-        let _ = self
-            .datapack_manager
-            .execute_function(server, &source, "#minecraft:load");
+        self.datapack_load_pending.store(true, Ordering::Release);
 
         let dynamic_recipes = self.recipe_manager.get_dynamic_recipes_internal();
         for player in self.get_all_players() {
@@ -1133,6 +1128,11 @@ impl Server {
         let source = crate::command::CommandSender::Console
             .into_source(self)
             .with_silent();
+        if self.datapack_load_pending.swap(false, Ordering::AcqRel) {
+            let _ = self
+                .datapack_manager
+                .execute_function(self, &source, "#minecraft:load");
+        }
         let _ = self
             .datapack_manager
             .execute_function(self, &source, "#minecraft:tick");


### PR DESCRIPTION
## Description

With game ticks frozen, `/reload` currently executes `#minecraft:load` immediately. Repeated reloads therefore run load functions multiple times before any game tick.

Mark load execution pending at startup and after reload, then consume it once before `#minecraft:tick` on the next game-logic tick. Execution uses the current enabled functions, so disabling a pack or changing its contents before that tick is respected. Remove the now-unused server argument from `reload_datapacks` and update its callers.

Based on the merged #3267 tick dispatcher. Fixes #3276.

## Testing

Independent local console harness compared unchanged upstream `0f6b4f740` and this patch against vanilla 26.2 and Paper 26.2-121. Upstream fails the frozen-reload expectations; the patch matches both references for startup, normal reload, repeated frozen reloads, one-time execution, disabling/enabling a pending pack, and load-before-tick ordering. Editing the function across two frozen reloads also executes only the latest contents once. Existing tick freeze/step/reload/disable checks pass before and after.

All 804 workspace tests pass. Workspace documentation tests: 7 passed, 23 ignored. Release Clippy for Pumpkin with all targets/features and warnings denied, formatting, and whitespace checks pass.

Validation ran on Windows using release builds with server/data/world optimization disabled. An additional explicit `/function parity:load` probe encounters the same pre-existing colon-parsing failure before and after this patch; that independent command issue is recorded separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Datapack loading now completes before datapack load actions run, improving reliability during server startup and reloads.
  - Datapack reload actions are processed on the next game tick, helping prevent timing-related issues.
  - Multiple datapack reload requests are consolidated to avoid unnecessary repeated processing.

- **Improvements**
  - Datapack-related commands now use a simpler and more consistent reload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->