### PR TITLE
fix: preserve player equipment on death

### DIFF
--- a/crates/pumpkin/src/entity/living.rs
+++ b/crates/pumpkin/src/entity/living.rs
@@ -1917,7 +1917,9 @@ impl LivingEntity {
             }
             self.entity.pose.store(EntityPose::Dying);
 
-            self.drop_equipment(looting_level);
+            if dyn_self.get_player().is_none() {
+                self.drop_equipment(looting_level);
+            }
 
             // Broadcast death message if it's a player and the gamerule is enabled
             self.broadcast_death_message(&*dyn_self, damage_type, source, cause);

--- a/crates/pumpkin/src/entity/player.rs
+++ b/crates/pumpkin/src/entity/player.rs
@@ -4508,7 +4508,15 @@ impl Player {
                 .main_inventory
                 .write()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            for item in main_inv.iter_mut() {
+            let mut equipment = std::mem::take(
+                &mut self
+                    .inventory()
+                    .entity_equipment
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .equipment,
+            );
+            for item in main_inv.iter_mut().chain(equipment.values_mut()) {
                 if !item.is_empty() {
                     let stack = std::mem::replace(item, ItemStack::EMPTY.clone());
                     self.increment_stat(


### PR DESCRIPTION
## Description

Player deaths were using the mob equipment-drop routine, which rolls a drop chance and randomizes durability. The player inventory drop loop then handled only the main inventory, leaving undropped armor and offhand items to be cleared on respawn.

Skip mob equipment drops for players and include their equipment in the player inventory drop loop. Armor and offhand items now drop with their existing durability, or remain in inventory when `keep_inventory` is enabled.

Fixes #3391.

## Testing

- Independent local Java 26.2 protocol-client harness reproduced the defect on upstream `0f6b4f740` with both `/kill` and actual slime contact damage. Mob-death cases verify attacker IDs and the combat-death packet.
- Before/after checks decoded dropped item IDs, counts and durability: four diamond armor pieces, an offhand shield and a main-hand sword. Baseline lost equipment or randomized its damage; the fix drops all six correctly.
- With `keep_inventory` enabled, both death causes produce no equipment drops and retain all six items after respawn.
- Vanilla 26.2 comparison confirmed all six drops after both deaths and inventory retention after `/kill`.
- Workspace regression suite: 804 tests passed, none skipped (`cargo nextest run --release --locked --workspace`).
- Clippy passed for all Pumpkin targets and features with `-D warnings`; formatting and whitespace checks passed.
- Workspace documentation tests: 7 passed, 23 ignored, no failures.

Vanilla applies ordinary combat wear to armor; Pumpkin's existing combat-wear gap is separate and unchanged. The local harness is outside this PR. No manual GUI or native Bedrock test was performed.

Implemented and tested with Codex.
