### PR TITLE
fix: Pterodactyl egg port sync and several gameplay bugs

### DIFF
--- a/crates/pumpkin-config/src/lib.rs
+++ b/crates/pumpkin-config/src/lib.rs
@@ -141,6 +141,35 @@ impl LoadConfiguration for PumpkinConfig {
     }
 }
 
+/// Environment variable that overrides `networking.java.address` at startup.
+///
+/// Hosting panels such as Pterodactyl assign a port per server; this lets them pass
+/// the bind address on every start without having to rewrite `pumpkin.toml`.
+pub const JAVA_ADDRESS_ENV: &str = "PUMPKIN_JAVA_ADDRESS";
+
+impl PumpkinConfig {
+    /// Applies overrides from environment variables on top of the loaded configuration.
+    ///
+    /// Overrides only affect the running server and are never written back to `pumpkin.toml`.
+    pub fn apply_env_overrides(&mut self) {
+        let Ok(value) = std::env::var(JAVA_ADDRESS_ENV) else {
+            return;
+        };
+        let value = value.trim();
+        if value.is_empty() {
+            return;
+        }
+        let address: std::net::SocketAddr = match value.parse() {
+            Ok(address) => address,
+            Err(err) => {
+                warn!("Ignoring {JAVA_ADDRESS_ENV}={value:?}: {err}");
+                return;
+            }
+        };
+        self.advanced.networking.java.address = address;
+    }
+}
+
 /// Advanced configuration for optional and feature-specific server settings.
 ///
 /// Allows enabling/disabling features, customizing behaviour, and

--- a/crates/pumpkin-config/src/networking/java.rs
+++ b/crates/pumpkin-config/src/networking/java.rs
@@ -10,6 +10,8 @@ pub struct JavaConfig {
     /// Whether Java Edition Clients are Accepted.
     pub enabled: bool,
     /// The address and port to which the Java Edition server will bind.
+    ///
+    /// Can be overridden at startup with the `PUMPKIN_JAVA_ADDRESS` environment variable.
     pub address: SocketAddr,
     /// Whether packet encryption is enabled. Required when online mode is enabled.
     pub encryption: bool,

--- a/crates/pumpkin/src/block/blocks/plant/mushroom_plant.rs
+++ b/crates/pumpkin/src/block/blocks/plant/mushroom_plant.rs
@@ -98,6 +98,10 @@ impl MushroomPlantBlock {
             for dx in -radius..=radius {
                 for dz in -radius..=radius {
                     let check_pos = pos.add(dx, dy, dz);
+                    // The mushroom itself is only replaced with air after this check.
+                    if check_pos == *pos {
+                        continue;
+                    }
                     if !world.is_loaded(&check_pos) {
                         return false;
                     }

--- a/crates/pumpkin/src/block/entities/brewing_stand.rs
+++ b/crates/pumpkin/src/block/entities/brewing_stand.rs
@@ -12,6 +12,7 @@ use pumpkin_data::potion::Potion;
 use pumpkin_data::potion_brewing::BREWING_RECIPES;
 use pumpkin_data::sound::{Sound, SoundCategory};
 use pumpkin_data::tag::{self, Taggable};
+use pumpkin_inventory::brewing::brewing_screen_handler::{is_fuel, is_ingredient, is_potion_item};
 use pumpkin_inventory::{Inventory, sync_read_items_from_nbt, sync_write_items_to_nbt};
 use pumpkin_nbt::compound::NbtCompound;
 use pumpkin_protocol::codec::recipe::DynamicRecipe;
@@ -264,22 +265,8 @@ impl BrewingStandBlockEntity {
             }
         }
 
-        // Check if we can immediately start the next brew
-        if let Ok(items) = self.items.read() {
-            let ingredient = items[3].clone();
-            drop(items);
-            if self.fuel.load(Ordering::Relaxed) > 0 && self.is_brewable(&ingredient, world) {
-                self.fuel.fetch_sub(1, Ordering::Relaxed);
-                self.brew_time.store(400, Ordering::Relaxed);
-                *self
-                    .ingredient_item
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                    Some(ingredient.get_item());
-            } else {
-                self.brew_time.store(0, Ordering::Relaxed);
-            }
-        }
+        // Like vanilla, the next brew is started by `tick` so it goes through `BrewingStartEvent`.
+        self.brew_time.store(0, Ordering::Relaxed);
 
         // Play sound at the center of the block
         let pos = Vector3::new(
@@ -418,19 +405,18 @@ impl pumpkin_inventory::Inventory for BrewingStandBlockEntity {
         }
 
         match slot {
-            // Slots 0-2 - potion bottles
-            0..=2 => stack
-                .get_data_component::<pumpkin_data::data_component_impl::PotionContentsImpl>()
-                .is_some(),
-            // Slot 3 - ingredient (must be tagged as brewable)
-            3 => {
-                // Check if item is a valid brewing ingredient
-                if stack.get_item().has_tag(&tag::Item::MINECRAFT_BREWING_FUEL) {
-                    return false; // Fuel should not go in ingredient slot
-                }
-                // Allow any item that's not fuel (ingredient validation happens during brewing)
-                true
+            // Slots 0-2 - potion bottles, one per slot
+            0..=2 => {
+                is_potion_item(stack.get_item())
+                    && self
+                        .items
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)[slot]
+                        .is_empty()
             }
+            // Slot 3 - ingredient. Fuel stays out because hoppers don't use vanilla's
+            // per-side slots yet and would otherwise fill the ingredient slot with it.
+            3 => !is_fuel(stack.get_item()) && is_ingredient(stack.get_item()),
             // Slot 4 - fuel
             4 => stack.get_item().has_tag(&tag::Item::MINECRAFT_BREWING_FUEL),
             _ => false,

--- a/crates/pumpkin/src/block/entities/hopper.rs
+++ b/crates/pumpkin/src/block/entities/hopper.rs
@@ -426,8 +426,9 @@ impl HopperBlockEntity {
                     dst = item.clone();
                     to.set_stack(j, dst);
                     success = true;
-                } else if dst.item_count < dst.get_max_stack_size() && dst.item == item.item {
-                    // TODO check Components equal
+                } else if dst.item_count < dst.get_max_stack_size()
+                    && dst.are_items_and_components_equal(item)
+                {
                     dst.item_count += 1;
                     to.set_stack(j, dst);
                     success = true;

--- a/crates/pumpkin/src/entity/decoration/armor_stand.rs
+++ b/crates/pumpkin/src/entity/decoration/armor_stand.rs
@@ -5,7 +5,8 @@ use crossbeam::atomic::AtomicCell;
 use pumpkin_data::item_stack::ItemStack;
 use pumpkin_data::{
     damage::DamageType,
-    data_component_impl::{EquipmentSlot, EquipmentType},
+    data_component::DataComponent,
+    data_component_impl::{CustomNameImpl, DataComponentImpl, EquipmentSlot, EquipmentType},
     entity::EntityStatus,
     item::Item,
     particle::Particle,
@@ -187,10 +188,14 @@ impl ArmorStandEntity {
 
     fn break_and_drop_items(&self) {
         let entity = self.get_entity();
-        //let name = entity.custom_name.unwrap_or(entity.get_name());
 
-        //TODO: i am stupid! let armor_stand_item = ItemStack::new_with_component(1, &Item::ARMOR_STAND, vec![(DataComponent::CustomName, self.get_custom_name())]);
-        let armor_stand_item = ItemStack::new(1, &Item::ARMOR_STAND);
+        let mut armor_stand_item = ItemStack::new(1, &Item::ARMOR_STAND);
+        if let Some(name) = &**entity.custom_name.load() {
+            armor_stand_item.patch.push((
+                DataComponent::CustomName,
+                Some(CustomNameImpl { name: name.clone() }.to_dyn()),
+            ));
+        }
         entity
             .world
             .load()
@@ -328,7 +333,12 @@ impl EntityBase for ArmorStandEntity {
             game_rules.mob_griefing
         };
 
-        if !mob_griefing_gamerule && source.is_some_and(|source| source.get_player().is_none()) {
+        // Like vanilla, only block damage caused by a mob (the shooter, not the projectile).
+        if !mob_griefing_gamerule
+            && cause
+                .or(source)
+                .is_some_and(|attacker| attacker.get_mob().is_some())
+        {
             return false;
         }
 

--- a/crates/pumpkin/src/main.rs
+++ b/crates/pumpkin/src/main.rs
@@ -67,11 +67,12 @@ async fn main() {
 
     let exec_dir = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
 
-    let config = PumpkinConfig::load(&exec_dir);
+    let mut config = PumpkinConfig::load(&exec_dir);
 
     let vanilla_data = VanillaData::load();
 
     pumpkin::init_logger(&config.advanced);
+    config.apply_env_overrides();
 
     info!(
         "{}",

--- a/egg-pumpkin.json
+++ b/egg-pumpkin.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2026-02-10T08:07:42+00:00",
+    "exported_at": "2026-09-10T00:00:00+00:00",
     "name": "Pumpkin",
     "author": "lilalexmed@proton.me",
     "description": "Pumpkin is a Minecraft server built entirely in Rust, offering a fast, efficient, and customizable experience. It prioritizes performance and player enjoyment while adhering to the core mechanics of the game.",
@@ -14,7 +14,7 @@
         "Debian": "ghcr.io\/pterodactyl\/yolks:debian"
     },
     "file_denylist": [],
-    "startup": ".\/pumpkin",
+    "startup": "PUMPKIN_JAVA_ADDRESS=0.0.0.0:{{SERVER_PORT}} .\/pumpkin",
     "config": {
         "files": "{\r\n    \"pumpkin.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"address = \\\"0.0.0.0:25565\\\"\": \"address = \\\"0.0.0.0:{{server.build.default.port}}\\\"\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server is now running.\"\r\n}",
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\nset -eux\r\n\r\napk add --no-cache curl jq\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\nARCH=$(uname -m)\r\ncase \"$ARCH\" in\r\n    x86_64|amd64)\r\n        PUMPKIN_ARCH=\"X64\"\r\n        ;;\r\n    aarch64|arm64)\r\n        PUMPKIN_ARCH=\"ARM64\"\r\n        ;;\r\n    *)\r\n        echo \"Unsupported architecture: $ARCH\"\r\n        exit 1\r\n        ;;\r\nesac\r\n\r\nBINARY_NAME=\"pumpkin-${PUMPKIN_ARCH}-Linux-musl\"\r\n\r\nif [ -n \"${DOWNLOAD_URL:-}\" ]; then\r\n    URL=\"$DOWNLOAD_URL\"\r\nelif [ \"${VERSION:-nightly}\" = \"latest\" ] || [ \"${VERSION:-nightly}\" = \"nightly\" ]; then\r\n    URL=\"https:\/\/github.com\/${GITHUB_PACKAGE:-Pumpkin-MC\/Pumpkin}\/releases\/download\/nightly\/${BINARY_NAME}\"\r\nelse\r\n    URL=\"https:\/\/github.com\/${GITHUB_PACKAGE:-Pumpkin-MC\/Pumpkin}\/releases\/download\/${VERSION}\/${BINARY_NAME}\"\r\nfi\r\n\r\necho \"Downloading Pumpkin from: $URL\"\r\ncurl -fsSL \"$URL\" -o \/mnt\/server\/pumpkin\r\nchmod +x \/mnt\/server\/pumpkin\r\n\r\n# Quickly start and kill server to generate initial configuration if not present\r\nif [ ! -f \/mnt\/server\/pumpkin.toml ]; then\r\n    timeout 2 .\/pumpkin || true\r\nfi",
+            "script": "#!\/bin\/ash\r\nset -eux\r\n\r\napk add --no-cache curl\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\nARCH=$(uname -m)\r\ncase \"$ARCH\" in\r\n    x86_64|amd64)\r\n        PUMPKIN_ARCH=\"X64\"\r\n        ;;\r\n    aarch64|arm64)\r\n        PUMPKIN_ARCH=\"ARM64\"\r\n        ;;\r\n    *)\r\n        echo \"Unsupported architecture: $ARCH\"\r\n        exit 1\r\n        ;;\r\nesac\r\n\r\nBINARY_NAME=\"pumpkin-${PUMPKIN_ARCH}-Linux-musl\"\r\nREPO=\"${GITHUB_PACKAGE:-Pumpkin-MC\/Pumpkin}\"\r\n\r\nif [ -n \"${DOWNLOAD_URL:-}\" ]; then\r\n    URL=\"$DOWNLOAD_URL\"\r\nelif [ \"${VERSION:-nightly}\" = \"nightly\" ]; then\r\n    URL=\"https:\/\/github.com\/${REPO}\/releases\/download\/nightly\/${BINARY_NAME}\"\r\nelif [ \"$VERSION\" = \"latest\" ]; then\r\n    URL=\"https:\/\/github.com\/${REPO}\/releases\/latest\/download\/${BINARY_NAME}\"\r\nelse\r\n    URL=\"https:\/\/github.com\/${REPO}\/releases\/download\/${VERSION}\/${BINARY_NAME}\"\r\nfi\r\n\r\necho \"Downloading Pumpkin from: $URL\"\r\n# Download to a temporary file so a failed download never replaces a working binary.\r\ncurl -fsSL --retry 3 \"$URL\" -o pumpkin.download\r\nmv -f pumpkin.download pumpkin\r\nchmod +x pumpkin\r\n\r\n# Seed a minimal config so the panel can write the allocated port on the first start.\r\n# Pumpkin fills in every other setting with its defaults when it starts.\r\nif [ ! -f pumpkin.toml ]; then\r\n    printf '[networking.java]\\naddress = \"0.0.0.0:25565\"\\n' > pumpkin.toml\r\nfi",
             "container": "ghcr.io\/pterodactyl\/installers:alpine",
             "entrypoint": "ash"
         }
@@ -41,7 +41,7 @@
         },
         {
             "name": "Pumpkin Version",
-            "description": "The version of Pumpkin to install. Options: 'nightly', 'latest', or a specific release tag (e.g. 'v0.1.0').\r\nScope: installation",
+            "description": "The version of Pumpkin to install: 'nightly' (newest development build), 'latest' (newest stable release) or a specific release tag (e.g. 'v0.1.0').\r\nScope: installation",
             "env_variable": "VERSION",
             "default_value": "nightly",
             "user_viewable": true,


### PR DESCRIPTION
## Description

### Pterodactyl egg: allocation port never updated after the first boot

The egg's `file` config parser matches a **line prefix** and replaces the **whole line**. The old find key `address = "0.0.0.0:25565"` therefore only matched on the first boot. After that, the line holds the allocated port, so later allocation changes were never applied. A looser prefix (`address = `) also matches the RCON, Bedrock and query `address` lines. Pterodactyl has no TOML parser, and the yolks entrypoint runs `exec env ${PARSED}` (no shell), so the startup command can't rewrite the file either.

- New `PUMPKIN_JAVA_ADDRESS` env var that overrides `networking.java.address` at startup. It is applied after the logger is initialised and never written back to `pumpkin.toml`; invalid values are logged and ignored.
- Egg startup: `PUMPKIN_JAVA_ADDRESS=0.0.0.0:{{SERVER_PORT}} ./pumpkin`.
- Egg install:
  - `VERSION=latest` resolves to `releases/latest` (it pointed at nightly).
  - Downloads to a temp file with `--retry 3`, so a failed download never replaces a working binary.
  - Seeds a minimal `pumpkin.toml` instead of running the server for 2s; drops unused `jq`.
- The existing `file` parser entry is kept, so older binaries without the override still get the right port on the first boot.

### Gameplay fixes

- **Huge mushrooms never grew from bone meal.** The space check in `grow_mushroom` tested the mushroom's own position, which is only replaced with air after the check. Vanilla removes the block first.
- **Brewing stand slots.** Hoppers use `is_valid_slot_for`, which accepted any non-fuel item in the ingredient slot (a hopper could jam it with cobblestone) and rejected glass bottles in the potion slots. It now follows the brewing screen's rules: real ingredients only, and potion items one per slot. Fuel stays out of the ingredient slot because hoppers don't have vanilla's per-side slots yet (`TODO check WorldlyContainer`).
- **Brewing stand chained brews.** `do_brew` started the next brew itself, which skipped `BrewingStartEvent`. Like vanilla, the timer now ends at 0 and `tick` starts the next brew.
- **Hopper stacking.** `add_one_item` merged stacks by item type only (`TODO check Components equal`), so renamed or enchanted items were merged into plain ones and lost their components. It now uses `are_items_and_components_equal`, the same check the extraction path got in #3147.
- **Armor stands.** A named armor stand dropped a plain item. And with `mobGriefing=false`, a player's projectile couldn't break one, because the check looked at the direct source (the arrow). Vanilla only blocks damage when the causing entity is a `Mob`.

## Testing

- `cargo clippy --workspace --all-targets --locked`: clean (workspace pedantic + nursery lints).
- `cargo fmt --all --check`: clean.
- `cargo test -p pumpkin -p pumpkin-config -p pumpkin-inventory`: 210 + 16 + 21 passed, 0 failed.
- `cargo test --workspace --no-fail-fast`: 781 passed, 0 failed, 20 ignored.
- Egg JSON validated; the install script round-trips exactly and passes `sh -n`.
- Checked the Pterodactyl wings `file` parser (prefix match, full-line replace) and the yolks entrypoint against upstream source.
- After rebasing onto current `master` (no conflicts), re-ran on the rebased code: clippy clean; `cargo test -p pumpkin -p pumpkin-config -p pumpkin-inventory`: 273 passed, 0 failed.
